### PR TITLE
Refactors in keymasqd

### DIFF
--- a/keymasq/keymasqd/device_manager.py
+++ b/keymasq/keymasqd/device_manager.py
@@ -135,60 +135,34 @@ def _fire_and_observe(coro: Awaitable[object], label: str) -> asyncio.Task[objec
     return task
 
 
-def _topology_manager(
-    manager: "DeviceManager",
-) -> runtime_topology._TopologyManager:  # pyright: ignore[reportPrivateUsage]
-    return cast(runtime_topology._TopologyManager, manager)  # pyright: ignore[reportPrivateUsage]
-
-
-def _topology_asyncio_runtime(
-) -> runtime_topology._AsyncioModule:  # pyright: ignore[reportPrivateUsage]
-    return cast(runtime_topology._AsyncioModule, ASYNCIO_RUNTIME)  # pyright: ignore[reportPrivateUsage]
-
-
-def _topology_live_interface_info_factory(
-) -> runtime_topology._LiveInterfaceInfoFactory:  # pyright: ignore[reportPrivateUsage]
-    return cast(  # pyright: ignore[reportPrivateUsage]
-        runtime_topology._LiveInterfaceInfoFactory,  # pyright: ignore[reportPrivateUsage]
-        LiveInterfaceInfo,
+def _topology_runtime_deps() -> runtime_topology.TopologyRuntimeDeps:
+    return runtime_topology.TopologyRuntimeDeps(
+        asyncio_mod=ASYNCIO_RUNTIME,
+        cancelled_error=asyncio.CancelledError,
+        contextlib_mod=contextlib,
+        live_interface_info_cls=LiveInterfaceInfo,
+        clear_device_path_cache_fn=clear_device_path_cache,
+        device_paths_fn=_device_paths,
+        device_input_fn=_device_input,
+        resolve_stable_path_fn=resolve_stable_path,
+        get_interface_id_fn=get_interface_id,
+        release_interface_fn=runtime_grab_lifecycle.release_interface_unlocked,
     )
 
 
-def _topology_device_input_fn() -> runtime_topology.DeviceInputFn:
-    return _device_input
-
-
-def _macro_manager(
-    manager: "DeviceManager",
-) -> runtime_macros._MacroManager:  # pyright: ignore[reportPrivateUsage]
-    return cast(runtime_macros._MacroManager, manager)  # pyright: ignore[reportPrivateUsage]
-
-
-def _macro_asyncio_runtime() -> runtime_macros._AsyncioModule:  # pyright: ignore[reportPrivateUsage]
-    return cast(runtime_macros._AsyncioModule, ASYNCIO_RUNTIME)  # pyright: ignore[reportPrivateUsage]
-
-
-def _macro_uinput_writer_impl(
-    device: object | None,
-) -> runtime_macros._WritableUInput | None:  # pyright: ignore[reportPrivateUsage]
-    return cast(  # pyright: ignore[reportPrivateUsage]
-        runtime_macros._WritableUInput | None,  # pyright: ignore[reportPrivateUsage]
-        runtime_adapters.identity_uinput_writer(device),
+def _macro_runtime_deps() -> runtime_macros.MacroRuntimeDeps:
+    return runtime_macros.MacroRuntimeDeps(
+        asyncio_mod=ASYNCIO_RUNTIME,
+        contextlib_mod=contextlib,
+        evdev_mod=evdev,
+        uinput_writer=runtime_adapters.identity_uinput_writer,
+        random_mod=random,
+        uuid_mod=uuid,
+        command_type=CommandType,
+        log=log,
+        int_value_fn=_int_value,
+        str_value_fn=_str_value,
     )
-
-
-def _macro_uinput_writer() -> runtime_macros.UInputWriter:
-    return _macro_uinput_writer_impl
-
-
-def _macro_command_type() -> runtime_macros._CommandTypeEnum:  # pyright: ignore[reportPrivateUsage]
-    return cast(runtime_macros._CommandTypeEnum, CommandType)  # pyright: ignore[reportPrivateUsage]
-
-
-def _combo_manager(
-    manager: "DeviceManager",
-) -> runtime_combos._ComboManager:  # pyright: ignore[reportPrivateUsage]
-    return cast(runtime_combos._ComboManager, manager)  # pyright: ignore[reportPrivateUsage]
 
 
 def _combo_runtime_deps(
@@ -338,24 +312,15 @@ class DeviceManager:
 
     async def start_topology_watcher(self) -> None:
         await runtime_topology.start_topology_watcher(
-            _topology_manager(self),
-            asyncio_mod=_topology_asyncio_runtime(),
-            cancelled_error=asyncio.CancelledError,
+            self,
             log=log,
-            live_interface_info_cls=_topology_live_interface_info_factory(),
-            clear_device_path_cache_fn=clear_device_path_cache,
-            device_paths_fn=_device_paths,
-            device_input_fn=_topology_device_input_fn(),
-            resolve_stable_path_fn=resolve_stable_path,
-            get_interface_id_fn=get_interface_id,
+            deps=_topology_runtime_deps(),
         )
 
     async def stop_topology_watcher(self) -> None:
         await runtime_topology.stop_topology_watcher(
-            _topology_manager(self),
-            asyncio_mod=_topology_asyncio_runtime(),
-            cancelled_error=asyncio.CancelledError,
-            contextlib_mod=contextlib,
+            self,
+            deps=_topology_runtime_deps(),
         )
 
     async def grab_device(
@@ -519,16 +484,16 @@ class DeviceManager:
 
             self.active_combos = parsed
             await runtime_combos.clear_combo_runtime(
-                _combo_manager(self),
+                self,
                 deps=_combo_runtime_deps(),
             )
             self.combo_state.engine.set_combos(parsed)
             runtime_combos.prime_combo_engine_with_held_bindings(
-                _combo_manager(self),
+                self,
                 combo_binding_cls=RuntimeComboBinding,
             )
             runtime_combos.refresh_combo_timeout_watchdog(
-                _combo_manager(self),
+                self,
                 deps=_combo_runtime_deps(),
             )
             log.info("Updated combos (%d active)", len(parsed))
@@ -668,7 +633,7 @@ class DeviceManager:
         trigger_value: int = 1,
     ) -> JsonObject:
         return await runtime_macros.play_macro(
-            _macro_manager(self),
+            self,
             macro_events,
             macro_name,
             replay_mouse_movement,
@@ -683,16 +648,7 @@ class DeviceManager:
             source_device,
             source_button,
             trigger_value,
-            asyncio_mod=_macro_asyncio_runtime(),
-            contextlib_mod=contextlib,
-            evdev_mod=evdev,
-            log=log,
-            int_value_fn=_int_value,
-            str_value_fn=_str_value,
-            uinput_writer=_macro_uinput_writer(),
-            random_mod=random,
-            uuid_mod=uuid,
-            command_type=_macro_command_type(),
+            deps=_macro_runtime_deps(),
         )
 
     def set_cursor_position_backend(self, enabled: bool) -> JsonObject:
@@ -785,11 +741,8 @@ class DeviceManager:
 
     async def cancel_macro_playback(self) -> JsonObject:
         return await runtime_macros.cancel_macro_playback(
-            _macro_manager(self),
-            asyncio_mod=_macro_asyncio_runtime(),
-            evdev_mod=evdev,
-            contextlib_mod=contextlib,
-            uinput_writer=_macro_uinput_writer(),
+            self,
+            deps=_macro_runtime_deps(),
         )
 
     def complete_macro_exec_wait(self, wait_id: str, returncode: int) -> JsonObject:
@@ -802,17 +755,17 @@ class DeviceManager:
         notify_event: asyncio.Event | None = None,
     ) -> JsonObject:
         return runtime_combos.begin_combo_capture(
-            _combo_manager(self),
+            self,
             token,
             hardware_ids,
             notify_event,
         )
 
     def read_combo_capture(self, token: str) -> JsonObject:
-        return runtime_combos.read_combo_capture(_combo_manager(self), token)
+        return runtime_combos.read_combo_capture(self, token)
 
     def end_combo_capture(self, token: str) -> JsonObject:
-        return runtime_combos.end_combo_capture(_combo_manager(self), token)
+        return runtime_combos.end_combo_capture(self, token)
 
 
 GrabbedDevice = runtime_grabbed_device.GrabbedDevice

--- a/keymasq/keymasqd/device_manager.py
+++ b/keymasq/keymasqd/device_manager.py
@@ -2,9 +2,6 @@ import asyncio
 import contextlib
 import errno
 import logging
-import random
-import time
-import uuid
 from collections import deque
 from collections.abc import AsyncIterator, Awaitable, Callable, Sequence
 from dataclasses import dataclass, field
@@ -138,9 +135,6 @@ def _fire_and_observe(coro: Awaitable[object], label: str) -> asyncio.Task[objec
 def _topology_runtime_deps() -> runtime_topology.TopologyRuntimeDeps:
     return runtime_topology.TopologyRuntimeDeps(
         asyncio_mod=ASYNCIO_RUNTIME,
-        cancelled_error=asyncio.CancelledError,
-        contextlib_mod=contextlib,
-        live_interface_info_cls=LiveInterfaceInfo,
         clear_device_path_cache_fn=clear_device_path_cache,
         device_paths_fn=_device_paths,
         device_input_fn=_device_input,
@@ -153,12 +147,8 @@ def _topology_runtime_deps() -> runtime_topology.TopologyRuntimeDeps:
 def _macro_runtime_deps() -> runtime_macros.MacroRuntimeDeps:
     return runtime_macros.MacroRuntimeDeps(
         asyncio_mod=ASYNCIO_RUNTIME,
-        contextlib_mod=contextlib,
         evdev_mod=evdev,
         uinput_writer=runtime_adapters.identity_uinput_writer,
-        random_mod=random,
-        uuid_mod=uuid,
-        command_type=CommandType,
         log=log,
         int_value_fn=_int_value,
         str_value_fn=_str_value,
@@ -172,8 +162,6 @@ def _combo_runtime_deps(
 ) -> runtime_combos.ComboRuntimeDeps:
     return runtime_combos.ComboRuntimeDeps(
         asyncio_mod=ASYNCIO_RUNTIME,
-        contextlib_mod=contextlib,
-        time_mod=time,
         evdev_mod=runtime_adapters.COMBO_EVDEV_RUNTIME,
         uinput_writer=runtime_adapters.identity_uinput_writer,
         emit_mouse_move_fn=runtime_adapters.combo_emit_mouse_move,
@@ -189,14 +177,7 @@ def _capability_device(
     return cast(common_devices._CapabilityDevice, device)  # pyright: ignore[reportPrivateUsage]
 
 
-@dataclass(frozen=True)
-class LiveInterfaceInfo:
-    hardware_id: str
-    vendor_id: str
-    product_id: str
-    stable_path: str
-    path: str
-    interface_id: str
+LiveInterfaceInfo = runtime_topology.LiveInterfaceInfo
 
 
 @dataclass
@@ -490,7 +471,6 @@ class DeviceManager:
             self.combo_state.engine.set_combos(parsed)
             runtime_combos.prime_combo_engine_with_held_bindings(
                 self,
-                combo_binding_cls=RuntimeComboBinding,
             )
             runtime_combos.refresh_combo_timeout_watchdog(
                 self,

--- a/keymasq/keymasqd/device_manager.py
+++ b/keymasq/keymasqd/device_manager.py
@@ -2,7 +2,6 @@ import asyncio
 import contextlib
 import errno
 import logging
-import queue
 import random
 import time
 import uuid
@@ -198,57 +197,22 @@ def _combo_manager(
     return cast(runtime_combos._ComboManager, manager)  # pyright: ignore[reportPrivateUsage]
 
 
-def _combo_asyncio_runtime() -> runtime_combos._AsyncioModule:  # pyright: ignore[reportPrivateUsage]
-    return cast(runtime_combos._AsyncioModule, ASYNCIO_RUNTIME)  # pyright: ignore[reportPrivateUsage]
-
-
-def _combo_evdev_runtime() -> runtime_combos._EvdevModule:  # pyright: ignore[reportPrivateUsage]
-    return cast(  # pyright: ignore[reportPrivateUsage]
-        runtime_combos._EvdevModule,  # pyright: ignore[reportPrivateUsage]
-        runtime_adapters.COMBO_EVDEV_RUNTIME,
-    )
-
-
-def _combo_emit_mouse_move_fn() -> runtime_combos._EmitMouseMoveFn:  # pyright: ignore[reportPrivateUsage]
-    return cast(  # pyright: ignore[reportPrivateUsage]
-        runtime_combos._EmitMouseMoveFn,  # pyright: ignore[reportPrivateUsage]
-        runtime_adapters.combo_emit_mouse_move,
-    )
-
-
-def _combo_uinput_writer_impl(
-    device: object | None,
-) -> runtime_combos._WritableUInput | None:  # pyright: ignore[reportPrivateUsage]
-    return cast(  # pyright: ignore[reportPrivateUsage]
-        runtime_combos._WritableUInput | None,  # pyright: ignore[reportPrivateUsage]
-        runtime_adapters.identity_uinput_writer(device),
-    )
-
-
-def _combo_uinput_writer() -> runtime_combos.UInputWriter:
-    return _combo_uinput_writer_impl
-
-
 def _combo_runtime_deps(
     *,
     resolve_code_fn: runtime_combos.ResolveCodeFn = resolve_output_code,
     fire_and_observe_fn: runtime_combos.FireAndObserve = _fire_and_observe,
 ) -> runtime_combos.ComboRuntimeDeps:
     return runtime_combos.ComboRuntimeDeps(
-        asyncio_mod=_combo_asyncio_runtime(),
+        asyncio_mod=cast(runtime_combos._AsyncioModule, ASYNCIO_RUNTIME),  # pyright: ignore[reportPrivateUsage]
         contextlib_mod=contextlib,
         time_mod=time,
-        evdev_mod=_combo_evdev_runtime(),
-        uinput_writer=_combo_uinput_writer(),
-        emit_mouse_move_fn=_combo_emit_mouse_move_fn(),
+        evdev_mod=cast(runtime_combos._EvdevModule, runtime_adapters.COMBO_EVDEV_RUNTIME),  # pyright: ignore[reportPrivateUsage]
+        uinput_writer=runtime_adapters.identity_uinput_writer,
+        emit_mouse_move_fn=runtime_adapters.combo_emit_mouse_move,
         get_trigger_axis_fn=get_trigger_axis,
         resolve_code_fn=resolve_code_fn,
         fire_and_observe_fn=fire_and_observe_fn,
     )
-
-
-def _combo_queue_module() -> runtime_combos._QueueModule:  # pyright: ignore[reportPrivateUsage]
-    return cast(runtime_combos._QueueModule, queue)  # pyright: ignore[reportPrivateUsage]
 
 
 def _capability_device(
@@ -848,13 +812,10 @@ class DeviceManager:
             token,
             hardware_ids,
             notify_event,
-            queue_mod=_combo_queue_module(),
         )
 
     def read_combo_capture(self, token: str) -> JsonObject:
-        return runtime_combos.read_combo_capture(
-            _combo_manager(self), token, queue_mod=_combo_queue_module()
-        )
+        return runtime_combos.read_combo_capture(_combo_manager(self), token)
 
     def end_combo_capture(self, token: str) -> JsonObject:
         return runtime_combos.end_combo_capture(_combo_manager(self), token)

--- a/keymasq/keymasqd/device_manager.py
+++ b/keymasq/keymasqd/device_manager.py
@@ -24,7 +24,6 @@ from keymasq.common.devices import (
 )
 from keymasq.common.ipc import CommandType
 from keymasq.common.models import (
-    ActionType,
     DeviceType,
     MappingAction,
 )
@@ -228,6 +227,24 @@ def _combo_uinput_writer_impl(
 
 def _combo_uinput_writer() -> runtime_combos.UInputWriter:
     return _combo_uinput_writer_impl
+
+
+def _combo_runtime_deps(
+    *,
+    resolve_code_fn: runtime_combos.ResolveCodeFn = resolve_output_code,
+    fire_and_observe_fn: runtime_combos.FireAndObserve = _fire_and_observe,
+) -> runtime_combos.ComboRuntimeDeps:
+    return runtime_combos.ComboRuntimeDeps(
+        asyncio_mod=_combo_asyncio_runtime(),
+        contextlib_mod=contextlib,
+        time_mod=time,
+        evdev_mod=_combo_evdev_runtime(),
+        uinput_writer=_combo_uinput_writer(),
+        emit_mouse_move_fn=_combo_emit_mouse_move_fn(),
+        get_trigger_axis_fn=get_trigger_axis,
+        resolve_code_fn=resolve_code_fn,
+        fire_and_observe_fn=fire_and_observe_fn,
+    )
 
 
 def _combo_queue_module() -> runtime_combos._QueueModule:  # pyright: ignore[reportPrivateUsage]
@@ -545,18 +562,7 @@ class DeviceManager:
             self.active_combos = parsed
             await runtime_combos.clear_combo_runtime(
                 _combo_manager(self),
-                asyncio_mod=_combo_asyncio_runtime(),
-                contextlib_mod=contextlib,
-                mapping_action_cls=MappingAction,
-                evdev_mod=_combo_evdev_runtime(),
-                uinput_writer=_combo_uinput_writer(),
-                emit_mouse_move_fn=_combo_emit_mouse_move_fn(),
-                get_trigger_axis_fn=get_trigger_axis,
-                resolve_code_fn=resolve_output_code,
-                fire_and_observe_fn=_fire_and_observe,
-                command_type=CommandType,
-                action_type_enum=ActionType,
-                time_mod=time,
+                deps=_combo_runtime_deps(),
             )
             self.combo_state.engine.set_combos(parsed)
             runtime_combos.prime_combo_engine_with_held_bindings(
@@ -565,18 +571,7 @@ class DeviceManager:
             )
             runtime_combos.refresh_combo_timeout_watchdog(
                 _combo_manager(self),
-                asyncio_mod=_combo_asyncio_runtime(),
-                time_mod=time,
-                action_type_enum=ActionType,
-                mapping_action_cls=MappingAction,
-                emit_mouse_move_fn=_combo_emit_mouse_move_fn(),
-                get_trigger_axis_fn=get_trigger_axis,
-                resolve_code_fn=resolve_output_code,
-                fire_and_observe_fn=_fire_and_observe,
-                command_type=CommandType,
-                contextlib_mod=contextlib,
-                evdev_mod=_combo_evdev_runtime(),
-                uinput_writer=_combo_uinput_writer(),
+                deps=_combo_runtime_deps(),
             )
             log.info("Updated combos (%d active)", len(parsed))
             return {"updated": True, "combo_count": len(parsed)}

--- a/keymasq/keymasqd/device_manager.py
+++ b/keymasq/keymasqd/device_manager.py
@@ -158,12 +158,6 @@ def _topology_device_input_fn() -> runtime_topology.DeviceInputFn:
     return _device_input
 
 
-def _grab_lifecycle_manager(
-    manager: "DeviceManager",
-) -> runtime_grab_lifecycle._GrabManager:  # pyright: ignore[reportPrivateUsage]
-    return cast(runtime_grab_lifecycle._GrabManager, manager)  # pyright: ignore[reportPrivateUsage]
-
-
 def _macro_manager(
     manager: "DeviceManager",
 ) -> runtime_macros._MacroManager:  # pyright: ignore[reportPrivateUsage]
@@ -375,7 +369,7 @@ class DeviceManager:
     ) -> JsonObject:
         async with self._op_lock:
             return await runtime_grab_lifecycle.grab_device_unlocked(
-                _grab_lifecycle_manager(self),
+                self,
                 hardware_id,
                 evdev_paths,
                 button_map,
@@ -407,12 +401,12 @@ class DeviceManager:
         async with self._op_lock:
             if immediate:
                 return await runtime_grab_lifecycle.release_device_unlocked(
-                    _grab_lifecycle_manager(self),
+                    self,
                     hardware_id,
                     log=log,
                 )
             return runtime_grab_lifecycle.schedule_hardware_release_unlocked(
-                _grab_lifecycle_manager(self),
+                self,
                 hardware_id,
                 grace_s,
                 asyncio_mod=runtime_grab_lifecycle.ASYNCIO_RUNTIME,
@@ -421,7 +415,7 @@ class DeviceManager:
 
     async def release_all_devices(self) -> None:
         await runtime_grab_lifecycle.release_all_devices(
-            _grab_lifecycle_manager(self),
+            self,
             fire_and_observe_fn=_fire_and_observe,
         )
 
@@ -431,7 +425,7 @@ class DeviceManager:
         mapping: JsonObject,
     ) -> JsonObject:
         return await runtime_grab_lifecycle.set_mapping(
-            _grab_lifecycle_manager(self),
+            self,
             hardware_id,
             mapping,
             json_object_fn=_json_object,

--- a/keymasq/keymasqd/device_manager.py
+++ b/keymasq/keymasqd/device_manager.py
@@ -203,10 +203,10 @@ def _combo_runtime_deps(
     fire_and_observe_fn: runtime_combos.FireAndObserve = _fire_and_observe,
 ) -> runtime_combos.ComboRuntimeDeps:
     return runtime_combos.ComboRuntimeDeps(
-        asyncio_mod=cast(runtime_combos._AsyncioModule, ASYNCIO_RUNTIME),  # pyright: ignore[reportPrivateUsage]
+        asyncio_mod=ASYNCIO_RUNTIME,
         contextlib_mod=contextlib,
         time_mod=time,
-        evdev_mod=cast(runtime_combos._EvdevModule, runtime_adapters.COMBO_EVDEV_RUNTIME),  # pyright: ignore[reportPrivateUsage]
+        evdev_mod=runtime_adapters.COMBO_EVDEV_RUNTIME,
         uinput_writer=runtime_adapters.identity_uinput_writer,
         emit_mouse_move_fn=runtime_adapters.combo_emit_mouse_move,
         get_trigger_axis_fn=get_trigger_axis,

--- a/keymasq/keymasqd/runtime/action_runner.py
+++ b/keymasq/keymasqd/runtime/action_runner.py
@@ -117,13 +117,12 @@ def dispatch_action_trigger(
     data: JsonObject | None,
     *,
     fire_and_observe_fn: FireAndObserve,
-    command_type: type[CommandType],
     label: str,
 ) -> bool:
     if broadcast_callback is None or data is None:
         return False
     fire_and_observe_fn(
-        broadcast_callback(command_type.ACTION_TRIGGER, data),
+        broadcast_callback(CommandType.ACTION_TRIGGER, data),
         label,
     )
     return True

--- a/keymasq/keymasqd/runtime/combos.py
+++ b/keymasq/keymasqd/runtime/combos.py
@@ -1,5 +1,4 @@
 import asyncio
-import contextlib
 import logging
 import queue
 from collections.abc import Awaitable, Callable, Mapping, Sequence
@@ -227,6 +226,19 @@ class ComboRuntimeState:
     )
 
 
+@dataclass(frozen=True)
+class ComboRuntimeDeps:
+    asyncio_mod: _AsyncioModule
+    contextlib_mod: _ContextlibModule
+    time_mod: _TimeModule
+    evdev_mod: _EvdevModule
+    uinput_writer: UInputWriter
+    emit_mouse_move_fn: _EmitMouseMoveFn
+    get_trigger_axis_fn: TriggerAxisFn
+    resolve_code_fn: ResolveCodeFn
+    fire_and_observe_fn: FireAndObserve
+
+
 def _evdev_code_name(raw_name: object, fallback: int) -> str:
     if isinstance(raw_name, tuple):
         names = cast(tuple[object, ...], raw_name)
@@ -245,24 +257,13 @@ async def on_device_event(
     stable_path: str | None,
     source: str | None,
     *,
-    evdev_mod: _EvdevModule,
     resolve_stable_path_fn: ResolveStablePathFn,
     get_interface_id_fn: GetInterfaceIdFn,
     combo_binding_cls: type[RuntimeComboBinding],
     combo_input_event_cls: type[ComboInputEvent],
     int_value_fn: IntValueFn,
     str_value_fn: StrValueFn,
-    time_mod: _TimeModule,
-    action_type_enum: type[ActionType],
-    mapping_action_cls: type[MappingAction],
-    emit_mouse_move_fn: _EmitMouseMoveFn,
-    get_trigger_axis_fn: TriggerAxisFn,
-    resolve_code_fn: ResolveCodeFn,
-    fire_and_observe_fn: FireAndObserve,
-    command_type: type[CommandType],
-    asyncio_mod: _AsyncioModule,
-    contextlib_mod: _ContextlibModule,
-    uinput_writer: UInputWriter,
+    deps: ComboRuntimeDeps,
 ) -> ComboDecision | bool | None:
     combo_payload = build_combo_event_payload(
         hardware_id,
@@ -272,7 +273,7 @@ async def on_device_event(
         event_value,
         stable_path=stable_path,
         source=source,
-        evdev_mod=evdev_mod,
+        evdev_mod=deps.evdev_mod,
         resolve_stable_path_fn=resolve_stable_path_fn,
         get_interface_id_fn=get_interface_id_fn,
     )
@@ -286,18 +287,7 @@ async def on_device_event(
         combo_input_event_cls=combo_input_event_cls,
         int_value_fn=int_value_fn,
         str_value_fn=str_value_fn,
-        time_mod=time_mod,
-        action_type_enum=action_type_enum,
-        mapping_action_cls=mapping_action_cls,
-        emit_mouse_move_fn=emit_mouse_move_fn,
-        get_trigger_axis_fn=get_trigger_axis_fn,
-        resolve_code_fn=resolve_code_fn,
-        fire_and_observe_fn=fire_and_observe_fn,
-        command_type=command_type,
-        asyncio_mod=asyncio_mod,
-        contextlib_mod=contextlib_mod,
-        evdev_mod=evdev_mod,
-        uinput_writer=uinput_writer,
+        deps=deps,
     )
 
 
@@ -362,18 +352,7 @@ async def process_runtime_combo_event(
     combo_input_event_cls: type[ComboInputEvent],
     int_value_fn: IntValueFn,
     str_value_fn: StrValueFn,
-    time_mod: _TimeModule,
-    action_type_enum: type[ActionType],
-    mapping_action_cls: type[MappingAction],
-    emit_mouse_move_fn: _EmitMouseMoveFn,
-    get_trigger_axis_fn: TriggerAxisFn,
-    resolve_code_fn: ResolveCodeFn,
-    fire_and_observe_fn: FireAndObserve,
-    command_type: type[CommandType],
-    asyncio_mod: _AsyncioModule,
-    contextlib_mod: _ContextlibModule,
-    evdev_mod: _EvdevModule,
-    uinput_writer: UInputWriter,
+    deps: ComboRuntimeDeps,
 ) -> ComboDecision | None:
     if payload is None or not manager.combo_state.active_combos:
         return None
@@ -400,7 +379,7 @@ async def process_runtime_combo_event(
         manager.combo_state.engine.prime_held_bindings(held_modifiers)
     decision = manager.combo_state.engine.handle_event(
         combo_input_event_cls(binding=binding, value=value),
-        time_mod.monotonic(),
+        deps.time_mod.monotonic(),
     )
     if decision.recall_events:
         emit_combo_recalls(manager, decision.recall_events)
@@ -408,48 +387,17 @@ async def process_runtime_combo_event(
         await apply_combo_action_transition(
             manager,
             decision.action_transition,
-            action_type_enum=action_type_enum,
-            mapping_action_cls=mapping_action_cls,
-            emit_mouse_move_fn=emit_mouse_move_fn,
-            get_trigger_axis_fn=get_trigger_axis_fn,
-            resolve_code_fn=resolve_code_fn,
-            fire_and_observe_fn=fire_and_observe_fn,
-            command_type=command_type,
-            asyncio_mod=asyncio_mod,
-            contextlib_mod=contextlib_mod,
-            evdev_mod=evdev_mod,
-            uinput_writer=uinput_writer,
+            deps=deps,
         )
     for transition in decision.extra_action_transitions:
         await apply_combo_action_transition(
             manager,
             transition,
-            action_type_enum=action_type_enum,
-            mapping_action_cls=mapping_action_cls,
-            emit_mouse_move_fn=emit_mouse_move_fn,
-            get_trigger_axis_fn=get_trigger_axis_fn,
-            resolve_code_fn=resolve_code_fn,
-            fire_and_observe_fn=fire_and_observe_fn,
-            command_type=command_type,
-            asyncio_mod=asyncio_mod,
-            contextlib_mod=contextlib_mod,
-            evdev_mod=evdev_mod,
-            uinput_writer=uinput_writer,
+            deps=deps,
         )
     refresh_combo_timeout_watchdog(
         manager,
-        asyncio_mod=asyncio_mod,
-        time_mod=time_mod,
-        action_type_enum=action_type_enum,
-        mapping_action_cls=mapping_action_cls,
-        emit_mouse_move_fn=emit_mouse_move_fn,
-        get_trigger_axis_fn=get_trigger_axis_fn,
-        resolve_code_fn=resolve_code_fn,
-        fire_and_observe_fn=fire_and_observe_fn,
-        command_type=command_type,
-        contextlib_mod=contextlib_mod,
-        evdev_mod=evdev_mod,
-        uinput_writer=uinput_writer,
+        deps=deps,
     )
     if (
         decision.consume_current_event
@@ -554,17 +502,7 @@ async def apply_combo_action_transition(
     manager: _ComboManager,
     transition: ComboActionTransition,
     *,
-    action_type_enum: type[ActionType],
-    mapping_action_cls: type[MappingAction],
-    emit_mouse_move_fn: _EmitMouseMoveFn,
-    get_trigger_axis_fn: TriggerAxisFn,
-    resolve_code_fn: ResolveCodeFn,
-    fire_and_observe_fn: FireAndObserve,
-    command_type: type[CommandType],
-    asyncio_mod: _AsyncioModule,
-    contextlib_mod: _ContextlibModule,
-    evdev_mod: _EvdevModule,
-    uinput_writer: UInputWriter,
+    deps: ComboRuntimeDeps,
 ) -> None:
     if transition.kind == "press":
         await start_combo_action(
@@ -573,31 +511,13 @@ async def apply_combo_action_transition(
             transition.action,
             transition.trigger_binding,
             transition.trigger_bindings,
-            action_type_enum=action_type_enum,
-            asyncio_mod=asyncio_mod,
-            emit_mouse_move_fn=emit_mouse_move_fn,
-            get_trigger_axis_fn=get_trigger_axis_fn,
-            resolve_code_fn=resolve_code_fn,
-            fire_and_observe_fn=fire_and_observe_fn,
-            command_type=command_type,
-            evdev_mod=evdev_mod,
-            uinput_writer=uinput_writer,
+            deps=deps,
         )
     elif transition.kind == "release":
         await stop_combo_action(
             manager,
             transition.combo_id,
-            asyncio_mod=asyncio_mod,
-            contextlib_mod=contextlib_mod,
-            mapping_action_cls=mapping_action_cls,
-            evdev_mod=evdev_mod,
-            uinput_writer=uinput_writer,
-            emit_mouse_move_fn=emit_mouse_move_fn,
-            get_trigger_axis_fn=get_trigger_axis_fn,
-            resolve_code_fn=resolve_code_fn,
-            fire_and_observe_fn=fire_and_observe_fn,
-            command_type=command_type,
-            action_type_enum=action_type_enum,
+            deps=deps,
         )
 
 
@@ -605,14 +525,13 @@ async def broadcast_combo_action(
     manager: _ComboManager,
     data: dict[str, object],
     *,
-    fire_and_observe_fn: FireAndObserve,
-    command_type: type[CommandType],
+    deps: ComboRuntimeDeps,
 ) -> None:
     dispatch_action_trigger(
         manager.broadcast_callback,
         data,
-        fire_and_observe_fn=fire_and_observe_fn,
-        command_type=command_type,
+        fire_and_observe_fn=deps.fire_and_observe_fn,
+        command_type=CommandType,
         label="combo action broadcast",
     )
 
@@ -729,8 +648,7 @@ async def _combo_superkey_machine(
     action: MappingAction,
     trigger_binding: RuntimeComboBinding,
     *,
-    fire_and_observe_fn: FireAndObserve,
-    command_type: type[CommandType],
+    deps: ComboRuntimeDeps,
 ) -> SuperkeyMachine | None:
     config = _combo_superkey_config(manager, combo_id, action)
     if config is None:
@@ -751,8 +669,7 @@ async def _combo_superkey_machine(
         await broadcast_combo_action(
             manager,
             payload,
-            fire_and_observe_fn=fire_and_observe_fn,
-            command_type=command_type,
+            deps=deps,
         )
 
     def combo_superkey_output_tracker(action_type: str, code: int, value: int) -> bool:
@@ -922,15 +839,7 @@ async def start_combo_action(
     trigger_binding: RuntimeComboBinding,
     trigger_bindings: Sequence[RuntimeComboBinding],
     *,
-    action_type_enum: type[ActionType],
-    asyncio_mod: _AsyncioModule,
-    emit_mouse_move_fn: _EmitMouseMoveFn,
-    get_trigger_axis_fn: TriggerAxisFn,
-    resolve_code_fn: ResolveCodeFn,
-    fire_and_observe_fn: FireAndObserve,
-    command_type: type[CommandType],
-    evdev_mod: _EvdevModule,
-    uinput_writer: UInputWriter,
+    deps: ComboRuntimeDeps,
 ) -> None:
     if action is None:
         return
@@ -938,17 +847,7 @@ async def start_combo_action(
     await stop_combo_action(
         manager,
         combo_id,
-        asyncio_mod=asyncio_mod,
-        contextlib_mod=contextlib,
-        mapping_action_cls=action.__class__,
-        evdev_mod=evdev_mod,
-        uinput_writer=uinput_writer,
-        emit_mouse_move_fn=emit_mouse_move_fn,
-        get_trigger_axis_fn=get_trigger_axis_fn,
-        resolve_code_fn=resolve_code_fn,
-        fire_and_observe_fn=fire_and_observe_fn,
-        command_type=command_type,
-        action_type_enum=action_type_enum,
+        deps=deps,
     )
     trigger_name = f"combo:{combo_id}"
     recalled_bindings, restore_bindings = _combo_trigger_recall_state(
@@ -957,14 +856,14 @@ async def start_combo_action(
         trigger_bindings,
     )
 
-    if action.action_type == action_type_enum.SUPERKEY:
+    if action.action_type == ActionType.SUPERKEY:
         config = cast(RuntimeSuperkeyConfig | None, action.superkey_config)
         if config is None:
             return
         if config.mode == SuperkeyMode.OVERLOAD:
             child_combo_ids: list[str] = []
             for index, child_action in enumerate(config.overload_actions):
-                if child_action.action_type == action_type_enum.SUPERKEY:
+                if child_action.action_type == ActionType.SUPERKEY:
                     # Combo-triggered overloads intentionally stop at one superkey layer
                     # so a saved superkey cannot recursively expand into more superkeys.
                     log.warning(
@@ -981,15 +880,7 @@ async def start_combo_action(
                     child_action,
                     trigger_binding,
                     trigger_name=f"{trigger_name}#overload#{index}",
-                    action_type_enum=action_type_enum,
-                    asyncio_mod=asyncio_mod,
-                    emit_mouse_move_fn=emit_mouse_move_fn,
-                    get_trigger_axis_fn=get_trigger_axis_fn,
-                    resolve_code_fn=resolve_code_fn,
-                    fire_and_observe_fn=fire_and_observe_fn,
-                    command_type=command_type,
-                    evdev_mod=evdev_mod,
-                    uinput_writer=uinput_writer,
+                    deps=deps,
                 )
                 if child_combo_id in manager.combo_state.active_actions:
                     child_combo_ids.append(child_combo_id)
@@ -1006,8 +897,7 @@ async def start_combo_action(
             combo_id,
             action,
             trigger_binding,
-            fire_and_observe_fn=fire_and_observe_fn,
-            command_type=command_type,
+            deps=deps,
         )
         if machine is None:
             return
@@ -1026,15 +916,7 @@ async def start_combo_action(
         action,
         trigger_binding,
         trigger_name=trigger_name,
-        action_type_enum=action_type_enum,
-        asyncio_mod=asyncio_mod,
-        emit_mouse_move_fn=emit_mouse_move_fn,
-        get_trigger_axis_fn=get_trigger_axis_fn,
-        resolve_code_fn=resolve_code_fn,
-        fire_and_observe_fn=fire_and_observe_fn,
-        command_type=command_type,
-        evdev_mod=evdev_mod,
-        uinput_writer=uinput_writer,
+        deps=deps,
     )
     if not _attach_combo_trigger_recall_state(
         manager,
@@ -1052,58 +934,44 @@ async def _start_combo_action_instance(
     trigger_binding: RuntimeComboBinding,
     *,
     trigger_name: str,
-    action_type_enum: type[ActionType],
-    asyncio_mod: _AsyncioModule,
-    emit_mouse_move_fn: _EmitMouseMoveFn,
-    get_trigger_axis_fn: TriggerAxisFn,
-    resolve_code_fn: ResolveCodeFn,
-    fire_and_observe_fn: FireAndObserve,
-    command_type: type[CommandType],
-    evdev_mod: _EvdevModule,
-    uinput_writer: UInputWriter,
+    deps: ComboRuntimeDeps,
 ) -> None:
-    if action is None or action.action_type == action_type_enum.SUPERKEY:
+    if action is None or action.action_type == ActionType.SUPERKEY:
         return
 
-    if action.action_type == action_type_enum.KEYBOARD and action.target:
+    if action.action_type == ActionType.KEYBOARD and action.target:
         await start_combo_key_action(
             manager,
             combo_id,
             action,
             manager.output_state.keyboard_uinput,
-            asyncio_mod=asyncio_mod,
-            resolve_code_fn=resolve_code_fn,
-            evdev_mod=evdev_mod,
-            uinput_writer=uinput_writer,
+            deps=deps,
         )
         return
 
-    if action.action_type == action_type_enum.MOUSE and action.target:
+    if action.action_type == ActionType.MOUSE and action.target:
         await start_combo_mouse_action(
             manager,
             combo_id,
             action,
             manager.output_state.mouse_uinput,
-            asyncio_mod=asyncio_mod,
-            resolve_code_fn=resolve_code_fn,
-            evdev_mod=evdev_mod,
-            uinput_writer=uinput_writer,
+            deps=deps,
         )
         return
 
-    if action.action_type == action_type_enum.GAMEPAD and action.target:
-        is_trigger, axis_code = get_trigger_axis_fn(action.target)
+    if action.action_type == ActionType.GAMEPAD and action.target:
+        is_trigger, axis_code = deps.get_trigger_axis_fn(action.target)
         if is_trigger and axis_code is not None:
             if action.tap_enabled:
-                task = asyncio_mod.create_task(
+                task = deps.asyncio_mod.create_task(
                     combo_tap_trigger(
                         manager,
                         combo_id,
                         axis_code,
                         action.tap_hold_ms,
-                        asyncio_mod=asyncio_mod,
-                        evdev_mod=evdev_mod,
-                        uinput_writer=uinput_writer,
+                        asyncio_mod=deps.asyncio_mod,
+                        evdev_mod=deps.evdev_mod,
+                        uinput_writer=deps.uinput_writer,
                     )
                 )
                 manager.combo_state.active_actions[combo_id] = ComboActionState(
@@ -1113,16 +981,16 @@ async def _start_combo_action_instance(
                 )
                 return
             if action.rapidfire_enabled:
-                task = asyncio_mod.create_task(
+                task = deps.asyncio_mod.create_task(
                     combo_rapidfire_trigger(
                         manager,
                         combo_id,
                         axis_code,
                         action.rapidfire_hold_ms,
                         action.rapidfire_wait_ms,
-                        asyncio_mod=asyncio_mod,
-                        evdev_mod=evdev_mod,
-                        uinput_writer=uinput_writer,
+                        asyncio_mod=deps.asyncio_mod,
+                        evdev_mod=deps.evdev_mod,
+                        uinput_writer=deps.uinput_writer,
                     )
                 )
                 manager.combo_state.active_actions[combo_id] = ComboActionState(
@@ -1136,8 +1004,8 @@ async def _start_combo_action_instance(
                 manager,
                 axis_code,
                 255,
-                evdev_mod=evdev_mod,
-                uinput_writer=uinput_writer,
+                evdev_mod=deps.evdev_mod,
+                uinput_writer=deps.uinput_writer,
             )
             manager.combo_state.active_actions[combo_id] = ComboActionState(
                 kind="trigger",
@@ -1149,22 +1017,19 @@ async def _start_combo_action_instance(
             combo_id,
             action,
             manager.output_state.gamepad_uinput,
-            asyncio_mod=asyncio_mod,
-            resolve_code_fn=resolve_code_fn,
-            evdev_mod=evdev_mod,
-            uinput_writer=uinput_writer,
+            deps=deps,
         )
         return
 
-    if action.action_type == action_type_enum.MOUSE_MOVE_ABS:
+    if action.action_type == ActionType.MOUSE_MOVE_ABS:
         await manager.set_cursor_position(int(action.move_x), int(action.move_y))
         return
 
-    if action.action_type == action_type_enum.MOUSE_MOVE_REL:
-        emit_combo_mouse_move(manager, action, emit_mouse_move_fn=emit_mouse_move_fn)
+    if action.action_type == ActionType.MOUSE_MOVE_REL:
+        emit_combo_mouse_move(manager, action, deps=deps)
         return
 
-    if action.action_type == action_type_enum.MACRO:
+    if action.action_type == ActionType.MACRO:
         macro_request = build_macro_playback_request(
             action,
             source_device="combo",
@@ -1191,8 +1056,7 @@ async def _start_combo_action_instance(
         await broadcast_combo_action(
             manager,
             action_payload,
-            fire_and_observe_fn=fire_and_observe_fn,
-            command_type=command_type,
+            deps=deps,
         )
         return
 
@@ -1203,28 +1067,25 @@ async def start_combo_key_action(
     action: MappingAction,
     uinput_dev: object | None,
     *,
-    asyncio_mod: _AsyncioModule,
-    resolve_code_fn: ResolveCodeFn,
-    evdev_mod: _EvdevModule,
-    uinput_writer: UInputWriter,
+    deps: ComboRuntimeDeps,
 ) -> None:
     target = str(action.target or "")
     if not target:
         return
-    code = resolve_code_fn(target)
+    code = deps.resolve_code_fn(target)
     if code is None:
         return
     if action.tap_enabled:
-        task = asyncio_mod.create_task(
+        task = deps.asyncio_mod.create_task(
             combo_tap_key(
                 manager,
                 combo_id,
                 uinput_dev,
                 code,
                 action.tap_hold_ms,
-                asyncio_mod=asyncio_mod,
-                evdev_mod=evdev_mod,
-                uinput_writer=uinput_writer,
+                asyncio_mod=deps.asyncio_mod,
+                evdev_mod=deps.evdev_mod,
+                uinput_writer=deps.uinput_writer,
             )
         )
         manager.combo_state.active_actions[combo_id] = ComboActionState(
@@ -1235,7 +1096,7 @@ async def start_combo_key_action(
         )
         return
     if action.rapidfire_enabled:
-        task = asyncio_mod.create_task(
+        task = deps.asyncio_mod.create_task(
             combo_rapidfire_key(
                 manager,
                 combo_id,
@@ -1243,9 +1104,9 @@ async def start_combo_key_action(
                 code,
                 action.rapidfire_hold_ms,
                 action.rapidfire_wait_ms,
-                asyncio_mod=asyncio_mod,
-                evdev_mod=evdev_mod,
-                uinput_writer=uinput_writer,
+                asyncio_mod=deps.asyncio_mod,
+                evdev_mod=deps.evdev_mod,
+                uinput_writer=deps.uinput_writer,
             )
         )
         manager.combo_state.active_actions[combo_id] = ComboActionState(
@@ -1256,7 +1117,7 @@ async def start_combo_key_action(
             task=task,
         )
         return
-    write_combo_key(uinput_dev, code, 1, evdev_mod=evdev_mod, uinput_writer=uinput_writer)
+    write_combo_key(uinput_dev, code, 1, evdev_mod=deps.evdev_mod, uinput_writer=deps.uinput_writer)
     manager.combo_state.active_actions[combo_id] = ComboActionState(
         kind="key",
         uinput=uinput_dev,
@@ -1270,10 +1131,7 @@ async def start_combo_mouse_action(
     action: MappingAction,
     uinput_dev: object | None,
     *,
-    asyncio_mod: _AsyncioModule,
-    resolve_code_fn: ResolveCodeFn,
-    evdev_mod: _EvdevModule,
-    uinput_writer: UInputWriter,
+    deps: ComboRuntimeDeps,
 ) -> None:
     target = resolve_mouse_output_target(action.target)
     if target is None:
@@ -1284,14 +1142,11 @@ async def start_combo_mouse_action(
             combo_id,
             action,
             uinput_dev,
-            asyncio_mod=asyncio_mod,
-            resolve_code_fn=resolve_code_fn,
-            evdev_mod=evdev_mod,
-            uinput_writer=uinput_writer,
+            deps=deps,
         )
         return
     if action.tap_enabled:
-        task = asyncio_mod.create_task(
+        task = deps.asyncio_mod.create_task(
             combo_tap_relative(
                 manager,
                 combo_id,
@@ -1299,9 +1154,9 @@ async def start_combo_mouse_action(
                 target.code,
                 target.relative_value,
                 action.tap_hold_ms,
-                asyncio_mod=asyncio_mod,
-                evdev_mod=evdev_mod,
-                uinput_writer=uinput_writer,
+                asyncio_mod=deps.asyncio_mod,
+                evdev_mod=deps.evdev_mod,
+                uinput_writer=deps.uinput_writer,
             )
         )
         manager.combo_state.active_actions[combo_id] = ComboActionState(
@@ -1312,7 +1167,7 @@ async def start_combo_mouse_action(
         )
         return
     if action.rapidfire_enabled:
-        task = asyncio_mod.create_task(
+        task = deps.asyncio_mod.create_task(
             combo_rapidfire_relative(
                 manager,
                 combo_id,
@@ -1321,9 +1176,9 @@ async def start_combo_mouse_action(
                 target.relative_value,
                 action.rapidfire_hold_ms,
                 action.rapidfire_wait_ms,
-                asyncio_mod=asyncio_mod,
-                evdev_mod=evdev_mod,
-                uinput_writer=uinput_writer,
+                asyncio_mod=deps.asyncio_mod,
+                evdev_mod=deps.evdev_mod,
+                uinput_writer=deps.uinput_writer,
             )
         )
         manager.combo_state.active_actions[combo_id] = ComboActionState(
@@ -1338,8 +1193,8 @@ async def start_combo_mouse_action(
         uinput_dev,
         target.code,
         target.relative_value,
-        evdev_mod=evdev_mod,
-        uinput_writer=uinput_writer,
+        evdev_mod=deps.evdev_mod,
+        uinput_writer=deps.uinput_writer,
     )
 
 
@@ -1347,17 +1202,7 @@ async def stop_combo_action(
     manager: _ComboManager,
     combo_id: str,
     *,
-    asyncio_mod: _AsyncioModule,
-    contextlib_mod: _ContextlibModule,
-    mapping_action_cls: type[MappingAction],
-    evdev_mod: _EvdevModule,
-    uinput_writer: UInputWriter,
-    emit_mouse_move_fn: _EmitMouseMoveFn,
-    get_trigger_axis_fn: TriggerAxisFn,
-    resolve_code_fn: ResolveCodeFn,
-    fire_and_observe_fn: FireAndObserve,
-    command_type: type[CommandType],
-    action_type_enum: type[ActionType],
+    deps: ComboRuntimeDeps,
 ) -> None:
     state = manager.combo_state.active_actions.pop(combo_id, None)
     if not state:
@@ -1369,17 +1214,7 @@ async def stop_combo_action(
             await stop_combo_action(
                 manager,
                 child_combo_id,
-                asyncio_mod=asyncio_mod,
-                contextlib_mod=contextlib_mod,
-                mapping_action_cls=mapping_action_cls,
-                evdev_mod=evdev_mod,
-                uinput_writer=uinput_writer,
-                emit_mouse_move_fn=emit_mouse_move_fn,
-                get_trigger_axis_fn=get_trigger_axis_fn,
-                resolve_code_fn=resolve_code_fn,
-                fire_and_observe_fn=fire_and_observe_fn,
-                command_type=command_type,
-                action_type_enum=action_type_enum,
+                deps=deps,
             )
         _restore_combo_trigger_bindings(manager, restore_bindings)
         return
@@ -1393,7 +1228,13 @@ async def stop_combo_action(
         uinput_dev = state.uinput
         code = state.code
         if code is not None:
-            write_combo_key(uinput_dev, code, 0, evdev_mod=evdev_mod, uinput_writer=uinput_writer)
+            write_combo_key(
+                uinput_dev,
+                code,
+                0,
+                evdev_mod=deps.evdev_mod,
+                uinput_writer=deps.uinput_writer,
+            )
         _restore_combo_trigger_bindings(manager, restore_bindings)
         return
     if kind == "trigger":
@@ -1403,8 +1244,8 @@ async def stop_combo_action(
                 manager,
                 axis_code,
                 0,
-                evdev_mod=evdev_mod,
-                uinput_writer=uinput_writer,
+                evdev_mod=deps.evdev_mod,
+                uinput_writer=deps.uinput_writer,
             )
         _restore_combo_trigger_bindings(manager, restore_bindings)
         return
@@ -1420,13 +1261,13 @@ async def stop_combo_action(
         task = state.task
         if task is not None and not task.done():
             task.cancel()
-            with contextlib_mod.suppress(asyncio_mod.CancelledError):
+            with deps.contextlib_mod.suppress(deps.asyncio_mod.CancelledError):
                 await task
         _restore_combo_trigger_bindings(manager, restore_bindings)
         return
     if kind == "macro_hold":
         action = state.action
-        if isinstance(action, mapping_action_cls):
+        if action is not None:
             macro_request = build_macro_playback_request(
                 action,
                 source_device=str(state.source_device or ""),
@@ -1444,35 +1285,14 @@ async def stop_combo_action(
 async def clear_combo_runtime(
     manager: _ComboManager,
     *,
-    asyncio_mod: _AsyncioModule,
-    contextlib_mod: _ContextlibModule,
-    mapping_action_cls: type[MappingAction],
-    evdev_mod: _EvdevModule,
-    uinput_writer: UInputWriter,
-    emit_mouse_move_fn: _EmitMouseMoveFn,
-    get_trigger_axis_fn: TriggerAxisFn,
-    resolve_code_fn: ResolveCodeFn,
-    fire_and_observe_fn: FireAndObserve,
-    command_type: type[CommandType],
-    action_type_enum: type[ActionType],
-    time_mod: _TimeModule,
+    deps: ComboRuntimeDeps,
 ) -> None:
     manager.combo_state.engine.reset()
     for combo_id in list(manager.combo_state.active_actions):
         await stop_combo_action(
             manager,
             combo_id,
-            asyncio_mod=asyncio_mod,
-            contextlib_mod=contextlib_mod,
-            mapping_action_cls=mapping_action_cls,
-            evdev_mod=evdev_mod,
-            uinput_writer=uinput_writer,
-            emit_mouse_move_fn=emit_mouse_move_fn,
-            get_trigger_axis_fn=get_trigger_axis_fn,
-            resolve_code_fn=resolve_code_fn,
-            fire_and_observe_fn=fire_and_observe_fn,
-            command_type=command_type,
-            action_type_enum=action_type_enum,
+            deps=deps,
         )
     # stop_combo_action() handles the pattern key-up transition for active combo
     # actions. This final pass is still required to fully tear down any cached
@@ -1487,7 +1307,7 @@ async def clear_combo_runtime(
         refcounts.clear()
     if manager.combo_state.timeout_task and not manager.combo_state.timeout_task.done():
         manager.combo_state.timeout_task.cancel()
-        with contextlib_mod.suppress(asyncio_mod.CancelledError):
+        with deps.contextlib_mod.suppress(deps.asyncio_mod.CancelledError):
             await manager.combo_state.timeout_task
     manager.combo_state.timeout_task = None
 
@@ -1497,18 +1317,7 @@ async def clear_combo_runtime_for_binding_scope(
     hardware_id: str,
     source: str | None,
     *,
-    asyncio_mod: _AsyncioModule,
-    contextlib_mod: _ContextlibModule,
-    mapping_action_cls: type[MappingAction],
-    evdev_mod: _EvdevModule,
-    uinput_writer: UInputWriter,
-    emit_mouse_move_fn: _EmitMouseMoveFn,
-    get_trigger_axis_fn: TriggerAxisFn,
-    resolve_code_fn: ResolveCodeFn,
-    fire_and_observe_fn: FireAndObserve,
-    command_type: type[CommandType],
-    action_type_enum: type[ActionType],
-    time_mod: _TimeModule,
+    deps: ComboRuntimeDeps,
 ) -> None:
     normalized_hardware_id = str(hardware_id or "").lower()
     normalized_source = None if source is None else str(source or "").lower()
@@ -1520,17 +1329,7 @@ async def clear_combo_runtime_for_binding_scope(
         await stop_combo_action(
             manager,
             combo_id,
-            asyncio_mod=asyncio_mod,
-            contextlib_mod=contextlib_mod,
-            mapping_action_cls=mapping_action_cls,
-            evdev_mod=evdev_mod,
-            uinput_writer=uinput_writer,
-            emit_mouse_move_fn=emit_mouse_move_fn,
-            get_trigger_axis_fn=get_trigger_axis_fn,
-            resolve_code_fn=resolve_code_fn,
-            fire_and_observe_fn=fire_and_observe_fn,
-            command_type=command_type,
-            action_type_enum=action_type_enum,
+            deps=deps,
         )
     matching_machine_ids = [
         combo.id
@@ -1544,36 +1343,14 @@ async def clear_combo_runtime_for_binding_scope(
             await machine.stop()
     refresh_combo_timeout_watchdog(
         manager,
-        asyncio_mod=asyncio_mod,
-        time_mod=time_mod,
-        action_type_enum=action_type_enum,
-        mapping_action_cls=mapping_action_cls,
-        emit_mouse_move_fn=emit_mouse_move_fn,
-        get_trigger_axis_fn=get_trigger_axis_fn,
-        resolve_code_fn=resolve_code_fn,
-        fire_and_observe_fn=fire_and_observe_fn,
-        command_type=command_type,
-        contextlib_mod=contextlib_mod,
-        evdev_mod=evdev_mod,
-        uinput_writer=uinput_writer,
+        deps=deps,
     )
 
 
 def refresh_combo_timeout_watchdog(
     manager: _ComboManager,
     *,
-    asyncio_mod: _AsyncioModule,
-    time_mod: _TimeModule,
-    action_type_enum: type[ActionType],
-    mapping_action_cls: type[MappingAction],
-    emit_mouse_move_fn: _EmitMouseMoveFn,
-    get_trigger_axis_fn: TriggerAxisFn,
-    resolve_code_fn: ResolveCodeFn,
-    fire_and_observe_fn: FireAndObserve,
-    command_type: type[CommandType],
-    contextlib_mod: _ContextlibModule,
-    evdev_mod: _EvdevModule,
-    uinput_writer: UInputWriter,
+    deps: ComboRuntimeDeps,
 ) -> None:
     deadline = manager.combo_state.engine.next_deadline()
     if deadline is None:
@@ -1583,22 +1360,11 @@ def refresh_combo_timeout_watchdog(
         return
     if manager.combo_state.timeout_task and not manager.combo_state.timeout_task.done():
         manager.combo_state.timeout_task.cancel()
-    manager.combo_state.timeout_task = asyncio_mod.create_task(
+    manager.combo_state.timeout_task = deps.asyncio_mod.create_task(
         combo_timeout_watchdog(
             manager,
             deadline,
-            asyncio_mod=asyncio_mod,
-            time_mod=time_mod,
-            action_type_enum=action_type_enum,
-            mapping_action_cls=mapping_action_cls,
-            emit_mouse_move_fn=emit_mouse_move_fn,
-            get_trigger_axis_fn=get_trigger_axis_fn,
-            resolve_code_fn=resolve_code_fn,
-            fire_and_observe_fn=fire_and_observe_fn,
-            command_type=command_type,
-            contextlib_mod=contextlib_mod,
-            evdev_mod=evdev_mod,
-            uinput_writer=uinput_writer,
+            deps=deps,
         )
     )
 
@@ -1607,41 +1373,19 @@ async def combo_timeout_watchdog(
     manager: _ComboManager,
     deadline: float,
     *,
-    asyncio_mod: _AsyncioModule,
-    time_mod: _TimeModule,
-    action_type_enum: type[ActionType],
-    mapping_action_cls: type[MappingAction],
-    emit_mouse_move_fn: _EmitMouseMoveFn,
-    get_trigger_axis_fn: TriggerAxisFn,
-    resolve_code_fn: ResolveCodeFn,
-    fire_and_observe_fn: FireAndObserve,
-    command_type: type[CommandType],
-    contextlib_mod: _ContextlibModule,
-    evdev_mod: _EvdevModule,
-    uinput_writer: UInputWriter,
+    deps: ComboRuntimeDeps,
 ) -> None:
     try:
-        await asyncio_mod.sleep(max(0.0, deadline - time_mod.monotonic()))
-        manager.combo_state.engine.expire_timeouts(time_mod.monotonic())
-    except asyncio_mod.CancelledError:
+        await deps.asyncio_mod.sleep(max(0.0, deadline - deps.time_mod.monotonic()))
+        manager.combo_state.engine.expire_timeouts(deps.time_mod.monotonic())
+    except deps.asyncio_mod.CancelledError:
         raise
     finally:
-        if manager.combo_state.timeout_task is asyncio_mod.current_task():
+        if manager.combo_state.timeout_task is deps.asyncio_mod.current_task():
             manager.combo_state.timeout_task = None
         refresh_combo_timeout_watchdog(
             manager,
-            asyncio_mod=asyncio_mod,
-            time_mod=time_mod,
-            action_type_enum=action_type_enum,
-            mapping_action_cls=mapping_action_cls,
-            emit_mouse_move_fn=emit_mouse_move_fn,
-            get_trigger_axis_fn=get_trigger_axis_fn,
-            resolve_code_fn=resolve_code_fn,
-            fire_and_observe_fn=fire_and_observe_fn,
-            command_type=command_type,
-            contextlib_mod=contextlib_mod,
-            evdev_mod=evdev_mod,
-            uinput_writer=uinput_writer,
+            deps=deps,
         )
 
 
@@ -1819,9 +1563,9 @@ def write_combo_trigger(
 
 
 def emit_combo_mouse_move(
-    manager: _ComboManager, action: MappingAction, *, emit_mouse_move_fn: _EmitMouseMoveFn
+    manager: _ComboManager, action: MappingAction, *, deps: ComboRuntimeDeps
 ) -> None:
-    emit_mouse_move_fn(
+    deps.emit_mouse_move_fn(
         manager.output_state.mouse_uinput,
         int(action.move_x),
         int(action.move_y),

--- a/keymasq/keymasqd/runtime/combos.py
+++ b/keymasq/keymasqd/runtime/combos.py
@@ -1,10 +1,10 @@
 import asyncio
 import logging
 import queue
-from collections.abc import Awaitable, Callable, Mapping, Sequence
+from collections.abc import Awaitable, Callable, Sequence
 from contextlib import AbstractContextManager
 from dataclasses import dataclass, field
-from typing import Protocol, cast
+from typing import Any, Protocol, cast
 
 from keymasq.common.combos import normalize_combo_evdev
 from keymasq.common.ipc import CommandType
@@ -74,73 +74,8 @@ class _EmitMouseMoveFn(Protocol):
     ) -> None: ...
 
 
-class _OutputState(Protocol):
-    @property
-    def keyboard_uinput(self) -> object | None: ...
-
-    @property
-    def mouse_uinput(self) -> object | None: ...
-
-    @property
-    def gamepad_uinput(self) -> object | None: ...
-
-
-class _GrabbedComboDevice(Protocol):
-    hardware_id: str
-    interface_id: str
-
-    def emit_combo_release(self, evdev_name: str) -> None: ...
-
-    def emit_combo_press(self, evdev_name: str) -> None: ...
-
-    def combo_passthrough_binding_active(self, evdev_name: str) -> bool: ...
-
-    def combo_source_binding_held(self, evdev_name: str) -> bool: ...
-
-    def combo_binding_recalled(self, evdev_name: str) -> bool: ...
-
-    def mark_combo_recalled_binding(self, evdev_name: str) -> None: ...
-
-    def clear_combo_recalled_binding(self, evdev_name: str) -> None: ...
-
-    def combo_passthrough_held_modifiers(self) -> set[str]: ...
-
-    def combo_held_source_bindings(self) -> set[str]: ...
-
-
-class _ComboManager(Protocol):
-    @property
-    def combo_state(self) -> "ComboRuntimeState": ...
-
-    @property
-    def output_state(self) -> _OutputState: ...
-
-    @property
-    def grabbed_devices(self) -> Mapping[str, Sequence[_GrabbedComboDevice]]: ...
-
-    @property
-    def broadcast_callback(self) -> Callable[[CommandType, JsonObject], Awaitable[None]] | None: ...
-
-    async def set_cursor_position(self, x: int, y: int) -> JsonObject: ...
-
-    async def play_macro(
-        self,
-        *,
-        macro_events: list[JsonObject],
-        macro_name: str = "",
-        replay_mouse_movement: bool = True,
-        replay_mouse_clicks: bool = True,
-        speed: float = 1.0,
-        loop_mode: str = "none",
-        loop_count: int = 1,
-        move_to_start: bool = False,
-        start_x: int = 0,
-        start_y: int = 0,
-        block_mouse_movement: bool = False,
-        source_device: str = "",
-        source_button: str = "",
-        trigger_value: int = 1,
-    ) -> JsonObject: ...
+type _GrabbedComboDevice = Any
+type _ComboManager = Any
 
 
 @dataclass

--- a/keymasq/keymasqd/runtime/combos.py
+++ b/keymasq/keymasqd/runtime/combos.py
@@ -23,6 +23,7 @@ from keymasq.keymasqd.combo_engine import (
     RuntimeCombo,
     RuntimeComboBinding,
 )
+from keymasq.keymasqd.runtime import adapters as runtime_adapters
 from keymasq.keymasqd.runtime.action_runner import (
     build_action_trigger_payload,
     build_macro_playback_request,
@@ -54,43 +55,8 @@ type ComboCaptureQueueState = tuple[
 ]
 
 
-class _WritableUInput(Protocol):
-    def write(self, event_type: int, code: int, value: int) -> None: ...
-
-    def syn(self) -> None: ...
-
-
-type UInputWriter = Callable[[object | None], _WritableUInput | None]
-
-
-class _EcodesByType(Protocol):
-    def get(self, key: int, default: dict[int, object] | None = None) -> dict[int, object]: ...
-
-
-class _Ecodes(Protocol):
-    EV_KEY: int
-    EV_REL: int
-    EV_ABS: int
-    bytype: _EcodesByType
-
-
-class _EvdevModule(Protocol):
-    @property
-    def ecodes(self) -> _Ecodes: ...
-
-
 class _TimeModule(Protocol):
     def monotonic(self) -> float: ...
-
-
-class _AsyncioModule(Protocol):
-    CancelledError: type[BaseException]
-
-    def create_task(self, coro: Awaitable[None], /) -> asyncio.Task[None]: ...
-
-    async def sleep(self, delay: float, /) -> None: ...
-
-    def current_task(self) -> asyncio.Task[None] | None: ...
 
 
 class _ContextlibModule(Protocol):
@@ -220,11 +186,11 @@ class ComboRuntimeState:
 
 @dataclass(frozen=True)
 class ComboRuntimeDeps:
-    asyncio_mod: _AsyncioModule
+    asyncio_mod: runtime_adapters.AsyncioRuntimeAdapter
     contextlib_mod: _ContextlibModule
     time_mod: _TimeModule
-    evdev_mod: _EvdevModule
-    uinput_writer: UInputWriter
+    evdev_mod: runtime_adapters.ComboEvdevAdapter
+    uinput_writer: runtime_adapters.UInputWriter
     emit_mouse_move_fn: _EmitMouseMoveFn
     get_trigger_axis_fn: TriggerAxisFn
     resolve_code_fn: ResolveCodeFn
@@ -292,7 +258,7 @@ def build_combo_event_payload(
     *,
     stable_path: str | None,
     source: str | None,
-    evdev_mod: _EvdevModule,
+    evdev_mod: runtime_adapters.ComboEvdevAdapter,
     resolve_stable_path_fn: ResolveStablePathFn,
     get_interface_id_fn: GetInterfaceIdFn,
 ) -> dict[str, object] | None:
@@ -670,9 +636,9 @@ async def _combo_superkey_machine(
     machine = SuperkeyMachine(
         config=config,
         event_name=trigger_name,
-        keyboard_uinput=cast(_WritableUInput, manager.output_state.keyboard_uinput),
-        mouse_uinput=cast(_WritableUInput, manager.output_state.mouse_uinput),
-        gamepad_uinput=cast(_WritableUInput, manager.output_state.gamepad_uinput),
+        keyboard_uinput=cast(runtime_adapters.WritableUInput, manager.output_state.keyboard_uinput),
+        mouse_uinput=cast(runtime_adapters.WritableUInput, manager.output_state.mouse_uinput),
+        gamepad_uinput=cast(runtime_adapters.WritableUInput, manager.output_state.gamepad_uinput),
         broadcast_callback=combo_superkey_broadcast,
         cursor_position_setter=manager.set_cursor_position,
         key_event_tracker=combo_superkey_output_tracker,

--- a/keymasq/keymasqd/runtime/combos.py
+++ b/keymasq/keymasqd/runtime/combos.py
@@ -4,7 +4,7 @@ import queue
 from collections.abc import Awaitable, Callable, Mapping, Sequence
 from contextlib import AbstractContextManager
 from dataclasses import dataclass, field
-from typing import ClassVar, Protocol, cast
+from typing import Protocol, cast
 
 from keymasq.common.combos import normalize_combo_evdev
 from keymasq.common.ipc import CommandType
@@ -75,7 +75,8 @@ class _Ecodes(Protocol):
 
 
 class _EvdevModule(Protocol):
-    ecodes: _Ecodes
+    @property
+    def ecodes(self) -> _Ecodes: ...
 
 
 class _TimeModule(Protocol):
@@ -83,7 +84,7 @@ class _TimeModule(Protocol):
 
 
 class _AsyncioModule(Protocol):
-    CancelledError: ClassVar[type[BaseException]]
+    CancelledError: type[BaseException]
 
     def create_task(self, coro: Awaitable[None], /) -> asyncio.Task[None]: ...
 
@@ -105,15 +106,6 @@ class _EmitMouseMoveFn(Protocol):
         *,
         absolute: bool = False,
     ) -> None: ...
-
-
-class _QueueFactory(Protocol):
-    def __call__(self) -> queue.SimpleQueue[dict[str, object]]: ...
-
-
-class _QueueModule(Protocol):
-    Empty: ClassVar[type[BaseException]]
-    SimpleQueue: _QueueFactory
 
 
 class _OutputState(Protocol):
@@ -1546,11 +1538,9 @@ def begin_combo_capture(
     token: str,
     hardware_ids: set[str],
     notify_event: asyncio.Event | None,
-    *,
-    queue_mod: _QueueModule,
 ) -> dict[str, object]:
     manager.combo_state.capture_queues[token] = (
-        queue_mod.SimpleQueue(),
+        queue.SimpleQueue(),
         set(hardware_ids),
         notify_event,
     )
@@ -1560,16 +1550,14 @@ def begin_combo_capture(
     }
 
 
-def read_combo_capture(
-    manager: _ComboManager, token: str, *, queue_mod: _QueueModule
-) -> dict[str, object]:
+def read_combo_capture(manager: _ComboManager, token: str) -> dict[str, object]:
     capture_state = manager.combo_state.capture_queues.get(token)
     if capture_state is None:
         return {"event": None}
     capture_queue, _hardware_ids, _notify_event = capture_state
     try:
         return {"event": capture_queue.get_nowait()}
-    except queue_mod.Empty:
+    except queue.Empty:
         return {"event": None}
 
 

--- a/keymasq/keymasqd/runtime/combos.py
+++ b/keymasq/keymasqd/runtime/combos.py
@@ -1,13 +1,13 @@
 import asyncio
+import contextlib
 import logging
 import queue
+import time
 from collections.abc import Awaitable, Callable, Sequence
-from contextlib import AbstractContextManager
 from dataclasses import dataclass, field
 from typing import Any, Protocol, cast
 
 from keymasq.common.combos import normalize_combo_evdev
-from keymasq.common.ipc import CommandType
 from keymasq.common.models import (
     ActionType,
     MappingAction,
@@ -53,14 +53,6 @@ type FireAndObserve = Callable[[Awaitable[object], str], asyncio.Task[object]]
 type ComboCaptureQueueState = tuple[
     queue.SimpleQueue[dict[str, object]], set[str], asyncio.Event | None
 ]
-
-
-class _TimeModule(Protocol):
-    def monotonic(self) -> float: ...
-
-
-class _ContextlibModule(Protocol):
-    def suppress(self, *exceptions: type[BaseException]) -> AbstractContextManager[None]: ...
 
 
 class _EmitMouseMoveFn(Protocol):
@@ -122,8 +114,6 @@ class ComboRuntimeState:
 @dataclass(frozen=True)
 class ComboRuntimeDeps:
     asyncio_mod: runtime_adapters.AsyncioRuntimeAdapter
-    contextlib_mod: _ContextlibModule
-    time_mod: _TimeModule
     evdev_mod: runtime_adapters.ComboEvdevAdapter
     uinput_writer: runtime_adapters.UInputWriter
     emit_mouse_move_fn: _EmitMouseMoveFn
@@ -152,8 +142,6 @@ async def on_device_event(
     *,
     resolve_stable_path_fn: ResolveStablePathFn,
     get_interface_id_fn: GetInterfaceIdFn,
-    combo_binding_cls: type[RuntimeComboBinding],
-    combo_input_event_cls: type[ComboInputEvent],
     int_value_fn: IntValueFn,
     str_value_fn: StrValueFn,
     deps: ComboRuntimeDeps,
@@ -176,8 +164,6 @@ async def on_device_event(
     return await process_runtime_combo_event(
         manager,
         combo_payload,
-        combo_binding_cls=combo_binding_cls,
-        combo_input_event_cls=combo_input_event_cls,
         int_value_fn=int_value_fn,
         str_value_fn=str_value_fn,
         deps=deps,
@@ -241,8 +227,6 @@ async def process_runtime_combo_event(
     manager: _ComboManager,
     payload: dict[str, object] | None,
     *,
-    combo_binding_cls: type[RuntimeComboBinding],
-    combo_input_event_cls: type[ComboInputEvent],
     int_value_fn: IntValueFn,
     str_value_fn: StrValueFn,
     deps: ComboRuntimeDeps,
@@ -255,7 +239,7 @@ async def process_runtime_combo_event(
     if value not in {0, 1, 2}:
         return None
 
-    binding = combo_binding_cls(
+    binding = RuntimeComboBinding(
         hardware_id=str_value_fn(payload.get("hardware_id"), ""),
         evdev=str_value_fn(payload.get("evdev"), ""),
         source=str_value_fn(payload.get("source"), ""),
@@ -265,14 +249,13 @@ async def process_runtime_combo_event(
             manager,
             binding.hardware_id,
             binding.source,
-            combo_binding_cls=combo_binding_cls,
         )
         if binding in held_modifiers:
             held_modifiers.discard(binding)
         manager.combo_state.engine.prime_held_bindings(held_modifiers)
     decision = manager.combo_state.engine.handle_event(
-        combo_input_event_cls(binding=binding, value=value),
-        deps.time_mod.monotonic(),
+        ComboInputEvent(binding=binding, value=value),
+        time.monotonic(),
     )
     if decision.recall_events:
         emit_combo_recalls(manager, decision.recall_events)
@@ -332,8 +315,6 @@ def held_combo_modifier_bindings_for_scope(
     manager: _ComboManager,
     hardware_id: str,
     source: str,
-    *,
-    combo_binding_cls: type[RuntimeComboBinding],
 ) -> set[RuntimeComboBinding]:
     held: set[RuntimeComboBinding] = set()
     for device in manager.grabbed_devices.get(hardware_id, []):
@@ -352,7 +333,7 @@ def held_combo_modifier_bindings_for_scope(
         modifier_names_str = [name for name in modifier_name_values if isinstance(name, str)]
         for evdev_name in modifier_names_str:
             held.add(
-                combo_binding_cls(
+                RuntimeComboBinding(
                     hardware_id=hardware_id,
                     evdev=evdev_name,
                     source=device.interface_id,
@@ -363,8 +344,6 @@ def held_combo_modifier_bindings_for_scope(
 
 def prime_combo_engine_with_held_bindings(
     manager: _ComboManager,
-    *,
-    combo_binding_cls: type[RuntimeComboBinding],
 ) -> None:
     held: set[RuntimeComboBinding] = set()
     for devices in manager.grabbed_devices.values():
@@ -382,7 +361,7 @@ def prime_combo_engine_with_held_bindings(
             held_names_str = [name for name in held_name_values if isinstance(name, str)]
             for evdev_name in held_names_str:
                 held.add(
-                    combo_binding_cls(
+                    RuntimeComboBinding(
                         hardware_id=str(device.hardware_id or "").lower(),
                         evdev=str(evdev_name or "").lower(),
                         source=str(device.interface_id or "").lower(),
@@ -424,7 +403,6 @@ async def broadcast_combo_action(
         manager.broadcast_callback,
         data,
         fire_and_observe_fn=deps.fire_and_observe_fn,
-        command_type=CommandType,
         label="combo action broadcast",
     )
 
@@ -1132,7 +1110,7 @@ async def stop_combo_action(
         task = state.task
         if task is not None and not task.done():
             task.cancel()
-            with deps.contextlib_mod.suppress(deps.asyncio_mod.CancelledError):
+            with contextlib.suppress(deps.asyncio_mod.CancelledError):
                 await task
         _restore_combo_trigger_bindings(manager, restore_bindings)
         return
@@ -1178,7 +1156,7 @@ async def clear_combo_runtime(
         refcounts.clear()
     if manager.combo_state.timeout_task and not manager.combo_state.timeout_task.done():
         manager.combo_state.timeout_task.cancel()
-        with deps.contextlib_mod.suppress(deps.asyncio_mod.CancelledError):
+        with contextlib.suppress(deps.asyncio_mod.CancelledError):
             await manager.combo_state.timeout_task
     manager.combo_state.timeout_task = None
 
@@ -1247,8 +1225,8 @@ async def combo_timeout_watchdog(
     deps: ComboRuntimeDeps,
 ) -> None:
     try:
-        await deps.asyncio_mod.sleep(max(0.0, deadline - deps.time_mod.monotonic()))
-        manager.combo_state.engine.expire_timeouts(deps.time_mod.monotonic())
+        await deps.asyncio_mod.sleep(max(0.0, deadline - time.monotonic()))
+        manager.combo_state.engine.expire_timeouts(time.monotonic())
     except deps.asyncio_mod.CancelledError:
         raise
     finally:

--- a/keymasq/keymasqd/runtime/combos.py
+++ b/keymasq/keymasqd/runtime/combos.py
@@ -776,22 +776,20 @@ async def combo_tap_key(
     code: int,
     hold_ms: int,
     *,
-    asyncio_mod: _AsyncioModule,
-    evdev_mod: _EvdevModule,
-    uinput_writer: UInputWriter,
+    deps: ComboRuntimeDeps,
 ) -> None:
-    task = asyncio_mod.current_task()
+    task = deps.asyncio_mod.current_task()
     pressed = False
 
     try:
-        write_combo_key(uinput_dev, code, 1, evdev_mod=evdev_mod, uinput_writer=uinput_writer)
+        write_combo_key(uinput_dev, code, 1, deps=deps)
         pressed = True
-        await asyncio_mod.sleep(max(0.001, float(hold_ms) / 1000.0))
-    except asyncio_mod.CancelledError:
+        await deps.asyncio_mod.sleep(max(0.001, float(hold_ms) / 1000.0))
+    except deps.asyncio_mod.CancelledError:
         raise
     finally:
         if pressed:
-            write_combo_key(uinput_dev, code, 0, evdev_mod=evdev_mod, uinput_writer=uinput_writer)
+            write_combo_key(uinput_dev, code, 0, deps=deps)
         prune_combo_action_task(manager, combo_id, task)
 
 
@@ -801,11 +799,9 @@ async def combo_tap_trigger(
     axis_code: int,
     hold_ms: int,
     *,
-    asyncio_mod: _AsyncioModule,
-    evdev_mod: _EvdevModule,
-    uinput_writer: UInputWriter,
+    deps: ComboRuntimeDeps,
 ) -> None:
-    task = asyncio_mod.current_task()
+    task = deps.asyncio_mod.current_task()
     pressed = False
 
     try:
@@ -813,12 +809,11 @@ async def combo_tap_trigger(
             manager,
             axis_code,
             255,
-            evdev_mod=evdev_mod,
-            uinput_writer=uinput_writer,
+            deps=deps,
         )
         pressed = True
-        await asyncio_mod.sleep(max(0.001, float(hold_ms) / 1000.0))
-    except asyncio_mod.CancelledError:
+        await deps.asyncio_mod.sleep(max(0.001, float(hold_ms) / 1000.0))
+    except deps.asyncio_mod.CancelledError:
         raise
     finally:
         if pressed:
@@ -826,8 +821,7 @@ async def combo_tap_trigger(
                 manager,
                 axis_code,
                 0,
-                evdev_mod=evdev_mod,
-                uinput_writer=uinput_writer,
+                deps=deps,
             )
         prune_combo_action_task(manager, combo_id, task)
 
@@ -969,9 +963,7 @@ async def _start_combo_action_instance(
                         combo_id,
                         axis_code,
                         action.tap_hold_ms,
-                        asyncio_mod=deps.asyncio_mod,
-                        evdev_mod=deps.evdev_mod,
-                        uinput_writer=deps.uinput_writer,
+                        deps=deps,
                     )
                 )
                 manager.combo_state.active_actions[combo_id] = ComboActionState(
@@ -988,9 +980,7 @@ async def _start_combo_action_instance(
                         axis_code,
                         action.rapidfire_hold_ms,
                         action.rapidfire_wait_ms,
-                        asyncio_mod=deps.asyncio_mod,
-                        evdev_mod=deps.evdev_mod,
-                        uinput_writer=deps.uinput_writer,
+                        deps=deps,
                     )
                 )
                 manager.combo_state.active_actions[combo_id] = ComboActionState(
@@ -1004,8 +994,7 @@ async def _start_combo_action_instance(
                 manager,
                 axis_code,
                 255,
-                evdev_mod=deps.evdev_mod,
-                uinput_writer=deps.uinput_writer,
+                deps=deps,
             )
             manager.combo_state.active_actions[combo_id] = ComboActionState(
                 kind="trigger",
@@ -1083,9 +1072,7 @@ async def start_combo_key_action(
                 uinput_dev,
                 code,
                 action.tap_hold_ms,
-                asyncio_mod=deps.asyncio_mod,
-                evdev_mod=deps.evdev_mod,
-                uinput_writer=deps.uinput_writer,
+                deps=deps,
             )
         )
         manager.combo_state.active_actions[combo_id] = ComboActionState(
@@ -1104,9 +1091,7 @@ async def start_combo_key_action(
                 code,
                 action.rapidfire_hold_ms,
                 action.rapidfire_wait_ms,
-                asyncio_mod=deps.asyncio_mod,
-                evdev_mod=deps.evdev_mod,
-                uinput_writer=deps.uinput_writer,
+                deps=deps,
             )
         )
         manager.combo_state.active_actions[combo_id] = ComboActionState(
@@ -1117,7 +1102,7 @@ async def start_combo_key_action(
             task=task,
         )
         return
-    write_combo_key(uinput_dev, code, 1, evdev_mod=deps.evdev_mod, uinput_writer=deps.uinput_writer)
+    write_combo_key(uinput_dev, code, 1, deps=deps)
     manager.combo_state.active_actions[combo_id] = ComboActionState(
         kind="key",
         uinput=uinput_dev,
@@ -1154,9 +1139,7 @@ async def start_combo_mouse_action(
                 target.code,
                 target.relative_value,
                 action.tap_hold_ms,
-                asyncio_mod=deps.asyncio_mod,
-                evdev_mod=deps.evdev_mod,
-                uinput_writer=deps.uinput_writer,
+                deps=deps,
             )
         )
         manager.combo_state.active_actions[combo_id] = ComboActionState(
@@ -1176,9 +1159,7 @@ async def start_combo_mouse_action(
                 target.relative_value,
                 action.rapidfire_hold_ms,
                 action.rapidfire_wait_ms,
-                asyncio_mod=deps.asyncio_mod,
-                evdev_mod=deps.evdev_mod,
-                uinput_writer=deps.uinput_writer,
+                deps=deps,
             )
         )
         manager.combo_state.active_actions[combo_id] = ComboActionState(
@@ -1193,8 +1174,7 @@ async def start_combo_mouse_action(
         uinput_dev,
         target.code,
         target.relative_value,
-        evdev_mod=deps.evdev_mod,
-        uinput_writer=deps.uinput_writer,
+        deps=deps,
     )
 
 
@@ -1232,8 +1212,7 @@ async def stop_combo_action(
                 uinput_dev,
                 code,
                 0,
-                evdev_mod=deps.evdev_mod,
-                uinput_writer=deps.uinput_writer,
+                deps=deps,
             )
         _restore_combo_trigger_bindings(manager, restore_bindings)
         return
@@ -1244,8 +1223,7 @@ async def stop_combo_action(
                 manager,
                 axis_code,
                 0,
-                evdev_mod=deps.evdev_mod,
-                uinput_writer=deps.uinput_writer,
+                deps=deps,
             )
         _restore_combo_trigger_bindings(manager, restore_bindings)
         return
@@ -1397,22 +1375,20 @@ async def combo_rapidfire_key(
     hold_ms: int,
     wait_ms: int,
     *,
-    asyncio_mod: _AsyncioModule,
-    evdev_mod: _EvdevModule,
-    uinput_writer: UInputWriter,
+    deps: ComboRuntimeDeps,
 ) -> None:
     try:
         while _combo_action_active(manager, combo_id):
-            write_combo_key(uinput_dev, code, 1, evdev_mod=evdev_mod, uinput_writer=uinput_writer)
-            await asyncio_mod.sleep(max(0.001, hold_ms / 1000.0))
+            write_combo_key(uinput_dev, code, 1, deps=deps)
+            await deps.asyncio_mod.sleep(max(0.001, hold_ms / 1000.0))
             if not _combo_action_active(manager, combo_id):
                 break
-            write_combo_key(uinput_dev, code, 0, evdev_mod=evdev_mod, uinput_writer=uinput_writer)
-            await asyncio_mod.sleep(max(0.001, wait_ms / 1000.0))
-    except asyncio_mod.CancelledError:
+            write_combo_key(uinput_dev, code, 0, deps=deps)
+            await deps.asyncio_mod.sleep(max(0.001, wait_ms / 1000.0))
+    except deps.asyncio_mod.CancelledError:
         raise
     finally:
-        write_combo_key(uinput_dev, code, 0, evdev_mod=evdev_mod, uinput_writer=uinput_writer)
+        write_combo_key(uinput_dev, code, 0, deps=deps)
 
 
 async def combo_tap_relative(
@@ -1423,11 +1399,9 @@ async def combo_tap_relative(
     value: int,
     hold_ms: int,
     *,
-    asyncio_mod: _AsyncioModule,
-    evdev_mod: _EvdevModule,
-    uinput_writer: UInputWriter,
+    deps: ComboRuntimeDeps,
 ) -> None:
-    task = asyncio_mod.current_task()
+    task = deps.asyncio_mod.current_task()
 
     try:
         await tap_relative_pulse(
@@ -1435,13 +1409,12 @@ async def combo_tap_relative(
                 uinput_dev,
                 code,
                 value,
-                evdev_mod=evdev_mod,
-                uinput_writer=uinput_writer,
+                deps=deps,
             ),
             hold_s=max(0.001, float(hold_ms) / 1000.0),
-            asyncio_mod=asyncio_mod,
+            asyncio_mod=deps.asyncio_mod,
         )
-    except asyncio_mod.CancelledError:
+    except deps.asyncio_mod.CancelledError:
         raise
     finally:
         prune_combo_action_task(manager, combo_id, task)
@@ -1456,9 +1429,7 @@ async def combo_rapidfire_relative(
     hold_ms: int,
     wait_ms: int,
     *,
-    asyncio_mod: _AsyncioModule,
-    evdev_mod: _EvdevModule,
-    uinput_writer: UInputWriter,
+    deps: ComboRuntimeDeps,
 ) -> None:
     try:
         await rapidfire_relative_pulses(
@@ -1466,15 +1437,14 @@ async def combo_rapidfire_relative(
                 uinput_dev,
                 code,
                 value,
-                evdev_mod=evdev_mod,
-                uinput_writer=uinput_writer,
+                deps=deps,
             ),
             is_active=lambda: _combo_action_active(manager, combo_id),
             hold_s=max(0.001, hold_ms / 1000.0),
             wait_s=max(0.001, wait_ms / 1000.0),
-            asyncio_mod=asyncio_mod,
+            asyncio_mod=deps.asyncio_mod,
         )
-    except asyncio_mod.CancelledError:
+    except deps.asyncio_mod.CancelledError:
         raise
 
 
@@ -1485,9 +1455,7 @@ async def combo_rapidfire_trigger(
     hold_ms: int,
     wait_ms: int,
     *,
-    asyncio_mod: _AsyncioModule,
-    evdev_mod: _EvdevModule,
-    uinput_writer: UInputWriter,
+    deps: ComboRuntimeDeps,
 ) -> None:
     try:
         while _combo_action_active(manager, combo_id):
@@ -1495,24 +1463,22 @@ async def combo_rapidfire_trigger(
                 manager,
                 axis_code,
                 255,
-                evdev_mod=evdev_mod,
-                uinput_writer=uinput_writer,
+                deps=deps,
             )
-            await asyncio_mod.sleep(max(0.001, hold_ms / 1000.0))
+            await deps.asyncio_mod.sleep(max(0.001, hold_ms / 1000.0))
             if not _combo_action_active(manager, combo_id):
                 break
             write_combo_trigger(
                 manager,
                 axis_code,
                 0,
-                evdev_mod=evdev_mod,
-                uinput_writer=uinput_writer,
+                deps=deps,
             )
-            await asyncio_mod.sleep(max(0.001, wait_ms / 1000.0))
-    except asyncio_mod.CancelledError:
+            await deps.asyncio_mod.sleep(max(0.001, wait_ms / 1000.0))
+    except deps.asyncio_mod.CancelledError:
         raise
     finally:
-        write_combo_trigger(manager, axis_code, 0, evdev_mod=evdev_mod, uinput_writer=uinput_writer)
+        write_combo_trigger(manager, axis_code, 0, deps=deps)
 
 
 def write_combo_key(
@@ -1520,13 +1486,12 @@ def write_combo_key(
     code: int,
     value: int,
     *,
-    evdev_mod: _EvdevModule,
-    uinput_writer: UInputWriter,
+    deps: ComboRuntimeDeps,
 ) -> None:
-    writer = uinput_writer(uinput_dev)
+    writer = deps.uinput_writer(uinput_dev)
     if writer is None:
         return
-    writer.write(evdev_mod.ecodes.EV_KEY, int(code), int(value))
+    writer.write(deps.evdev_mod.ecodes.EV_KEY, int(code), int(value))
     writer.syn()
 
 
@@ -1535,15 +1500,14 @@ def write_combo_relative(
     code: int,
     value: int,
     *,
-    evdev_mod: _EvdevModule,
-    uinput_writer: UInputWriter,
+    deps: ComboRuntimeDeps,
 ) -> None:
     write_relative_pulse(
         uinput_dev,
         code,
         value,
-        ev_rel_code=evdev_mod.ecodes.EV_REL,
-        uinput_writer=uinput_writer,
+        ev_rel_code=deps.evdev_mod.ecodes.EV_REL,
+        uinput_writer=deps.uinput_writer,
     )
 
 
@@ -1552,13 +1516,12 @@ def write_combo_trigger(
     axis_code: int,
     value: int,
     *,
-    evdev_mod: _EvdevModule,
-    uinput_writer: UInputWriter,
+    deps: ComboRuntimeDeps,
 ) -> None:
-    writer = uinput_writer(manager.output_state.gamepad_uinput)
+    writer = deps.uinput_writer(manager.output_state.gamepad_uinput)
     if writer is None:
         return
-    writer.write(evdev_mod.ecodes.EV_ABS, int(axis_code), int(value))
+    writer.write(deps.evdev_mod.ecodes.EV_ABS, int(axis_code), int(value))
     writer.syn()
 
 

--- a/keymasq/keymasqd/runtime/grab_lifecycle.py
+++ b/keymasq/keymasqd/runtime/grab_lifecycle.py
@@ -206,29 +206,17 @@ def _manager_op_lock(manager: _GrabManager) -> asyncio.Lock:
     return manager._op_lock  # pyright: ignore[reportPrivateUsage]
 
 
-def _combo_asyncio_runtime() -> runtime_combos._AsyncioModule:  # pyright: ignore[reportPrivateUsage]
-    return cast(runtime_combos._AsyncioModule, ASYNCIO_RUNTIME)  # pyright: ignore[reportPrivateUsage]
-
-
-def _combo_evdev_runtime() -> runtime_combos._EvdevModule:  # pyright: ignore[reportPrivateUsage]
-    return cast(runtime_combos._EvdevModule, COMBO_EVDEV_RUNTIME)  # pyright: ignore[reportPrivateUsage]
-
-
-def _combo_uinput_writer() -> runtime_combos.UInputWriter:
-    return _identity_uinput
-
-
 def _combo_runtime_deps(
     *,
     resolve_code_fn: runtime_combos.ResolveCodeFn = resolve_output_code,
     fire_and_observe_fn: runtime_combos.FireAndObserve = _fire_and_forget,
 ) -> runtime_combos.ComboRuntimeDeps:
     return runtime_combos.ComboRuntimeDeps(
-        asyncio_mod=_combo_asyncio_runtime(),
+        asyncio_mod=cast(runtime_combos._AsyncioModule, ASYNCIO_RUNTIME),  # pyright: ignore[reportPrivateUsage]
         contextlib_mod=contextlib,
         time_mod=time,
-        evdev_mod=_combo_evdev_runtime(),
-        uinput_writer=_combo_uinput_writer(),
+        evdev_mod=cast(runtime_combos._EvdevModule, COMBO_EVDEV_RUNTIME),  # pyright: ignore[reportPrivateUsage]
+        uinput_writer=_identity_uinput,
         emit_mouse_move_fn=_combo_emit_mouse_move,
         get_trigger_axis_fn=get_trigger_axis,
         resolve_code_fn=resolve_code_fn,

--- a/keymasq/keymasqd/runtime/grab_lifecycle.py
+++ b/keymasq/keymasqd/runtime/grab_lifecycle.py
@@ -212,10 +212,10 @@ def _combo_runtime_deps(
     fire_and_observe_fn: runtime_combos.FireAndObserve = _fire_and_forget,
 ) -> runtime_combos.ComboRuntimeDeps:
     return runtime_combos.ComboRuntimeDeps(
-        asyncio_mod=cast(runtime_combos._AsyncioModule, ASYNCIO_RUNTIME),  # pyright: ignore[reportPrivateUsage]
+        asyncio_mod=ASYNCIO_RUNTIME,
         contextlib_mod=contextlib,
         time_mod=time,
-        evdev_mod=cast(runtime_combos._EvdevModule, COMBO_EVDEV_RUNTIME),  # pyright: ignore[reportPrivateUsage]
+        evdev_mod=COMBO_EVDEV_RUNTIME,
         uinput_writer=_identity_uinput,
         emit_mouse_move_fn=_combo_emit_mouse_move,
         get_trigger_axis_fn=get_trigger_axis,

--- a/keymasq/keymasqd/runtime/grab_lifecycle.py
+++ b/keymasq/keymasqd/runtime/grab_lifecycle.py
@@ -1,7 +1,5 @@
 import asyncio
-import contextlib
 import logging
-import time
 from collections.abc import Awaitable, Callable, Sequence
 from typing import Any, cast
 
@@ -9,7 +7,7 @@ import evdev
 
 from keymasq.common.devices import resolve_evdev_event_type
 from keymasq.common.models import DeviceType, MappingAction
-from keymasq.keymasqd.combo_engine import ComboDecision, ComboInputEvent, RuntimeComboBinding
+from keymasq.keymasqd.combo_engine import ComboDecision
 from keymasq.keymasqd.output_helpers import get_trigger_axis, resolve_output_code
 from keymasq.keymasqd.runtime import actions as runtime_actions
 from keymasq.keymasqd.runtime import adapters as runtime_adapters
@@ -57,8 +55,6 @@ def _combo_runtime_deps(
 ) -> runtime_combos.ComboRuntimeDeps:
     return runtime_combos.ComboRuntimeDeps(
         asyncio_mod=ASYNCIO_RUNTIME,
-        contextlib_mod=contextlib,
-        time_mod=time,
         evdev_mod=COMBO_EVDEV_RUNTIME,
         uinput_writer=runtime_adapters.identity_uinput_writer,
         emit_mouse_move_fn=runtime_adapters.combo_emit_mouse_move,
@@ -172,8 +168,6 @@ async def grab_device_unlocked(
             source,
             resolve_stable_path_fn=resolve_stable_path_fn,
             get_interface_id_fn=get_interface_id_fn,
-            combo_binding_cls=RuntimeComboBinding,
-            combo_input_event_cls=ComboInputEvent,
             int_value_fn=int_value_fn,
             str_value_fn=str_value_fn,
             deps=_combo_runtime_deps(fire_and_observe_fn=fire_and_observe_fn),

--- a/keymasq/keymasqd/runtime/grab_lifecycle.py
+++ b/keymasq/keymasqd/runtime/grab_lifecycle.py
@@ -8,8 +8,7 @@ from typing import Final, Protocol, TypeVar, cast
 import evdev
 
 from keymasq.common.devices import resolve_evdev_event_type
-from keymasq.common.ipc import CommandType
-from keymasq.common.models import ActionType, DeviceType, MappingAction
+from keymasq.common.models import DeviceType, MappingAction
 from keymasq.keymasqd.combo_engine import ComboDecision, ComboInputEvent, RuntimeComboBinding
 from keymasq.keymasqd.output_helpers import get_trigger_axis, resolve_output_code
 from keymasq.keymasqd.runtime import actions as runtime_actions
@@ -219,6 +218,24 @@ def _combo_uinput_writer() -> runtime_combos.UInputWriter:
     return _identity_uinput
 
 
+def _combo_runtime_deps(
+    *,
+    resolve_code_fn: runtime_combos.ResolveCodeFn = resolve_output_code,
+    fire_and_observe_fn: runtime_combos.FireAndObserve = _fire_and_forget,
+) -> runtime_combos.ComboRuntimeDeps:
+    return runtime_combos.ComboRuntimeDeps(
+        asyncio_mod=_combo_asyncio_runtime(),
+        contextlib_mod=contextlib,
+        time_mod=time,
+        evdev_mod=_combo_evdev_runtime(),
+        uinput_writer=_combo_uinput_writer(),
+        emit_mouse_move_fn=_combo_emit_mouse_move,
+        get_trigger_axis_fn=get_trigger_axis,
+        resolve_code_fn=resolve_code_fn,
+        fire_and_observe_fn=fire_and_observe_fn,
+    )
+
+
 def _outputs_manager(manager: _GrabManager) -> runtime_outputs._OutputManager:  # pyright: ignore[reportPrivateUsage]
     return cast(runtime_outputs._OutputManager, manager)  # pyright: ignore[reportPrivateUsage]
 
@@ -348,24 +365,13 @@ async def grab_device_unlocked(
             event_value,
             stable_path,
             source,
-            evdev_mod=_combo_evdev_runtime(),
             resolve_stable_path_fn=resolve_stable_path_fn,
             get_interface_id_fn=get_interface_id_fn,
             combo_binding_cls=RuntimeComboBinding,
             combo_input_event_cls=ComboInputEvent,
             int_value_fn=int_value_fn,
             str_value_fn=str_value_fn,
-            time_mod=time,
-            action_type_enum=ActionType,
-            mapping_action_cls=MappingAction,
-            emit_mouse_move_fn=_combo_emit_mouse_move,
-            get_trigger_axis_fn=get_trigger_axis,
-            resolve_code_fn=resolve_output_code,
-            fire_and_observe_fn=fire_and_observe_fn,
-            command_type=CommandType,
-            asyncio_mod=_combo_asyncio_runtime(),
-            contextlib_mod=contextlib,
-            uinput_writer=_combo_uinput_writer(),
+            deps=_combo_runtime_deps(fire_and_observe_fn=fire_and_observe_fn),
         )
 
     async def runtime_cleanup_callback(
@@ -376,18 +382,7 @@ async def grab_device_unlocked(
             manager,
             cleanup_hardware_id,
             cleanup_source,
-            asyncio_mod=_combo_asyncio_runtime(),
-            contextlib_mod=contextlib,
-            mapping_action_cls=MappingAction,
-            evdev_mod=_combo_evdev_runtime(),
-            uinput_writer=_combo_uinput_writer(),
-            emit_mouse_move_fn=_combo_emit_mouse_move,
-            get_trigger_axis_fn=get_trigger_axis,
-            resolve_code_fn=resolve_output_code,
-            fire_and_observe_fn=fire_and_observe_fn,
-            command_type=CommandType,
-            action_type_enum=ActionType,
-            time_mod=time,
+            deps=_combo_runtime_deps(fire_and_observe_fn=fire_and_observe_fn),
         )
 
     for path in sorted(requested_paths):
@@ -603,18 +598,7 @@ async def release_device_unlocked(
         manager,
         hardware_id,
         None,
-        asyncio_mod=_combo_asyncio_runtime(),
-        contextlib_mod=contextlib,
-        mapping_action_cls=MappingAction,
-        evdev_mod=_combo_evdev_runtime(),
-        uinput_writer=_combo_uinput_writer(),
-        emit_mouse_move_fn=_combo_emit_mouse_move,
-        get_trigger_axis_fn=get_trigger_axis,
-        resolve_code_fn=resolve_output_code,
-        fire_and_observe_fn=_fire_and_forget,
-        command_type=CommandType,
-        action_type_enum=ActionType,
-        time_mod=time,
+        deps=_combo_runtime_deps(),
     )
     manager.grab_state.desired_grabs.pop(hardware_id, None)
     devices = manager.grabbed_devices.pop(hardware_id, [])
@@ -791,18 +775,7 @@ async def release_interface_unlocked(
         manager,
         hardware_id,
         str(getattr(removed, "interface_id", "") or "").lower(),
-        asyncio_mod=_combo_asyncio_runtime(),
-        contextlib_mod=contextlib,
-        mapping_action_cls=MappingAction,
-        evdev_mod=_combo_evdev_runtime(),
-        uinput_writer=_combo_uinput_writer(),
-        emit_mouse_move_fn=_combo_emit_mouse_move,
-        get_trigger_axis_fn=get_trigger_axis,
-        resolve_code_fn=resolve_output_code,
-        fire_and_observe_fn=_fire_and_forget,
-        command_type=CommandType,
-        action_type_enum=ActionType,
-        time_mod=time,
+        deps=_combo_runtime_deps(),
     )
     removed.release_tracked_outputs()
     await removed.release()
@@ -825,18 +798,7 @@ async def release_all_devices(
         await manager.cancel_macro_playback()
         await runtime_combos.clear_combo_runtime(
             manager,
-            asyncio_mod=_combo_asyncio_runtime(),
-            contextlib_mod=contextlib,
-            mapping_action_cls=MappingAction,
-            evdev_mod=_combo_evdev_runtime(),
-            uinput_writer=_combo_uinput_writer(),
-            emit_mouse_move_fn=_combo_emit_mouse_move,
-            get_trigger_axis_fn=get_trigger_axis,
-            resolve_code_fn=resolve_output_code,
-            fire_and_observe_fn=fire_and_observe_fn,
-            command_type=CommandType,
-            action_type_enum=ActionType,
-            time_mod=time,
+            deps=_combo_runtime_deps(fire_and_observe_fn=fire_and_observe_fn),
         )
         hardware_ids = set(manager.grabbed_devices) | set(manager.grab_state.desired_grabs)
         for hardware_id in list(hardware_ids):

--- a/keymasq/keymasqd/runtime/grab_lifecycle.py
+++ b/keymasq/keymasqd/runtime/grab_lifecycle.py
@@ -2,8 +2,8 @@ import asyncio
 import contextlib
 import logging
 import time
-from collections.abc import Awaitable, Callable, Coroutine, Mapping, Sequence
-from typing import Final, Protocol, TypeVar, cast
+from collections.abc import Awaitable, Callable, Sequence
+from typing import Any, cast
 
 import evdev
 
@@ -17,7 +17,6 @@ from keymasq.keymasqd.runtime import combos as runtime_combos
 from keymasq.keymasqd.runtime import outputs as runtime_outputs
 
 log = logging.getLogger("keymasqd.devices")
-_T = TypeVar("_T")
 type JsonObject = dict[str, object]
 type JsonObjectFn = Callable[[object], JsonObject | None]
 type StrValueFn = Callable[..., str]
@@ -30,135 +29,10 @@ type GetInterfaceIdFn = Callable[[str], str | None]
 type PrimaryInputClassFn = Callable[[set[DeviceType]], DeviceType]
 type FireAndObserve = Callable[[Awaitable[object], str], asyncio.Task[object]]
 type DesiredGrabConfigFactory = Callable[..., object]
-
-
-class _WritableUInput(Protocol):
-    def write(self, event_type: int, code: int, value: int) -> None: ...
-
-    def syn(self) -> None: ...
-
-    def close(self) -> None: ...
-
-
-type UInputWriter = Callable[[object | None], _WritableUInput | None]
-
-
-class _InputDevice(Protocol):
-    path: str
-
-    def capabilities(self) -> dict[int, Sequence[object]]: ...
-
-
-class _ManagedGrabbedDevice(Protocol):
-    path: str
-    hardware_id: str
-    interface_id: str
-
-    def update_button_map(
-        self,
-        button_map: dict[str, str],
-        button_codes: dict[str, int],
-        button_values: dict[str, int] | None = None,
-    ) -> None: ...
-
-    async def grab(self) -> None: ...
-
-    async def release(self) -> None: ...
-
-    def release_tracked_outputs(self) -> None: ...
-
-    def has_held_source_inputs(self) -> bool: ...
-
-    def emit_combo_release(self, evdev_name: str) -> None: ...
-
-    def emit_combo_press(self, evdev_name: str) -> None: ...
-
-    def combo_passthrough_binding_active(self, evdev_name: str) -> bool: ...
-
-    def combo_source_binding_held(self, evdev_name: str) -> bool: ...
-
-    def combo_binding_recalled(self, evdev_name: str) -> bool: ...
-
-    def mark_combo_recalled_binding(self, evdev_name: str) -> None: ...
-
-    def clear_combo_recalled_binding(self, evdev_name: str) -> None: ...
-
-    def combo_passthrough_held_modifiers(self) -> set[str]: ...
-
-    def combo_held_source_bindings(self) -> set[str]: ...
-
-    async def reset_mapping_runtime_state(self) -> None: ...
-
-
-type GrabbedDeviceFactory = Callable[..., _ManagedGrabbedDevice]
-
-
-class _OutputState(Protocol):
-    device_count: int
-    keyboard_uinput: _WritableUInput | None
-    mouse_uinput: _WritableUInput | None
-    gamepad_uinput: _WritableUInput | None
-
-
-class _MacroState(Protocol):
-    mouse_rel_suppressed: bool
-
-
-class _GrabState(Protocol):
-    release_grace_s: float
-    held_release_retry_s: float
-    desired_paths: dict[str, set[str]]
-    desired_grabs: dict[str, object]
-    pending_interface_release: dict[tuple[str, str], asyncio.Task[None]]
-    pending_hardware_release: dict[str, asyncio.Task[None]]
-
-
-class _GrabManager(Protocol):
-    grabbed_devices: dict[str, list[_ManagedGrabbedDevice]]
-    active_mappings: dict[str, dict[str, MappingAction]]
-    verbosity: int
-    broadcast_callback: Callable[[object, JsonObject], Awaitable[None]] | None
-    recording_manager: object | None
-    output_state: _OutputState
-    macro_state: _MacroState
-    grab_state: _GrabState
-    combo_state: runtime_combos.ComboRuntimeState
-    _op_lock: asyncio.Lock
-    _device_input: Callable[[str], _InputDevice]
-
-    async def play_macro(self, **kwargs: object) -> JsonObject: ...
-
-    async def set_cursor_position(self, x: int, y: int) -> JsonObject: ...
-
-    async def cancel_macro_playback(self) -> JsonObject: ...
-
-    def _detect_device_types(self, raw_device: _InputDevice) -> set[DeviceType]: ...
-
-    def _record_diagnostic(self, label: str, duration_us: float) -> None: ...
-
-
-class _ErrnoModule(Protocol):
-    EBUSY: Final[int]
-    ENOENT: Final[int]
-    ENODEV: Final[int]
-
-
-class _AsyncioModule(Protocol):
-    async def sleep(self, delay: float, /) -> None: ...
-
-    def create_task(self, coro: Coroutine[object, object, _T], /) -> asyncio.Task[_T]: ...
-
-    def current_task(self) -> asyncio.Task[None] | None: ...
-
-
-class _Ecodes(Protocol):
-    EV_SYN: Final[int]
-    bytype: Final[Mapping[int, Mapping[int, object]]]
-
-
-class _EvdevModule(Protocol):
-    @property
-    def ecodes(self) -> _Ecodes: ...
+type GrabbedDeviceFactory = Callable[..., Any]
+type _ManagedGrabbedDevice = Any
+type _GrabManager = Any
+type _ErrnoModule = Any
 
 
 ASYNCIO_RUNTIME = runtime_adapters.ASYNCIO_RUNTIME
@@ -167,43 +41,13 @@ COMBO_EVDEV_RUNTIME = runtime_adapters.COMBO_EVDEV_RUNTIME
 
 def _normalize_evdev_name(value: object, default: str) -> str:
     if isinstance(value, (tuple, list)):
-        return default if not value else str(cast(object, value[0]))
+        items = cast(Sequence[object], value)
+        return default if not items else str(items[0])
     return str(value)
-
-
-def _identity_uinput(device: object | None) -> _WritableUInput | None:
-    return cast(_WritableUInput | None, runtime_adapters.identity_uinput_writer(device))
 
 
 def _fire_and_forget(coro: Awaitable[object], _label: str) -> asyncio.Task[object]:
     return asyncio.ensure_future(coro)
-
-
-def _manager_device_input(manager: _GrabManager, path: str) -> _InputDevice:
-    device_input = manager._device_input  # pyright: ignore[reportPrivateUsage]
-    return device_input(path)
-
-
-def _manager_detect_device_types(
-    manager: _GrabManager, raw_device: _InputDevice
-) -> set[DeviceType]:
-    detect_device_types = cast(
-        Callable[[_InputDevice], set[DeviceType]],
-        manager._detect_device_types,  # pyright: ignore[reportPrivateUsage]
-    )
-    return detect_device_types(raw_device)
-
-
-def _manager_record_diagnostic(manager: _GrabManager, label: str, duration_us: float) -> None:
-    record_diagnostic = cast(
-        Callable[[str, float], None],
-        manager._record_diagnostic,  # pyright: ignore[reportPrivateUsage]
-    )
-    record_diagnostic(label, duration_us)
-
-
-def _manager_op_lock(manager: _GrabManager) -> asyncio.Lock:
-    return manager._op_lock  # pyright: ignore[reportPrivateUsage]
 
 
 def _combo_runtime_deps(
@@ -216,38 +60,11 @@ def _combo_runtime_deps(
         contextlib_mod=contextlib,
         time_mod=time,
         evdev_mod=COMBO_EVDEV_RUNTIME,
-        uinput_writer=_identity_uinput,
-        emit_mouse_move_fn=_combo_emit_mouse_move,
+        uinput_writer=runtime_adapters.identity_uinput_writer,
+        emit_mouse_move_fn=runtime_adapters.combo_emit_mouse_move,
         get_trigger_axis_fn=get_trigger_axis,
         resolve_code_fn=resolve_code_fn,
         fire_and_observe_fn=fire_and_observe_fn,
-    )
-
-
-def _outputs_manager(manager: _GrabManager) -> runtime_outputs._OutputManager:  # pyright: ignore[reportPrivateUsage]
-    return cast(runtime_outputs._OutputManager, manager)  # pyright: ignore[reportPrivateUsage]
-
-
-def _outputs_evdev_runtime() -> runtime_outputs._EvdevModule:  # pyright: ignore[reportPrivateUsage]
-    return cast(runtime_outputs._EvdevModule, evdev)  # pyright: ignore[reportPrivateUsage]
-
-
-def _outputs_uinput_writer() -> runtime_outputs.UInputWriter:
-    return _identity_uinput
-
-
-def _combo_emit_mouse_move(
-    uinput_dev: object | None,
-    move_x: int,
-    move_y: int,
-    *,
-    absolute: bool = False,
-) -> None:
-    runtime_adapters.combo_emit_mouse_move(
-        uinput_dev,
-        move_x,
-        move_y,
-        absolute=absolute,
     )
 
 
@@ -377,7 +194,7 @@ async def grab_device_unlocked(
         if path in existing_by_path:
             continue
         try:
-            raw_device = _manager_device_input(manager, path)
+            raw_device = manager._device_input(path)
             available_count += 1
             caps = raw_device.capabilities()
             has_mapped_buttons = device_has_mapped_buttons(
@@ -390,20 +207,20 @@ async def grab_device_unlocked(
             if has_mapped_buttons or force_grab_unmapped:
                 if hardware_id not in manager.grabbed_devices and not created_global_uinputs:
                     runtime_outputs.create_global_uinputs(
-                        _outputs_manager(manager),
-                        evdev_mod=_outputs_evdev_runtime(),
+                        manager,
+                        evdev_mod=evdev,  # pyright: ignore[reportArgumentType]
                         log=log,
-                        uinput_writer=_outputs_uinput_writer(),
+                        uinput_writer=runtime_adapters.identity_uinput_writer,
                     )
                     created_global_uinputs = True
-                detected_types = _manager_detect_device_types(manager, raw_device)
+                detected_types = manager._detect_device_types(raw_device)
                 detected_type = primary_input_class_fn(detected_types)
 
                 def mapping_getter(hid: str = hardware_id) -> dict[str, MappingAction]:
                     return manager.active_mappings.get(hid, {})
 
                 def diagnostics_recorder(label: str, duration_us: float) -> None:
-                    _manager_record_diagnostic(manager, label, duration_us)
+                    manager._record_diagnostic(label, duration_us)
 
                 device = grabbed_device_cls(
                     path=path,
@@ -454,7 +271,7 @@ async def grab_device_unlocked(
                     continue
                 await device.release()
             if created_global_uinputs:
-                runtime_outputs.destroy_global_uinputs(_outputs_manager(manager), log=log)
+                runtime_outputs.destroy_global_uinputs(manager, log=log)
             raise
         except Exception as exc:
             log.error("Failed to grab %s: %s", path, exc)
@@ -463,7 +280,7 @@ async def grab_device_unlocked(
                     continue
                 await device.release()
             if created_global_uinputs:
-                runtime_outputs.destroy_global_uinputs(_outputs_manager(manager), log=log)
+                runtime_outputs.destroy_global_uinputs(manager, log=log)
             raise
 
     waiting_for_device = bool(requested_paths and available_count == 0 and not devices)
@@ -475,7 +292,7 @@ async def grab_device_unlocked(
         and grabbed_count == 0
     ):
         if created_global_uinputs:
-            runtime_outputs.destroy_global_uinputs(_outputs_manager(manager), log=log)
+            runtime_outputs.destroy_global_uinputs(manager, log=log)
         raise ValueError(
             f"No interfaces for {hardware_id} matched mapped buttons "
             f"(paths={len(requested_paths)}, mapped_names={len(mapped_evdev_names)}, "
@@ -507,7 +324,7 @@ async def grab_with_retry(
     device: _ManagedGrabbedDevice,
     path: str,
     *,
-    asyncio_mod: _AsyncioModule,
+    asyncio_mod: runtime_adapters.AsyncioRuntimeAdapter,
     log: logging.Logger,
     errno_mod: _ErrnoModule,
 ) -> None:
@@ -544,7 +361,7 @@ def device_has_mapped_buttons(
     mapped_evdev_names: set[str],
     mapped_bindings: set[tuple[int, int]] | None,
     *,
-    evdev_mod: _EvdevModule,
+    evdev_mod: Any,
 ) -> bool:
     mapped_binding_set = {
         (int(event_type), int(code)) for event_type, code in (mapped_bindings or set())
@@ -594,7 +411,7 @@ async def release_device_unlocked(
     for device in devices:
         await device.release()
 
-    runtime_outputs.destroy_global_uinputs(_outputs_manager(manager), log=log)
+    runtime_outputs.destroy_global_uinputs(manager, log=log)
     manager.active_mappings.pop(hardware_id, None)
     manager.grab_state.desired_paths.pop(hardware_id, None)
     log.info("Released device %s", hardware_id)
@@ -606,7 +423,7 @@ def schedule_hardware_release_unlocked(
     hardware_id: str,
     grace_s: float | None,
     *,
-    asyncio_mod: _AsyncioModule,
+    asyncio_mod: runtime_adapters.AsyncioRuntimeAdapter,
     log: logging.Logger,
 ) -> dict[str, object]:
     devices = manager.grabbed_devices.get(hardware_id, [])
@@ -641,14 +458,14 @@ async def delayed_hardware_release(
     hardware_id: str,
     delay: float,
     *,
-    asyncio_mod: _AsyncioModule,
+    asyncio_mod: runtime_adapters.AsyncioRuntimeAdapter,
     log: logging.Logger,
 ) -> None:
     next_delay = float(delay)
     try:
         while True:
             await asyncio_mod.sleep(next_delay)
-            async with _manager_op_lock(manager):
+            async with manager._op_lock:
                 task = manager.grab_state.pending_hardware_release.get(hardware_id)
                 if task is not asyncio_mod.current_task():
                     return
@@ -707,7 +524,7 @@ def schedule_interface_release(
     hardware_id: str,
     path: str,
     *,
-    asyncio_mod: _AsyncioModule,
+    asyncio_mod: runtime_adapters.AsyncioRuntimeAdapter,
     log: logging.Logger,
 ) -> None:
     cancel_pending_interface_release(manager, hardware_id, path)
@@ -724,12 +541,12 @@ async def delayed_interface_release(
     path: str,
     delay: float,
     *,
-    asyncio_mod: _AsyncioModule,
+    asyncio_mod: runtime_adapters.AsyncioRuntimeAdapter,
 ) -> None:
     key = (hardware_id, path)
     try:
         await asyncio_mod.sleep(delay)
-        async with _manager_op_lock(manager):
+        async with manager._op_lock:
             task = manager.grab_state.pending_interface_release.get(key)
             if task is not asyncio_mod.current_task():
                 return
@@ -776,13 +593,13 @@ async def release_interface_unlocked(
             manager.active_mappings.pop(hardware_id, None)
             manager.grab_state.desired_paths.pop(hardware_id, None)
             manager.grab_state.desired_grabs.pop(hardware_id, None)
-        runtime_outputs.destroy_global_uinputs(_outputs_manager(manager), log=log)
+        runtime_outputs.destroy_global_uinputs(manager, log=log)
 
 
 async def release_all_devices(
     manager: _GrabManager, *, fire_and_observe_fn: FireAndObserve
 ) -> None:
-    async with _manager_op_lock(manager):
+    async with manager._op_lock:
         await manager.cancel_macro_playback()
         await runtime_combos.clear_combo_runtime(
             manager,
@@ -806,7 +623,7 @@ async def set_mapping(
     float_value_fn: FloatValueFn,
     log: logging.Logger,
 ) -> dict[str, object]:
-    async with _manager_op_lock(manager):
+    async with manager._op_lock:
         cancel_pending_hardware_release(manager, hardware_id)
         if hardware_id not in manager.grabbed_devices:
             raise ValueError(f"Device {hardware_id} not grabbed")

--- a/keymasq/keymasqd/runtime/grabbed_device.py
+++ b/keymasq/keymasqd/runtime/grabbed_device.py
@@ -1,8 +1,8 @@
 import asyncio
 import logging
 import time
-from collections.abc import Awaitable, Callable, Coroutine, Sequence
-from typing import Final, TypeVar, cast
+from collections.abc import Awaitable, Callable, Sequence
+from typing import Final, cast
 
 import evdev
 
@@ -16,15 +16,10 @@ from keymasq.common.devices import (
 from keymasq.common.models import ActionType, DeviceType, MappingAction
 from keymasq.keymasqd.output_helpers import resolve_output_code
 from keymasq.keymasqd.recording import RecordingManager
+from keymasq.keymasqd.runtime import adapters as runtime_adapters
 from keymasq.keymasqd.runtime import grabbed_device_events as runtime_events
 from keymasq.keymasqd.runtime import grabbed_device_grab as runtime_grab
 from keymasq.keymasqd.runtime import grabbed_device_outputs as runtime_outputs
-from keymasq.keymasqd.runtime.grabbed_device_types import (
-    AsyncioEvent as _AsyncioEvent,
-)
-from keymasq.keymasqd.runtime.grabbed_device_types import (
-    AsyncioLoop as _AsyncioLoop,
-)
 from keymasq.keymasqd.runtime.grabbed_device_types import (
     AsyncioModule as _AsyncioModule,
 )
@@ -35,6 +30,7 @@ from keymasq.keymasqd.runtime.grabbed_device_types import (
     GrabbedDeviceState,
     MacroPlayer,
     MappingGetter,
+    identity_uinput_writer,
 )
 from keymasq.keymasqd.runtime.grabbed_device_types import (
     ManagedInputDevice as _ManagedInputDevice,
@@ -49,8 +45,6 @@ ACTIVE_KEY_IDLE_LOG_INTERVAL_S = 1.0
 ACTIVE_KEY_IDLE_MAX_WAIT_S = 300.0
 COMBO_HELD_REARM_MODIFIERS = frozenset({"shift", "ctrl", "alt", "meta"})
 
-_T = TypeVar("_T")
-
 __all__ = [
     "ASYNCIO_RUNTIME",
     "ACTIVE_KEY_IDLE_LOG_INTERVAL_S",
@@ -63,36 +57,7 @@ __all__ = [
 ]
 
 
-class _AsyncioRuntimeAdapter:
-    def get_running_loop(self) -> _AsyncioLoop:
-        return asyncio.get_running_loop()
-
-    def create_event(self) -> _AsyncioEvent:
-        return asyncio.Event()
-
-    def wait_for(self, aw: Awaitable[_T], timeout: float) -> Awaitable[_T]:
-        return asyncio.wait_for(aw, timeout)
-
-    async def sleep(self, delay: float, /) -> None:
-        await asyncio.sleep(delay)
-
-    def current_task(self) -> asyncio.Task[object] | None:
-        return cast(asyncio.Task[object] | None, asyncio.current_task())
-
-    def create_task(self, coro: Coroutine[object, object, _T], /) -> asyncio.Task[_T]:
-        return asyncio.create_task(coro)
-
-    def to_thread(
-        self,
-        func: Callable[..., _T],
-        /,
-        *args: object,
-        **kwargs: object,
-    ) -> Awaitable[_T]:
-        return asyncio.to_thread(func, *args, **kwargs)
-
-
-ASYNCIO_RUNTIME: Final[_AsyncioModule] = _AsyncioRuntimeAdapter()
+ASYNCIO_RUNTIME: Final[_AsyncioModule] = cast(_AsyncioModule, runtime_adapters.ASYNCIO_RUNTIME)
 
 
 def _device_input(path: str) -> _ManagedInputDevice:
@@ -100,7 +65,7 @@ def _device_input(path: str) -> _ManagedInputDevice:
 
 
 def _uinput_writer(device: object | None) -> _WritableUInput | None:
-    return cast(_WritableUInput | None, device)
+    return identity_uinput_writer(device)
 
 
 class GrabbedDevice:

--- a/keymasq/keymasqd/runtime/grabbed_device_actions.py
+++ b/keymasq/keymasqd/runtime/grabbed_device_actions.py
@@ -1,9 +1,9 @@
-import contextlib
 import logging
 from collections.abc import Callable
 from typing import cast
 
-from keymasq.common.models import MappingAction, SuperkeyMode
+from keymasq.common.ipc import CommandType
+from keymasq.common.models import ActionType, MappingAction, SuperkeyMode
 from keymasq.keymasqd.output_helpers import (
     get_trigger_axis,
     resolve_output_code,
@@ -58,18 +58,16 @@ async def execute_action(
     shared_output_tracker: Callable[[str, int, int], bool] | None = None,
 ) -> None:
     asyncio_mod = deps.asyncio_mod
-    action_type_enum = deps.action_type_enum
     evdev_mod = deps.evdev_mod
     uinput_writer = deps.uinput_writer
     fire_and_observe_fn = deps.fire_and_observe_fn
-    superkey_machine_cls: type[SuperkeyMachine] = deps.superkey_machine_cls
-    if action.action_type == action_type_enum.PASSTHROUGH:
+    if action.action_type == ActionType.PASSTHROUGH:
         passthrough(device_runtime, event, evdev_mod=evdev_mod, uinput_writer=uinput_writer)
 
-    elif action.action_type == action_type_enum.SUPPRESS:
+    elif action.action_type == ActionType.SUPPRESS:
         pass
 
-    elif action.action_type == action_type_enum.KEYBOARD:
+    elif action.action_type == ActionType.KEYBOARD:
         await _execute_key_action(
             device_runtime,
             action,
@@ -82,7 +80,7 @@ async def execute_action(
             shared_output_tracker=shared_output_tracker,
         )
 
-    elif action.action_type == action_type_enum.MOUSE:
+    elif action.action_type == ActionType.MOUSE:
         await _execute_mouse_action(
             device_runtime,
             action,
@@ -92,7 +90,7 @@ async def execute_action(
             shared_output_tracker=shared_output_tracker,
         )
 
-    elif action.action_type == action_type_enum.GAMEPAD:
+    elif action.action_type == ActionType.GAMEPAD:
         if action.target:
             is_trigger, axis_code = get_trigger_axis(action.target)
             if is_trigger:
@@ -125,7 +123,6 @@ async def execute_action(
                             device_runtime,
                             event_name,
                             asyncio_mod=asyncio_mod,
-                            contextlib_mod=contextlib,
                         )
                 elif action.tap_enabled:
                     if event.value == 1 and not device_runtime.state.tap_active.get(
@@ -151,7 +148,7 @@ async def execute_action(
                     should_emit = True
                     if shared_output_tracker is not None:
                         should_emit = shared_output_tracker(
-                            action_type_enum.GAMEPAD.value,
+                            ActionType.GAMEPAD.value,
                             axis_code,
                             int(event.value),
                         )
@@ -176,7 +173,7 @@ async def execute_action(
                     shared_output_tracker=shared_output_tracker,
                 )
 
-    elif action.action_type == action_type_enum.EXEC:
+    elif action.action_type == ActionType.EXEC:
         if event.value == 1:
             dispatch_action_trigger(
                 device_runtime.broadcast_callback,
@@ -186,11 +183,10 @@ async def execute_action(
                     source_button=event_name,
                 ),
                 fire_and_observe_fn=fire_and_observe_fn,
-                command_type=deps.command_type,
                 label=f"exec action {event_name}",
             )
 
-    elif action.action_type == action_type_enum.COMPOSITOR_DISPATCH:
+    elif action.action_type == ActionType.COMPOSITOR_DISPATCH:
         if event.value == 1:
             dispatch_action_trigger(
                 device_runtime.broadcast_callback,
@@ -200,11 +196,10 @@ async def execute_action(
                     source_button=event_name,
                 ),
                 fire_and_observe_fn=fire_and_observe_fn,
-                command_type=deps.command_type,
                 label=f"compositor action {event_name}",
             )
 
-    elif action.action_type == action_type_enum.START_MACRO_RECORDING:
+    elif action.action_type == ActionType.START_MACRO_RECORDING:
         if event.value == 1:
             dispatch_action_trigger(
                 device_runtime.broadcast_callback,
@@ -214,11 +209,10 @@ async def execute_action(
                     source_button=event_name,
                 ),
                 fire_and_observe_fn=fire_and_observe_fn,
-                command_type=deps.command_type,
                 label=f"start recording action {event_name}",
             )
 
-    elif action.action_type == action_type_enum.STOP_MACRO_RECORDING:
+    elif action.action_type == ActionType.STOP_MACRO_RECORDING:
         if event.value == 1:
             dispatch_action_trigger(
                 device_runtime.broadcast_callback,
@@ -228,11 +222,10 @@ async def execute_action(
                     source_button=event_name,
                 ),
                 fire_and_observe_fn=fire_and_observe_fn,
-                command_type=deps.command_type,
                 label=f"stop recording action {event_name}",
             )
 
-    elif action.action_type == action_type_enum.CANCEL_MACRO_PLAYBACK:
+    elif action.action_type == ActionType.CANCEL_MACRO_PLAYBACK:
         if event.value == 1:
             dispatch_action_trigger(
                 device_runtime.broadcast_callback,
@@ -242,14 +235,13 @@ async def execute_action(
                     source_button=event_name,
                 ),
                 fire_and_observe_fn=fire_and_observe_fn,
-                command_type=deps.command_type,
                 label=f"cancel macro action {event_name}",
             )
 
     elif action.action_type in (
-        action_type_enum.PROFILE_ENABLE,
-        action_type_enum.PROFILE_DISABLE,
-        action_type_enum.PROFILE_TOGGLE,
+        ActionType.PROFILE_ENABLE,
+        ActionType.PROFILE_DISABLE,
+        ActionType.PROFILE_TOGGLE,
     ):
         if event.value == 1:
             dispatch_action_trigger(
@@ -260,11 +252,10 @@ async def execute_action(
                     source_button=event_name,
                 ),
                 fire_and_observe_fn=fire_and_observe_fn,
-                command_type=deps.command_type,
                 label=f"profile action {event_name}",
             )
 
-    elif action.action_type == action_type_enum.MACRO:
+    elif action.action_type == ActionType.MACRO:
         macro_request = build_macro_playback_request(
             action,
             source_device=device_runtime.hardware_id,
@@ -277,7 +268,7 @@ async def execute_action(
                 f"macro action {event_name}",
             )
 
-    elif action.action_type in (action_type_enum.MOUSE_MOVE_REL, action_type_enum.MOUSE_MOVE_ABS):
+    elif action.action_type in (ActionType.MOUSE_MOVE_REL, ActionType.MOUSE_MOVE_ABS):
         await _execute_move_action(
             device_runtime,
             action,
@@ -286,7 +277,7 @@ async def execute_action(
             deps=deps,
         )
 
-    elif action.action_type == action_type_enum.SUPERKEY:
+    elif action.action_type == ActionType.SUPERKEY:
         if action.superkey_config:
             if action.superkey_config.mode == SuperkeyMode.OVERLOAD:
                 await _execute_overload_superkey(
@@ -305,7 +296,7 @@ async def execute_action(
                     if device_runtime.broadcast_callback:
                         fire_and_observe_fn(
                             device_runtime.broadcast_callback(
-                                deps.command_type.ACTION_TRIGGER,
+                                CommandType.ACTION_TRIGGER,
                                 data,
                             ),
                             f"superkey action {event_name}",
@@ -323,7 +314,7 @@ async def execute_action(
                         value,
                     )
 
-                machine = superkey_machine_cls(
+                machine = SuperkeyMachine(
                     config=cast(RuntimeSuperkeyConfig, action.superkey_config),
                     event_name=event_name,
                     keyboard_uinput=cast(WritableUInput, device_runtime.keyboard_uinput),
@@ -363,7 +354,7 @@ async def _execute_overload_superkey(
         )
 
     for index, child_action in enumerate(config.overload_actions):
-        if child_action.action_type == deps.action_type_enum.SUPERKEY:
+        if child_action.action_type == ActionType.SUPERKEY:
             log.warning(
                 "Skipping unexpected nested superkey in overload fanout for '%s' at child %d",
                 config.name,
@@ -425,7 +416,6 @@ async def _execute_key_action(
                 device_runtime,
                 event_name,
                 asyncio_mod=deps.asyncio_mod,
-                contextlib_mod=contextlib,
             )
     elif action.tap_enabled:
         if event.value == 1 and not device_runtime.state.tap_active.get(event_name, False):
@@ -536,7 +526,6 @@ async def _execute_relative_mouse_action(
                 device_runtime,
                 event_name,
                 asyncio_mod=deps.asyncio_mod,
-                contextlib_mod=contextlib,
             )
         return
 
@@ -602,7 +591,6 @@ async def _execute_move_action(
                 device_runtime,
                 event_name,
                 asyncio_mod=deps.asyncio_mod,
-                contextlib_mod=contextlib,
             )
     elif action.tap_enabled:
         if event.value == 1 and not device_runtime.state.tap_active.get(event_name, False):
@@ -618,7 +606,7 @@ async def _execute_move_action(
                 f"tap move {event_name}",
             )
     elif event.value == 1:
-        if action.action_type == deps.action_type_enum.MOUSE_MOVE_ABS:
+        if action.action_type == ActionType.MOUSE_MOVE_ABS:
             cursor_position_setter = device_runtime.cursor_position_setter
             if cursor_position_setter is not None:
                 await cursor_position_setter(int(action.move_x), int(action.move_y))

--- a/keymasq/keymasqd/runtime/grabbed_device_actions.py
+++ b/keymasq/keymasqd/runtime/grabbed_device_actions.py
@@ -3,10 +3,7 @@ import logging
 from collections.abc import Callable
 from typing import cast
 
-import evdev
-
-from keymasq.common.ipc import CommandType
-from keymasq.common.models import ActionType, MappingAction, SuperkeyMode
+from keymasq.common.models import MappingAction, SuperkeyMode
 from keymasq.keymasqd.output_helpers import (
     get_trigger_axis,
     resolve_output_code,
@@ -17,6 +14,7 @@ from keymasq.keymasqd.runtime.action_runner import (
     dispatch_action_trigger,
 )
 from keymasq.keymasqd.runtime.grabbed_device_outputs import (
+    bucket_for_uinput,
     emit_configured_mouse_move,
     passthrough,
     track_superkey_output,
@@ -35,12 +33,9 @@ from keymasq.keymasqd.runtime.grabbed_device_repeat import (
     tap_trigger,
 )
 from keymasq.keymasqd.runtime.grabbed_device_types import (
-    AsyncioModule,
-    EvdevModule,
-    FireAndObserve,
+    ActionExecutionDeps,
     GrabbedDeviceRuntime,
     InputEventLike,
-    UInputWriter,
     WritableUInput,
 )
 from keymasq.keymasqd.runtime.mouse_actions import (
@@ -59,15 +54,15 @@ async def execute_action(
     event: InputEventLike,
     event_name: str,
     *,
-    asyncio_mod: AsyncioModule,
-    command_type: type[CommandType],
-    fire_and_observe_fn: FireAndObserve,
-    action_type_enum: type[ActionType],
-    superkey_machine_cls: type[SuperkeyMachine],
-    evdev_mod: EvdevModule,
-    uinput_writer: UInputWriter,
+    deps: ActionExecutionDeps,
     shared_output_tracker: Callable[[str, int, int], bool] | None = None,
 ) -> None:
+    asyncio_mod = deps.asyncio_mod
+    action_type_enum = deps.action_type_enum
+    evdev_mod = deps.evdev_mod
+    uinput_writer = deps.uinput_writer
+    fire_and_observe_fn = deps.fire_and_observe_fn
+    superkey_machine_cls: type[SuperkeyMachine] = deps.superkey_machine_cls
     if action.action_type == action_type_enum.PASSTHROUGH:
         passthrough(device_runtime, event, evdev_mod=evdev_mod, uinput_writer=uinput_writer)
 
@@ -80,8 +75,7 @@ async def execute_action(
             action,
             event,
             event_name,
-            asyncio_mod=asyncio_mod,
-            fire_and_observe_fn=fire_and_observe_fn,
+            deps=deps,
             uinput_dev=device_runtime.keyboard_uinput,
             target_kind="key",
             trigger_kind="key",
@@ -94,10 +88,7 @@ async def execute_action(
             action,
             event,
             event_name,
-            asyncio_mod=asyncio_mod,
-            fire_and_observe_fn=fire_and_observe_fn,
-            evdev_mod=evdev_mod,
-            uinput_writer=uinput_writer,
+            deps=deps,
             shared_output_tracker=shared_output_tracker,
         )
 
@@ -120,9 +111,9 @@ async def execute_action(
                                     action.rapidfire_hold_ms,
                                     action.rapidfire_wait_ms,
                                     event_name,
-                                    asyncio_mod=asyncio_mod,
-                                    evdev_mod=evdev_mod,
-                                    uinput_writer=uinput_writer,
+                                    asyncio_mod=deps.asyncio_mod,
+                                    evdev_mod=deps.evdev_mod,
+                                    uinput_writer=deps.uinput_writer,
                                 )
                             ),
                             axis_code=axis_code,
@@ -147,9 +138,9 @@ async def execute_action(
                                 axis_code,
                                 action.tap_hold_ms,
                                 event_name,
-                                asyncio_mod=asyncio_mod,
-                                evdev_mod=evdev_mod,
-                                uinput_writer=uinput_writer,
+                                asyncio_mod=deps.asyncio_mod,
+                                evdev_mod=deps.evdev_mod,
+                                uinput_writer=deps.uinput_writer,
                             ),
                             f"tap action {event_name}",
                         )
@@ -178,8 +169,7 @@ async def execute_action(
                     action,
                     event,
                     event_name,
-                    asyncio_mod=asyncio_mod,
-                    fire_and_observe_fn=fire_and_observe_fn,
+                    deps=deps,
                     uinput_dev=device_runtime.gamepad_uinput,
                     target_kind="key",
                     trigger_kind="key",
@@ -196,7 +186,7 @@ async def execute_action(
                     source_button=event_name,
                 ),
                 fire_and_observe_fn=fire_and_observe_fn,
-                command_type=command_type,
+                command_type=deps.command_type,
                 label=f"exec action {event_name}",
             )
 
@@ -210,7 +200,7 @@ async def execute_action(
                     source_button=event_name,
                 ),
                 fire_and_observe_fn=fire_and_observe_fn,
-                command_type=command_type,
+                command_type=deps.command_type,
                 label=f"compositor action {event_name}",
             )
 
@@ -224,7 +214,7 @@ async def execute_action(
                     source_button=event_name,
                 ),
                 fire_and_observe_fn=fire_and_observe_fn,
-                command_type=command_type,
+                command_type=deps.command_type,
                 label=f"start recording action {event_name}",
             )
 
@@ -238,7 +228,7 @@ async def execute_action(
                     source_button=event_name,
                 ),
                 fire_and_observe_fn=fire_and_observe_fn,
-                command_type=command_type,
+                command_type=deps.command_type,
                 label=f"stop recording action {event_name}",
             )
 
@@ -252,7 +242,7 @@ async def execute_action(
                     source_button=event_name,
                 ),
                 fire_and_observe_fn=fire_and_observe_fn,
-                command_type=command_type,
+                command_type=deps.command_type,
                 label=f"cancel macro action {event_name}",
             )
 
@@ -270,7 +260,7 @@ async def execute_action(
                     source_button=event_name,
                 ),
                 fire_and_observe_fn=fire_and_observe_fn,
-                command_type=command_type,
+                command_type=deps.command_type,
                 label=f"profile action {event_name}",
             )
 
@@ -293,8 +283,7 @@ async def execute_action(
             action,
             event,
             event_name,
-            asyncio_mod=asyncio_mod,
-            fire_and_observe_fn=fire_and_observe_fn,
+            deps=deps,
         )
 
     elif action.action_type == action_type_enum.SUPERKEY:
@@ -305,13 +294,7 @@ async def execute_action(
                     action,
                     event,
                     event_name,
-                    asyncio_mod=asyncio_mod,
-                    command_type=command_type,
-                    fire_and_observe_fn=fire_and_observe_fn,
-                    action_type_enum=action_type_enum,
-                    superkey_machine_cls=superkey_machine_cls,
-                    evdev_mod=evdev_mod,
-                    uinput_writer=uinput_writer,
+                    deps=deps,
                 )
                 return
 
@@ -321,7 +304,10 @@ async def execute_action(
                 async def superkey_broadcast(data: dict[str, object]) -> None:
                     if device_runtime.broadcast_callback:
                         fire_and_observe_fn(
-                            device_runtime.broadcast_callback(command_type.ACTION_TRIGGER, data),
+                            device_runtime.broadcast_callback(
+                                deps.command_type.ACTION_TRIGGER,
+                                data,
+                            ),
                             f"superkey action {event_name}",
                         )
 
@@ -362,13 +348,7 @@ async def _execute_overload_superkey(
     event: InputEventLike,
     event_name: str,
     *,
-    asyncio_mod: AsyncioModule,
-    command_type: type[CommandType],
-    fire_and_observe_fn: FireAndObserve,
-    action_type_enum: type[ActionType],
-    superkey_machine_cls: type[SuperkeyMachine],
-    evdev_mod: EvdevModule,
-    uinput_writer: UInputWriter,
+    deps: ActionExecutionDeps,
 ) -> None:
     config = action.superkey_config
     if config is None:
@@ -383,7 +363,7 @@ async def _execute_overload_superkey(
         )
 
     for index, child_action in enumerate(config.overload_actions):
-        if child_action.action_type == action_type_enum.SUPERKEY:
+        if child_action.action_type == deps.action_type_enum.SUPERKEY:
             log.warning(
                 "Skipping unexpected nested superkey in overload fanout for '%s' at child %d",
                 config.name,
@@ -396,13 +376,7 @@ async def _execute_overload_superkey(
             child_action,
             event,
             child_event_name,
-            asyncio_mod=asyncio_mod,
-            command_type=command_type,
-            fire_and_observe_fn=fire_and_observe_fn,
-            action_type_enum=action_type_enum,
-            superkey_machine_cls=superkey_machine_cls,
-            evdev_mod=evdev_mod,
-            uinput_writer=uinput_writer,
+            deps=deps,
             shared_output_tracker=overload_output_tracker,
         )
 
@@ -413,8 +387,7 @@ async def _execute_key_action(
     event: InputEventLike,
     event_name: str,
     *,
-    asyncio_mod: AsyncioModule,
-    fire_and_observe_fn: FireAndObserve,
+    deps: ActionExecutionDeps,
     uinput_dev: object | None,
     target_kind: str,
     trigger_kind: str,
@@ -432,7 +405,7 @@ async def _execute_key_action(
                 device_runtime,
                 event_name,
                 trigger_kind,
-                lambda: asyncio_mod.create_task(
+                lambda: deps.asyncio_mod.create_task(
                     rapidfire_key(
                         device_runtime,
                         code,
@@ -440,7 +413,7 @@ async def _execute_key_action(
                         action.rapidfire_wait_ms,
                         event_name,
                         uinput_dev,
-                        asyncio_mod=asyncio_mod,
+                        asyncio_mod=deps.asyncio_mod,
                     )
                 ),
                 code=code,
@@ -451,31 +424,27 @@ async def _execute_key_action(
             await stop_rapidfire_async(
                 device_runtime,
                 event_name,
-                asyncio_mod=asyncio_mod,
+                asyncio_mod=deps.asyncio_mod,
                 contextlib_mod=contextlib,
             )
     elif action.tap_enabled:
         if event.value == 1 and not device_runtime.state.tap_active.get(event_name, False):
             device_runtime.state.tap_active[event_name] = True
-            fire_and_observe_fn(
+            deps.fire_and_observe_fn(
                 tap_key(
                     device_runtime,
                     code,
                     action.tap_hold_ms,
                     event_name,
                     uinput_dev,
-                    asyncio_mod=asyncio_mod,
+                    asyncio_mod=deps.asyncio_mod,
                 ),
                 f"tap action {event_name}",
             )
     else:
         should_emit = True
         if shared_output_tracker is not None:
-            bucket = "keyboard" if uinput_dev is device_runtime.keyboard_uinput else None
-            if uinput_dev is device_runtime.mouse_uinput:
-                bucket = "mouse"
-            elif uinput_dev is device_runtime.gamepad_uinput:
-                bucket = "gamepad"
+            bucket = bucket_for_uinput(device_runtime, uinput_dev)
             if bucket is not None:
                 should_emit = shared_output_tracker(bucket, int(code), int(event.value))
         if not should_emit:
@@ -485,8 +454,8 @@ async def _execute_key_action(
             uinput_dev,
             code,
             int(event.value),
-            evdev_mod=evdev,
-            uinput_writer=_uinput_writer,
+            evdev_mod=deps.evdev_mod,
+            uinput_writer=deps.uinput_writer,
         )
 
 
@@ -496,10 +465,7 @@ async def _execute_mouse_action(
     event: InputEventLike,
     event_name: str,
     *,
-    asyncio_mod: AsyncioModule,
-    fire_and_observe_fn: FireAndObserve,
-    evdev_mod: EvdevModule,
-    uinput_writer: UInputWriter,
+    deps: ActionExecutionDeps,
     shared_output_tracker: Callable[[str, int, int], bool] | None = None,
 ) -> None:
     target = resolve_mouse_output_target(action.target)
@@ -513,10 +479,7 @@ async def _execute_mouse_action(
             event_name,
             code=target.code,
             relative_value=target.relative_value,
-            asyncio_mod=asyncio_mod,
-            fire_and_observe_fn=fire_and_observe_fn,
-            evdev_mod=evdev_mod,
-            uinput_writer=uinput_writer,
+            deps=deps,
             shared_output_tracker=shared_output_tracker,
         )
         return
@@ -525,8 +488,7 @@ async def _execute_mouse_action(
         action,
         event,
         event_name,
-        asyncio_mod=asyncio_mod,
-        fire_and_observe_fn=fire_and_observe_fn,
+        deps=deps,
         uinput_dev=device_runtime.mouse_uinput,
         target_kind="key",
         trigger_kind="key",
@@ -542,10 +504,7 @@ async def _execute_relative_mouse_action(
     *,
     code: int,
     relative_value: int,
-    asyncio_mod: AsyncioModule,
-    fire_and_observe_fn: FireAndObserve,
-    evdev_mod: EvdevModule,
-    uinput_writer: UInputWriter,
+    deps: ActionExecutionDeps,
     shared_output_tracker: Callable[[str, int, int], bool] | None = None,
 ) -> None:
     del shared_output_tracker
@@ -556,7 +515,7 @@ async def _execute_relative_mouse_action(
                 device_runtime,
                 event_name,
                 "relative",
-                lambda: asyncio_mod.create_task(
+                lambda: deps.asyncio_mod.create_task(
                     rapidfire_relative(
                         device_runtime,
                         code,
@@ -565,7 +524,7 @@ async def _execute_relative_mouse_action(
                         action.rapidfire_wait_ms,
                         event_name,
                         device_runtime.mouse_uinput,
-                        asyncio_mod=asyncio_mod,
+                        asyncio_mod=deps.asyncio_mod,
                     )
                 ),
                 code=code,
@@ -576,7 +535,7 @@ async def _execute_relative_mouse_action(
             await stop_rapidfire_async(
                 device_runtime,
                 event_name,
-                asyncio_mod=asyncio_mod,
+                asyncio_mod=deps.asyncio_mod,
                 contextlib_mod=contextlib,
             )
         return
@@ -584,7 +543,7 @@ async def _execute_relative_mouse_action(
     if action.tap_enabled:
         if event.value == 1 and not device_runtime.state.tap_active.get(event_name, False):
             device_runtime.state.tap_active[event_name] = True
-            fire_and_observe_fn(
+            deps.fire_and_observe_fn(
                 tap_relative(
                     device_runtime,
                     code,
@@ -592,7 +551,7 @@ async def _execute_relative_mouse_action(
                     action.tap_hold_ms,
                     event_name,
                     device_runtime.mouse_uinput,
-                    asyncio_mod=asyncio_mod,
+                    asyncio_mod=deps.asyncio_mod,
                 ),
                 f"tap action {event_name}",
             )
@@ -605,8 +564,8 @@ async def _execute_relative_mouse_action(
         device_runtime.mouse_uinput,
         code,
         relative_value,
-        ev_rel_code=evdev_mod.ecodes.EV_REL,
-        uinput_writer=uinput_writer,
+        ev_rel_code=deps.evdev_mod.ecodes.EV_REL,
+        uinput_writer=deps.uinput_writer,
     )
 
 
@@ -616,8 +575,7 @@ async def _execute_move_action(
     event: InputEventLike,
     event_name: str,
     *,
-    asyncio_mod: AsyncioModule,
-    fire_and_observe_fn: FireAndObserve,
+    deps: ActionExecutionDeps,
 ) -> None:
     if action.rapidfire_enabled:
         if event.value == 1:
@@ -625,14 +583,14 @@ async def _execute_move_action(
                 device_runtime,
                 event_name,
                 "move",
-                lambda: asyncio_mod.create_task(
+                lambda: deps.asyncio_mod.create_task(
                     rapidfire_move(
                         device_runtime,
                         action,
                         event_name,
                         action.rapidfire_hold_ms,
                         action.rapidfire_wait_ms,
-                        asyncio_mod=asyncio_mod,
+                        asyncio_mod=deps.asyncio_mod,
                     )
                 ),
                 code=None,
@@ -643,30 +601,26 @@ async def _execute_move_action(
             await stop_rapidfire_async(
                 device_runtime,
                 event_name,
-                asyncio_mod=asyncio_mod,
+                asyncio_mod=deps.asyncio_mod,
                 contextlib_mod=contextlib,
             )
     elif action.tap_enabled:
         if event.value == 1 and not device_runtime.state.tap_active.get(event_name, False):
             device_runtime.state.tap_active[event_name] = True
-            fire_and_observe_fn(
+            deps.fire_and_observe_fn(
                 tap_move(
                     device_runtime,
                     action,
                     event_name,
                     action.tap_hold_ms,
-                    asyncio_mod=asyncio_mod,
+                    asyncio_mod=deps.asyncio_mod,
                 ),
                 f"tap move {event_name}",
             )
     elif event.value == 1:
-        if action.action_type == ActionType.MOUSE_MOVE_ABS:
+        if action.action_type == deps.action_type_enum.MOUSE_MOVE_ABS:
             cursor_position_setter = device_runtime.cursor_position_setter
             if cursor_position_setter is not None:
                 await cursor_position_setter(int(action.move_x), int(action.move_y))
                 return
         emit_configured_mouse_move(device_runtime, action)
-
-
-def _uinput_writer(device: object | None) -> WritableUInput | None:
-    return cast(WritableUInput | None, device)

--- a/keymasq/keymasqd/runtime/grabbed_device_events.py
+++ b/keymasq/keymasqd/runtime/grabbed_device_events.py
@@ -13,7 +13,6 @@ from keymasq.common.devices import (
     classify_event_device_type,
     normalize_evdev_binding_value,
 )
-from keymasq.common.ipc import CommandType
 from keymasq.common.models import ActionType, MappingAction
 from keymasq.keymasqd.combo_engine import ComboDecision
 from keymasq.keymasqd.runtime import grabbed_device_actions as runtime_actions
@@ -50,10 +49,7 @@ def build_action_execution_deps(
 ) -> ActionExecutionDeps:
     return ActionExecutionDeps(
         asyncio_mod=cast(AsyncioModule, asyncio),
-        command_type=CommandType,
         fire_and_observe_fn=fire_and_observe_fn,
-        action_type_enum=ActionType,
-        superkey_machine_cls=runtime_actions.SuperkeyMachine,
         evdev_mod=evdev,
         uinput_writer=identity_uinput_writer,
     )
@@ -68,9 +64,7 @@ def build_event_processing_deps(
         evdev_mod=evdev,
         time_mod=time,
         log=log,
-        combo_decision_cls=ComboDecision,
         classify_event_device_type_fn=classify_event_device_type,
-        action_type_enum=ActionType,
         action_deps=build_action_execution_deps(fire_and_observe_fn=fire_and_observe_fn),
     )
 
@@ -133,7 +127,6 @@ def _log_mapped_action(
     event_name: str,
     *,
     evdev_mod: EvdevModule,
-    action_type_enum: type[ActionType],
     log: logging.Logger,
 ) -> None:
     if device_runtime.verbosity < 2:
@@ -152,7 +145,7 @@ def _log_mapped_action(
             event.value,
         )
         return
-    if action.action_type == action_type_enum.SUPPRESS:
+    if action.action_type == ActionType.SUPPRESS:
         log.debug(
             "[%s] %s (%s) -> SUPPRESS value=%s",
             device_runtime.hardware_id,
@@ -161,11 +154,7 @@ def _log_mapped_action(
             event.value,
         )
         return
-    if action.action_type in (
-        action_type_enum.KEYBOARD,
-        action_type_enum.MOUSE,
-        action_type_enum.GAMEPAD,
-    ):
+    if action.action_type in (ActionType.KEYBOARD, ActionType.MOUSE, ActionType.GAMEPAD):
         target = action.target or "?"
         mods: list[str] = []
         if action.rapidfire_enabled:
@@ -184,10 +173,7 @@ def _log_mapped_action(
             event.value,
         )
         return
-    if action.action_type in (
-        action_type_enum.MOUSE_MOVE_REL,
-        action_type_enum.MOUSE_MOVE_ABS,
-    ):
+    if action.action_type in (ActionType.MOUSE_MOVE_REL, ActionType.MOUSE_MOVE_ABS):
         log.debug(
             "[%s] %s (%s) -> %s x=%s y=%s value=%s",
             device_runtime.hardware_id,
@@ -199,7 +185,7 @@ def _log_mapped_action(
             event.value,
         )
         return
-    if action.action_type == action_type_enum.EXEC:
+    if action.action_type == ActionType.EXEC:
         log.debug(
             "[%s] %s (%s) -> EXEC %s value=%s",
             device_runtime.hardware_id,
@@ -209,7 +195,7 @@ def _log_mapped_action(
             event.value,
         )
         return
-    if action.action_type == action_type_enum.SUPERKEY:
+    if action.action_type == ActionType.SUPERKEY:
         sk_name = action.superkey_config.name if action.superkey_config else "?"
         log.debug(
             "[%s] %s (%s) -> SUPERKEY:%s value=%s",
@@ -322,7 +308,6 @@ async def process_event(
 ) -> None:
     evdev_mod = deps.evdev_mod
     time_mod = deps.time_mod
-    action_type_enum = deps.action_type_enum
     started_ns = time_mod.perf_counter_ns()
     diag_label = "unknown"
     combo_consumed = False
@@ -371,7 +356,7 @@ async def process_event(
     )
     if consumed is True:
         return
-    if isinstance(consumed, deps.combo_decision_cls):
+    if isinstance(consumed, ComboDecision):
         if consumed.consume_current_event:
             if not (
                 event.type == evdev_mod.ecodes.EV_KEY
@@ -460,7 +445,6 @@ async def process_event(
 
     if recording_active and not _is_recording_control_action(
         action,
-        action_type_enum=action_type_enum,
     ):
         recording_manager = device_runtime.recording_manager
         if recording_manager is None:
@@ -477,7 +461,6 @@ async def process_event(
         event,
         event_name,
         evdev_mod=evdev_mod,
-        action_type_enum=action_type_enum,
         log=deps.log,
     )
 
@@ -517,16 +500,14 @@ async def process_event(
 
 def _is_recording_control_action(
     action: MappingAction | None,
-    *,
-    action_type_enum: type[ActionType],
 ) -> bool:
     return bool(
         action
         and action.action_type
         in (
-            action_type_enum.START_MACRO_RECORDING,
-            action_type_enum.STOP_MACRO_RECORDING,
-            action_type_enum.CANCEL_MACRO_PLAYBACK,
+            ActionType.START_MACRO_RECORDING,
+            ActionType.STOP_MACRO_RECORDING,
+            ActionType.CANCEL_MACRO_PLAYBACK,
         )
     )
 

--- a/keymasq/keymasqd/runtime/grabbed_device_events.py
+++ b/keymasq/keymasqd/runtime/grabbed_device_events.py
@@ -19,20 +19,17 @@ from keymasq.keymasqd.combo_engine import ComboDecision
 from keymasq.keymasqd.runtime import grabbed_device_actions as runtime_actions
 from keymasq.keymasqd.runtime import grabbed_device_outputs as runtime_outputs
 from keymasq.keymasqd.runtime.grabbed_device_types import (
+    ActionExecutionDeps,
     AsyncioModule,
-    ClassifyEventDeviceTypeFn,
     EvdevModule,
+    EventProcessingDeps,
+    FireAndObserve,
     GrabbedDeviceRuntime,
     InputEventLike,
     TimeModule,
-    WritableUInput,
+    identity_uinput_writer,
     runtime_is_running,
 )
-from keymasq.keymasqd.superkey_state import SuperkeyMachine
-
-
-def _uinput_writer(device: object | None) -> WritableUInput | None:
-    return cast(WritableUInput | None, device)
 
 
 def _fire_and_observe(coro: Awaitable[object], label: str) -> asyncio.Task[object]:
@@ -46,6 +43,36 @@ def _fire_and_observe(coro: Awaitable[object], label: str) -> asyncio.Task[objec
 
     task.add_done_callback(_log_task_result)
     return task
+
+
+def build_action_execution_deps(
+    *, fire_and_observe_fn: FireAndObserve = _fire_and_observe
+) -> ActionExecutionDeps:
+    return ActionExecutionDeps(
+        asyncio_mod=cast(AsyncioModule, asyncio),
+        command_type=CommandType,
+        fire_and_observe_fn=fire_and_observe_fn,
+        action_type_enum=ActionType,
+        superkey_machine_cls=runtime_actions.SuperkeyMachine,
+        evdev_mod=evdev,
+        uinput_writer=identity_uinput_writer,
+    )
+
+
+def build_event_processing_deps(
+    *,
+    log: logging.Logger,
+    fire_and_observe_fn: FireAndObserve = _fire_and_observe,
+) -> EventProcessingDeps:
+    return EventProcessingDeps(
+        evdev_mod=evdev,
+        time_mod=time,
+        log=log,
+        combo_decision_cls=ComboDecision,
+        classify_event_device_type_fn=classify_event_device_type,
+        action_type_enum=ActionType,
+        action_deps=build_action_execution_deps(fire_and_observe_fn=fire_and_observe_fn),
+    )
 
 
 def _evdev_code_name(raw_name: object, fallback: int) -> str:
@@ -213,12 +240,7 @@ async def event_loop(
                 await process_event(
                     device_runtime,
                     event,
-                    evdev_mod=evdev,
-                    time_mod=time,
-                    log=log,
-                    combo_decision_cls=ComboDecision,
-                    classify_event_device_type_fn=classify_event_device_type,
-                    action_type_enum=ActionType,
+                    deps=build_event_processing_deps(log=log),
                 )
                 error_backoff = 0.01
             except Exception as exc:
@@ -261,7 +283,11 @@ async def cleanup_runtime_failure(
         log.warning(
             "Failed to reset superkeys after event error on %s: %s", device_runtime.path, exc
         )
-    runtime_outputs.release_all_keys(device_runtime, evdev_mod=evdev, uinput_writer=_uinput_writer)
+    runtime_outputs.release_all_keys(
+        device_runtime,
+        evdev_mod=evdev,
+        uinput_writer=identity_uinput_writer,
+    )
 
 
 async def recover_from_event_processing_error(device_runtime: GrabbedDeviceRuntime) -> None:
@@ -292,13 +318,11 @@ async def process_event(
     device_runtime: GrabbedDeviceRuntime,
     event: InputEventLike,
     *,
-    evdev_mod: EvdevModule,
-    time_mod: TimeModule,
-    log: logging.Logger,
-    combo_decision_cls: type[ComboDecision],
-    classify_event_device_type_fn: ClassifyEventDeviceTypeFn,
-    action_type_enum: type[ActionType],
+    deps: EventProcessingDeps,
 ) -> None:
+    evdev_mod = deps.evdev_mod
+    time_mod = deps.time_mod
+    action_type_enum = deps.action_type_enum
     started_ns = time_mod.perf_counter_ns()
     diag_label = "unknown"
     combo_consumed = False
@@ -306,7 +330,13 @@ async def process_event(
     suppress_recalled_release_passthrough = False
 
     event_name = get_event_name(event, evdev_mod=evdev_mod)
-    _log_raw_hardware_event(device_runtime, event, event_name, evdev_mod=evdev_mod, log=log)
+    _log_raw_hardware_event(
+        device_runtime,
+        event,
+        event_name,
+        evdev_mod=evdev_mod,
+        log=deps.log,
+    )
     if event.type == evdev_mod.ecodes.EV_KEY:
         if int(event.value) == 1:
             device_runtime.state.held_source_keys.add(event_name)
@@ -341,7 +371,7 @@ async def process_event(
     )
     if consumed is True:
         return
-    if isinstance(consumed, combo_decision_cls):
+    if isinstance(consumed, deps.combo_decision_cls):
         if consumed.consume_current_event:
             if not (
                 event.type == evdev_mod.ecodes.EV_KEY
@@ -375,7 +405,7 @@ async def process_event(
             device_runtime,
             event,
             evdev_mod=evdev_mod,
-            uinput_writer=_uinput_writer,
+            uinput_writer=identity_uinput_writer,
         )
         _record_diagnostics(device_runtime, "passthrough_other", started_ns, time_mod=time_mod)
         return
@@ -388,7 +418,7 @@ async def process_event(
             device_runtime,
             event,
             evdev_mod=evdev_mod,
-            uinput_writer=_uinput_writer,
+            uinput_writer=identity_uinput_writer,
         )
         if int(event.value) == 0:
             device_runtime.state.combo_passthrough_held.discard(event_name)
@@ -414,7 +444,7 @@ async def process_event(
             device_runtime,
             event,
             evdev_mod=evdev_mod,
-            uinput_writer=_uinput_writer,
+            uinput_writer=identity_uinput_writer,
         )
         diag_label = "combo_passthrough" if combo_passthrough_requested else "passthrough_fast"
         _record_diagnostics(device_runtime, diag_label, started_ns, time_mod=time_mod)
@@ -437,7 +467,7 @@ async def process_event(
             return
         input_event = cast(evdev.InputEvent, event)
         recording_manager.record_event(
-            classify_event_device_type_fn(input_event, device_runtime.device_types),
+            deps.classify_event_device_type_fn(input_event, device_runtime.device_types),
             input_event,
         )
 
@@ -448,7 +478,7 @@ async def process_event(
         event_name,
         evdev_mod=evdev_mod,
         action_type_enum=action_type_enum,
-        log=log,
+        log=deps.log,
     )
 
     if action:
@@ -457,13 +487,7 @@ async def process_event(
             action,
             event,
             event_name,
-            asyncio_mod=cast(runtime_actions.AsyncioModule, asyncio),
-            command_type=CommandType,
-            fire_and_observe_fn=_fire_and_observe,
-            action_type_enum=action_type_enum,
-            superkey_machine_cls=SuperkeyMachine,
-            evdev_mod=evdev_mod,
-            uinput_writer=_uinput_writer,
+            deps=deps.action_deps,
         )
         diag_label = (
             f"combo_release_action_{action.action_type.value}"
@@ -481,7 +505,7 @@ async def process_event(
             device_runtime,
             event,
             evdev_mod=evdev_mod,
-            uinput_writer=_uinput_writer,
+            uinput_writer=identity_uinput_writer,
         )
         diag_label = "combo_passthrough" if combo_passthrough_requested else "passthrough_mapped"
 

--- a/keymasq/keymasqd/runtime/grabbed_device_grab.py
+++ b/keymasq/keymasqd/runtime/grabbed_device_grab.py
@@ -28,14 +28,13 @@ async def broadcast_grab_status(
     active_names: list[str],
     *,
     waited_s: float,
-    command_type: type[CommandType],
     log: logging.Logger,
 ) -> None:
     if device_runtime.broadcast_callback is None:
         return
     try:
         await device_runtime.broadcast_callback(
-            command_type.DEVICE_GRAB_STATUS,
+            CommandType.DEVICE_GRAB_STATUS,
             {
                 "hardware_id": device_runtime.hardware_id,
                 "path": device_runtime.path,
@@ -134,7 +133,6 @@ async def wait_for_active_keys_to_clear(
                     "ready",
                     [],
                     waited_s=now - started_at,
-                    command_type=CommandType,
                     log=log,
                 )
                 log.info(
@@ -158,7 +156,6 @@ async def wait_for_active_keys_to_clear(
                 "timed_out",
                 active_names,
                 waited_s=now - started_at,
-                command_type=CommandType,
                 log=log,
             )
             log.error(
@@ -177,7 +174,6 @@ async def wait_for_active_keys_to_clear(
                 "waiting",
                 active_names,
                 waited_s=now - started_at,
-                command_type=CommandType,
                 log=log,
             )
             log.warning(
@@ -193,7 +189,6 @@ async def wait_for_active_keys_to_clear(
                 "waiting",
                 active_names,
                 waited_s=now - started_at,
-                command_type=CommandType,
                 log=log,
             )
             log.info(
@@ -243,19 +238,17 @@ def seed_startup_held_actions(device_runtime: GrabbedDeviceRuntime) -> None:
             mapping,
         )
         device_runtime.state.held_source_actions[event_name] = action
-        reconcile_startup_held_action(device_runtime, action, action_type_enum=ActionType)
+        reconcile_startup_held_action(device_runtime, action)
 
 
 def reconcile_startup_held_action(
     device_runtime: GrabbedDeviceRuntime,
     action: MappingAction | None,
-    *,
-    action_type_enum: type[ActionType],
 ) -> None:
     if action is None or not action.target:
         return
 
-    if action.action_type == action_type_enum.KEYBOARD:
+    if action.action_type == ActionType.KEYBOARD:
         code = resolve_output_code(action.target)
         if code is not None:
             runtime_outputs.ensure_key_released(
@@ -265,7 +258,7 @@ def reconcile_startup_held_action(
             )
         return
 
-    if action.action_type == action_type_enum.MOUSE:
+    if action.action_type == ActionType.MOUSE:
         code = resolve_output_code(action.target)
         if code is not None:
             runtime_outputs.ensure_key_released(
@@ -275,7 +268,7 @@ def reconcile_startup_held_action(
             )
         return
 
-    if action.action_type == action_type_enum.GAMEPAD:
+    if action.action_type == ActionType.GAMEPAD:
         is_trigger, axis_code = get_trigger_axis(action.target)
         if is_trigger and axis_code is not None:
             runtime_outputs.ensure_trigger_released(

--- a/keymasq/keymasqd/runtime/grabbed_device_outputs.py
+++ b/keymasq/keymasqd/runtime/grabbed_device_outputs.py
@@ -10,6 +10,7 @@ from keymasq.keymasqd.runtime.grabbed_device_types import (
     InputEventLike,
     UInputWriter,
     WritableUInput,
+    identity_uinput_writer,
 )
 
 
@@ -147,7 +148,7 @@ def ensure_key_released(
                 code,
                 0,
                 evdev_mod=evdev,
-                uinput_writer=_uinput_writer,
+                uinput_writer=identity_uinput_writer,
             )
     except Exception:
         pass
@@ -214,7 +215,3 @@ def release_all_keys(
     device_runtime.state.combo_passthrough_held.clear()
     device_runtime.state.combo_recalled_bindings.clear()
     device_runtime.state.held_source_actions.clear()
-
-
-def _uinput_writer(device: object | None) -> WritableUInput | None:
-    return cast(WritableUInput | None, device)

--- a/keymasq/keymasqd/runtime/grabbed_device_repeat.py
+++ b/keymasq/keymasqd/runtime/grabbed_device_repeat.py
@@ -1,4 +1,5 @@
 import asyncio
+import contextlib
 from typing import cast
 
 import evdev
@@ -12,7 +13,6 @@ from keymasq.keymasqd.runtime.grabbed_device_outputs import (
 )
 from keymasq.keymasqd.runtime.grabbed_device_types import (
     AsyncioModule,
-    ContextlibModule,
     EvdevModule,
     GrabbedDeviceRuntime,
     TaskFactory,
@@ -86,12 +86,11 @@ async def stop_rapidfire_async(
     event_name: str,
     *,
     asyncio_mod: AsyncioModule,
-    contextlib_mod: ContextlibModule,
 ) -> None:
     task = device_runtime.state.rapidfire_tasks.get(event_name)
     stop_rapidfire(device_runtime, event_name)
     if task is not None and not task.done():
-        with contextlib_mod.suppress(asyncio.CancelledError):
+        with contextlib.suppress(asyncio.CancelledError):
             await task
 
 

--- a/keymasq/keymasqd/runtime/grabbed_device_types.py
+++ b/keymasq/keymasqd/runtime/grabbed_device_types.py
@@ -1,5 +1,4 @@
 import asyncio
-import contextlib
 import logging
 from collections.abc import AsyncIterator, Awaitable, Callable, Coroutine, Mapping, Sequence
 from dataclasses import dataclass, field
@@ -8,7 +7,7 @@ from typing import Final, Protocol, TypeVar, cast
 import evdev
 
 from keymasq.common.ipc import CommandType
-from keymasq.common.models import ActionType, MappingAction
+from keymasq.common.models import MappingAction
 from keymasq.keymasqd.combo_engine import ComboDecision
 from keymasq.keymasqd.recording import RecordingManager
 from keymasq.keymasqd.superkey_state import SuperkeyMachine
@@ -109,12 +108,6 @@ class AsyncioModule(Protocol):
     ) -> Awaitable[_T]: ...
 
 
-class ContextlibModule(Protocol):
-    def suppress(
-        self, *exceptions: type[BaseException]
-    ) -> contextlib.AbstractContextManager[None]: ...
-
-
 class TimeModule(Protocol):
     def monotonic(self) -> float: ...
 
@@ -147,10 +140,7 @@ def identity_uinput_writer(device: object | None) -> WritableUInput | None:
 @dataclass(frozen=True)
 class ActionExecutionDeps:
     asyncio_mod: AsyncioModule
-    command_type: type[CommandType]
     fire_and_observe_fn: FireAndObserve
-    action_type_enum: type[ActionType]
-    superkey_machine_cls: type[SuperkeyMachine]
     evdev_mod: EvdevModule
     uinput_writer: UInputWriter
 
@@ -160,9 +150,7 @@ class EventProcessingDeps:
     evdev_mod: EvdevModule
     time_mod: TimeModule
     log: logging.Logger
-    combo_decision_cls: type[ComboDecision]
     classify_event_device_type_fn: ClassifyEventDeviceTypeFn
-    action_type_enum: type[ActionType]
     action_deps: ActionExecutionDeps
 
 

--- a/keymasq/keymasqd/runtime/grabbed_device_types.py
+++ b/keymasq/keymasqd/runtime/grabbed_device_types.py
@@ -1,13 +1,14 @@
 import asyncio
 import contextlib
+import logging
 from collections.abc import AsyncIterator, Awaitable, Callable, Coroutine, Mapping, Sequence
 from dataclasses import dataclass, field
-from typing import Final, Protocol, TypeVar
+from typing import Final, Protocol, TypeVar, cast
 
 import evdev
 
 from keymasq.common.ipc import CommandType
-from keymasq.common.models import MappingAction
+from keymasq.common.models import ActionType, MappingAction
 from keymasq.keymasqd.combo_engine import ComboDecision
 from keymasq.keymasqd.recording import RecordingManager
 from keymasq.keymasqd.superkey_state import SuperkeyMachine
@@ -65,6 +66,8 @@ class WritableUInput(Protocol):
 
 type UInputWriter = Callable[[object | None], WritableUInput | None]
 type TaskFactory = Callable[[], asyncio.Task[None]]
+type RelativePulseEmitter = Callable[[], None]
+type RelativePulseActive = Callable[[], bool]
 
 
 class ErrnoModule(Protocol):
@@ -135,6 +138,32 @@ class EvdevModule(Protocol):
 
 
 type ClassifyEventDeviceTypeFn = Callable[[evdev.InputEvent, list[str]], str]
+
+
+def identity_uinput_writer(device: object | None) -> WritableUInput | None:
+    return cast(WritableUInput | None, device)
+
+
+@dataclass(frozen=True)
+class ActionExecutionDeps:
+    asyncio_mod: AsyncioModule
+    command_type: type[CommandType]
+    fire_and_observe_fn: FireAndObserve
+    action_type_enum: type[ActionType]
+    superkey_machine_cls: type[SuperkeyMachine]
+    evdev_mod: EvdevModule
+    uinput_writer: UInputWriter
+
+
+@dataclass(frozen=True)
+class EventProcessingDeps:
+    evdev_mod: EvdevModule
+    time_mod: TimeModule
+    log: logging.Logger
+    combo_decision_cls: type[ComboDecision]
+    classify_event_device_type_fn: ClassifyEventDeviceTypeFn
+    action_type_enum: type[ActionType]
+    action_deps: ActionExecutionDeps
 
 
 @dataclass

--- a/keymasq/keymasqd/runtime/macros.py
+++ b/keymasq/keymasqd/runtime/macros.py
@@ -1,7 +1,12 @@
+import contextlib
 import logging
+import random
+import uuid
 from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any
+
+from keymasq.common.ipc import CommandType
 
 type JsonObject = dict[str, object]
 type IntValueFn = Callable[[object, int], int]
@@ -12,12 +17,8 @@ type _MacroManager = Any
 @dataclass(frozen=True)
 class MacroRuntimeDeps:
     asyncio_mod: Any
-    contextlib_mod: Any
     evdev_mod: Any
     uinput_writer: Any
-    random_mod: Any
-    uuid_mod: Any
-    command_type: Any
     log: logging.Logger
     int_value_fn: IntValueFn
     str_value_fn: StrValueFn
@@ -207,7 +208,7 @@ async def cancel_macro_instances(
         task.cancel()
 
     if tasks:
-        with deps.contextlib_mod.suppress(Exception):
+        with contextlib.suppress(Exception):
             await asyncio_mod.wait_for(
                 asyncio_mod.gather(*tasks, return_exceptions=True),
                 timeout=1.0,
@@ -531,7 +532,7 @@ async def run_macro_control_action(
     if action_type == "wait_random":
         min_ms = max(0, int_value_fn(ev.get("min_ms"), 0))
         max_ms = max(min_ms, int_value_fn(ev.get("max_ms"), min_ms))
-        sampled_ms = deps.random_mod.randint(min_ms, max_ms)
+        sampled_ms = random.randint(min_ms, max_ms)
         scaled = sampled_ms / max(speed, 0.01)
         if scaled > 0:
             loop = asyncio_mod.get_running_loop()
@@ -546,7 +547,7 @@ async def run_macro_control_action(
             return 0.0
         if manager.broadcast_callback:
             await manager.broadcast_callback(
-                deps.command_type.ACTION_TRIGGER,
+                CommandType.ACTION_TRIGGER,
                 {
                     "action_type": "exec",
                     "cmd": command,
@@ -571,21 +572,21 @@ async def run_macro_control_action(
                 deps=deps,
             )
 
-        wait_id = deps.uuid_mod.uuid4().hex
+        wait_id = uuid.uuid4().hex
         try:
             waiter = loop.create_future()
             manager.macro_state.exec_waiters[wait_id] = waiter
 
             if manager.broadcast_callback:
                 await manager.broadcast_callback(
-                    deps.command_type.ACTION_TRIGGER,
+                    CommandType.ACTION_TRIGGER,
                     {
                         "action_type": "exec",
                         "cmd": command,
                         "macro_exec_wait_id": wait_id,
                     },
                 )
-                with deps.contextlib_mod.suppress(asyncio_mod.TimeoutError):
+                with contextlib.suppress(asyncio_mod.TimeoutError):
                     await asyncio_mod.wait_for(waiter, timeout=max(0.1, timeout_ms / 1000.0))
         finally:
             manager.macro_state.exec_waiters.pop(wait_id, None)

--- a/keymasq/keymasqd/runtime/macros.py
+++ b/keymasq/keymasqd/runtime/macros.py
@@ -1,127 +1,26 @@
-import asyncio
 import logging
-from collections.abc import Awaitable, Callable, Mapping, Sequence
-from contextlib import AbstractContextManager
-from typing import ClassVar, Final, Protocol
-
-from keymasq.common.ipc import CommandType
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
 
 type JsonObject = dict[str, object]
 type IntValueFn = Callable[[object, int], int]
 type StrValueFn = Callable[[object, str], str]
+type _MacroManager = Any
 
 
-class _WritableUInput(Protocol):
-    def write(self, event_type: int, code: int, value: int) -> None: ...
-
-    def syn(self) -> None: ...
-
-
-type UInputWriter = Callable[[object | None], _WritableUInput | None]
-type BroadcastCallback = Callable[[CommandType, JsonObject], Awaitable[None]]
-
-
-class _OutputState(Protocol):
-    @property
-    def keyboard_uinput(self) -> object | None: ...
-
-    @property
-    def mouse_uinput(self) -> object | None: ...
-
-    @property
-    def gamepad_uinput(self) -> object | None: ...
-
-
-class _MacroState(Protocol):
-    tasks: dict[int, asyncio.Task[None]]
-    instance_meta: dict[int, dict[str, str]]
-    instance_seq: int
-    instance_held: dict[int, set[tuple[str, int]]]
-    held_refcount: dict[tuple[str, int], int]
-    cancel_instance_ids: set[int]
-    mouse_inhibit_count: int
-    exec_waiters: dict[str, asyncio.Future[int]]
-    mouse_rel_suppressed: bool
-    mouse_rel_suppression_watchdog_task: asyncio.Task[None] | None
-
-
-class _TrackedOutputDevice(Protocol):
-    def release_tracked_outputs(self) -> None: ...
-
-
-class _UUIDLike(Protocol):
-    @property
-    def hex(self) -> str: ...
-
-
-class _UUIDModule(Protocol):
-    def uuid4(self) -> _UUIDLike: ...
-
-
-class _RandomModule(Protocol):
-    def randint(self, a: int, b: int) -> int: ...
-
-
-class _CommandTypeEnum(Protocol):
-    ACTION_TRIGGER: ClassVar[CommandType]
-
-
-class _Ecodes(Protocol):
-    EV_KEY: Final[int]
-    EV_REL: Final[int]
-    EV_ABS: Final[int]
-    EV_SYN: Final[int]
-    REL_X: Final[int]
-    REL_Y: Final[int]
-
-
-class _EvdevModule(Protocol):
-    @property
-    def ecodes(self) -> _Ecodes: ...
-
-
-class _AsyncioLoop(Protocol):
-    def create_future(self) -> asyncio.Future[int]: ...
-
-    def time(self) -> float: ...
-
-
-class _AsyncioModule(Protocol):
-    CancelledError: ClassVar[type[BaseException]]
-    TimeoutError: ClassVar[type[BaseException]]
-
-    def create_task(self, coro: Awaitable[None], /) -> asyncio.Task[None]: ...
-
-    async def sleep(self, delay: float, /) -> None: ...
-
-    def get_running_loop(self) -> _AsyncioLoop: ...
-
-    def gather(self, *aws: object, return_exceptions: bool = False) -> Awaitable[object]: ...
-
-    def wait_for(self, aw: Awaitable[object], timeout: float) -> Awaitable[object]: ...
-
-
-class _ContextlibModule(Protocol):
-    def suppress(self, *exceptions: type[BaseException]) -> AbstractContextManager[None]: ...
-
-
-class _MacroManager(Protocol):
-    @property
-    def output_state(self) -> _OutputState: ...
-
-    @property
-    def macro_state(self) -> _MacroState: ...
-
-    @property
-    def grabbed_devices(self) -> Mapping[str, Sequence[_TrackedOutputDevice]]: ...
-
-    @property
-    def broadcast_callback(self) -> BroadcastCallback | None: ...
-
-    @property
-    def verbosity(self) -> int: ...
-
-    async def set_cursor_position(self, x: int, y: int) -> dict[str, object]: ...
+@dataclass(frozen=True)
+class MacroRuntimeDeps:
+    asyncio_mod: Any
+    contextlib_mod: Any
+    evdev_mod: Any
+    uinput_writer: Any
+    random_mod: Any
+    uuid_mod: Any
+    command_type: Any
+    log: logging.Logger
+    int_value_fn: IntValueFn
+    str_value_fn: StrValueFn
 
 
 async def play_macro(
@@ -141,17 +40,9 @@ async def play_macro(
     source_button: str,
     trigger_value: int,
     *,
-    asyncio_mod: _AsyncioModule,
-    contextlib_mod: _ContextlibModule,
-    evdev_mod: _EvdevModule,
-    log: logging.Logger,
-    int_value_fn: IntValueFn,
-    str_value_fn: StrValueFn,
-    uinput_writer: UInputWriter,
-    random_mod: _RandomModule,
-    uuid_mod: _UUIDModule,
-    command_type: _CommandTypeEnum,
+    deps: MacroRuntimeDeps,
 ) -> dict[str, object]:
+    asyncio_mod = deps.asyncio_mod
     if not (
         manager.output_state.keyboard_uinput
         or manager.output_state.mouse_uinput
@@ -175,10 +66,7 @@ async def play_macro(
             cancelled = await cancel_macro_instances(
                 manager,
                 hold_instances,
-                asyncio_mod=asyncio_mod,
-                contextlib_mod=contextlib_mod,
-                evdev_mod=evdev_mod,
-                uinput_writer=uinput_writer,
+                deps=deps,
             )
             return {"status": "ok", "cancelled": cancelled > 0}
         return {"status": "ok", "cancelled": False}
@@ -196,10 +84,7 @@ async def play_macro(
             cancelled = await cancel_macro_instances(
                 manager,
                 toggle_instances,
-                asyncio_mod=asyncio_mod,
-                contextlib_mod=contextlib_mod,
-                evdev_mod=evdev_mod,
-                uinput_writer=uinput_writer,
+                deps=deps,
             )
             return {"status": "ok", "cancelled": cancelled > 0}
 
@@ -238,16 +123,7 @@ async def play_macro(
             start_x=int(start_x),
             start_y=int(start_y),
             block_mouse_movement=block_mouse_movement,
-            asyncio_mod=asyncio_mod,
-            evdev_mod=evdev_mod,
-            log=log,
-            int_value_fn=int_value_fn,
-            str_value_fn=str_value_fn,
-            uinput_writer=uinput_writer,
-            contextlib_mod=contextlib_mod,
-            random_mod=random_mod,
-            uuid_mod=uuid_mod,
-            command_type=command_type,
+            deps=deps,
         )
     )
     manager.macro_state.tasks[instance_id] = task
@@ -257,19 +133,13 @@ async def play_macro(
 async def cancel_macro_playback(
     manager: _MacroManager,
     *,
-    asyncio_mod: _AsyncioModule,
-    contextlib_mod: _ContextlibModule,
-    evdev_mod: _EvdevModule,
-    uinput_writer: UInputWriter,
+    deps: MacroRuntimeDeps,
 ) -> dict[str, object]:
     running_ids = running_macro_instance_ids(manager)
     cancelled = await cancel_macro_instances(
         manager,
         running_ids,
-        asyncio_mod=asyncio_mod,
-        contextlib_mod=contextlib_mod,
-        evdev_mod=evdev_mod,
-        uinput_writer=uinput_writer,
+        deps=deps,
     )
     for devices in manager.grabbed_devices.values():
         for device in devices:
@@ -311,11 +181,9 @@ async def cancel_macro_instances(
     manager: _MacroManager,
     instance_ids: list[int],
     *,
-    asyncio_mod: _AsyncioModule,
-    contextlib_mod: _ContextlibModule,
-    evdev_mod: _EvdevModule,
-    uinput_writer: UInputWriter,
+    deps: MacroRuntimeDeps,
 ) -> int:
+    asyncio_mod = deps.asyncio_mod
     unique_ids = list(dict.fromkeys(int(i) for i in instance_ids))
     if not unique_ids:
         return 0
@@ -327,8 +195,7 @@ async def cancel_macro_instances(
         release_macro_held_for_instance(
             manager,
             instance_id,
-            evdev_mod=evdev_mod,
-            uinput_writer=uinput_writer,
+            deps=deps,
         )
 
     tasks = [
@@ -340,7 +207,7 @@ async def cancel_macro_instances(
         task.cancel()
 
     if tasks:
-        with contextlib_mod.suppress(Exception):
+        with deps.contextlib_mod.suppress(Exception):
             await asyncio_mod.wait_for(
                 asyncio_mod.gather(*tasks, return_exceptions=True),
                 timeout=1.0,
@@ -377,22 +244,18 @@ async def play_macro_task(
     start_y: int,
     block_mouse_movement: bool,
     *,
-    asyncio_mod: _AsyncioModule,
-    evdev_mod: _EvdevModule,
-    log: logging.Logger,
-    int_value_fn: IntValueFn,
-    str_value_fn: StrValueFn,
-    uinput_writer: UInputWriter,
-    contextlib_mod: _ContextlibModule,
-    random_mod: _RandomModule,
-    uuid_mod: _UUIDModule,
-    command_type: _CommandTypeEnum,
+    deps: MacroRuntimeDeps,
 ) -> None:
+    asyncio_mod = deps.asyncio_mod
+    evdev_mod = deps.evdev_mod
+    int_value_fn = deps.int_value_fn
+    str_value_fn = deps.str_value_fn
+    uinput_writer = deps.uinput_writer
     mouse_btn_codes = frozenset(range(0x110, 0x118))
     pending_abs_moves: dict[str, dict[str, int]] = {}
 
     if manager.verbosity >= 1:
-        log.debug("Macro playback started: %s", macro_name or "<unnamed>")
+        deps.log.debug("Macro playback started: %s", macro_name or "<unnamed>")
 
     speed_factor = max(0.01, speed)
     macro_duration_us = (
@@ -405,7 +268,7 @@ async def play_macro_task(
             acquire_macro_mouse_inhibit(
                 manager,
                 timeout_s=suppression_timeout_s,
-                asyncio_mod=asyncio_mod,
+                deps=deps,
             )
 
         iterations = 0
@@ -416,7 +279,7 @@ async def play_macro_task(
                 begin_mouse_rel_suppression(
                     manager,
                     timeout_s=max(0.1, suppression_timeout_s),
-                    asyncio_mod=asyncio_mod,
+                    deps=deps,
                 )
             iterations += 1
             pending_abs_moves.clear()
@@ -458,13 +321,7 @@ async def play_macro_task(
                         manager,
                         ev,
                         speed,
-                        asyncio_mod=asyncio_mod,
-                        contextlib_mod=contextlib_mod,
-                        random_mod=random_mod,
-                        uuid_mod=uuid_mod,
-                        command_type=command_type,
-                        str_value_fn=str_value_fn,
-                        int_value_fn=int_value_fn,
+                        deps=deps,
                     )
                     continue
 
@@ -548,21 +405,20 @@ async def play_macro_task(
     except asyncio_mod.CancelledError:
         pass
     except Exception as exc:
-        log.warning("Macro playback aborted: %s", exc)
+        deps.log.warning("Macro playback aborted: %s", exc)
     finally:
         manager.macro_state.cancel_instance_ids.discard(instance_id)
         release_macro_held_for_instance(
             manager,
             instance_id,
-            evdev_mod=evdev_mod,
-            uinput_writer=uinput_writer,
+            deps=deps,
         )
         manager.macro_state.tasks.pop(instance_id, None)
         manager.macro_state.instance_meta.pop(instance_id, None)
         if block_mouse_movement:
             release_macro_mouse_inhibit(manager)
         if manager.verbosity >= 1:
-            log.debug("Macro playback finished: %s", macro_name or "<unnamed>")
+            deps.log.debug("Macro playback finished: %s", macro_name or "<unnamed>")
 
 
 def track_macro_key_press(
@@ -597,17 +453,16 @@ def release_macro_held_for_instance(
     manager: _MacroManager,
     instance_id: int,
     *,
-    evdev_mod: _EvdevModule,
-    uinput_writer: UInputWriter,
+    deps: MacroRuntimeDeps,
 ) -> None:
     held = manager.macro_state.instance_held.pop(instance_id, set())
     if not held:
         return
 
     uinputs = {
-        "keyboard": uinput_writer(manager.output_state.keyboard_uinput),
-        "mouse": uinput_writer(manager.output_state.mouse_uinput),
-        "gamepad": uinput_writer(manager.output_state.gamepad_uinput),
+        "keyboard": deps.uinput_writer(manager.output_state.keyboard_uinput),
+        "mouse": deps.uinput_writer(manager.output_state.mouse_uinput),
+        "gamepad": deps.uinput_writer(manager.output_state.gamepad_uinput),
     }
     synced: set[str] = set()
     held_refcount = manager.macro_state.held_refcount
@@ -621,7 +476,7 @@ def release_macro_held_for_instance(
             if not uinput:
                 continue
             try:
-                uinput.write(evdev_mod.ecodes.EV_KEY, int(code), 0)
+                uinput.write(deps.evdev_mod.ecodes.EV_KEY, int(code), 0)
                 synced.add(device_class)
             except Exception:
                 continue
@@ -639,10 +494,10 @@ def release_macro_held_for_instance(
 
 
 def acquire_macro_mouse_inhibit(
-    manager: _MacroManager, timeout_s: float, *, asyncio_mod: _AsyncioModule
+    manager: _MacroManager, timeout_s: float, *, deps: MacroRuntimeDeps
 ) -> None:
     manager.macro_state.mouse_inhibit_count += 1
-    begin_mouse_rel_suppression(manager, timeout_s=max(0.1, timeout_s), asyncio_mod=asyncio_mod)
+    begin_mouse_rel_suppression(manager, timeout_s=max(0.1, timeout_s), deps=deps)
 
 
 def release_macro_mouse_inhibit(manager: _MacroManager) -> None:
@@ -657,14 +512,11 @@ async def run_macro_control_action(
     ev: dict[str, object],
     speed: float,
     *,
-    asyncio_mod: _AsyncioModule,
-    contextlib_mod: _ContextlibModule,
-    random_mod: _RandomModule,
-    uuid_mod: _UUIDModule,
-    command_type: _CommandTypeEnum,
-    str_value_fn: StrValueFn,
-    int_value_fn: IntValueFn,
+    deps: MacroRuntimeDeps,
 ) -> float:
+    asyncio_mod = deps.asyncio_mod
+    str_value_fn = deps.str_value_fn
+    int_value_fn = deps.int_value_fn
     action_type = str_value_fn(ev.get("macro_action"), "")
     if action_type == "wait_fixed":
         duration_ms = max(0, int_value_fn(ev.get("duration_ms"), 0))
@@ -679,7 +531,7 @@ async def run_macro_control_action(
     if action_type == "wait_random":
         min_ms = max(0, int_value_fn(ev.get("min_ms"), 0))
         max_ms = max(min_ms, int_value_fn(ev.get("max_ms"), min_ms))
-        sampled_ms = random_mod.randint(min_ms, max_ms)
+        sampled_ms = deps.random_mod.randint(min_ms, max_ms)
         scaled = sampled_ms / max(speed, 0.01)
         if scaled > 0:
             loop = asyncio_mod.get_running_loop()
@@ -694,7 +546,7 @@ async def run_macro_control_action(
             return 0.0
         if manager.broadcast_callback:
             await manager.broadcast_callback(
-                command_type.ACTION_TRIGGER,
+                deps.command_type.ACTION_TRIGGER,
                 {
                     "action_type": "exec",
                     "cmd": command,
@@ -716,24 +568,24 @@ async def run_macro_control_action(
             acquire_macro_mouse_inhibit(
                 manager,
                 timeout_s=max(1.0, timeout_ms / 1000.0 + 1.0),
-                asyncio_mod=asyncio_mod,
+                deps=deps,
             )
 
-        wait_id = uuid_mod.uuid4().hex
+        wait_id = deps.uuid_mod.uuid4().hex
         try:
             waiter = loop.create_future()
             manager.macro_state.exec_waiters[wait_id] = waiter
 
             if manager.broadcast_callback:
                 await manager.broadcast_callback(
-                    command_type.ACTION_TRIGGER,
+                    deps.command_type.ACTION_TRIGGER,
                     {
                         "action_type": "exec",
                         "cmd": command,
                         "macro_exec_wait_id": wait_id,
                     },
                 )
-                with contextlib_mod.suppress(asyncio_mod.TimeoutError):
+                with deps.contextlib_mod.suppress(asyncio_mod.TimeoutError):
                     await asyncio_mod.wait_for(waiter, timeout=max(0.1, timeout_ms / 1000.0))
         finally:
             manager.macro_state.exec_waiters.pop(wait_id, None)
@@ -759,8 +611,9 @@ def complete_macro_exec_wait(
 
 
 def begin_mouse_rel_suppression(
-    manager: _MacroManager, timeout_s: float, *, asyncio_mod: _AsyncioModule
+    manager: _MacroManager, timeout_s: float, *, deps: MacroRuntimeDeps
 ) -> None:
+    asyncio_mod = deps.asyncio_mod
     manager.macro_state.mouse_rel_suppressed = True
     if (
         manager.macro_state.mouse_rel_suppression_watchdog_task
@@ -768,7 +621,7 @@ def begin_mouse_rel_suppression(
     ):
         manager.macro_state.mouse_rel_suppression_watchdog_task.cancel()
     manager.macro_state.mouse_rel_suppression_watchdog_task = asyncio_mod.create_task(
-        mouse_rel_suppression_watchdog(manager, timeout_s, asyncio_mod=asyncio_mod)
+        mouse_rel_suppression_watchdog(manager, timeout_s, deps=deps)
     )
 
 
@@ -783,8 +636,9 @@ def end_mouse_rel_suppression(manager: _MacroManager) -> None:
 
 
 async def mouse_rel_suppression_watchdog(
-    manager: _MacroManager, timeout_s: float, *, asyncio_mod: _AsyncioModule
+    manager: _MacroManager, timeout_s: float, *, deps: MacroRuntimeDeps
 ) -> None:
+    asyncio_mod = deps.asyncio_mod
     try:
         await asyncio_mod.sleep(timeout_s)
         manager.macro_state.mouse_rel_suppressed = False

--- a/keymasq/keymasqd/runtime/topology.py
+++ b/keymasq/keymasqd/runtime/topology.py
@@ -1,164 +1,44 @@
-import asyncio
 import logging
-from collections.abc import Awaitable, Callable, Mapping, Sequence
-from contextlib import AbstractContextManager
-from typing import Protocol, TypeVar, cast
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from typing import Any
 
 from keymasq.common.ipc import CommandType
-from keymasq.keymasqd.runtime import grab_lifecycle
+from keymasq.keymasqd.runtime import adapters as runtime_adapters
 
 type JsonObject = dict[str, object]
-_T = TypeVar("_T")
-
-
-class _DeviceInfo(Protocol):
-    @property
-    def vendor(self) -> int: ...
-
-    @property
-    def product(self) -> int: ...
-
-
-class _InputDevice(Protocol):
-    @property
-    def info(self) -> _DeviceInfo: ...
-
-
-class _LiveInterfaceInfo(Protocol):
-    @property
-    def hardware_id(self) -> str: ...
-
-    @property
-    def vendor_id(self) -> str: ...
-
-    @property
-    def product_id(self) -> str: ...
-
-    @property
-    def stable_path(self) -> str: ...
-
-    @property
-    def path(self) -> str: ...
-
-    @property
-    def interface_id(self) -> str: ...
-
-
-type Snapshot = dict[str, _LiveInterfaceInfo]
-
-
-class _LiveInterfaceInfoFactory(Protocol):
-    def __call__(
-        self,
-        *,
-        hardware_id: str,
-        vendor_id: str,
-        product_id: str,
-        stable_path: str,
-        path: str,
-        interface_id: str,
-    ) -> _LiveInterfaceInfo: ...
-
-
-class _GrabbedDevice(Protocol):
-    @property
-    def path(self) -> str: ...
-
-    @property
-    def stable_path(self) -> str: ...
-
-
-class _TopologyState(Protocol):
-    poll_s: float
-    debounce_s: float
-    watcher_task: asyncio.Task[None] | None
-    reconcile_task: asyncio.Task[None] | None
-    live_snapshot: Snapshot
-    reconciled_snapshot: Snapshot
-
-
-class _GrabState(Protocol):
-    @property
-    def desired_grabs(self) -> Mapping[str, object]: ...
-
-
-type BroadcastCallback = Callable[[CommandType, JsonObject], Awaitable[None]]
-
-
-class _TopologyManager(Protocol):
-    @property
-    def topology_state(self) -> _TopologyState: ...
-
-    @property
-    def grab_state(self) -> _GrabState: ...
-
-    @property
-    def grabbed_devices(self) -> Mapping[str, Sequence[_GrabbedDevice]]: ...
-
-    @property
-    def broadcast_callback(self) -> BroadcastCallback | None: ...
-
-    @property
-    def _command_type(self) -> type[CommandType]: ...
-
-    @property
-    def _op_lock(self) -> asyncio.Lock: ...
-
-
-class _AsyncioModule(Protocol):
-    async def sleep(self, delay: float, /) -> None: ...
-
-    def create_task(self, coro: Awaitable[_T], /) -> asyncio.Task[_T]: ...
-
-    def current_task(self) -> asyncio.Task[None] | None: ...
-
-    def to_thread(
-        self,
-        func: Callable[..., _T],
-        /,
-        *args: object,
-        **kwargs: object,
-    ) -> Awaitable[_T]: ...
-
-
-class _ContextlibModule(Protocol):
-    def suppress(self, *exceptions: type[BaseException]) -> AbstractContextManager[None]: ...
-
-
+type Snapshot = dict[str, Any]
+type _TopologyManager = Any
 type ClearDevicePathCacheFn = Callable[[], None]
 type DevicePathsFn = Callable[[], list[str]]
-type DeviceInputFn = Callable[[str], _InputDevice]
+type DeviceInputFn = Callable[[str], Any]
 type ResolveStablePathFn = Callable[[str], str]
 type GetInterfaceIdFn = Callable[[str], str | None]
-type ReleaseInterfaceFn = Callable[[_TopologyManager, str, str], Awaitable[None]]
-
-_release_interface_unlocked = cast(
-    ReleaseInterfaceFn,
-    grab_lifecycle.release_interface_unlocked,
-)
+type ReleaseInterfaceFn = Callable[[Any, str, str], Awaitable[None]]
+type LiveInterfaceInfoFactory = Callable[..., Any]
 
 
-def _manager_op_lock(manager: _TopologyManager) -> asyncio.Lock:
-    return manager._op_lock  # pyright: ignore[reportPrivateUsage]
-
-
-def _manager_command_type(manager: _TopologyManager) -> type[CommandType]:
-    return manager._command_type  # pyright: ignore[reportPrivateUsage]
+@dataclass(frozen=True)
+class TopologyRuntimeDeps:
+    asyncio_mod: runtime_adapters.AsyncioRuntimeAdapter
+    cancelled_error: type[BaseException]
+    contextlib_mod: Any
+    live_interface_info_cls: LiveInterfaceInfoFactory
+    clear_device_path_cache_fn: ClearDevicePathCacheFn
+    device_paths_fn: DevicePathsFn
+    device_input_fn: DeviceInputFn
+    resolve_stable_path_fn: ResolveStablePathFn
+    get_interface_id_fn: GetInterfaceIdFn
+    release_interface_fn: ReleaseInterfaceFn
 
 
 async def start_topology_watcher(
     manager: _TopologyManager,
     *,
-    asyncio_mod: _AsyncioModule,
-    cancelled_error: type[BaseException],
     log: logging.Logger,
-    live_interface_info_cls: _LiveInterfaceInfoFactory,
-    clear_device_path_cache_fn: ClearDevicePathCacheFn,
-    device_paths_fn: DevicePathsFn,
-    device_input_fn: DeviceInputFn,
-    resolve_stable_path_fn: ResolveStablePathFn,
-    get_interface_id_fn: GetInterfaceIdFn,
+    deps: TopologyRuntimeDeps,
 ) -> None:
+    asyncio_mod = deps.asyncio_mod
     if (
         manager.topology_state.watcher_task is not None
         and not manager.topology_state.watcher_task.done()
@@ -166,12 +46,12 @@ async def start_topology_watcher(
         return
     snapshot = await asyncio_mod.to_thread(
         scan_live_interfaces_sync,
-        live_interface_info_cls=live_interface_info_cls,
-        clear_device_path_cache_fn=clear_device_path_cache_fn,
-        device_paths_fn=device_paths_fn,
-        device_input_fn=device_input_fn,
-        resolve_stable_path_fn=resolve_stable_path_fn,
-        get_interface_id_fn=get_interface_id_fn,
+        live_interface_info_cls=deps.live_interface_info_cls,
+        clear_device_path_cache_fn=deps.clear_device_path_cache_fn,
+        device_paths_fn=deps.device_paths_fn,
+        device_input_fn=deps.device_input_fn,
+        resolve_stable_path_fn=deps.resolve_stable_path_fn,
+        get_interface_id_fn=deps.get_interface_id_fn,
         log=log,
     )
     manager.topology_state.live_snapshot = dict(snapshot)
@@ -179,15 +59,8 @@ async def start_topology_watcher(
     manager.topology_state.watcher_task = asyncio_mod.create_task(
         topology_watch_loop(
             manager,
-            asyncio_mod=asyncio_mod,
-            cancelled_error=cancelled_error,
             log=log,
-            live_interface_info_cls=live_interface_info_cls,
-            clear_device_path_cache_fn=clear_device_path_cache_fn,
-            device_paths_fn=device_paths_fn,
-            device_input_fn=device_input_fn,
-            resolve_stable_path_fn=resolve_stable_path_fn,
-            get_interface_id_fn=get_interface_id_fn,
+            deps=deps,
         )
     )
 
@@ -195,53 +68,45 @@ async def start_topology_watcher(
 async def stop_topology_watcher(
     manager: _TopologyManager,
     *,
-    asyncio_mod: _AsyncioModule,
-    cancelled_error: type[BaseException],
-    contextlib_mod: _ContextlibModule,
+    deps: TopologyRuntimeDeps,
 ) -> None:
     task = manager.topology_state.watcher_task
     manager.topology_state.watcher_task = None
     if task is not None and not task.done():
         task.cancel()
-        with contextlib_mod.suppress(cancelled_error):
+        with deps.contextlib_mod.suppress(deps.cancelled_error):
             await task
 
     reconcile_task = manager.topology_state.reconcile_task
     manager.topology_state.reconcile_task = None
     if reconcile_task is not None and not reconcile_task.done():
         reconcile_task.cancel()
-        with contextlib_mod.suppress(cancelled_error):
+        with deps.contextlib_mod.suppress(deps.cancelled_error):
             await reconcile_task
 
 
 async def topology_watch_loop(
     manager: _TopologyManager,
     *,
-    asyncio_mod: _AsyncioModule,
-    cancelled_error: type[BaseException],
     log: logging.Logger,
-    live_interface_info_cls: _LiveInterfaceInfoFactory,
-    clear_device_path_cache_fn: ClearDevicePathCacheFn,
-    device_paths_fn: DevicePathsFn,
-    device_input_fn: DeviceInputFn,
-    resolve_stable_path_fn: ResolveStablePathFn,
-    get_interface_id_fn: GetInterfaceIdFn,
+    deps: TopologyRuntimeDeps,
 ) -> None:
+    asyncio_mod = deps.asyncio_mod
     try:
         while True:
             await asyncio_mod.sleep(manager.topology_state.poll_s)
             try:
                 snapshot = await asyncio_mod.to_thread(
                     scan_live_interfaces_sync,
-                    live_interface_info_cls=live_interface_info_cls,
-                    clear_device_path_cache_fn=clear_device_path_cache_fn,
-                    device_paths_fn=device_paths_fn,
-                    device_input_fn=device_input_fn,
-                    resolve_stable_path_fn=resolve_stable_path_fn,
-                    get_interface_id_fn=get_interface_id_fn,
+                    live_interface_info_cls=deps.live_interface_info_cls,
+                    clear_device_path_cache_fn=deps.clear_device_path_cache_fn,
+                    device_paths_fn=deps.device_paths_fn,
+                    device_input_fn=deps.device_input_fn,
+                    resolve_stable_path_fn=deps.resolve_stable_path_fn,
+                    get_interface_id_fn=deps.get_interface_id_fn,
                     log=log,
                 )
-            except cancelled_error:
+            except deps.cancelled_error:
                 raise
             except Exception as exc:
                 log.warning("Topology scan failed: %s", exc)
@@ -252,9 +117,8 @@ async def topology_watch_loop(
                 schedule_topology_reconcile(
                     manager,
                     snapshot,
-                    asyncio_mod=asyncio_mod,
-                    cancelled_error=cancelled_error,
                     log=log,
+                    deps=deps,
                 )
                 continue
 
@@ -265,11 +129,10 @@ async def topology_watch_loop(
                 schedule_topology_reconcile(
                     manager,
                     snapshot,
-                    asyncio_mod=asyncio_mod,
-                    cancelled_error=cancelled_error,
                     log=log,
+                    deps=deps,
                 )
-    except cancelled_error:
+    except deps.cancelled_error:
         raise
 
 
@@ -277,10 +140,10 @@ def schedule_topology_reconcile(
     manager: _TopologyManager,
     snapshot: Snapshot,
     *,
-    asyncio_mod: _AsyncioModule,
-    cancelled_error: type[BaseException],
     log: logging.Logger,
+    deps: TopologyRuntimeDeps,
 ) -> None:
+    asyncio_mod = deps.asyncio_mod
     task = manager.topology_state.reconcile_task
     if task is not None and not task.done():
         task.cancel()
@@ -288,8 +151,8 @@ def schedule_topology_reconcile(
     async def _run() -> None:
         try:
             await asyncio_mod.sleep(manager.topology_state.debounce_s)
-            await reconcile_topology(manager, snapshot, log=log)
-        except cancelled_error:
+            await reconcile_topology(manager, snapshot, log=log, deps=deps)
+        except deps.cancelled_error:
             raise
         except Exception as exc:
             log.warning("Topology reconcile failed: %s", exc)
@@ -306,12 +169,13 @@ async def reconcile_topology(
     snapshot: Snapshot,
     *,
     log: logging.Logger,
+    deps: TopologyRuntimeDeps,
 ) -> None:
-    async with _manager_op_lock(manager):
+    async with manager._op_lock:
         previous = dict(manager.topology_state.reconciled_snapshot)
         desired_hardware_ids = set(manager.grab_state.desired_grabs)
         events = build_topology_events(manager, previous, snapshot, desired_hardware_ids)
-        await reconcile_topology_unlocked(manager, snapshot)
+        await reconcile_topology_unlocked(manager, snapshot, deps=deps)
         manager.topology_state.reconciled_snapshot = dict(snapshot)
 
     for event_type, payload in events:
@@ -323,7 +187,9 @@ async def reconcile_topology(
             log.warning("Failed to broadcast topology event %s: %s", event_type.value, exc)
 
 
-async def reconcile_topology_unlocked(manager: _TopologyManager, snapshot: Snapshot) -> None:
+async def reconcile_topology_unlocked(
+    manager: _TopologyManager, snapshot: Snapshot, *, deps: TopologyRuntimeDeps
+) -> None:
     live_paths = set(snapshot)
     removed: list[tuple[str, str]] = []
 
@@ -334,7 +200,7 @@ async def reconcile_topology_unlocked(manager: _TopologyManager, snapshot: Snaps
                 removed.append((hardware_id, device.path))
 
     for hardware_id, path in removed:
-        await _release_interface_unlocked(manager, hardware_id, path)
+        await deps.release_interface_fn(manager, hardware_id, path)
 
 
 def build_topology_events(
@@ -351,7 +217,7 @@ def build_topology_events(
             continue
         events.append(
             (
-                _manager_command_type(manager).DEVICE_DISCONNECTED,
+                manager._command_type.DEVICE_DISCONNECTED,
                 live_interface_payload(info),
             )
         )
@@ -362,7 +228,7 @@ def build_topology_events(
             continue
         events.append(
             (
-                _manager_command_type(manager).DEVICE_CONNECTED,
+                manager._command_type.DEVICE_CONNECTED,
                 live_interface_payload(info),
             )
         )
@@ -370,7 +236,7 @@ def build_topology_events(
     return events
 
 
-def live_interface_payload(info: _LiveInterfaceInfo) -> JsonObject:
+def live_interface_payload(info: Any) -> JsonObject:
     return {
         "hardware_id": info.hardware_id,
         "vendor_id": info.vendor_id,
@@ -383,7 +249,7 @@ def live_interface_payload(info: _LiveInterfaceInfo) -> JsonObject:
 
 def scan_live_interfaces_sync(
     *,
-    live_interface_info_cls: _LiveInterfaceInfoFactory,
+    live_interface_info_cls: LiveInterfaceInfoFactory,
     clear_device_path_cache_fn: ClearDevicePathCacheFn,
     device_paths_fn: DevicePathsFn,
     device_input_fn: DeviceInputFn,

--- a/keymasq/keymasqd/runtime/topology.py
+++ b/keymasq/keymasqd/runtime/topology.py
@@ -1,3 +1,5 @@
+import asyncio
+import contextlib
 import logging
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
@@ -15,15 +17,21 @@ type DeviceInputFn = Callable[[str], Any]
 type ResolveStablePathFn = Callable[[str], str]
 type GetInterfaceIdFn = Callable[[str], str | None]
 type ReleaseInterfaceFn = Callable[[Any, str, str], Awaitable[None]]
-type LiveInterfaceInfoFactory = Callable[..., Any]
+
+
+@dataclass(frozen=True)
+class LiveInterfaceInfo:
+    hardware_id: str
+    vendor_id: str
+    product_id: str
+    stable_path: str
+    path: str
+    interface_id: str
 
 
 @dataclass(frozen=True)
 class TopologyRuntimeDeps:
     asyncio_mod: runtime_adapters.AsyncioRuntimeAdapter
-    cancelled_error: type[BaseException]
-    contextlib_mod: Any
-    live_interface_info_cls: LiveInterfaceInfoFactory
     clear_device_path_cache_fn: ClearDevicePathCacheFn
     device_paths_fn: DevicePathsFn
     device_input_fn: DeviceInputFn
@@ -46,7 +54,6 @@ async def start_topology_watcher(
         return
     snapshot = await asyncio_mod.to_thread(
         scan_live_interfaces_sync,
-        live_interface_info_cls=deps.live_interface_info_cls,
         clear_device_path_cache_fn=deps.clear_device_path_cache_fn,
         device_paths_fn=deps.device_paths_fn,
         device_input_fn=deps.device_input_fn,
@@ -74,14 +81,14 @@ async def stop_topology_watcher(
     manager.topology_state.watcher_task = None
     if task is not None and not task.done():
         task.cancel()
-        with deps.contextlib_mod.suppress(deps.cancelled_error):
+        with contextlib.suppress(asyncio.CancelledError):
             await task
 
     reconcile_task = manager.topology_state.reconcile_task
     manager.topology_state.reconcile_task = None
     if reconcile_task is not None and not reconcile_task.done():
         reconcile_task.cancel()
-        with deps.contextlib_mod.suppress(deps.cancelled_error):
+        with contextlib.suppress(asyncio.CancelledError):
             await reconcile_task
 
 
@@ -98,7 +105,6 @@ async def topology_watch_loop(
             try:
                 snapshot = await asyncio_mod.to_thread(
                     scan_live_interfaces_sync,
-                    live_interface_info_cls=deps.live_interface_info_cls,
                     clear_device_path_cache_fn=deps.clear_device_path_cache_fn,
                     device_paths_fn=deps.device_paths_fn,
                     device_input_fn=deps.device_input_fn,
@@ -106,7 +112,7 @@ async def topology_watch_loop(
                     get_interface_id_fn=deps.get_interface_id_fn,
                     log=log,
                 )
-            except deps.cancelled_error:
+            except asyncio.CancelledError:
                 raise
             except Exception as exc:
                 log.warning("Topology scan failed: %s", exc)
@@ -132,7 +138,7 @@ async def topology_watch_loop(
                     log=log,
                     deps=deps,
                 )
-    except deps.cancelled_error:
+    except asyncio.CancelledError:
         raise
 
 
@@ -152,7 +158,7 @@ def schedule_topology_reconcile(
         try:
             await asyncio_mod.sleep(manager.topology_state.debounce_s)
             await reconcile_topology(manager, snapshot, log=log, deps=deps)
-        except deps.cancelled_error:
+        except asyncio.CancelledError:
             raise
         except Exception as exc:
             log.warning("Topology reconcile failed: %s", exc)
@@ -249,7 +255,6 @@ def live_interface_payload(info: Any) -> JsonObject:
 
 def scan_live_interfaces_sync(
     *,
-    live_interface_info_cls: LiveInterfaceInfoFactory,
     clear_device_path_cache_fn: ClearDevicePathCacheFn,
     device_paths_fn: DevicePathsFn,
     device_input_fn: DeviceInputFn,
@@ -268,7 +273,7 @@ def scan_live_interfaces_sync(
             product_id = f"{info.product:04x}"
             hardware_id = f"{vendor_id}:{product_id}"
             stable_path = resolve_stable_path_fn(path)
-            snapshot[stable_path] = live_interface_info_cls(
+            snapshot[stable_path] = LiveInterfaceInfo(
                 hardware_id=hardware_id,
                 vendor_id=vendor_id,
                 product_id=product_id,

--- a/tests/keymasqd/device_manager_support.py
+++ b/tests/keymasqd/device_manager_support.py
@@ -84,12 +84,12 @@ def _combo_runtime_deps(
     fire_and_observe_fn: cdm.FireAndObserve = dm._fire_and_observe,
 ) -> cdm.ComboRuntimeDeps:
     return cdm.ComboRuntimeDeps(
-        asyncio_mod=dm._combo_asyncio_runtime(),
+        asyncio_mod=cast(cdm._AsyncioModule, dm.ASYNCIO_RUNTIME),  # pyright: ignore[reportPrivateUsage]
         contextlib_mod=dm.contextlib,
         time_mod=dm.time,
-        evdev_mod=dm._combo_evdev_runtime(),
-        uinput_writer=dm._combo_uinput_writer(),
-        emit_mouse_move_fn=dm._combo_emit_mouse_move_fn(),
+        evdev_mod=cast(cdm._EvdevModule, dm.runtime_adapters.COMBO_EVDEV_RUNTIME),  # pyright: ignore[reportPrivateUsage]
+        uinput_writer=dm.runtime_adapters.identity_uinput_writer,
+        emit_mouse_move_fn=dm.runtime_adapters.combo_emit_mouse_move,
         get_trigger_axis_fn=dm.get_trigger_axis,
         resolve_code_fn=resolve_code_fn,
         fire_and_observe_fn=fire_and_observe_fn,

--- a/tests/keymasqd/device_manager_support.py
+++ b/tests/keymasqd/device_manager_support.py
@@ -165,13 +165,7 @@ async def _runtime_run_macro_control_action(
         manager,
         ev,
         speed,
-        asyncio_mod=dm._macro_asyncio_runtime(),
-        contextlib_mod=dm.contextlib,
-        random_mod=dm.random,
-        uuid_mod=dm.uuid,
-        command_type=dm._macro_command_type(),
-        str_value_fn=dm._str_value,
-        int_value_fn=dm._int_value,
+        deps=dm._macro_runtime_deps(),
     )
 
 
@@ -179,12 +173,7 @@ async def _runtime_process_grabbed_event(device: GrabbedDevice, event: evdev.Inp
     await gde.process_event(
         device,
         event,
-        evdev_mod=evdev,
-        time_mod=gde.time,
-        log=gdm.log,
-        combo_decision_cls=ComboDecision,
-        classify_event_device_type_fn=gde.classify_event_device_type,
-        action_type_enum=ActionType,
+        deps=gde.build_event_processing_deps(log=gdm.log),
     )
 
 
@@ -199,13 +188,7 @@ async def _runtime_execute_grabbed_action(
         action,
         event,
         event_name,
-        asyncio_mod=gdm.ASYNCIO_RUNTIME,
-        command_type=dm.CommandType,
-        fire_and_observe_fn=gde._fire_and_observe,
-        action_type_enum=ActionType,
-        superkey_machine_cls=gda.SuperkeyMachine,
-        evdev_mod=evdev,
-        uinput_writer=lambda device: cast(gdt.WritableUInput | None, device),
+        deps=gde.build_action_execution_deps(fire_and_observe_fn=gde._fire_and_observe),
     )
 
 
@@ -257,7 +240,7 @@ def _runtime_write_grabbed_key(
         code,
         value,
         evdev_mod=evdev,
-        uinput_writer=lambda device: cast(gdt.WritableUInput | None, device),
+        uinput_writer=gdt.identity_uinput_writer,
     )
 
 
@@ -291,7 +274,7 @@ async def _runtime_tap_grabbed_trigger(
         event_name,
         asyncio_mod=gdm.ASYNCIO_RUNTIME,
         evdev_mod=evdev,
-        uinput_writer=lambda device: cast(gdt.WritableUInput | None, device),
+        uinput_writer=gdt.identity_uinput_writer,
     )
 
 
@@ -306,16 +289,9 @@ async def _runtime_tap_grabbed_move(
 
 async def _runtime_topology_watch_loop(manager: DeviceManager) -> None:
     await tdm.topology_watch_loop(
-        dm._topology_manager(manager),
-        asyncio_mod=dm._topology_asyncio_runtime(),
-        cancelled_error=asyncio.CancelledError,
+        manager,
         log=dm.log,
-        live_interface_info_cls=dm._topology_live_interface_info_factory(),
-        clear_device_path_cache_fn=dm.clear_device_path_cache,
-        device_paths_fn=dm._device_paths,
-        device_input_fn=dm._topology_device_input_fn(),
-        resolve_stable_path_fn=dm.resolve_stable_path,
-        get_interface_id_fn=dm.get_interface_id,
+        deps=dm._topology_runtime_deps(),
     )
 
 
@@ -324,11 +300,10 @@ def _runtime_schedule_topology_reconcile(
     snapshot: dict[str, dm.LiveInterfaceInfo],
 ) -> None:
     tdm.schedule_topology_reconcile(
-        dm._topology_manager(manager),
+        manager,
         snapshot,
-        asyncio_mod=dm._topology_asyncio_runtime(),
-        cancelled_error=asyncio.CancelledError,
         log=dm.log,
+        deps=dm._topology_runtime_deps(),
     )
 
 

--- a/tests/keymasqd/device_manager_support.py
+++ b/tests/keymasqd/device_manager_support.py
@@ -16,7 +16,7 @@ import pytest
 from keymasq.common.ipc import CommandType
 from keymasq.common.models import ActionType, DeviceType, MappingAction, SuperkeyMode
 from keymasq.keymasqd import device_manager as dm
-from keymasq.keymasqd.combo_engine import ComboDecision, ComboInputEvent
+from keymasq.keymasqd.combo_engine import ComboDecision
 from keymasq.keymasqd.device_manager import DesiredGrabConfig, DeviceManager
 from keymasq.keymasqd.runtime import actions as adm
 from keymasq.keymasqd.runtime import combos as cdm
@@ -85,8 +85,6 @@ def _combo_runtime_deps(
 ) -> cdm.ComboRuntimeDeps:
     return cdm.ComboRuntimeDeps(
         asyncio_mod=dm.ASYNCIO_RUNTIME,
-        contextlib_mod=dm.contextlib,
-        time_mod=dm.time,
         evdev_mod=dm.runtime_adapters.COMBO_EVDEV_RUNTIME,
         uinput_writer=dm.runtime_adapters.identity_uinput_writer,
         emit_mouse_move_fn=dm.runtime_adapters.combo_emit_mouse_move,
@@ -117,8 +115,6 @@ async def _runtime_on_device_event(
         source,
         resolve_stable_path_fn=dm.resolve_stable_path,
         get_interface_id_fn=dm.get_interface_id,
-        combo_binding_cls=dm.RuntimeComboBinding,
-        combo_input_event_cls=ComboInputEvent,
         int_value_fn=dm._int_value,
         str_value_fn=dm._str_value,
         deps=_combo_runtime_deps(),
@@ -422,7 +418,6 @@ __all__ = [
     'SuperkeyMode',
     'dm',
     'ComboDecision',
-    'ComboInputEvent',
     'DesiredGrabConfig',
     'DeviceManager',
     'adm',

--- a/tests/keymasqd/device_manager_support.py
+++ b/tests/keymasqd/device_manager_support.py
@@ -84,10 +84,10 @@ def _combo_runtime_deps(
     fire_and_observe_fn: cdm.FireAndObserve = dm._fire_and_observe,
 ) -> cdm.ComboRuntimeDeps:
     return cdm.ComboRuntimeDeps(
-        asyncio_mod=cast(cdm._AsyncioModule, dm.ASYNCIO_RUNTIME),  # pyright: ignore[reportPrivateUsage]
+        asyncio_mod=dm.ASYNCIO_RUNTIME,
         contextlib_mod=dm.contextlib,
         time_mod=dm.time,
-        evdev_mod=cast(cdm._EvdevModule, dm.runtime_adapters.COMBO_EVDEV_RUNTIME),  # pyright: ignore[reportPrivateUsage]
+        evdev_mod=dm.runtime_adapters.COMBO_EVDEV_RUNTIME,
         uinput_writer=dm.runtime_adapters.identity_uinput_writer,
         emit_mouse_move_fn=dm.runtime_adapters.combo_emit_mouse_move,
         get_trigger_axis_fn=dm.get_trigger_axis,

--- a/tests/keymasqd/device_manager_support.py
+++ b/tests/keymasqd/device_manager_support.py
@@ -78,6 +78,24 @@ def _make_grabbed_device(
     )
 
 
+def _combo_runtime_deps(
+    *,
+    resolve_code_fn: cdm.ResolveCodeFn = dm.resolve_output_code,
+    fire_and_observe_fn: cdm.FireAndObserve = dm._fire_and_observe,
+) -> cdm.ComboRuntimeDeps:
+    return cdm.ComboRuntimeDeps(
+        asyncio_mod=dm._combo_asyncio_runtime(),
+        contextlib_mod=dm.contextlib,
+        time_mod=dm.time,
+        evdev_mod=dm._combo_evdev_runtime(),
+        uinput_writer=dm._combo_uinput_writer(),
+        emit_mouse_move_fn=dm._combo_emit_mouse_move_fn(),
+        get_trigger_axis_fn=dm.get_trigger_axis,
+        resolve_code_fn=resolve_code_fn,
+        fire_and_observe_fn=fire_and_observe_fn,
+    )
+
+
 async def _runtime_on_device_event(
     manager: DeviceManager,
     hardware_id: str,
@@ -103,36 +121,14 @@ async def _runtime_on_device_event(
         combo_input_event_cls=ComboInputEvent,
         int_value_fn=dm._int_value,
         str_value_fn=dm._str_value,
-        time_mod=dm.time,
-        action_type_enum=dm.ActionType,
-        mapping_action_cls=dm.MappingAction,
-        emit_mouse_move_fn=dm._combo_emit_mouse_move_fn(),
-        get_trigger_axis_fn=dm.get_trigger_axis,
-        resolve_code_fn=dm.resolve_output_code,
-        fire_and_observe_fn=dm._fire_and_observe,
-        command_type=dm.CommandType,
-        asyncio_mod=dm._combo_asyncio_runtime(),
-        contextlib_mod=dm.contextlib,
-        evdev_mod=dm._combo_evdev_runtime(),
-        uinput_writer=dm._combo_uinput_writer(),
+        deps=_combo_runtime_deps(),
     )
 
 
 async def _runtime_clear_combo_runtime(manager: DeviceManager) -> None:
     await cdm.clear_combo_runtime(
         manager,
-        asyncio_mod=dm._combo_asyncio_runtime(),
-        contextlib_mod=dm.contextlib,
-        mapping_action_cls=dm.MappingAction,
-        evdev_mod=dm._combo_evdev_runtime(),
-        uinput_writer=dm._combo_uinput_writer(),
-        emit_mouse_move_fn=dm._combo_emit_mouse_move_fn(),
-        get_trigger_axis_fn=dm.get_trigger_axis,
-        resolve_code_fn=dm.resolve_output_code,
-        fire_and_observe_fn=dm._fire_and_observe,
-        command_type=dm.CommandType,
-        action_type_enum=dm.ActionType,
-        time_mod=dm.time,
+        deps=_combo_runtime_deps(),
     )
 
 
@@ -143,36 +139,14 @@ async def _runtime_clear_combo_scope(
         manager,
         hardware_id,
         source,
-        asyncio_mod=dm._combo_asyncio_runtime(),
-        contextlib_mod=dm.contextlib,
-        mapping_action_cls=dm.MappingAction,
-        evdev_mod=dm._combo_evdev_runtime(),
-        uinput_writer=dm._combo_uinput_writer(),
-        emit_mouse_move_fn=dm._combo_emit_mouse_move_fn(),
-        get_trigger_axis_fn=dm.get_trigger_axis,
-        resolve_code_fn=dm.resolve_output_code,
-        fire_and_observe_fn=dm._fire_and_observe,
-        command_type=dm.CommandType,
-        action_type_enum=dm.ActionType,
-        time_mod=dm.time,
+        deps=_combo_runtime_deps(),
     )
 
 
 def _runtime_refresh_combo_watchdog(manager: DeviceManager) -> None:
     cdm.refresh_combo_timeout_watchdog(
         manager,
-        asyncio_mod=dm._combo_asyncio_runtime(),
-        time_mod=dm.time,
-        action_type_enum=dm.ActionType,
-        mapping_action_cls=dm.MappingAction,
-        emit_mouse_move_fn=dm._combo_emit_mouse_move_fn(),
-        get_trigger_axis_fn=dm.get_trigger_axis,
-        resolve_code_fn=dm.resolve_output_code,
-        fire_and_observe_fn=dm._fire_and_observe,
-        command_type=dm.CommandType,
-        contextlib_mod=dm.contextlib,
-        evdev_mod=dm._combo_evdev_runtime(),
-        uinput_writer=dm._combo_uinput_writer(),
+        deps=_combo_runtime_deps(),
     )
 
 
@@ -180,18 +154,7 @@ async def _runtime_combo_timeout_watchdog(manager: DeviceManager, deadline: floa
     await cdm.combo_timeout_watchdog(
         manager,
         deadline,
-        asyncio_mod=dm._combo_asyncio_runtime(),
-        time_mod=dm.time,
-        action_type_enum=dm.ActionType,
-        mapping_action_cls=dm.MappingAction,
-        emit_mouse_move_fn=dm._combo_emit_mouse_move_fn(),
-        get_trigger_axis_fn=dm.get_trigger_axis,
-        resolve_code_fn=dm.resolve_output_code,
-        fire_and_observe_fn=dm._fire_and_observe,
-        command_type=dm.CommandType,
-        contextlib_mod=dm.contextlib,
-        evdev_mod=dm._combo_evdev_runtime(),
-        uinput_writer=dm._combo_uinput_writer(),
+        deps=_combo_runtime_deps(),
     )
 
 
@@ -453,15 +416,7 @@ async def _runtime_start_combo_action(
         action,
         binding,
         trigger_bindings or (binding,),
-        action_type_enum=dm.ActionType,
-        asyncio_mod=dm._combo_asyncio_runtime(),
-        emit_mouse_move_fn=dm._combo_emit_mouse_move_fn(),
-        get_trigger_axis_fn=dm.get_trigger_axis,
-        resolve_code_fn=resolve_code_fn,
-        fire_and_observe_fn=dm._fire_and_observe,
-        command_type=dm.CommandType,
-        evdev_mod=dm._combo_evdev_runtime(),
-        uinput_writer=dm._combo_uinput_writer(),
+        deps=_combo_runtime_deps(resolve_code_fn=cast(cdm.ResolveCodeFn, resolve_code_fn)),
     )
 
 
@@ -469,17 +424,7 @@ async def _runtime_stop_combo_action(manager: DeviceManager, combo_id: str) -> N
     await cdm.stop_combo_action(
         manager,
         combo_id,
-        asyncio_mod=dm._combo_asyncio_runtime(),
-        contextlib_mod=dm.contextlib,
-        mapping_action_cls=dm.MappingAction,
-        evdev_mod=dm._combo_evdev_runtime(),
-        uinput_writer=dm._combo_uinput_writer(),
-        emit_mouse_move_fn=dm._combo_emit_mouse_move_fn(),
-        get_trigger_axis_fn=dm.get_trigger_axis,
-        resolve_code_fn=dm.resolve_output_code,
-        fire_and_observe_fn=dm._fire_and_observe,
-        command_type=dm.CommandType,
-        action_type_enum=dm.ActionType,
+        deps=_combo_runtime_deps(),
     )
 
 __all__ = [

--- a/tests/keymasqd/macro_backend_support.py
+++ b/tests/keymasqd/macro_backend_support.py
@@ -52,16 +52,7 @@ async def _play_macro_task(manager: DeviceManager, **kwargs: object) -> None:
         start_x=int(kwargs["start_x"]),
         start_y=int(kwargs["start_y"]),
         block_mouse_movement=bool(kwargs["block_mouse_movement"]),
-        asyncio_mod=dm._macro_asyncio_runtime(),
-        evdev_mod=dm.evdev,
-        log=dm.log,
-        int_value_fn=dm._int_value,
-        str_value_fn=dm._str_value,
-        uinput_writer=dm._macro_uinput_writer(),
-        contextlib_mod=dm.contextlib,
-        random_mod=dm.random,
-        uuid_mod=dm.uuid,
-        command_type=dm._macro_command_type(),
+        deps=dm._macro_runtime_deps(),
     )
 
 
@@ -69,12 +60,7 @@ async def _process_grabbed_event(device: GrabbedDevice, event: evdev.InputEvent)
     await gde.process_event(
         device,
         event,
-        evdev_mod=evdev,
-        time_mod=gde.time,
-        log=gdm.log,
-        combo_decision_cls=ComboDecision,
-        classify_event_device_type_fn=gde.classify_event_device_type,
-        action_type_enum=ActionType,
+        deps=gde.build_event_processing_deps(log=gdm.log),
     )
 
 __all__ = [

--- a/tests/keymasqd/test_device_manager_core.py
+++ b/tests/keymasqd/test_device_manager_core.py
@@ -514,7 +514,7 @@ class TestMacroControlActions:
 
         monkeypatch.setattr(dm.asyncio, "sleep", fake_sleep)
         monkeypatch.setattr(dm.asyncio, "get_running_loop", lambda: _FakeLoop())
-        monkeypatch.setattr(dm.random, "randint", lambda _minimum, _maximum: 50)
+        monkeypatch.setattr(mdm.random, "randint", lambda _minimum, _maximum: 50)
 
         result = await _runtime_run_macro_control_action(
             manager,

--- a/tests/keymasqd/test_device_manager_core.py
+++ b/tests/keymasqd/test_device_manager_core.py
@@ -416,9 +416,8 @@ class TestListDevices:
         schedule_topology_reconcile.assert_called_once_with(
             manager,
             snapshot,
-            asyncio_mod=dm._topology_asyncio_runtime(),
-            cancelled_error=asyncio.CancelledError,
             log=dm.log,
+            deps=dm._topology_runtime_deps(),
         )
 
     @pytest.mark.asyncio
@@ -467,9 +466,8 @@ class TestListDevices:
         schedule_topology_reconcile.assert_called_once_with(
             manager,
             snapshot,
-            asyncio_mod=dm._topology_asyncio_runtime(),
-            cancelled_error=asyncio.CancelledError,
             log=dm.log,
+            deps=dm._topology_runtime_deps(),
         )
 
 

--- a/tests/keymasqd/test_device_manager_runtime_recovery.py
+++ b/tests/keymasqd/test_device_manager_runtime_recovery.py
@@ -495,7 +495,7 @@ class TestDeviceManagerHelpers:
             Mock(side_effect=lambda *args, **kwargs: refreshes.append("refresh")),
         )
 
-        monkeypatch.setattr(dm.time, "monotonic", lambda: 10.0)
+        monkeypatch.setattr(cdm.time, "monotonic", lambda: 10.0)
         monkeypatch.setattr(dm.asyncio, "sleep", AsyncMock())
 
         task = asyncio.create_task(_runtime_combo_timeout_watchdog(manager, 10.5))

--- a/tests/keymasqd/test_device_manager_runtime_recovery.py
+++ b/tests/keymasqd/test_device_manager_runtime_recovery.py
@@ -43,13 +43,9 @@ class TestEventLoopRecovery:
                 action,
                 event,
                 event_name,
-                asyncio_mod=gdm.ASYNCIO_RUNTIME,
-                command_type=dm.CommandType,
-                fire_and_observe_fn=lambda coro, _label: asyncio.create_task(coro),
-                action_type_enum=ActionType,
-                superkey_machine_cls=gda.SuperkeyMachine,
-                evdev_mod=evdev,
-                uinput_writer=lambda device: cast(gdt.WritableUInput | None, device),
+                deps=gde.build_action_execution_deps(
+                    fire_and_observe_fn=lambda coro, _label: asyncio.create_task(coro)
+                ),
             )
             raise RuntimeError("boom")
 

--- a/tests/keymasqd/test_grabbed_device_runtime_helpers.py
+++ b/tests/keymasqd/test_grabbed_device_runtime_helpers.py
@@ -239,7 +239,6 @@ class TestGrabbedDeviceHelpers:
                 "waiting",
                 ["key_a"],
                 waited_s=1.5,
-                command_type=CommandType,
                 log=gdm.log,
             )
 
@@ -286,13 +285,11 @@ class TestGrabbedDeviceHelpers:
             device,
             dm.MappingAction(action_type=ActionType.GAMEPAD, target="btn_lt")
             ,
-            action_type_enum=ActionType,
         )
         gdg.reconcile_startup_held_action(
             device,
             dm.MappingAction(action_type=ActionType.GAMEPAD, target="btn_south")
             ,
-            action_type_enum=ActionType,
         )
 
         assert gamepad.writes == [

--- a/tests/test_profile_handoff.py
+++ b/tests/test_profile_handoff.py
@@ -4,7 +4,6 @@ import evdev
 import pytest
 
 from keymasq.common.models import ActionType, MappingAction
-from keymasq.keymasqd.combo_engine import ComboDecision
 from keymasq.keymasqd.device_manager import DeviceManager
 from keymasq.keymasqd.runtime import grabbed_device as gdm
 from keymasq.keymasqd.runtime import grabbed_device_events as gde
@@ -47,12 +46,7 @@ async def _process_event(device: GrabbedDevice, event: evdev.InputEvent) -> None
     await gde.process_event(
         device,
         event,
-        evdev_mod=evdev,
-        time_mod=gde.time,
-        log=gdm.log,
-        combo_decision_cls=ComboDecision,
-        classify_event_device_type_fn=gde.classify_event_device_type,
-        action_type_enum=ActionType,
+        deps=gde.build_event_processing_deps(log=gdm.log),
     )
 
 


### PR DESCRIPTION
## Summary
- Introduce a shared `ComboRuntimeDeps` bundle to pass combo runtime dependencies through the daemon/runtime stack.
- Simplify combo lifecycle and watchdog helpers in `keymasq/keymasqd/runtime/combos.py` by replacing long parameter lists with the new dependency object.
- Update `DeviceManager` and grab lifecycle wiring to construct and reuse the shared dependency bundle.
- Trim the test support scaffolding to match the new combo runtime dependency structure.

## Testing
- Not run (PR content only).
- Expected validation: `./scripts/check.sh keymasqd`
- Expected validation: targeted keymasqd tests covering combo start/stop, timeout watchdog, and grab lifecycle paths.