### PR TITLE
Improve slurp capture handling and macro editor updates

### DIFF
--- a/docs/DEPENDENCIES.md
+++ b/docs/DEPENDENCIES.md
@@ -109,6 +109,11 @@ differentiator is the compositor/session environment itself.
   path used by the listener for recording start-position capture and similar
   pointer reads
 - On unsupported compositors, `slurp` is not used
+- Path resolution checks the embedded build path first, then `/usr/bin/slurp`,
+  `/run/current-system/sw/bin/slurp`, and finally `PATH`
+- `SLURP_PATH` overrides auto-detection entirely:
+  set it to an absolute path to force that binary, or set it to an empty string
+  to disable slurp integration and force the fallback cursor-query path
 
 `slurp` is not a universal base runtime dependency, but it is a real
 feature/runtime dependency for supported Wayland environments rather than just a

--- a/flake.nix
+++ b/flake.nix
@@ -329,6 +329,7 @@
               pkgs.nodejs
               pkgs.cloc
               pkgs.glow
+	      pkgs.slurp
               # GitHub Actions
               pkgs.gh           # GitHub CLI - manage workflows, PRs, releases
               pkgs.act          # run GitHub Actions locally

--- a/keymasq/common/paths.py
+++ b/keymasq/common/paths.py
@@ -22,6 +22,7 @@ import contextlib
 import importlib
 import logging
 import os
+import shutil
 from pathlib import Path
 
 log = logging.getLogger(__name__)
@@ -54,6 +55,10 @@ with contextlib.suppress(ImportError, AttributeError):
 
 KEYMASQ_RECORD_HELPER_PATH = Path(_build_helper_path)
 SLURP_PATH = Path(_build_slurp_path)
+SLURP_FALLBACK_PATHS = (
+    Path("/usr/bin/slurp"),
+    Path("/run/current-system/sw/bin/slurp"),
+)
 
 
 def ensure_config_dirs() -> None:
@@ -79,6 +84,26 @@ def resolve_keymasq_record_helper_path() -> str | None:
 
 
 def resolve_slurp_path() -> str | None:
-    if SLURP_PATH.is_file() and os.access(SLURP_PATH, os.X_OK):
-        return str(SLURP_PATH)
+    env_slurp_path = os.environ.get("SLURP_PATH")
+    if env_slurp_path is not None:
+        if env_slurp_path == "":
+            return None
+        env_path = Path(env_slurp_path)
+        if env_path.is_file() and os.access(env_path, os.X_OK):
+            return str(env_path)
+        return None
+
+    candidates: list[Path] = [SLURP_PATH, *SLURP_FALLBACK_PATHS]
+    path_slurp = shutil.which("slurp")
+    if path_slurp:
+        candidates.append(Path(path_slurp))
+
+    seen: set[str] = set()
+    for candidate in candidates:
+        candidate_str = str(candidate)
+        if candidate_str in seen:
+            continue
+        seen.add(candidate_str)
+        if candidate.is_file() and os.access(candidate, os.X_OK):
+            return candidate_str
     return None

--- a/keymasq/gui/widgets/key_selector_dialog.py
+++ b/keymasq/gui/widgets/key_selector_dialog.py
@@ -301,6 +301,7 @@ class KeySelectorDialog(Adw.Dialog):
         self._capture_delay_seconds: float = 2.0
         self._capture_timeout_id: int = 0
         self._capture_pending: bool = False
+        self._capture_request_id: int = 0
         self._slurp_capture = get_slurp_capture()
         self._slurp_capture.set_compositor(detect_compositor_sync())
         self._slurp_available = self._slurp_capture.available
@@ -1080,12 +1081,18 @@ class KeySelectorDialog(Adw.Dialog):
 
     def _on_capture_position_clicked(self, btn: Gtk.Button) -> None:
         self._cancel_capture_position("")
+        self._capture_request_id += 1
+        request_id = self._capture_request_id
 
         if self._slurp_available:
             self._capture_pending = True
             self.mouse_move_capture_btn.set_sensitive(False)
             self.mouse_move_capture_status.set_text("Click to capture position...")
-            self._slurp_capture.capture_point(self._on_slurp_capture_result)
+            self._slurp_capture.capture_point(
+                lambda result, expected_id=request_id: self._on_slurp_capture_result(
+                    expected_id, result
+                )
+            )
         else:
             self._capture_delay_seconds = float(self.mouse_move_capture_delay_spin.get_value())
             self._capture_pending = True
@@ -1095,10 +1102,12 @@ class KeySelectorDialog(Adw.Dialog):
             )
             self._capture_timeout_id = GLib.timeout_add(
                 int(self._capture_delay_seconds * 1000),
-                self._capture_position_after_delay,
+                lambda expected_id=request_id: self._capture_position_after_delay(expected_id),
             )
 
-    def _on_slurp_capture_result(self, result) -> None:
+    def _on_slurp_capture_result(self, request_id: int, result) -> None:
+        if request_id != self._capture_request_id:
+            return
         self._capture_pending = False
         self.mouse_move_capture_btn.set_sensitive(True)
 
@@ -1110,19 +1119,23 @@ class KeySelectorDialog(Adw.Dialog):
         self.mouse_move_y_spin.set_value(result.y)
         self.mouse_move_capture_status.set_text(f"Captured: {result.x}, {result.y}")
 
-    def _capture_position_after_delay(self) -> bool:
+    def _capture_position_after_delay(self, request_id: int) -> bool:
         self._capture_timeout_id = 0
-        if not self._capture_pending:
+        if request_id != self._capture_request_id or not self._capture_pending:
             return False
         self.mouse_move_capture_status.set_text("Reading cursor position...")
         session_request_async(
             {"command": "get_cursor_position"},
-            self._on_capture_position_response,
+            lambda response, expected_id=request_id: self._on_capture_position_response(
+                expected_id, response
+            ),
             timeout=5.0,
         )
         return False
 
-    def _on_capture_position_response(self, response: dict | None) -> bool:
+    def _on_capture_position_response(self, request_id: int, response: dict | None) -> bool:
+        if request_id != self._capture_request_id:
+            return False
         self._capture_pending = False
         self.mouse_move_capture_btn.set_sensitive(True)
 
@@ -1141,6 +1154,7 @@ class KeySelectorDialog(Adw.Dialog):
         return False
 
     def _cancel_capture_position(self, status_text: str) -> None:
+        self._capture_request_id += 1
         if self._capture_timeout_id:
             GLib.source_remove(self._capture_timeout_id)
             self._capture_timeout_id = 0

