### PR TITLE
Add GNOME Shell cursor positioning bridge support

### DIFF
--- a/docs/GNOME.md
+++ b/docs/GNOME.md
@@ -54,7 +54,10 @@ when switching windows.
 GNOME does not expose window information the same way other Wayland compositors
 do. The extension runs inside GNOME Shell and forwards the focused window name
 and pointer position to Keymasq so that window-aware profiles and pointer
-features work.
+features work. It also accepts an allowlisted pointer-position request from
+`keymasq-session`, letting absolute mouse moves and macro playback ask GNOME
+Shell to position the cursor through Mutter instead of relying on uinput
+relative-motion fallback.
 
 The same bridge also handles GNOME compositor actions. These are allowlisted
 bridge RPCs, not arbitrary shell commands. Keymasq currently supports:
@@ -67,7 +70,8 @@ bridge RPCs, not arbitrary shell commands. Keymasq currently supports:
 
 If the extension is missing or disconnected, Keymasq keeps running but
 window-based profile activation is unavailable until the extension reconnects.
-GNOME compositor actions are also unavailable until the bridge reconnects.
+GNOME compositor actions and compositor-side cursor positioning are also
+unavailable until the bridge reconnects.
 
 If Keymasq updates the installed bridge files but your current GNOME session is
 still running the old extension code, Keymasq now shows a warning telling you

--- a/docs/LISTENER_VM_TESTS.md
+++ b/docs/LISTENER_VM_TESTS.md
@@ -122,6 +122,7 @@ The `activate_title` bridge command is used by the GNOME VM test to switch focus
 - `hello` handshake
 - `focus_changed` messages
 - pointer request/response
+- pointer set request/response through the GNOME Shell bridge
 
 The full `listener-vm-gnome` test exercises the keymasq-session GNOME listener end-to-end (compositor detection → bridge connection → window tracking → cursor position). The two tests are separate to avoid socket conflicts between the probe and `keymasq-session`.
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -162,6 +162,8 @@ Compositor dispatch actions are routed through the active window-listener implem
 - KDE Plasma dispatch is restricted to a fixed whitelist of supported KWin actions
 - Hyprland dispatch is sent through the Hyprland IPC command socket
 - Niri dispatch is sent through the Niri IPC command socket with a fixed allowlist
+- GNOME dispatch and cursor-position requests are restricted to allowlisted RPCs
+  handled by the Keymasq GNOME Shell bridge
 
 This keeps compositor-specific control inside the listener boundary instead of treating it as unrestricted command execution.
 

--- a/gnome-extension/keymasq-bridge@nyrda/extension.js
+++ b/gnome-extension/keymasq-bridge@nyrda/extension.js
@@ -1,3 +1,4 @@
+import Clutter from 'gi://Clutter'
 import GLib from 'gi://GLib'
 import Gio from 'gi://Gio'
 import Meta from 'gi://Meta'
