### PR TITLE
Add native X11 cursor positioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,9 @@ summarize user-visible changes accumulated toward the first public release.
 - Routed absolute mouse move actions through compositor-aware cursor position
   setters so screen-position workflows behave consistently across session
   backends.
+- Added an X11-native absolute cursor position setter via the X11 listener, so
+  XFCE/X11 sessions no longer need to fall back to keymasqd's virtual mouse for
+  absolute pointer moves.
 - Tightened slurp capture handling and macro editor updates for point-capture
   and absolute-position editing flows.
 - Reworked macro recording and macro manager flows with clearer source

--- a/docs/ACTIONS.md
+++ b/docs/ACTIONS.md
@@ -115,6 +115,10 @@ Capture opens a crosshair overlay — click anywhere to set the coordinates.
 On other platforms, Capture gives you 2 seconds to move your cursor to the
 desired position, then reads the coordinates automatically.
 
+Absolute mouse moves use a session-native cursor setter when the active
+listener provides one, including Hyprland and X11. Other sessions fall back to
+keymasqd's virtual mouse output.
+
 ![Mouse tab — buttons and Move Cursor with Relative/Absolute mode](assets/screenshots/keymasq_key_action_mouse.png)
 
 ## Gamepad

--- a/docs/DEPENDENCIES.md
+++ b/docs/DEPENDENCIES.md
@@ -47,7 +47,7 @@ What they are used for:
   integrations
 - `evdev`: input device access, recording, capture, and remap runtime
 - `uvloop`: default `asyncio` event loop policy
-- `python-xlib`: X11 listener support
+- `python-xlib`: X11 listener support, including cursor position read/write
 - `tomli-w`: writing profile, hardware, and superkey TOML files
 
 

--- a/docs/LISTENER_VM_TESTS.md
+++ b/docs/LISTENER_VM_TESTS.md
@@ -178,6 +178,12 @@ The Sway test validates the wlroots fallback listener (`WlrootsWaylandListener`)
 
 The XFCE test uses the X11 listener backed by `python-xlib`. The listener reads `_NET_ACTIVE_WINDOW` from the X root window and watches `PropertyNotify` events for title and class changes. On X11, GTK's `window.present()` works for focus switching, so no compositor-specific activation helpers are needed.
 
+**Cursor position**: The X11 listener reads cursor coordinates with
+`query_pointer()` and sets absolute cursor positions through XWarpPointer on
+the root window. This keeps absolute mouse move playback in the X server's
+screen coordinate space instead of relying on keymasqd's virtual mouse
+fallback.
+
 ## Focus Switching Summary
 
 | Compositor | `present()` works? | Activation method |

--- a/docs/LISTENER_VM_TESTS.md
+++ b/docs/LISTENER_VM_TESTS.md
@@ -64,7 +64,7 @@ Each desktop test validates:
 4. **Focus switching** — a second window is opened, then focus moves back to the first; the listener tracks each change.
 5. **Title change** — an existing window is retitled; the listener picks up the new title.
 6. **Window close** — a window is closed; the listener reports focus moving to the remaining window.
-7. **Cursor position** — where supported, the test moves the pointer to a known location and verifies that `get_cursor_position` returns integer coordinates in the expected on-screen range. The XFCE/X11 job also issues a native cursor-set request through macro playback and confirms that the pointer lands at the requested coordinates through the X11 listener.
+7. **Cursor position** — where supported, the test moves the pointer to a known location and verifies that `get_cursor_position` returns integer coordinates in the expected on-screen range. For listeners that implement native cursor setting (`gnome`, `hyprland`, and `x11`), the same shared harness also issues a native cursor-set request through macro playback and confirms that the pointer lands at the requested coordinates.
 8. **Listener-scoped dispatch** — compositor-specific tests can trigger a compositor dispatch through Keymasq and verify the observable result.
 
 The shared desktop harness includes the cursor-position check for GNOME, KDE, Hyprland, XFCE/X11, COSMIC, Sway, and Niri. The bridge-only `listener-vm-gnome-bridge` job separately validates raw bridge pointer request/response behavior.
@@ -126,6 +126,10 @@ The `activate_title` bridge command is used by the GNOME VM test to switch focus
 
 The full `listener-vm-gnome` test exercises the keymasq-session GNOME listener end-to-end (compositor detection → bridge connection → window tracking → cursor position). The two tests are separate to avoid socket conflicts between the probe and `keymasq-session`.
 
+**Native cursor set**: The full GNOME listener VM test also exercises the listener's
+native `set_cursor_position` path through macro playback and verifies that the
+pointer lands at the requested coordinates.
+
 ### KDE Plasma 6
 
 The KDE test does not use a generic Wayland foreign-toplevel protocol. It exercises the real KDE listener path in [keymasq/session/listeners/kde.py](../keymasq/session/listeners/kde.py):