--- a/keymasq/gui/widgets/macro_editor_dialog.py
+++ b/keymasq/gui/widgets/macro_editor_dialog.py
@@ -136,6 +136,12 @@ def _get_dropdown_selected_id(
     return default_id
 
 
+def _set_entry_text_if_needed(entry: Gtk.Entry, text: str) -> None:
+    """Avoid redundant Gtk.Entry updates that reset caret/focus state."""
+    if entry.get_text() != text:
+        entry.set_text(text)
+
+
 # ---------------------------------------------------------------------------
 # Data model
 # ---------------------------------------------------------------------------
@@ -1452,7 +1458,7 @@ class TimelineWidget(Gtk.DrawingArea):
             elif track == "movement":
                 gap_scope = "movement"
 
-            gap_btn = Gtk.Button(label=f"Insert Gap Note at {t_label}")
+            gap_btn = Gtk.Button(label=f"Insert Wait at {t_label}")
             gap_btn.add_css_class("flat")
 
             def _insert_gap(_b, _t=t_us, _scope=gap_scope, _p=popover):
@@ -1567,7 +1573,7 @@ class TimelineWidget(Gtk.DrawingArea):
             if box.get_first_child():
                 box.append(Gtk.Separator())
             if ev.mode == "gap":
-                label = f"Delete Gap Note ({ev.x}ms, {ev.scope})"
+                label = f"Delete Wait ({ev.x}ms, {ev.scope})"
             else:
                 label = f"Delete Move {ev.mode.upper()} ({ev.x}, {ev.y})"
             del_move_btn = Gtk.Button(label=label)
@@ -1645,6 +1651,10 @@ class MacroEditorDialog(Adw.Dialog):
         self._capture_delay_seconds: float = 2.0
         self._capture_timeout_id: int = 0
         self._capture_pending: bool = False
+        self._capture_request_id: int = 0
+        self._move_capture_timeout_id: int = 0
+        self._move_capture_pending: bool = False
+        self._move_capture_request_id: int = 0
         self._slurp_capture = get_slurp_capture()
         self._slurp_capture.set_compositor(detect_compositor_sync())
         self._slurp_available = self._slurp_capture.available
@@ -2009,7 +2019,7 @@ class MacroEditorDialog(Adw.Dialog):
 
         box.append(Gtk.Separator())
 
-        insert_title = Gtk.Label(label="Insert Gap")
+        insert_title = Gtk.Label(label="Insert Wait")
         insert_title.add_css_class("heading")
         insert_title.set_halign(Gtk.Align.START)
         box.append(insert_title)
@@ -2027,7 +2037,7 @@ class MacroEditorDialog(Adw.Dialog):
         box.append(at_row)
 
         gap_insert_row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=8)
-        gap_insert_row.append(Gtk.Label(label="Gap (ms):"))
+        gap_insert_row.append(Gtk.Label(label="Wait (ms):"))
         insert_gap_ms_spin = Gtk.SpinButton()
         self._insert_gap_ms_spin = insert_gap_ms_spin
         insert_gap_ms_spin.set_adjustment(
@@ -2044,7 +2054,7 @@ class MacroEditorDialog(Adw.Dialog):
         scope_row.append(self._insert_gap_scope_combo)
         box.append(scope_row)
 
-        insert_btn = Gtk.Button(label="Insert Gap")
+        insert_btn = Gtk.Button(label="Insert Wait")
         insert_btn.add_css_class("suggested-action")
         insert_btn.connect("clicked", self._on_insert_gap_clicked)
         box.append(insert_btn)
@@ -2182,6 +2192,43 @@ class MacroEditorDialog(Adw.Dialog):
         panel.append(move_row)
         self._move_row = move_row
         self._move_row.set_visible(False)
+
+        move_capture_row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=8)
+        move_capture_row.set_halign(Gtk.Align.START)
+        move_capture_row.set_margin_start(24)
+
+        if not self._slurp_available:
+            move_capture_label = Gtk.Label(label="Capture new position in:")
+            move_capture_label.add_css_class("dim-label")
+            move_capture_row.append(move_capture_label)
+
+        self._move_capture_delay_spin = Gtk.SpinButton()
+        self._move_capture_delay_spin.set_adjustment(
+            Gtk.Adjustment(
+                value=self._capture_delay_seconds, lower=0.2, upper=15.0, step_increment=0.2
+            )
+        )
+        self._move_capture_delay_spin.set_digits(1)
+        self._move_capture_delay_spin.set_width_chars(4)
+        self._move_capture_delay_spin.set_visible(not self._slurp_available)
+        move_capture_row.append(self._move_capture_delay_spin)
+
+        if not self._slurp_available:
+            move_capture_row.append(Gtk.Label(label="s"))
+
+        self._move_capture_btn = Gtk.Button(label="Capture")
+        self._move_capture_btn.connect("clicked", self._on_capture_selected_move_clicked)
+        move_capture_row.append(self._move_capture_btn)
+
+        self._move_capture_status = Gtk.Label(label="")
+        self._move_capture_status.add_css_class("dim-label")
+        self._move_capture_status.set_halign(Gtk.Align.START)
+        self._move_capture_status.set_hexpand(True)
+        move_capture_row.append(self._move_capture_status)
+
+        panel.append(move_capture_row)
+        self._move_capture_row = move_capture_row
+        self._move_capture_row.set_visible(False)
 
         gap_row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=8)
         gap_row.set_halign(Gtk.Align.START)
@@ -2435,17 +2482,41 @@ class MacroEditorDialog(Adw.Dialog):
         if self._slurp_available:
             self._macro_capture_delay_spin.set_sensitive(False)
         else:
-            self._macro_capture_delay_spin.set_sensitive(enabled)
+            self._macro_capture_delay_spin.set_sensitive(enabled and not self._capture_pending)
         self._macro_capture_btn.set_sensitive(enabled and not self._capture_pending)
+
+    def _update_selected_move_capture_controls(
+        self,
+        selected_move: EditableMove | None = None,
+    ) -> None:
+        if not hasattr(self, "_move_capture_row"):
+            return
+        move = selected_move
+        if move is None:
+            selected_obj = self._timeline._selected if hasattr(self, "_timeline") else None
+            move = selected_obj if isinstance(selected_obj, EditableMove) else None
+        enabled = bool(move is not None and move.mode == "abs")
+        self._move_capture_row.set_visible(enabled)
+        if self._slurp_available:
+            self._move_capture_delay_spin.set_sensitive(False)
+        else:
+            self._move_capture_delay_spin.set_sensitive(enabled and not self._move_capture_pending)
+        self._move_capture_btn.set_sensitive(enabled and not self._move_capture_pending)
 
     def _on_capture_start_position_clicked(self, btn: Gtk.Button) -> None:
         self._cancel_capture_start_position("")
