### PR TITLE
Switch recording unlock to runtime Polkit lease

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -269,8 +269,8 @@ a warning when this happens so the missing optimization is visible.
 ### Recording and capture unlock
 
 Packaged installs handle this automatically. For manual installs, if macro
-recording prompts do not appear or fail, you can disable the unlock requirement
-in `/etc/keymasq/security.toml`:
+recording unlock requests do not appear or fail, you can disable the unlock
+requirement in `/etc/keymasq/security.toml`:
 
 ```toml
 [recording_guard]

--- a/docs/MACROS.md
+++ b/docs/MACROS.md
@@ -365,10 +365,10 @@ Keymasq treats macros with care because recording captures raw input, which
 could be misused as a keylogger.
 
 - **Recording is allowed by default**, but guarded by an unlock step. Before
-  you can record a macro, Keymasq asks you to confirm through a one-time
-  unlock prompt. This is intentional — recording captures your raw keystrokes,
-  so the unlock prevents anything from silently recording in the background
-  without your knowledge.
+  you can record a macro, Keymasq asks Polkit to authorize a runtime unlock
+  for the active GUI. This is intentional — recording captures your raw
+  keystrokes, so the unlock prevents anything from silently recording in the
+  background without your knowledge.
 
 - **Macros are stored in `/var/lib/keymasq/macros/`**, owned by the `keymasq`
   system user, not mixed into your profile files. The GUI asks Keymasq to save

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -15,7 +15,7 @@ the compositor sees Keymasq's output as normal hardware input.
 - The daemon runs as a dedicated `keymasq` system user, not root
 - GUI and CLI never touch input devices directly — they talk to a per-user
   session broker, which talks to the daemon
-- Recording and capture features require an explicit unlock prompt to prevent
+- Recording and capture features require an explicit Polkit unlock to prevent
   silent keylogging
 - The daemon accepts only one session connection at a time, preventing rogue
   processes from issuing commands
@@ -104,7 +104,6 @@ Keymasq treats recording and capture features as sensitive because they can obse
 - Tier 1: recording and capture commands require an active unlock lease by default
 - Unlock is per-user and time-bounded by default
 - GUI can keep a runtime unlock lease refreshed while it remains the active owner
-- "Don't ask again" GUI flows use a longer-lived lease
 - Permanent unlock is an explicit administrative decision outside normal runtime flow
 
 When locked, recording/capture requests fail with `recording_locked`.

--- a/keymasq/gui/widgets/combo_editor_dialog.py
+++ b/keymasq/gui/widgets/combo_editor_dialog.py
@@ -270,6 +270,10 @@ class ComboEditorDialog(Adw.Dialog):
 
         self.unlock_button = Gtk.Button()
         self.unlock_button.set_child(self._make_unlock_button_content())
+        self.unlock_button.set_tooltip_text(
+            "Authorize raw original-input capture so combo capture can read the actual "
+            "keys and buttons before remapping."
+        )
         self.unlock_button.add_css_class("flat")
         self.unlock_button.connect("clicked", self._on_unlock_clicked)
         top_row.append(self.unlock_button)
@@ -663,6 +667,10 @@ class ComboEditorDialog(Adw.Dialog):
             self.add_step_button.set_visible(not needs_unlock)
 
         self.unlock_button.set_visible(needs_unlock)
+        self.unlock_button.set_tooltip_text(
+            "Authorize raw original-input capture so combo capture can read the actual "
+            "keys and buttons before remapping."
+        )
         if self._recording_unlocked:
             self.capture_privilege_status.set_text(
                 "Original-input capture is unlocked. Capture reads raw key events before remapping."

--- a/keymasq/gui/widgets/device_tab.py
+++ b/keymasq/gui/widgets/device_tab.py
@@ -1207,6 +1207,10 @@ class DeviceTab(ProfileManagedTab):
 
         unlock_btn = Gtk.Button()
         unlock_btn.set_child(self._make_unlock_button_content("Unlock"))
+        unlock_btn.set_tooltip_text(
+            "Authorize raw original-input capture so Keymasq can detect additional "
+            "keys and mouse buttons before remapping."
+        )
         unlock_btn.connect(
             "clicked",
             self._on_add_inputs_unlock_clicked,
@@ -1465,11 +1469,18 @@ class DeviceTab(ProfileManagedTab):
         label = "Claim" if recording_unlocked else "Unlock"
         unlock_btn.set_child(self._make_unlock_button_content(label))
         if recording_unlocked:
+            unlock_btn.set_tooltip_text(
+                "Claim this GUI as the active owner before capturing additional inputs."
+            )
             privilege_status.set_text(
                 "Unlock active in another session. Claim unlock to add additional keys and "
                 "mouse buttons."
             )
         else:
+            unlock_btn.set_tooltip_text(
+                "Authorize raw original-input capture so Keymasq can detect additional "
+                "keys and mouse buttons before remapping."
+            )
             privilege_status.set_text(
                 "Original-input capture uses privileged raw events. Unlock to add additional "
                 "keys and mouse buttons."

--- a/keymasq/gui/widgets/macro_manager_dialog.py
+++ b/keymasq/gui/widgets/macro_manager_dialog.py
@@ -594,7 +594,9 @@ class MacroManagerDialog(Adw.Dialog):
             self._record_btn.set_child(
                 self._make_button_content("channel-insecure-symbolic", "Unlock")
             )
-            self._record_btn.set_tooltip_text("Unlock recording")
+            self._record_btn.set_tooltip_text(
+                "Authorize raw original-input capture before starting live macro recording."
+            )
         else:
             self._record_btn.set_child(
                 self._make_button_content("media-record-symbolic", "Record", "error")

--- a/keymasq/gui/widgets/record_macro_dialog.py
+++ b/keymasq/gui/widgets/record_macro_dialog.py
@@ -203,6 +203,10 @@ class RecordMacroDialog(Adw.Dialog):
 
         self._unlock_btn = Gtk.Button()
         self._unlock_btn.set_child(self._make_unlock_button_content("Unlock"))
+        self._unlock_btn.set_tooltip_text(
+            "Authorize raw original-input capture before live macro recording can read "
+            "keyboard, mouse, and gamepad events."
+        )
         self._unlock_btn.connect("clicked", self._on_unlock_clicked)
         footer.append(self._unlock_btn)
 
@@ -662,6 +666,15 @@ class RecordMacroDialog(Adw.Dialog):
         self._unlock_btn.set_visible(not has_active_unlock)
         label = "Claim" if self._recording_unlocked else "Unlock"
         self._unlock_btn.set_child(self._make_unlock_button_content(label))
+        if self._recording_unlocked:
+            self._unlock_btn.set_tooltip_text(
+                "Claim this GUI as the active owner before recording macros with raw input."
+            )
+        else:
+            self._unlock_btn.set_tooltip_text(
+                "Authorize raw original-input capture before live macro recording can read "
+                "keyboard, mouse, and gamepad events."
+            )
 
     def _device_types(self, device: dict) -> list[str]:
         return normalize_input_classes(

--- a/keymasq/gui/window.py
+++ b/keymasq/gui/window.py
@@ -78,6 +78,7 @@ class MainWindow(Adw.ApplicationWindow):
         self._gui_allow_left_right_click_remap = False
         self._recording_refresh_lease_id: str = ""
         self._recording_claim_attempt_key: tuple[str, int] | None = None
+        self._unlock_request_inflight = False
         self._unlock_refresh_inflight = False
         self._placeholder_subtitle: Gtk.Label | None = None
         self._menu_unlock_btn: Gtk.Button | None = None
@@ -645,6 +646,10 @@ class MainWindow(Adw.ApplicationWindow):
 
         menu_unlock_btn = Gtk.Button(label="Unlock Recording")
         menu_unlock_btn.set_halign(Gtk.Align.FILL)
+        menu_unlock_btn.set_tooltip_text(
+            "Authorize raw original-input capture for adding inputs, combo capture, "
+            "and live macro recording. Uses Polkit and stays tied to this GUI session."
+        )
         menu_unlock_btn.connect("clicked", self._on_menu_unlock_clicked, menu_popover)
         menu_box.append(menu_unlock_btn)
         self._menu_unlock_btn = menu_unlock_btn
@@ -984,60 +989,7 @@ class MainWindow(Adw.ApplicationWindow):
         self._on_add_device(_button)
 
     def present_unlock_dialog(self, on_success=None) -> None:
-        self._present_unlock_dialog(on_success=on_success)
-
-    def _present_unlock_dialog(self, on_success=None) -> None:
-        dialog = Adw.Dialog(title="Unlock Recording", content_width=420, content_height=-1)
-        box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=12)
-        box.set_margin_top(16)
-        box.set_margin_bottom(16)
-        box.set_margin_start(16)
-        box.set_margin_end(16)
-
-        message = Gtk.Label(
-            label=(
-                "Unlock input capture while running the GUI.\n"
-                "This is used for adding additional keys and buttons, combo capture, "
-                "and macro recording."
-            )
-        )
-        message.set_wrap(True)
-        message.set_halign(Gtk.Align.START)
-        box.append(message)
-
-        remember_check = Gtk.CheckButton(label="Don't ask again for 24 hours")
-        remember_check.set_halign(Gtk.Align.START)
-        box.append(remember_check)
-
-        status_label = Gtk.Label()
-        status_label.set_halign(Gtk.Align.START)
-        status_label.add_css_class("dim-label")
-        box.append(status_label)
-
-        button_row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=8)
-        button_row.set_halign(Gtk.Align.END)
-
-        cancel_btn = Gtk.Button(label="Cancel")
-        cancel_btn.connect("clicked", self._on_close_dialog_clicked, dialog)
-        button_row.append(cancel_btn)
-
-        unlock_btn = Gtk.Button(label="Unlock")
-        unlock_btn.add_css_class("suggested-action")
-        unlock_btn.connect(
-            "clicked",
-            self._on_confirm_unlock_clicked,
-            dialog,
-            remember_check,
-            status_label,
-            unlock_btn,
-            cancel_btn,
-            on_success,
-        )
-        button_row.append(unlock_btn)
-
-        box.append(button_row)
-        dialog.set_child(box)
-        dialog.present(self)
+        self._start_recording_unlock(on_success=on_success)
 
     def _on_quit_clicked(self, _button: Gtk.Button) -> None:
         self.get_application().quit()
@@ -1045,23 +997,17 @@ class MainWindow(Adw.ApplicationWindow):
     def _on_retry_connection_clicked(self, _button: Gtk.Button) -> None:
         self._retry_connection_check()
 
-    def _on_close_dialog_clicked(self, _button: Gtk.Button, dialog: Adw.Dialog) -> None:
-        dialog.close()
+    def _start_recording_unlock(self, on_success=None) -> None:
+        if self._unlock_request_inflight:
+            return
 
-    def _on_confirm_unlock_clicked(
-        self,
-        _button: Gtk.Button,
-        dialog: Adw.Dialog,
-        remember_check: Gtk.CheckButton,
-        status_label: Gtk.Label,
-        unlock_btn: Gtk.Button,
-        cancel_btn: Gtk.Button,
-        on_success,
-    ) -> None:
-        unlock_btn.set_sensitive(False)
-        cancel_btn.set_sensitive(False)
-        remember = bool(remember_check.get_active())
-        status_label.set_label("Requesting authorization...")
+        if self.demo_mode:
+            self._show_unlock_error_dialog("Recording unlock is unavailable in demo mode.")
+            return
+
+        self._unlock_request_inflight = True
+        if self._menu_unlock_btn is not None:
+            self._menu_unlock_btn.set_sensitive(False)
 
         def worker() -> tuple[str, dict | None]:
             error_msg = ""
@@ -1088,32 +1034,21 @@ class MainWindow(Adw.ApplicationWindow):
                     or "Authorization failed"
                 )
 
-            if not error_msg and remember:
-                completed = subprocess.run(
-                    [
-                        "pkexec",
-                        helper_path,
-                        "unlock-persistent",
-                        "--uid",
-                        str(uid),
-                        "--ttl",
-                        "86400",
-                    ],
-                    capture_output=True,
-                    text=True,
-                )
-                if completed.returncode != 0:
-                    error_msg = (
-                        completed.stderr.strip()
-                        or completed.stdout.strip()
-                        or "Authorization failed"
-                    )
-
             if not error_msg:
                 claim_response = session_request(
                     {"command": "claim_recording_unlock_refresh"},
                     timeout=3.0,
                 )
+                if not isinstance(claim_response, dict):
+                    error_msg = (
+                        "Authorization succeeded, but keymasq-session did not grant "
+                        "the recording unlock lease."
+                    )
+                elif claim_response.get("status") != "ok":
+                    error_msg = str(
+                        claim_response.get("message")
+                        or "keymasq-session did not grant the recording unlock lease."
+                    )
 
             return error_msg, claim_response
 
@@ -1130,10 +1065,6 @@ class MainWindow(Adw.ApplicationWindow):
             return self._on_unlock_finished(
                 success,
                 error_msg,
-                dialog,
-                status_label,
-                unlock_btn,
-                cancel_btn,
                 on_success,
                 claim_response,
             )
@@ -1147,13 +1078,13 @@ class MainWindow(Adw.ApplicationWindow):
         self,
         success: bool,
         error_msg: str,
-        dialog: Adw.Dialog,
-        status_label: Gtk.Label,
-        unlock_btn: Gtk.Button,
-        cancel_btn: Gtk.Button,
         on_success,
         claim_response: dict | None = None,
     ) -> bool:
+        self._unlock_request_inflight = False
+        if self._menu_unlock_btn is not None:
+            self._menu_unlock_btn.set_sensitive(True)
+
         if success:
             lease_id = ""
             if isinstance(claim_response, dict) and claim_response.get("status") == "ok":
@@ -1166,16 +1097,23 @@ class MainWindow(Adw.ApplicationWindow):
             else:
                 self._update_unlock_state(None)
                 self._request_recording_refresh_lease()
-            dialog.close()
             if callable(on_success):
                 on_success()
             return False
 
-        unlock_btn.set_sensitive(True)
-        cancel_btn.set_sensitive(True)
-        status_label.set_label(error_msg or "Authorization failed")
-        status_label.add_css_class("error")
+        self._show_unlock_error_dialog(error_msg or "Authorization failed")
         return False
+
+    def _show_unlock_error_dialog(self, message: str) -> None:
+        dialog = Adw.AlertDialog(
+            heading="Unlock Failed",
+            body=(
+                message
+                or "Keymasq could not authorize raw original-input capture for this GUI."
+            ),
+        )
+        dialog.add_response("ok", "OK")
+        dialog.present(self)
 
     def _refresh_macro_menu_state(self) -> None:
         if self._menu_unlock_btn is not None:
@@ -1197,7 +1135,7 @@ class MainWindow(Adw.ApplicationWindow):
             if self._recording_unlock_source == "runtime":
                 text = "unlock: 🟢 runtime"
             elif self._recording_unlock_source == "persistent":
-                text = "unlock: 🟢 24h"
+                text = "unlock: 🟢 persistent"
             else:
                 text = "unlock: 🟢"
 

--- a/keymasq/record.py
+++ b/keymasq/record.py
@@ -8,7 +8,6 @@ from pathlib import Path
 
 from keymasq.common.recording_guard import (
     parse_unlock_expires_at,
-    persistent_unlock_path,
     resolve_unlock_status,
     runtime_unlock_path,
 )
@@ -62,17 +61,6 @@ def main() -> None:
     runtime_lock_parser = subparsers.add_parser("lock-runtime", help="Clear runtime unlock")
     runtime_lock_parser.add_argument("--uid", type=int, required=True)
 
-    persistent_unlock_parser = subparsers.add_parser(
-        "unlock-persistent", help="Set persistent unlock"
-    )
-    persistent_unlock_parser.add_argument("--uid", type=int, required=True)
-    persistent_unlock_parser.add_argument("--ttl", type=int, default=0)
-
-    persistent_lock_parser = subparsers.add_parser(
-        "lock-persistent", help="Clear persistent unlock"
-    )
-    persistent_lock_parser.add_argument("--uid", type=int, required=True)
-
     args = parser.parse_args()
 
     try:
@@ -100,17 +88,6 @@ def main() -> None:
         if args.command == "lock-runtime":
             _remove_lease(runtime_unlock_path(args.uid))
             print(json.dumps({"status": "ok", "scope": "runtime", "locked": True}))
-            return
-
-        if args.command == "unlock-persistent":
-            expires_at = 0 if int(args.ttl) == 0 else int(time.time()) + max(1, int(args.ttl))
-            _write_lease(persistent_unlock_path(args.uid), expires_at)
-            print(json.dumps({"status": "ok", "scope": "persistent", "expires_at": expires_at}))
-            return
-
-        if args.command == "lock-persistent":
-            _remove_lease(persistent_unlock_path(args.uid))
-            print(json.dumps({"status": "ok", "scope": "persistent", "locked": True}))
             return
 
         raise ValueError("Unknown command")

--- a/tests/gui/test_combo_editor_dialog.py
+++ b/tests/gui/test_combo_editor_dialog.py
@@ -17,6 +17,8 @@ class TestComboEditorDialog:
         closed: list[str] = []
         dialog.connect("closed", lambda *_args: closed.append("closed"))
 
+        assert "raw original-input capture" in (dialog.unlock_button.get_tooltip_text() or "")
+
         parent.present()
         dialog.present(parent)
         flush_gtk_events()
@@ -507,5 +509,4 @@ class TestComboEditorDialog:
         assert dialog.validation_label.get_visible() is True
         assert "could not be loaded" in dialog.validation_label.get_text().lower()
         assert dialog.save_button.get_sensitive() is False
-
 

--- a/tests/gui/test_device_tab_widget.py
+++ b/tests/gui/test_device_tab_widget.py
@@ -740,6 +740,7 @@ class TestDeviceTabWidget:
         assert start_btn.get_sensitive() is False
         assert unlock_btn.get_visible() is True
         assert "Unlock to add additional keys and mouse buttons." in privilege_status.get_text()
+        assert "raw original-input capture" in (unlock_btn.get_tooltip_text() or "")
 
         unlock_btn.emit("clicked")
         assert len(unlock_callbacks) == 1

--- a/tests/gui/test_gui_demo_and_dialogs.py
+++ b/tests/gui/test_gui_demo_and_dialogs.py
@@ -77,6 +77,7 @@ class TestRecordMacroDialog:
         )
         assert dialog._unlock_btn.get_visible() is True
         assert dialog._unlock_status.get_label() == "Unlock required"
+        assert "raw original-input capture" in (dialog._unlock_btn.get_tooltip_text() or "")
 
         dialog._apply_unlock_state(
             {
@@ -87,6 +88,7 @@ class TestRecordMacroDialog:
         )
         assert dialog._unlock_btn.get_visible() is True
         assert dialog._unlock_status.get_label() == "Unlock active in another session"
+        assert "active owner" in (dialog._unlock_btn.get_tooltip_text() or "")
 
         dialog._apply_unlock_state(
             {
@@ -692,6 +694,9 @@ class TestDialogConstruction:
 
         assert dialog.get_child() is not None
         assert callable(dialog._on_close_clicked)
+        dialog._recording_unlocked = False
+        dialog._sync_record_button_state()
+        assert "raw original-input capture" in (dialog._record_btn.get_tooltip_text() or "")
 
     def test_type_macro_builder_normalizes_common_pasted_text(self):
         gi.require_version("Gtk", "4.0")

--- a/tests/gui/test_main_window.py
+++ b/tests/gui/test_main_window.py
@@ -108,31 +108,71 @@ class TestMainWindow:
         assert add_calls == [True]
         assert unlock_calls == []
 
-    def test_main_window_unlock_dialog_copy_mentions_additional_keys(self, temp_config_dir):
-        from gi.repository import Adw, Gtk
-
+    def test_main_window_unlock_uses_runtime_polkit_without_prompt(
+        self, temp_config_dir, monkeypatch
+    ):
+        from keymasq.gui import window as window_module
+        from keymasq.gui.session_client import GuiTaskResult
         from keymasq.gui.window import MainWindow
 
         window = MainWindow(demo_mode=True)
-        presented: list[Adw.Dialog] = []
+        window.demo_mode = False
+        commands: list[list[str]] = []
+        alerts: list[object] = []
+        success_calls: list[bool] = []
 
-        def monkeypatch_present(self, root) -> None:
-            presented.append(self)
+        monkeypatch.setattr(
+            window_module,
+            "resolve_keymasq_record_helper_path",
+            lambda: "/usr/bin/keymasq-record",
+        )
+        monkeypatch.setattr(
+            window_module,
+            "run_gui_task",
+            lambda worker, callback: callback(GuiTaskResult(value=worker())),
+        )
 
-        original_present = Adw.Dialog.present
-        Adw.Dialog.present = monkeypatch_present  # type: ignore[method-assign]
-        try:
-            window._present_unlock_dialog()
-        finally:
-            Adw.Dialog.present = original_present  # type: ignore[method-assign]
+        def fake_run(cmd, capture_output, text):
+            commands.append(cmd)
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
 
-        assert len(presented) == 1
-        content = presented[0].get_child()
-        assert isinstance(content, Gtk.Box)
-        message = content.get_first_child()
-        assert isinstance(message, Gtk.Label)
-        assert "additional keys and buttons" in message.get_label()
-        assert "device setup" not in message.get_label()
+        monkeypatch.setattr(window_module.subprocess, "run", fake_run)
+        monkeypatch.setattr(
+            window_module,
+            "session_request",
+            lambda payload, timeout=3.0: {
+                "status": "ok",
+                "lease_id": "lease-1",
+                "recording_unlocked": True,
+                "recording_unlock_required": True,
+                "recording_unlock_source": "runtime",
+                "recording_unlock_expires_at": 123,
+                "recording_refresh_owner": True,
+            },
+        )
+        monkeypatch.setattr(
+            window_module.Adw.AlertDialog,
+            "present",
+            lambda self, root: alerts.append(self),
+        )
+
+        window.present_unlock_dialog(on_success=lambda: success_calls.append(True))
+
+        assert commands == [
+            [
+                "pkexec",
+                "/usr/bin/keymasq-record",
+                "unlock-runtime",
+                "--uid",
+                str(window_module.os.getuid()),
+                "--ttl",
+                "60",
+            ]
+        ]
+        assert all("unlock-persistent" not in cmd for cmd in commands)
+        assert window._recording_refresh_lease_id == "lease-1"
+        assert success_calls == [True]
+        assert alerts == []
 
     def test_main_window_syncs_manual_profile_selection_across_tabs(self, temp_config_dir):
         from keymasq.common.models import (

--- a/tests/test_record_cli.py
+++ b/tests/test_record_cli.py
@@ -97,6 +97,22 @@ def test_main_unlock_runtime_extends_previous_expiry(
     assert payload["expires_at"] == 21
 
 
+def test_main_rejects_persistent_unlock_command(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["keymasq-record", "unlock-persistent", "--uid", "1000", "--ttl", "86400"],
+    )
+
+    with pytest.raises(SystemExit) as excinfo:
+        record.main()
+
+    assert excinfo.value.code == 2
+    assert "invalid choice" in capsys.readouterr().err
+
+
 def test_main_error_emits_json_and_exits(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:


### PR DESCRIPTION
## Summary
- Replace the old 24-hour persistent recording unlock flow with a runtime Polkit-backed lease tied to the active GUI session.
- Update the main window unlock flow to request `unlock-runtime`, refresh the lease through `keymasq-session`, and show an alert on failure instead of an inline dialog.
- Refresh GUI copy and tooltips across macro, combo, and device dialogs to describe raw original-input capture more clearly.
- Remove persistent unlock commands from `keymasq-record` and update docs and tests to match the new behavior.

## Testing
- `Not run` in this environment.
- Added GUI coverage for unlock tooltips and runtime unlock behavior in the main window.
- Added CLI coverage to reject the removed `unlock-persistent` command.
- Updated dialog/widget tests to verify the new capture/unlock copy.