### PR TITLE
Improve macro recording source selection

### DIFF
--- a/docs/MACROS.md
+++ b/docs/MACROS.md
@@ -87,6 +87,24 @@ reach them will be captured too, which is rarely what you want.
 | Move to start | Before playback, move the cursor to the position it was at when recording began. |
 | Block mouse movement | Prevent accidental mouse movement during playback (requires a grabbed mouse device). |
 
+**Recording sources:** the recording settings dialog separates Keymasq output
+devices from direct physical input sources.
+
+- Prefer **Recommended: Remapped Output** if you want the macro to capture what
+  Keymasq emits after your mappings, combos, and passthrough handling.
+- Use **Direct Input Sources** only when you explicitly need raw hardware events
+  before Keymasq remapping.
+- **Selected sources below are authoritative.** The quick-selection buttons for
+  keyboards, mice, and gamepads only update the source list below; they are not
+  separate recording state.
+- If both a managed physical device and its matching Keymasq passthrough device
+  are selected, Keymasq records the passthrough stream and skips the matching
+  raw stream to avoid duplicate events.
+
+Recording preferences are stored in
+`~/.config/keymasq/recording_settings.toml`. Device-specific overrides use
+stable recording IDs instead of volatile `/dev/input/eventN` paths.
+
 ![Recording settings — Move to start and Block mouse movement options](assets/screenshots/keymasq_macro_recording_settings.png)
 
 ![Save dialog — name your recorded macro before saving](assets/screenshots/keymasq_save_macro_dialog.png)

--- a/keymasq/gui/widgets/combo_editor_dialog.py
+++ b/keymasq/gui/widgets/combo_editor_dialog.py
@@ -260,7 +260,8 @@ class ComboEditorDialog(Adw.Dialog):
         self.add_step_button.connect("clicked", self._on_add_step_clicked)
         top_row.append(self.add_step_button)
 
-        self.unlock_button = Gtk.Button(label="Unlock Capture")
+        self.unlock_button = Gtk.Button()
+        self.unlock_button.set_child(self._make_unlock_button_content())
         self.unlock_button.add_css_class("flat")
         self.unlock_button.connect("clicked", self._on_unlock_clicked)
         top_row.append(self.unlock_button)
@@ -663,6 +664,14 @@ class ComboEditorDialog(Adw.Dialog):
                 "Original-input capture uses privileged raw events. "
                 "Unlock to capture original keys."
             )
+
+    def _make_unlock_button_content(self) -> Gtk.Box:
+        box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=6)
+        icon = Gtk.Image.new_from_icon_name("channel-insecure-symbolic")
+        box.append(icon)
+        lbl = Gtk.Label(label="Unlock Capture")
+        box.append(lbl)
+        return box
 
     def _on_unlock_clicked(self, _button: Gtk.Button) -> None:
         root = self.get_root()

--- a/keymasq/gui/widgets/device_tab.py
+++ b/keymasq/gui/widgets/device_tab.py
@@ -1058,8 +1058,8 @@ class DeviceTab(ProfileManagedTab):
         start_btn = Gtk.Button(label="Start Capture")
         start_btn.add_css_class("suggested-action")
 
-        unlock_btn = Gtk.Button(label="Unlock")
-        unlock_btn.add_css_class("destructive-action")
+        unlock_btn = Gtk.Button()
+        unlock_btn.set_child(self._make_unlock_button_content("Unlock"))
         unlock_btn.connect(
             "clicked",
             self._on_add_inputs_unlock_clicked,
@@ -1299,7 +1299,8 @@ class DeviceTab(ProfileManagedTab):
             return
 
         unlock_btn.set_visible(True)
-        unlock_btn.set_label("Claim Unlock" if recording_unlocked else "Unlock")
+        label = "Claim" if recording_unlocked else "Unlock"
+        unlock_btn.set_child(self._make_unlock_button_content(label))
         if recording_unlocked:
             privilege_status.set_text(
                 "Unlock active in another session. Claim unlock to add additional keys and "
@@ -1310,6 +1311,14 @@ class DeviceTab(ProfileManagedTab):
                 "Original-input capture uses privileged raw events. Unlock to add additional "
                 "keys and mouse buttons."
             )
+
+    def _make_unlock_button_content(self, label: str) -> Gtk.Box:
+        box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=6)
+        icon = Gtk.Image.new_from_icon_name("channel-insecure-symbolic")
+        box.append(icon)
+        lbl = Gtk.Label(label=label)
+        box.append(lbl)
+        return box
 
     def _on_add_inputs_unlock_clicked(
         self,

--- a/keymasq/gui/widgets/macro_manager_dialog.py
+++ b/keymasq/gui/widgets/macro_manager_dialog.py
@@ -83,10 +83,53 @@ class MacroManagerDialog(Adw.Dialog):
         content.set_margin_start(12)
         content.set_margin_end(12)
 
+        # Toolbar row for create actions
+        toolbar = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=6)
+        toolbar.set_margin_bottom(4)
+
+        record_btn = Gtk.Button()
+        record_btn.set_child(
+            self._make_button_content("media-record-symbolic", "Record", "error")
+        )
+        record_btn.set_tooltip_text("Record a new macro")
+        record_btn.connect("clicked", self._on_record_new)
+        toolbar.append(record_btn)
+        self._record_btn = record_btn
+
+        empty_btn = Gtk.Button()
+        empty_btn.set_child(
+            self._make_button_content("document-new-symbolic", "Empty")
+        )
+        empty_btn.set_tooltip_text("Create an empty macro to edit")
+        empty_btn.connect("clicked", self._on_create_empty_macro)
+        toolbar.append(empty_btn)
+
+        type_btn = Gtk.Button()
+        type_btn.set_child(
+            self._make_button_content("input-keyboard-symbolic", "Type")
+        )
+        type_btn.set_tooltip_text("Create a macro that types text")
+        type_btn.connect("clicked", self._on_create_type_macro)
+        toolbar.append(type_btn)
+
+        toolbar_spacer = Gtk.Box()
+        toolbar_spacer.set_hexpand(True)
+        toolbar.append(toolbar_spacer)
+
+        settings_btn = Gtk.Button()
+        settings_btn.set_child(
+            self._make_button_content("emblem-system-symbolic", "Settings")
+        )
+        settings_btn.set_tooltip_text("Recording settings")
+        settings_btn.connect("clicked", self._on_record_settings)
+        toolbar.append(settings_btn)
+
+        content.append(toolbar)
+
         scrolled = Gtk.ScrolledWindow()
         scrolled.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
-        scrolled.set_min_content_height(180)
-        scrolled.set_max_content_height(360)
+        scrolled.set_min_content_height(240)
+        scrolled.set_max_content_height(400)
         scrolled.set_vexpand(True)
 
         self._listbox = Gtk.ListBox()
@@ -105,62 +148,25 @@ class MacroManagerDialog(Adw.Dialog):
         inner.append(content)
         inner.append(Gtk.Separator())
 
-        footer = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=8)
+        footer = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=8)
         footer.set_margin_top(8)
         footer.set_margin_bottom(8)
         footer.set_margin_start(12)
         footer.set_margin_end(12)
 
-        action_size_group = Gtk.SizeGroup(mode=Gtk.SizeGroupMode.HORIZONTAL)
-        utility_size_group = Gtk.SizeGroup(mode=Gtk.SizeGroupMode.HORIZONTAL)
-
-        create_row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=8)
-
-        record_btn = Gtk.Button(label="Record Macro…")
-        record_btn.connect("clicked", self._on_record_new)
-        action_size_group.add_widget(record_btn)
-        create_row.append(record_btn)
-        self._record_btn = record_btn
-
-        empty_btn = Gtk.Button(label="Empty Macro…")
-        empty_btn.add_css_class("suggested-action")
-        empty_btn.connect("clicked", self._on_create_empty_macro)
-        action_size_group.add_widget(empty_btn)
-        create_row.append(empty_btn)
-
-        type_btn = Gtk.Button(label="Type Macro…")
-        type_btn.connect("clicked", self._on_create_type_macro)
-        action_size_group.add_widget(type_btn)
-        create_row.append(type_btn)
-
-        footer.append(create_row)
-
-        utility_row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=8)
-
-        settings_btn = Gtk.Button(label="Recording Settings…")
-        settings_btn.connect("clicked", self._on_record_settings)
-        utility_size_group.add_widget(settings_btn)
-        utility_row.append(settings_btn)
-
         cancel_playback_btn = Gtk.Button(label="Cancel Playback")
         cancel_playback_btn.add_css_class("destructive-action")
         cancel_playback_btn.connect("clicked", self._on_cancel_playback)
-        utility_size_group.add_widget(cancel_playback_btn)
-        utility_row.append(cancel_playback_btn)
+        footer.append(cancel_playback_btn)
         self._cancel_playback_btn = cancel_playback_btn
 
-        spacer = Gtk.Box()
-        spacer.set_hexpand(True)
-        utility_row.append(spacer)
+        footer_spacer = Gtk.Box()
+        footer_spacer.set_hexpand(True)
+        footer.append(footer_spacer)
 
-        close_wrap = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL)
-        close_wrap.set_halign(Gtk.Align.END)
         close_btn = Gtk.Button(label="Close")
         close_btn.connect("clicked", self._on_close_clicked)
-        close_wrap.append(close_btn)
-        utility_row.append(close_wrap)
-
-        footer.append(utility_row)
+        footer.append(close_btn)
 
         inner.append(footer)
         frame.set_child(inner)
@@ -169,6 +175,21 @@ class MacroManagerDialog(Adw.Dialog):
 
     def _on_close_clicked(self, _button: Gtk.Button) -> None:
         self.close()
+
+    def _make_button_content(
+        self,
+        icon_name: str,
+        label: str,
+        icon_css_class: str | None = None,
+    ) -> Gtk.Box:
+        box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=6)
+        icon = Gtk.Image.new_from_icon_name(icon_name)
+        if icon_css_class:
+            icon.add_css_class(icon_css_class)
+        box.append(icon)
+        lbl = Gtk.Label(label=label)
+        box.append(lbl)
+        return box
 
     def _load_initial_state(self) -> bool:
         run_gui_task(self._fetch_initial_state, self._on_initial_state_loaded)
@@ -514,16 +535,25 @@ class MacroManagerDialog(Adw.Dialog):
             return
 
         if self._recording_active:
-            self._record_btn.set_label("Stop Recording")
+            self._record_btn.set_child(
+                self._make_button_content("media-playback-stop-symbolic", "Stop")
+            )
+            self._record_btn.set_tooltip_text("Stop recording")
             self._record_btn.add_css_class("destructive-action")
             return
 
-        self._record_btn.add_css_class("destructive-action")
+        self._record_btn.remove_css_class("destructive-action")
 
         if not self._recording_unlocked:
-            self._record_btn.set_label("Unlock Recording")
+            self._record_btn.set_child(
+                self._make_button_content("channel-insecure-symbolic", "Unlock")
+            )
+            self._record_btn.set_tooltip_text("Unlock recording")
         else:
-            self._record_btn.set_label("Record Macro…")
+            self._record_btn.set_child(
+                self._make_button_content("media-record-symbolic", "Record", "error")
+            )
+            self._record_btn.set_tooltip_text("Record a new macro")
 
     def _on_unlock_success(self) -> None:
         session_request_async({"command": "get_status"}, self._on_status_after_unlock)

--- a/keymasq/gui/widgets/record_macro_dialog.py
+++ b/keymasq/gui/widgets/record_macro_dialog.py
@@ -3,20 +3,16 @@ import gi
 gi.require_version("Gtk", "4.0")
 gi.require_version("Adw", "1")
 
-import json
 import threading
 from collections.abc import Callable
 
 from gi.repository import Adw, GLib, Gtk  # pyright: ignore[reportAttributeAccessIssue]
 
 from keymasq.common.devices import input_class_label, normalize_input_classes
-from keymasq.common.paths import CONFIG_DIR, ensure_config_dirs
 from keymasq.gui.session_client import session_request
 
 
 class RecordMacroDialog(Adw.Dialog):
-    _SETTINGS_PATH = CONFIG_DIR / "recording_settings.json"
-
     def __init__(self, parent: Gtk.Window, on_saved: Callable | None = None):
         super().__init__(title="Macro Recording Settings", content_width=480)
         self._parent = parent
@@ -26,14 +22,11 @@ class RecordMacroDialog(Adw.Dialog):
         self._record_mouse_movement = False
         self._record_mouse_clicks = False
         self._record_start_position = False