+        self._capture_request_id += 1
+        request_id = self._capture_request_id
 
         if self._slurp_available:
             self._capture_pending = True
             self._macro_capture_btn.set_sensitive(False)
             self._macro_capture_status.set_text("Click to capture position...")
-            self._slurp_capture.capture_point(self._on_slurp_capture_result)
+            self._slurp_capture.capture_point(
+                lambda result, expected_id=request_id: self._on_slurp_capture_result(
+                    expected_id, result
+                )
+            )
         else:
             self._capture_delay_seconds = float(self._macro_capture_delay_spin.get_value())
             self._capture_pending = True
@@ -2455,10 +2526,45 @@ class MacroEditorDialog(Adw.Dialog):
             )
             self._capture_timeout_id = GLib.timeout_add(
                 int(self._capture_delay_seconds * 1000),
-                self._capture_start_position_after_delay,
+                lambda expected_id=request_id: self._capture_start_position_after_delay(
+                    expected_id
+                ),
             )
 
-    def _on_slurp_capture_result(self, result) -> None:
+    def _on_capture_selected_move_clicked(self, btn: Gtk.Button) -> None:
+        selected_obj = self._timeline._selected
+        if not isinstance(selected_obj, EditableMove) or selected_obj.mode != "abs":
+            return
+        self._cancel_capture_selected_move("")
+        self._move_capture_request_id += 1
+        request_id = self._move_capture_request_id
+
+        if self._slurp_available:
+            self._move_capture_pending = True
+            self._update_selected_move_capture_controls(selected_obj)
+            self._move_capture_status.set_text("Click to capture position...")
+            self._slurp_capture.capture_point(
+                lambda result, move=selected_obj, expected_id=request_id: (
+                    self._on_move_slurp_capture_result(expected_id, move, result)
+                )
+            )
+        else:
+            self._capture_delay_seconds = float(self._move_capture_delay_spin.get_value())
+            self._move_capture_pending = True
+            self._update_selected_move_capture_controls(selected_obj)
+            self._move_capture_status.set_text(
+                f"Move cursor now... capturing in {self._capture_delay_seconds:.1f}s"
+            )
+            self._move_capture_timeout_id = GLib.timeout_add(
+                int(self._capture_delay_seconds * 1000),
+                lambda move=selected_obj, expected_id=request_id: (
+                    self._capture_selected_move_after_delay(expected_id, move)
+                ),
+            )
+
+    def _on_slurp_capture_result(self, request_id: int, result) -> None:
+        if request_id != self._capture_request_id:
+            return
         self._capture_pending = False
         self._update_macro_move_start_controls()
 
@@ -2471,19 +2577,68 @@ class MacroEditorDialog(Adw.Dialog):
         self._macro_move_to_start_check.set_active(True)
         self._macro_capture_status.set_text(f"Captured: {result.x}, {result.y}")
 
-    def _capture_start_position_after_delay(self) -> bool:
+    def _on_move_slurp_capture_result(self, request_id: int, move: EditableMove, result) -> None:
+        if request_id != self._move_capture_request_id:
+            return
+        self._move_capture_pending = False
+        self._update_selected_move_capture_controls()
+
+        if result is None:
+            self._move_capture_status.set_text("Capture cancelled or failed")
+            return
+
+        if move.mode != "abs" or move not in self._synthetic_moves:
+            self._move_capture_status.set_text("Capture target no longer available")
+            return
+
+        move.x = int(result.x)
+        move.y = int(result.y)
+        if self._timeline._selected is move:
+            self._updating_props = True
+            try:
+                self._move_x_spin.set_value(move.x)
+                self._move_y_spin.set_value(move.y)
+            finally:
+                self._updating_props = False
+            self._on_selection_changed(move)
+        self._timeline.queue_draw()
+        self._move_capture_status.set_text(f"Captured: {result.x}, {result.y}")
+
+    def _capture_start_position_after_delay(self, request_id: int) -> bool:
         self._capture_timeout_id = 0
-        if not self._capture_pending:
+        if request_id != self._capture_request_id or not self._capture_pending:
             return False
         self._macro_capture_status.set_text("Reading cursor position...")
         session_request_async(
             {"command": "get_cursor_position"},
-            self._on_capture_start_position_response,
+            lambda response, expected_id=request_id: self._on_capture_start_position_response(
+                expected_id, response
+            ),
             timeout=5.0,
         )
         return False
 
-    def _on_capture_start_position_response(self, response: dict | None) -> bool:
+    def _capture_selected_move_after_delay(self, request_id: int, move: EditableMove) -> bool:
+        self._move_capture_timeout_id = 0
+        if request_id != self._move_capture_request_id or not self._move_capture_pending:
+            return False
+        self._move_capture_status.set_text("Reading cursor position...")
+        session_request_async(
+            {"command": "get_cursor_position"},
+            lambda response, expected_move=move, expected_id=request_id: (
+                self._on_capture_selected_move_response(expected_id, expected_move, response)
+            ),
+            timeout=5.0,
+        )
+        return False
+
+    def _on_capture_start_position_response(
+        self,
+        request_id: int,
+        response: dict | None,
+    ) -> bool:
+        if request_id != self._capture_request_id:
+            return False
         self._capture_pending = False
         self._update_macro_move_start_controls()
 
@@ -2496,13 +2651,54 @@ class MacroEditorDialog(Adw.Dialog):
             self._macro_capture_status.set_text(message)
             return False
 
-        self._macro_start_x_spin.set_value(int(response.get("x", 0)))
-        self._macro_start_y_spin.set_value(int(response.get("y", 0)))
+        x = int(response.get("x", 0))
+        y = int(response.get("y", 0))
+        self._macro_start_x_spin.set_value(x)
+        self._macro_start_y_spin.set_value(y)
         self._macro_move_to_start_check.set_active(True)
         self._macro_capture_status.set_text("Captured")
         return False
 
