### PR TITLE
Remove obsolete CLI device and hardware commands

### DIFF
--- a/keymasq/cli/__init__.py
+++ b/keymasq/cli/__init__.py
@@ -1,11 +1,1 @@
-from keymasq.cli.commands import (
-    create_hardware,
-    list_devices,
-    test_device,
-)
-
-__all__ = [
-    "create_hardware",
-    "list_devices",
-    "test_device",
-]
+__all__: list[str] = []

--- a/keymasq/cli/__main__.py
+++ b/keymasq/cli/__main__.py
@@ -1,18 +1,13 @@
 import argparse
-import asyncio
-import sys
 
 from keymasq import __version__
 from keymasq.cli.commands import (
     cancel_macro_cli,
-    create_hardware,
-    list_devices,
     list_macros_cli,
     list_profiles_cli,
     play_macro_cli,
     set_diagnostics_cli,
     set_profile_state_cli,
-    test_device,
 )
 from keymasq.common.asyncio_runtime import ensure_uvloop
 
@@ -31,17 +26,6 @@ def main() -> None:
     )
 
     subparsers = parser.add_subparsers(dest="command", help="Available commands")
-
-    devices_parser = subparsers.add_parser("devices", help="List available devices")
-    devices_parser.add_argument("-v", "--verbose", action="store_true", help="Show details")
-
-    hardware_parser = subparsers.add_parser("hardware", help="Hardware configuration")
-    hardware_parser.add_argument("action", choices=["create", "list"], help="Action to perform")
-    hardware_parser.add_argument("--vid", help="Vendor ID (e.g., 046d)")
-    hardware_parser.add_argument("--pid", help="Product ID (e.g., c08b)")
-
-    test_parser = subparsers.add_parser("test", help="Test device events")
-    test_parser.add_argument("device", help="Device path (e.g., /dev/input/event5)")
 
     macros_parser = subparsers.add_parser("macros", help="Macro commands")
     macros_sub = macros_parser.add_subparsers(dest="macros_command", required=True)
@@ -79,19 +63,7 @@ def main() -> None:
 
     args = parser.parse_args()
 
-    if args.command == "devices":
-        asyncio.run(list_devices(args.verbose))
-    elif args.command == "hardware":
-        if args.action == "list":
-            print("Hardware configs not yet implemented")
-        elif args.action == "create":
-            if not args.vid or not args.pid:
-                print("Error: --vid and --pid required")
-                sys.exit(1)
-            create_hardware(args.vid, args.pid)
-    elif args.command == "test":
-        asyncio.run(test_device(args.device))
-    elif args.command == "macros":
+    if args.command == "macros":
         if args.macros_command == "list":
             list_macros_cli()
         elif args.macros_command == "play":

--- a/keymasq/cli/commands.py
+++ b/keymasq/cli/commands.py
@@ -1,102 +1,11 @@
-import asyncio
 import json
 import socket
 import sys
-from collections.abc import Callable, Iterable
 from typing import Any, cast
-
-import evdev
 
 from keymasq.common.paths import SESSION_SOCKET_PATH
 
 JsonObject = dict[str, Any]