-        self._record_keyboard = True
-        self._record_mouse = False
-        self._record_gamepad = True
         self._device_overrides: dict[str, bool] = {}
         self._recording_unlocked = False
         self._recording_unlock_required = True
         self._recording_refresh_owner = False
-        self._load_settings()
+        self._applying_settings = False
         self._build_ui()
         self._load_initial_state_async()
 
@@ -63,8 +56,8 @@ class RecordMacroDialog(Adw.Dialog):
 
         intro_label = Gtk.Label(
             label=(
-                "Record from Keymasq output devices to capture remapped events. "
-                "Managed physical devices are shown below for reference."
+                "The selected sources below are what will actually be recorded. "
+                "Quick actions only update those source selections."
             )
         )
         intro_label.set_wrap(True)
@@ -72,30 +65,52 @@ class RecordMacroDialog(Adw.Dialog):
         intro_label.add_css_class("dim-label")
         content.append(intro_label)
 
-        cat_label = Gtk.Label(label="Event classes to include:")
-        cat_label.add_css_class("heading")
-        cat_label.set_halign(Gtk.Align.START)
-        content.append(cat_label)
+        quick_label = Gtk.Label(label="Quick Selection")
+        quick_label.add_css_class("heading")
+        quick_label.set_halign(Gtk.Align.START)
+        content.append(quick_label)
 
-        cat_row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=16)
-        cat_row.set_halign(Gtk.Align.START)
+        quick_help = Gtk.Label(
+            label=(
+                "Use these actions to update the source list below. "
+                "They are helpers only, not separate recording state."
+            )
+        )
+        quick_help.set_wrap(True)
+        quick_help.set_halign(Gtk.Align.START)
+        quick_help.add_css_class("dim-label")
+        quick_help.add_css_class("caption")
+        content.append(quick_help)
 
-        self._keyboard_check = Gtk.CheckButton(label="Keyboards")
-        self._keyboard_check.set_active(self._record_keyboard)
-        self._keyboard_check.connect("toggled", self._on_category_toggled, "keyboard")
-        cat_row.append(self._keyboard_check)
+        quick_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=8)
+        for label, device_type in (
+            ("Keyboards", "keyboard"),
+            ("Mice", "mouse"),
+            ("Gamepads", "gamepad"),
+        ):
+            row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=8)
+            row.set_halign(Gtk.Align.START)
 
-        self._mouse_check = Gtk.CheckButton(label="Mice")
-        self._mouse_check.set_active(self._record_mouse)
-        self._mouse_check.connect("toggled", self._on_category_toggled, "mouse")
-        cat_row.append(self._mouse_check)
+            type_label = Gtk.Label(label=label)
+            type_label.set_width_chars(10)
+            type_label.set_halign(Gtk.Align.START)
+            row.append(type_label)
 
-        self._gamepad_check = Gtk.CheckButton(label="Gamepads")
-        self._gamepad_check.set_active(self._record_gamepad)
-        self._gamepad_check.connect("toggled", self._on_category_toggled, "gamepad")
-        cat_row.append(self._gamepad_check)
+            select_btn = Gtk.Button(label="Select All")
+            select_btn.connect("clicked", self._on_select_type_clicked, device_type, True)
+            row.append(select_btn)
 
-        content.append(cat_row)
+            clear_btn = Gtk.Button(label="Clear")
+            clear_btn.connect("clicked", self._on_select_type_clicked, device_type, False)
+            row.append(clear_btn)
+
+            quick_box.append(row)
+
+        reset_btn = Gtk.Button(label="Reset to Recommended")
+        reset_btn.set_halign(Gtk.Align.START)
+        reset_btn.connect("clicked", self._on_reset_to_recommended_clicked)
+        quick_box.append(reset_btn)
+        content.append(quick_box)
 
         options_row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=16)
         options_row.set_halign(Gtk.Align.START)
@@ -131,15 +146,28 @@ class RecordMacroDialog(Adw.Dialog):
 
         sources_help = Gtk.Label(
             label=(
-                "Recommended sources are Keymasq virtual outputs. "
-                "Direct sources capture raw input. "
-                "Managed devices are already routed through Keymasq."
+                "Recommended sources are Keymasq outputs and passthrough devices. "
+                "Direct sources capture raw input before remapping."
             )
         )
         sources_help.set_wrap(True)
         sources_help.set_halign(Gtk.Align.START)
         sources_help.add_css_class("dim-label")
         content.append(sources_help)
+
+        self._selection_summary = Gtk.Label(label="Selected sources: 0")
+        self._selection_summary.set_wrap(True)
+        self._selection_summary.set_halign(Gtk.Align.START)
+        self._selection_summary.add_css_class("caption")
+        content.append(self._selection_summary)
+
+        self._selection_warning = Gtk.Label(label="")
+        self._selection_warning.set_wrap(True)
+        self._selection_warning.set_halign(Gtk.Align.START)
+        self._selection_warning.add_css_class("caption")
+        self._selection_warning.add_css_class("error")
+        self._selection_warning.set_visible(False)
+        content.append(self._selection_warning)
 
         scrolled = Gtk.ScrolledWindow()
         scrolled.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
@@ -196,7 +224,6 @@ class RecordMacroDialog(Adw.Dialog):
         self._loading_label.set_visible(True)
 
         def worker() -> None:
-            self._sync_settings_to_session()
             devices_result = session_request({"command": "list_devices_for_recording"})
             settings_result = session_request({"command": "get_recording_settings"})
             GLib.idle_add(self._apply_initial_state, devices_result, settings_result)
@@ -208,6 +235,7 @@ class RecordMacroDialog(Adw.Dialog):
         devices_result: dict | None,
         settings_result: dict | None,
     ) -> bool:
+        self._apply_recording_settings(settings_result)
         self._devices = (devices_result or {}).get("devices", [])
         self._loading_label.set_visible(False)
         self._populate_device_list()
@@ -219,8 +247,6 @@ class RecordMacroDialog(Adw.Dialog):
             self._device_listbox.remove(self._device_listbox.get_first_child())
         self._device_checks.clear()
 
-        selected_types = self._get_selected_types()
-
         if not self._devices:
             row = Gtk.ListBoxRow()
             row.set_selectable(False)
@@ -230,57 +256,50 @@ class RecordMacroDialog(Adw.Dialog):
             lbl.set_margin_bottom(8)
             row.set_child(lbl)
             self._device_listbox.append(row)
+            self._update_selection_ui()
             return
 
-        recommended = [
-            device for device in self._devices if self._is_keymasq_output_device(device)
-        ]
+        recommended = [device for device in self._devices if self._is_recommended_device(device)]
         direct = [
             device
             for device in self._devices
-            if not self._is_keymasq_output_device(device)
-            and not device.get("grabbed_by_keymasq", False)
+            if self._device_kind(device) == "physical"
         ]
         managed = [
             device
             for device in self._devices
-            if device.get("grabbed_by_keymasq", False)
-            and not self._is_keymasq_output_device(device)
+            if self._device_kind(device) == "other_virtual"
         ]
 
         self._append_device_section(
             "Recommended: Remapped Output",
             "Use these to record what Keymasq emits after remapping.",
             recommended,
-            selected_types,
             selectable=True,
         )
         self._append_device_section(
             "Direct Input Sources",
-            "Use these to capture raw events before remapping.",
+            (
+                "Use these to capture raw events before remapping. "
+                "If a matching Keymasq passthrough is also selected, Keymasq records that instead."
+            ),
             direct,
-            selected_types,
             selectable=True,
         )
         self._append_device_section(
-            "Managed by Keymasq",
-            (
-                "These physical devices are grabbed by Keymasq. "
-                "Record their matching Keymasq output above."
-            ),
+            "Other Virtual Sources",
+            "Use these only when you explicitly want events from another virtual input source.",
             managed,
-            selected_types,
-            selectable=False,
+            selectable=True,
         )
 
-        self._update_unlock_ui()
+        self._update_selection_ui()
 
     def _append_device_section(
         self,
         title: str,
         description: str,
         devices: list[dict],
-        selected_types: set[str],
         *,
         selectable: bool,
     ) -> None:
@@ -311,14 +330,11 @@ class RecordMacroDialog(Adw.Dialog):
         self._device_listbox.append(header_row)
 
         for device in devices:
-            self._device_listbox.append(
-                self._build_device_row(device, selected_types, selectable=selectable)
-            )
+            self._device_listbox.append(self._build_device_row(device, selectable=selectable))
 
     def _build_device_row(
         self,
         device: dict,
-        selected_types: set[str],
         *,
         selectable: bool,
     ) -> Gtk.ListBoxRow:
@@ -332,14 +348,12 @@ class RecordMacroDialog(Adw.Dialog):
         row_box.set_margin_end(12)
 
         path = str(device.get("path", ""))
+        recording_id = self._device_recording_id(device)
         if selectable:
             check = Gtk.CheckButton()
-            if path in self._device_overrides:
-                check.set_active(bool(self._device_overrides[path]))
-            else:
-                check.set_active(self._device_matches_selected_types(device, selected_types))
+            check.set_active(self._is_selected_device(device))
             check.connect("toggled", self._on_device_check_toggled)
-            self._device_checks[path] = check
+            self._device_checks[recording_id] = check
             row_box.append(check)
         else:
             status_icon = Gtk.Image.new_from_icon_name("dialog-information-symbolic")
@@ -356,10 +370,13 @@ class RecordMacroDialog(Adw.Dialog):
         info_box.append(name_label)
 
         detail_parts = [self._device_type_text(device)]
-        if self._is_keymasq_output_device(device):
+        kind = self._device_kind(device)
+        if kind in {"keymasq_output", "keymasq_passthrough"}:
             detail_parts.append("Keymasq output")
         elif device.get("grabbed_by_keymasq", False):
             detail_parts.append("Managed physical device")
+        elif kind == "other_virtual":
+            detail_parts.append("Virtual device")
         else:
             detail_parts.append("Direct physical device")
         detail_parts.append(path)
@@ -388,95 +405,119 @@ class RecordMacroDialog(Adw.Dialog):
         row.set_child(row_box)
         return row
 
-    def _is_keymasq_output_device(self, device: dict) -> bool:
-        name = str(device.get("name", "") or "").lower()
-        return name.startswith("keymasq-")
+    def _device_recording_id(self, device: dict) -> str:
+        recording_id = str(device.get("recording_id", "") or "")
+        if recording_id:
+            return recording_id
+        stable_path = str(device.get("stable_path", "") or "")
+        if stable_path:
+            return f"physical:{stable_path}"
+        path = str(device.get("path", "") or "")
+        return f"physical:{path}" if path else ""
+
+    def _device_kind(self, device: dict) -> str:
+        return str(device.get("recording_kind", "physical") or "physical")
+
+    def _is_recommended_device(self, device: dict) -> bool:
+        return self._device_kind(device) in {"keymasq_output", "keymasq_passthrough"}
 
     def _device_tooltip_text(self, device: dict) -> str:
-        name = str(device.get("name", "") or "")
-        lowered = name.lower()
-        if lowered in {"keymasq-keyboard", "keymasq-mouse", "keymasq-gamepad"}:
+        kind = self._device_kind(device)
+        if kind == "keymasq_output":
             return "Synthetic Keymasq events."
-        if lowered.startswith("keymasq-"):
-            source_name = self._find_passthrough_source_name(device)
+        if kind == "keymasq_passthrough":
+            source_name = str(device.get("source_hardware_id", "") or "")
+            source_interface = str(device.get("source_interface_id", "") or "")
+            if source_name and source_interface:
+                return f"Passthrough from {source_name} {source_interface}."
             if source_name:
                 return f"Passthrough from {source_name}."
-            return "Passthrough from a managed device."
+            return "Passthrough from a managed physical device."
         if device.get("grabbed_by_keymasq", False):
             return (
                 "Managed physical device. "
-                "Record its matching Keymasq output to capture remapped events."
+                "If its matching Keymasq passthrough is selected, Keymasq records that instead."
             )
+        if kind == "other_virtual":
+            return "Virtual input source outside Keymasq."
         return "Direct physical input source."
 
-    def _find_passthrough_source_name(self, output_device: dict) -> str | None:
-        vendor_id = str(output_device.get("vendor_id", "") or "")
-        product_id = str(output_device.get("product_id", "") or "")
-        device_type = str(output_device.get("device_type", "") or "")
-        for device in self._devices:
-            if not device.get("grabbed_by_keymasq", False):
-                continue
-            if str(device.get("vendor_id", "") or "") != vendor_id:
-                continue
-            if str(device.get("product_id", "") or "") != product_id:
-                continue
-            if device_type not in self._device_types(device):
-                continue
-            return str(device.get("name", "") or "")
-        return None
-
     def _device_badge_text(self, device: dict, selectable: bool) -> str:
-        name = str(device.get("name", "") or "").lower()
-        if name in {"keymasq-keyboard", "keymasq-mouse", "keymasq-gamepad"}:
+        kind = self._device_kind(device)
+        if kind in {"keymasq_output", "keymasq_passthrough"}:
             return "Recommended"
-        if self._is_keymasq_output_device(device):
-            return "Passthrough"
         if device.get("grabbed_by_keymasq", False):
             return "Managed"
+        if kind == "other_virtual":
+            return "Virtual"
         if selectable:
             return "Raw"
         return ""
 
-    def _get_selected_types(self) -> set[str]:
-        types = set()
-        if self._keyboard_check.get_active():
-            types.add("keyboard")
-        if self._mouse_check.get_active():
-            types.add("mouse")
-        if self._gamepad_check.get_active():
-            types.add("gamepad")
-        return types
+    def _is_selected_device(self, device: dict) -> bool:
+        recording_id = self._device_recording_id(device)
+        if recording_id in self._device_overrides:
+            return bool(self._device_overrides[recording_id])
+        return self._is_recommended_device(device)
 
-    def _on_category_toggled(self, check: Gtk.CheckButton, device_type: str) -> None:
-        active = check.get_active()
-
-        if device_type == "keyboard":
-            self._record_keyboard = active
-        elif device_type == "mouse":
-            self._record_mouse = active
-        elif device_type == "gamepad":
-            self._record_gamepad = active
-
+    def _find_device_by_recording_id(self, recording_id: str) -> dict | None:
         for device in self._devices:
-            if (
-                device_type in self._device_types(device)
-                and not device.get("grabbed_by_keymasq", False)
-            ):
-                dev_check = self._device_checks.get(device["path"])
-                if dev_check:
-                    dev_check.handler_block_by_func(self._on_device_check_toggled)
-                    dev_check.set_active(active)
-                    dev_check.handler_unblock_by_func(self._on_device_check_toggled)
-                    self._device_overrides[device["path"]] = active
+            if self._device_recording_id(device) == recording_id:
+                return device
+        return None
 
-        self._save_settings_async()
+    def _store_device_selection(self, device: dict, active: bool) -> None:
+        recording_id = self._device_recording_id(device)
+        if not recording_id:
+            return
+        if active == self._is_recommended_device(device):
+            self._device_overrides.pop(recording_id, None)
+            return
+        self._device_overrides[recording_id] = active
+
+    def _set_device_type_selection(self, device_type: str, active: bool) -> None:
+        for device in self._devices:
+            if device_type not in self._device_types(device):
+                continue
+            self._store_device_selection(device, active)
+            recording_id = self._device_recording_id(device)
+            dev_check = self._device_checks.get(recording_id)
+            if dev_check:
+                dev_check.handler_block_by_func(self._on_device_check_toggled)
+                dev_check.set_active(active)
+                dev_check.handler_unblock_by_func(self._on_device_check_toggled)
+
+    def _on_select_type_clicked(
+        self,
+        _btn: Gtk.Button,
+        device_type: str,
+        active: bool,
+    ) -> None:
+        self._set_device_type_selection(device_type, active)
+        self._update_selection_ui()
+        self._sync_settings_async()
+
+    def _on_reset_to_recommended_clicked(self, _btn: Gtk.Button) -> None:
+        self._device_overrides.clear()
+        for device in self._devices:
+            recording_id = self._device_recording_id(device)
+            dev_check = self._device_checks.get(recording_id)
+            if dev_check:
+                dev_check.handler_block_by_func(self._on_device_check_toggled)
+                dev_check.set_active(self._is_selected_device(device))
+                dev_check.handler_unblock_by_func(self._on_device_check_toggled)
+        self._update_selection_ui()
+        self._sync_settings_async()
 
     def _on_record_options_changed(self, check: Gtk.CheckButton) -> None:
+        if self._applying_settings:
+            return
+
         self._record_mouse_movement = self._record_movement_check.get_active()
         self._record_mouse_clicks = self._record_clicks_check.get_active()
         self._record_start_position = self._record_start_pos_check.get_active()
-        self._save_settings_async()
-        threading.Thread(target=self._sync_settings_to_session, daemon=True).start()
+        self._update_selection_ui()
+        self._sync_settings_async()
 
     def _refresh_unlock_state(self) -> None:
         result = session_request({"command": "get_recording_settings"})
@@ -519,11 +560,19 @@ class RecordMacroDialog(Adw.Dialog):
         threading.Thread(target=self._refresh_unlock_state, daemon=True).start()
 
     def _on_device_check_toggled(self, check: Gtk.CheckButton) -> None:
-        for path, dev_check in self._device_checks.items():
+        if self._applying_settings:
+            return
+
+        for recording_id, dev_check in self._device_checks.items():
             if dev_check is check:
-                self._device_overrides[path] = check.get_active()
+                device = self._find_device_by_recording_id(recording_id)
+                if device is not None:
+                    self._store_device_selection(device, check.get_active())
+                else:
+                    self._device_overrides[recording_id] = check.get_active()
                 break
-        self._save_settings_async()
+        self._update_selection_ui()
+        self._sync_settings_async()
 
     def _update_unlock_ui(self) -> None:
         if not self._recording_unlock_required:
@@ -540,33 +589,53 @@ class RecordMacroDialog(Adw.Dialog):
             device.get("device_type", "other"),
         )
 
-    def _device_matches_selected_types(self, device: dict, selected_types: set[str]) -> bool:
-        return bool(selected_types.intersection(self._device_types(device)))
-
     def _device_type_text(self, device: dict) -> str:
         return " / ".join(input_class_label(dtype) for dtype in self._device_types(device))
 
-    def _get_selected_device_types(self) -> list[str]:
-        return list(self._get_selected_types())
+    def _update_selection_ui(self) -> None:
+        self._update_unlock_ui()
+        self._update_selection_summary()
+
+    def _update_selection_summary(self) -> None:
+        selected_devices = [device for device in self._devices if self._is_selected_device(device)]
+        counts = {"keyboard": 0, "mouse": 0, "gamepad": 0}
+        for device in selected_devices:
+            for device_type in {"keyboard", "mouse", "gamepad"}:
+                if device_type in self._device_types(device):
+                    counts[device_type] += 1
+
+        detail_parts: list[str] = []
+        if counts["keyboard"]:
+            detail_parts.append(f"Keyboard {counts['keyboard']}")
+        if counts["mouse"]:
+            detail_parts.append(f"Mouse {counts['mouse']}")
+        if counts["gamepad"]:
+            detail_parts.append(f"Gamepad {counts['gamepad']}")
+
+        summary = f"Selected sources: {len(selected_devices)}"
+        if detail_parts:
+            summary = f"{summary} ({', '.join(detail_parts)})"
+        self._selection_summary.set_label(summary)
+
+        has_selected_mouse = any(
+            "mouse" in self._device_types(device) for device in selected_devices
+        )
+        warning = ""
+        if not selected_devices:
+            warning = "No recording sources selected. Starting a recording will capture nothing."
+        elif (self._record_mouse_movement or self._record_mouse_clicks) and not has_selected_mouse:
+            warning = (
+                "Mouse movement or clicks are enabled, but no selected source can produce mouse "
+                "events."
+            )
+        self._selection_warning.set_label(warning)
+        self._selection_warning.set_visible(bool(warning))
 
     def _on_save_settings(self, btn: Gtk.Button) -> None:
         self._save_btn.set_sensitive(False)
 
         def worker() -> None:
-            self._save_settings()
-            result = session_request(
-                {
-                    "command": "set_recording_settings",
-                    "include_mouse_movement": self._record_mouse_movement,
-                    "include_mouse_clicks": self._record_mouse_clicks,
-                    "record_start_position": self._record_start_position,
-                    "record_keyboard": self._record_keyboard,
-                    "record_mouse": self._record_mouse,
-                    "record_gamepad": self._record_gamepad,
-                    "device_overrides": self._device_overrides,
-                },
-                timeout=2.0,
-            )
+            result = session_request(self._settings_payload(), timeout=2.0)
             GLib.idle_add(self._on_save_settings_done, result)
 
         threading.Thread(target=worker, daemon=True).start()
@@ -584,57 +653,44 @@ class RecordMacroDialog(Adw.Dialog):
         return False
 
     def _sync_settings_to_session(self) -> None:
-        session_request(
-            {
-                "command": "set_recording_settings",
-                "include_mouse_movement": self._record_mouse_movement,
-                "include_mouse_clicks": self._record_mouse_clicks,
-                "record_start_position": self._record_start_position,
-                "record_keyboard": self._record_keyboard,
-                "record_mouse": self._record_mouse,
-                "record_gamepad": self._record_gamepad,
-                "device_overrides": self._device_overrides,
-            },
-            timeout=0.5,
+        session_request(self._settings_payload(), timeout=0.5)
+
+    def _sync_settings_async(self) -> None:
+        threading.Thread(target=self._sync_settings_to_session, daemon=True).start()
+
+    def _settings_payload(self) -> dict[str, object]:
+        return {
+            "command": "set_recording_settings",
+            "include_mouse_movement": self._record_mouse_movement,
+            "include_mouse_clicks": self._record_mouse_clicks,
+            "record_start_position": self._record_start_position,
+            "device_overrides": self._device_overrides,
+        }
+
+    def _apply_recording_settings(self, result: dict | None) -> None:
+        data = result or {}
+        overrides = data.get("device_overrides", {})
+
+        self._record_mouse_movement = bool(
+            data.get("include_mouse_movement", self._record_mouse_movement)
         )
+        self._record_mouse_clicks = bool(
+            data.get("include_mouse_clicks", self._record_mouse_clicks)
+        )
+        self._record_start_position = bool(
+            data.get("record_start_position", self._record_start_position)
+        )
+        if isinstance(overrides, dict):
+            self._device_overrides = {str(k): bool(v) for k, v in overrides.items()}
 
-    def _load_settings(self) -> None:
+        self._applying_settings = True
         try:
-            if self._SETTINGS_PATH.exists():
-                data = json.loads(self._SETTINGS_PATH.read_text())
-                self._record_mouse_movement = bool(data.get("include_mouse_movement", False))
-                self._record_mouse_clicks = bool(data.get("include_mouse_clicks", False))
-                self._record_start_position = bool(data.get("record_start_position", False))
-                self._record_keyboard = bool(data.get("record_keyboard", True))
-                self._record_mouse = bool(data.get("record_mouse", False))
-                self._record_gamepad = bool(data.get("record_gamepad", True))
-                overrides = data.get("device_overrides", {})
-                if isinstance(overrides, dict):
-                    self._device_overrides = {str(k): bool(v) for k, v in overrides.items()}
-        except Exception:
-            pass
-
-    def _save_settings(self) -> None:
-        try:
-            ensure_config_dirs()
-            self._SETTINGS_PATH.write_text(
-                json.dumps(
-                    {
-                        "include_mouse_movement": self._record_mouse_movement,
-                        "include_mouse_clicks": self._record_mouse_clicks,
-                        "record_start_position": self._record_start_position,
-                        "record_keyboard": self._record_keyboard,
-                        "record_mouse": self._record_mouse,
-                        "record_gamepad": self._record_gamepad,
-                        "device_overrides": self._device_overrides,
-                    }
-                )
-            )
-        except Exception:
-            pass
-
-    def _save_settings_async(self) -> None:
-        threading.Thread(target=self._save_settings, daemon=True).start()
+            self._record_movement_check.set_active(self._record_mouse_movement)
+            self._record_clicks_check.set_active(self._record_mouse_clicks)
+            self._record_start_pos_check.set_active(self._record_start_position)
+        finally:
+            self._applying_settings = False
+        self._update_selection_ui()
 
     def _show_error(self, message: str) -> None:
         dialog = Adw.AlertDialog()

--- a/keymasq/gui/widgets/record_macro_dialog.py
+++ b/keymasq/gui/widgets/record_macro_dialog.py
@@ -54,112 +54,103 @@ class RecordMacroDialog(Adw.Dialog):
         content.set_margin_start(16)
         content.set_margin_end(16)
 
-        intro_label = Gtk.Label(
-            label=(
-                "The selected sources below are what will actually be recorded. "
-                "Quick actions only update those source selections."
-            )
-        )
-        intro_label.set_wrap(True)
-        intro_label.set_halign(Gtk.Align.START)
-        intro_label.add_css_class("dim-label")
-        content.append(intro_label)
+        # Recording options in a compact boxed list
+        options_frame = Gtk.ListBox()
+        options_frame.set_selection_mode(Gtk.SelectionMode.NONE)
+        options_frame.add_css_class("boxed-list")
 
-        quick_label = Gtk.Label(label="Quick Selection")
-        quick_label.add_css_class("heading")
-        quick_label.set_halign(Gtk.Align.START)
-        content.append(quick_label)
+        self._record_movement_check = Gtk.CheckButton()
+        self._record_movement_check.set_active(self._record_mouse_movement)
+        self._record_movement_check.connect("toggled", self._on_record_options_changed)
+        movement_row = Adw.ActionRow(title="Record mouse movement")
+        movement_row.add_prefix(self._record_movement_check)
+        movement_row.set_activatable_widget(self._record_movement_check)
+        options_frame.append(movement_row)
 
-        quick_help = Gtk.Label(
-            label=(
-                "Use these actions to update the source list below. "
-                "They are helpers only, not separate recording state."
-            )
+        self._record_clicks_check = Gtk.CheckButton()
+        self._record_clicks_check.set_active(self._record_mouse_clicks)
+        self._record_clicks_check.connect("toggled", self._on_record_options_changed)
+        clicks_row = Adw.ActionRow(title="Record mouse clicks")
+        clicks_row.add_prefix(self._record_clicks_check)
+        clicks_row.set_activatable_widget(self._record_clicks_check)
+        options_frame.append(clicks_row)
+
+        self._record_start_pos_check = Gtk.CheckButton()
+        self._record_start_pos_check.set_active(self._record_start_position)
+        self._record_start_pos_check.connect("toggled", self._on_record_options_changed)
+        start_pos_row = Adw.ActionRow(
+            title="Record initial mouse position",
+            subtitle="For 'move to start' playback",
         )
-        quick_help.set_wrap(True)
-        quick_help.set_halign(Gtk.Align.START)
-        quick_help.add_css_class("dim-label")
-        quick_help.add_css_class("caption")
-        content.append(quick_help)
+        start_pos_row.add_prefix(self._record_start_pos_check)
+        start_pos_row.set_activatable_widget(self._record_start_pos_check)
+        options_frame.append(start_pos_row)
+
+        content.append(options_frame)
+
+        # Quick Selection as a collapsed expander with compact inline controls
+        quick_expander = Gtk.Expander(label="Quick Selection")
+        quick_expander.set_expanded(False)
 
         quick_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=8)
+        quick_box.set_margin_top(8)
+
+        quick_row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=12)
+        quick_row.set_halign(Gtk.Align.START)
+
         for label, device_type in (
             ("Keyboards", "keyboard"),
             ("Mice", "mouse"),
             ("Gamepads", "gamepad"),
         ):