+    def _on_capture_selected_move_response(
+        self,
+        request_id: int,
+        move: EditableMove,
+        response: dict | None,
+    ) -> bool:
+        if request_id != self._move_capture_request_id:
+            return False
+        self._move_capture_pending = False
+        self._update_selected_move_capture_controls()
+
+        if not response or response.get("status") != "ok":
+            message = (
+                (response or {}).get("message") or (response or {}).get("error") or "Capture failed"
+            )
+            if "Unknown command: get_cursor_position" in message:
+                message = "Please restart Keymasq Session, then try again"
+            self._move_capture_status.set_text(message)
+            return False
+
+        if move.mode != "abs" or move not in self._synthetic_moves:
+            self._move_capture_status.set_text("Capture target no longer available")
+            return False
+
+        move.x = int(response.get("x", 0))
+        move.y = int(response.get("y", 0))
+        if self._timeline._selected is move:
+            self._updating_props = True
+            try:
+                self._move_x_spin.set_value(move.x)
+                self._move_y_spin.set_value(move.y)
+            finally:
+                self._updating_props = False
+            self._on_selection_changed(move)
+        self._timeline.queue_draw()
+        self._move_capture_status.set_text("Captured")
+        return False
+
     def _cancel_capture_start_position(self, status_text: str) -> None:
+        self._capture_request_id += 1
         if self._capture_timeout_id:
             GLib.source_remove(self._capture_timeout_id)
             self._capture_timeout_id = 0
@@ -2511,6 +2707,17 @@ class MacroEditorDialog(Adw.Dialog):
             self._macro_capture_status.set_text(status_text)
         if hasattr(self, "_macro_capture_btn"):
             self._update_macro_move_start_controls()
+
+    def _cancel_capture_selected_move(self, status_text: str) -> None:
+        self._move_capture_request_id += 1
+        if self._move_capture_timeout_id:
+            GLib.source_remove(self._move_capture_timeout_id)
+            self._move_capture_timeout_id = 0
+        self._move_capture_pending = False
+        if hasattr(self, "_move_capture_status"):
+            self._move_capture_status.set_text(status_text)
+        if hasattr(self, "_move_capture_btn"):
+            self._update_selected_move_capture_controls()
 
     def _build_footer(self) -> Gtk.Widget:
         footer = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=8)
@@ -3156,10 +3363,14 @@ class MacroEditorDialog(Adw.Dialog):
         selected_obj: object | None,
     ) -> None:
         if selected_obj is None:
+            self._cancel_capture_selected_move("")
             self._revealer.set_reveal_child(False)
+            self._update_selected_move_capture_controls(None)
             return
 
         self._revealer.set_reveal_child(True)
+        if not isinstance(selected_obj, EditableMove) or selected_obj.mode != "abs":
+            self._cancel_capture_selected_move("")
         if isinstance(selected_obj, EditableControl):
             control = selected_obj
             self._prop_title.set_label("Control")
@@ -3204,25 +3415,27 @@ class MacroEditorDialog(Adw.Dialog):
                     self._control_b_spin.set_value(max(1, int(control.max_ms)))
                 elif control.mode == "exec_async":
                     self._control_cmd_row.set_visible(True)
-                    self._control_cmd_entry.set_text(control.command)
+                    _set_entry_text_if_needed(self._control_cmd_entry, control.command)
                 elif control.mode == "exec_sync":
                     self._control_cmd_row.set_visible(True)
                     self._control_sync_row.set_visible(True)
                     self._control_timeout_hint_label.set_visible(True)
-                    self._control_cmd_entry.set_text(control.command)
+                    _set_entry_text_if_needed(self._control_cmd_entry, control.command)
                     self._control_timeout_spin.set_value(max(1, int(control.timeout_ms)))
                     self._control_inhibit_check.set_active(bool(control.inhibit_mouse))
                     self._update_timeout_clamp_hint(int(control.timeout_ms))
             finally:
                 self._updating_props = False
+            self._move_capture_row.set_visible(False)
+            self._update_selected_move_capture_controls(None)
             return
 
         self._control_row.set_visible(False)
         if isinstance(selected_obj, EditableMove):
             move = selected_obj
             if move.mode == "gap":
-                self._prop_title.set_label("Gap Note")
-                self._key_info_label.set_label(f"Insert {int(move.x)}ms gap ({move.scope})")
+                self._prop_title.set_label("Wait")
+                self._key_info_label.set_label(f"Insert {int(move.x)}ms wait ({move.scope})")
             else:
                 self._prop_title.set_label(f"Mouse Move ({move.mode.upper()})")
                 self._key_info_label.set_label(f"Move {move.mode.upper()} (x={move.x}, y={move.y})")
@@ -3237,10 +3450,11 @@ class MacroEditorDialog(Adw.Dialog):
             self._change_key_btn.set_visible(False)
             self._move_row.set_visible(True)
             self._gap_row.set_visible(move.mode == "gap")
+            self._move_capture_row.set_visible(move.mode == "abs")
             self._move_mode_label.set_label(
                 f"Mode: {move.mode.upper()}" if move.mode != "gap" else "Mode: GAP"
             )
-            self._move_x_label.set_label("Gap (ms):" if move.mode == "gap" else "X:")
+            self._move_x_label.set_label("Wait (ms):" if move.mode == "gap" else "X:")
             self._move_y_label.set_label("Unused:" if move.mode == "gap" else "Y:")
             self._move_y_spin.set_sensitive(move.mode != "gap")
 
@@ -3252,6 +3466,7 @@ class MacroEditorDialog(Adw.Dialog):
                 _set_dropdown_selected_id(self._gap_scope_combo, _SCOPE_OPTIONS, move.scope)
             finally:
                 self._updating_props = False
+            self._update_selected_move_capture_controls(move)
             return
 
         if isinstance(selected_obj, dict):
@@ -3269,12 +3484,14 @@ class MacroEditorDialog(Adw.Dialog):
             self._move_row.set_visible(False)
             self._gap_row.set_visible(False)
             self._control_row.set_visible(False)
+            self._move_capture_row.set_visible(False)
 
             self._updating_props = True
             try:
                 self._press_spin.set_value(int(selected_obj.get("t_us", 0)) / 1000)
             finally:
                 self._updating_props = False
+            self._update_selected_move_capture_controls(None)
             return
 
         assert isinstance(selected_obj, EditableEvent)
@@ -3292,6 +3509,7 @@ class MacroEditorDialog(Adw.Dialog):
         self._change_key_btn.set_visible(True)
         self._move_row.set_visible(False)
         self._gap_row.set_visible(False)
+        self._move_capture_row.set_visible(False)
 
         self._updating_props = True
         try:
@@ -3300,6 +3518,7 @@ class MacroEditorDialog(Adw.Dialog):
             self._release_spin.set_value(ev.release_t_us / 1000)
         finally:
             self._updating_props = False
