### PR TITLE
Improve Macro recording UX and settings

### DIFF
--- a/docs/MACROS.md
+++ b/docs/MACROS.md
@@ -72,6 +72,11 @@ net.
 5. Press **Toggle Recording** again to stop.
 6. The GUI opens a save dialog — give the macro a name and save it.
 
+Until that save dialog is saved or discarded, Keymasq blocks new macro
+recordings. If you try to record again, the session sends a desktop
+notification and the GUI presents the existing save dialog. Closing the GUI or
+the save dialog discards the unsaved recording.
+
 Starting and stopping from a hotkey keeps the recording clean. If you click
 buttons in the GUI to start or stop, those clicks and any mouse movement to
 reach them will be captured too, which is rarely what you want.

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -83,6 +83,12 @@ Keymasq treats recording and capture features as sensitive because they can obse
 
 When locked, recording/capture requests fail with `recording_locked`.
 
+When a recorded macro is waiting in the Save Macro dialog, new macro recording
+requests fail with `macro_save_pending` until the recording is saved,
+discarded, or the owning GUI connection closes. The pending recording payload
+is held in `keymasq-session` memory only; it is written to disk only after an
+explicit save.
+
 If `macro_edit_requires_unlock = true`, macro inspection and edit operations are promoted into the same sensitive class.
 
 ## Runtime Unlock Ownership Chain

--- a/keymasq/gui/style.css
+++ b/keymasq/gui/style.css
@@ -31,6 +31,46 @@
 .status-inactive { background: alpha(@error_color, 0.15); color: @error_color; }
 .status-standby { background: alpha(@shade_color, 0.08); }
 
+.recording-locked-notice {
+  background: alpha(@warning_color, 0.12);
+  border-left: 3px solid @warning_color;
+  border-radius: 6px;
+  padding: 10px 12px;
+}
+
+.recording-overlay {
+  background: transparent;
+}
+
+.recording-overlay-panel {
+  background: @window_bg_color;
+  border: 1px solid alpha(@borders, 0.7);
+  border-radius: 8px;
+  box-shadow: 0 8px 32px alpha(black, 0.35);
+  padding: 28px 30px;
+}
+
+.recording-overlay-dot {
+  background: @error_color;
+  border-radius: 999px;
+}
+
+.recording-overlay-stats {
+  margin-top: 2px;
+  margin-bottom: 2px;
+}
+
+.recording-overlay-stat {
+  min-width: 128px;
+  padding: 10px 14px;
+  border-radius: 8px;
+  background: alpha(@shade_color, 0.08);
+}
+
+.recording-stop-button {
+  font-weight: 700;
+}
+
 /* Mouse button section titles */
 .button-section-title {
   margin-top: 8px;

--- a/keymasq/gui/widgets/macro_manager_dialog.py
+++ b/keymasq/gui/widgets/macro_manager_dialog.py
@@ -525,6 +525,7 @@ class MacroManagerDialog(Adw.Dialog):
         self._recording_active = True
         self._recording_unlocked = True
         self._sync_record_button_state()
+        self.close()
 
     def _on_recording_stopped(self, data: dict) -> None:
         self._recording_active = False

--- a/keymasq/gui/widgets/macro_manager_dialog.py
+++ b/keymasq/gui/widgets/macro_manager_dialog.py
@@ -494,7 +494,7 @@ class MacroManagerDialog(Adw.Dialog):
         if command == "start_recording" and self._is_recording_locked(result):
             self._recording_unlocked = False
             self._sync_record_button_state()
-            self._open_recording_settings_dialog()
+            self._open_recording_settings_dialog(reason="recording_locked")
             return False
 
         fallback = (
@@ -570,14 +570,14 @@ class MacroManagerDialog(Adw.Dialog):
     def _on_record_settings(self, btn: Gtk.Button) -> None:
         self._open_recording_settings_dialog()
 
-    def _open_recording_settings_dialog(self) -> None:
+    def _open_recording_settings_dialog(self, reason: str = "settings") -> None:
         present_settings = getattr(self._parent, "present_recording_settings_dialog", None)
         if callable(present_settings):
-            present_settings()
+            present_settings(reason=reason)
             return
         from keymasq.gui.widgets.record_macro_dialog import RecordMacroDialog
 
-        record_dialog = RecordMacroDialog(self._parent)
+        record_dialog = RecordMacroDialog(self._parent, reason=reason)
         record_dialog.present(self._parent)
 
     def _is_recording_locked(self, result: dict) -> bool:

--- a/keymasq/gui/widgets/macro_manager_dialog.py
+++ b/keymasq/gui/widgets/macro_manager_dialog.py
@@ -497,6 +497,11 @@ class MacroManagerDialog(Adw.Dialog):
             self._open_recording_settings_dialog(reason="recording_locked")
             return False
 
+        if command == "start_recording" and self._is_macro_save_pending(result):
+            present_pending_save = getattr(self._parent, "present_pending_macro_save_dialog", None)
+            if callable(present_pending_save) and present_pending_save():
+                return False
+
         fallback = (
             "Failed to stop recording"
             if command == "stop_recording"
@@ -587,6 +592,13 @@ class MacroManagerDialog(Adw.Dialog):
             return True
         message = str(result.get("message", "") or "").strip().lower()
         return "recording_locked" in message
+
+    def _is_macro_save_pending(self, result: dict) -> bool:
+        error_code = str(result.get("error_code", "") or "").strip().lower()
+        if error_code == "macro_save_pending":
+            return True
+        message = str(result.get("message", "") or "").strip().lower()
+        return "save or discard" in message and "recording" in message
 
     def _on_create_type_macro(self, btn: Gtk.Button) -> None:
         dialog = TypeMacroDialog(self._parent, on_created=self._load_macros)

--- a/keymasq/gui/widgets/record_macro_dialog.py
+++ b/keymasq/gui/widgets/record_macro_dialog.py
@@ -13,10 +13,16 @@ from keymasq.gui.session_client import session_request
 
 
 class RecordMacroDialog(Adw.Dialog):
-    def __init__(self, parent: Gtk.Window, on_saved: Callable | None = None):
+    def __init__(
+        self,
+        parent: Gtk.Window,
+        on_saved: Callable | None = None,
+        reason: str = "settings",
+    ):
         super().__init__(title="Macro Recording Settings", content_width=480)
         self._parent = parent
         self._on_saved = on_saved
+        self._reason = reason
         self._devices: list[dict] = []
         self._device_checks: dict[str, Gtk.CheckButton] = {}
         self._record_mouse_movement = False
@@ -31,6 +37,9 @@ class RecordMacroDialog(Adw.Dialog):
         self._settings_sync_generation = 0
         self._settings_sync_worker_running = False
         self._build_ui()
+        self.set_presentation_reason(reason)
+        self._register_parent_events()
+        self.connect("closed", self._on_dialog_closed)
         self._load_initial_state_async()
 
     def _build_ui(self) -> None:
@@ -43,12 +52,12 @@ class RecordMacroDialog(Adw.Dialog):
         frame = Gtk.Frame()
         inner = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=0)
 
-        title_label = Gtk.Label(label="Macro Recording Settings")
-        title_label.add_css_class("title-3")
-        title_label.set_halign(Gtk.Align.CENTER)
-        title_label.set_margin_top(12)
-        title_label.set_margin_bottom(12)
-        inner.append(title_label)
+        self._title_label = Gtk.Label(label="Macro Recording Settings")
+        self._title_label.add_css_class("title-3")
+        self._title_label.set_halign(Gtk.Align.CENTER)
+        self._title_label.set_margin_top(12)
+        self._title_label.set_margin_bottom(12)
+        inner.append(self._title_label)
         inner.append(Gtk.Separator())
 
         content = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=12)
@@ -56,6 +65,9 @@ class RecordMacroDialog(Adw.Dialog):
         content.set_margin_bottom(12)
         content.set_margin_start(16)
         content.set_margin_end(16)
+
+        self._locked_notice = self._build_locked_notice()
+        content.append(self._locked_notice)
 
         # Recording options in a compact boxed list
         options_frame = Gtk.ListBox()
@@ -172,6 +184,7 @@ class RecordMacroDialog(Adw.Dialog):
         self._device_listbox = Gtk.ListBox()
         self._device_listbox.set_selection_mode(Gtk.SelectionMode.NONE)
         self._device_listbox.add_css_class("boxed-list")
+        self._device_listbox.connect("row-activated", self._on_device_row_activated)
         scrolled.set_child(self._device_listbox)
         content.append(scrolled)
 
@@ -199,11 +212,7 @@ class RecordMacroDialog(Adw.Dialog):
         self._unlock_status.set_halign(Gtk.Align.START)
         footer.append(self._unlock_status)
 
-        cancel_btn = Gtk.Button(label="Cancel")
-        cancel_btn.connect("clicked", self._on_cancel_clicked)
-        footer.append(cancel_btn)
-
-        self._save_btn = Gtk.Button(label="Save Settings")
+        self._save_btn = Gtk.Button(label="Done")
         self._save_btn.add_css_class("suggested-action")
         self._save_btn.connect("clicked", self._on_save_settings)
         footer.append(self._save_btn)
@@ -213,7 +222,56 @@ class RecordMacroDialog(Adw.Dialog):
         main_box.append(frame)
         self.set_child(main_box)
 
-    def _on_cancel_clicked(self, _button: Gtk.Button) -> None:
+    def _build_locked_notice(self) -> Gtk.Box:
+        notice = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=10)
+        notice.add_css_class("recording-locked-notice")
+        notice.set_margin_bottom(2)
+        notice.set_visible(False)
+
+        icon = Gtk.Image.new_from_icon_name("channel-insecure-symbolic")
+        icon.set_valign(Gtk.Align.START)
+        notice.append(icon)
+
+        text_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=2)
+        text_box.set_hexpand(True)
+
+        title = Gtk.Label(label="Recording was blocked")
+        title.add_css_class("heading")
+        title.set_halign(Gtk.Align.START)
+        text_box.append(title)
+
+        body = Gtk.Label(
+            label=(
+                "Macro recording is locked. Unlock recording before starting a live "
+                "recording."
+            )
+        )
+        body.set_wrap(True)
+        body.set_halign(Gtk.Align.START)
+        text_box.append(body)
+
+        notice.append(text_box)
+        return notice
+
+    def set_presentation_reason(self, reason: str = "settings") -> None:
+        self._reason = reason
+        locked = reason == "recording_locked"
+        title = "Unlock Macro Recording" if locked else "Macro Recording Settings"
+        self.set_title(title)
+        self._title_label.set_label(title)
+        self._locked_notice.set_visible(locked)
+
+    def _register_parent_events(self) -> None:
+        register_event_handler = getattr(self._parent, "register_event_handler", None)
+        if callable(register_event_handler):
+            register_event_handler("recording_started", self._on_recording_started)
+
+    def _on_dialog_closed(self, _dialog: Adw.Dialog) -> None:
+        unregister_event_handler = getattr(self._parent, "unregister_event_handler", None)
+        if callable(unregister_event_handler):
+            unregister_event_handler("recording_started", self._on_recording_started)
+
+    def _on_recording_started(self, _event: dict) -> None:
         self.close()
 
     def _load_initial_state_async(self) -> None:
@@ -337,6 +395,7 @@ class RecordMacroDialog(Adw.Dialog):
     ) -> Gtk.ListBoxRow:
         row = Gtk.ListBoxRow()
         row.set_selectable(False)
+        row.set_activatable(selectable)
 
         row_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=12)
         row_box.set_margin_top(6)
@@ -351,6 +410,7 @@ class RecordMacroDialog(Adw.Dialog):
             check.set_active(self._is_selected_device(device))
             check.connect("toggled", self._on_device_check_toggled)
             self._device_checks[recording_id] = check
+            row._recording_id = recording_id  # type: ignore[attr-defined]
             row_box.append(check)
         else:
             status_icon = Gtk.Image.new_from_icon_name("dialog-information-symbolic")
@@ -401,6 +461,20 @@ class RecordMacroDialog(Adw.Dialog):
 
         row.set_child(row_box)
         return row
+
+    def _on_device_row_activated(
+        self,
+        _listbox: Gtk.ListBox,
+        row: Gtk.ListBoxRow,
+    ) -> None:
+        recording_id = str(getattr(row, "_recording_id", "") or "")
+        if not recording_id:
+            return
+
+        check = self._device_checks.get(recording_id)
+        if check is None:
+            return
+        check.set_active(not check.get_active())
 
     def _device_recording_id(self, device: dict) -> str:
         recording_id = str(device.get("recording_id", "") or "")

--- a/keymasq/gui/widgets/record_macro_dialog.py
+++ b/keymasq/gui/widgets/record_macro_dialog.py
@@ -27,6 +27,9 @@ class RecordMacroDialog(Adw.Dialog):
         self._recording_unlock_required = True
         self._recording_refresh_owner = False
         self._applying_settings = False
+        self._settings_sync_lock = threading.Lock()
+        self._settings_sync_generation = 0
+        self._settings_sync_worker_running = False
         self._build_ui()
         self._load_initial_state_async()
 
@@ -657,9 +660,26 @@ class RecordMacroDialog(Adw.Dialog):
         return False
 
     def _sync_settings_to_session(self) -> None:
-        session_request(self._settings_payload(), timeout=0.5)
+        while True:
+            with self._settings_sync_lock:
+                generation = self._settings_sync_generation
+
+            try:
+                session_request(self._settings_payload(), timeout=0.5)
+            except Exception:
+                pass
+
+            with self._settings_sync_lock:
+                if generation == self._settings_sync_generation:
+                    self._settings_sync_worker_running = False
+                    return
 
     def _sync_settings_async(self) -> None:
+        with self._settings_sync_lock:
+            self._settings_sync_generation += 1
+            if self._settings_sync_worker_running:
+                return
+            self._settings_sync_worker_running = True
         threading.Thread(target=self._sync_settings_to_session, daemon=True).start()
 
     def _settings_payload(self) -> dict[str, object]:
@@ -668,7 +688,7 @@ class RecordMacroDialog(Adw.Dialog):
             "include_mouse_movement": self._record_mouse_movement,
             "include_mouse_clicks": self._record_mouse_clicks,
             "record_start_position": self._record_start_position,
-            "device_overrides": self._device_overrides,
+            "device_overrides": dict(self._device_overrides),
         }
 
     def _apply_recording_settings(self, result: dict | None) -> None:

--- a/keymasq/gui/widgets/recording_overlay.py
+++ b/keymasq/gui/widgets/recording_overlay.py
@@ -10,48 +10,89 @@ from keymasq.gui.session_client import session_request_async
 
 class RecordingOverlay(Gtk.Box):
     def __init__(self, window):
-        super().__init__(orientation=Gtk.Orientation.VERTICAL, spacing=4)
+        super().__init__(orientation=Gtk.Orientation.VERTICAL)
         self._window = window
         self._start_ms: int = 0
         self._event_count: int = 0
         self._timer_id: int = 0
-        self.add_css_class("card")
-        self.set_margin_top(8)
-        self.set_margin_end(8)
+        self._stop_btn: Gtk.Button | None = None
+        self.add_css_class("recording-overlay")
+        self.set_hexpand(True)
+        self.set_vexpand(True)
         self._build_ui()
 
     def _build_ui(self) -> None:
-        self.set_margin_top(10)
-        self.set_margin_bottom(10)
-        self.set_margin_start(14)
-        self.set_margin_end(14)
+        self.set_halign(Gtk.Align.FILL)
+        self.set_valign(Gtk.Align.FILL)
 
-        top_row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=12)
+        panel = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=18)
+        panel.add_css_class("recording-overlay-panel")
+        panel.set_halign(Gtk.Align.CENTER)
+        panel.set_valign(Gtk.Align.CENTER)
+        panel.set_size_request(420, -1)
+        panel.set_margin_top(24)
+        panel.set_margin_bottom(24)
+        panel.set_margin_start(24)
+        panel.set_margin_end(24)
+        self.append(panel)
 
-        indicator_label = Gtk.Label(label="⏺ Recording")
-        indicator_label.add_css_class("heading")
-        indicator_label.set_hexpand(True)
-        top_row.append(indicator_label)
+        header = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=10)
+        header.set_halign(Gtk.Align.CENTER)
+        panel.append(header)
 
-        stop_btn = Gtk.Button(label="Stop")
+        dot = Gtk.Box()
+        dot.add_css_class("recording-overlay-dot")
+        dot.set_size_request(12, 12)
+        dot.set_valign(Gtk.Align.CENTER)
+        header.append(dot)
+
+        title = Gtk.Label(label="Recording macro")
+        title.add_css_class("title-2")
+        title.set_valign(Gtk.Align.CENTER)
+        header.append(title)
+
+        body = Gtk.Label(label="Input is being captured until recording is stopped.")
+        body.add_css_class("dim-label")
+        body.set_wrap(True)
+        body.set_justify(Gtk.Justification.CENTER)
+        body.set_halign(Gtk.Align.CENTER)
+        panel.append(body)
+
+        stats = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=12)
+        stats.add_css_class("recording-overlay-stats")
+        stats.set_halign(Gtk.Align.CENTER)
+        panel.append(stats)
+
+        duration_stat, self._duration_label = self._build_stat("Duration", "00:00.000")
+        stats.append(duration_stat)
+
+        events_stat, self._events_label = self._build_stat("Events", "0")
+        stats.append(events_stat)
+
+        stop_btn = Gtk.Button(label="Stop Recording")
         stop_btn.add_css_class("destructive-action")
-        stop_btn.add_css_class("flat")
+        stop_btn.add_css_class("recording-stop-button")
+        stop_btn.set_halign(Gtk.Align.CENTER)
+        stop_btn.set_size_request(220, 48)
         stop_btn.connect("clicked", self._on_stop_clicked)
-        top_row.append(stop_btn)
+        self._stop_btn = stop_btn
+        panel.append(stop_btn)
 
-        self.append(top_row)
+    def _build_stat(self, title: str, value: str) -> tuple[Gtk.Box, Gtk.Label]:
+        box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=3)
+        box.add_css_class("recording-overlay-stat")
 
-        self._duration_label = Gtk.Label(label="00:00.000")
-        self._duration_label.add_css_class("caption")
-        self._duration_label.add_css_class("dim-label")
-        self._duration_label.set_halign(Gtk.Align.START)
-        self.append(self._duration_label)
+        title_label = Gtk.Label(label=title)
+        title_label.add_css_class("caption")
+        title_label.add_css_class("dim-label")
+        title_label.set_halign(Gtk.Align.CENTER)
+        box.append(title_label)
 
-        self._events_label = Gtk.Label(label="0 events")
-        self._events_label.add_css_class("caption")
-        self._events_label.add_css_class("dim-label")
-        self._events_label.set_halign(Gtk.Align.START)
-        self.append(self._events_label)
+        value_label = Gtk.Label(label=value)
+        value_label.add_css_class("title-3")
+        value_label.set_halign(Gtk.Align.CENTER)
+        box.append(value_label)
+        return box, value_label
 
     def on_started(self, data: dict) -> None:
         import time
@@ -59,7 +100,10 @@ class RecordingOverlay(Gtk.Box):
         self._start_ms = int(time.monotonic() * 1000)
         self._event_count = 0
         self._duration_label.set_label("00:00.000")
-        self._events_label.set_label("0 events")
+        self._events_label.set_label("0")
+        if self._stop_btn:
+            self._stop_btn.set_label("Stop Recording")
+            self._stop_btn.set_sensitive(True)
         if self._timer_id:
             GLib.source_remove(self._timer_id)
         self._timer_id = GLib.timeout_add(100, self._update_timer)
@@ -69,10 +113,19 @@ class RecordingOverlay(Gtk.Box):
         self._event_count = data.get("event_count", self._event_count)
         self._update_display(duration_ms)
 
+    def on_stopped(self) -> None:
+        if self._timer_id:
+            GLib.source_remove(self._timer_id)
+            self._timer_id = 0
+        if self._stop_btn:
+            self._stop_btn.set_label("Stop Recording")
+            self._stop_btn.set_sensitive(True)
+
     def _update_timer(self) -> bool:
         import time
 
         if not self.get_visible():
+            self._timer_id = 0
             return False
         elapsed_ms = int(time.monotonic() * 1000) - self._start_ms
         self._update_display(elapsed_ms)
@@ -84,13 +137,14 @@ class RecordingOverlay(Gtk.Box):
         minutes = total_s // 60
         seconds = total_s % 60
         self._duration_label.set_label(f"{minutes:02d}:{seconds:02d}.{ms:03d}")
-        self._events_label.set_label(f"{self._event_count} events")
+        self._events_label.set_label(str(self._event_count))
 
     def _on_stop_clicked(self, btn: Gtk.Button) -> None:
         if self._timer_id:
             GLib.source_remove(self._timer_id)
             self._timer_id = 0
         btn.set_sensitive(False)