-            row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=8)
-            row.set_halign(Gtk.Align.START)
+            type_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=4)
 
             type_label = Gtk.Label(label=label)
-            type_label.set_width_chars(10)
-            type_label.set_halign(Gtk.Align.START)
-            row.append(type_label)
+            type_box.append(type_label)
 
-            select_btn = Gtk.Button(label="Select All")
+            select_btn = Gtk.Button()
+            select_btn.set_icon_name("object-select-symbolic")
+            select_btn.set_tooltip_text(f"Select all {label.lower()}")
+            select_btn.add_css_class("flat")
             select_btn.connect("clicked", self._on_select_type_clicked, device_type, True)
-            row.append(select_btn)
+            type_box.append(select_btn)
 
-            clear_btn = Gtk.Button(label="Clear")
+            clear_btn = Gtk.Button()
+            clear_btn.set_icon_name("edit-clear-symbolic")
+            clear_btn.set_tooltip_text(f"Clear all {label.lower()}")
+            clear_btn.add_css_class("flat")
             clear_btn.connect("clicked", self._on_select_type_clicked, device_type, False)
-            row.append(clear_btn)
+            type_box.append(clear_btn)
 
-            quick_box.append(row)
+            quick_row.append(type_box)
 
-        reset_btn = Gtk.Button(label="Reset to Recommended")
-        reset_btn.set_halign(Gtk.Align.START)
-        reset_btn.connect("clicked", self._on_reset_to_recommended_clicked)
-        quick_box.append(reset_btn)
-        content.append(quick_box)
+        quick_box.append(quick_row)
+        quick_expander.set_child(quick_box)
+        content.append(quick_expander)
 
-        options_row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=16)
-        options_row.set_halign(Gtk.Align.START)
+        sources_header = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=8)
+        sources_header.set_margin_top(4)
 
-        self._record_movement_check = Gtk.CheckButton(label="Record mouse movement")
-        self._record_movement_check.set_active(self._record_mouse_movement)
-        self._record_movement_check.connect("toggled", self._on_record_options_changed)
-        options_row.append(self._record_movement_check)
-
-        self._record_clicks_check = Gtk.CheckButton(label="Record mouse clicks")
-        self._record_clicks_check.set_active(self._record_mouse_clicks)
-        self._record_clicks_check.connect("toggled", self._on_record_options_changed)
-        options_row.append(self._record_clicks_check)
-
-        content.append(options_row)
-
-        start_pos_row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=16)
-        start_pos_row.set_halign(Gtk.Align.START)
-
-        self._record_start_pos_check = Gtk.CheckButton(
-            label="Record initial mouse position (for 'move to start' playback)"
-        )
-        self._record_start_pos_check.set_active(self._record_start_position)
-        self._record_start_pos_check.connect("toggled", self._on_record_options_changed)
-        start_pos_row.append(self._record_start_pos_check)
-
-        content.append(start_pos_row)
-
-        devices_label = Gtk.Label(label="Recording sources:")
+        devices_label = Gtk.Label(label="Recording sources")
         devices_label.add_css_class("heading")
         devices_label.set_halign(Gtk.Align.START)
-        content.append(devices_label)
+        sources_header.append(devices_label)
 
-        sources_help = Gtk.Label(
-            label=(
-                "Recommended sources are Keymasq outputs and passthrough devices. "
-                "Direct sources capture raw input before remapping."
-            )
-        )
-        sources_help.set_wrap(True)
-        sources_help.set_halign(Gtk.Align.START)
-        sources_help.add_css_class("dim-label")
-        content.append(sources_help)
-
-        self._selection_summary = Gtk.Label(label="Selected sources: 0")
-        self._selection_summary.set_wrap(True)
+        self._selection_summary = Gtk.Label(label="0 selected")
         self._selection_summary.set_halign(Gtk.Align.START)
         self._selection_summary.add_css_class("caption")
-        content.append(self._selection_summary)
+        self._selection_summary.add_css_class("dim-label")
+        sources_header.append(self._selection_summary)
+
+        reset_btn = Gtk.Button(label="Reset")
+        reset_btn.set_tooltip_text("Reset to recommended sources")
+        reset_btn.add_css_class("flat")
+        reset_btn.set_hexpand(True)
+        reset_btn.set_halign(Gtk.Align.END)
+        reset_btn.connect("clicked", self._on_reset_to_recommended_clicked)
+        sources_header.append(reset_btn)
+
+        content.append(sources_header)
 
         self._selection_warning = Gtk.Label(label="")
         self._selection_warning.set_wrap(True)
@@ -171,8 +162,9 @@ class RecordMacroDialog(Adw.Dialog):
 
         scrolled = Gtk.ScrolledWindow()
         scrolled.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
-        scrolled.set_min_content_height(280)
-        scrolled.set_max_content_height(420)
+        scrolled.set_vexpand(True)
+        scrolled.set_min_content_height(200)
+        scrolled.set_max_content_height(500)
 
         self._device_listbox = Gtk.ListBox()
         self._device_listbox.set_selection_mode(Gtk.SelectionMode.NONE)
@@ -308,23 +300,24 @@ class RecordMacroDialog(Adw.Dialog):
 
         header_row = Gtk.ListBoxRow()
         header_row.set_selectable(False)
-        header_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=2)
-        header_box.set_margin_top(10)
+        header_row.set_tooltip_text(description)
+
+        header_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=8)
+        header_box.set_margin_top(6)
         header_box.set_margin_bottom(4)
         header_box.set_margin_start(12)
         header_box.set_margin_end(12)
 
         title_label = Gtk.Label(label=title)
         title_label.set_halign(Gtk.Align.START)
-        title_label.add_css_class("heading")
+        title_label.add_css_class("caption")
+        title_label.add_css_class("dim-label")
         header_box.append(title_label)
 
-        desc_label = Gtk.Label(label=description)
-        desc_label.set_wrap(True)
-        desc_label.set_halign(Gtk.Align.START)
-        desc_label.add_css_class("dim-label")
-        desc_label.add_css_class("caption")
-        header_box.append(desc_label)
+        separator = Gtk.Separator(orientation=Gtk.Orientation.HORIZONTAL)
+        separator.set_hexpand(True)
+        separator.set_valign(Gtk.Align.CENTER)
+        header_box.append(separator)
 
         header_row.set_child(header_box)
         self._device_listbox.append(header_row)
@@ -606,15 +599,16 @@ class RecordMacroDialog(Adw.Dialog):
 
         detail_parts: list[str] = []
         if counts["keyboard"]:
-            detail_parts.append(f"Keyboard {counts['keyboard']}")
+            detail_parts.append(f"{counts['keyboard']}kb")
         if counts["mouse"]:
-            detail_parts.append(f"Mouse {counts['mouse']}")
+            detail_parts.append(f"{counts['mouse']}m")
         if counts["gamepad"]:
-            detail_parts.append(f"Gamepad {counts['gamepad']}")
+            detail_parts.append(f"{counts['gamepad']}gp")
 
-        summary = f"Selected sources: {len(selected_devices)}"
         if detail_parts:
-            summary = f"{summary} ({', '.join(detail_parts)})"
+            summary = f"{len(selected_devices)} selected ({', '.join(detail_parts)})"
+        else:
+            summary = f"{len(selected_devices)} selected"
         self._selection_summary.set_label(summary)
 
         has_selected_mouse = any(

--- a/keymasq/gui/widgets/record_macro_dialog.py
+++ b/keymasq/gui/widgets/record_macro_dialog.py
@@ -185,7 +185,8 @@ class RecordMacroDialog(Adw.Dialog):
         footer.set_margin_start(12)
         footer.set_margin_end(12)
 
-        self._unlock_btn = Gtk.Button(label="Unlock")
+        self._unlock_btn = Gtk.Button()
+        self._unlock_btn.set_child(self._make_unlock_button_content("Unlock"))
         self._unlock_btn.connect("clicked", self._on_unlock_clicked)
         footer.append(self._unlock_btn)
 
@@ -567,6 +568,14 @@ class RecordMacroDialog(Adw.Dialog):
         self._update_selection_ui()
         self._sync_settings_async()
 
+    def _make_unlock_button_content(self, label: str) -> Gtk.Box:
+        box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=6)
+        icon = Gtk.Image.new_from_icon_name("channel-insecure-symbolic")
+        box.append(icon)
+        lbl = Gtk.Label(label=label)
+        box.append(lbl)
+        return box
+
     def _update_unlock_ui(self) -> None:
         if not self._recording_unlock_required:
             self._unlock_btn.set_visible(False)
@@ -574,7 +583,8 @@ class RecordMacroDialog(Adw.Dialog):
 
         has_active_unlock = self._recording_unlocked and self._recording_refresh_owner
         self._unlock_btn.set_visible(not has_active_unlock)
