### PR TITLE
Add `keymasq status` and JSON CLI output

### DIFF
--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -12,6 +12,13 @@ systemctl status keymasqd
 systemctl --user status keymasq-session
 ```
 
+Check the Keymasq runtime state from the user session:
+
+```bash
+keymasq status
+keymasq --json status
+```
+
 Follow live logs:
 
 ```bash

--- a/keymasq/cli/__main__.py
+++ b/keymasq/cli/__main__.py
@@ -1,4 +1,5 @@
 import argparse
+import sys
 
 from keymasq import __version__
 from keymasq.cli.commands import (
@@ -8,16 +9,25 @@ from keymasq.cli.commands import (
     play_macro_cli,
     set_diagnostics_cli,
     set_profile_state_cli,
+    status_cli,
 )
 from keymasq.common.asyncio_runtime import ensure_uvloop
 
 
 def main() -> None:
     ensure_uvloop()
+    argv = sys.argv[1:]
+    json_output = "--json" in argv
+    argv = [arg for arg in argv if arg != "--json"]
 
     parser = argparse.ArgumentParser(
         prog="keymasq",
         description="Keymasq CLI - Key remapping tool",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Print raw session response as JSON",
     )
     parser.add_argument(
         "--version",
@@ -26,6 +36,8 @@ def main() -> None:
     )
 
     subparsers = parser.add_subparsers(dest="command", help="Available commands")
+
+    subparsers.add_parser("status", help="Show Keymasq runtime status")
 
     macros_parser = subparsers.add_parser("macros", help="Macro commands")
     macros_sub = macros_parser.add_subparsers(dest="macros_command", required=True)
@@ -61,26 +73,29 @@ def main() -> None:
     toggle_parser = profiles_sub.add_parser("toggle", help="Toggle profile enabled state")
     toggle_parser.add_argument("profile_name", help="Profile name")
 
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
+    json_output = json_output or bool(args.json)
 
-    if args.command == "macros":
+    if args.command == "status":
+        status_cli(json_output=json_output)
+    elif args.command == "macros":
         if args.macros_command == "list":
-            list_macros_cli()
+            list_macros_cli(json_output=json_output)
         elif args.macros_command == "play":
-            play_macro_cli(args.name, args.speed)
+            play_macro_cli(args.name, args.speed, json_output=json_output)
         elif args.macros_command == "cancel":
-            cancel_macro_cli()
+            cancel_macro_cli(json_output=json_output)
     elif args.command == "diagnostics":
-        set_diagnostics_cli(args.state == "on", args.interval)
+        set_diagnostics_cli(args.state == "on", args.interval, json_output=json_output)
     elif args.command == "profiles":
         if args.profiles_command == "list":
-            list_profiles_cli()
+            list_profiles_cli(json_output=json_output)
         elif args.profiles_command == "enable":
-            set_profile_state_cli("enable_profile", args.profile_name)
+            set_profile_state_cli("enable_profile", args.profile_name, json_output=json_output)
         elif args.profiles_command == "disable":
-            set_profile_state_cli("disable_profile", args.profile_name)
+            set_profile_state_cli("disable_profile", args.profile_name, json_output=json_output)
         elif args.profiles_command == "toggle":
-            set_profile_state_cli("toggle_profile", args.profile_name)
+            set_profile_state_cli("toggle_profile", args.profile_name, json_output=json_output)
     else:
         parser.print_help()
 

--- a/keymasq/cli/commands.py
+++ b/keymasq/cli/commands.py
@@ -8,6 +8,10 @@ from keymasq.common.paths import SESSION_SOCKET_PATH
 JsonObject = dict[str, Any]
 
 
+def _session_unavailable() -> JsonObject:
+    return {"status": "error", "message": "Session unavailable"}
+
+
 def _session_request(payload: JsonObject, timeout: float = 5.0) -> JsonObject | None:
     if not SESSION_SOCKET_PATH.exists():
         return None
@@ -39,11 +43,115 @@ def _session_request(payload: JsonObject, timeout: float = 5.0) -> JsonObject | 
         return None
 
 
-def list_macros_cli() -> None:
-    result = _session_request({"command": "list_macros"}) or {}
+def _request_or_error(payload: JsonObject) -> JsonObject:
+    return _session_request(payload) or _session_unavailable()
+
+
+def _message(result: JsonObject, default: str) -> str:
+    return str(result.get("message") or result.get("error") or default)
+
+
+def _print_json(result: JsonObject) -> None:
+    print(json.dumps(result, indent=2, sort_keys=True))
+
+
+def _handled_json_or_error(result: JsonObject, json_output: bool) -> bool:
+    if json_output:
+        _print_json(result)
+        if result.get("status") != "ok":
+            sys.exit(1)
+        return True
+
     if result.get("status") != "ok":
-        print(f"Error: {result.get('message', 'Session unavailable')}")
+        print(f"Error: {_message(result, 'Session unavailable')}")
         sys.exit(1)
+    return False
+
+
+def _bool_status(value: object, true_text: str, false_text: str) -> str:
+    return true_text if bool(value) else false_text
+
+
+def _names(value: object) -> str:
+    if not isinstance(value, list):
+        return "passthrough"
+    names = [str(name) for name in value if str(name)]
+    return ", ".join(names) if names else "passthrough"
+
+
+def _device_label(hardware_id: str, device: JsonObject) -> str:
+    device_name = str(device.get("device_name") or "").strip()
+    if not device_name or device_name == hardware_id:
+        return hardware_id
+    return f"{device_name} ({hardware_id})"
+
+
+def status_cli(*, json_output: bool = False) -> None:
+    result = _request_or_error({"command": "get_status"})
+    if _handled_json_or_error(result, json_output):
+        return
+
+    keymasqd_state = _bool_status(
+        result.get("keymasqd_connected"), "connected", "disconnected"
+    )
+    print(f"keymasqd: {keymasqd_state}")
+
+    compositor_name = str(result.get("compositor_name") or result.get("compositor_id") or "unknown")
+    compositor_id = str(result.get("compositor_id") or "")
+    compositor = (
+        f"{compositor_name} ({compositor_id})"
+        if compositor_id and compositor_id != compositor_name
+        else compositor_name
+    )
+    if not bool(result.get("compositor_supported", False)):
+        compositor = f"{compositor} [unsupported]"
+    print(f"compositor: {compositor}")
+
+    listener_name = str(result.get("listener_name") or "none")
+    listener_state = _bool_status(result.get("listener_active"), "active", "inactive")
+    print(f"listener: {listener_state} ({listener_name})")
+
+    recording_state = _bool_status(result.get("recording_active"), "active", "idle")
+    print(f"recording: {recording_state}")
+
+    unlock_required = bool(result.get("recording_unlock_required", True))
+    raw_unlocked = bool(result.get("recording_unlocked", False))
+    unlocked = raw_unlocked or not unlock_required
+    if not unlock_required:
+        unlock_state = "not required"
+    elif unlocked:
+        source = str(result.get("recording_unlock_source") or "unknown")
+        unlock_state = f"unlocked ({source})"
+    else:
+        unlock_state = "locked"
+    print(f"recording unlock: {unlock_state}")
+
+    if "active_profiles" in result:
+        print(f"active profiles: {_names(result.get('active_profiles'))}")
+
+    raw_devices = result.get("devices")
+    if isinstance(raw_devices, dict) and raw_devices:
+        print("devices:")
+        for hardware_id in sorted(str(key) for key in raw_devices):
+            raw_device = raw_devices.get(hardware_id)
+            device = cast(JsonObject, raw_device) if isinstance(raw_device, dict) else {}
+            print(f"  {_device_label(hardware_id, device)}")
+            print(f"    active: {_names(device.get('profiles'))}")
+            print(f"    mappings: {int(device.get('mapping_count', 0) or 0)}")
+
+    raw_window = result.get("window")
+    window = cast(JsonObject, raw_window) if isinstance(raw_window, dict) else {}
+    title = str(window.get("title") or "")
+    app_id = str(window.get("app_id") or window.get("class") or "")
+    if title or app_id:
+        label = f"{app_id} - {title}" if app_id and title else app_id or title
+        print(f"window: {label}")
+
+
+def list_macros_cli(*, json_output: bool = False) -> None:
+    result = _request_or_error({"command": "list_macros"})
+    if _handled_json_or_error(result, json_output):
+        return
 
     macros = result.get("macros", [])
     if not macros:
@@ -57,19 +165,17 @@ def list_macros_cli() -> None:
         print(f"{name}\t{duration_ms}ms\t{event_count} events")
 
 
-def play_macro_cli(name: str, speed: float = 1.0) -> None:
-    result = _session_request({"command": "play_macro", "name": name, "speed": float(speed)}) or {}
-    if result.get("status") != "ok":
-        print(f"Error: {result.get('message', 'Session unavailable')}")
-        sys.exit(1)
+def play_macro_cli(name: str, speed: float = 1.0, *, json_output: bool = False) -> None:
+    result = _request_or_error({"command": "play_macro", "name": name, "speed": float(speed)})
+    if _handled_json_or_error(result, json_output):
+        return
     print(f"Played macro: {name}")
 
 
-def cancel_macro_cli() -> None:
-    result = _session_request({"command": "cancel_macro_playback"}) or {}
-    if result.get("status") != "ok":
-        print(f"Error: {result.get('message', 'Session unavailable')}")
-        sys.exit(1)
+def cancel_macro_cli(*, json_output: bool = False) -> None:
+    result = _request_or_error({"command": "cancel_macro_playback"})
+    if _handled_json_or_error(result, json_output):
+        return
     cancelled = bool(result.get("cancelled", True))
     if cancelled:
         print("Cancelled running macro playback")
@@ -77,16 +183,14 @@ def cancel_macro_cli() -> None:
         print("No macro playback was running")
 
 
-def set_diagnostics_cli(enabled: bool, interval: float = 5.0) -> None:
-    result = (
-        _session_request(
-            {"command": "set_diagnostics", "enabled": bool(enabled), "interval": float(interval)}
-        )
-        or {}
+def set_diagnostics_cli(
+    enabled: bool, interval: float = 5.0, *, json_output: bool = False
+) -> None:
+    result = _request_or_error(
+        {"command": "set_diagnostics", "enabled": bool(enabled), "interval": float(interval)}
     )
-    if result.get("status") != "ok":
-        print(f"Error: {result.get('message', 'Session unavailable')}")
-        sys.exit(1)
+    if _handled_json_or_error(result, json_output):
+        return
 
     raw_data = result.get("data")
     data = cast(JsonObject, raw_data) if isinstance(raw_data, dict) else {}
@@ -102,11 +206,10 @@ def _profile_kind(profile: JsonObject) -> str:
     return "standard"
 
 
-def list_profiles_cli() -> None:
-    result = _session_request({"command": "list_profiles"}) or {}
-    if result.get("status") != "ok":
-        print(f"Error: {result.get('message', 'Session unavailable')}")
-        sys.exit(1)
+def list_profiles_cli(*, json_output: bool = False) -> None:
+    result = _request_or_error({"command": "list_profiles"})
+    if _handled_json_or_error(result, json_output):
+        return
 
     profiles = result.get("profiles", [])
     devices = result.get("devices", [])
@@ -145,20 +248,17 @@ def list_profiles_cli() -> None:
             print(f"    mappings: {mapping_count}")
 
 
-def set_profile_state_cli(command: str, profile_name: str) -> None:
-    result = (
-        _session_request(
-            {
-                "command": command,
-                "profile_name": profile_name,
-            }
-        )
-        or {}
+def set_profile_state_cli(
+    command: str, profile_name: str, *, json_output: bool = False
+) -> None:
+    result = _request_or_error(
+        {
+            "command": command,
+            "profile_name": profile_name,
+        }
     )
-
-    if result.get("status") != "ok":
-        print(f"Error: {result.get('message', 'Session unavailable')}")
-        sys.exit(1)
+    if _handled_json_or_error(result, json_output):
+        return
 
     enabled = bool(result.get("enabled", False))
     active_profiles = ", ".join(str(name) for name in result.get("active_profiles", []))

--- a/keymasq/session/manager/profiles.py
+++ b/keymasq/session/manager/profiles.py
@@ -57,17 +57,20 @@ async def set_profile_enabled(
 
 
 def build_active_profiles_payload(manager: "SessionManager") -> JsonObject:
+    devices: dict[str, JsonObject] = {}
+    for hardware_id, resolved in sorted(manager.profile_state.resolved_devices.items()):
+        hardware = manager.hardware.get_hardware(hardware_id)
+        devices[hardware_id] = {
+            "device_name": hardware.name if hardware else hardware_id,
+            "profiles": list(resolved.active_profile_names),
+            "mapping_count": resolved.mapping_count,
+            "always_grab_all": resolved.always_grab_all,
+        }
+
     return {
         "status": "ok",
         "active_profiles": list(manager.profile_state.active_profile_names),
-        "devices": {
-            hardware_id: {
-                "profiles": list(resolved.active_profile_names),
-                "mapping_count": resolved.mapping_count,
-                "always_grab_all": resolved.always_grab_all,
-            }
-            for hardware_id, resolved in sorted(manager.profile_state.resolved_devices.items())
-        },
+        "devices": devices,
     }
 
 

--- a/scripts/dev-cli.sh
+++ b/scripts/dev-cli.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/$(basename "${BASH_SOURCE[0]}")"
+REPO_ROOT="${REPO_ROOT:-$(cd "$(dirname "${SCRIPT_PATH}")/.." && pwd)}"
+
+if [[ ! -f "${REPO_ROOT}/flake.nix" ]]; then
+  echo "flake.nix not found under: ${REPO_ROOT}" >&2
+  exit 1
+fi
+
+if [[ -z "${IN_NIX_SHELL:-}" ]]; then
+  exec nix develop "${REPO_ROOT}" -c "${SCRIPT_PATH}" "$@"
+fi
+
+export PYTHONPATH="${REPO_ROOT}${PYTHONPATH:+:${PYTHONPATH}}"
+
+exec python -m keymasq.cli "$@"

--- a/tests/session/test_session_manager_command_runtime.py
+++ b/tests/session/test_session_manager_command_runtime.py
@@ -76,6 +76,9 @@ async def test_get_active_profiles_does_not_include_window_state() -> None:
             always_grab_all=False,
         )
     }
+    manager.hardware.get_hardware = lambda _hardware_id: SimpleNamespace(  # type: ignore[assignment]
+        name="Gaming Keyboard"
+    )
     manager.compositor_state.current_window = {
         "class": "steam",
         "title": "Counter-Strike 2",
@@ -93,6 +96,8 @@ async def test_get_active_profiles_does_not_include_window_state() -> None:
     assert result["status"] == "ok"
     assert result["active_profiles"] == ["Gaming"]
     assert "devices" in result
+    devices = cast(dict[str, dict[str, object]], result["devices"])
+    assert devices["1234:5678"]["device_name"] == "Gaming Keyboard"
     assert "window" not in result
 
 

--- a/tests/test_cli_commands_helpers.py
+++ b/tests/test_cli_commands_helpers.py
@@ -1,3 +1,5 @@
+import json
+
 import pytest
 
 from keymasq.cli import commands
@@ -27,6 +29,77 @@ def test_list_macros_cli_prints_macros(
     assert "combo" in out
     assert "150ms" in out
     assert "4 events" in out
+
+
+def test_list_macros_cli_json_prints_response(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(
+        commands,
+        "_session_request",
+        lambda payload: {"status": "ok", "macros": [{"name": "combo"}]},
+    )
+
+    commands.list_macros_cli(json_output=True)
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload == {"status": "ok", "macros": [{"name": "combo"}]}
+
+
+def test_status_cli_prints_runtime_summary(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(
+        commands,
+        "_session_request",
+        lambda payload: {
+            "status": "ok",
+            "keymasqd_connected": True,
+            "compositor_id": "gnome",
+            "compositor_name": "GNOME Shell",
+            "compositor_supported": True,
+            "listener_active": True,
+            "listener_name": "gnome",
+            "recording_active": False,
+            "recording_unlock_required": True,
+            "recording_unlocked": False,
+            "active_profiles": ["Base"],
+            "devices": {
+                "1234:5678": {
+                    "device_name": "Example Keyboard",
+                    "profiles": ["Base"],
+                    "mapping_count": 2,
+                }
+            },
+            "window": {"app_id": "firefox", "title": "Example"},
+        },
+    )
+
+    commands.status_cli()
+
+    out = capsys.readouterr().out
+    assert "keymasqd: connected" in out
+    assert "compositor: GNOME Shell (gnome)" in out
+    assert "listener: active (gnome)" in out
+    assert "recording unlock: locked" in out
+    assert "active profiles: Base" in out
+    assert "Example Keyboard (1234:5678)" in out
+    assert "window: firefox - Example" in out
+
+
+def test_status_cli_json_prints_response(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(
+        commands,
+        "_session_request",
+        lambda payload: {"status": "ok", "keymasqd_connected": False},
+    )
+
+    commands.status_cli(json_output=True)
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload == {"status": "ok", "keymasqd_connected": False}
 
 
 def test_set_diagnostics_cli_exits_on_error(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_entrypoints_and_cli.py
+++ b/tests/test_entrypoints_and_cli.py
@@ -119,13 +119,28 @@ def test_session_script_entrypoint_calls_manager_main(monkeypatch: pytest.Monkey
 def test_cli_main_profiles_toggle_routes_to_helper(monkeypatch: pytest.MonkeyPatch) -> None:
     from keymasq.cli import __main__ as cli_main
 
-    calls: list[tuple[str, str]] = []
+    calls: list[tuple[str, str, bool]] = []
 
-    def _set_profile_state(command: str, profile_name: str) -> None:
-        calls.append((command, profile_name))
+    def _set_profile_state(command: str, profile_name: str, *, json_output: bool) -> None:
+        calls.append((command, profile_name, json_output))
 
     monkeypatch.setattr(cli_main, "set_profile_state_cli", _set_profile_state)
     monkeypatch.setattr(sys, "argv", ["keymasq", "profiles", "toggle", "gaming"])
 
     cli_main.main()
-    assert calls == [("toggle_profile", "gaming")]
+    assert calls == [("toggle_profile", "gaming", False)]
+
+
+def test_cli_main_status_routes_json_flag(monkeypatch: pytest.MonkeyPatch) -> None:
+    from keymasq.cli import __main__ as cli_main
+
+    calls: list[bool] = []
+
+    def _status_cli(*, json_output: bool) -> None:
+        calls.append(json_output)
+
+    monkeypatch.setattr(cli_main, "status_cli", _status_cli)
+    monkeypatch.setattr(sys, "argv", ["keymasq", "status", "--json"])
+
+    cli_main.main()
+    assert calls == [True]


### PR DESCRIPTION
## Summary
- Added a new `keymasq status` command to inspect runtime state from the user session.
- Added a global `--json` flag that prints raw session responses for `status` and existing CLI subcommands.
- Extended status payloads to include device names so CLI output can show friendlier device labels.
- Added a dev helper script for launching the CLI through `nix develop`.
- Updated troubleshooting docs and added coverage for the new CLI routing and output formats.

## Testing
- `pytest tests/test_cli_commands_helpers.py`
- `pytest tests/test_entrypoints_and_cli.py`
- `pytest tests/session/test_session_manager_command_runtime.py`
- Not run: `./scripts/check.sh full`