+        btn.set_label("Stopping...")
         session_request_async(
             {"command": "stop_recording"},
             lambda _result: self._on_stop_done(btn),
@@ -98,4 +152,5 @@ class RecordingOverlay(Gtk.Box):
 
     def _on_stop_done(self, btn: Gtk.Button) -> bool:
         btn.set_sensitive(True)
+        btn.set_label("Stop Recording")
         return False

--- a/keymasq/gui/widgets/save_macro_dialog.py
+++ b/keymasq/gui/widgets/save_macro_dialog.py
@@ -15,6 +15,9 @@ class SaveMacroDialog(Adw.Dialog):
         self._parent = parent
         self._recording_data = recording_data
         self._saved = False
+        self._closing_after_resolution = False
+        self._request_inflight = False
+        self._request_error_message: str | None = None
         self._pending_save_token = str(recording_data.get("pending_save_token", "") or "")
         has_start_pos = ("start_x" in recording_data) and ("start_y" in recording_data)
         self._move_to_start = bool(recording_data.get("move_to_start", has_start_pos))
@@ -156,6 +159,7 @@ class SaveMacroDialog(Adw.Dialog):
         discard_btn.add_css_class("destructive-action")
         discard_btn.add_css_class("flat")
         discard_btn.connect("clicked", self._on_discard_clicked)
+        self._discard_btn = discard_btn
         footer.append(discard_btn)
 
         self._save_btn = Gtk.Button(label="Save")
@@ -169,6 +173,14 @@ class SaveMacroDialog(Adw.Dialog):
         main_box.append(frame)
         self.set_child(main_box)
         self._update_start_pos_controls()
+
+    def do_close_attempt(self) -> None:
+        if self._saved or self._closing_after_resolution:
+            self.force_close()
+            return
+        if self._request_inflight:
+            return
+        self._begin_discard_request()
 
     def _on_move_to_start_toggled(self, check: Gtk.CheckButton) -> None:
         self._move_to_start = check.get_active()
@@ -267,32 +279,79 @@ class SaveMacroDialog(Adw.Dialog):
         )
 
     def _on_save_request_start(self) -> None:
-        self._save_btn.set_sensitive(False)
+        self._request_error_message = None
+        self._set_request_inflight(True)
 
     def _on_save_request_done(self) -> None:
         if not self._saved:
-            self._save_btn.set_sensitive(True)
+            self._set_request_inflight(False)
+            if self._request_error_message:
+                self._show_error(self._request_error_message)
+                self._request_error_message = None
 
     def _on_save_finished(self, result: dict | None) -> bool:
         if result and result.get("status") == "ok":
             self._saved = True
-            self.close()
+            self._closing_after_resolution = True
+            self.force_close()
         else:
-            msg = (result or {}).get("message", "Failed to save macro")
-            self._show_error(msg)
+            self._request_error_message = (result or {}).get("message", "Failed to save macro")
         return False
 
     def _on_discard_clicked(self, btn: Gtk.Button) -> None:
-        self._saved = True  # Prevent double-discard in _on_dialog_closed
-        session_request_async(self._discard_payload(), lambda _result: False)
-        self.close()
+        self._begin_discard_request()
 
     def _on_dialog_closed(self, dialog) -> None:
+        return
+
+    def _begin_discard_request(self) -> None:
+        self._hide_error()
+        self._request_error_message = None
+        self._set_request_inflight(True)
+        session_request_with_hooks(
+            self._discard_payload(),
+            self._on_discard_finished,
+            on_start=lambda: None,
+            on_done=self._on_discard_request_done,
+        )
+
+    def _on_discard_request_done(self) -> None:
         if not self._saved:
-            session_request_async(self._discard_payload(), lambda _result: False)
+            self._set_request_inflight(False)
+            if self._request_error_message:
+                self._show_error(self._request_error_message)
+                self._request_error_message = None
+
+    def _on_discard_finished(self, result: dict | None) -> bool:
+        if result and result.get("status") == "ok":
+            self._saved = True
+            self._closing_after_resolution = True
+            self.force_close()
+        else:
+            self._request_error_message = (result or {}).get(
+                "message",
+                "Failed to discard recording",
+            )
+        return False
 
     def _discard_payload(self) -> dict[str, object]:
         payload: dict[str, object] = {"command": "discard_recording"}
         if self._pending_save_token:
             payload["pending_save_token"] = self._pending_save_token
         return payload
+
+    def _set_request_inflight(self, inflight: bool) -> None:
+        self._request_inflight = inflight
+        self.set_can_close(not inflight)
+        self._save_btn.set_sensitive(False if inflight else self._save_btn.get_sensitive())
+        self._discard_btn.set_sensitive(not inflight)
+        self._name_entry.set_sensitive(not inflight)
+        self._move_to_start_check.set_sensitive(not inflight)
+        self._block_mouse_check.set_sensitive(not inflight)
+        if inflight:
+            self._start_x_spin.set_sensitive(False)
+            self._start_y_spin.set_sensitive(False)
+            return
+
+        self._update_start_pos_controls()
+        self._validate_name(self._name_entry.get_text().strip())

--- a/keymasq/gui/widgets/save_macro_dialog.py
+++ b/keymasq/gui/widgets/save_macro_dialog.py
@@ -15,6 +15,7 @@ class SaveMacroDialog(Adw.Dialog):
         self._parent = parent
         self._recording_data = recording_data
         self._saved = False
+        self._pending_save_token = str(recording_data.get("pending_save_token", "") or "")
         has_start_pos = ("start_x" in recording_data) and ("start_y" in recording_data)
         self._move_to_start = bool(recording_data.get("move_to_start", has_start_pos))
         self._start_x = int(recording_data.get("start_x", 0) or 0)
@@ -256,6 +257,8 @@ class SaveMacroDialog(Adw.Dialog):
                 "block_mouse_movement": self._block_mouse_check.get_active(),
             }
         )