+        self._update_selected_move_capture_controls(None)
 
     def _refresh_after_key_timing_change(self, ev: EditableEvent) -> None:
         self._events.sort(key=lambda e: e.press_t_us)
@@ -3549,8 +3768,10 @@ class MacroEditorDialog(Adw.Dialog):
         if not isinstance(selected_obj, EditableControl):
             return
         if selected_obj.mode in {"exec_sync", "exec_async"}:
-            selected_obj.command = entry.get_text().strip()
-            self._refresh_after_control_change(selected_obj)
+            # Do not rebuild the property panel while the command entry is focused.
+            # The full control refresh path toggles row visibility, which drops focus
+            # from the Gtk.Entry and makes typing impossible.
+            selected_obj.command = entry.get_text()
 
     def _on_control_timeout_changed(self, spin: Gtk.SpinButton) -> None:
         if self._updating_props:
@@ -3588,6 +3809,7 @@ class MacroEditorDialog(Adw.Dialog):
             return
 
         self._cancel_capture_start_position("")
+        self._cancel_capture_selected_move("")
         self._apply_macro_state(self._initial_macro_data)
 
         self._timeline._selected = None
@@ -3645,7 +3867,7 @@ class MacroEditorDialog(Adw.Dialog):
         box.set_margin_start(12)
         box.set_margin_end(12)
 
-        title = Gtk.Label(label="Insert Gap Note")
+        title = Gtk.Label(label="Insert Wait")
         title.add_css_class("heading")
         box.append(title)
 
@@ -3667,7 +3889,7 @@ class MacroEditorDialog(Adw.Dialog):
         box.append(at_row)
 
         gap_row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=8)
-        gap_row.append(Gtk.Label(label="Gap:"))
+        gap_row.append(Gtk.Label(label="Wait:"))
         gap_spin = Gtk.SpinButton()
         gap_spin.set_adjustment(Gtk.Adjustment(value=100, lower=1, upper=60000, step_increment=10))
         gap_spin.set_digits(0)
@@ -4391,4 +4613,5 @@ class MacroEditorDialog(Adw.Dialog):
 
     def close(self) -> None:
         self._cancel_capture_start_position("")
+        self._cancel_capture_selected_move("")
         super().close()

--- a/keymasq/session/listeners/hyprland.py
+++ b/keymasq/session/listeners/hyprland.py
@@ -276,7 +276,10 @@ class HyprlandListener(WindowListener):
                         return None
                     cmd_writer.write(command.encode())
                     await cmd_writer.drain()
-                    return await cmd_reader.read(read_size)
+                    response = await cmd_reader.read(read_size)
+                    if not response:
+                        raise ConnectionError("Hyprland command socket closed")
+                    return response
                 except Exception:
                     try:
                         cmd_writer = self._cmd_writer

--- a/keymasq/session/listeners/niri.py
+++ b/keymasq/session/listeners/niri.py
@@ -749,7 +749,7 @@ class NiriListener(WindowListener):
                     await cmd_writer.drain()
                     reply = await asyncio.wait_for(cmd_reader.readline(), timeout=timeout_s)
                     if not reply:
-                        return False, None
+                        raise ConnectionError("Niri command socket closed")
 
                     ok, body = parse_niri_reply(reply.decode("utf-8", errors="replace").strip())
                     if ok:

--- a/tests/gui/macro_editor_dialog_support.py
+++ b/tests/gui/macro_editor_dialog_support.py
@@ -13,6 +13,7 @@ gi.require_version("Adw", "1")
 import evdev  # noqa: E402
 
 from keymasq.common.models import ActionType  # noqa: E402
+from keymasq.gui.widgets.macro_editor_dialog import EditableControl  # noqa: E402
 from keymasq.gui.widgets.macro_editor_dialog import EditableEvent  # noqa: E402
 from keymasq.gui.widgets.macro_editor_dialog import EditableMove  # noqa: E402
 from keymasq.gui.widgets.macro_editor_dialog import MacroEditorDialog  # noqa: E402
@@ -57,6 +58,7 @@ __all__ = [
     'sys',
     'evdev',
     'ActionType',
+    'EditableControl',
     'EditableEvent',
     'EditableMove',
     'MacroEditorDialog',

--- a/tests/gui/test_gui_device_tab_misc.py
+++ b/tests/gui/test_gui_device_tab_misc.py
@@ -828,7 +828,9 @@ def test_key_selector_dialog_mouse_capture_and_move_mapping_paths(monkeypatch):
     assert results[0].move_y == 480
 
     error_dialog = KeySelectorDialog(Gtk.Box(), "Back")
+    error_dialog._on_capture_position_clicked(Gtk.Button())
     error_dialog._on_capture_position_response(
+        error_dialog._capture_request_id,
         {"status": "error", "message": "Unknown command: get_cursor_position"}
     )
 
@@ -836,6 +838,60 @@ def test_key_selector_dialog_mouse_capture_and_move_mapping_paths(monkeypatch):
         error_dialog.mouse_move_capture_status.get_text()
         == "Please restart Keymasq Session, then try again"
     )
+
+
+def test_key_selector_dialog_repeated_delayed_capture_ignores_stale_response(monkeypatch):
+    from collections.abc import Callable
+    from gi.repository import Gtk
+
+    from keymasq.gui.widgets import key_selector_dialog as dialog_module
+    from keymasq.gui.widgets.key_selector_dialog import KeySelectorDialog
+
+    callbacks: list[Callable[[], bool]] = []
+    requests: list[Callable[[dict[str, object]], bool | None]] = []
+
+    class _SlurpCapture:
+        available = False
+
+        def set_compositor(self, compositor: str) -> None:
+            return None
+
+    def fake_timeout_add(_delay, callback):
+        callbacks.append(callback)
+        return len(callbacks)
+
+    def fake_source_remove(_source_id):
+        return None
+
+    def fake_session_request_async(payload, callback, timeout=5.0):
+        assert payload == {"command": "get_cursor_position"}
+        requests.append(callback)
+
+    monkeypatch.setattr(dialog_module, "get_slurp_capture", lambda: _SlurpCapture())
+    monkeypatch.setattr(dialog_module, "detect_compositor_sync", lambda: "hyprland")
+    monkeypatch.setattr(dialog_module.GLib, "timeout_add", fake_timeout_add)
+    monkeypatch.setattr(dialog_module.GLib, "source_remove", fake_source_remove)
+    monkeypatch.setattr(dialog_module, "session_request_async", fake_session_request_async)
+
+    dialog = KeySelectorDialog(Gtk.Box(), "Back")
+    dialog.mouse_move_abs_check.set_active(True)
+    dialog._on_mouse_move_mode_changed(dialog.mouse_move_abs_check)
+
+    dialog._on_capture_position_clicked(Gtk.Button())
+    timer1 = callbacks.pop(0)
+    assert timer1() is False
+    stale_response = requests.pop(0)
+
+    dialog._on_capture_position_clicked(Gtk.Button())
+    timer2 = callbacks.pop(0)
+    stale_response({"status": "ok", "x": 100, "y": 200})
+
+    assert timer2() is False
+    fresh_response = requests.pop(0)
+    fresh_response({"status": "ok", "x": 300, "y": 400})
+
+    assert dialog.mouse_move_x_spin.get_value_as_int() == 300
+    assert dialog.mouse_move_y_spin.get_value_as_int() == 400
 
 
 def test_shared_navigation_picker_builds_dropdown():