@@ -149,6 +153,10 @@ The Hyprland test uses the Hyprland listener which connects to `.socket2.sock` f
 **Focus switching**: The test uses `hyprctl dispatch focuswindow title:<name>` to switch focus, which is Hyprland's native IPC mechanism.
 
 **Window tags**: Hyprland is the only compositor in the matrix that supports window tags. The test verifies that `get_active_window` returns a `tags` field (currently `[]` for the test windows).
+
+**Native cursor set**: The Hyprland VM test uses the shared native cursor-set
+subtest, which routes a cursor move through the Hyprland listener and confirms
+that the compositor reports the exact requested coordinates afterward.
 
 ### Niri
 
@@ -180,7 +188,8 @@ The XFCE test uses the X11 listener backed by `python-xlib`. The listener reads 
 
 **Cursor position**: The X11 listener reads cursor coordinates with
 `query_pointer()` and sets absolute cursor positions through XWarpPointer on
-the root window. The XFCE VM test validates both directions: it checks
+the root window. The shared native cursor-set subtest validates both directions
+on XFCE/X11: it checks
 `get_cursor_position` against a known on-screen pointer location, then plays a
 macro with `move_to_start` enabled and verifies that the pointer jumps to the
 exact requested coordinates. This exercises the same native

--- a/docs/LISTENER_VM_TESTS.md
+++ b/docs/LISTENER_VM_TESTS.md
@@ -64,7 +64,7 @@ Each desktop test validates:
 4. **Focus switching** — a second window is opened, then focus moves back to the first; the listener tracks each change.
 5. **Title change** — an existing window is retitled; the listener picks up the new title.
 6. **Window close** — a window is closed; the listener reports focus moving to the remaining window.
-7. **Cursor position** — where supported, the test moves the pointer to a known location and verifies that `get_cursor_position` returns integer coordinates in the expected on-screen range.
+7. **Cursor position** — where supported, the test moves the pointer to a known location and verifies that `get_cursor_position` returns integer coordinates in the expected on-screen range. The XFCE/X11 job also issues a native cursor-set request through macro playback and confirms that the pointer lands at the requested coordinates through the X11 listener.
 8. **Listener-scoped dispatch** — compositor-specific tests can trigger a compositor dispatch through Keymasq and verify the observable result.
 
 The shared desktop harness includes the cursor-position check for GNOME, KDE, Hyprland, XFCE/X11, COSMIC, Sway, and Niri. The bridge-only `listener-vm-gnome-bridge` job separately validates raw bridge pointer request/response behavior.
@@ -180,9 +180,13 @@ The XFCE test uses the X11 listener backed by `python-xlib`. The listener reads 
 
 **Cursor position**: The X11 listener reads cursor coordinates with
 `query_pointer()` and sets absolute cursor positions through XWarpPointer on
-the root window. This keeps absolute mouse move playback in the X server's
-screen coordinate space instead of relying on keymasqd's virtual mouse
-fallback.
+the root window. The XFCE VM test validates both directions: it checks
+`get_cursor_position` against a known on-screen pointer location, then plays a
+macro with `move_to_start` enabled and verifies that the pointer jumps to the
+exact requested coordinates. This exercises the same native
+`set_cursor_position` path that absolute cursor workflows use and keeps cursor
+placement in the X server's screen coordinate space instead of relying on
+keymasqd's virtual mouse fallback.
 
 ## Focus Switching Summary
 

--- a/keymasq/session/listeners/x11.py
+++ b/keymasq/session/listeners/x11.py
@@ -73,6 +73,8 @@ class _XWindow(Protocol):
 
     def query_pointer(self) -> _XPointer: ...
 
+    def warp_pointer(self, x: int, y: int) -> None: ...
+
 
 class _XEvent(Protocol):
     type: int
@@ -237,6 +239,13 @@ class X11Listener(WindowListener):
         except Exception:
             log.debug("X11 cursor get failed", exc_info=True)
             return None
+
+    @property
+    def supports_native_cursor_position_set(self) -> bool:
+        return True
+
+    async def set_cursor_position(self, x: int, y: int) -> tuple[bool, str]:
+        return await asyncio.to_thread(self._warp_cursor_position, int(x), int(y))
 
     async def _listen(self) -> None:
         if self._xdisplay is None:
@@ -504,3 +513,14 @@ class X11Listener(WindowListener):
                 return int(pointer.root_x), int(pointer.root_y)
             except Exception:
                 return None