-
-
-async def list_devices(verbose: bool = False) -> None:
-    print("Available input devices:\n")
-
-    list_devices = cast(Callable[[], list[str]], evdev.list_devices)
-    devices = list_devices()
-
-    for path in sorted(devices):
-        try:
-            device = evdev.InputDevice(path)
-            info = device.info
-
-            print(f"{path}")
-            print(f"  Name: {device.name}")
-            print(f"  VID:PID: {info.vendor:04x}:{info.product:04x}")
-
-            if verbose:
-                caps = device.capabilities()
-                print("  Capabilities:")
-                for ev_type, codes in caps.items():
-                    type_name = evdev.ecodes.EV.get(ev_type, f"UNKNOWN({ev_type})")
-                    type_codes = cast(dict[int, str], evdev.ecodes.bytype[ev_type])
-                    code_names: list[str] = []
-                    for code in codes:
-                        if isinstance(code, tuple):
-                            tuple_code = cast(tuple[object, ...], code)
-                            first = tuple_code[0] if tuple_code else None
-                            second = tuple_code[1] if len(tuple_code) > 1 else None
-                            if isinstance(first, int):
-                                code_name = type_codes.get(first, str(first))
-                            else:
-                                code_name = str(first)
-                            code_names.append(f"{code_name}[{second}]")
-                        else:
-                            code_name = type_codes.get(code, str(code))
-                            code_names.append(code_name)
-                    print(f"    {type_name}: {', '.join(str(c) for c in code_names[:10])}")
-                    if len(code_names) > 10:
-                        print(f"      ... and {len(code_names) - 10} more")
-
-            print()
-
-        except Exception as e:
-            if verbose:
-                print(f"{path}: Error - {e}\n")
-
-
-def create_hardware(vid: str, pid: str) -> None:
-    print(f"Creating hardware config for {vid}:{pid}")
-    print("This feature requires the GUI for interactive setup.")
-    print("Run: keymasq")
-
-
-async def test_device(device_path: str) -> None:
-    try:
-        device = evdev.InputDevice(device_path)
-        print(f"Listening on: {device.name}")
-        print(f"Path: {device_path}")
-        print("Press Ctrl+C to stop\n")
-
-        loop = asyncio.get_event_loop()
-
-        def _read_events() -> list[evdev.InputEvent]:
-            read = cast(Callable[[], Iterable[evdev.InputEvent]], device.read)
-            return list(read())
-
-        while True:
-            events = await loop.run_in_executor(None, _read_events)
-
-            for event in events:
-                if event.type == evdev.ecodes.EV_SYN:
-                    continue
-
-                type_name = evdev.ecodes.EV.get(event.type, f"UNKNOWN({event.type})")
-                code_name = evdev.ecodes.bytype[event.type].get(event.code, str(event.code))
-
-                print(f"{type_name:12} {code_name:20} value={event.value}")
-
-    except FileNotFoundError:
-        print(f"Error: Device not found: {device_path}")
-        sys.exit(1)
-    except PermissionError:
-        print("Error: Permission denied. Try with sudo or add user to 'input' group.")
-        sys.exit(1)
-    except KeyboardInterrupt:
-        print("\nStopped.")
 
 
 def _session_request(payload: JsonObject, timeout: float = 5.0) -> JsonObject | None:
@@ -234,6 +143,7 @@ def list_profiles_cli() -> None:
             print(f"  {hardware_id}  {device_name}")
             print(f"    active: {active_profiles or 'passthrough'}")
             print(f"    mappings: {mapping_count}")
+
 
 def set_profile_state_cli(command: str, profile_name: str) -> None:
     result = (

--- a/tests/test_entrypoints_and_cli.py
+++ b/tests/test_entrypoints_and_cli.py
@@ -26,7 +26,7 @@ def test_root_entrypoint_prefers_cli_when_args(monkeypatch: pytest.MonkeyPatch) 
         "keymasq.gui.__main__",
         _module_with_main(lambda: called.append("gui")),
     )
-    monkeypatch.setattr(sys, "argv", ["keymasq", "devices"])
+    monkeypatch.setattr(sys, "argv", ["keymasq", "profiles", "list"])
 
     app_main.main()
     assert called == ["cli"]
@@ -116,20 +116,6 @@ def test_session_script_entrypoint_calls_manager_main(monkeypatch: pytest.Monkey
     assert called == ["manager"]
 
 
-def test_cli_main_hardware_create_requires_vid_pid(
-    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
-) -> None:
-    from keymasq.cli import __main__ as cli_main
-
-    monkeypatch.setattr(sys, "argv", ["keymasq", "hardware", "create"])
-
-    with pytest.raises(SystemExit) as excinfo:
-        cli_main.main()
-
-    assert excinfo.value.code == 1
-    assert "--vid and --pid required" in capsys.readouterr().out
-
-
 def test_cli_main_profiles_toggle_routes_to_helper(monkeypatch: pytest.MonkeyPatch) -> None:
     from keymasq.cli import __main__ as cli_main
 
@@ -143,18 +129,3 @@ def test_cli_main_profiles_toggle_routes_to_helper(monkeypatch: pytest.MonkeyPat
 
     cli_main.main()
     assert calls == [("toggle_profile", "gaming")]
-
-
-def test_cli_main_devices_runs_async_handler(monkeypatch: pytest.MonkeyPatch) -> None:
-    from keymasq.cli import __main__ as cli_main
-
-    called: list[bool] = []
-
-    async def _list_devices(verbose: bool) -> None:
-        called.append(verbose)
-
-    monkeypatch.setattr(cli_main, "list_devices", _list_devices)
-    monkeypatch.setattr(sys, "argv", ["keymasq", "devices", "--verbose"])
-
-    cli_main.main()
-    assert called == [True]


### PR DESCRIPTION
## Summary
- remove early diagnostic CLI commands for raw device listing, hardware placeholders, and evdev event testing
- keep the CLI focused on session-backed macros, diagnostics, and profile management
- update entrypoint CLI tests for the reduced command surface

## Tests
- nix develop -c ./scripts/check.sh full