+        if self._pending_save_token:
+            payload["pending_save_token"] = self._pending_save_token
         session_request_with_hooks(
             payload,
             self._on_save_finished,
@@ -281,9 +284,15 @@ class SaveMacroDialog(Adw.Dialog):
 
     def _on_discard_clicked(self, btn: Gtk.Button) -> None:
         self._saved = True  # Prevent double-discard in _on_dialog_closed
-        session_request_async({"command": "discard_recording"}, lambda _result: False)
+        session_request_async(self._discard_payload(), lambda _result: False)
         self.close()
 
     def _on_dialog_closed(self, dialog) -> None:
         if not self._saved:
-            session_request_async({"command": "discard_recording"}, lambda _result: False)
+            session_request_async(self._discard_payload(), lambda _result: False)
+
+    def _discard_payload(self) -> dict[str, object]:
+        payload: dict[str, object] = {"command": "discard_recording"}
+        if self._pending_save_token:
+            payload["pending_save_token"] = self._pending_save_token
+        return payload

--- a/keymasq/gui/window.py
+++ b/keymasq/gui/window.py
@@ -69,6 +69,7 @@ class MainWindow(Adw.ApplicationWindow):
         self._connection_body_label: Gtk.Label | None = None
         self._macro_manager_dialog: Adw.Dialog | None = None
         self._record_macro_dialog: Adw.Dialog | None = None
+        self._save_macro_dialog: Adw.Dialog | None = None
         self._recording_unlocked = False
         self._recording_unlock_required = True
         self._recording_unlock_source = "none"
@@ -292,9 +293,24 @@ class MainWindow(Adw.ApplicationWindow):
     def _on_recording_stopped(self, event: dict) -> None:
         from keymasq.gui.widgets.save_macro_dialog import SaveMacroDialog
 
-        parent = self._macro_manager_dialog if self._macro_manager_dialog else self
-        dialog = SaveMacroDialog(parent, event)
-        dialog.present(parent)
+        if self._save_macro_dialog is not None:
+            self._save_macro_dialog.present(self)
+            return
+
+        dialog = SaveMacroDialog(self, event)
+        dialog.connect("closed", self._on_save_macro_dialog_closed)
+        self._save_macro_dialog = dialog
+        dialog.present(self)
+
+    def present_pending_macro_save_dialog(self) -> bool:
+        if self._save_macro_dialog is None:
+            return False
+        self._save_macro_dialog.present(self)
+        return True
+
+    def _on_save_macro_dialog_closed(self, dialog) -> None:
+        if dialog is self._save_macro_dialog:
+            self._save_macro_dialog = None
 
     def _close_dialogs_for_recording_start(self) -> None:
         for dialog in (self._record_macro_dialog, self._macro_manager_dialog):

--- a/keymasq/gui/window.py
+++ b/keymasq/gui/window.py
@@ -283,6 +283,8 @@ class MainWindow(Adw.ApplicationWindow):
             self._recording_overlay.on_progress(event)
         elif event_type == "recording_auth_requested":
             self.present_recording_settings_dialog(reason="recording_locked")
+        elif event_type == "macro_save_pending":
+            self.present_pending_macro_save_dialog()
 
         callbacks = self._event_handlers.get(event_type)
         if callbacks is None:

--- a/keymasq/gui/window.py
+++ b/keymasq/gui/window.py
@@ -271,6 +271,7 @@ class MainWindow(Adw.ApplicationWindow):
             self._apply_profile_runtime_state(event)
             self._queue_profile_reload()
         elif event_type == "recording_started":
+            self._close_dialogs_for_recording_start()
             self._recording_overlay.set_visible(True)
             self._recording_overlay.on_started(event)
         elif event_type == "recording_stopped":
@@ -294,6 +295,11 @@ class MainWindow(Adw.ApplicationWindow):
         parent = self._macro_manager_dialog if self._macro_manager_dialog else self
         dialog = SaveMacroDialog(parent, event)
         dialog.present(parent)
+
+    def _close_dialogs_for_recording_start(self) -> None:
+        for dialog in (self._record_macro_dialog, self._macro_manager_dialog):
+            if dialog is not None:
+                dialog.close()
 
     def set_macro_manager_dialog(self, dialog: Adw.Dialog | None) -> None:
         self._macro_manager_dialog = dialog

--- a/keymasq/gui/window.py
+++ b/keymasq/gui/window.py
@@ -274,12 +274,13 @@ class MainWindow(Adw.ApplicationWindow):
             self._recording_overlay.set_visible(True)
             self._recording_overlay.on_started(event)
         elif event_type == "recording_stopped":
+            self._recording_overlay.on_stopped()
             self._recording_overlay.set_visible(False)
             self._on_recording_stopped(event)
         elif event_type == "recording_progress":
             self._recording_overlay.on_progress(event)
         elif event_type == "recording_auth_requested":
-            self.present_recording_settings_dialog()
+            self.present_recording_settings_dialog(reason="recording_locked")
 
         callbacks = self._event_handlers.get(event_type)
         if callbacks is None:
@@ -666,10 +667,8 @@ class MainWindow(Adw.ApplicationWindow):
         from keymasq.gui.widgets.recording_overlay import RecordingOverlay
 
         self._recording_overlay = RecordingOverlay(self)
-        self._recording_overlay.set_halign(Gtk.Align.END)
-        self._recording_overlay.set_valign(Gtk.Align.START)
-        self._recording_overlay.set_margin_top(8)
-        self._recording_overlay.set_margin_end(8)
+        self._recording_overlay.set_halign(Gtk.Align.FILL)
+        self._recording_overlay.set_valign(Gtk.Align.FILL)
         self._recording_overlay.set_visible(False)
 
         content_overlay = Gtk.Overlay()
@@ -1186,14 +1185,15 @@ class MainWindow(Adw.ApplicationWindow):
         self._unlock_status_label.set_label(text)
         self._unlock_status_label.set_tooltip_text(tooltip)
 
-    def present_recording_settings_dialog(self) -> None:
+    def present_recording_settings_dialog(self, reason: str = "settings") -> None:
         if self._record_macro_dialog is not None:
+            self._record_macro_dialog.set_presentation_reason(reason)
             self._record_macro_dialog.present(self)
             return
 
         from keymasq.gui.widgets.record_macro_dialog import RecordMacroDialog
 
-        dialog = RecordMacroDialog(self)
+        dialog = RecordMacroDialog(self, reason=reason)
         dialog.connect("closed", self._on_record_macro_dialog_closed)
         self._record_macro_dialog = dialog
         dialog.present(self)

--- a/keymasq/session/manager/commands.py
+++ b/keymasq/session/manager/commands.py
@@ -197,8 +197,20 @@ async def _handle_recording_commands(
     writer: asyncio.StreamWriter,
 ) -> JsonObject | None:
     if command == "start_recording":
+        if runtime_recording.has_pending_macro_save(manager):
+            return await runtime_recording.start_recording(
+                manager,
+                reset_if_active=False,
+                owner_peer=peer,
+                owner_writer=writer,
+            )
         runtime_recording.update_recording_settings(manager, request)
-        start_result = await runtime_recording.start_recording(manager, reset_if_active=False)
+        start_result = await runtime_recording.start_recording(
+            manager,
+            reset_if_active=False,
+            owner_peer=peer,
+            owner_writer=writer,
+        )
         runtime_recording.notify_recording_unlock_required(manager, start_result)
         return start_result
 
@@ -238,6 +250,16 @@ async def _handle_recording_commands(
             return {"status": "error", "message": "Name required"}
         if not manager.recording_state.pending_data:
             return {"status": "error", "message": "No pending recording"}
+        pending_save_token = str_value(request.get("pending_save_token"), "").strip()
+        if pending_save_token and not runtime_recording.pending_macro_save_token_matches(
+            manager,
+            pending_save_token,
+        ):
+            return {
+                "status": "error",
+                "error_code": "stale_pending_macro_save",
+                "message": "Pending recording has already changed.",
+            }
         save_result = await runtime_recording.save_recording(
             manager,
             name,
@@ -251,7 +273,17 @@ async def _handle_recording_commands(
         return {"status": "ok", "name": save_result.get("name", name)}
 
     if command == "discard_recording":
-        manager.recording_state.pending_data = None
+        pending_save_token = str_value(request.get("pending_save_token"), "").strip()
+        if pending_save_token and not runtime_recording.pending_macro_save_token_matches(
+            manager,
+            pending_save_token,
+        ):
+            return {
+                "status": "error",
+                "error_code": "stale_pending_macro_save",
+                "message": "Pending recording has already changed.",
+            }
+        runtime_recording.clear_pending_macro_save(manager)
         return {"status": "ok"}
 
     return None

--- a/keymasq/session/manager/core.py
+++ b/keymasq/session/manager/core.py
@@ -297,6 +297,7 @@ class SessionManager:
         except Exception as e:
             log.debug(f"Session client error: {e}")
         finally:
+            runtime_recording.clear_pending_macro_save_if_writer(self, writer)
             await runtime_recording.clear_recording_refresh_owner_if_writer(self, peer, writer)
             self.session_clients.discard(writer)
             self.session_client_peers.pop(writer, None)

--- a/keymasq/session/manager/core.py
+++ b/keymasq/session/manager/core.py
@@ -474,7 +474,7 @@ class SessionManager:
 
     async def _send_notification_async(self, title: str, message: str) -> None:
         try:
-            await self.dbus.notify(title, message, app_name="keymasq", timeout_ms=2000)
+            await self.dbus.notify(title, message, app_name="keymasq", timeout_ms=5000)
         except Exception as e:
             log.debug(f"Failed to send notification: {e}")
 

--- a/keymasq/session/manager/events.py
+++ b/keymasq/session/manager/events.py
@@ -219,6 +219,13 @@ async def handle_start_macro_trigger(manager: "SessionManager") -> None:
     result = await runtime_recording.start_recording(manager, reset_if_active=False)
     if result.get("status") != "ok":
         if result.get("error_code") == runtime_recording.MACRO_SAVE_PENDING_ERROR_CODE:
+            manager.broadcast_to_session_clients(
+                {
+                    "event": "macro_save_pending",
+                    "message": result.get("message", ""),
+                    "pending_save_token": result.get("pending_save_token", ""),
+                }
+            )
             return
         runtime_recording.notify_recording_unlock_required(manager, result)
         manager.broadcast_to_session_clients({"event": "recording_auth_requested"})

--- a/keymasq/session/manager/events.py
+++ b/keymasq/session/manager/events.py
@@ -103,11 +103,19 @@ async def handle_event(
             recording_data["start_x"] = int(manager.recording_state.start_cursor[0])
             recording_data["start_y"] = int(manager.recording_state.start_cursor[1])
             recording_data["move_to_start"] = True
-        manager.recording_state.pending_data = recording_data
+        if runtime_recording.has_pending_macro_save(manager):
+            manager.recording_state.pending_data = recording_data
+            pending_save_token = str(manager.recording_state.pending_save_token or "")
+        else:
+            pending_save_token = runtime_recording.begin_pending_macro_save(
+                manager,
+                recording_data,
+            )
         manager.recording_state.start_cursor = None
         manager.broadcast_to_session_clients(
             {
                 "event": "recording_stopped",
+                "pending_save_token": pending_save_token,
                 "duration_ms": recording_data.get("duration_ms", 0),
                 "event_count": len(_json_list(recording_data.get("events"))),
                 "device_types": recording_data.get("device_types", []),
@@ -210,6 +218,8 @@ async def handle_start_macro_trigger(manager: "SessionManager") -> None:
 
     result = await runtime_recording.start_recording(manager, reset_if_active=False)
     if result.get("status") != "ok":
+        if result.get("error_code") == runtime_recording.MACRO_SAVE_PENDING_ERROR_CODE:
+            return
         runtime_recording.notify_recording_unlock_required(manager, result)
         manager.broadcast_to_session_clients({"event": "recording_auth_requested"})
 

--- a/keymasq/session/manager/recording.py
+++ b/keymasq/session/manager/recording.py
@@ -4,6 +4,7 @@ import re
 import secrets
 import tomllib
 from datetime import datetime
+from time import monotonic
 from typing import TYPE_CHECKING, cast
 
 import tomli_w
@@ -27,6 +28,11 @@ if TYPE_CHECKING:
     from .core import SessionManager
 
 log = logging.getLogger("keymasq-session")
+MACRO_SAVE_PENDING_ERROR_CODE = "macro_save_pending"
+MACRO_SAVE_PENDING_MESSAGE = (
+    "Save or discard the current recording before starting another recording."
+)
+MACRO_SAVE_PENDING_NOTIFICATION_COOLDOWN_S = 8.0
 
 
 def is_sensitive_session_command(
@@ -64,6 +70,121 @@ def has_active_gui_recording_owner(manager: "SessionManager") -> bool:
     if owner is None:
         return False
     return bool(str(owner.get("lease_id", "") or "").strip())
+
+
+def has_pending_macro_save(manager: "SessionManager") -> bool:
+    state = manager.recording_state
+    return state.pending_data is not None and bool(state.pending_save_token)
+
+
+def macro_save_pending_response(manager: "SessionManager") -> JsonObject:
+    state = manager.recording_state
+    response: JsonObject = {
+        "status": "error",
+        "error_code": MACRO_SAVE_PENDING_ERROR_CODE,
+        "message": MACRO_SAVE_PENDING_MESSAGE,
+    }
+    if state.pending_save_token:
+        response["pending_save_token"] = state.pending_save_token
+    return response
+
+
+def notify_macro_save_pending(manager: "SessionManager") -> None:
+    token = manager.recording_state.pending_save_token or ""
+    now = monotonic()
+    if (
+        token
+        and manager.recording_state.pending_save_notification_token == token
+        and now - manager.recording_state.pending_save_notification_at
+        < MACRO_SAVE_PENDING_NOTIFICATION_COOLDOWN_S
+    ):
+        return
+
+    manager.recording_state.pending_save_notification_token = token
+    manager.recording_state.pending_save_notification_at = now
+    manager.send_notification(
+        "Keymasq: Macro Save Pending",
+        MACRO_SAVE_PENDING_MESSAGE,
+    )
+
+
+def _set_active_recording_owner(
+    manager: "SessionManager",
+    *,
+    peer: PeerCredentials | None = None,
+    writer: asyncio.StreamWriter | None = None,
+) -> None:
+    state = manager.recording_state
+    if peer is not None and writer is not None:
+        state.active_owner_writer_id = id(writer)
+        state.active_owner_pid = int(peer.pid)
+        state.active_owner_uid = int(peer.uid)
+        return
+
+    owner = manager.unlock_state.refresh_owner
+    if owner is not None:
+        state.active_owner_writer_id = int_value(owner.get("writer_id"), 0) or None
+        state.active_owner_pid = int_value(owner.get("pid"), 0) or None
+        state.active_owner_uid = int_value(owner.get("uid"), 0) or None
+        return
+
+    state.active_owner_writer_id = None
+    state.active_owner_pid = None
+    state.active_owner_uid = None
+
+
+def _clear_active_recording_owner(manager: "SessionManager") -> None:
+    state = manager.recording_state
+    state.active_owner_writer_id = None
+    state.active_owner_pid = None
+    state.active_owner_uid = None
+
+
+def begin_pending_macro_save(manager: "SessionManager", recording_data: JsonObject) -> str:
+    state = manager.recording_state
+    token = secrets.token_urlsafe(16)
+    state.pending_data = recording_data
+    state.pending_save_token = token
+    state.pending_save_owner_writer_id = state.active_owner_writer_id
+    state.pending_save_owner_pid = state.active_owner_pid
+    state.pending_save_owner_uid = state.active_owner_uid
+    state.pending_save_created_at = monotonic()
+    state.pending_save_notification_token = None
+    state.pending_save_notification_at = 0.0
+    _clear_active_recording_owner(manager)
+    return token
+
+
+def clear_pending_macro_save(manager: "SessionManager") -> None:
+    state = manager.recording_state
+    state.pending_data = None
+    state.pending_save_token = None
+    state.pending_save_owner_writer_id = None
+    state.pending_save_owner_pid = None
+    state.pending_save_owner_uid = None
+    state.pending_save_created_at = 0.0
+    state.pending_save_notification_token = None
+    state.pending_save_notification_at = 0.0
+
+
+def clear_pending_macro_save_if_writer(
+    manager: "SessionManager",
+    writer: asyncio.StreamWriter,
+) -> None:
+    state = manager.recording_state
+    if not has_pending_macro_save(manager):
+        return
+    owner_writer_id = state.pending_save_owner_writer_id
+    if owner_writer_id == id(writer) or owner_writer_id is None:
+        clear_pending_macro_save(manager)
+
+
+def pending_macro_save_token_matches(
+    manager: "SessionManager",
+    token: str,
+) -> bool:
+    current = manager.recording_state.pending_save_token
+    return bool(current) and token == current
 
 
 async def resolve_unlock_status_async(
@@ -598,12 +719,16 @@ async def stop_recording(
                 recording_data["start_x"] = int(manager.recording_state.start_cursor[0])
                 recording_data["start_y"] = int(manager.recording_state.start_cursor[1])
                 recording_data["move_to_start"] = True
-            manager.recording_state.pending_data = recording_data
+            if has_pending_macro_save(manager):
+                manager.recording_state.pending_data = recording_data
+            else:
+                begin_pending_macro_save(manager, recording_data)
             manager.recording_state.active = False
             manager.recording_state.start_cursor = None
             return {"status": "ok", **recording_data}
         manager.recording_state.active = False
         manager.recording_state.start_cursor = None
+        _clear_active_recording_owner(manager)
         return {"status": "ok"}
     return {"status": "error", "message": result.error or "Failed to stop recording"}
 
@@ -828,7 +953,14 @@ def save_recording_settings_to_disk(
 async def start_recording(
     manager: "SessionManager",
     reset_if_active: bool = False,
+    *,
+    owner_peer: PeerCredentials | None = None,
+    owner_writer: asyncio.StreamWriter | None = None,
 ) -> JsonObject:
+    if has_pending_macro_save(manager):
+        notify_macro_save_pending(manager)
+        return macro_save_pending_response(manager)
+
     if manager.recording_state.active:
         if not reset_if_active:
             return {"status": "error", "message": "Recording already in progress"}
@@ -840,6 +972,7 @@ async def start_recording(
         except Exception:
             pass
         manager.recording_state.active = False
+        _clear_active_recording_owner(manager)
 
     settings = manager.recording_state.settings
     include_mouse_movement = settings.get("include_mouse_movement", False)
@@ -917,6 +1050,11 @@ async def start_recording(
 
     if result.status == "ok":
         manager.recording_state.active = True
+        _set_active_recording_owner(
+            manager,
+            peer=owner_peer,
+            writer=owner_writer,
+        )
         response_data = json_object(result.data)
         return response_data if response_data else {"status": "ok"}
 
@@ -1076,7 +1214,7 @@ async def save_recording(
         if created is not None:
             created_name = str(created.get("name", safe_name))
 
-    manager.recording_state.pending_data = None
+    clear_pending_macro_save(manager)
     manager.broadcast_to_session_clients({"event": "macro_saved", "name": created_name})
     return {"status": "ok", "name": created_name}
 

--- a/keymasq/session/manager/recording.py
+++ b/keymasq/session/manager/recording.py
@@ -32,7 +32,7 @@ MACRO_SAVE_PENDING_ERROR_CODE = "macro_save_pending"
 MACRO_SAVE_PENDING_MESSAGE = (
     "Save or discard the current recording before starting another recording."
 )
-MACRO_SAVE_PENDING_NOTIFICATION_COOLDOWN_S = 8.0
+MACRO_SAVE_PENDING_NOTIFICATION_COOLDOWN_S = 5.0
 
 
 def is_sensitive_session_command(

--- a/keymasq/session/manager/state.py
+++ b/keymasq/session/manager/state.py
@@ -30,6 +30,16 @@ class CaptureRuntimeState:
 class RecordingRuntimeState:
     active: bool = False
     pending_data: JsonObject | None = None
+    pending_save_token: str | None = None
+    pending_save_owner_writer_id: int | None = None
+    pending_save_owner_pid: int | None = None
+    pending_save_owner_uid: int | None = None
+    pending_save_created_at: float = 0.0
+    pending_save_notification_token: str | None = None
+    pending_save_notification_at: float = 0.0
+    active_owner_writer_id: int | None = None
+    active_owner_pid: int | None = None
+    active_owner_uid: int | None = None
     start_cursor: tuple[int, int] | None = None
     settings: JsonObject = field(default_factory=default_recording_settings)
     settings_pending_save: JsonObject | None = None

--- a/tests/gui/test_gui_demo_and_dialogs.py
+++ b/tests/gui/test_gui_demo_and_dialogs.py
@@ -426,6 +426,79 @@ class TestRecordingOverlay:
         assert overlay._stop_btn.get_sensitive() is True
 
 
+class TestSaveMacroDialog:
+    def test_save_macro_dialog_sends_pending_save_token(self, monkeypatch):
+        gi.require_version("Gtk", "4.0")
+        from gi.repository import GLib, Gtk
+
+        import keymasq.gui.widgets.save_macro_dialog as save_macro_dialog_module
+        from keymasq.gui.widgets.save_macro_dialog import SaveMacroDialog
+
+        monkeypatch.setattr(GLib, "idle_add", lambda callback, *args: 0)
+        captured: dict[str, object] = {}
+
+        def fake_session_request_with_hooks(payload, callback, on_start=None, on_done=None):
+            captured.update(payload)
+            if on_start:
+                on_start()
+            callback({"status": "ok"})
+            if on_done:
+                on_done()
+
+        monkeypatch.setattr(
+            save_macro_dialog_module,
+            "session_request_with_hooks",
+            fake_session_request_with_hooks,
+        )
+
+        dialog = SaveMacroDialog(
+            Gtk.Window(),
+            {
+                "duration_ms": 100,
+                "event_count": 2,
+                "device_types": ["keyboard"],
+                "pending_save_token": "pending-1",
+            },
+        )
+        dialog._name_entry.set_text("macro_1")
+        dialog._on_save_clicked(dialog._save_btn)
+
+        assert captured["command"] == "save_recording"
+        assert captured["pending_save_token"] == "pending-1"
+
+    def test_save_macro_dialog_discard_sends_pending_save_token(self, monkeypatch):
+        gi.require_version("Gtk", "4.0")
+        from gi.repository import GLib, Gtk
+
+        import keymasq.gui.widgets.save_macro_dialog as save_macro_dialog_module
+        from keymasq.gui.widgets.save_macro_dialog import SaveMacroDialog
+
+        monkeypatch.setattr(GLib, "idle_add", lambda callback, *args: 0)
+        captured: dict[str, object] = {}
+        monkeypatch.setattr(
+            save_macro_dialog_module,
+            "session_request_async",
+            lambda payload, callback: captured.update(payload),
+        )
+
+        dialog = SaveMacroDialog(
+            Gtk.Window(),
+            {
+                "duration_ms": 100,
+                "event_count": 2,
+                "device_types": ["keyboard"],
+                "pending_save_token": "pending-1",
+            },
+        )
+
+        dialog._on_discard_clicked(Gtk.Button())
+
+        assert captured == {
+            "command": "discard_recording",
+            "pending_save_token": "pending-1",
+        }
+
+
 class TestDialogConstruction:
     def test_about_dialog_uses_packaged_app_identity(self, monkeypatch):
         from keymasq import __version__
@@ -616,6 +689,39 @@ class TestDialogConstruction:
 
         assert result is False
         assert captured["reason"] == "recording_locked"
+
+    def test_macro_manager_presents_pending_save_dialog_after_macro_save_pending(
+        self,
+        monkeypatch,
+    ):
+        gi.require_version("Gtk", "4.0")
+        from gi.repository import GLib, Gtk
+
+        from keymasq.gui.widgets.macro_manager_dialog import MacroManagerDialog
+
+        monkeypatch.setattr(GLib, "idle_add", lambda callback, *args: 0)
+        presented: list[bool] = []
+
+        class Parent(Gtk.Window):
+            def present_pending_macro_save_dialog(self) -> bool:
+                presented.append(True)
+                return True
+
+        dialog = MacroManagerDialog(Parent())
+
+        result = dialog._on_record_request_finished(
+            {
+                "status": "error",
+                "error_code": "macro_save_pending",
+                "message": (
+                    "Save or discard the current recording before starting another recording."
+                ),
+            },
+            "start_recording",
+        )
+
+        assert result is False
+        assert presented == [True]
 
     def test_macro_manager_edit_opens_editor_with_closed_handler(self, monkeypatch):
         gi.require_version("Gtk", "4.0")

--- a/tests/gui/test_gui_demo_and_dialogs.py
+++ b/tests/gui/test_gui_demo_and_dialogs.py
@@ -64,6 +64,7 @@ class TestRecordMacroDialog:
         from keymasq.gui.widgets.record_macro_dialog import RecordMacroDialog
 
         monkeypatch.setattr(RecordMacroDialog, "_load_initial_state_async", lambda self: None)
+        monkeypatch.setattr(RecordMacroDialog, "_sync_settings_async", lambda self: None)
 
         dialog = RecordMacroDialog(Gtk.Window())
 
@@ -97,6 +98,84 @@ class TestRecordMacroDialog:
         assert dialog._unlock_btn.get_visible() is False
         assert dialog._unlock_status.get_label() == "Unlock active"
 
+    def test_record_dialog_live_settings_footer_uses_done_without_cancel(self, monkeypatch):
+        gi.require_version("Gtk", "4.0")
+        from gi.repository import Gtk
+
+        from keymasq.gui.widgets.record_macro_dialog import RecordMacroDialog
+
+        monkeypatch.setattr(RecordMacroDialog, "_load_initial_state_async", lambda self: None)
+        monkeypatch.setattr(RecordMacroDialog, "_sync_settings_async", lambda self: None)
+
+        dialog = RecordMacroDialog(Gtk.Window())
+
+        labels: list[str] = []
+
+        def collect_button_labels(widget) -> None:
+            if isinstance(widget, Gtk.Button):
+                label = widget.get_label()
+                if label:
+                    labels.append(label)
+
+            child = widget.get_first_child()
+            while child is not None:
+                collect_button_labels(child)
+                child = child.get_next_sibling()
+
+        collect_button_labels(dialog.get_child())
+
+        assert "Done" in labels
+        assert "Cancel" not in labels
+        assert "Save Settings" not in labels
+
+    def test_record_dialog_locked_reason_explains_blocked_recording(self, monkeypatch):
+        gi.require_version("Gtk", "4.0")
+        from gi.repository import Gtk
+
+        from keymasq.gui.widgets.record_macro_dialog import RecordMacroDialog
+
+        monkeypatch.setattr(RecordMacroDialog, "_load_initial_state_async", lambda self: None)
+
+        dialog = RecordMacroDialog(Gtk.Window(), reason="recording_locked")
+
+        assert dialog._title_label.get_label() == "Unlock Macro Recording"
+        assert dialog._locked_notice.get_visible() is True
+
+        dialog.set_presentation_reason("settings")
+
+        assert dialog._title_label.get_label() == "Macro Recording Settings"
+        assert dialog._locked_notice.get_visible() is False
+
+    def test_record_dialog_closes_when_recording_starts(self, monkeypatch):
+        gi.require_version("Gtk", "4.0")
+        from gi.repository import Gtk
+
+        from keymasq.gui.widgets.record_macro_dialog import RecordMacroDialog
+
+        monkeypatch.setattr(RecordMacroDialog, "_load_initial_state_async", lambda self: None)
+        registered: dict[str, object] = {}
+        unregistered: list[tuple[str, object]] = []
+
+        class Parent(Gtk.Window):
+            def register_event_handler(self, event_type: str, callback) -> None:
+                registered[event_type] = callback
+
+            def unregister_event_handler(self, event_type: str, callback) -> None:
+                unregistered.append((event_type, callback))
+
+        dialog = RecordMacroDialog(Parent())
+        closed: list[bool] = []
+        monkeypatch.setattr(dialog, "close", lambda: closed.append(True))
+
+        callback = dialog._on_recording_started
+        callback({"event": "recording_started"})
+
+        assert closed == [True]
+
+        dialog._on_dialog_closed(dialog)
+
+        assert unregistered == [("recording_started", callback)]
+
     def test_record_dialog_defaults_to_recommended_sources(self, monkeypatch):
         gi.require_version("Gtk", "4.0")
         from gi.repository import Gtk
@@ -104,6 +183,7 @@ class TestRecordMacroDialog:
         from keymasq.gui.widgets.record_macro_dialog import RecordMacroDialog
 
         monkeypatch.setattr(RecordMacroDialog, "_load_initial_state_async", lambda self: None)
+        monkeypatch.setattr(RecordMacroDialog, "_sync_settings_async", lambda self: None)
 
         dialog = RecordMacroDialog(Gtk.Window())
         dialog._apply_recording_settings({"status": "ok", "device_overrides": {}})
@@ -132,6 +212,57 @@ class TestRecordMacroDialog:
         assert dialog._device_checks["physical:/dev/input/by-id/raw-mouse"].get_active() is False
         assert dialog._selection_summary.get_label() == "1 selected (1kb)"
 
+    def test_record_dialog_source_row_activation_toggles_checkbox(self, monkeypatch):
+        gi.require_version("Gtk", "4.0")
+        from gi.repository import Gtk
+
+        from keymasq.gui.widgets.record_macro_dialog import RecordMacroDialog
+
+        monkeypatch.setattr(RecordMacroDialog, "_load_initial_state_async", lambda self: None)
+        monkeypatch.setattr(RecordMacroDialog, "_sync_settings_async", lambda self: None)
+
+        dialog = RecordMacroDialog(Gtk.Window())
+        dialog._apply_recording_settings({"status": "ok", "device_overrides": {}})
+        dialog._devices = [
+            {
+                "path": "/dev/input/event20",
+                "recording_id": "keymasq:output:keyboard",
+                "recording_kind": "keymasq_output",
+                "device_type": "keyboard",
+                "device_types": ["keyboard"],
+                "name": "keymasq-keyboard",
+            },
+            {
+                "path": "/dev/input/event0",
+                "recording_id": "physical:/dev/input/by-id/raw-mouse",
+                "recording_kind": "physical",
+                "device_type": "mouse",
+                "device_types": ["mouse"],
+                "name": "Raw Mouse",
+            },
+        ]
+
+        dialog._populate_device_list()
+
+        raw_row = None
+        row = dialog._device_listbox.get_first_child()
+        while row is not None:
+            if getattr(row, "_recording_id", "") == "physical:/dev/input/by-id/raw-mouse":
+                raw_row = row
+                break
+            row = row.get_next_sibling()
+
+        assert raw_row is not None
+        dialog._on_device_row_activated(dialog._device_listbox, raw_row)
+        assert dialog._device_checks["physical:/dev/input/by-id/raw-mouse"].get_active() is True
+        assert dialog._device_overrides == {"physical:/dev/input/by-id/raw-mouse": True}
+        assert dialog._selection_summary.get_label() == "2 selected (1kb, 1m)"
+
+        dialog._on_device_row_activated(dialog._device_listbox, raw_row)
+        assert dialog._device_checks["physical:/dev/input/by-id/raw-mouse"].get_active() is False
+        assert dialog._device_overrides == {}
+        assert dialog._selection_summary.get_label() == "1 selected (1kb)"
+
     def test_record_dialog_bulk_selection_is_helper_only(self, monkeypatch):
         gi.require_version("Gtk", "4.0")
         from gi.repository import Gtk
@@ -139,6 +270,7 @@ class TestRecordMacroDialog:
         from keymasq.gui.widgets.record_macro_dialog import RecordMacroDialog
 
         monkeypatch.setattr(RecordMacroDialog, "_load_initial_state_async", lambda self: None)
+        monkeypatch.setattr(RecordMacroDialog, "_sync_settings_async", lambda self: None)
 
         dialog = RecordMacroDialog(Gtk.Window())
         dialog._apply_recording_settings(
@@ -226,6 +358,72 @@ class TestRecordMacroDialog:
             {"physical:/dev/input/by-id/raw-mouse": True},
             {},
         ]
+
+
+class TestRecordingOverlay:
+    def test_recording_overlay_uses_prominent_centered_panel(self):
+        gi.require_version("Gtk", "4.0")
+        from gi.repository import Gtk
+
+        from keymasq.gui.widgets.recording_overlay import RecordingOverlay
+
+        overlay = RecordingOverlay(Gtk.Window())
+
+        assert overlay.has_css_class("recording-overlay")
+        assert overlay.get_hexpand() is True
+        assert overlay.get_vexpand() is True
+
+        panel = overlay.get_first_child()
+        assert panel is not None
+        assert panel.has_css_class("recording-overlay-panel")
+        assert panel.has_css_class("card") is False
+        assert panel.get_halign() == Gtk.Align.CENTER
+        assert panel.get_valign() == Gtk.Align.CENTER
+        width_request, _height_request = panel.get_size_request()
+        assert width_request >= 420
+
+        assert overlay._stop_btn is not None
+        assert overlay._stop_btn.get_label() == "Stop Recording"
+
+    def test_recording_overlay_updates_status_and_stop_feedback(self, monkeypatch):
+        gi.require_version("Gtk", "4.0")
+        from gi.repository import Gtk
+
+        import keymasq.gui.widgets.recording_overlay as recording_overlay_module
+        from keymasq.gui.widgets.recording_overlay import RecordingOverlay
+
+        callbacks = []
+
+        def fake_session_request_async(payload, callback, timeout=5.0):
+            callbacks.append((payload, callback))
+
+        monkeypatch.setattr(
+            recording_overlay_module, "session_request_async", fake_session_request_async
+        )
+
+        overlay = RecordingOverlay(Gtk.Window())
+        overlay.on_started({"event": "recording_started"})
+        overlay.on_progress({"duration_ms": 62025, "event_count": 444})
+
+        assert overlay._duration_label.get_label() == "01:02.025"
+        assert overlay._events_label.get_label() == "444"
+
+        assert overlay._stop_btn is not None
+        overlay._on_stop_clicked(overlay._stop_btn)
+
+        assert callbacks[0][0] == {"command": "stop_recording"}
+        assert overlay._stop_btn.get_sensitive() is False
+        assert overlay._stop_btn.get_label() == "Stopping..."
+
+        assert callbacks[0][1]({"status": "ok"}) is False
+        assert overlay._stop_btn.get_sensitive() is True
+        assert overlay._stop_btn.get_label() == "Stop Recording"
+
+        overlay.on_started({"event": "recording_started"})
+        assert overlay._timer_id != 0
+        overlay.on_stopped()
+        assert overlay._timer_id == 0
+        assert overlay._stop_btn.get_sensitive() is True
 
 
 class TestDialogConstruction:
@@ -371,6 +569,36 @@ class TestDialogConstruction:
 
         assert dialog.get_child() is not None
         assert callable(dialog._on_close_clicked)
+
+    def test_macro_manager_opens_locked_recording_mode_after_recording_locked(
+        self,
+        monkeypatch,
+    ):
+        gi.require_version("Gtk", "4.0")
+        from gi.repository import GLib, Gtk
+
+        from keymasq.gui.widgets.macro_manager_dialog import MacroManagerDialog
+
+        monkeypatch.setattr(GLib, "idle_add", lambda callback, *args: 0)
+        captured: dict[str, object] = {}
+
+        class Parent(Gtk.Window):
+            def present_recording_settings_dialog(self, reason: str = "settings") -> None:
+                captured["reason"] = reason
+
+        dialog = MacroManagerDialog(Parent())
+
+        result = dialog._on_record_request_finished(
+            {
+                "status": "error",
+                "error_code": "recording_locked",
+                "message": "recording_locked",
+            },
+            "start_recording",
+        )
+
+        assert result is False
+        assert captured["reason"] == "recording_locked"
 
     def test_macro_manager_edit_opens_editor_with_closed_handler(self, monkeypatch):
         gi.require_version("Gtk", "4.0")

--- a/tests/gui/test_gui_demo_and_dialogs.py
+++ b/tests/gui/test_gui_demo_and_dialogs.py
@@ -570,6 +570,23 @@ class TestDialogConstruction:
         assert dialog.get_child() is not None
         assert callable(dialog._on_close_clicked)
 
+    def test_macro_manager_closes_when_recording_starts(self, monkeypatch):
+        gi.require_version("Gtk", "4.0")
+        from gi.repository import GLib, Gtk
+
+        from keymasq.gui.widgets.macro_manager_dialog import MacroManagerDialog
+
+        monkeypatch.setattr(GLib, "idle_add", lambda callback, *args: 0)
+
+        dialog = MacroManagerDialog(Gtk.Window())
+        closed: list[bool] = []
+        monkeypatch.setattr(dialog, "close", lambda: closed.append(True))
+
+        dialog._on_recording_started({"event": "recording_started"})
+
+        assert dialog._recording_active is True
+        assert closed == [True]
+
     def test_macro_manager_opens_locked_recording_mode_after_recording_locked(
         self,
         monkeypatch,

--- a/tests/gui/test_gui_demo_and_dialogs.py
+++ b/tests/gui/test_gui_demo_and_dialogs.py
@@ -1,4 +1,7 @@
 # ruff: noqa: F403, F405, I001
+import threading
+import time
+
 from tests.gui.support import *
 
 class TestDemoDevice:
@@ -175,6 +178,54 @@ class TestRecordMacroDialog:
         dialog._on_reset_to_recommended_clicked(Gtk.Button())
         assert dialog._device_checks["physical:/dev/input/by-id/raw-mouse"].get_active() is False
         assert dialog._selection_warning.get_visible() is True
+
+    def test_record_dialog_reset_sync_wins_over_inflight_selection(self, monkeypatch):
+        gi.require_version("Gtk", "4.0")
+        from gi.repository import Gtk
+
+        import keymasq.gui.widgets.record_macro_dialog as record_macro_dialog_module
+        from keymasq.gui.widgets.record_macro_dialog import RecordMacroDialog
+
+        monkeypatch.setattr(RecordMacroDialog, "_load_initial_state_async", lambda self: None)
+
+        first_started = threading.Event()
+        release_first = threading.Event()
+        captured_payloads: list[dict[str, object]] = []
+
+        def fake_session_request(payload, timeout=5.0):
+            snapshot = dict(payload)
+            snapshot["device_overrides"] = dict(payload.get("device_overrides", {}))
+            captured_payloads.append(snapshot)
+            if len(captured_payloads) == 1:
+                first_started.set()
+                assert release_first.wait(2.0)
+            return {"status": "ok"}
+
+        monkeypatch.setattr(record_macro_dialog_module, "session_request", fake_session_request)
+
+        dialog = RecordMacroDialog(Gtk.Window())
+        dialog._device_overrides = {"physical:/dev/input/by-id/raw-mouse": True}
+
+        dialog._sync_settings_async()
+        assert first_started.wait(2.0)
+
+        dialog._device_overrides.clear()
+        dialog._sync_settings_async()
+        release_first.set()
+
+        for _ in range(100):
+            with dialog._settings_sync_lock:
+                worker_running = dialog._settings_sync_worker_running
+            if not worker_running:
+                break
+            time.sleep(0.01)
+        else:
+            pytest.fail("settings sync worker did not finish")
+
+        assert [payload["device_overrides"] for payload in captured_payloads] == [
+            {"physical:/dev/input/by-id/raw-mouse": True},
+            {},
+        ]
 
 
 class TestDialogConstruction:

--- a/tests/gui/test_gui_demo_and_dialogs.py
+++ b/tests/gui/test_gui_demo_and_dialogs.py
@@ -475,10 +475,19 @@ class TestSaveMacroDialog:
 
         monkeypatch.setattr(GLib, "idle_add", lambda callback, *args: 0)
         captured: dict[str, object] = {}
+
+        def fake_session_request_with_hooks(payload, callback, on_start=None, on_done=None):
+            captured.update(payload)
+            if on_start:
+                on_start()
+            callback({"status": "ok"})
+            if on_done:
+                on_done()
+
         monkeypatch.setattr(
             save_macro_dialog_module,
-            "session_request_async",
-            lambda payload, callback: captured.update(payload),
+            "session_request_with_hooks",
+            fake_session_request_with_hooks,
         )
 
         dialog = SaveMacroDialog(
@@ -497,6 +506,47 @@ class TestSaveMacroDialog:
             "command": "discard_recording",
             "pending_save_token": "pending-1",
         }
+
+    def test_save_macro_dialog_discard_failure_keeps_dialog_open(self, monkeypatch):
+        gi.require_version("Gtk", "4.0")
+        from gi.repository import GLib, Gtk
+
+        import keymasq.gui.widgets.save_macro_dialog as save_macro_dialog_module
+        from keymasq.gui.widgets.save_macro_dialog import SaveMacroDialog
+
+        monkeypatch.setattr(GLib, "idle_add", lambda callback, *args: 0)
+
+        def fake_session_request_with_hooks(payload, callback, on_start=None, on_done=None):
+            if on_start:
+                on_start()
+            callback({"status": "error", "message": "discard failed"})
+            if on_done:
+                on_done()
+
+        monkeypatch.setattr(
+            save_macro_dialog_module,
+            "session_request_with_hooks",
+            fake_session_request_with_hooks,
+        )
+
+        dialog = SaveMacroDialog(
+            Gtk.Window(),
+            {
+                "duration_ms": 100,
+                "event_count": 2,
+                "device_types": ["keyboard"],
+                "pending_save_token": "pending-1",
+            },
+        )
+        force_closed: list[bool] = []
+        monkeypatch.setattr(dialog, "force_close", lambda: force_closed.append(True))
+
+        dialog._on_discard_clicked(Gtk.Button())
+
+        assert force_closed == []
+        assert dialog._saved is False
+        assert dialog._error_label.get_label() == "discard failed"
+        assert dialog.get_can_close() is True
 
 
 class TestDialogConstruction:

--- a/tests/gui/test_main_window.py
+++ b/tests/gui/test_main_window.py
@@ -500,6 +500,21 @@ class TestMainWindow:
         }
         assert window._profile_runtime_state["window"] == {"class": "steam"}
 
+    def test_main_window_recording_auth_event_opens_locked_recording_dialog(self, monkeypatch):
+        from keymasq.gui.window import MainWindow
+
+        window = MainWindow(demo_mode=True)
+        captured: dict[str, object] = {}
+        monkeypatch.setattr(
+            window,
+            "present_recording_settings_dialog",
+            lambda reason="settings": captured.setdefault("reason", reason),
+        )
+
+        window._handle_session_event({"event": "recording_auth_requested"})
+
+        assert captured["reason"] == "recording_locked"
+
     def test_main_window_ignores_status_response_after_destroy(self, temp_config_dir):
         from keymasq.gui.window import MainWindow
 

--- a/tests/gui/test_main_window.py
+++ b/tests/gui/test_main_window.py
@@ -515,6 +515,22 @@ class TestMainWindow:
 
         assert captured["reason"] == "recording_locked"
 
+    def test_main_window_macro_save_pending_event_presents_existing_save_dialog(self):
+        from keymasq.gui.window import MainWindow
+
+        window = MainWindow(demo_mode=True)
+        presented: list[bool] = []
+
+        class DummyDialog:
+            def present(self, parent) -> None:
+                presented.append(True)
+
+        window._save_macro_dialog = DummyDialog()  # type: ignore[assignment]
+
+        window._handle_session_event({"event": "macro_save_pending"})
+
+        assert presented == [True]
+
     def test_main_window_recording_started_closes_tracked_dialogs(self):
         from keymasq.gui.window import MainWindow
 

--- a/tests/gui/test_main_window.py
+++ b/tests/gui/test_main_window.py
@@ -545,6 +545,47 @@ class TestMainWindow:
         assert closed == ["settings", "macros"]
         assert overlay_events == [{"visible": True}, {"event": "recording_started"}]
 
+    def test_main_window_recording_stopped_tracks_single_save_macro_dialog(self, monkeypatch):
+        import keymasq.gui.widgets.save_macro_dialog as save_macro_dialog_module
+        from keymasq.gui.window import MainWindow
+
+        window = MainWindow(demo_mode=True)
+        created: list[dict] = []
+        presented: list[object] = []
+
+        class DummySaveMacroDialog:
+            def __init__(self, parent, event: dict) -> None:
+                self.parent = parent
+                self.event = event
+                created.append(event)
+
+            def connect(self, signal: str, callback) -> None:
+                self.signal = signal
+                self.callback = callback
+
+            def present(self, parent) -> None:
+                presented.append(parent)
+
+        monkeypatch.setattr(save_macro_dialog_module, "SaveMacroDialog", DummySaveMacroDialog)
+
+        window._on_recording_stopped(
+            {"event": "recording_stopped", "pending_save_token": "pending-1"}
+        )
+        first_dialog = window._save_macro_dialog
+        window._on_recording_stopped(
+            {"event": "recording_stopped", "pending_save_token": "pending-1"}
+        )
+
+        assert len(created) == 1
+        assert first_dialog is window._save_macro_dialog
+        assert presented == [window, window]
+
+        assert window.present_pending_macro_save_dialog() is True
+        assert presented == [window, window, window]
+
+        window._on_save_macro_dialog_closed(first_dialog)
+        assert window._save_macro_dialog is None
+
     def test_main_window_ignores_status_response_after_destroy(self, temp_config_dir):
         from keymasq.gui.window import MainWindow
 

--- a/tests/gui/test_main_window.py
+++ b/tests/gui/test_main_window.py
@@ -515,6 +515,36 @@ class TestMainWindow:
 
         assert captured["reason"] == "recording_locked"
 
+    def test_main_window_recording_started_closes_tracked_dialogs(self):
+        from keymasq.gui.window import MainWindow
+
+        window = MainWindow(demo_mode=True)
+        closed: list[str] = []
+        overlay_events: list[dict] = []
+
+        class DummyDialog:
+            def __init__(self, name: str) -> None:
+                self.name = name
+
+            def close(self) -> None:
+                closed.append(self.name)
+
+        class DummyOverlay:
+            def set_visible(self, visible: bool) -> None:
+                overlay_events.append({"visible": visible})
+
+            def on_started(self, event: dict) -> None:
+                overlay_events.append(event)
+
+        window._record_macro_dialog = DummyDialog("settings")  # type: ignore[assignment]
+        window._macro_manager_dialog = DummyDialog("macros")  # type: ignore[assignment]
+        window._recording_overlay = DummyOverlay()  # type: ignore[assignment]
+
+        window._handle_session_event({"event": "recording_started"})
+
+        assert closed == ["settings", "macros"]
+        assert overlay_events == [{"visible": True}, {"event": "recording_started"}]
+
     def test_main_window_ignores_status_response_after_destroy(self, temp_config_dir):
         from keymasq.gui.window import MainWindow
 

--- a/tests/session/test_session_manager_command_runtime.py
+++ b/tests/session/test_session_manager_command_runtime.py
@@ -232,7 +232,13 @@ async def test_start_macro_trigger_blocks_when_macro_save_is_pending() -> None:
         "Keymasq: Macro Save Pending",
         "Save or discard the current recording before starting another recording.",
     )
-    manager.broadcast_to_session_clients.assert_not_called()  # type: ignore[attr-defined]
+    manager.broadcast_to_session_clients.assert_called_once_with(  # type: ignore[attr-defined]
+        {
+            "event": "macro_save_pending",
+            "message": "Save or discard the current recording before starting another recording.",
+            "pending_save_token": "pending-1",
+        }
+    )
     manager.client.send_command.assert_not_awaited()
 
 

--- a/tests/session/test_session_manager_command_runtime.py
+++ b/tests/session/test_session_manager_command_runtime.py
@@ -157,7 +157,12 @@ async def test_sensitive_recording_commands_do_not_require_owner_when_unlock_not
     )
 
     assert result == {"status": "ok"}
-    start_recording.assert_awaited_once_with(manager, reset_if_active=False)
+    start_recording.assert_awaited_once_with(
+        manager,
+        reset_if_active=False,
+        owner_peer=peer,
+        owner_writer=writer,
+    )
     monkeypatch.undo()
 
 
@@ -204,6 +209,31 @@ async def test_start_macro_trigger_warns_when_gui_is_open_but_locked() -> None:
     )
     start_recording.assert_not_awaited()
     monkeypatch.undo()
+
+
+@pytest.mark.asyncio
+async def test_start_macro_trigger_blocks_when_macro_save_is_pending() -> None:
+    manager = SessionManager()
+    manager.recording_state.pending_data = {"events": [{"t_us": 0}]}
+    manager.recording_state.pending_save_token = "pending-1"
+    manager.unlock_state.refresh_owner = {
+        "uid": 1000,
+        "pid": 111,
+        "writer_id": 222,
+        "lease_id": "lease-1",
+    }
+    manager.send_notification = Mock()  # type: ignore[method-assign]
+    manager.broadcast_to_session_clients = Mock()  # type: ignore[method-assign]
+    manager.client.send_command = AsyncMock()
+
+    await session_events_module.handle_start_macro_trigger(manager)
+
+    manager.send_notification.assert_called_once_with(  # type: ignore[attr-defined]
+        "Keymasq: Macro Save Pending",
+        "Save or discard the current recording before starting another recording.",
+    )
+    manager.broadcast_to_session_clients.assert_not_called()  # type: ignore[attr-defined]
+    manager.client.send_command.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -300,6 +330,80 @@ async def test_handle_session_request_create_macro_broadcasts_saved_event() -> N
     manager.broadcast_to_session_clients.assert_called_once_with(  # type: ignore[attr-defined]
         {"event": "macro_saved", "name": "Speedrun"}
     )
+
+
+@pytest.mark.asyncio
+async def test_save_recording_clears_pending_macro_save_state() -> None:
+    manager = SessionManager()
+    manager.recording_state.pending_data = {
+        "duration_ms": 10,
+        "device_types": ["keyboard"],
+        "events": [{"type": 1, "code": 30, "value": 1, "t_us": 0}],
+    }
+    manager.recording_state.pending_save_token = "pending-1"
+    manager.recording_state.pending_save_owner_writer_id = 123
+    manager.client.send_command = AsyncMock(
+        return_value=Response(status="ok", data={"macro": {"name": "Saved"}})
+    )
+    manager.broadcast_to_session_clients = Mock()  # type: ignore[method-assign]
+    peer = PeerCredentials(pid=1, uid=1000, gid=1000)
+
+    result = await manager._handle_session_request(
+        {
+            "command": "save_recording",
+            "name": "Saved",
+            "pending_save_token": "pending-1",
+        },
+        "client",
+        peer,
+        object(),
+    )
+
+    assert result == {"status": "ok", "name": "Saved"}
+    assert manager.recording_state.pending_data is None
+    assert manager.recording_state.pending_save_token is None
+    assert manager.recording_state.pending_save_owner_writer_id is None
+
+
+@pytest.mark.asyncio
+async def test_discard_recording_rejects_stale_pending_macro_save_token() -> None:
+    manager = SessionManager()
+    manager.recording_state.pending_data = {"events": [{"t_us": 0}]}
+    manager.recording_state.pending_save_token = "current"
+    peer = PeerCredentials(pid=1, uid=1000, gid=1000)
+
+    result = await manager._handle_session_request(
+        {"command": "discard_recording", "pending_save_token": "stale"},
+        "client",
+        peer,
+        object(),
+    )
+
+    assert result["status"] == "error"
+    assert result["error_code"] == "stale_pending_macro_save"
+    assert manager.recording_state.pending_data == {"events": [{"t_us": 0}]}
+    assert manager.recording_state.pending_save_token == "current"
+
+
+@pytest.mark.asyncio
+async def test_discard_recording_clears_pending_macro_save_state() -> None:
+    manager = SessionManager()
+    manager.recording_state.pending_data = {"events": [{"t_us": 0}]}
+    manager.recording_state.pending_save_token = "pending-1"
+    manager.recording_state.pending_save_owner_writer_id = 123
+    peer = PeerCredentials(pid=1, uid=1000, gid=1000)
+
+    result = await manager._handle_session_request(
+        {"command": "discard_recording", "pending_save_token": "pending-1"},
+        "client",
+        peer,
+        object(),
+    )
+
+    assert result == {"status": "ok"}
+    assert manager.recording_state.pending_data is None
+    assert manager.recording_state.pending_save_token is None
+    assert manager.recording_state.pending_save_owner_writer_id is None
 
 
 @pytest.mark.asyncio

--- a/tests/session/test_session_manager_recording_settings.py
+++ b/tests/session/test_session_manager_recording_settings.py
@@ -216,3 +216,39 @@ async def test_start_recording_defaults_to_recommended_sources_only() -> None:
         "keymasq:output:keyboard",
         "keymasq:passthrough:1234:5678:mouse",
     ]
+
+
+@pytest.mark.asyncio
+async def test_start_recording_blocks_when_macro_save_is_pending() -> None:
+    manager = SessionManager()
+    manager.send_notification = Mock()  # type: ignore[method-assign]
+    manager.client = SimpleNamespace(send_command=AsyncMock())  # type: ignore[assignment]
+    manager.recording_state.pending_data = {"events": [{"t_us": 0}]}
+    manager.recording_state.pending_save_token = "pending-1"
+
+    result = await session_recording_module.start_recording(manager)
+
+    assert result == {
+        "status": "error",
+        "error_code": "macro_save_pending",
+        "message": "Save or discard the current recording before starting another recording.",
+        "pending_save_token": "pending-1",
+    }
+    manager.send_notification.assert_called_once_with(  # type: ignore[attr-defined]
+        "Keymasq: Macro Save Pending",
+        "Save or discard the current recording before starting another recording.",
+    )
+    manager.client.send_command.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_start_recording_pending_save_notification_is_rate_limited() -> None:
+    manager = SessionManager()
+    manager.send_notification = Mock()  # type: ignore[method-assign]
+    manager.recording_state.pending_data = {"events": [{"t_us": 0}]}
+    manager.recording_state.pending_save_token = "pending-1"
+
+    await session_recording_module.start_recording(manager)
+    await session_recording_module.start_recording(manager)
+
+    manager.send_notification.assert_called_once()  # type: ignore[attr-defined]

--- a/tests/test_session_manager_core.py
+++ b/tests/test_session_manager_core.py
@@ -195,5 +195,5 @@ async def test_send_notification_logs_even_when_dbus_notification_fails(
         "Keymasq: Grab Pending",
         "Test Keyboard is waiting.",
         app_name="keymasq",
-        timeout_ms=2000,
+        timeout_ms=5000,
     )

--- a/tests/test_session_manager_recording.py
+++ b/tests/test_session_manager_recording.py
@@ -37,6 +37,23 @@ async def test_owner_disconnect_cleans_runtime_unlock() -> None:
     )
 
 
+def test_owner_disconnect_discards_pending_macro_save() -> None:
+    manager = SessionManager()
+    writer = object()
+    manager.recording_state.pending_data = {"events": [{"t_us": 0}]}
+    manager.recording_state.pending_save_token = "pending-1"
+    manager.recording_state.pending_save_owner_writer_id = id(writer)
+
+    session_recording_module.clear_pending_macro_save_if_writer(
+        manager,
+        writer,  # type: ignore[arg-type]
+    )
+
+    assert manager.recording_state.pending_data is None
+    assert manager.recording_state.pending_save_token is None
+    assert manager.recording_state.pending_save_owner_writer_id is None
+
+
 @pytest.mark.asyncio
 async def test_last_client_disconnect_cleans_runtime_unlock_without_owner() -> None:
     manager = SessionManager()


### PR DESCRIPTION
## Summary
- Improve the Macro Recording Settings dialog so it matches the current live-settings model:
  - serialize async settings syncs so the newest dialog state wins over in-flight requests
  - make recording source rows toggle on row activation, not only on the checkbox
  - remove the misleading `Cancel` action and rename `Save Settings` to `Done`
  - keep settings dialog state aligned with the current `recording_settings.toml` flow
- Clarify the locked-recording path:
  - distinguish normal settings presentation from the "recording was blocked because recording is locked" presentation
  - open the locked/unlock-focused dialog when recording is requested from binds or Macro Manager while unlocked access is missing
  - close recording-related dialogs when recording successfully starts so the active recording UI becomes the foreground state
- Redesign the in-recording UI:
  - replace the tiny corner indicator with a centered, opaque recording overlay
  - show clearer status information and a prominent centered `Stop Recording` action
  - reset overlay timers/button state cleanly when recording stops externally
- Make unsaved recorded macros session-owned and block new recordings reliably until they are resolved:
  - create a session-side pending-save token when recording stops
  - block all new recording starts while an unsaved recording is pending
  - re-present the existing `Save Macro` dialog instead of starting another recording
  - send desktop notifications when recording is blocked by a pending save
  - discard pending recording data automatically if the owning GUI connection closes or crashes
  - pass pending-save tokens through save/discard requests and reject stale clears
- Update docs to describe the new pending-save behavior and the fact that unsaved recordings remain in session memory until explicitly saved.
- Increase the notification popup timeout to 5 seconds and the pending-save resend cooldown to 5 seconds.

## Testing
- `nix develop -c ./scripts/check.sh full`
  - result: `818 passed`
- `nix develop -c ./scripts/check.sh session`
  - result: `201 passed, 617 deselected`
- Focused checks while iterating:
  - `nix develop -c pytest tests/gui/test_gui_demo_and_dialogs.py::TestRecordMacroDialog -q`
  - `nix develop -c pytest tests/gui/test_gui_demo_and_dialogs.py::TestRecordingOverlay -q`
  - `nix develop -c pytest tests/gui/test_main_window.py::TestMainWindow::test_main_window_recording_started_closes_tracked_dialogs -q`
  - `nix develop -c pytest tests/session/test_session_manager_recording_settings.py::test_start_recording_blocks_when_macro_save_is_pending -q`
  - `nix develop -c pytest tests/session/test_session_manager_command_runtime.py::test_start_macro_trigger_blocks_when_macro_save_is_pending -q`
- Manual smoke testing completed on the branch:
  - live recording start/stop flow works from Macro Manager and from toggle-recording binds
  - `Save Macro` dialog blocks new recordings until save/discard
  - save and discard both re-enable recording immediately
  - closing the GUI with a pending save discards the unsaved recording and recording is not left stuck
  - locked recording requests open the improved unlock/settings flow
  - overall behavior works as expected