--- a/tests/gui/test_macro_editor_dialog_widget.py
+++ b/tests/gui/test_macro_editor_dialog_widget.py
@@ -1,4 +1,8 @@
 # ruff: noqa: F403, F405, I001
+from collections.abc import Callable
+
+from keymasq.gui.widgets.macro_editor_dialog import EditableControl
+
 from tests.gui.macro_editor_dialog_support import *
 
 def test_macro_editor_initial_state_load_applies_macro_fields(monkeypatch) -> None:
@@ -128,6 +132,8 @@ def test_macro_editor_gap_note_controls_shift_timeline(monkeypatch) -> None:
     dialog._timeline._selected = gap
 
     dialog._on_selection_changed(gap)
+    assert dialog._prop_title.get_label() == "Wait"
+    assert dialog._move_x_label.get_label() == "Wait (ms):"
     dialog._move_x_spin.set_value(150)
     dialog._on_move_x_changed(dialog._move_x_spin)
 
@@ -143,6 +149,97 @@ def test_macro_editor_gap_note_controls_shift_timeline(monkeypatch) -> None:
     dialog._on_gap_scope_changed(dialog._gap_scope_combo)
 
     assert gap.scope == "keyboard"
+
+
+def test_macro_editor_abs_move_capture_updates_selected_move(monkeypatch) -> None:
+    dialog = _build_macro_dialog(monkeypatch, slurp_available=True)
+    move = EditableMove(mode="abs", t_us=5000, x=10, y=20)
+    dialog._synthetic_moves = [move]
+    dialog._timeline._selected = move
+
+    dialog._on_selection_changed(move)
+    assert dialog._move_capture_row.get_visible() is True
+
+    dialog._on_capture_selected_move_clicked(dialog._move_capture_btn)
+    assert dialog._test_slurp.capture_callback is not None
+
+    class _Result:
+        def __init__(self, x: int, y: int) -> None:
+            self.x = x
+            self.y = y
+
+    dialog._test_slurp.capture_callback(_Result(640, 480))
+
+    assert move.x == 640
+    assert move.y == 480
+    assert dialog._move_x_spin.get_value_as_int() == 640
+    assert dialog._move_y_spin.get_value_as_int() == 480
+    assert dialog._move_capture_status.get_text() == "Captured: 640, 480"
+
+
+def test_macro_editor_repeated_abs_move_capture_updates_every_run(monkeypatch) -> None:
+    dialog = _build_macro_dialog(monkeypatch, slurp_available=True)
+    move = EditableMove(mode="abs", t_us=5000, x=10, y=20)
+    dialog._synthetic_moves = [move]
+    dialog._timeline._selected = move
+    dialog._on_selection_changed(move)
+
+    class _Result:
+        def __init__(self, x: int, y: int) -> None:
+            self.x = x
+            self.y = y
+
+    for x, y in ((100, 200), (300, 400), (500, 600)):
+        dialog._on_capture_selected_move_clicked(dialog._move_capture_btn)
+        assert dialog._test_slurp.capture_callback is not None
+        dialog._test_slurp.capture_callback(_Result(x, y))
+        assert dialog._move_x_spin.get_value_as_int() == x
+        assert dialog._move_y_spin.get_value_as_int() == y
+
+
+def test_set_entry_text_if_needed_skips_redundant_updates() -> None:
+    class _FakeEntry:
+        def __init__(self, text: str) -> None:
+            self.text = text
+            self.set_calls: list[str] = []
+
+        def get_text(self) -> str:
+            return self.text
+
+        def set_text(self, text: str) -> None:
+            self.text = text
+            self.set_calls.append(text)
+
+    entry = _FakeEntry("echo hi")
+
+    macro_editor_dialog_module._set_entry_text_if_needed(entry, "echo hi")
+    assert entry.set_calls == []
+
+    macro_editor_dialog_module._set_entry_text_if_needed(entry, "echo bye")
+    assert entry.set_calls == ["echo bye"]
+
+
+def test_macro_editor_exec_command_edit_does_not_refresh_control_panel(monkeypatch) -> None:
+    dialog = _build_macro_dialog(monkeypatch)
+
+    for mode, command_text in (("exec_sync", "echo hi"), ("exec_async", "printf 'x'")):
+        control = EditableControl(mode=mode, t_us=5000, command="")
+        dialog._control_events = [control]
+        dialog._timeline._selected = control
+        dialog._on_selection_changed(control)
+
+        def fail_refresh(_control: EditableControl) -> None:
+            raise AssertionError("command typing should not trigger full control refresh")
+
+        original_refresh = dialog._refresh_after_control_change
+        dialog._refresh_after_control_change = fail_refresh  # type: ignore[method-assign]
+        try:
+            dialog._control_cmd_entry.set_text(command_text)
+        finally:
+            dialog._refresh_after_control_change = original_refresh  # type: ignore[method-assign]
+
+        assert control.command == command_text
+        assert dialog._control_cmd_entry.get_text() == command_text
 
 
 def test_macro_editor_loop_and_capture_start_position_controls(monkeypatch) -> None:
@@ -164,7 +261,9 @@ def test_macro_editor_loop_and_capture_start_position_controls(monkeypatch) -> N
             self.x = x
             self.y = y
 
-    dialog._on_slurp_capture_result(_Result(640, 480))
+    dialog._on_capture_start_position_clicked(dialog._macro_capture_btn)
+    assert dialog._test_slurp.capture_callback is not None
+    dialog._test_slurp.capture_callback(_Result(640, 480))
 
     assert dialog._macro_loop_mode == "count"
     assert dialog._macro_loop_count == 4