+
+    def _warp_cursor_position(self, x: int, y: int) -> tuple[bool, str]:
+        with self._x_lock:
+            if self._root is None or self._xdisplay is None:
+                return False, "X11 display unavailable"
+            try:
+                self._root.warp_pointer(int(x), int(y))
+                self._xdisplay.sync()
+                return True, "ok"
+            except Exception as exc:
+                return False, str(exc)

--- a/nix/listener-vm-matrix.nix
+++ b/nix/listener-vm-matrix.nix
@@ -694,8 +694,12 @@ EOF
 
             with subtest("cursor position"):
                 uses_slurp = "${expectedCompositor}" in ("wayland", "cosmic", "niri")
-                if uses_slurp:
+                x11_native_cursor_set = "${expectedCompositor}" == "x11"
+                x11_target_x = 160
+                x11_target_y = 120
+                if uses_slurp or x11_native_cursor_set:
                     # Slurp-based compositors need keymasqd uinput devices and a __slurp_trigger macro.
+                    # X11 uses the same grabbed-keyboard setup so macro playback has output devices.
                     # Create a hardware config for the QEMU AT keyboard so keymasqd grabs it.
                     import base64
                     hw_toml = (
@@ -802,6 +806,46 @@ EOF
                 assert cy >= 0, f"cursor y={cy} is negative"
                 assert cx < 4096, f"cursor x={cx} is implausibly large"
                 assert cy < 4096, f"cursor y={cy} is implausibly large"
+
+                if x11_native_cursor_set:
+                    create_macro = session_query_json(
+                        "create_macro",
+                        {
+                            "macro": {
+                                "name": "x11-cursor-set",
+                                "events": [],
+                                "move_to_start": True,
+                                "start_x": x11_target_x,
+                                "start_y": x11_target_y,
+                            }
+                        },
+                    )
+                    machine.log(f"create_macro: {create_macro}")
+                    assert create_macro.get("status") == "ok", create_macro
+
+                    play_macro = session_query_json(
+                        "play_macro",
+                        {"name": "x11-cursor-set"},
+                    )
+                    machine.log(f"play_macro: {play_macro}")
+                    assert play_macro.get("status") == "ok", play_macro
+
+                    moved = None
+                    deadline = time.time() + 10
+                    while time.time() < deadline:
+                        moved = session_query("get_cursor_position")
+                        machine.log(f"get_cursor_position after X11 set: {moved}")
+                        if (
+                            moved.get("status") == "ok"
+                            and moved.get("x") == x11_target_x
+                            and moved.get("y") == x11_target_y
+                        ):
+                            break
+                        time.sleep(1)
+
+                    assert moved is not None and moved.get("status") == "ok", moved
+                    assert moved.get("x") == x11_target_x, moved
+                    assert moved.get("y") == x11_target_y, moved
       '';
     };
 

--- a/nix/listener-vm-matrix.nix
+++ b/nix/listener-vm-matrix.nix
@@ -694,12 +694,13 @@ EOF
 
             with subtest("cursor position"):
                 uses_slurp = "${expectedCompositor}" in ("wayland", "cosmic", "niri")
-                x11_native_cursor_set = "${expectedCompositor}" == "x11"
-                x11_target_x = 160
-                x11_target_y = 120
-                if uses_slurp or x11_native_cursor_set:
+                native_cursor_set = "${expectedCompositor}" in ("gnome", "hyprland", "x11")
+                native_target_x = 160
+                native_target_y = 120
+                if uses_slurp or native_cursor_set:
                     # Slurp-based compositors need keymasqd uinput devices and a __slurp_trigger macro.
-                    # X11 uses the same grabbed-keyboard setup so macro playback has output devices.
+                    # Native cursor-set listeners use the same grabbed-keyboard setup so macro playback
+                    # has output devices.
                     # Create a hardware config for the QEMU AT keyboard so keymasqd grabs it.
                     import base64
                     hw_toml = (
@@ -807,16 +808,17 @@ EOF
                 assert cx < 4096, f"cursor x={cx} is implausibly large"
                 assert cy < 4096, f"cursor y={cy} is implausibly large"
 
-                if x11_native_cursor_set:
+                if native_cursor_set:
+                    macro_name = "${expectedCompositor}-cursor-set"
                     create_macro = session_query_json(
                         "create_macro",
                         {
                             "macro": {
-                                "name": "x11-cursor-set",
+                                "name": macro_name,
                                 "events": [],
                                 "move_to_start": True,
-                                "start_x": x11_target_x,
-                                "start_y": x11_target_y,
+                                "start_x": native_target_x,
+                                "start_y": native_target_y,
                             }
                         },
                     )
@@ -825,7 +827,7 @@ EOF
 
                     play_macro = session_query_json(
                         "play_macro",
-                        {"name": "x11-cursor-set"},
+                        {"name": macro_name},
                     )
                     machine.log(f"play_macro: {play_macro}")
                     assert play_macro.get("status") == "ok", play_macro
@@ -834,18 +836,18 @@ EOF
                     deadline = time.time() + 10
                     while time.time() < deadline:
                         moved = session_query("get_cursor_position")
-                        machine.log(f"get_cursor_position after X11 set: {moved}")
+                        machine.log(f"get_cursor_position after native set: {moved}")
                         if (
                             moved.get("status") == "ok"
-                            and moved.get("x") == x11_target_x
-                            and moved.get("y") == x11_target_y
+                            and moved.get("x") == native_target_x
+                            and moved.get("y") == native_target_y
                         ):
                             break
                         time.sleep(1)
 
                     assert moved is not None and moved.get("status") == "ok", moved
-                    assert moved.get("x") == x11_target_x, moved
-                    assert moved.get("y") == x11_target_y, moved
+                    assert moved.get("x") == native_target_x, moved
+                    assert moved.get("y") == native_target_y, moved
       '';
     };
 