@@ -6,7 +7,7 @@ import Shell from 'gi://Shell'
 import {Extension} from 'resource:///org/gnome/shell/extensions/extension.js'
 
 class KeymasqBridge {
-    static PROTOCOL_VERSION = 2
+    static PROTOCOL_VERSION = 3
 
     constructor() {
         this._socketPath = GLib.build_filenamev([
@@ -182,6 +183,8 @@ class KeymasqBridge {
                 y,
                 mods,
             })
+        } else if (message.type === 'set_pointer') {
+            this._handleSetPointer(message)
         } else if (message.type === 'get_active_window') {
             const requestId = Number(message.request_id || 0)
             this._sendMessage({
@@ -210,6 +213,40 @@ class KeymasqBridge {
         } else if (message.type === 'dispatch') {
             this._handleDispatch(message)
         }
+    }
+
+    _handleSetPointer(message) {
+        const requestId = Number(message.request_id || 0)
+        const x = Math.trunc(Number(message.x))
+        const y = Math.trunc(Number(message.y))
+
+        if (!Number.isFinite(x) || !Number.isFinite(y)) {
+            this._pointerSetResult(requestId, false, 'invalid pointer coordinates', 0, 0)
+            return
+        }
+
+        try {
+            const seat = Clutter.get_default_backend()?.get_default_seat?.() || null
+            if (!seat || typeof seat.warp_pointer !== 'function') {
+                this._pointerSetResult(requestId, false, 'GNOME pointer warp unavailable', x, y)
+                return
+            }
+            seat.warp_pointer(x, y)
+            this._pointerSetResult(requestId, true, 'ok', x, y)
+        } catch (e) {
+            this._pointerSetResult(requestId, false, String(e), x, y)
+        }
+    }
+
+    _pointerSetResult(requestId, ok, message, x, y) {
+        this._sendMessage({
+            type: 'pointer_set_result',
+            request_id: requestId,
+            ok,
+            message,
+            x,
+            y,
+        })
     }
 
     _handleDispatch(message) {

--- a/gnome-extension/keymasq-bridge@nyrda/metadata.json
+++ b/gnome-extension/keymasq-bridge@nyrda/metadata.json
@@ -3,6 +3,6 @@
   "name": "Keymasq Bridge",
   "description": "Bridge active window and pointer data to keymasq-session",
   "shell-version": ["46", "47", "48", "49", "50"],
-  "version": 1,
+  "version": 2,
   "url": "https://github.com/nyrda/keymasq"
 }

--- a/keymasq/session/listeners/gnome.py
+++ b/keymasq/session/listeners/gnome.py
@@ -4,6 +4,7 @@ import contextlib
 import json
 import logging
 import os
+import shutil
 from pathlib import Path
 from typing import cast
 
@@ -125,31 +126,52 @@ class GnomeListener(WindowListener):
         return False
 
     @classmethod
+    def _gsettings_candidates(cls) -> list[str]:
+        candidates = [
+            "/usr/bin/gsettings",
+            "/run/current-system/sw/bin/gsettings",
+        ]
+        path_candidate = shutil.which("gsettings")
+        if path_candidate:
+            candidates.append(path_candidate)
+
+        unique: list[str] = []
+        seen: set[str] = set()
+        for candidate in candidates:
+            if not candidate or candidate in seen:
+                continue
+            seen.add(candidate)
+            unique.append(candidate)
+        return unique
+
+    @classmethod
     async def _gsettings_get(cls, schema: str, key: str) -> str | None:
-        try:
-            process = await asyncio.create_subprocess_exec(
-                "gsettings",
-                "get",
-                schema,
-                key,
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.PIPE,
-            )
-        except Exception:
-            return None
+        for candidate in cls._gsettings_candidates():
+            try:
+                process = await asyncio.create_subprocess_exec(
+                    candidate,
+                    "get",
+                    schema,
+                    key,
+                    stdout=asyncio.subprocess.PIPE,
+                    stderr=asyncio.subprocess.PIPE,
+                )
+            except Exception:
+                continue
 
-        try:
-            stdout, _stderr = await asyncio.wait_for(process.communicate(), timeout=0.8)
-        except Exception:
-            with contextlib.suppress(ProcessLookupError):
-                process.kill()
-            with contextlib.suppress(Exception):
-                await process.communicate()
-            return None
+            try:
+                stdout, _stderr = await asyncio.wait_for(process.communicate(), timeout=0.8)
+            except Exception:
+                with contextlib.suppress(ProcessLookupError):
+                    process.kill()
+                with contextlib.suppress(Exception):
+                    await process.communicate()
+                continue
 
-        if process.returncode != 0:
-            return None
-        return stdout.decode("utf-8", errors="replace").strip()
+            if process.returncode != 0:
+                continue
+            return stdout.decode("utf-8", errors="replace").strip()
+        return None
 
     @classmethod
     def _parse_enabled_extensions(cls, raw_value: str | None) -> list[str] | None:

--- a/keymasq/session/listeners/gnome.py
+++ b/keymasq/session/listeners/gnome.py
@@ -31,7 +31,7 @@ def _int_value(value: object, default: int = 0) -> int:
 
 class GnomeListener(WindowListener):
     _EXTENSION_UUID = "keymasq-bridge@nyrda"
-    _BRIDGE_PROTOCOL_VERSION = 2
+    _BRIDGE_PROTOCOL_VERSION = 3
     _NO_ARG_DISPATCHERS = frozenset({"close_active"})
     _TOGGLE_DISPATCHERS = frozenset({"fullscreen", "maximize"})
     _WORKSPACE_DISPATCHERS = frozenset({"workspace", "move_to_workspace"})
@@ -48,6 +48,7 @@ class GnomeListener(WindowListener):
         self._reader_task: asyncio.Task[None] | None = None
         self._request_id = 0
         self._pending_pointer: dict[int, asyncio.Future[JsonObject | None]] = {}
+        self._pending_pointer_set: dict[int, asyncio.Future[JsonObject | None]] = {}
         self._pending_activate: dict[int, asyncio.Future[JsonObject | None]] = {}
         self._pending_window: dict[int, asyncio.Future[JsonObject | None]] = {}
         self._pending_dispatch: dict[int, asyncio.Future[JsonObject | None]] = {}
@@ -64,6 +65,10 @@ class GnomeListener(WindowListener):
 
     @property
     def supports_compositor_dispatch(self) -> bool:
+        return True
+
+    @property
+    def supports_native_cursor_position_set(self) -> bool:
         return True
 
     @property
@@ -406,6 +411,11 @@ class GnomeListener(WindowListener):
                 future.set_result(None)
         self._pending_pointer.clear()
 
+        for future in list(self._pending_pointer_set.values()):
+            if not future.done():
+                future.set_result(None)
+        self._pending_pointer_set.clear()
+
         for future in list(self._pending_activate.values()):
             if not future.done():
                 future.set_result(None)
@@ -535,6 +545,14 @@ class GnomeListener(WindowListener):
             future.set_result(payload)
             return
 
+        if msg_type == "pointer_set_result":
+            request_id = _int_value(payload.get("request_id"), 0)
+            future = self._pending_pointer_set.pop(request_id, None)
+            if future is None or future.done():
+                return
+            future.set_result(payload)
+            return
+
         if msg_type == "activated":
             request_id = _int_value(payload.get("request_id"), 0)
             future = self._pending_activate.pop(request_id, None)
@@ -621,7 +639,7 @@ class GnomeListener(WindowListener):
             elif self._bridge_protocol < self._BRIDGE_PROTOCOL_VERSION:
                 details["warning"] = (
                     "GNOME bridge update detected. Log out and back in to reload the "
-                    "updated GNOME Shell extension and enable new GNOME actions."
+                    "updated GNOME Shell extension and enable new GNOME bridge features."
                 )
             else:
                 details["warning"] = (
@@ -645,6 +663,8 @@ class GnomeListener(WindowListener):
             self._pending_window[request_id] = future
         elif msg_type == "get_pointer":
             self._pending_pointer[request_id] = future
+        elif msg_type == "set_pointer":
+            self._pending_pointer_set[request_id] = future
         elif msg_type == "activate_title":
             self._pending_activate[request_id] = future
         elif msg_type == "dispatch":
@@ -659,6 +679,7 @@ class GnomeListener(WindowListener):
         except Exception:
             self._pending_window.pop(request_id, None)
             self._pending_pointer.pop(request_id, None)
+            self._pending_pointer_set.pop(request_id, None)
             self._pending_activate.pop(request_id, None)
             self._pending_dispatch.pop(request_id, None)
             return None
@@ -727,6 +748,25 @@ class GnomeListener(WindowListener):
         x = _int_value(result.get("x"), 0)
         y = _int_value(result.get("y"), 0)
         return x, y
+
+    async def set_cursor_position(self, x: int, y: int) -> tuple[bool, str]:
+        if self._writer is None or not self._bridge_connected:
+            return False, "GNOME bridge not connected"
+        if not self._bridge_protocol_compatible:
+            warning = str(self.runtime_support_details().get("warning", "") or "").strip()
+            return False, warning or "GNOME bridge protocol is not ready"
+
+        result = await self._send_request(
+            {
+                "type": "set_pointer",
+                "x": int(x),
+                "y": int(y),
+            },
+            timeout=0.6,
+        )
+        if result is None:
+            return False, "GNOME bridge not connected"
+        return bool(result.get("ok")), _str_value(result.get("message"), "")
 
     async def health_check(self) -> bool:
         if not self.running:

--- a/nix/listener-vms/gnome-bridge-probe.py
+++ b/nix/listener-vms/gnome-bridge-probe.py
@@ -49,6 +49,7 @@ def main() -> int:
     result: dict[str, object] = {
         "hello": False,
         "pointer": None,
+        "pointer_set": None,
         "focus_titles": [],
         "messages": [],
     }
@@ -64,6 +65,7 @@ def main() -> int:
 
         deadline = time.monotonic() + args.timeout
         request_id = 1
+        pointer_set_requested = False
         buffer = bytearray()
 
         with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as server:
@@ -90,6 +92,20 @@ def main() -> int:
                         request_id += 1
                     elif message_type == "pointer":
                         result["pointer"] = message
+                        if not pointer_set_requested:
+                            pointer_set_requested = True
+                            send_message(
+                                conn,
+                                {
+                                    "type": "set_pointer",
+                                    "request_id": request_id,
+                                    "x": int(message.get("x", 0)),
+                                    "y": int(message.get("y", 0)),
+                                },
+                            )
+                            request_id += 1
+                    elif message_type == "pointer_set_result":
+                        result["pointer_set"] = message
                     elif message_type == "focus_changed":
                         title = str(message.get("title", "") or "")
                         result["focus_titles"].append(title)
@@ -98,6 +114,7 @@ def main() -> int:
                     if (
                         result["hello"] is True
                         and result["pointer"] is not None
+                        and result["pointer_set"] is not None
                         and (not args.require_focus or bool(result["focus_titles"]))
                         and all(title in focus_titles for title in args.expect_title)
                     ):
@@ -107,6 +124,9 @@ def main() -> int:
         if result["hello"] is not True:
             exit_code = 1
         if result["pointer"] is None:
+            exit_code = 1
+        pointer_set = result.get("pointer_set")
+        if not isinstance(pointer_set, dict) or pointer_set.get("ok") is not True:
             exit_code = 1
         if args.require_focus and not result["focus_titles"]:
             exit_code = 1

--- a/tests/session/test_session_manager_command_acl.py
+++ b/tests/session/test_session_manager_command_acl.py
@@ -251,8 +251,8 @@ async def test_handle_session_request_get_compositor_merges_listener_runtime_war
         def runtime_support_details(self) -> dict[str, bool | str | int]:
             return {
                 "warning": "GNOME bridge update detected. Log out and back in.",
-                "bridge_protocol": 1,
-                "bridge_protocol_expected": 2,
+                "bridge_protocol": 2,
+                "bridge_protocol_expected": 3,
             }
 
     manager.compositor_state.window_listener = _Listener()  # type: ignore[assignment]
@@ -281,5 +281,5 @@ async def test_handle_session_request_get_compositor_merges_listener_runtime_war
     assert result["supported"] is True
     assert result["compositor_dispatch_available"] is False
     details = cast(dict[str, object], result["details"])
-    assert details["bridge_protocol"] == 1
+    assert details["bridge_protocol"] == 2
     assert "Log out and back in" in str(details["warning"])

--- a/tests/test_gnome_listener.py
+++ b/tests/test_gnome_listener.py
@@ -141,6 +141,56 @@ def test_gnome_probe_shell_process_uses_to_thread(monkeypatch) -> None:
     assert len(calls) == 1
 
 
+def test_gnome_gsettings_candidates_prefer_host_paths(monkeypatch) -> None:
+    monkeypatch.setattr(gnome_module.shutil, "which", lambda _name: "/nix/store/fake/bin/gsettings")
+
+    assert GnomeListener._gsettings_candidates() == [
+        "/usr/bin/gsettings",
+        "/run/current-system/sw/bin/gsettings",
+        "/nix/store/fake/bin/gsettings",
+    ]
+
+
+def test_gnome_gsettings_get_prefers_first_successful_candidate(monkeypatch) -> None:
+    calls: list[str] = []
+
+    class _FakeProcess:
+        def __init__(self, returncode: int, stdout: bytes) -> None:
+            self.returncode = returncode
+            self._stdout = stdout
+
+        async def communicate(self) -> tuple[bytes, bytes]:
+            return self._stdout, b""
+
+        def kill(self) -> None:
+            return None
+
+    monkeypatch.setattr(
+        GnomeListener,
+        "_gsettings_candidates",
+        classmethod(lambda cls: ["/usr/bin/gsettings", "/nix/store/fake/bin/gsettings"]),
+    )
+
+    async def _fake_create_subprocess_exec(*args, **kwargs):
+        assert kwargs["stdout"] == asyncio.subprocess.PIPE
+        assert kwargs["stderr"] == asyncio.subprocess.PIPE
+        calls.append(str(args[0]))
+        if args[0] == "/usr/bin/gsettings":
+            raise FileNotFoundError(args[0])
+        return _FakeProcess(0, b"['keymasq-bridge@nyrda']\n")
+
+    monkeypatch.setattr(
+        gnome_module.asyncio,
+        "create_subprocess_exec",
+        _fake_create_subprocess_exec,
+    )
+
+    result = asyncio.run(GnomeListener._gsettings_get("org.gnome.shell", "enabled-extensions"))
+
+    assert result == "['keymasq-bridge@nyrda']"
+    assert calls == ["/usr/bin/gsettings", "/nix/store/fake/bin/gsettings"]
+
+
 def test_gnome_probe_requires_extension(monkeypatch, tmp_path) -> None:
     runtime_dir = tmp_path / "runtime"
     runtime_dir.mkdir(parents=True, exist_ok=True)

--- a/tests/test_gnome_listener.py
+++ b/tests/test_gnome_listener.py
@@ -268,7 +268,7 @@ async def test_gnome_hello_marks_bridge_protocol_compatible() -> None:
     listener._writer = _FakeWriter()
     listener._bridge_connected = True
 
-    await listener._handle_bridge_message({"type": "hello", "protocol": 2})
+    await listener._handle_bridge_message({"type": "hello", "protocol": 3})
 
     assert listener.compositor_dispatch_available is True
     assert listener.runtime_support_details()["warning"] == ""
@@ -281,11 +281,11 @@ async def test_gnome_hello_reports_stale_bridge_protocol_warning() -> None:
     listener._writer = _FakeWriter()
     listener._bridge_connected = True
 
-    await listener._handle_bridge_message({"type": "hello", "protocol": 1})
+    await listener._handle_bridge_message({"type": "hello", "protocol": 2})
 
     details = listener.runtime_support_details()
     assert listener.compositor_dispatch_available is False
-    assert details["bridge_protocol"] == 1
+    assert details["bridge_protocol"] == 2
     assert "Log out and back in" in str(details["warning"])
 
 
@@ -346,7 +346,7 @@ async def test_gnome_dispatch_sends_bridge_request_and_resolves_result() -> None
     listener = GnomeListener(_callback)
     listener._writer = _FakeWriter()
     listener._bridge_connected = True
-    await listener._handle_bridge_message({"type": "hello", "protocol": 2})
+    await listener._handle_bridge_message({"type": "hello", "protocol": 3})
 
     async def _respond() -> None:
         await asyncio.sleep(0)
@@ -373,6 +373,64 @@ async def test_gnome_dispatch_sends_bridge_request_and_resolves_result() -> None
         }
     ]
     assert observed == [("org.gnome.Nautilus", "Home", [])]
+
+
+@pytest.mark.asyncio
+async def test_gnome_set_cursor_position_sends_bridge_request_and_resolves_result() -> None:
+    listener = GnomeListener(lambda *_args: asyncio.sleep(0))
+    listener._writer = _FakeWriter()
+    listener._bridge_connected = True
+    await listener._handle_bridge_message({"type": "hello", "protocol": 3})
+
+    async def _respond() -> None:
+        await asyncio.sleep(0)
+        await listener._handle_bridge_message(
+            {
+                "type": "pointer_set_result",
+                "request_id": 1,
+                "ok": True,
+                "message": "ok",
+                "x": 123,
+                "y": 456,
+            }
+        )
+
+    asyncio.create_task(_respond())
+
+    assert listener.supports_native_cursor_position_set is True
+    assert await listener.set_cursor_position(123, 456) == (True, "ok")
+    assert listener._writer.payloads == [
+        {
+            "type": "set_pointer",
+            "request_id": 1,
+            "x": 123,
+            "y": 456,
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_gnome_set_cursor_position_rejects_stale_bridge_protocol() -> None:
+    listener = GnomeListener(lambda *_args: asyncio.sleep(0))
+    listener._writer = _FakeWriter()
+    listener._bridge_connected = True
+    await listener._handle_bridge_message({"type": "hello", "protocol": 2})
+
+    ok, message = await listener.set_cursor_position(123, 456)
+
+    assert ok is False
+    assert "Log out and back in" in message
+    assert listener._writer.payloads == []
+
+
+@pytest.mark.asyncio
+async def test_gnome_set_cursor_position_fails_when_bridge_missing() -> None:
+    listener = GnomeListener(lambda *_args: asyncio.sleep(0))
+
+    assert await listener.set_cursor_position(123, 456) == (
+        False,
+        "GNOME bridge not connected",
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Adds a new GNOME Shell bridge RPC to set the cursor position through Mutter, alongside the existing pointer and compositor dispatch bridge.
- Bumps the GNOME bridge protocol to version 3 and wires `keymasq-session` to detect stale extension installs with an updated warning.
- Expands the GNOME listener tests and VM probe to cover pointer set request/response handling.
- Updates GNOME, install, security, and listener VM docs to reflect the new allowlisted cursor-positioning path and packaging notes.

## Testing
- `pytest tests/test_gnome_listener.py`
- `pytest tests/session/test_session_manager_command_acl.py`
- Not run: full `./scripts/check.sh full`