@@ -176,6 +275,7 @@ def test_macro_editor_loop_and_capture_start_position_controls(monkeypatch) -> N
     assert dialog._macro_capture_status.get_text() == "Captured: 640, 480"
 
     dialog._on_capture_start_position_response(
+        dialog._capture_request_id,
         {"status": "error", "message": "Unknown command: get_cursor_position"}
     )
 
@@ -183,6 +283,118 @@ def test_macro_editor_loop_and_capture_start_position_controls(monkeypatch) -> N
         dialog._macro_capture_status.get_text()
         == "Please restart Keymasq Session, then try again"
     )
+
+
+def test_macro_editor_repeated_start_capture_updates_every_run(monkeypatch) -> None:
+    dialog = _build_macro_dialog(monkeypatch, slurp_available=True)
+    dialog._macro_move_to_start_check.set_active(True)
+    dialog._on_macro_move_to_start_toggled(dialog._macro_move_to_start_check)
+
+    class _Result:
+        def __init__(self, x: int, y: int) -> None:
+            self.x = x
+            self.y = y
+
+    for x, y in ((100, 200), (300, 400), (500, 600)):
+        dialog._on_capture_start_position_clicked(dialog._macro_capture_btn)
+        assert dialog._test_slurp.capture_callback is not None
+        dialog._test_slurp.capture_callback(_Result(x, y))
+        assert dialog._macro_start_x_spin.get_value_as_int() == x
+        assert dialog._macro_start_y_spin.get_value_as_int() == y
+
+
+def test_macro_editor_delayed_start_capture_ignores_stale_response(monkeypatch) -> None:
+    callbacks: list[Callable[[], bool]] = []
+    requests: list[Callable[[dict[str, object]], bool | None]] = []
+
+    def fake_timeout_add(_delay, callback):
+        callbacks.append(callback)
+        return len(callbacks)
+
+    def fake_source_remove(_source_id):
+        return None
+
+    def fake_session_request_async(payload, callback, timeout=5.0):
+        assert payload == {"command": "get_cursor_position"}
+        requests.append(callback)
+
+    monkeypatch.setattr(macro_editor_dialog_module.GLib, "timeout_add", fake_timeout_add)
+    monkeypatch.setattr(macro_editor_dialog_module.GLib, "source_remove", fake_source_remove)
+    monkeypatch.setattr(
+        macro_editor_dialog_module,
+        "session_request_async",
+        fake_session_request_async,
+    )
+
+    dialog = _build_macro_dialog(monkeypatch, slurp_available=False)
+    dialog._macro_move_to_start_check.set_active(True)
+    dialog._on_macro_move_to_start_toggled(dialog._macro_move_to_start_check)
+
+    dialog._on_capture_start_position_clicked(dialog._macro_capture_btn)
+    timer1 = callbacks.pop(0)
+    assert timer1() is False
+    assert len(requests) == 1
+    stale_response = requests.pop(0)
+
+    dialog._on_capture_start_position_clicked(dialog._macro_capture_btn)
+    timer2 = callbacks.pop(0)
+    stale_response({"status": "ok", "x": 100, "y": 200})
+
+    assert timer2() is False
+    assert len(requests) == 1
+    fresh_response = requests.pop(0)
+    fresh_response({"status": "ok", "x": 300, "y": 400})
+
+    assert dialog._macro_start_x_spin.get_value_as_int() == 300
+    assert dialog._macro_start_y_spin.get_value_as_int() == 400
+
+
+def test_macro_editor_delayed_abs_move_capture_ignores_stale_response(monkeypatch) -> None:
+    callbacks: list[Callable[[], bool]] = []
+    requests: list[Callable[[dict[str, object]], bool | None]] = []
+
+    def fake_timeout_add(_delay, callback):
+        callbacks.append(callback)
+        return len(callbacks)
+
+    def fake_source_remove(_source_id):
+        return None
+
+    def fake_session_request_async(payload, callback, timeout=5.0):
+        assert payload == {"command": "get_cursor_position"}
+        requests.append(callback)
+
+    monkeypatch.setattr(macro_editor_dialog_module.GLib, "timeout_add", fake_timeout_add)
+    monkeypatch.setattr(macro_editor_dialog_module.GLib, "source_remove", fake_source_remove)
+    monkeypatch.setattr(
+        macro_editor_dialog_module,
+        "session_request_async",
+        fake_session_request_async,
+    )
+
+    dialog = _build_macro_dialog(monkeypatch, slurp_available=False)
+    move = EditableMove(mode="abs", t_us=5000, x=10, y=20)
+    dialog._synthetic_moves = [move]
+    dialog._timeline._selected = move
+    dialog._on_selection_changed(move)
+
+    dialog._on_capture_selected_move_clicked(dialog._move_capture_btn)
+    timer1 = callbacks.pop(0)
+    assert timer1() is False
+    assert len(requests) == 1
+    stale_response = requests.pop(0)
+
+    dialog._on_capture_selected_move_clicked(dialog._move_capture_btn)
+    timer2 = callbacks.pop(0)
+    stale_response({"status": "ok", "x": 100, "y": 200})
+
+    assert timer2() is False
+    assert len(requests) == 1
+    fresh_response = requests.pop(0)
+    fresh_response({"status": "ok", "x": 300, "y": 400})
+
+    assert dialog._move_x_spin.get_value_as_int() == 300
+    assert dialog._move_y_spin.get_value_as_int() == 400
 
 
 def test_macro_editor_insert_delete_and_save_payload(monkeypatch) -> None:

--- a/tests/test_hyprland_listener.py
+++ b/tests/test_hyprland_listener.py
@@ -17,3 +17,53 @@ async def test_hyprland_set_cursor_position_uses_movecursor_dispatcher() -> None
     assert await listener.set_cursor_position(123, 456) == (True, "ok")
 
     listener.dispatch.assert_awaited_once_with("movecursor", "123 456")