--- a/tests/test_x11_listener.py
+++ b/tests/test_x11_listener.py
@@ -1,14 +1,17 @@
 import inspect
 from types import SimpleNamespace
 
+import pytest
+
 from keymasq.session.listeners import x11 as x11_listener_module
 from keymasq.session.listeners.x11 import X11Listener
 
 
-def test_x11_handle_event_syncs_on_active_window_property(monkeypatch) -> None:
-    async def _cb(_window_class: str, _window_title: str, _tags: list[str]) -> None:
-        return
+async def _cb(_window_class: str, _window_title: str, _tags: list[str]) -> None:
+    return
 
+
+def test_x11_handle_event_syncs_on_active_window_property(monkeypatch) -> None:
     listener = X11Listener(_cb)
     listener._root = SimpleNamespace(id=10)
     listener._atom_active = 99
@@ -31,9 +34,6 @@ def test_x11_handle_event_syncs_on_active_window_property(monkeypatch) -> None:
 
 
 def test_x11_handle_event_tracks_active_window_metadata(monkeypatch) -> None:
-    async def _cb(_window_class: str, _window_title: str, _tags: list[str]) -> None:
-        return
-
     listener = X11Listener(_cb)
     listener._active_window_id = 42
     listener._window_watch_atoms = {7, 8}
@@ -49,9 +49,6 @@ def test_x11_handle_event_tracks_active_window_metadata(monkeypatch) -> None:
 
 
 def test_x11_handle_event_ignores_unrelated_window_metadata(monkeypatch) -> None:
-    async def _cb(_window_class: str, _window_title: str, _tags: list[str]) -> None:
-        return
-
     listener = X11Listener(_cb)
     listener._active_window_id = 42
     listener._window_watch_atoms = {7, 8}
@@ -70,3 +67,28 @@ def test_x11_listener_uses_event_wait_not_poll_sleep() -> None:
     source = inspect.getsource(X11Listener._listen)
     assert "await self._fd_event.wait()" in source
     assert "asyncio.sleep" not in source
+
+
+@pytest.mark.asyncio
+async def test_x11_set_cursor_position_warps_root_pointer() -> None:
+    listener = X11Listener(_cb)
+    calls: list[tuple[object, ...]] = []
+
+    listener._root = SimpleNamespace(
+        warp_pointer=lambda x, y: calls.append(("warp_pointer", x, y))
+    )
+    listener._xdisplay = SimpleNamespace(sync=lambda: calls.append(("sync",)))
+
+    assert listener.supports_native_cursor_position_set is True
+    assert await listener.set_cursor_position(123, 456) == (True, "ok")
+    assert calls == [("warp_pointer", 123, 456), ("sync",)]
+
+
+@pytest.mark.asyncio
+async def test_x11_set_cursor_position_reports_missing_display() -> None:
+    listener = X11Listener(_cb)
+
+    assert await listener.set_cursor_position(123, 456) == (
+        False,
+        "X11 display unavailable",
+    )


### PR DESCRIPTION
## Summary
- Adds native absolute cursor positioning support to the X11 session listener using `warp_pointer()` on the root window.
- Enables absolute mouse move playback in X11 sessions without falling back to keymasqd's virtual mouse output.
- Updates docs and changelog to describe the new X11 cursor read/write behavior and install guidance.
- Expands X11 listener tests to cover cursor warping success and missing-display failure cases.

## Testing
- `pytest tests/test_x11_listener.py`
- Not run: full project checks via `./scripts/check.sh full`
- Not run: GUI/session integration checks beyond the X11 listener unit tests