-        self._unlock_btn.set_label("Claim Unlock" if self._recording_unlocked else "Unlock")
+        label = "Claim" if self._recording_unlocked else "Unlock"
+        self._unlock_btn.set_child(self._make_unlock_button_content(label))
 
     def _device_types(self, device: dict) -> list[str]:
         return normalize_input_classes(

--- a/keymasq/keymasqd/daemon_capture_commands.py
+++ b/keymasq/keymasqd/daemon_capture_commands.py
@@ -8,6 +8,7 @@ from keymasq.keymasqd.daemon_helpers import (
     JsonObjectList,
     float_like,
     int_like,
+    json_object_list,
     str_list,
 )
 
@@ -18,6 +19,8 @@ class _GrabbedDeviceRef(Protocol):
 
 class _CaptureCommandDeviceManager(Protocol):
     grabbed_devices: dict[str, list[_GrabbedDeviceRef]]
+
+    async def list_devices(self) -> JsonObject: ...
 
     def begin_combo_capture(
         self, token: str, hardware_ids: set[str], notify_event: asyncio.Event
@@ -72,8 +75,12 @@ async def handle_capture_command(
     data: JsonObject,
 ) -> JsonObject | None:
     if command_type == CommandType.START_RECORDING:
+        devices = cast(JsonObjectList, data.get("devices", []))
+        recording_ids = str_list(data.get("recording_ids", []))
+        if recording_ids:
+            devices = await resolve_recording_devices(daemon, recording_ids)
         return await daemon.recording_manager.start(
-            cast(JsonObjectList, data.get("devices", [])),
+            devices,
             include_mouse_movement=bool(data.get("include_mouse_movement", False)),
             include_mouse_clicks=bool(data.get("include_mouse_clicks", False)),
         )
@@ -103,6 +110,23 @@ async def handle_capture_command(
         return await capture_combo(daemon, hardware_ids, timeout_s)
 
     return None
+
+
+async def resolve_recording_devices(
+    daemon: _CaptureCommandDaemon,
+    recording_ids: list[str],
+) -> JsonObjectList:
+    wanted = {str(recording_id) for recording_id in recording_ids if str(recording_id)}
+    if not wanted:
+        return []
+
+    result = await daemon.device_manager.list_devices()
+    devices: JsonObjectList = []
+    for device in json_object_list(result.get("devices", [])):
+        recording_id = str(device.get("recording_id", "") or "")
+        if recording_id in wanted:
+            devices.append(device)
+    return devices
 
 
 async def capture_combo(

--- a/keymasq/keymasqd/device_manager.py
+++ b/keymasq/keymasqd/device_manager.py
@@ -119,6 +119,18 @@ def _device_paths() -> list[str]:
     return cast(Callable[[], list[str]], evdev.list_devices)()
 
 
+def _uinput_device_path(uinput_dev: object | None) -> str | None:
+    input_device = getattr(uinput_dev, "device", None)
+    path = getattr(input_device, "path", None)
+    return path if isinstance(path, str) and path else None
+
+
+def _is_virtual_input(device: object) -> bool:
+    phys = str(getattr(device, "phys", "") or "").lower()
+    name = str(getattr(device, "name", "") or "").lower()
+    return phys == "py-evdev-uinput" or name.startswith("keymasq-")
+
+
 def _fire_and_observe(coro: Awaitable[object], label: str) -> asyncio.Task[object]:
     task = asyncio.ensure_future(coro)
 
@@ -554,6 +566,8 @@ class DeviceManager:
     def _list_devices_sync(self) -> JsonObject:
         clear_device_path_cache()
         devices: list[JsonObject] = []
+        virtual_metadata = self._recording_virtual_device_metadata()
+        grabbed_metadata = self._recording_grabbed_source_metadata()
 
         for path in _device_paths():
             try:
@@ -570,10 +584,30 @@ class DeviceManager:
 
                 device_types = self._detect_device_types(device)
                 device_type = primary_input_class(device_types)
+                stable_path = resolve_stable_path(path)
+                interface_id = get_interface_id(stable_path)
+                metadata = virtual_metadata.get(path, {})
+                grabbed_source = grabbed_metadata.get(stable_path)
+                is_grabbed = grabbed_source is not None
+                recording_kind = str(metadata.get("recording_kind", "") or "")
+                if not recording_kind:
+                    recording_kind = (
+                        "physical" if not _is_virtual_input(device) else "other_virtual"
+                    )
+                recording_id = str(metadata.get("recording_id", "") or "")
+                if not recording_id:
+                    recording_id = (
+                        f"physical:{stable_path}"
+                        if recording_kind == "physical"
+                        else f"virtual:{device.name or path}:{stable_path}"
+                    )
 
                 devices.append(
                     {
                         "path": path,
+                        "open_path": path,
+                        "stable_path": stable_path,
+                        "interface_id": str(interface_id or ""),
                         "name": device.name,
                         "phys": _optional_str(getattr(device, "phys", None)),
                         "uniq": _optional_str(getattr(device, "uniq", None)),
@@ -582,12 +616,65 @@ class DeviceManager:
                         "capabilities": capabilities,
                         "device_types": device_types,
                         "device_type": device_type.value,
+                        "recording_id": recording_id,
+                        "recording_kind": recording_kind,
+                        "grabbed_by_keymasq": is_grabbed,
+                        **metadata,
+                        **(grabbed_source or {}),
                     }
                 )
             except Exception as e:
                 log.debug(f"Could not read device {path}: {e}")
 
         return {"devices": devices}
+
+    def _recording_virtual_device_metadata(self) -> dict[str, JsonObject]:
+        metadata: dict[str, JsonObject] = {}
+        output_devices = {
+            "keyboard": self.output_state.keyboard_uinput,
+            "mouse": self.output_state.mouse_uinput,
+            "gamepad": self.output_state.gamepad_uinput,
+        }
+        for output_class, uinput_dev in output_devices.items():
+            path = _uinput_device_path(uinput_dev)
+            if not path:
+                continue
+            metadata[path] = {
+                "recording_id": f"keymasq:output:{output_class}",
+                "recording_kind": "keymasq_output",
+                "keymasq_output": output_class,
+            }
+
+        for devices in self.grabbed_devices.values():
+            for grabbed in devices:
+                path = _uinput_device_path(getattr(grabbed, "uinput", None))
+                if not path:
+                    continue
+                hardware_id = str(getattr(grabbed, "hardware_id", "") or "")
+                interface_id = str(getattr(grabbed, "interface_id", "") or "")
+                stable_path = str(getattr(grabbed, "stable_path", "") or "")
+                metadata[path] = {
+                    "recording_id": f"keymasq:passthrough:{hardware_id}:{interface_id}",
+                    "recording_kind": "keymasq_passthrough",
+                    "source_hardware_id": hardware_id,
+                    "source_interface_id": interface_id,
+                    "source_stable_path": stable_path,
+                    "source_path": str(getattr(grabbed, "path", "") or ""),
+                }
+        return metadata
+
+    def _recording_grabbed_source_metadata(self) -> dict[str, JsonObject]:
+        metadata: dict[str, JsonObject] = {}
+        for devices in self.grabbed_devices.values():
+            for grabbed in devices:
+                stable_path = str(getattr(grabbed, "stable_path", "") or "")
+                if not stable_path:
+                    continue
+                metadata[stable_path] = {
+                    "source_hardware_id": str(getattr(grabbed, "hardware_id", "") or ""),
+                    "source_interface_id": str(getattr(grabbed, "interface_id", "") or ""),
+                }
+        return metadata
 
     def _detect_device_types(self, device: _ManagedInputDevice) -> list[str]:
         return detect_input_classes(_capability_device(device))

--- a/keymasq/keymasqd/recording.py
+++ b/keymasq/keymasqd/recording.py
@@ -7,6 +7,7 @@ import evdev
 from keymasq.common.devices import (
     classify_event_device_type,
     normalize_input_classes,
+    resolve_stable_path,
 )
 from keymasq.common.ipc import CommandType
 
@@ -42,17 +43,16 @@ class RecordingManager:
         self._stopped = True
         self._include_mouse_movement = False
         self._include_mouse_clicks = False
+        self._record_grabbed_source_keys: set[str] = set()
 
     @property
     def is_recording(self) -> bool:
         return not self._stopped
 
-    def should_record_grabbed_event(self, _device_path: str, _device_types: list[str]) -> bool:
-        # Macro recording should follow the explicit device selection sent by the
-        # session/UI. Grabbed physical devices are represented in the recording
-        # UI by their matching keymasq-* outputs, so recording them here would
-        # duplicate the same input stream.
-        return False
+    def should_record_grabbed_event(self, device_path: str, _device_types: list[str]) -> bool:
+        return _physical_source_key(resolve_stable_path(device_path)) in (
+            self._record_grabbed_source_keys
+        )
 
     async def start(
         self,
@@ -69,9 +69,10 @@ class RecordingManager:
         self._stopped = False
         self._include_mouse_movement = bool(include_mouse_movement)
         self._include_mouse_clicks = bool(include_mouse_clicks)
+        extra_devices, self._record_grabbed_source_keys = _build_recording_plan(devices)
 
-        for dev in devices:
-            path_value = dev.get("path")
+        for dev in extra_devices:
+            path_value = dev.get("open_path", dev.get("path"))
             if not isinstance(path_value, str) or not path_value:
                 continue
             try:
@@ -158,6 +159,7 @@ class RecordingManager:
             except Exception:
                 pass
         self._extra_devices = []
+        self._record_grabbed_source_keys = set()
 
         duration_ms = int(_event_time_us(self._events[-1]) / 1000) if self._events else 0
         device_types = sorted({str(event.get("device_type", "other")) for event in self._events})
@@ -192,3 +194,66 @@ class RecordingManager:
                     "duration_ms": duration_ms,
                 },
             )
+
+
+def _str_value(value: object, default: str = "") -> str:
+    return default if value is None else str(value)
+
+
+def _physical_source_key(stable_path: str) -> str:
+    return f"physical:{stable_path}"
+
+
+def _recording_device_kind(device: RecordingDevice) -> str:
+    return _str_value(
+        device.get("recording_kind", device.get("kind", "physical")),
+        "physical",
+    )
+
+
+def _recording_device_path(device: RecordingDevice) -> str:
+    return _str_value(device.get("open_path", device.get("path", "")), "")
+
+
+def _recording_device_source_key(device: RecordingDevice) -> str:
+    source_stable_path = _str_value(device.get("source_stable_path"), "")
+    if source_stable_path:
+        return _physical_source_key(source_stable_path)
+
+    stable_path = _str_value(device.get("stable_path"), "")
+    if stable_path:
+        return _physical_source_key(stable_path)
+
+    path = _recording_device_path(device)
+    if path:
+        return _physical_source_key(resolve_stable_path(path))
+
+    return _str_value(device.get("recording_id"), "")
+
+
+def _build_recording_plan(
+    devices: list[RecordingDevice],
+) -> tuple[list[RecordingDevice], set[str]]:
+    selected = [device for device in devices if _recording_device_path(device)]
+    passthrough_sources = {
+        _recording_device_source_key(device)
+        for device in selected
+        if _recording_device_kind(device) == "keymasq_passthrough"
+    }
+    passthrough_sources.discard("")
+
+    extra_devices: list[RecordingDevice] = []
+    grabbed_source_keys: set[str] = set()
+
+    for device in selected:
+        kind = _recording_device_kind(device)
+        source_key = _recording_device_source_key(device)
+        if kind == "physical" and source_key in passthrough_sources:
+            continue
+        if kind == "physical" and bool(device.get("grabbed_by_keymasq", False)):
+            if source_key:
+                grabbed_source_keys.add(source_key)
+            continue
+        extra_devices.append(device)
+
+    return extra_devices, grabbed_source_keys

--- a/keymasq/keymasqd/runtime/grabbed_device_events.py
+++ b/keymasq/keymasqd/runtime/grabbed_device_events.py
@@ -453,7 +453,10 @@ async def process_event(
         record_grabbed_event = True
         if callable(should_record_grabbed_event):
             record_grabbed_event = bool(
-                should_record_grabbed_event(device_runtime.path, device_runtime.device_types)
+                should_record_grabbed_event(
+                    device_runtime.stable_path,
+                    device_runtime.device_types,
+                )
             )
         if record_grabbed_event:
             input_event = cast(evdev.InputEvent, event)

--- a/keymasq/session/manager/commands.py
+++ b/keymasq/session/manager/commands.py
@@ -435,9 +435,7 @@ async def _handle_capture_commands(
             ["keyboard", "gamepad", "mouse"],
             include_grabbed=True,
         )
-        manager.recording_state.devices_cache = [
-            d for d in devices if not d.get("grabbed_by_keymasq")
-        ]
+        manager.recording_state.devices_cache = devices
         return {"status": "ok", "devices": devices}
 
     if command == "begin_capture":

--- a/keymasq/session/manager/core.py
+++ b/keymasq/session/manager/core.py
@@ -58,7 +58,7 @@ TOPOLOGY_REFRESH_RETRY_S = 1.0
 
 
 class SessionManager:
-    RECORDING_SETTINGS_PATH = CONFIG_DIR / "recording_settings.json"
+    RECORDING_SETTINGS_PATH = CONFIG_DIR / "recording_settings.toml"
     MAX_SESSION_CLIENT_BUFFER_BYTES = 16 * 1024 * 1024
 
     def __init__(self, verbosity: int = 0) -> None:

--- a/keymasq/session/manager/recording.py
+++ b/keymasq/session/manager/recording.py
@@ -788,7 +788,10 @@ def load_recording_settings_from_disk(manager: "SessionManager") -> None:
                 str(recording_id): bool(enabled) for recording_id, enabled in overrides.items()
             }
     except Exception:
-        pass
+        log.exception(
+            "Failed to load recording settings from %s",
+            manager.RECORDING_SETTINGS_PATH,
+        )
 
 
 def save_recording_settings_to_disk(
@@ -816,7 +819,10 @@ def save_recording_settings_to_disk(
         with manager.RECORDING_SETTINGS_PATH.open("wb") as f:
             tomli_w.dump(data, f)
     except Exception:
-        pass
+        log.exception(
+            "Failed to save recording settings to %s",
+            manager.RECORDING_SETTINGS_PATH,
+        )
 
 
 async def start_recording(

--- a/keymasq/session/manager/recording.py
+++ b/keymasq/session/manager/recording.py
@@ -1,10 +1,12 @@
 import asyncio
-import json
 import logging
 import re
 import secrets
+import tomllib
 from datetime import datetime
 from typing import TYPE_CHECKING, cast
+
+import tomli_w
 
 from keymasq.common.devices import normalize_input_classes
 from keymasq.common.ipc import Command, CommandType
@@ -739,7 +741,7 @@ def update_recording_settings(manager: "SessionManager", request: JsonObject) ->
         overrides = json_object(request.get("device_overrides"))
         if overrides is not None:
             settings["device_overrides"] = {
-                str(path): bool(enabled) for path, enabled in overrides.items()
+                str(recording_id): bool(enabled) for recording_id, enabled in overrides.items()
             }
     queue_recording_settings_save(manager, dict(settings))
 
@@ -771,9 +773,8 @@ def load_recording_settings_from_disk(manager: "SessionManager") -> None:
     try:
         if not manager.RECORDING_SETTINGS_PATH.exists():
             return
-        data = json_object(json.loads(manager.RECORDING_SETTINGS_PATH.read_text()))
-        if data is None:
-            return
+        with manager.RECORDING_SETTINGS_PATH.open("rb") as f:
+            data = cast(JsonObject, tomllib.load(f))
         settings = manager.recording_state.settings
         settings["include_mouse_movement"] = bool(data.get("include_mouse_movement", False))
         settings["include_mouse_clicks"] = bool(data.get("include_mouse_clicks", False))
@@ -784,7 +785,7 @@ def load_recording_settings_from_disk(manager: "SessionManager") -> None:
         overrides = json_object(data.get("device_overrides"))
         if overrides is not None:
             settings["device_overrides"] = {
-                str(path): bool(enabled) for path, enabled in overrides.items()
+                str(recording_id): bool(enabled) for recording_id, enabled in overrides.items()
             }
     except Exception:
         pass
@@ -796,18 +797,24 @@ def save_recording_settings_to_disk(
 ) -> None:
     settings = settings or manager.recording_state.settings
     try:
-        existing: JsonObject = {}
-        if manager.RECORDING_SETTINGS_PATH.exists():
-            loaded = json_object(json.loads(manager.RECORDING_SETTINGS_PATH.read_text()))
-            if loaded is not None:
-                existing = dict(loaded)
-
-        existing["include_mouse_movement"] = bool(settings.get("include_mouse_movement", False))
-        existing["include_mouse_clicks"] = bool(settings.get("include_mouse_clicks", False))
-        existing["record_start_position"] = bool(settings.get("record_start_position", False))
+        data: JsonObject = {
+            "include_mouse_movement": bool(settings.get("include_mouse_movement", False)),
+            "include_mouse_clicks": bool(settings.get("include_mouse_clicks", False)),
+            "record_start_position": bool(settings.get("record_start_position", False)),
+            "record_keyboard": bool(settings.get("record_keyboard", True)),
+            "record_mouse": bool(settings.get("record_mouse", False)),
+            "record_gamepad": bool(settings.get("record_gamepad", True)),
+            "device_overrides": {
+                str(recording_id): bool(enabled)
+                for recording_id, enabled in (
+                    json_object(settings.get("device_overrides")) or {}
+                ).items()
+            },
+        }
 
         manager.RECORDING_SETTINGS_PATH.parent.mkdir(parents=True, exist_ok=True)
-        manager.RECORDING_SETTINGS_PATH.write_text(json.dumps(existing))
+        with manager.RECORDING_SETTINGS_PATH.open("wb") as f:
+            tomli_w.dump(data, f)
     except Exception:
         pass
 
@@ -832,46 +839,34 @@ async def start_recording(
     include_mouse_movement = settings.get("include_mouse_movement", False)
     include_mouse_clicks = settings.get("include_mouse_clicks", False)
     record_start_position = settings.get("record_start_position", False)
-    device_types: list[str] = []
-    if settings.get("record_keyboard", True):
-        device_types.append("keyboard")
-    if settings.get("record_gamepad", True):
-        device_types.append("gamepad")
-    if settings.get("record_mouse", False) or (include_mouse_movement or include_mouse_clicks):
-        device_types.append("mouse")
+    device_types = ["keyboard", "gamepad", "mouse"]
 
     devices: list[JsonObject]
     if manager.recording_state.devices_cache:
-        devices = [
-            d
-            for d in manager.recording_state.devices_cache
-            if _recording_device_matches_types(d, device_types)
-        ]
+        devices = list(manager.recording_state.devices_cache)
     else:
         try:
             devices = await asyncio.wait_for(
-                get_devices_for_recording(manager, device_types),
+                get_devices_for_recording(manager, device_types, include_grabbed=True),
                 timeout=1.5,
             )
         except Exception:
             devices = []
 
-    overrides = json_object(settings.get("device_overrides"))
-    if overrides:
-        devices = [
-            d
+    overrides = json_object(settings.get("device_overrides")) or {}
+    devices = [d for d in devices if _recording_device_enabled(d, overrides)]
+    recording_ids = list(
+        dict.fromkeys(
+            recording_id
             for d in devices
-            if bool(
-                overrides.get(
-                    str(d.get("path", "")),
-                    _recording_device_matches_types(d, device_types),
-                )
-            )
-        ]
+            if (recording_id := _recording_device_id(d))
+        )
+    )
     log.debug(
-        "recording start device selection: types=%s overrides=%r devices=%s",
+        "recording start device selection: types=%s overrides=%r recording_ids=%s devices=%s",
         device_types,
         overrides,
+        recording_ids,
         [str(d.get("path", "")) for d in devices],
     )
 
@@ -903,7 +898,7 @@ async def start_recording(
             Command(
                 command=CommandType.START_RECORDING,
                 data={
-                    "devices": devices,
+                    "recording_ids": recording_ids,
                     "include_mouse_movement": include_mouse_movement,
                     "include_mouse_clicks": include_mouse_clicks,
                     "start_x": start_x,
@@ -928,7 +923,11 @@ async def start_recording(
 
 async def refresh_recording_devices_cache(manager: "SessionManager") -> None:
     try:
-        devices = await get_devices_for_recording(manager, ["keyboard", "gamepad", "mouse"])
+        devices = await get_devices_for_recording(
+            manager,
+            ["keyboard", "gamepad", "mouse"],
+            include_grabbed=True,
+        )
         manager.recording_state.devices_cache = devices
     except Exception:
         pass
@@ -940,9 +939,32 @@ def _recording_device_types(device: JsonObject) -> list[str]:
         str_value(device.get("device_type"), "other"),
     )
 
+def _recording_device_id(device: JsonObject) -> str:
+    recording_id = str_value(device.get("recording_id"), "")
+    if recording_id:
+        return recording_id
+    stable_path = str_value(device.get("stable_path"), "")
+    if stable_path:
+        return f"physical:{stable_path}"
+    path = str_value(device.get("path"), "")
+    return f"physical:{path}" if path else ""
 
-def _recording_device_matches_types(device: JsonObject, device_types: list[str]) -> bool:
-    return bool(set(device_types).intersection(_recording_device_types(device)))
+
+def _recording_device_selected_by_default(device: JsonObject) -> bool:
+    return str_value(device.get("recording_kind"), "physical") in {
+        "keymasq_output",
+        "keymasq_passthrough",
+    }
+
+
+def _recording_device_enabled(
+    device: JsonObject,
+    overrides: JsonObject,
+) -> bool:
+    recording_id = _recording_device_id(device)
+    if recording_id in overrides:
+        return bool(overrides.get(recording_id))
+    return _recording_device_selected_by_default(device)
 
 
 async def get_devices_for_recording(
@@ -970,24 +992,37 @@ async def get_devices_for_recording(
         if d is None:
             continue
         path = str_value(d.get("path"), "")
+        stable_path = str_value(d.get("stable_path"), path)
         dtype = str_value(d.get("device_type"), "other")
         resolved_types = _recording_device_types(d)
         if not path or not set(device_types).intersection(resolved_types):
             continue
 
-        is_grabbed = path in grabbed_paths
+        is_grabbed = bool(d.get("grabbed_by_keymasq", False)) or path in grabbed_paths
+        if stable_path in grabbed_paths:
+            is_grabbed = True
         if is_grabbed and not include_grabbed:
             continue
 
         devices.append(
             {
                 "path": path,
+                "open_path": str_value(d.get("open_path"), path),
+                "stable_path": stable_path,
+                "interface_id": str_value(d.get("interface_id"), ""),
                 "name": str_value(d.get("name"), path),
                 "vendor_id": str(d.get("vendor_id", "") or ""),
                 "product_id": str(d.get("product_id", "") or ""),
                 "device_type": dtype,
                 "device_types": resolved_types,
+                "recording_id": str_value(d.get("recording_id"), f"physical:{stable_path}"),
+                "recording_kind": str_value(d.get("recording_kind"), "physical"),
                 "grabbed_by_keymasq": is_grabbed,
+                "source_hardware_id": str_value(d.get("source_hardware_id"), ""),
+                "source_interface_id": str_value(d.get("source_interface_id"), ""),
+                "source_stable_path": str_value(d.get("source_stable_path"), ""),
+                "source_path": str_value(d.get("source_path"), ""),
+                "keymasq_output": str_value(d.get("keymasq_output"), ""),
             }
         )
 

--- a/tests/gui/test_device_tab_widget.py
+++ b/tests/gui/test_device_tab_widget.py
@@ -726,7 +726,6 @@ class TestDeviceTabWidget:
         assert isinstance(start_btn, Gtk.Button)
         assert start_btn.get_sensitive() is False
         assert unlock_btn.get_visible() is True
-        assert unlock_btn.has_css_class("destructive-action") is True
         assert "Unlock to add additional keys and mouse buttons." in privilege_status.get_text()
 
         unlock_btn.emit("clicked")

--- a/tests/gui/test_gui_demo_and_dialogs.py
+++ b/tests/gui/test_gui_demo_and_dialogs.py
@@ -96,6 +96,88 @@ class TestRecordMacroDialog:
         assert dialog._unlock_btn.get_visible() is False
         assert dialog._unlock_status.get_label() == "Unlock active"
 
+    def test_record_dialog_defaults_to_recommended_sources(self, monkeypatch):
+        gi.require_version("Gtk", "4.0")
+        from gi.repository import Gtk
+
+        from keymasq.gui.widgets.record_macro_dialog import RecordMacroDialog
+
+        monkeypatch.setattr(RecordMacroDialog, "_load_initial_state_async", lambda self: None)
+
+        dialog = RecordMacroDialog(Gtk.Window())
+        dialog._apply_recording_settings({"status": "ok", "device_overrides": {}})
+        dialog._devices = [
+            {
+                "path": "/dev/input/event20",
+                "recording_id": "keymasq:output:keyboard",
+                "recording_kind": "keymasq_output",
+                "device_type": "keyboard",
+                "device_types": ["keyboard"],
+                "name": "keymasq-keyboard",
+            },
+            {
+                "path": "/dev/input/event0",
+                "recording_id": "physical:/dev/input/by-id/raw-mouse",
+                "recording_kind": "physical",
+                "device_type": "mouse",
+                "device_types": ["mouse"],
+                "name": "Raw Mouse",
+            },
+        ]
+
+        dialog._populate_device_list()
+
+        assert dialog._device_checks["keymasq:output:keyboard"].get_active() is True
+        assert dialog._device_checks["physical:/dev/input/by-id/raw-mouse"].get_active() is False
+        assert dialog._selection_summary.get_label() == "Selected sources: 1 (Keyboard 1)"
+
+    def test_record_dialog_bulk_selection_is_helper_only(self, monkeypatch):
+        gi.require_version("Gtk", "4.0")
+        from gi.repository import Gtk
+
+        from keymasq.gui.widgets.record_macro_dialog import RecordMacroDialog
+
+        monkeypatch.setattr(RecordMacroDialog, "_load_initial_state_async", lambda self: None)
+
+        dialog = RecordMacroDialog(Gtk.Window())
+        dialog._apply_recording_settings(
+            {
+                "status": "ok",
+                "include_mouse_movement": True,
+                "device_overrides": {},
+            }
+        )
+        dialog._devices = [
+            {
+                "path": "/dev/input/event20",
+                "recording_id": "keymasq:output:keyboard",
+                "recording_kind": "keymasq_output",
+                "device_type": "keyboard",
+                "device_types": ["keyboard"],
+                "name": "keymasq-keyboard",
+            },
+            {
+                "path": "/dev/input/event0",
+                "recording_id": "physical:/dev/input/by-id/raw-mouse",
+                "recording_kind": "physical",
+                "device_type": "mouse",
+                "device_types": ["mouse"],
+                "name": "Raw Mouse",
+            },
+        ]
+
+        dialog._populate_device_list()
+        assert dialog._selection_warning.get_visible() is True
+
+        dialog._on_select_type_clicked(Gtk.Button(), "mouse", True)
+        assert dialog._device_checks["physical:/dev/input/by-id/raw-mouse"].get_active() is True
+        assert dialog._selection_summary.get_label() == "Selected sources: 2 (Keyboard 1, Mouse 1)"
+        assert dialog._selection_warning.get_visible() is False
+
+        dialog._on_reset_to_recommended_clicked(Gtk.Button())
+        assert dialog._device_checks["physical:/dev/input/by-id/raw-mouse"].get_active() is False
+        assert dialog._selection_warning.get_visible() is True
+
 
 class TestDialogConstruction:
     def test_about_dialog_uses_packaged_app_identity(self, monkeypatch):

--- a/tests/gui/test_gui_demo_and_dialogs.py
+++ b/tests/gui/test_gui_demo_and_dialogs.py
@@ -72,7 +72,6 @@ class TestRecordMacroDialog:
             }
         )
         assert dialog._unlock_btn.get_visible() is True
-        assert dialog._unlock_btn.get_label() == "Unlock"
         assert dialog._unlock_status.get_label() == "Unlock required"
 
         dialog._apply_unlock_state(
@@ -83,7 +82,6 @@ class TestRecordMacroDialog:
             }
         )
         assert dialog._unlock_btn.get_visible() is True
-        assert dialog._unlock_btn.get_label() == "Claim Unlock"
         assert dialog._unlock_status.get_label() == "Unlock active in another session"
 
         dialog._apply_unlock_state(

--- a/tests/gui/test_gui_demo_and_dialogs.py
+++ b/tests/gui/test_gui_demo_and_dialogs.py
@@ -129,7 +129,7 @@ class TestRecordMacroDialog:
 
         assert dialog._device_checks["keymasq:output:keyboard"].get_active() is True
         assert dialog._device_checks["physical:/dev/input/by-id/raw-mouse"].get_active() is False
-        assert dialog._selection_summary.get_label() == "Selected sources: 1 (Keyboard 1)"
+        assert dialog._selection_summary.get_label() == "1 selected (1kb)"
 
     def test_record_dialog_bulk_selection_is_helper_only(self, monkeypatch):
         gi.require_version("Gtk", "4.0")
@@ -171,7 +171,7 @@ class TestRecordMacroDialog:
 
         dialog._on_select_type_clicked(Gtk.Button(), "mouse", True)
         assert dialog._device_checks["physical:/dev/input/by-id/raw-mouse"].get_active() is True
-        assert dialog._selection_summary.get_label() == "Selected sources: 2 (Keyboard 1, Mouse 1)"
+        assert dialog._selection_summary.get_label() == "2 selected (1kb, 1m)"
         assert dialog._selection_warning.get_visible() is False
 
         dialog._on_reset_to_recommended_clicked(Gtk.Button())

--- a/tests/keymasqd/test_daemon_capture_commands.py
+++ b/tests/keymasqd/test_daemon_capture_commands.py
@@ -42,6 +42,46 @@ async def test_macro_play_by_name_loads_store_and_forwards_runtime_options(daemo
 
 
 @pytest.mark.asyncio
+async def test_start_recording_resolves_recording_ids_before_start(daemon_testbed):
+    daemon, device_manager, recording_manager, _macro_store, _capture_manager = daemon_testbed
+    selected = {
+        "path": "/dev/input/event10",
+        "recording_id": "keymasq:passthrough:1234:5678:mouse",
+        "recording_kind": "keymasq_passthrough",
+        "device_type": "mouse",
+        "device_types": ["mouse"],
+    }
+    device_manager.list_devices.return_value = {
+        "devices": [
+            selected,
+            {
+                "path": "/dev/input/event0",
+                "recording_id": "physical:/dev/input/by-id/raw",
+                "recording_kind": "physical",
+                "device_type": "mouse",
+                "device_types": ["mouse"],
+            },
+        ]
+    }
+
+    result = await daemon._handle_command(
+        CommandType.START_RECORDING,
+        {
+            "recording_ids": ["keymasq:passthrough:1234:5678:mouse"],
+            "include_mouse_movement": True,
+            "include_mouse_clicks": False,
+        },
+    )
+
+    assert result == {"recording": "started"}
+    recording_manager.start.assert_awaited_once_with(
+        [selected],
+        include_mouse_movement=True,
+        include_mouse_clicks=False,
+    )
+
+
+@pytest.mark.asyncio
 async def test_set_cursor_position_command_forwards_to_device_manager(daemon_testbed):
     daemon, device_manager, _recording_manager, _macro_store, _capture_manager = daemon_testbed
     device_manager.set_cursor_position.return_value = {"status": "ok", "x": 123, "y": 456}

--- a/tests/keymasqd/test_device_manager_core.py
+++ b/tests/keymasqd/test_device_manager_core.py
@@ -321,6 +321,115 @@ class TestDeviceDetection:
 
 
 class TestListDevices:
+    def test_list_devices_marks_physical_recording_identity(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        manager = DeviceManager()
+
+        class FakeDevice:
+            path = "/dev/input/event0"
+            name = "Raw Keyboard"
+            phys = "usb-test"
+            uniq = ""
+            info = SimpleNamespace(vendor=0x1234, product=0x5678)
+
+            def capabilities(self):
+                return {evdev.ecodes.EV_KEY: [evdev.ecodes.KEY_A]}
+
+            def input_props(self):
+                return []
+
+        monkeypatch.setattr(dm, "_device_paths", lambda: ["/dev/input/event0"])
+        monkeypatch.setattr(dm.evdev, "InputDevice", lambda _path: FakeDevice())
+        monkeypatch.setattr(dm, "resolve_stable_path", lambda _path: "/dev/input/by-id/raw-kbd")
+        monkeypatch.setattr(dm, "get_interface_id", lambda _path: "kbd")
+
+        result = manager._list_devices_sync()
+        result_devices = cast(list[dict[str, object]], result["devices"])
+        device = result_devices[0]
+
+        assert device["path"] == "/dev/input/event0"
+        assert device["open_path"] == "/dev/input/event0"
+        assert device["stable_path"] == "/dev/input/by-id/raw-kbd"
+        assert device["recording_id"] == "physical:/dev/input/by-id/raw-kbd"
+        assert device["recording_kind"] == "physical"
+        assert device["grabbed_by_keymasq"] is False
+
+    def test_list_devices_marks_keymasq_outputs_and_passthrough_sources(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        manager = DeviceManager()
+        manager.output_state.keyboard_uinput = SimpleNamespace(
+            device=SimpleNamespace(path="/dev/input/event10")
+        )  # type: ignore[assignment]
+        manager.grabbed_devices = {
+            "1234:5678": [
+                SimpleNamespace(
+                    path="/dev/input/event0",
+                    stable_path="/dev/input/by-id/raw-kbd",
+                    hardware_id="1234:5678",
+                    interface_id="kbd",
+                    uinput=SimpleNamespace(device=SimpleNamespace(path="/dev/input/event20")),
+                )
+            ]
+        }
+
+        class FakeDevice:
+            def __init__(self, path: str) -> None:
+                self.path = path
+                self.name = {
+                    "/dev/input/event0": "Raw Keyboard",
+                    "/dev/input/event10": "keymasq-keyboard",
+                    "/dev/input/event20": "keymasq-1234:5678",
+                }[path]
+                self.phys = "py-evdev-uinput" if path != "/dev/input/event0" else "usb-test"
+                self.uniq = ""
+                self.info = SimpleNamespace(vendor=0x1234, product=0x5678)
+
+            def capabilities(self):
+                return {evdev.ecodes.EV_KEY: [evdev.ecodes.KEY_A]}
+
+            def input_props(self):
+                return []
+
+        stable_paths = {
+            "/dev/input/event0": "/dev/input/by-id/raw-kbd",
+            "/dev/input/event10": "/dev/input/event10",
+            "/dev/input/event20": "/dev/input/event20",
+        }
+        monkeypatch.setattr(
+            dm,
+            "_device_paths",
+            lambda: ["/dev/input/event0", "/dev/input/event10", "/dev/input/event20"],
+        )
+        monkeypatch.setattr(dm.evdev, "InputDevice", FakeDevice)
+        monkeypatch.setattr(dm, "resolve_stable_path", lambda path: stable_paths[path])
+        monkeypatch.setattr(dm, "get_interface_id", lambda path: "kbd" if "raw" in path else path)
+
+        result = manager._list_devices_sync()
+        result_devices = cast(list[dict[str, object]], result["devices"])
+        devices = {device["path"]: device for device in result_devices}
+
+        raw = devices["/dev/input/event0"]
+        assert raw["recording_id"] == "physical:/dev/input/by-id/raw-kbd"
+        assert raw["recording_kind"] == "physical"
+        assert raw["grabbed_by_keymasq"] is True
+        assert raw["source_hardware_id"] == "1234:5678"
+        assert raw["source_interface_id"] == "kbd"
+
+        output = devices["/dev/input/event10"]
+        assert output["recording_id"] == "keymasq:output:keyboard"
+        assert output["recording_kind"] == "keymasq_output"
+        assert output["keymasq_output"] == "keyboard"
+
+        passthrough = devices["/dev/input/event20"]
+        assert passthrough["recording_id"] == "keymasq:passthrough:1234:5678:kbd"
+        assert passthrough["recording_kind"] == "keymasq_passthrough"
+        assert passthrough["source_stable_path"] == "/dev/input/by-id/raw-kbd"
+        assert passthrough["source_path"] == "/dev/input/event0"
+
     @pytest.mark.asyncio
     async def test_list_devices_offloads_scan_to_thread(
         self,

--- a/tests/keymasqd/test_macro_backend_recording.py
+++ b/tests/keymasqd/test_macro_backend_recording.py
@@ -86,36 +86,163 @@ async def test_recording_ignores_start_stop_mapping_buttons() -> None:
     assert recorder.calls[0][1].code == evdev.ecodes.KEY_F14
 
 
-@pytest.mark.asyncio
-async def test_real_recording_manager_skips_grabbed_device_stream() -> None:
-    recorder = RecordingManager()
-    event_callback = AsyncMock()
-    keyboard_uinput = MagicMock()
+class _QuietInputDevice:
+    def close(self) -> None:
+        pass
 
-    await recorder.start([])
+    async def async_read_loop(self):
+        while True:
+            await asyncio.sleep(60)
+            yield evdev.InputEvent(1, 1, evdev.ecodes.EV_SYN, 0, 0)
 
-    mapping = {
-        "btn_macro": MappingAction(action_type=ActionType.KEYBOARD, target="key_a"),
-    }
-    grabbed = GrabbedDevice(
+
+def _grabbed_recording_device(
+    recorder: RecordingManager,
+    *,
+    stable_path: str = "/dev/input/by-id/raw-kbd",
+) -> GrabbedDevice:
+    device = GrabbedDevice(
         path="/dev/input/event0",
         hardware_id="test",
         button_map={"btn_macro": "key_f14"},
-        mapping_getter=lambda: mapping,
-        event_callback=event_callback,
+        mapping_getter=lambda: {
+            "btn_macro": MappingAction(action_type=ActionType.KEYBOARD, target="key_a"),
+        },
+        event_callback=AsyncMock(),
         device_type=DeviceType.KEYBOARD,
-        keyboard_uinput=keyboard_uinput,
+        keyboard_uinput=MagicMock(),
         recording_manager=recorder,
+    )
+    device.stable_path = stable_path
+    return device
+
+
+@pytest.mark.asyncio
+async def test_recording_manager_records_selected_grabbed_raw_stream(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    recorder = RecordingManager()
+    monkeypatch.setattr(
+        recording_module,
+        "resolve_stable_path",
+        lambda path: "/dev/input/by-id/raw-kbd" if path == "/dev/input/event0" else path,
+    )
+
+    await recorder.start(
+        [
+            {
+                "path": "/dev/input/event0",
+                "stable_path": "/dev/input/by-id/raw-kbd",
+                "recording_id": "physical:/dev/input/by-id/raw-kbd",
+                "recording_kind": "physical",
+                "device_type": "keyboard",
+                "device_types": ["keyboard"],
+                "grabbed_by_keymasq": True,
+            }
+        ]
     )
 
     await _process_grabbed_event(
-        grabbed,
+        _grabbed_recording_device(recorder),
         evdev.InputEvent(1, 200, evdev.ecodes.EV_KEY, evdev.ecodes.KEY_F14, 1),
     )
-
     result = await recorder.stop()
 
+    assert result["event_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_recording_manager_prefers_selected_passthrough_over_grabbed_raw(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    recorder = RecordingManager()
+    opened_paths: list[str] = []
+
+    def fake_input_device(path: str):
+        opened_paths.append(path)
+        return _QuietInputDevice()
+
+    monkeypatch.setattr(recording_module.evdev, "InputDevice", fake_input_device)
+    monkeypatch.setattr(
+        recording_module,
+        "resolve_stable_path",
+        lambda path: "/dev/input/by-id/raw-kbd" if path == "/dev/input/event0" else path,
+    )
+
+    await recorder.start(
+        [
+            {
+                "path": "/dev/input/event0",
+                "stable_path": "/dev/input/by-id/raw-kbd",
+                "recording_id": "physical:/dev/input/by-id/raw-kbd",
+                "recording_kind": "physical",
+                "device_type": "keyboard",
+                "device_types": ["keyboard"],
+                "grabbed_by_keymasq": True,
+            },
+            {
+                "path": "/dev/input/event10",
+                "stable_path": "/dev/input/event10",
+                "recording_id": "keymasq:passthrough:test:kbd",
+                "recording_kind": "keymasq_passthrough",
+                "source_stable_path": "/dev/input/by-id/raw-kbd",
+                "device_type": "keyboard",
+                "device_types": ["keyboard"],
+            },
+        ]
+    )
+
+    await _process_grabbed_event(
+        _grabbed_recording_device(recorder),
+        evdev.InputEvent(1, 200, evdev.ecodes.EV_KEY, evdev.ecodes.KEY_F14, 1),
+    )
+    result = await recorder.stop()
+
+    assert opened_paths == ["/dev/input/event10"]
     assert result["event_count"] == 0
+
+
+@pytest.mark.asyncio
+async def test_recording_manager_keeps_unrelated_grabbed_raw_when_passthrough_selected(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    recorder = RecordingManager()
+    monkeypatch.setattr(recording_module.evdev, "InputDevice", lambda _path: _QuietInputDevice())
+    monkeypatch.setattr(
+        recording_module,
+        "resolve_stable_path",
+        lambda path: "/dev/input/by-id/raw-kbd" if path == "/dev/input/event0" else path,
+    )
+
+    await recorder.start(
+        [
+            {
+                "path": "/dev/input/event0",
+                "stable_path": "/dev/input/by-id/raw-kbd",
+                "recording_id": "physical:/dev/input/by-id/raw-kbd",
+                "recording_kind": "physical",
+                "device_type": "keyboard",
+                "device_types": ["keyboard"],
+                "grabbed_by_keymasq": True,
+            },
+            {
+                "path": "/dev/input/event10",
+                "recording_id": "keymasq:passthrough:other:kbd",
+                "recording_kind": "keymasq_passthrough",
+                "source_stable_path": "/dev/input/by-id/other-kbd",
+                "device_type": "keyboard",
+                "device_types": ["keyboard"],
+            },
+        ]
+    )
+
+    await _process_grabbed_event(
+        _grabbed_recording_device(recorder),
+        evdev.InputEvent(1, 200, evdev.ecodes.EV_KEY, evdev.ecodes.KEY_F14, 1),
+    )
+    result = await recorder.stop()
+
+    assert result["event_count"] == 1
 
 
 @pytest.mark.asyncio

--- a/tests/session/test_session_manager_recording_settings.py
+++ b/tests/session/test_session_manager_recording_settings.py
@@ -1,4 +1,6 @@
 # ruff: noqa: F403, F405, I001
+import tomllib
+
 from tests.session.profile_support import *
 
 @pytest.mark.asyncio
@@ -46,3 +48,131 @@ async def test_recording_settings_persistence_applies_latest_snapshot_last() -> 
         "record_start_position": False,
     }
     monkeypatch.undo()
+
+
+def test_recording_settings_save_load_toml_uses_recording_ids(tmp_path) -> None:
+    manager = SessionManager()
+    manager.RECORDING_SETTINGS_PATH = tmp_path / "recording_settings.toml"
+    manager.recording_state.settings = {
+        "include_mouse_movement": True,
+        "include_mouse_clicks": True,
+        "record_start_position": True,
+        "record_keyboard": False,
+        "record_mouse": True,
+        "record_gamepad": False,
+        "device_overrides": {
+            "keymasq:passthrough:1234:5678:mouse": True,
+            "physical:/dev/input/by-id/usb-test-event-mouse": False,
+        },
+    }
+
+    session_recording_module.save_recording_settings_to_disk(manager)
+
+    with manager.RECORDING_SETTINGS_PATH.open("rb") as f:
+        written = tomllib.load(f)
+    assert written == manager.recording_state.settings
+
+    loaded_manager = SessionManager()
+    loaded_manager.RECORDING_SETTINGS_PATH = manager.RECORDING_SETTINGS_PATH
+    session_recording_module.load_recording_settings_from_disk(loaded_manager)
+
+    assert loaded_manager.recording_state.settings == manager.recording_state.settings
+
+
+@pytest.mark.asyncio
+async def test_start_recording_sends_recording_ids_from_cache() -> None:
+    manager = SessionManager()
+    sent_commands: list[CommandType] = []
+    sent_payloads: list[dict[str, object]] = []
+
+    async def send_command(command):
+        sent_commands.append(command.command)
+        sent_payloads.append(dict(command.data or {}))
+        return Response(status="ok", data={"status": "ok"})
+
+    manager.client = SimpleNamespace(send_command=send_command)  # type: ignore[assignment]
+    manager.recording_state.settings = {
+        "include_mouse_movement": False,
+        "include_mouse_clicks": False,
+        "record_start_position": False,
+        "record_keyboard": True,
+        "record_mouse": False,
+        "record_gamepad": False,
+        "device_overrides": {
+            "keymasq:passthrough:1234:5678:kbd": True,
+            "physical:/dev/input/by-id/usb-raw-event-kbd": False,
+        },
+    }
+    manager.recording_state.devices_cache = [
+        {
+            "path": "/dev/input/event20",
+            "recording_id": "keymasq:passthrough:1234:5678:kbd",
+            "recording_kind": "keymasq_passthrough",
+            "device_type": "keyboard",
+            "device_types": ["keyboard"],
+        },
+        {
+            "path": "/dev/input/event0",
+            "stable_path": "/dev/input/by-id/usb-raw-event-kbd",
+            "recording_id": "physical:/dev/input/by-id/usb-raw-event-kbd",
+            "recording_kind": "physical",
+            "device_type": "keyboard",
+            "device_types": ["keyboard"],
+        },
+    ]
+
+    result = await session_recording_module.start_recording(manager)
+
+    assert result == {"status": "ok"}
+    assert sent_commands == [CommandType.START_RECORDING]
+    assert sent_payloads[0]["recording_ids"] == ["keymasq:passthrough:1234:5678:kbd"]
+
+
+@pytest.mark.asyncio
+async def test_start_recording_defaults_to_recommended_sources_only() -> None:
+    manager = SessionManager()
+    sent_payloads: list[dict[str, object]] = []
+
+    async def send_command(command):
+        sent_payloads.append(dict(command.data or {}))
+        return Response(status="ok", data={"status": "ok"})
+
+    manager.client = SimpleNamespace(send_command=send_command)  # type: ignore[assignment]
+    manager.recording_state.settings = {
+        "include_mouse_movement": False,
+        "include_mouse_clicks": False,
+        "record_start_position": False,
+        "device_overrides": {},
+    }
+    manager.recording_state.devices_cache = [
+        {
+            "path": "/dev/input/event20",
+            "recording_id": "keymasq:output:keyboard",
+            "recording_kind": "keymasq_output",
+            "device_type": "keyboard",
+            "device_types": ["keyboard"],
+        },
+        {
+            "path": "/dev/input/event21",
+            "recording_id": "keymasq:passthrough:1234:5678:mouse",
+            "recording_kind": "keymasq_passthrough",
+            "device_type": "mouse",
+            "device_types": ["mouse"],
+        },
+        {
+            "path": "/dev/input/event0",
+            "stable_path": "/dev/input/by-id/usb-raw-event-kbd",
+            "recording_id": "physical:/dev/input/by-id/usb-raw-event-kbd",
+            "recording_kind": "physical",
+            "device_type": "keyboard",
+            "device_types": ["keyboard"],
+        },
+    ]
+
+    result = await session_recording_module.start_recording(manager)
+
+    assert result == {"status": "ok"}
+    assert sent_payloads[0]["recording_ids"] == [
+        "keymasq:output:keyboard",
+        "keymasq:passthrough:1234:5678:mouse",
+    ]

--- a/tests/session/test_session_manager_recording_settings.py
+++ b/tests/session/test_session_manager_recording_settings.py
@@ -1,4 +1,5 @@
 # ruff: noqa: F403, F405, I001
+import logging
 import tomllib
 
 from tests.session.profile_support import *
@@ -77,6 +78,45 @@ def test_recording_settings_save_load_toml_uses_recording_ids(tmp_path) -> None:
     session_recording_module.load_recording_settings_from_disk(loaded_manager)
 
     assert loaded_manager.recording_state.settings == manager.recording_state.settings
+
+
+def test_recording_settings_load_logs_errors(tmp_path, caplog) -> None:
+    manager = SessionManager()
+    manager.RECORDING_SETTINGS_PATH = tmp_path / "recording_settings.toml"
+    manager.RECORDING_SETTINGS_PATH.write_text("not = [valid toml", encoding="utf-8")
+
+    caplog.set_level(logging.ERROR, logger="keymasq-session")
+
+    session_recording_module.load_recording_settings_from_disk(manager)
+
+    assert (
+        f"Failed to load recording settings from {manager.RECORDING_SETTINGS_PATH}"
+        in caplog.text
+    )
+
+
+def test_recording_settings_save_logs_errors(tmp_path, caplog, monkeypatch) -> None:
+    manager = SessionManager()
+    manager.RECORDING_SETTINGS_PATH = tmp_path / "recording_settings.toml"
+    manager.recording_state.settings = {
+        "include_mouse_movement": True,
+        "include_mouse_clicks": False,
+        "record_start_position": False,
+        "device_overrides": {},
+    }
+
+    def raise_dump_error(_data, _fp) -> None:
+        raise OSError("disk full")
+
+    monkeypatch.setattr(session_recording_module.tomli_w, "dump", raise_dump_error)
+    caplog.set_level(logging.ERROR, logger="keymasq-session")
+
+    session_recording_module.save_recording_settings_to_disk(manager)
+
+    assert (
+        f"Failed to save recording settings to {manager.RECORDING_SETTINGS_PATH}"
+        in caplog.text
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Reworked the macro recording dialog to separate recommended Keymasq outputs from direct physical and other virtual input sources.
- Added quick-selection controls, selection summaries, and validation warnings so users can see exactly what will be recorded.
- Switched recording settings and device overrides to stable recording IDs, with backend support for resolving those IDs to live devices.
- Updated device metadata, recording logic, and session settings plumbing to handle passthrough devices without duplicating events.
- Documented the new recording source model and preference storage in `docs/MACROS.md`.

## Testing
- Added and updated unit/integration coverage for the recording dialog, device manager, daemon capture commands, session recording settings, and macro backend recording behavior.
- Not run locally in this pass.