+
+
+class _FakeWriter:
+    def __init__(self) -> None:
+        self.closed = False
+        self.payloads: list[bytes] = []
+
+    def write(self, data: bytes) -> None:
+        self.payloads.append(data)
+
+    async def drain(self) -> None:
+        return None
+
+    def close(self) -> None:
+        self.closed = True
+
+    async def wait_closed(self) -> None:
+        return None
+
+
+class _FakeReader:
+    def __init__(self, responses: list[bytes]) -> None:
+        self._responses = list(responses)
+
+    async def read(self, _size: int) -> bytes:
+        if not self._responses:
+            return b""
+        return self._responses.pop(0)
+
+
+@pytest.mark.asyncio
+async def test_hyprland_send_cmd_retries_after_eof(monkeypatch) -> None:
+    listener = HyprlandListener(_noop_callback)
+    pairs = [
+        (_FakeReader([b""]), _FakeWriter()),
+        (_FakeReader([b"100,200"]), _FakeWriter()),
+    ]
+
+    async def fake_ensure() -> bool:
+        if listener._cmd_reader is None or listener._cmd_writer is None:
+            if not pairs:
+                return False
+            listener._cmd_reader, listener._cmd_writer = pairs.pop(0)  # type: ignore[assignment]
+        return True
+
+    monkeypatch.setattr(listener, "_ensure_cmd_connection", fake_ensure)
+
+    response = await listener._send_cmd("cursorpos", read_size=256)
+
+    assert response == b"100,200"

--- a/tests/test_niri_listener.py
+++ b/tests/test_niri_listener.py
@@ -122,6 +122,32 @@ def test_probe_available_checks_socket_connectivity(monkeypatch, tmp_path) -> No
 
 
 @pytest.mark.asyncio
+async def test_send_cmd_request_retries_after_eof(monkeypatch) -> None:
+    async def _cb(_window_class: str, _window_title: str, _tags: list[str]) -> None:
+        return
+
+    listener = NiriListener(_cb)
+    pairs = [
+        (_FakeReader([b""]), _FakeWriter()),
+        (_FakeReader([b'{"Ok":"Handled"}\n']), _FakeWriter()),
+    ]
+
+    async def fake_ensure() -> bool:
+        if listener._cmd_reader is None or listener._cmd_writer is None:
+            if not pairs:
+                return False
+            listener._cmd_reader, listener._cmd_writer = pairs.pop(0)  # type: ignore[assignment]
+        return True
+
+    monkeypatch.setattr(listener, "_ensure_cmd_connection", fake_ensure)
+
+    ok, body = await listener._send_cmd_request({"Action": {}}, timeout_s=0.5)
+
+    assert ok is True
+    assert body == "Handled"
+
+
+@pytest.mark.asyncio
 async def test_send_event_stream_request_writes_event_stream_request() -> None:
     async def _cb(_window_class: str, _window_title: str, _tags: list[str]) -> None:
         return

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -60,6 +60,71 @@ def test_resolve_slurp_path_uses_build_override(
         importlib.reload(paths)
 
 
+def test_resolve_slurp_path_honors_environment_override(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import keymasq.common.paths as paths
+
+    slurp = tmp_path / "slurp"
+    slurp.write_text("#!/bin/sh\n", encoding="utf-8")
+    slurp.chmod(0o755)
+
+    monkeypatch.setenv("SLURP_PATH", str(slurp))
+    monkeypatch.setattr(paths, "SLURP_PATH", tmp_path / "missing-build-slurp")
+    monkeypatch.setattr(paths, "SLURP_FALLBACK_PATHS", ())
+    monkeypatch.setattr(paths.shutil, "which", lambda _name: None)
+
+    assert paths.resolve_slurp_path() == str(slurp)
+
+
+def test_resolve_slurp_path_empty_environment_override_disables_slurp(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import keymasq.common.paths as paths
+
+    monkeypatch.setenv("SLURP_PATH", "")
+
+    assert paths.resolve_slurp_path() is None
+
+
+def test_resolve_slurp_path_uses_nixos_system_profile_fallback(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import keymasq.common.paths as paths
+
+    nixos_slurp = tmp_path / "run-current-system-sw-bin-slurp"
+    nixos_slurp.write_text("#!/bin/sh\n", encoding="utf-8")
+    nixos_slurp.chmod(0o755)
+
+    monkeypatch.delenv("SLURP_PATH", raising=False)
+    monkeypatch.setattr(paths, "SLURP_PATH", tmp_path / "missing-build-slurp")
+    monkeypatch.setattr(
+        paths,
+        "SLURP_FALLBACK_PATHS",
+        (tmp_path / "missing-usr-bin-slurp", nixos_slurp),
+    )
+    monkeypatch.setattr(paths.shutil, "which", lambda _name: None)
+
+    assert paths.resolve_slurp_path() == str(nixos_slurp)
+
+
+def test_resolve_slurp_path_uses_path_lookup_fallback(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import keymasq.common.paths as paths
+
+    path_slurp = tmp_path / "path-slurp"
+    path_slurp.write_text("#!/bin/sh\n", encoding="utf-8")
+    path_slurp.chmod(0o755)
+
+    monkeypatch.delenv("SLURP_PATH", raising=False)
+    monkeypatch.setattr(paths, "SLURP_PATH", tmp_path / "missing-build-slurp")
+    monkeypatch.setattr(paths, "SLURP_FALLBACK_PATHS", ())
+    monkeypatch.setattr(paths.shutil, "which", lambda _name: str(path_slurp))
+
+    assert paths.resolve_slurp_path() == str(path_slurp)
+
+
 def test_ensure_config_dirs_creates_expected_directories(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -125,7 +190,10 @@ def test_resolve_slurp_path_returns_none_for_non_executable(
     slurp.write_text("#!/bin/sh\n", encoding="utf-8")
     slurp.chmod(0o644)
 
+    monkeypatch.delenv("SLURP_PATH", raising=False)
     monkeypatch.setattr(paths, "SLURP_PATH", slurp)
+    monkeypatch.setattr(paths, "SLURP_FALLBACK_PATHS", ())
+    monkeypatch.setattr(paths.shutil, "which", lambda _name: None)
 
     assert paths.resolve_slurp_path() is None
 


### PR DESCRIPTION
## Summary
- add ABS mouse-position capture to the macro editor, rename Gap Note to Wait, and stop exec command typing from dropping focus
- harden delayed and slurp-backed cursor capture flows across the macro editor and key selector dialogs
- make slurp resolution more aggressive with `SLURP_PATH` override support and fix Hyprland/Niri command socket EOF handling

## Testing
- nix develop -c pytest tests/test_paths.py
- nix develop -c pytest tests/gui/test_macro_editor_dialog_widget.py
- nix develop -c ruff check keymasq/common/paths.py tests/test_paths.py
- nix develop -c ruff check keymasq/gui/widgets/macro_editor_dialog.py tests/gui/macro_editor_dialog_support.py tests/gui/test_macro_editor_dialog_widget.py
- nix develop -c ./scripts/check.sh gui
- nix develop -c ./scripts/check.sh full