### PR TITLE
Add ad-hoc macro compile/play commands to the CLI

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -107,7 +107,9 @@ keymasq --json play --json < macro.json
 
 `play --json` accepts either an event list or a macro object with an `events`
 field. JSON playback uses the existing macro runtime and supports the full macro
-event schema. The compact token grammar intentionally does not support `exec`.
+event schema. Pointer moves compiled from `move_abs` and `move_rel` are semantic
+macro actions, for example `{"macro_action":"mouse_move_abs","x":100,"y":200}`.
+The compact token grammar intentionally does not support `exec`.
 
 | Option | Description |
 |---|---|

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -34,7 +34,10 @@ Compile text into a temporary keyboard macro and play it immediately.
 keymasq type "hello"
 echo "hello" | keymasq type
 keymasq type --speed 1.5 "hello"
-keymasq type --unicode "é"
+keymasq type "café"
+keymasq type "user<tab>password<enter>"
+keymasq type "user<tab><wait:100:250>password<enter>"
+keymasq type --no-unicode "café"
 keymasq type --print-json "hello"
 ```
 
@@ -43,10 +46,24 @@ keymasq type --print-json "hello"
 | `--down-ms MS` | Key down duration for each typed key. Default: `10` |
 | `--pause-ms MS` | Pause between typed characters. Default: `20` |
 | `--speed SPEED` | Playback speed multiplier. The compiler does not rewrite waits or timestamps |
-| `--unicode` | Use Linux Ctrl+Shift+U input for unsupported characters |
+| `--no-unicode` | Fail on unsupported characters instead of using Linux Ctrl+Shift+U input |
 | `--print-json` | Print the compiled macro JSON instead of playing it |
 
-When no text argument is given, `type` reads the full text from stdin.
+When no text argument is given, `type` reads the full text from stdin. By
+default, unsupported characters fall back to Linux Unicode input
+(`Ctrl+Shift+U`). Use `--no-unicode` when you want direct key events only.
+
+The type compiler supports a small set of inline controls:
+
+| Control | Description |
+|---|---|
+| `<tab>` | Press Tab |
+| `<enter>` | Press Enter |
+| `<wait:MS>` | Wait a fixed number of milliseconds |
+| `<wait:MIN:MAX>` | Wait a random number of milliseconds in the inclusive range |
+
+Use `\<` to type a literal `<`. Backslashes are otherwise treated as normal
+text, so `\\<tab>` types `\<tab>`.
 
 ### play
 
@@ -124,14 +141,18 @@ Control macro playback.
 
 ```bash
 keymasq macros list
+keymasq macros create <name> [--force] [JSON]
 keymasq macros play <name> [--speed SPEED]
+keymasq macros delete <name>
 keymasq macros cancel
 ```
 
 | Subcommand | Description |
 |---|---|
 | `list` | List available macros |
+| `create <name>` | Create a stored macro from JSON |
 | `play <name>` | Play a macro by name |
+| `delete <name>` | Delete a stored macro |
 | `cancel` | Cancel all running macro playback |
 
 **Options for `play`:**
@@ -139,6 +160,24 @@ keymasq macros cancel
 | Option | Description |
 |---|---|
 | `--speed SPEED` | Playback speed multiplier |
+
+**Options for `create`:**
+
+| Option | Description |
+|---|---|
+| `-f, --force` | Overwrite an existing macro by updating it |
+
+`macros create` reads macro JSON from stdin when no JSON argument is provided.
+It accepts either a macro object with an `events` field or a raw event list. The
+CLI-provided name is always used for the stored macro.
+
+```bash
+keymasq type "test123üäß<tab><wait:20>12345<tab><wait:20>" --print-json \
+  | keymasq macros create type_stuff
+
+keymasq play key_a wait:20 key_b --print-json \
+  | keymasq macros create demo_sequence --force
+```
 
 ### diagnostics
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -26,6 +26,80 @@ keymasq status
 keymasq --json status
 ```
 
+### type
+
+Compile text into a temporary keyboard macro and play it immediately.
+
+```bash
+keymasq type "hello"
+echo "hello" | keymasq type
+keymasq type --speed 1.5 "hello"
+keymasq type --unicode "é"
+keymasq type --print-json "hello"
+```
+
+| Option | Description |
+|---|---|
+| `--down-ms MS` | Key down duration for each typed key. Default: `10` |
+| `--pause-ms MS` | Pause between typed characters. Default: `20` |
+| `--speed SPEED` | Playback speed multiplier. The compiler does not rewrite waits or timestamps |
+| `--unicode` | Use Linux Ctrl+Shift+U input for unsupported characters |
+| `--print-json` | Print the compiled macro JSON instead of playing it |
+
+When no text argument is given, `type` reads the full text from stdin.
+
+### play
+
+Compile compact event tokens into a temporary macro and play it immediately.
+
+```bash
+keymasq play key_a
+keymasq play key_leftctrl:1 wait:20 key_c wait:20 key_leftctrl:0
+keymasq play move_abs:100:200 wait:10 btn_left
+keymasq play key_a wait:10:20 key_b
+keymasq play --speed 0.5 key_a wait:20 key_b
+keymasq play --print-json key_a wait:20 key_b
+```
+
+The compact grammar uses `:` for all parameters:
+
+| Token | Description |
+|---|---|
+| `key_a` | Tap a key: down then up |
+| `key_a:1` / `key_a:down` | Press and hold a key |
+| `key_a:0` / `key_a:up` | Release a held key |
+| `btn_left` | Click a button: down then up |
+| `btn_left:1` / `btn_left:down` | Press and hold a button |
+| `btn_left:0` / `btn_left:up` | Release a held button |
+| `move_abs:X:Y` | Move the pointer to absolute coordinates |
+| `move_rel:DX:DY` | Move the pointer relative to the current position |
+| `wait:MS` | Wait a fixed number of milliseconds |
+| `wait:MIN:MAX` | Wait a random number of milliseconds in the inclusive range |
+
+The compact compiler automatically releases any held keys/buttons at the end of
+the macro, in reverse press order. It rejects duplicate explicit presses and
+releases without matching presses.
+
+For full macro support, pass canonical macro JSON:
+
+```bash
+keymasq play --json '[{"device_type":"keyboard","type":1,"code":30,"value":1,"t_us":0}]'
+cat macro.json | keymasq play --json
+keymasq --json play --json < macro.json
+```
+
+`play --json` accepts either an event list or a macro object with an `events`
+field. JSON playback uses the existing macro runtime and supports the full macro
+event schema. The compact token grammar intentionally does not support `exec`.
+
+| Option | Description |
+|---|---|
+| `--json` | Read macro JSON instead of compact event tokens |
+| `--speed SPEED` | Playback speed multiplier. The compiler does not rewrite waits or timestamps |
+| `--print-json` | Print the compiled macro JSON instead of playing it |
+
+When no compact tokens or JSON payload are given, `play` reads from stdin.
+
 ### profiles
 
 Manage profile state.

--- a/keymasq/cli/__main__.py
+++ b/keymasq/cli/__main__.py
@@ -34,6 +34,10 @@ def _add_json_output(parser: argparse.ArgumentParser) -> None:
     )
 
 
+def _docs_url() -> str:
+    return f"https://keymasq.tools/docs/{__version__}/CLI.md"
+
+
 def main() -> None:
     ensure_uvloop()
     argv = sys.argv[1:]
@@ -41,6 +45,7 @@ def main() -> None:
     parser = argparse.ArgumentParser(
         prog="keymasq",
         description="Keymasq CLI - Key remapping tool",
+        epilog=f"Full CLI reference: {_docs_url()}",
     )
     parser.add_argument(
         "--json",
@@ -59,7 +64,17 @@ def main() -> None:
     status_parser = subparsers.add_parser("status", help="Show Keymasq runtime status")
     _add_json_output(status_parser)
 
-    type_parser = subparsers.add_parser("type", help="Type text using an ad-hoc macro")
+    type_parser = subparsers.add_parser(
+        "type",
+        help="Type text using an ad-hoc macro",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=(
+            "Inline controls: <tab>, <enter>, <wait:MS>, <wait:MIN:MAX>\n"
+            r"Use \< to type a literal <." "\n"
+            'Example: keymasq type "user<tab><wait:100:250>password<enter>"\n'
+            f"Full reference: {_docs_url()}"
+        ),
+    )
     type_parser.add_argument("text", nargs="*", help="Text to type; stdin is used when omitted")
     type_parser.add_argument("--down-ms", type=int, default=10, help="Key down duration")
     type_parser.add_argument("--pause-ms", type=int, default=20, help="Pause between characters")
@@ -75,7 +90,17 @@ def main() -> None:
         help="Print the compiled macro JSON instead of playing it",
     )
 
-    play_parser = subparsers.add_parser("play", help="Play an ad-hoc macro")
+    play_parser = subparsers.add_parser(
+        "play",
+        help="Play an ad-hoc macro",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=(
+            "Compact tokens: key_a, key_a:1, key_a:0, btn_left,\n"
+            "move_abs:X:Y, move_rel:DX:DY, wait:MS, wait:MIN:MAX\n"
+            'Example: keymasq play key_leftctrl:1 wait:20 key_c wait:20 key_leftctrl:0\n'
+            f"Full reference: {_docs_url()}"
+        ),
+    )
     play_parser.add_argument(
         "--json",
         dest="input_json",
@@ -94,7 +119,11 @@ def main() -> None:
         help="Compact event tokens or JSON payload; stdin is used when omitted",
     )
 
-    macros_parser = subparsers.add_parser("macros", help="Macro commands")
+    macros_parser = subparsers.add_parser(
+        "macros",
+        help="Macro commands",
+        epilog=f"Full reference: {_docs_url()}",
+    )
     macros_sub = macros_parser.add_subparsers(dest="macros_command", required=True)
 
     macros_list_parser = macros_sub.add_parser("list", help="List available macros")

--- a/keymasq/cli/__main__.py
+++ b/keymasq/cli/__main__.py
@@ -6,19 +6,35 @@ from keymasq.cli.commands import (
     cancel_macro_cli,
     list_macros_cli,
     list_profiles_cli,
+    play_adhoc_cli,
     play_macro_cli,
     set_diagnostics_cli,
     set_profile_state_cli,
     status_cli,
+    type_cli,
 )
 from keymasq.common.asyncio_runtime import ensure_uvloop
+
+
+def _positive_float(value: str) -> float:
+    parsed = float(value)
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError("must be greater than 0")
+    return parsed
+
+
+def _add_json_output(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--json",
+        dest="json_output",
+        action="store_true",
+        help="Print raw session response as JSON",
+    )
 
 
 def main() -> None:
     ensure_uvloop()
     argv = sys.argv[1:]
-    json_output = "--json" in argv
-    argv = [arg for arg in argv if arg != "--json"]
 
     parser = argparse.ArgumentParser(
         prog="keymasq",
@@ -26,6 +42,7 @@ def main() -> None:
     )
     parser.add_argument(
         "--json",
+        dest="global_json",
         action="store_true",
         help="Print raw session response as JSON",
     )
@@ -37,18 +54,62 @@ def main() -> None:
 
     subparsers = parser.add_subparsers(dest="command", help="Available commands")
 
-    subparsers.add_parser("status", help="Show Keymasq runtime status")
+    status_parser = subparsers.add_parser("status", help="Show Keymasq runtime status")
+    _add_json_output(status_parser)
+
+    type_parser = subparsers.add_parser("type", help="Type text using an ad-hoc macro")
+    type_parser.add_argument("text", nargs="*", help="Text to type; stdin is used when omitted")
+    type_parser.add_argument("--down-ms", type=int, default=10, help="Key down duration")
+    type_parser.add_argument("--pause-ms", type=int, default=20, help="Pause between characters")
+    type_parser.add_argument(
+        "--unicode",
+        action="store_true",
+        help="Use Linux Ctrl+Shift+U input for unsupported characters",
+    )
+    type_parser.add_argument("--speed", type=_positive_float, default=1.0, help="Playback speed")
+    type_parser.add_argument(
+        "--print-json",
+        action="store_true",
+        help="Print the compiled macro JSON instead of playing it",
+    )
+
+    play_parser = subparsers.add_parser("play", help="Play an ad-hoc macro")
+    play_parser.add_argument(
+        "--json",
+        dest="input_json",
+        action="store_true",
+        help="Read canonical macro JSON instead of compact event tokens",
+    )
+    play_parser.add_argument("--speed", type=_positive_float, default=1.0, help="Playback speed")
+    play_parser.add_argument(
+        "--print-json",
+        action="store_true",
+        help="Print the compiled macro JSON instead of playing it",
+    )
+    play_parser.add_argument(
+        "events",
+        nargs="*",
+        help="Compact event tokens or JSON payload; stdin is used when omitted",
+    )
 
     macros_parser = subparsers.add_parser("macros", help="Macro commands")
     macros_sub = macros_parser.add_subparsers(dest="macros_command", required=True)
 
-    macros_sub.add_parser("list", help="List available macros")
+    macros_list_parser = macros_sub.add_parser("list", help="List available macros")
+    _add_json_output(macros_list_parser)
 
-    play_parser = macros_sub.add_parser("play", help="Play a macro by name")
-    play_parser.add_argument("name", help="Macro name")
-    play_parser.add_argument("--speed", type=float, default=1.0, help="Playback speed")
+    macros_play_parser = macros_sub.add_parser("play", help="Play a macro by name")
+    macros_play_parser.add_argument("name", help="Macro name")
+    macros_play_parser.add_argument(
+        "--speed",
+        type=_positive_float,
+        default=1.0,
+        help="Playback speed",
+    )
+    _add_json_output(macros_play_parser)
 
-    macros_sub.add_parser("cancel", help="Cancel running macro playback")
+    macros_cancel_parser = macros_sub.add_parser("cancel", help="Cancel running macro playback")
+    _add_json_output(macros_cancel_parser)
 
     diagnostics_parser = subparsers.add_parser("diagnostics", help="Toggle keymasqd diagnostics")
     diagnostics_parser.add_argument("state", choices=["on", "off"], help="Enable or disable")
@@ -58,26 +119,54 @@ def main() -> None:
         default=5.0,
         help="Logging interval in seconds when enabled",
     )
+    _add_json_output(diagnostics_parser)
 
     profiles_parser = subparsers.add_parser("profiles", help="Profile management")
     profiles_sub = profiles_parser.add_subparsers(dest="profiles_command", required=True)
 
-    profiles_sub.add_parser("list", help="Show devices and profiles overview")
+    profiles_list_parser = profiles_sub.add_parser(
+        "list",
+        help="Show devices and profiles overview",
+    )
+    _add_json_output(profiles_list_parser)
 
     enable_parser = profiles_sub.add_parser("enable", help="Enable a profile")
     enable_parser.add_argument("profile_name", help="Profile name")
+    _add_json_output(enable_parser)
 
     disable_parser = profiles_sub.add_parser("disable", help="Disable a profile")
     disable_parser.add_argument("profile_name", help="Profile name")
+    _add_json_output(disable_parser)
 
     toggle_parser = profiles_sub.add_parser("toggle", help="Toggle profile enabled state")
     toggle_parser.add_argument("profile_name", help="Profile name")
+    _add_json_output(toggle_parser)
 
     args = parser.parse_args(argv)
-    json_output = json_output or bool(args.json)
+    json_output = bool(getattr(args, "global_json", False)) or bool(
+        getattr(args, "json_output", False)
+    )
 
     if args.command == "status":
         status_cli(json_output=json_output)
+    elif args.command == "type":
+        type_cli(
+            args.text,
+            down_ms=args.down_ms,
+            pause_ms=args.pause_ms,
+            speed=args.speed,
+            use_unicode_input=args.unicode,
+            print_json=args.print_json,
+            json_output=json_output,
+        )
+    elif args.command == "play":
+        play_adhoc_cli(
+            args.events,
+            input_json=args.input_json,
+            speed=args.speed,
+            print_json=args.print_json,
+            json_output=json_output,
+        )
     elif args.command == "macros":
         if args.macros_command == "list":
             list_macros_cli(json_output=json_output)

--- a/keymasq/cli/__main__.py
+++ b/keymasq/cli/__main__.py
@@ -4,6 +4,8 @@ import sys
 from keymasq import __version__
 from keymasq.cli.commands import (
     cancel_macro_cli,
+    create_macro_cli,
+    delete_macro_cli,
     list_macros_cli,
     list_profiles_cli,
     play_adhoc_cli,
@@ -62,9 +64,9 @@ def main() -> None:
     type_parser.add_argument("--down-ms", type=int, default=10, help="Key down duration")
     type_parser.add_argument("--pause-ms", type=int, default=20, help="Pause between characters")
     type_parser.add_argument(
-        "--unicode",
+        "--no-unicode",
         action="store_true",
-        help="Use Linux Ctrl+Shift+U input for unsupported characters",
+        help="Fail on unsupported characters instead of using Linux Ctrl+Shift+U input",
     )
     type_parser.add_argument("--speed", type=_positive_float, default=1.0, help="Playback speed")
     type_parser.add_argument(
@@ -98,6 +100,21 @@ def main() -> None:
     macros_list_parser = macros_sub.add_parser("list", help="List available macros")
     _add_json_output(macros_list_parser)
 
+    macros_create_parser = macros_sub.add_parser("create", help="Create a macro from JSON")
+    macros_create_parser.add_argument("name", help="Macro name")
+    macros_create_parser.add_argument(
+        "json",
+        nargs="*",
+        help="Macro JSON payload; stdin is used when omitted",
+    )
+    macros_create_parser.add_argument(
+        "-f",
+        "--force",
+        action="store_true",
+        help="Overwrite an existing macro",
+    )
+    _add_json_output(macros_create_parser)
+
     macros_play_parser = macros_sub.add_parser("play", help="Play a macro by name")
     macros_play_parser.add_argument("name", help="Macro name")
     macros_play_parser.add_argument(
@@ -110,6 +127,10 @@ def main() -> None:
 
     macros_cancel_parser = macros_sub.add_parser("cancel", help="Cancel running macro playback")
     _add_json_output(macros_cancel_parser)
+
+    macros_delete_parser = macros_sub.add_parser("delete", help="Delete a macro")
+    macros_delete_parser.add_argument("name", help="Macro name")
+    _add_json_output(macros_delete_parser)
 
     diagnostics_parser = subparsers.add_parser("diagnostics", help="Toggle keymasqd diagnostics")
     diagnostics_parser.add_argument("state", choices=["on", "off"], help="Enable or disable")
@@ -155,7 +176,7 @@ def main() -> None:
             down_ms=args.down_ms,
             pause_ms=args.pause_ms,
             speed=args.speed,
-            use_unicode_input=args.unicode,
+            use_unicode_input=not args.no_unicode,
             print_json=args.print_json,
             json_output=json_output,
         )
@@ -170,10 +191,19 @@ def main() -> None:
     elif args.command == "macros":
         if args.macros_command == "list":
             list_macros_cli(json_output=json_output)
+        elif args.macros_command == "create":
+            create_macro_cli(
+                args.name,
+                args.json,
+                force=args.force,
+                json_output=json_output,
+            )
         elif args.macros_command == "play":
             play_macro_cli(args.name, args.speed, json_output=json_output)
         elif args.macros_command == "cancel":
             cancel_macro_cli(json_output=json_output)
+        elif args.macros_command == "delete":
+            delete_macro_cli(args.name, json_output=json_output)
     elif args.command == "diagnostics":
         set_diagnostics_cli(args.state == "on", args.interval, json_output=json_output)
     elif args.command == "profiles":

--- a/keymasq/cli/commands.py
+++ b/keymasq/cli/commands.py
@@ -3,9 +3,17 @@ import socket
 import sys
 from typing import Any, cast
 
+from keymasq.common.macro_compile import (
+    build_compact_macro_events,
+    build_macro_payload,
+    build_type_macro_events,
+    macro_definition_from_events,
+    parse_macro_json,
+)
 from keymasq.common.paths import SESSION_SOCKET_PATH
 
 JsonObject = dict[str, Any]
+IntLike = int | float | str | bytes
 
 
 def _session_unavailable() -> JsonObject:
@@ -172,6 +180,87 @@ def play_macro_cli(name: str, speed: float = 1.0, *, json_output: bool = False) 
     print(f"Played macro: {name}")
 
 
+def type_cli(
+    text_parts: list[str],
+    *,
+    down_ms: int = 10,
+    pause_ms: int = 20,
+    speed: float = 1.0,
+    use_unicode_input: bool = False,
+    print_json: bool = False,
+    json_output: bool = False,
+) -> None:
+    text = " ".join(text_parts) if text_parts else _read_stdin_or_exit("No text provided")
+    try:
+        events = build_type_macro_events(
+            text,
+            max(1, int(down_ms)),
+            max(0, int(pause_ms)),
+            use_unicode_input=use_unicode_input,
+        )
+    except ValueError as exc:
+        print(f"Error: {exc}")
+        sys.exit(1)
+
+    if print_json:
+        _print_json(macro_definition_from_events(events, device_types=["keyboard"]))
+        return
+
+    payload = build_macro_payload(events, speed=float(speed))
+    result = _request_or_error({"command": "play_macro_payload", **payload})
+    if _handled_json_or_error(result, json_output):
+        return
+    print(f"Played type macro: {len(text)} chars")
+
+
+def play_adhoc_cli(
+    tokens: list[str],
+    *,
+    input_json: bool = False,
+    speed: float = 1.0,
+    print_json: bool = False,
+    json_output: bool = False,
+) -> None:
+    try:
+        if input_json:
+            macro_data = parse_macro_json(_json_input_from_args_or_stdin(tokens))
+            raw_events = macro_data.get("events", [])
+            if not isinstance(raw_events, list):
+                raise ValueError("macro JSON events must be a list")
+            events = [cast(JsonObject, event) for event in raw_events if isinstance(event, dict)]
+            payload = build_macro_payload(
+                events,
+                name=str(macro_data.get("name", "") or ""),
+                speed=float(speed),
+                loop_mode=str(macro_data.get("loop_mode", "none") or "none"),
+                loop_count=int(cast(IntLike, macro_data.get("loop_count", 1) or 1)),
+                loop_stop_behavior=str(
+                    macro_data.get("loop_stop_behavior", "finish_run") or "finish_run"
+                ),
+                move_to_start=bool(macro_data.get("move_to_start", False)),
+                start_x=int(cast(IntLike, macro_data.get("start_x", 0) or 0)),
+                start_y=int(cast(IntLike, macro_data.get("start_y", 0) or 0)),
+                block_mouse_movement=bool(macro_data.get("block_mouse_movement", False)),
+            )
+        else:
+            event_tokens = tokens or _read_stdin_tokens_or_exit("No macro events provided")
+            events = build_compact_macro_events(event_tokens)
+            payload = build_macro_payload(events, speed=float(speed))
+    except (TypeError, ValueError, json.JSONDecodeError) as exc:
+        print(f"Error: {exc}")
+        sys.exit(1)
+
+    if print_json:
+        _print_json(macro_definition_from_events(cast(list[JsonObject], payload["macro_events"])))
+        return
+
+    result = _request_or_error({"command": "play_macro_payload", **payload})
+    if _handled_json_or_error(result, json_output):
+        return
+    event_count = len(cast(list[JsonObject], payload["macro_events"]))
+    print(f"Played ad-hoc macro: {event_count} events")
+
+
 def cancel_macro_cli(*, json_output: bool = False) -> None:
     result = _request_or_error({"command": "cancel_macro_playback"})
     if _handled_json_or_error(result, json_output):
@@ -181,6 +270,28 @@ def cancel_macro_cli(*, json_output: bool = False) -> None:
         print("Cancelled running macro playback")
     else:
         print("No macro playback was running")
+
+
+def _read_stdin_or_exit(message: str) -> str:
+    if sys.stdin.isatty():
+        print(f"Error: {message}")
+        sys.exit(1)
+    return sys.stdin.read()
+
+
+def _read_stdin_tokens_or_exit(message: str) -> list[str]:
+    text = _read_stdin_or_exit(message)
+    tokens = text.split()
+    if not tokens:
+        print(f"Error: {message}")
+        sys.exit(1)
+    return tokens
+
+
+def _json_input_from_args_or_stdin(parts: list[str]) -> str:
+    if parts:
+        return " ".join(parts)
+    return _read_stdin_or_exit("No macro JSON provided")
 
 
 def set_diagnostics_cli(

--- a/keymasq/cli/commands.py
+++ b/keymasq/cli/commands.py
@@ -180,13 +180,45 @@ def play_macro_cli(name: str, speed: float = 1.0, *, json_output: bool = False) 
     print(f"Played macro: {name}")
 
 
+def create_macro_cli(
+    name: str,
+    json_parts: list[str],
+    *,
+    force: bool = False,
+    json_output: bool = False,
+) -> None:
+    try:
+        macro = _macro_definition_from_json_input(name, json_parts)
+    except (TypeError, ValueError, json.JSONDecodeError) as exc:
+        print(f"Error: {exc}")
+        sys.exit(1)
+
+    command = "update_macro" if force else "create_macro"
+    request: JsonObject = {"command": command, "macro": macro}
+    if force:
+        request["name"] = name
+
+    result = _request_or_error(request)
+    if _handled_json_or_error(result, json_output):
+        return
+    action = "Updated" if force else "Created"
+    print(f"{action} macro: {name}")
+
+
+def delete_macro_cli(name: str, *, json_output: bool = False) -> None:
+    result = _request_or_error({"command": "delete_macro", "name": name})
+    if _handled_json_or_error(result, json_output):
+        return
+    print(f"Deleted macro: {name}")
+
+
 def type_cli(
     text_parts: list[str],
     *,
     down_ms: int = 10,
     pause_ms: int = 20,
     speed: float = 1.0,
-    use_unicode_input: bool = False,
+    use_unicode_input: bool = True,
     print_json: bool = False,
     json_output: bool = False,
 ) -> None:
@@ -292,6 +324,40 @@ def _json_input_from_args_or_stdin(parts: list[str]) -> str:
     if parts:
         return " ".join(parts)
     return _read_stdin_or_exit("No macro JSON provided")
+
+
+def _macro_definition_from_json_input(name: str, json_parts: list[str]) -> JsonObject:
+    macro_data = parse_macro_json(_json_input_from_args_or_stdin(json_parts))
+    raw_events = macro_data.get("events", [])
+    if not isinstance(raw_events, list):
+        raise ValueError("macro JSON events must be a list")
+    events = [cast(JsonObject, event) for event in raw_events if isinstance(event, dict)]
+    macro = macro_definition_from_events(
+        events,
+        name=name,
+        device_types=_macro_device_types(macro_data),
+    )
+    for key in (
+        "created_at",
+        "loop_mode",
+        "loop_count",
+        "loop_stop_behavior",
+        "move_to_start",
+        "start_x",
+        "start_y",
+        "block_mouse_movement",
+        "gap_notes",
+    ):
+        if key in macro_data:
+            macro[key] = macro_data[key]
+    return macro
+
+
+def _macro_device_types(macro_data: JsonObject) -> list[str] | None:
+    raw_device_types = macro_data.get("device_types")
+    if not isinstance(raw_device_types, list):
+        return None
+    return [str(device_type) for device_type in raw_device_types if str(device_type)]
 
 
 def set_diagnostics_cli(

--- a/keymasq/common/macro_compile.py
+++ b/keymasq/common/macro_compile.py
@@ -62,27 +62,36 @@ def build_type_macro_events(
         if use_unicode_input
         else normalize_type_macro_text(text)
     )
+    tokens = _type_macro_tokens(normalized)
 
-    for i, ch in enumerate(normalized):
-        try:
-            code, needs_shift = char_to_key(ch)
-        except ValueError as exc:
-            if use_unicode_input:
-                t_us = _append_unicode_char_events(
-                    events,
-                    ch,
-                    t_us,
-                    down_ms,
-                    modifier_settle_us,
-                )
-                if i < len(normalized) - 1 and pause_ms > 0:
-                    t_us += pause_ms * 1000
-                continue
+    for i, (kind, value) in enumerate(tokens):
+        if kind == "wait":
+            _append_wait_event(events, value.split(":"), t_us)
+            continue
 
-            char_name = unicodedata.name(ch, "UNKNOWN")
-            raise ValueError(
-                f"Unsupported character at position {i + 1}: {ch!r} ({char_name})"
-            ) from exc
+        if kind == "key":
+            code, needs_shift = char_to_key(value)
+        else:
+            ch = value
+            try:
+                code, needs_shift = char_to_key(ch)
+            except ValueError as exc:
+                if use_unicode_input:
+                    t_us = _append_unicode_char_events(
+                        events,
+                        ch,
+                        t_us,
+                        down_ms,
+                        modifier_settle_us,
+                    )
+                    if _should_add_type_pause(tokens, i, pause_ms):
+                        t_us += pause_ms * 1000
+                    continue
+
+                char_name = unicodedata.name(ch, "UNKNOWN")
+                raise ValueError(
+                    f"Unsupported character at position {i + 1}: {ch!r} ({char_name})"
+                ) from exc
 
         t_us = _append_direct_key_events(
             events,
@@ -93,10 +102,55 @@ def build_type_macro_events(
             modifier_settle_us,
         )
 
-        if i < len(normalized) - 1 and pause_ms > 0:
+        if _should_add_type_pause(tokens, i, pause_ms):
             t_us += pause_ms * 1000
 
     return events
+
+
+def _type_macro_tokens(text: str) -> list[tuple[str, str]]:
+    tokens: list[tuple[str, str]] = []
+    index = 0
+    while index < len(text):
+        if text.startswith(r"\<", index):
+            tokens.append(("char", "<"))
+            index += 2
+            continue
+
+        if text[index] != "<":
+            tokens.append(("char", text[index]))
+            index += 1
+            continue
+
+        end = text.find(">", index + 1)
+        if end < 0:
+            tokens.append(("char", text[index]))
+            index += 1
+            continue
+
+        raw_tag = text[index + 1 : end]
+        tag = raw_tag.strip().lower()
+        if tag == "enter":
+            tokens.append(("key", "\n"))
+            index = end + 1
+            continue
+        if tag == "tab":
+            tokens.append(("key", "\t"))
+            index = end + 1
+            continue
+        if tag.startswith("wait:"):
+            tokens.append(("wait", tag.removeprefix("wait:")))
+            index = end + 1
+            continue
+
+        tokens.extend(("char", ch) for ch in text[index : end + 1])
+        index = end + 1
+
+    return tokens
+
+
+def _should_add_type_pause(tokens: list[tuple[str, str]], index: int, pause_ms: int) -> bool:
+    return pause_ms > 0 and index < len(tokens) - 1 and tokens[index + 1][0] != "wait"
 
 
 def can_type_directly(ch: str) -> bool:
@@ -319,10 +373,7 @@ def macro_definition_from_events(
     device_types: list[str] | None = None,
 ) -> JsonObject:
     inferred_device_types = device_types or _infer_device_types(events)
-    duration_ms = (
-        max((int(cast(IntLike, event.get("t_us", 0))) for event in events), default=0)
-        // 1000
-    )
+    duration_ms = max((_event_end_us(event) for event in events), default=0) // 1000
     data: JsonObject = {
         "duration_ms": duration_ms,
         "device_types": inferred_device_types,
@@ -331,6 +382,16 @@ def macro_definition_from_events(
     if name:
         data["name"] = name
     return data
+
+
+def _event_end_us(event: JsonObject) -> int:
+    t_us = int(cast(IntLike, event.get("t_us", 0)))
+    action = str(event.get("macro_action", "") or "")
+    if action == "wait_fixed":
+        return t_us + int(cast(IntLike, event.get("duration_ms", 0))) * 1000
+    if action == "wait_random":
+        return t_us + int(cast(IntLike, event.get("max_ms", 0))) * 1000
+    return t_us
 
 
 def _append_key_event(

--- a/keymasq/common/macro_compile.py
+++ b/keymasq/common/macro_compile.py
@@ -230,7 +230,6 @@ def build_compact_macro_events(tokens: list[str]) -> list[JsonObject]:
     held_order: list[tuple[str, int]] = []
     t_us = 0
     sequence_step_us = 1
-    move_seq = 0
 
     def advance_sequence() -> None:
         nonlocal t_us
@@ -257,12 +256,10 @@ def build_compact_macro_events(tokens: list[str]) -> list[JsonObject]:
                 raise ValueError(f"{name} requires x and y arguments")
             x = _parse_int(args[0], f"{name} x")
             y = _parse_int(args[1], f"{name} y")
-            move_id = f"cli{move_seq}"
-            move_seq += 1
             if name == "move_abs":
-                _append_abs_move_events(events, x, y, t_us, move_id)
+                _append_mouse_move_event(events, "mouse_move_abs", x, y, t_us)
             else:
-                _append_rel_move_events(events, x, y, t_us, move_id)
+                _append_mouse_move_event(events, "mouse_move_rel", x, y, t_us)
             advance_sequence()
             continue
 
@@ -517,93 +514,24 @@ def _append_wait_event(events: list[JsonObject], args: list[str], t_us: int) -> 
     raise ValueError("wait requires one duration or min:max arguments")
 
 
-def _append_abs_move_events(
+def _append_mouse_move_event(
     events: list[JsonObject],
+    action: str,
     x: int,
     y: int,
     t_us: int,
-    move_id: str,
 ) -> None:
-    events.extend(
-        [
-            {
-                "device_type": "mouse",
-                "type": evdev.ecodes.EV_REL,
-                "code": evdev.ecodes.REL_X,
-                "value": -2147483648,
-                "t_us": int(t_us),
-                "synthetic_move": True,
-                "move_id": move_id,
-                "move_mode": "abs",
-                "move_step": 0,
-            },
-            {
-                "device_type": "mouse",
-                "type": evdev.ecodes.EV_REL,
-                "code": evdev.ecodes.REL_Y,
-                "value": -2147483648,
-                "t_us": int(t_us),
-                "synthetic_move": True,
-                "move_id": move_id,
-                "move_mode": "abs",
-                "move_step": 0,
-            },
-            {
-                "device_type": "mouse",
-                "type": evdev.ecodes.EV_REL,
-                "code": evdev.ecodes.REL_X,
-                "value": int(x),
-                "t_us": int(t_us) + 1,
-                "synthetic_move": True,
-                "move_id": move_id,
-                "move_mode": "abs",
-                "move_step": 1,
-            },
-            {
-                "device_type": "mouse",
-                "type": evdev.ecodes.EV_REL,
-                "code": evdev.ecodes.REL_Y,
-                "value": int(y),
-                "t_us": int(t_us) + 1,
-                "synthetic_move": True,
-                "move_id": move_id,
-                "move_mode": "abs",
-                "move_step": 1,
-            },
-        ]
-    )
-
-
-def _append_rel_move_events(
-    events: list[JsonObject],
-    x: int,
-    y: int,
-    t_us: int,
-    move_id: str,
-) -> None:
-    events.extend(
-        [
-            {
-                "device_type": "mouse",
-                "type": evdev.ecodes.EV_REL,
-                "code": evdev.ecodes.REL_X,
-                "value": int(x),
-                "t_us": int(t_us),
-                "synthetic_move": True,
-                "move_id": move_id,
-                "move_mode": "rel",
-            },
-            {
-                "device_type": "mouse",
-                "type": evdev.ecodes.EV_REL,
-                "code": evdev.ecodes.REL_Y,
-                "value": int(y),
-                "t_us": int(t_us),
-                "synthetic_move": True,
-                "move_id": move_id,
-                "move_mode": "rel",
-            },
-        ]
+    events.append(
+        {
+            "device_type": "macro",
+            "type": 0,
+            "code": 0,
+            "value": 0,
+            "t_us": int(t_us),
+            "macro_action": action,
+            "x": int(x),
+            "y": int(y),
+        }
     )
 
 
@@ -624,6 +552,10 @@ def _parse_non_negative_int(value: str, label: str) -> int:
 def _infer_device_types(events: list[JsonObject]) -> list[str]:
     found: list[str] = []
     for event in events:
+        if str(event.get("macro_action", "") or "") in {"mouse_move_abs", "mouse_move_rel"}:
+            if "mouse" not in found:
+                found.append("mouse")
+            continue
         device_type = str(event.get("device_type", "") or "")
         if device_type and device_type != "macro" and device_type not in found:
             found.append(device_type)

--- a/keymasq/common/macro_compile.py
+++ b/keymasq/common/macro_compile.py
@@ -1,0 +1,569 @@
+import json
+import unicodedata
+from typing import cast
+
+import evdev
+
+JsonObject = dict[str, object]
+IntLike = int | float | str | bytes
+
+_TYPE_MACRO_TEXT_TRANSLATION = str.maketrans(
+    {
+        "\u00a0": " ",
+        "\u00ad": "",
+        "\u2007": " ",
+        "\u200b": "",
+        "\u200c": "",
+        "\u200d": "",
+        "\u2010": "-",
+        "\u2011": "-",
+        "\u2012": "-",
+        "\u2013": "-",
+        "\u2014": "-",
+        "\u2015": "-",
+        "\u2018": "'",
+        "\u2019": "'",
+        "\u201a": "'",
+        "\u201b": "'",
+        "\u201c": '"',
+        "\u201d": '"',
+        "\u201e": '"',
+        "\u201f": '"',
+        "\u2026": "...",
+        "\u202f": " ",
+        "\u2212": "-",
+        "\ufeff": "",
+    }
+)
+
+
+def normalize_type_macro_text(text: str) -> str:
+    normalized = unicodedata.normalize("NFKC", text)
+    normalized = normalized.replace("\r\n", "\n").replace("\r", "\n")
+    return normalized.translate(_TYPE_MACRO_TEXT_TRANSLATION)
+
+
+def normalize_unicode_type_macro_text(text: str) -> str:
+    return text.replace("\r\n", "\n").replace("\r", "\n")
+
+
+def build_type_macro_events(
+    text: str,
+    down_ms: int,
+    pause_ms: int,
+    *,
+    use_unicode_input: bool = False,
+) -> list[JsonObject]:
+    events: list[JsonObject] = []
+    t_us = 0
+    modifier_settle_us = 1_000
+    normalized = (
+        normalize_unicode_type_macro_text(text)
+        if use_unicode_input
+        else normalize_type_macro_text(text)
+    )
+
+    for i, ch in enumerate(normalized):
+        try:
+            code, needs_shift = char_to_key(ch)
+        except ValueError as exc:
+            if use_unicode_input:
+                t_us = _append_unicode_char_events(
+                    events,
+                    ch,
+                    t_us,
+                    down_ms,
+                    modifier_settle_us,
+                )
+                if i < len(normalized) - 1 and pause_ms > 0:
+                    t_us += pause_ms * 1000
+                continue
+
+            char_name = unicodedata.name(ch, "UNKNOWN")
+            raise ValueError(
+                f"Unsupported character at position {i + 1}: {ch!r} ({char_name})"
+            ) from exc
+
+        t_us = _append_direct_key_events(
+            events,
+            code,
+            needs_shift,
+            t_us,
+            down_ms,
+            modifier_settle_us,
+        )
+
+        if i < len(normalized) - 1 and pause_ms > 0:
+            t_us += pause_ms * 1000
+
+    return events
+
+
+def can_type_directly(ch: str) -> bool:
+    try:
+        char_to_key(ch)
+    except ValueError:
+        return False
+    return True
+
+
+def char_to_key(ch: str) -> tuple[int, bool]:
+    letters = "abcdefghijklmnopqrstuvwxyz"
+    if ch.lower() in letters:
+        return getattr(evdev.ecodes, f"KEY_{ch.upper()}"), ch.isupper()
+
+    digits = {
+        "1": evdev.ecodes.KEY_1,
+        "2": evdev.ecodes.KEY_2,
+        "3": evdev.ecodes.KEY_3,
+        "4": evdev.ecodes.KEY_4,
+        "5": evdev.ecodes.KEY_5,
+        "6": evdev.ecodes.KEY_6,
+        "7": evdev.ecodes.KEY_7,
+        "8": evdev.ecodes.KEY_8,
+        "9": evdev.ecodes.KEY_9,
+        "0": evdev.ecodes.KEY_0,
+    }
+    if ch in digits:
+        return digits[ch], False
+
+    specials = {
+        " ": (evdev.ecodes.KEY_SPACE, False),
+        "\n": (evdev.ecodes.KEY_ENTER, False),
+        "\t": (evdev.ecodes.KEY_TAB, False),
+        "-": (evdev.ecodes.KEY_MINUS, False),
+        "_": (evdev.ecodes.KEY_MINUS, True),
+        "=": (evdev.ecodes.KEY_EQUAL, False),
+        "+": (evdev.ecodes.KEY_EQUAL, True),
+        "[": (evdev.ecodes.KEY_LEFTBRACE, False),
+        "{": (evdev.ecodes.KEY_LEFTBRACE, True),
+        "]": (evdev.ecodes.KEY_RIGHTBRACE, False),
+        "}": (evdev.ecodes.KEY_RIGHTBRACE, True),
+        "\\": (evdev.ecodes.KEY_BACKSLASH, False),
+        "|": (evdev.ecodes.KEY_BACKSLASH, True),
+        ";": (evdev.ecodes.KEY_SEMICOLON, False),
+        ":": (evdev.ecodes.KEY_SEMICOLON, True),
+        "'": (evdev.ecodes.KEY_APOSTROPHE, False),
+        '"': (evdev.ecodes.KEY_APOSTROPHE, True),
+        ",": (evdev.ecodes.KEY_COMMA, False),
+        "<": (evdev.ecodes.KEY_COMMA, True),
+        ".": (evdev.ecodes.KEY_DOT, False),
+        ">": (evdev.ecodes.KEY_DOT, True),
+        "/": (evdev.ecodes.KEY_SLASH, False),
+        "?": (evdev.ecodes.KEY_SLASH, True),
+        "`": (evdev.ecodes.KEY_GRAVE, False),
+        "~": (evdev.ecodes.KEY_GRAVE, True),
+        "!": (evdev.ecodes.KEY_1, True),
+        "@": (evdev.ecodes.KEY_2, True),
+        "#": (evdev.ecodes.KEY_3, True),
+        "$": (evdev.ecodes.KEY_4, True),
+        "%": (evdev.ecodes.KEY_5, True),
+        "^": (evdev.ecodes.KEY_6, True),
+        "&": (evdev.ecodes.KEY_7, True),
+        "*": (evdev.ecodes.KEY_8, True),
+        "(": (evdev.ecodes.KEY_9, True),
+        ")": (evdev.ecodes.KEY_0, True),
+    }
+    if ch in specials:
+        return specials[ch]
+
+    raise ValueError(f"Unsupported character for typing macro: {ch!r}")
+
+
+def build_compact_macro_events(tokens: list[str]) -> list[JsonObject]:
+    events: list[JsonObject] = []
+    held: dict[tuple[str, int], int] = {}
+    held_order: list[tuple[str, int]] = []
+    t_us = 0
+    sequence_step_us = 1
+    move_seq = 0
+
+    def advance_sequence() -> None:
+        nonlocal t_us
+        t_us += sequence_step_us
+
+    for token in tokens:
+        token = token.strip()
+        if not token:
+            continue
+
+        parts = token.split(":")
+        name = parts[0].strip().lower()
+        args = [part.strip() for part in parts[1:]]
+        if not name or any(arg == "" for arg in args):
+            raise ValueError(f"invalid macro token: {token!r}")
+
+        if name == "wait":
+            _append_wait_event(events, args, t_us)
+            advance_sequence()
+            continue
+
+        if name in {"move_abs", "move_rel"}:
+            if len(args) != 2:
+                raise ValueError(f"{name} requires x and y arguments")
+            x = _parse_int(args[0], f"{name} x")
+            y = _parse_int(args[1], f"{name} y")
+            move_id = f"cli{move_seq}"
+            move_seq += 1
+            if name == "move_abs":
+                _append_abs_move_events(events, x, y, t_us, move_id)
+            else:
+                _append_rel_move_events(events, x, y, t_us, move_id)
+            advance_sequence()
+            continue
+
+        device_type, code = resolve_key_or_button(name)
+        if len(args) > 1:
+            raise ValueError(f"{name} accepts at most one state argument")
+
+        state = args[0].lower() if args else ""
+        held_key = (device_type, code)
+        if not state:
+            _append_key_event(events, device_type, code, 1, t_us)
+            _append_key_event(events, device_type, code, 0, t_us)
+            advance_sequence()
+            continue
+
+        if state in {"1", "down"}:
+            if held_key in held:
+                raise ValueError(f"{name} is already held")
+            _append_key_event(events, device_type, code, 1, t_us)
+            held[held_key] = 1
+            held_order.append(held_key)
+            advance_sequence()
+            continue
+
+        if state in {"0", "up"}:
+            if held_key not in held:
+                raise ValueError(f"{name} release without matching press")
+            _append_key_event(events, device_type, code, 0, t_us)
+            held.pop(held_key, None)
+            held_order.remove(held_key)
+            advance_sequence()
+            continue
+
+        raise ValueError(f"invalid state for {name}: {state!r}")
+
+    for device_type, code in reversed(held_order):
+        _append_key_event(events, device_type, code, 0, t_us)
+        t_us += sequence_step_us
+
+    return events
+
+
+def resolve_key_or_button(name: str) -> tuple[str, int]:
+    normalized = name.strip().upper()
+    if not normalized:
+        raise ValueError("empty key/button token")
+    if not (normalized.startswith("KEY_") or normalized.startswith("BTN_")):
+        if normalized.startswith("BTN"):
+            normalized = f"BTN_{normalized[3:]}"
+        else:
+            normalized = f"KEY_{normalized}"
+    normalized = normalized.replace("-", "_")
+    code = evdev.ecodes.ecodes.get(normalized)
+    if not isinstance(code, int):
+        raise ValueError(f"unknown key/button: {name}")
+    if code not in evdev.ecodes.bytype.get(evdev.ecodes.EV_KEY, {}):
+        raise ValueError(f"not an EV_KEY code: {name}")
+    device_type = "mouse" if normalized.startswith("BTN_") else "keyboard"
+    return device_type, int(code)
+
+
+def parse_macro_json(value: str) -> JsonObject:
+    decoded = json.loads(value)
+    if isinstance(decoded, list):
+        return {"events": cast(list[object], decoded)}
+    if isinstance(decoded, dict):
+        raw = cast(JsonObject, decoded)
+        if "events" in raw:
+            return raw
+        if "macro_events" in raw:
+            payload = dict(raw)
+            payload["events"] = payload.pop("macro_events")
+            return payload
+    raise ValueError("macro JSON must be an event list or macro object")
+
+
+def build_macro_payload(
+    events: list[JsonObject],
+    *,
+    name: str = "",
+    speed: float = 1.0,
+    loop_mode: str = "none",
+    loop_count: int = 1,
+    loop_stop_behavior: str = "finish_run",
+    move_to_start: bool = False,
+    start_x: int = 0,
+    start_y: int = 0,
+    block_mouse_movement: bool = False,
+) -> JsonObject:
+    return {
+        "macro_name": name,
+        "macro_events": events,
+        "speed": float(speed),
+        "loop_mode": loop_mode,
+        "loop_count": int(loop_count),
+        "loop_stop_behavior": loop_stop_behavior,
+        "move_to_start": bool(move_to_start),
+        "start_x": int(start_x),
+        "start_y": int(start_y),
+        "block_mouse_movement": bool(block_mouse_movement),
+    }
+
+
+def macro_definition_from_events(
+    events: list[JsonObject],
+    *,
+    name: str = "",
+    device_types: list[str] | None = None,
+) -> JsonObject:
+    inferred_device_types = device_types or _infer_device_types(events)
+    duration_ms = (
+        max((int(cast(IntLike, event.get("t_us", 0))) for event in events), default=0)
+        // 1000
+    )
+    data: JsonObject = {
+        "duration_ms": duration_ms,
+        "device_types": inferred_device_types,
+        "events": events,
+    }
+    if name:
+        data["name"] = name
+    return data
+
+
+def _append_key_event(
+    events: list[JsonObject],
+    device_type: str,
+    code: int,
+    value: int,
+    t_us: int,
+) -> None:
+    events.append(
+        {
+            "device_type": device_type,
+            "type": evdev.ecodes.EV_KEY,
+            "code": int(code),
+            "value": int(value),
+            "t_us": int(t_us),
+        }
+    )
+
+
+def _append_direct_key_events(
+    events: list[JsonObject],
+    code: int,
+    needs_shift: bool,
+    t_us: int,
+    down_ms: int,
+    modifier_settle_us: int,
+) -> int:
+    if needs_shift:
+        _append_key_event(events, "keyboard", evdev.ecodes.KEY_LEFTSHIFT, 1, t_us)
+        t_us += modifier_settle_us
+
+    _append_key_event(events, "keyboard", code, 1, t_us)
+    t_us += down_ms * 1000
+    _append_key_event(events, "keyboard", code, 0, t_us)
+
+    if needs_shift:
+        t_us += modifier_settle_us
+        _append_key_event(events, "keyboard", evdev.ecodes.KEY_LEFTSHIFT, 0, t_us)
+
+    return t_us
+
+
+def _append_unicode_char_events(
+    events: list[JsonObject],
+    ch: str,
+    t_us: int,
+    down_ms: int,
+    modifier_settle_us: int,
+) -> int:
+    _append_key_event(events, "keyboard", evdev.ecodes.KEY_LEFTCTRL, 1, t_us)
+    t_us += modifier_settle_us
+    _append_key_event(events, "keyboard", evdev.ecodes.KEY_LEFTSHIFT, 1, t_us)
+    t_us += modifier_settle_us
+
+    _append_key_event(events, "keyboard", evdev.ecodes.KEY_U, 1, t_us)
+    t_us += down_ms * 1000
+    _append_key_event(events, "keyboard", evdev.ecodes.KEY_U, 0, t_us)
+
+    t_us += modifier_settle_us
+    _append_key_event(events, "keyboard", evdev.ecodes.KEY_LEFTSHIFT, 0, t_us)
+    t_us += modifier_settle_us
+    _append_key_event(events, "keyboard", evdev.ecodes.KEY_LEFTCTRL, 0, t_us)
+    t_us += modifier_settle_us
+
+    for hex_digit in f"{ord(ch):x}":
+        code, needs_shift = char_to_key(hex_digit)
+        t_us = _append_direct_key_events(
+            events,
+            code,
+            needs_shift,
+            t_us,
+            down_ms,
+            modifier_settle_us,
+        )
+
+    code, needs_shift = char_to_key("\n")
+    return _append_direct_key_events(
+        events,
+        code,
+        needs_shift,
+        t_us,
+        down_ms,
+        modifier_settle_us,
+    )
+
+
+def _append_wait_event(events: list[JsonObject], args: list[str], t_us: int) -> None:
+    if len(args) == 1:
+        duration_ms = _parse_non_negative_int(args[0], "wait duration")
+        events.append(
+            {
+                "device_type": "macro",
+                "type": 0,
+                "code": 0,
+                "value": 0,
+                "t_us": int(t_us),
+                "macro_action": "wait_fixed",
+                "duration_ms": duration_ms,
+            }
+        )
+        return
+
+    if len(args) == 2:
+        min_ms = _parse_non_negative_int(args[0], "wait min")
+        max_ms = _parse_non_negative_int(args[1], "wait max")
+        if max_ms < min_ms:
+            raise ValueError("wait max must be greater than or equal to wait min")
+        events.append(
+            {
+                "device_type": "macro",
+                "type": 0,
+                "code": 0,
+                "value": 0,
+                "t_us": int(t_us),
+                "macro_action": "wait_random",
+                "min_ms": min_ms,
+                "max_ms": max_ms,
+            }
+        )
+        return
+
+    raise ValueError("wait requires one duration or min:max arguments")
+
+
+def _append_abs_move_events(
+    events: list[JsonObject],
+    x: int,
+    y: int,
+    t_us: int,
+    move_id: str,
+) -> None:
+    events.extend(
+        [
+            {
+                "device_type": "mouse",
+                "type": evdev.ecodes.EV_REL,
+                "code": evdev.ecodes.REL_X,
+                "value": -2147483648,
+                "t_us": int(t_us),
+                "synthetic_move": True,
+                "move_id": move_id,
+                "move_mode": "abs",
+                "move_step": 0,
+            },
+            {
+                "device_type": "mouse",
+                "type": evdev.ecodes.EV_REL,
+                "code": evdev.ecodes.REL_Y,
+                "value": -2147483648,
+                "t_us": int(t_us),
+                "synthetic_move": True,
+                "move_id": move_id,
+                "move_mode": "abs",
+                "move_step": 0,
+            },
+            {
+                "device_type": "mouse",
+                "type": evdev.ecodes.EV_REL,
+                "code": evdev.ecodes.REL_X,
+                "value": int(x),
+                "t_us": int(t_us) + 1,
+                "synthetic_move": True,
+                "move_id": move_id,
+                "move_mode": "abs",
+                "move_step": 1,
+            },
+            {
+                "device_type": "mouse",
+                "type": evdev.ecodes.EV_REL,
+                "code": evdev.ecodes.REL_Y,
+                "value": int(y),
+                "t_us": int(t_us) + 1,
+                "synthetic_move": True,
+                "move_id": move_id,
+                "move_mode": "abs",
+                "move_step": 1,
+            },
+        ]
+    )
+
+
+def _append_rel_move_events(
+    events: list[JsonObject],
+    x: int,
+    y: int,
+    t_us: int,
+    move_id: str,
+) -> None:
+    events.extend(
+        [
+            {
+                "device_type": "mouse",
+                "type": evdev.ecodes.EV_REL,
+                "code": evdev.ecodes.REL_X,
+                "value": int(x),
+                "t_us": int(t_us),
+                "synthetic_move": True,
+                "move_id": move_id,
+                "move_mode": "rel",
+            },
+            {
+                "device_type": "mouse",
+                "type": evdev.ecodes.EV_REL,
+                "code": evdev.ecodes.REL_Y,
+                "value": int(y),
+                "t_us": int(t_us),
+                "synthetic_move": True,
+                "move_id": move_id,
+                "move_mode": "rel",
+            },
+        ]
+    )
+
+
+def _parse_int(value: str, label: str) -> int:
+    try:
+        return int(value, 10)
+    except ValueError as exc:
+        raise ValueError(f"{label} must be an integer") from exc
+
+
+def _parse_non_negative_int(value: str, label: str) -> int:
+    parsed = _parse_int(value, label)
+    if parsed < 0:
+        raise ValueError(f"{label} must be non-negative")
+    return parsed
+
+
+def _infer_device_types(events: list[JsonObject]) -> list[str]:
+    found: list[str] = []
+    for event in events:
+        device_type = str(event.get("device_type", "") or "")
+        if device_type and device_type != "macro" and device_type not in found:
+            found.append(device_type)
+    return found

--- a/keymasq/gui/widgets/macro_editor_dialog.py
+++ b/keymasq/gui/widgets/macro_editor_dialog.py
@@ -195,14 +195,12 @@ def parse_events(
 
     EV_KEY press/release pairs → EditableEvent.
     EV_REL events → movement waveform (read-only).
-    Synthetic mouse-move REL events are parsed into EditableMove.
+    Semantic mouse-move macro actions are parsed into EditableMove.
     Any unsupported/unmatched events are preserved in passthrough_events.
     EV_SYN events are discarded.
     """
     ev_key = evdev.ecodes.EV_KEY
     ev_rel = evdev.ecodes.EV_REL
-    rel_x = evdev.ecodes.REL_X
-    rel_y = evdev.ecodes.REL_Y
 
     editable: list[EditableEvent] = []
     rel_events: list[MacroEvent] = []
@@ -210,10 +208,19 @@ def parse_events(
     editable_moves: list[EditableMove] = []
     control_events: list[EditableControl] = []
     open_presses: dict[tuple, list[int]] = {}  # (device_type, code) -> press_t_us stack
-    synthetic_rel_by_move_id: dict[str, list[MacroEvent]] = {}
 
     for ev in raw_events:
         macro_action = str(ev.get("macro_action", "") or "")
+        if macro_action in {"mouse_move_abs", "mouse_move_rel"}:
+            editable_moves.append(
+                EditableMove(
+                    mode="abs" if macro_action == "mouse_move_abs" else "rel",
+                    t_us=int(ev.get("t_us", 0)),
+                    x=int(ev.get("x", 0) or 0),
+                    y=int(ev.get("y", 0) or 0),
+                )
+            )
+            continue
         if macro_action:
             control_events.append(
                 EditableControl(
@@ -251,14 +258,7 @@ def parse_events(
             else:
                 passthrough_events.append(ev)
         elif ev["type"] == ev_rel:
-            if ev.get("synthetic_move"):
-                move_id = str(ev.get("move_id", ""))
-                if move_id:
-                    synthetic_rel_by_move_id.setdefault(move_id, []).append(ev)
-                else:
-                    passthrough_events.append(ev)
-            else:
-                rel_events.append(ev)
+            rel_events.append(ev)
         else:
             passthrough_events.append(ev)
 
@@ -273,37 +273,6 @@ def parse_events(
                     "t_us": press_t,
                 }
             )
-
-    for move_events in synthetic_rel_by_move_id.values():
-        mode = str(move_events[0].get("move_mode", "rel"))
-        if mode == "abs":
-            target_x = None
-            target_y = None
-            t_us = None
-            for ev in move_events:
-                if ev.get("move_step") == 1:
-                    if ev.get("code") == rel_x:
-                        target_x = int(ev.get("value", 0))
-                        t_us = int(ev.get("t_us", 0)) - 1
-                    elif ev.get("code") == rel_y:
-                        target_y = int(ev.get("value", 0))
-                        t_us = int(ev.get("t_us", 0)) - 1
-            if target_x is not None and target_y is not None and t_us is not None:
-                editable_moves.append(EditableMove(mode="abs", t_us=t_us, x=target_x, y=target_y))
-            else:
-                passthrough_events.extend(move_events)
-        else:
-            rel_x = next(
-                (int(e.get("value", 0)) for e in move_events if e.get("code") == rel_x), None
-            )
-            rel_y = next(
-                (int(e.get("value", 0)) for e in move_events if e.get("code") == rel_y), None
-            )
-            t_us = next((int(e.get("t_us", 0)) for e in move_events), None)
-            if rel_x is not None and rel_y is not None and t_us is not None:
-                editable_moves.append(EditableMove(mode="rel", t_us=t_us, x=rel_x, y=rel_y))
-            else:
-                passthrough_events.extend(move_events)
 
     editable.sort(key=lambda e: e.press_t_us)
     editable_moves.sort(key=lambda m: m.t_us)
@@ -321,9 +290,6 @@ def reconstruct_events(
 ) -> list[MacroEvent]:
     """Reconstruct raw event list from editable, REL and passthrough events."""
     ev_key = evdev.ecodes.EV_KEY
-    ev_rel = evdev.ecodes.EV_REL
-    rel_x = evdev.ecodes.REL_X
-    rel_y = evdev.ecodes.REL_Y
     raw: list[MacroEvent] = []
 
     for ev in editable:
@@ -348,84 +314,21 @@ def reconstruct_events(
 
     raw.extend(rel_events)
 
-    for idx, move in enumerate(editable_moves):
+    for move in editable_moves:
         if move.mode == "gap":
             continue
-        move_id = f"m{idx}"
-        if move.mode == "abs":
-            raw.extend(
-                [
-                    {
-                        "device_type": "mouse",
-                        "type": ev_rel,
-                        "code": rel_x,
-                        "value": -2147483648,
-                        "t_us": int(move.t_us),
-                        "synthetic_move": True,
-                        "move_id": move_id,
-                        "move_mode": "abs",
-                        "move_step": 0,
-                    },
-                    {
-                        "device_type": "mouse",
-                        "type": ev_rel,
-                        "code": rel_y,
-                        "value": -2147483648,
-                        "t_us": int(move.t_us),
-                        "synthetic_move": True,
-                        "move_id": move_id,
-                        "move_mode": "abs",
-                        "move_step": 0,
-                    },
-                    {
-                        "device_type": "mouse",
-                        "type": ev_rel,
-                        "code": rel_x,
-                        "value": int(move.x),
-                        "t_us": int(move.t_us) + 1,
-                        "synthetic_move": True,
-                        "move_id": move_id,
-                        "move_mode": "abs",
-                        "move_step": 1,
-                    },
-                    {
-                        "device_type": "mouse",
-                        "type": ev_rel,
-                        "code": rel_y,
-                        "value": int(move.y),
-                        "t_us": int(move.t_us) + 1,
-                        "synthetic_move": True,
-                        "move_id": move_id,
-                        "move_mode": "abs",
-                        "move_step": 1,
-                    },
-                ]
-            )
-        else:
-            raw.extend(
-                [
-                    {
-                        "device_type": "mouse",
-                        "type": ev_rel,
-                        "code": rel_x,
-                        "value": int(move.x),
-                        "t_us": int(move.t_us),
-                        "synthetic_move": True,
-                        "move_id": move_id,
-                        "move_mode": "rel",
-                    },
-                    {
-                        "device_type": "mouse",
-                        "type": ev_rel,
-                        "code": rel_y,
-                        "value": int(move.y),
-                        "t_us": int(move.t_us),
-                        "synthetic_move": True,
-                        "move_id": move_id,
-                        "move_mode": "rel",
-                    },
-                ]
-            )
+        raw.append(
+            {
+                "device_type": "macro",
+                "type": 0,
+                "code": 0,
+                "value": 0,
+                "t_us": int(move.t_us),
+                "macro_action": "mouse_move_abs" if move.mode == "abs" else "mouse_move_rel",
+                "x": int(move.x),
+                "y": int(move.y),
+            }
+        )
 
     for control in control_events:
         event = {
@@ -1813,7 +1716,7 @@ class MacroEditorDialog(Adw.Dialog):
         if self._synthetic_moves:
             self._duration_us = max(
                 self._duration_us,
-                max(m.t_us + (1 if m.mode == "abs" else 0) for m in self._synthetic_moves),
+                max(m.t_us for m in self._synthetic_moves),
             )
         if self._control_events:
             self._duration_us = max(
@@ -2777,9 +2680,7 @@ class MacroEditorDialog(Adw.Dialog):
 
     def _update_stats(self) -> None:
         duration_s = self._duration_us / 1e6
-        synthetic_count = sum(
-            4 if m.mode == "abs" else 2 for m in self._synthetic_moves if m.mode != "gap"
-        )
+        synthetic_count = sum(1 for m in self._synthetic_moves if m.mode != "gap")
         event_count = (
             len(self._events) * 2
             + len(self._rel_events)
@@ -2970,7 +2871,7 @@ class MacroEditorDialog(Adw.Dialog):
         if self._synthetic_moves:
             latest = max(
                 latest,
-                max(m.t_us + (1 if m.mode == "abs" else 0) for m in self._synthetic_moves),
+                max(m.t_us for m in self._synthetic_moves),
             )
         timed_controls = [c for c in self._control_events if self._control_affects_timing(c)]
         if timed_controls:

--- a/keymasq/gui/widgets/macro_manager_dialog.py
+++ b/keymasq/gui/widgets/macro_manager_dialog.py
@@ -4,12 +4,17 @@ gi.require_version("Gtk", "4.0")
 gi.require_version("Adw", "1")
 
 import logging
-import unicodedata
 from datetime import datetime
 
-import evdev
 from gi.repository import Adw, GLib, Gtk  # pyright: ignore[reportAttributeAccessIssue]
 
+from keymasq.common.macro_compile import (
+    build_type_macro_events,
+    can_type_directly,
+    char_to_key,
+    normalize_type_macro_text,
+    normalize_unicode_type_macro_text,
+)
 from keymasq.gui.session_client import (
     GuiTaskResult,
     JsonDict,
@@ -21,44 +26,8 @@ from keymasq.gui.session_client import (
 
 log = logging.getLogger("keymasq.gui.widgets.macro_manager_dialog")
 
-_TYPE_MACRO_TEXT_TRANSLATION = str.maketrans(
-    {
-        "\u00a0": " ",
-        "\u00ad": "",
-        "\u2007": " ",
-        "\u200b": "",
-        "\u200c": "",
-        "\u200d": "",
-        "\u2010": "-",
-        "\u2011": "-",
-        "\u2012": "-",
-        "\u2013": "-",
-        "\u2014": "-",
-        "\u2015": "-",
-        "\u2018": "'",
-        "\u2019": "'",
-        "\u201a": "'",
-        "\u201b": "'",
-        "\u201c": '"',
-        "\u201d": '"',
-        "\u201e": '"',
-        "\u201f": '"',
-        "\u2026": "...",
-        "\u202f": " ",
-        "\u2212": "-",
-        "\ufeff": "",
-    }
-)
-
-
-def _normalize_type_macro_text(text: str) -> str:
-    normalized = unicodedata.normalize("NFKC", text)
-    normalized = normalized.replace("\r\n", "\n").replace("\r", "\n")
-    return normalized.translate(_TYPE_MACRO_TEXT_TRANSLATION)
-
-
-def _normalize_unicode_type_macro_text(text: str) -> str:
-    return text.replace("\r\n", "\n").replace("\r", "\n")
+_normalize_type_macro_text = normalize_type_macro_text
+_normalize_unicode_type_macro_text = normalize_unicode_type_macro_text
 
 
 def _suggest_unique_macro_name(existing_names: set[str]) -> str:
@@ -863,199 +832,17 @@ class TypeMacroDialog(Adw.Dialog):
         *,
         use_unicode_input: bool = False,
     ) -> list[dict]:
-        events: list[dict] = []
-        t_us = 0
-        modifier_settle_us = 1_000
-        text = (
-            _normalize_unicode_type_macro_text(text)
-            if use_unicode_input
-            else _normalize_type_macro_text(text)
-        )
-
-        for i, ch in enumerate(text):
-            try:
-                code, needs_shift = self._char_to_key(ch)
-            except ValueError as exc:
-                if use_unicode_input:
-                    t_us = self._append_unicode_char_events(
-                        events,
-                        ch,
-                        t_us,
-                        down_ms,
-                        modifier_settle_us,
-                    )
-                    if i < len(text) - 1 and pause_ms > 0:
-                        t_us += pause_ms * 1000
-                    continue
-
-                char_name = unicodedata.name(ch, "UNKNOWN")
-                raise ValueError(
-                    f"Unsupported character at position {i + 1}: {ch!r} ({char_name})"
-                ) from exc
-
-            t_us = self._append_direct_key_events(
-                events,
-                code,
-                needs_shift,
-                t_us,
+        return list(
+            build_type_macro_events(
+                text,
                 down_ms,
-                modifier_settle_us,
+                pause_ms,
+                use_unicode_input=use_unicode_input,
             )
-
-            if i < len(text) - 1 and pause_ms > 0:
-                t_us += pause_ms * 1000
-
-        return events
-
-    def _append_key_event(
-        self,
-        events: list[dict],
-        code: int,
-        value: int,
-        t_us: int,
-    ) -> None:
-        events.append(
-            {
-                "device_type": "keyboard",
-                "type": evdev.ecodes.EV_KEY,
-                "code": code,
-                "value": value,
-                "t_us": t_us,
-            }
-        )
-
-    def _append_direct_key_events(
-        self,
-        events: list[dict],
-        code: int,
-        needs_shift: bool,
-        t_us: int,
-        down_ms: int,
-        modifier_settle_us: int,
-    ) -> int:
-        if needs_shift:
-            self._append_key_event(events, evdev.ecodes.KEY_LEFTSHIFT, 1, t_us)
-            t_us += modifier_settle_us
-
-        self._append_key_event(events, code, 1, t_us)
-        t_us += down_ms * 1000
-        self._append_key_event(events, code, 0, t_us)
-
-        if needs_shift:
-            t_us += modifier_settle_us
-            self._append_key_event(events, evdev.ecodes.KEY_LEFTSHIFT, 0, t_us)
-
-        return t_us
-
-    def _append_unicode_char_events(
-        self,
-        events: list[dict],
-        ch: str,
-        t_us: int,
-        down_ms: int,
-        modifier_settle_us: int,
-    ) -> int:
-        self._append_key_event(events, evdev.ecodes.KEY_LEFTCTRL, 1, t_us)
-        t_us += modifier_settle_us
-        self._append_key_event(events, evdev.ecodes.KEY_LEFTSHIFT, 1, t_us)
-        t_us += modifier_settle_us
-
-        self._append_key_event(events, evdev.ecodes.KEY_U, 1, t_us)
-        t_us += down_ms * 1000
-        self._append_key_event(events, evdev.ecodes.KEY_U, 0, t_us)
-
-        t_us += modifier_settle_us
-        self._append_key_event(events, evdev.ecodes.KEY_LEFTSHIFT, 0, t_us)
-        t_us += modifier_settle_us
-        self._append_key_event(events, evdev.ecodes.KEY_LEFTCTRL, 0, t_us)
-        t_us += modifier_settle_us
-
-        for hex_digit in f"{ord(ch):x}":
-            code, needs_shift = self._char_to_key(hex_digit)
-            t_us = self._append_direct_key_events(
-                events,
-                code,
-                needs_shift,
-                t_us,
-                down_ms,
-                modifier_settle_us,
-            )
-
-        code, needs_shift = self._char_to_key("\n")
-        return self._append_direct_key_events(
-            events,
-            code,
-            needs_shift,
-            t_us,
-            down_ms,
-            modifier_settle_us,
         )
 
     def _can_type_directly(self, ch: str) -> bool:
-        try:
-            self._char_to_key(ch)
-        except ValueError:
-            return False
-        return True
+        return can_type_directly(ch)
 
     def _char_to_key(self, ch: str) -> tuple[int, bool]:
-        letters = "abcdefghijklmnopqrstuvwxyz"
-        if ch.lower() in letters:
-            return getattr(evdev.ecodes, f"KEY_{ch.upper()}"), ch.isupper()
-
-        digits = {
-            "1": evdev.ecodes.KEY_1,
-            "2": evdev.ecodes.KEY_2,
-            "3": evdev.ecodes.KEY_3,
-            "4": evdev.ecodes.KEY_4,
-            "5": evdev.ecodes.KEY_5,
-            "6": evdev.ecodes.KEY_6,
-            "7": evdev.ecodes.KEY_7,
-            "8": evdev.ecodes.KEY_8,
-            "9": evdev.ecodes.KEY_9,
-            "0": evdev.ecodes.KEY_0,
-        }
-        if ch in digits:
-            return digits[ch], False
-
-        specials = {
-            " ": (evdev.ecodes.KEY_SPACE, False),
-            "\n": (evdev.ecodes.KEY_ENTER, False),
-            "\t": (evdev.ecodes.KEY_TAB, False),
-            "-": (evdev.ecodes.KEY_MINUS, False),
-            "_": (evdev.ecodes.KEY_MINUS, True),
-            "=": (evdev.ecodes.KEY_EQUAL, False),
-            "+": (evdev.ecodes.KEY_EQUAL, True),
-            "[": (evdev.ecodes.KEY_LEFTBRACE, False),
-            "{": (evdev.ecodes.KEY_LEFTBRACE, True),
-            "]": (evdev.ecodes.KEY_RIGHTBRACE, False),
-            "}": (evdev.ecodes.KEY_RIGHTBRACE, True),
-            "\\": (evdev.ecodes.KEY_BACKSLASH, False),
-            "|": (evdev.ecodes.KEY_BACKSLASH, True),
-            ";": (evdev.ecodes.KEY_SEMICOLON, False),
-            ":": (evdev.ecodes.KEY_SEMICOLON, True),
-            "'": (evdev.ecodes.KEY_APOSTROPHE, False),
-            '"': (evdev.ecodes.KEY_APOSTROPHE, True),
-            ",": (evdev.ecodes.KEY_COMMA, False),
-            "<": (evdev.ecodes.KEY_COMMA, True),
-            ".": (evdev.ecodes.KEY_DOT, False),
-            ">": (evdev.ecodes.KEY_DOT, True),
-            "/": (evdev.ecodes.KEY_SLASH, False),
-            "?": (evdev.ecodes.KEY_SLASH, True),
-            "`": (evdev.ecodes.KEY_GRAVE, False),
-            "~": (evdev.ecodes.KEY_GRAVE, True),
-            "!": (evdev.ecodes.KEY_1, True),
-            "@": (evdev.ecodes.KEY_2, True),
-            "#": (evdev.ecodes.KEY_3, True),
-            "$": (evdev.ecodes.KEY_4, True),
-            "%": (evdev.ecodes.KEY_5, True),
-            "^": (evdev.ecodes.KEY_6, True),
-            "&": (evdev.ecodes.KEY_7, True),
-            "*": (evdev.ecodes.KEY_8, True),
-            "(": (evdev.ecodes.KEY_9, True),
-            ")": (evdev.ecodes.KEY_0, True),
-        }
-        if ch in specials:
-            return specials[ch]
-
-        raise ValueError(f"Unsupported character for typing macro: {repr(ch)}")
+        return char_to_key(ch)

--- a/keymasq/keymasqd/daemon.py
+++ b/keymasq/keymasqd/daemon.py
@@ -60,6 +60,10 @@ class _DaemonDeviceManager(Protocol):
     recording_manager: object | None
     grabbed_devices: dict[str, list[_GrabbedDeviceRef]]
 
+    def initialize_output_devices(self) -> None: ...
+
+    def shutdown_output_devices(self) -> None: ...
+
     async def start_topology_watcher(self) -> None: ...
 
     async def stop_topology_watcher(self) -> None: ...
@@ -240,6 +244,7 @@ class Daemon:
 
         log.info(f"Starting keymasqd (socket: {SOCKET_PATH})")
 
+        self.device_manager.initialize_output_devices()
         await self.socket_server.start()
         await self.device_manager.start_topology_watcher()
 
@@ -261,6 +266,7 @@ class Daemon:
         await self.device_manager.stop_topology_watcher()
         await self.device_manager.cancel_macro_playback()
         await self.device_manager.release_all_devices()
+        self.device_manager.shutdown_output_devices()
 
         if self.socket_server:
             await self.socket_server.stop()

--- a/keymasq/keymasqd/device_manager.py
+++ b/keymasq/keymasqd/device_manager.py
@@ -5,7 +5,7 @@ import logging
 from collections import deque
 from collections.abc import AsyncIterator, Awaitable, Callable, Sequence
 from dataclasses import dataclass, field
-from typing import Protocol, cast
+from typing import Any, Protocol, cast
 
 import evdev
 
@@ -37,6 +37,7 @@ from keymasq.keymasqd.runtime import combos as runtime_combos
 from keymasq.keymasqd.runtime import grab_lifecycle as runtime_grab_lifecycle
 from keymasq.keymasqd.runtime import grabbed_device as runtime_grabbed_device
 from keymasq.keymasqd.runtime import macros as runtime_macros
+from keymasq.keymasqd.runtime import outputs as runtime_outputs
 from keymasq.keymasqd.runtime import topology as runtime_topology
 
 log = logging.getLogger("keymasqd.devices")
@@ -294,6 +295,17 @@ class DeviceManager:
         self._command_type = CommandType
         self._desired_grab_config_cls = DesiredGrabConfig
         self._device_input = _device_input
+
+    def initialize_output_devices(self) -> None:
+        runtime_outputs.create_global_uinputs(
+            cast(Any, self),
+            evdev_mod=evdev,  # pyright: ignore[reportArgumentType]
+            log=log,
+            uinput_writer=runtime_adapters.identity_uinput_writer,
+        )
+
+    def shutdown_output_devices(self) -> None:
+        runtime_outputs.destroy_global_uinputs(cast(Any, self), log=log)
 
     @property
     def active_combos(self) -> list[RuntimeCombo]:

--- a/keymasq/keymasqd/runtime/macros.py
+++ b/keymasq/keymasqd/runtime/macros.py
@@ -291,7 +291,6 @@ async def play_macro_task(
     str_value_fn = deps.str_value_fn
     uinput_writer = deps.uinput_writer
     mouse_btn_codes = frozenset(range(0x110, 0x118))
-    pending_abs_moves: dict[str, dict[str, int]] = {}
 
     if manager.verbosity >= 1:
         deps.log.debug("Macro playback started: %s", macro_name or "<unnamed>")
@@ -321,7 +320,6 @@ async def play_macro_task(
                     deps=deps,
                 )
             iterations += 1
-            pending_abs_moves.clear()
             if move_to_start:
                 await manager.set_cursor_position(int(start_x), int(start_y))
 
@@ -355,6 +353,29 @@ async def play_macro_task(
                     await asyncio_mod.sleep(remaining)
 
                 action_type = str(ev.get("macro_action", "") or "")
+                if action_type in {"mouse_move_abs", "mouse_move_rel"}:
+                    if not replay_mouse_movement:
+                        continue
+                    x = int_value_fn(ev.get("x"), 0)
+                    y = int_value_fn(ev.get("y"), 0)
+                    if action_type == "mouse_move_abs":
+                        await manager.set_cursor_position(x, y)
+                    else:
+                        uinput = manager.output_state.mouse_uinput
+                        output = uinput_writer(uinput) if uinput else None
+                        if output is not None:
+                            output.write(
+                                evdev_mod.ecodes.EV_REL,
+                                evdev_mod.ecodes.REL_X,
+                                x,
+                            )
+                            output.write(
+                                evdev_mod.ecodes.EV_REL,
+                                evdev_mod.ecodes.REL_Y,
+                                y,
+                            )
+                            output.syn()
+                    continue
                 if action_type:
                     timeline_offset_s += await run_macro_control_action(
                         manager,
@@ -368,24 +389,6 @@ async def play_macro_task(
                 event_code = int_value_fn(ev.get("code"), 0)
                 event_value = int_value_fn(ev.get("value"), 0)
                 device_type = str_value_fn(ev.get("device_type"), "other")
-
-                if (
-                    event_type == evdev_mod.ecodes.EV_REL
-                    and ev.get("synthetic_move")
-                    and ev.get("move_mode") == "abs"
-                ):
-                    move_id = str_value_fn(ev.get("move_id"), "")
-                    if move_id:
-                        slot = pending_abs_moves.setdefault(move_id, {})
-                        if ev.get("move_step") == 1:
-                            if event_code == evdev_mod.ecodes.REL_X:
-                                slot["x"] = event_value
-                            elif event_code == evdev_mod.ecodes.REL_Y:
-                                slot["y"] = event_value
-                            if "x" in slot and "y" in slot:
-                                await manager.set_cursor_position(slot["x"], slot["y"])
-                                pending_abs_moves.pop(move_id, None)
-                    continue
 
                 if event_type == evdev_mod.ecodes.EV_SYN:
                     continue

--- a/keymasq/session/manager/commands.py
+++ b/keymasq/session/manager/commands.py
@@ -13,6 +13,7 @@ from .common import (
     JsonObject,
     float_value,
     int_value,
+    json_list,
     json_object,
     str_value,
 )
@@ -417,7 +418,7 @@ async def _handle_macro_commands(
             return {"status": "error", "message": "Macro not found"}
 
         macro = runtime_recording.sanitize_macro_for_policy(manager, macro)
-        payload: JsonObject = {
+        named_payload: JsonObject = {
             "macro_name": str(macro.get("name", name) or name),
             "macro_events": macro.get("events", []),
             "replay_mouse_movement": request.get("replay_mouse_movement", True),
@@ -436,7 +437,46 @@ async def _handle_macro_commands(
 
         try:
             result = await manager.client.send_command(
-                Command(command=CommandType.PLAY_MACRO, data=payload)
+                Command(command=CommandType.PLAY_MACRO, data=named_payload)
+            )
+        except Exception:
+            return {"status": "error", "message": "Daemon unavailable"}
+        if result.status == "ok":
+            response_data = json_object(result.data)
+            return response_data if response_data else {"status": "ok"}
+        return {"status": "error", "message": result.error or "playback failed"}
+
+    if command == "play_macro_payload":
+        macro_events = [
+            event
+            for raw_event in json_list(request.get("macro_events"))
+            if (event := json_object(raw_event)) is not None
+        ]
+        if not macro_events:
+            return {"status": "error", "message": "macro_events required"}
+
+        macro = runtime_recording.sanitize_macro_for_policy(manager, {"events": macro_events})
+        sanitized_events = json_list(macro.get("events"))
+        adhoc_payload: JsonObject = {
+            "macro_name": str_value(request.get("macro_name"), ""),
+            "macro_events": sanitized_events,
+            "replay_mouse_movement": bool(request.get("replay_mouse_movement", True)),
+            "replay_mouse_clicks": bool(request.get("replay_mouse_clicks", True)),
+            "speed": float_value(request.get("speed"), 1.0),
+            "loop_mode": str_value(request.get("loop_mode", "none"), "none") or "none",
+            "loop_count": int_value(request.get("loop_count"), 1),
+            "loop_stop_behavior": normalize_macro_loop_stop_behavior(
+                request.get("loop_stop_behavior")
+            ),
+            "move_to_start": bool(request.get("move_to_start", False)),
+            "start_x": int_value(request.get("start_x"), 0),
+            "start_y": int_value(request.get("start_y"), 0),
+            "block_mouse_movement": bool(request.get("block_mouse_movement", False)),
+        }
+
+        try:
+            result = await manager.client.send_command(
+                Command(command=CommandType.PLAY_MACRO, data=adhoc_payload)
             )
         except Exception:
             return {"status": "error", "message": "Daemon unavailable"}

--- a/tests/common/test_macro_compile.py
+++ b/tests/common/test_macro_compile.py
@@ -96,6 +96,101 @@ def test_type_macro_builder_normalizes_common_pasted_text() -> None:
     assert evdev.ecodes.KEY_MINUS in press_codes
 
 
+def test_type_macro_builder_expands_enter_and_tab_controls() -> None:
+    events = build_type_macro_events("a<enter>b<tab>c", 10, 0)
+
+    press_codes = [
+        event["code"]
+        for event in events
+        if event["type"] == evdev.ecodes.EV_KEY and event["value"] == 1
+    ]
+    assert press_codes == [
+        evdev.ecodes.KEY_A,
+        evdev.ecodes.KEY_ENTER,
+        evdev.ecodes.KEY_B,
+        evdev.ecodes.KEY_TAB,
+        evdev.ecodes.KEY_C,
+    ]
+
+
+def test_type_macro_builder_adds_fixed_and_random_wait_controls() -> None:
+    events = build_type_macro_events("a<wait:10>b<wait:20:30>c", 10, 0)
+
+    waits = [event for event in events if event.get("macro_action")]
+    assert waits == [
+        {
+            "device_type": "macro",
+            "type": 0,
+            "code": 0,
+            "value": 0,
+            "t_us": 10_000,
+            "macro_action": "wait_fixed",
+            "duration_ms": 10,
+        },
+        {
+            "device_type": "macro",
+            "type": 0,
+            "code": 0,
+            "value": 0,
+            "t_us": 20_000,
+            "macro_action": "wait_random",
+            "min_ms": 20,
+            "max_ms": 30,
+        },
+    ]
+
+
+def test_type_macro_builder_keeps_backslash_sequences_literal() -> None:
+    events = build_type_macro_events(r"a\nb", 10, 0)
+
+    press_codes = [
+        event["code"]
+        for event in events
+        if event["type"] == evdev.ecodes.EV_KEY and event["value"] == 1
+    ]
+    assert press_codes == [
+        evdev.ecodes.KEY_A,
+        evdev.ecodes.KEY_BACKSLASH,
+        evdev.ecodes.KEY_N,
+        evdev.ecodes.KEY_B,
+    ]
+
+
+def test_type_macro_builder_escapes_literal_less_than_before_control() -> None:
+    events = build_type_macro_events(r"a\<tab>b\\<tab>c", 10, 0)
+
+    press_codes = [
+        event["code"]
+        for event in events
+        if event["type"] == evdev.ecodes.EV_KEY and event["value"] == 1
+    ]
+    assert press_codes == [
+        evdev.ecodes.KEY_A,
+        evdev.ecodes.KEY_LEFTSHIFT,
+        evdev.ecodes.KEY_COMMA,
+        evdev.ecodes.KEY_T,
+        evdev.ecodes.KEY_A,
+        evdev.ecodes.KEY_B,
+        evdev.ecodes.KEY_LEFTSHIFT,
+        evdev.ecodes.KEY_DOT,
+        evdev.ecodes.KEY_B,
+        evdev.ecodes.KEY_BACKSLASH,
+        evdev.ecodes.KEY_LEFTSHIFT,
+        evdev.ecodes.KEY_COMMA,
+        evdev.ecodes.KEY_T,
+        evdev.ecodes.KEY_A,
+        evdev.ecodes.KEY_B,
+        evdev.ecodes.KEY_LEFTSHIFT,
+        evdev.ecodes.KEY_DOT,
+        evdev.ecodes.KEY_C,
+    ]
+
+
+def test_type_macro_builder_rejects_invalid_wait_control() -> None:
+    with pytest.raises(ValueError, match="wait duration must be an integer"):
+        build_type_macro_events("a<wait:soon>b", 10, 0)
+
+
 def test_type_macro_builder_reports_unsupported_character_position() -> None:
     with pytest.raises(ValueError, match=r"position 2: 'é'"):
         build_type_macro_events("aé", 10, 0)

--- a/tests/common/test_macro_compile.py
+++ b/tests/common/test_macro_compile.py
@@ -51,15 +51,31 @@ def test_compact_random_wait() -> None:
     ]
 
 
-def test_compact_move_events_use_synthetic_macro_shape() -> None:
+def test_compact_move_events_use_macro_action_shape() -> None:
     events = build_compact_macro_events(["move_abs:100:200", "move_rel:-5:2"])
 
-    abs_events = [event for event in events if event.get("move_mode") == "abs"]
-    rel_events = [event for event in events if event.get("move_mode") == "rel"]
-    assert len(abs_events) == 4
-    assert len(rel_events) == 2
-    assert {event["value"] for event in abs_events if event.get("move_step") == 1} == {100, 200}
-    assert {event["value"] for event in rel_events} == {-5, 2}
+    assert events == [
+        {
+            "device_type": "macro",
+            "type": 0,
+            "code": 0,
+            "value": 0,
+            "t_us": 0,
+            "macro_action": "mouse_move_abs",
+            "x": 100,
+            "y": 200,
+        },
+        {
+            "device_type": "macro",
+            "type": 0,
+            "code": 0,
+            "value": 0,
+            "t_us": 1,
+            "macro_action": "mouse_move_rel",
+            "x": -5,
+            "y": 2,
+        },
+    ]
 
 
 def test_compact_releases_held_keys_at_end_in_reverse_order() -> None:

--- a/tests/common/test_macro_compile.py
+++ b/tests/common/test_macro_compile.py
@@ -1,0 +1,109 @@
+import json
+
+import evdev
+import pytest
+
+from keymasq.common.macro_compile import (
+    build_compact_macro_events,
+    build_type_macro_events,
+    parse_macro_json,
+)
+
+
+def _key_values(events: list[dict[str, object]], code: int) -> list[int]:
+    return [
+        int(event["value"])
+        for event in events
+        if event.get("type") == evdev.ecodes.EV_KEY and event.get("code") == code
+    ]
+
+
+def test_compact_key_token_emits_tap() -> None:
+    events = build_compact_macro_events(["key_a"])
+
+    assert _key_values(events, evdev.ecodes.KEY_A) == [1, 0]
+    assert events[0]["device_type"] == "keyboard"
+
+
+def test_compact_explicit_hold_release_and_waits() -> None:
+    events = build_compact_macro_events(["key_leftctrl:1", "wait:20", "key_c", "key_leftctrl:0"])
+
+    assert _key_values(events, evdev.ecodes.KEY_LEFTCTRL) == [1, 0]
+    assert _key_values(events, evdev.ecodes.KEY_C) == [1, 0]
+    wait = next(event for event in events if event.get("macro_action") == "wait_fixed")
+    assert wait["duration_ms"] == 20
+
+
+def test_compact_random_wait() -> None:
+    events = build_compact_macro_events(["wait:10:20"])
+
+    assert events == [
+        {
+            "device_type": "macro",
+            "type": 0,
+            "code": 0,
+            "value": 0,
+            "t_us": 0,
+            "macro_action": "wait_random",
+            "min_ms": 10,
+            "max_ms": 20,
+        }
+    ]
+
+
+def test_compact_move_events_use_synthetic_macro_shape() -> None:
+    events = build_compact_macro_events(["move_abs:100:200", "move_rel:-5:2"])
+
+    abs_events = [event for event in events if event.get("move_mode") == "abs"]
+    rel_events = [event for event in events if event.get("move_mode") == "rel"]
+    assert len(abs_events) == 4
+    assert len(rel_events) == 2
+    assert {event["value"] for event in abs_events if event.get("move_step") == 1} == {100, 200}
+    assert {event["value"] for event in rel_events} == {-5, 2}
+
+
+def test_compact_releases_held_keys_at_end_in_reverse_order() -> None:
+    events = build_compact_macro_events(["key_leftctrl:1", "key_leftshift:1"])
+
+    assert events[-2]["code"] == evdev.ecodes.KEY_LEFTSHIFT
+    assert events[-2]["value"] == 0
+    assert events[-1]["code"] == evdev.ecodes.KEY_LEFTCTRL
+    assert events[-1]["value"] == 0
+
+
+def test_compact_rejects_release_without_press() -> None:
+    with pytest.raises(ValueError, match="release without matching press"):
+        build_compact_macro_events(["key_a:0"])
+
+
+def test_compact_rejects_duplicate_down() -> None:
+    with pytest.raises(ValueError, match="already held"):
+        build_compact_macro_events(["key_a:1", "key_a:down"])
+
+
+def test_type_macro_builder_normalizes_common_pasted_text() -> None:
+    events = build_type_macro_events("A\u00a0\u201cHi\u201d\u2026\r\nx\u2014y", 10, 0)
+
+    press_codes = [
+        event["code"]
+        for event in events
+        if event["type"] == evdev.ecodes.EV_KEY and event["value"] == 1
+    ]
+    assert evdev.ecodes.KEY_SPACE in press_codes
+    assert evdev.ecodes.KEY_APOSTROPHE in press_codes
+    assert press_codes.count(evdev.ecodes.KEY_DOT) == 3
+    assert press_codes.count(evdev.ecodes.KEY_ENTER) == 1
+    assert evdev.ecodes.KEY_MINUS in press_codes
+
+
+def test_type_macro_builder_reports_unsupported_character_position() -> None:
+    with pytest.raises(ValueError, match=r"position 2: 'é'"):
+        build_type_macro_events("aé", 10, 0)
+
+
+def test_parse_macro_json_accepts_event_list_and_macro_object() -> None:
+    events_json = json.dumps([{"t_us": 0}])
+    macro_json = json.dumps({"name": "demo", "events": [{"t_us": 1}]})
+
+    assert parse_macro_json(events_json)["events"] == [{"t_us": 0}]
+    assert parse_macro_json(macro_json)["name"] == "demo"

--- a/tests/gui/test_macro_editor_parser.py
+++ b/tests/gui/test_macro_editor_parser.py
@@ -93,7 +93,7 @@ def test_parse_handles_overlapping_same_key_presses() -> None:
     assert editable[1].release_t_us == 140
 
 
-def test_parse_reconstruct_synthetic_moves_separate_from_waveform() -> None:
+def test_parse_reconstruct_macro_move_actions_separate_from_waveform() -> None:
     raw = [
         {
             "device_type": "mouse",
@@ -110,24 +110,14 @@ def test_parse_reconstruct_synthetic_moves_separate_from_waveform() -> None:
             "t_us": 100,
         },
         {
-            "device_type": "mouse",
-            "type": evdev.ecodes.EV_REL,
-            "code": evdev.ecodes.REL_X,
-            "value": 300,
+            "device_type": "macro",
+            "type": 0,
+            "code": 0,
+            "value": 0,
             "t_us": 200,
-            "synthetic_move": True,
-            "move_id": "m1",
-            "move_mode": "rel",
-        },
-        {
-            "device_type": "mouse",
-            "type": evdev.ecodes.EV_REL,
-            "code": evdev.ecodes.REL_Y,
-            "value": 200,
-            "t_us": 200,
-            "synthetic_move": True,
-            "move_id": "m1",
-            "move_mode": "rel",
+            "macro_action": "mouse_move_rel",
+            "x": 300,
+            "y": 200,
         },
     ]
 
@@ -142,7 +132,19 @@ def test_parse_reconstruct_synthetic_moves_separate_from_waveform() -> None:
     assert synthetic_moves[0].y == 200
 
     rebuilt = reconstruct_events(editable, rel_events, passthrough, synthetic_moves, control_events)
-    assert sum(1 for e in rebuilt if e.get("synthetic_move")) == 2
+    move_actions = [e for e in rebuilt if e.get("macro_action") == "mouse_move_rel"]
+    assert move_actions == [
+        {
+            "device_type": "macro",
+            "type": 0,
+            "code": 0,
+            "value": 0,
+            "t_us": 200,
+            "macro_action": "mouse_move_rel",
+            "x": 300,
+            "y": 200,
+        }
+    ]
 
 
 def test_unmatched_key_press_is_classified_for_keyboard_track() -> None:
@@ -164,5 +166,4 @@ def test_unmatched_key_press_is_classified_for_keyboard_track() -> None:
     assert control_events == []
     assert len(passthrough) == 1
     assert _passthrough_track(passthrough[0]) == "keyboard"
-
 

--- a/tests/keymasqd/daemon_support.py
+++ b/tests/keymasqd/daemon_support.py
@@ -38,6 +38,8 @@ def daemon_testbed(monkeypatch):
         cancel_macro_playback=AsyncMock(return_value={"canceled": True}),
         set_diagnostics=AsyncMock(return_value={"status": "ok"}),
         complete_macro_exec_wait=Mock(return_value={"completed": True}),
+        initialize_output_devices=Mock(return_value=None),
+        shutdown_output_devices=Mock(return_value=None),
         start_topology_watcher=AsyncMock(return_value=None),
         stop_topology_watcher=AsyncMock(return_value=None),
         release_all_devices=AsyncMock(return_value=None),

--- a/tests/keymasqd/test_daemon_capture_commands.py
+++ b/tests/keymasqd/test_daemon_capture_commands.py
@@ -311,6 +311,8 @@ async def test_start_offloads_macro_store_prep_to_thread(
     assert to_thread_calls[0][0].__name__ == "_prepare_macro_store"
     macro_store.ensure.assert_called_once()
     macro_store.register_internal.assert_called_once()
+    device_manager.initialize_output_devices.assert_called_once()
+    device_manager.shutdown_output_devices.assert_called_once()
     device_manager.start_topology_watcher.assert_awaited_once()
     device_manager.stop_topology_watcher.assert_awaited_once()
     assert device_manager.broadcast_callback == fake_socket_server.broadcast_event

--- a/tests/keymasqd/test_macro_backend_recording.py
+++ b/tests/keymasqd/test_macro_backend_recording.py
@@ -325,6 +325,41 @@ async def test_play_macro_allows_concurrent_playback() -> None:
 
 
 @pytest.mark.asyncio
+async def test_play_macro_uses_daemon_lifetime_outputs_without_active_grab(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = DeviceManager()
+    created: list[bool] = []
+    destroyed: list[bool] = []
+
+    def fake_create_global_uinputs(_manager: DeviceManager, **_kwargs: object) -> None:
+        created.append(True)
+        _manager.output_state.keyboard_uinput = MagicMock()
+        _manager.output_state.device_count += 1
+
+    def fake_destroy_global_uinputs(_manager: DeviceManager, **_kwargs: object) -> None:
+        destroyed.append(True)
+        _manager.output_state.device_count = max(0, _manager.output_state.device_count - 1)
+        if _manager.output_state.device_count == 0:
+            _manager.output_state.keyboard_uinput = None
+
+    monkeypatch.setattr(dm.runtime_outputs, "create_global_uinputs", fake_create_global_uinputs)
+    monkeypatch.setattr(dm.runtime_outputs, "destroy_global_uinputs", fake_destroy_global_uinputs)
+
+    manager.initialize_output_devices()
+    result = await manager.play_macro(macro_events=[], macro_name="adhoc")
+    await asyncio.sleep(0.02)
+
+    assert result["status"] == "ok"
+    assert created == [True]
+    assert destroyed == []
+    assert manager.output_state.keyboard_uinput is not None
+    manager.shutdown_output_devices()
+    assert destroyed == [True]
+    assert manager.output_state.keyboard_uinput is None
+
+
+@pytest.mark.asyncio
 async def test_play_macro_can_move_mouse_to_saved_start() -> None:
     manager = DeviceManager()
     manager.output_state.mouse_uinput = MagicMock()
@@ -611,7 +646,8 @@ async def test_play_macro_count_loop_repeats_events() -> None:
         loop_count=2,
     )
 
-    await asyncio.sleep(0.01)
+    if manager.macro_state.tasks:
+        await asyncio.gather(*manager.macro_state.tasks.values())
 
     press_calls = [
         c

--- a/tests/keymasqd/test_macro_backend_recording.py
+++ b/tests/keymasqd/test_macro_backend_recording.py
@@ -664,7 +664,7 @@ async def test_play_macro_count_loop_repeats_events() -> None:
 
 
 @pytest.mark.asyncio
-async def test_play_macro_handles_synthetic_abs_and_unusual_device_type_routing() -> None:
+async def test_play_macro_handles_macro_moves_and_unusual_device_type_routing() -> None:
     manager = DeviceManager()
     manager.output_state.keyboard_uinput = MagicMock()
     manager.output_state.mouse_uinput = MagicMock()
@@ -675,26 +675,24 @@ async def test_play_macro_handles_synthetic_abs_and_unusual_device_type_routing(
         instance_id=1,
         macro_events=[
             {
+                "device_type": "macro",
+                "type": 0,
+                "code": 0,
+                "value": 0,
                 "t_us": 0,
-                "type": evdev.ecodes.EV_REL,
-                "code": evdev.ecodes.REL_X,
-                "value": 320,
-                "device_type": "mouse",
-                "synthetic_move": True,
-                "move_mode": "abs",
-                "move_id": "abs-1",
-                "move_step": 1,
+                "macro_action": "mouse_move_abs",
+                "x": 320,
+                "y": 240,
             },
             {
+                "device_type": "macro",
+                "type": 0,
+                "code": 0,
+                "value": 0,
                 "t_us": 0,
-                "type": evdev.ecodes.EV_REL,
-                "code": evdev.ecodes.REL_Y,
-                "value": 240,
-                "device_type": "mouse",
-                "synthetic_move": True,
-                "move_mode": "abs",
-                "move_id": "abs-1",
-                "move_step": 1,
+                "macro_action": "mouse_move_rel",
+                "x": 7,
+                "y": -3,
             },
             {
                 "t_us": 0,
@@ -753,8 +751,8 @@ async def test_play_macro_handles_synthetic_abs_and_unusual_device_type_routing(
                 "device_type": "other",
             },
         ],
-        macro_name="synthetic",
-        replay_mouse_movement=False,
+        macro_name="macro-moves",
+        replay_mouse_movement=True,
         replay_mouse_clicks=False,
         speed=1.0,
         loop_mode="none",
@@ -771,6 +769,9 @@ async def test_play_macro_handles_synthetic_abs_and_unusual_device_type_routing(
         (evdev.ecodes.EV_KEY, evdev.ecodes.KEY_Q, 0),
     ]
     assert [call.args for call in manager.output_state.mouse_uinput.write.call_args_list] == [
+        (evdev.ecodes.EV_REL, evdev.ecodes.REL_X, 7),
+        (evdev.ecodes.EV_REL, evdev.ecodes.REL_Y, -3),
+        (evdev.ecodes.EV_REL, evdev.ecodes.REL_X, 5),
         (evdev.ecodes.EV_REL, evdev.ecodes.REL_WHEEL, -1),
         (
             evdev.ecodes.EV_REL,

--- a/tests/session/test_session_manager_command_runtime.py
+++ b/tests/session/test_session_manager_command_runtime.py
@@ -1,5 +1,6 @@
 # ruff: noqa: F403, F405, I001
 from tests.session.command_support import *
+from keymasq.common.ipc import CommandType
 
 @pytest.mark.asyncio
 async def test_handle_session_request_get_compositor_reports_kde_dispatch_availability() -> None:
@@ -137,6 +138,58 @@ async def test_get_recording_settings_uses_unlock_and_owner_state_only() -> None
     assert "authorized" not in result
     resolve_unlock_status_async.assert_awaited_once_with(manager, peer.uid)
     monkeypatch.undo()
+
+
+@pytest.mark.asyncio
+async def test_play_macro_payload_forwards_sanitized_events() -> None:
+    manager = SessionManager()
+    peer = PeerCredentials(pid=1, uid=1000, gid=1000)
+    sent_commands = []
+
+    async def send_command(command):
+        sent_commands.append(command)
+        return Response(status="ok", data={"status": "ok", "played": True})
+
+    manager.client.send_command = send_command  # type: ignore[method-assign]
+    manager.security_policy.macro_exec_timeout_max_ms = 100
+
+    result = await manager._handle_session_request(
+        {
+            "command": "play_macro_payload",
+            "macro_events": [
+                {
+                    "device_type": "macro",
+                    "macro_action": "exec_sync",
+                    "timeout_ms": 999,
+                    "t_us": 0,
+                }
+            ],
+            "speed": 1.5,
+        },
+        "client",
+        peer,
+        object(),
+    )
+
+    assert result == {"status": "ok", "played": True}
+    assert sent_commands[0].command == CommandType.PLAY_MACRO
+    assert sent_commands[0].data["speed"] == 1.5
+    assert sent_commands[0].data["macro_events"][0]["timeout_ms"] == 100
+
+
+@pytest.mark.asyncio
+async def test_play_macro_payload_requires_events() -> None:
+    manager = SessionManager()
+    peer = PeerCredentials(pid=1, uid=1000, gid=1000)
+
+    result = await manager._handle_session_request(
+        {"command": "play_macro_payload", "macro_events": []},
+        "client",
+        peer,
+        object(),
+    )
+
+    assert result == {"status": "error", "message": "macro_events required"}
 
 
 @pytest.mark.asyncio

--- a/tests/test_cli_commands_helpers.py
+++ b/tests/test_cli_commands_helpers.py
@@ -109,3 +109,73 @@ def test_set_diagnostics_cli_exits_on_error(monkeypatch: pytest.MonkeyPatch) -> 
         commands.set_diagnostics_cli(True, interval=3.0)
 
     assert excinfo.value.code == 1
+
+
+def test_type_cli_compiles_and_sends_payload(monkeypatch: pytest.MonkeyPatch) -> None:
+    sent: list[dict[str, object]] = []
+
+    def _session_request(payload: dict[str, object]) -> dict[str, object]:
+        sent.append(payload)
+        return {"status": "ok"}
+
+    monkeypatch.setattr(commands, "_session_request", _session_request)
+
+    commands.type_cli(["Hi"], speed=1.5)
+
+    payload = sent[0]
+    assert payload["command"] == "play_macro_payload"
+    assert payload["speed"] == 1.5
+    assert len(payload["macro_events"]) > 0
+
+
+def test_play_adhoc_cli_compiles_compact_tokens(monkeypatch: pytest.MonkeyPatch) -> None:
+    sent: list[dict[str, object]] = []
+
+    def _session_request(payload: dict[str, object]) -> dict[str, object]:
+        sent.append(payload)
+        return {"status": "ok"}
+
+    monkeypatch.setattr(commands, "_session_request", _session_request)
+
+    commands.play_adhoc_cli(["key_a", "wait:10:20", "btn_left"], speed=0.5)
+
+    payload = sent[0]
+    assert payload["command"] == "play_macro_payload"
+    assert payload["speed"] == 0.5
+    events = payload["macro_events"]
+    assert isinstance(events, list)
+    assert any(event.get("macro_action") == "wait_random" for event in events)
+
+
+def test_play_adhoc_cli_reads_json_payload(monkeypatch: pytest.MonkeyPatch) -> None:
+    sent: list[dict[str, object]] = []
+
+    def _session_request(payload: dict[str, object]) -> dict[str, object]:
+        sent.append(payload)
+        return {"status": "ok"}
+
+    monkeypatch.setattr(commands, "_session_request", _session_request)
+
+    commands.play_adhoc_cli(
+        ['{"events":[{"device_type":"keyboard","type":1,"code":30,"value":1,"t_us":0}]}'],
+        input_json=True,
+    )
+
+    payload = sent[0]
+    assert payload["command"] == "play_macro_payload"
+    assert payload["macro_events"] == [
+        {"device_type": "keyboard", "type": 1, "code": 30, "value": 1, "t_us": 0}
+    ]
+
+
+def test_play_adhoc_cli_print_json_does_not_send(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr(commands, "_session_request", lambda payload: pytest.fail("sent request"))
+
+    commands.play_adhoc_cli(["key_a"], print_json=True)
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["device_types"] == ["keyboard"]
+    assert len(payload["events"]) == 2

--- a/tests/test_cli_commands_helpers.py
+++ b/tests/test_cli_commands_helpers.py
@@ -1,5 +1,6 @@
 import json
 
+import evdev
 import pytest
 
 from keymasq.cli import commands
@@ -44,6 +45,59 @@ def test_list_macros_cli_json_prints_response(
 
     payload = json.loads(capsys.readouterr().out)
     assert payload == {"status": "ok", "macros": [{"name": "combo"}]}
+
+
+def test_create_macro_cli_sends_create_payload(monkeypatch: pytest.MonkeyPatch) -> None:
+    sent: list[dict[str, object]] = []
+
+    def _session_request(payload: dict[str, object]) -> dict[str, object]:
+        sent.append(payload)
+        return {"status": "ok"}
+
+    monkeypatch.setattr(commands, "_session_request", _session_request)
+
+    commands.create_macro_cli("stored", ['{"events":[{"device_type":"keyboard","t_us":0}]}'])
+
+    payload = sent[0]
+    assert payload["command"] == "create_macro"
+    macro = payload["macro"]
+    assert isinstance(macro, dict)
+    assert macro["name"] == "stored"
+    assert macro["device_types"] == ["keyboard"]
+    assert macro["events"] == [{"device_type": "keyboard", "t_us": 0}]
+
+
+def test_create_macro_cli_force_sends_update_payload(monkeypatch: pytest.MonkeyPatch) -> None:
+    sent: list[dict[str, object]] = []
+
+    def _session_request(payload: dict[str, object]) -> dict[str, object]:
+        sent.append(payload)
+        return {"status": "ok"}
+
+    monkeypatch.setattr(commands, "_session_request", _session_request)
+
+    commands.create_macro_cli("stored", ['[{"device_type":"mouse","t_us":0}]'], force=True)
+
+    payload = sent[0]
+    assert payload["command"] == "update_macro"
+    assert payload["name"] == "stored"
+    macro = payload["macro"]
+    assert isinstance(macro, dict)
+    assert macro["name"] == "stored"
+
+
+def test_delete_macro_cli_sends_delete_payload(monkeypatch: pytest.MonkeyPatch) -> None:
+    sent: list[dict[str, object]] = []
+
+    def _session_request(payload: dict[str, object]) -> dict[str, object]:
+        sent.append(payload)
+        return {"status": "ok"}
+
+    monkeypatch.setattr(commands, "_session_request", _session_request)
+
+    commands.delete_macro_cli("stored")
+
+    assert sent == [{"command": "delete_macro", "name": "stored"}]
 
 
 def test_status_cli_prints_runtime_summary(
@@ -126,6 +180,38 @@ def test_type_cli_compiles_and_sends_payload(monkeypatch: pytest.MonkeyPatch) ->
     assert payload["command"] == "play_macro_payload"
     assert payload["speed"] == 1.5
     assert len(payload["macro_events"]) > 0
+
+
+def test_type_cli_uses_unicode_fallback_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    sent: list[dict[str, object]] = []
+
+    def _session_request(payload: dict[str, object]) -> dict[str, object]:
+        sent.append(payload)
+        return {"status": "ok"}
+
+    monkeypatch.setattr(commands, "_session_request", _session_request)
+
+    commands.type_cli(["é"])
+
+    events = sent[0]["macro_events"]
+    assert isinstance(events, list)
+    press_codes = [event["code"] for event in events if event.get("value") == 1]
+    assert press_codes[:3] == [
+        evdev.ecodes.KEY_LEFTCTRL,
+        evdev.ecodes.KEY_LEFTSHIFT,
+        evdev.ecodes.KEY_U,
+    ]
+
+
+def test_type_cli_no_unicode_rejects_unsupported_character(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(commands, "_session_request", lambda payload: pytest.fail("sent request"))
+
+    with pytest.raises(SystemExit) as excinfo:
+        commands.type_cli(["é"], use_unicode_input=False)
+
+    assert excinfo.value.code == 1
 
 
 def test_play_adhoc_cli_compiles_compact_tokens(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_entrypoints_and_cli.py
+++ b/tests/test_entrypoints_and_cli.py
@@ -144,3 +144,59 @@ def test_cli_main_status_routes_json_flag(monkeypatch: pytest.MonkeyPatch) -> No
 
     cli_main.main()
     assert calls == [True]
+
+
+def test_cli_main_type_routes_to_helper(monkeypatch: pytest.MonkeyPatch) -> None:
+    from keymasq.cli import __main__ as cli_main
+
+    calls: list[dict[str, object]] = []
+
+    def _type_cli(text: list[str], **kwargs: object) -> None:
+        calls.append({"text": text, **kwargs})
+
+    monkeypatch.setattr(cli_main, "type_cli", _type_cli)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["keymasq", "type", "--speed", "1.25", "--down-ms", "5", "hello"],
+    )
+
+    cli_main.main()
+    assert calls == [
+        {
+            "text": ["hello"],
+            "down_ms": 5,
+            "pause_ms": 20,
+            "speed": 1.25,
+            "use_unicode_input": False,
+            "print_json": False,
+            "json_output": False,
+        }
+    ]
+
+
+def test_cli_main_play_routes_json_input_to_helper(monkeypatch: pytest.MonkeyPatch) -> None:
+    from keymasq.cli import __main__ as cli_main
+
+    calls: list[dict[str, object]] = []
+
+    def _play_cli(events: list[str], **kwargs: object) -> None:
+        calls.append({"events": events, **kwargs})
+
+    monkeypatch.setattr(cli_main, "play_adhoc_cli", _play_cli)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["keymasq", "--json", "play", "--json", "--speed", "2", '{"events":[]}'],
+    )
+
+    cli_main.main()
+    assert calls == [
+        {
+            "events": ['{"events":[]}'],
+            "input_json": True,
+            "speed": 2.0,
+            "print_json": False,
+            "json_output": True,
+        }
+    ]

--- a/tests/test_entrypoints_and_cli.py
+++ b/tests/test_entrypoints_and_cli.py
@@ -168,11 +168,26 @@ def test_cli_main_type_routes_to_helper(monkeypatch: pytest.MonkeyPatch) -> None
             "down_ms": 5,
             "pause_ms": 20,
             "speed": 1.25,
-            "use_unicode_input": False,
+            "use_unicode_input": True,
             "print_json": False,
             "json_output": False,
         }
     ]
+
+
+def test_cli_main_type_no_unicode_routes_to_helper(monkeypatch: pytest.MonkeyPatch) -> None:
+    from keymasq.cli import __main__ as cli_main
+
+    calls: list[dict[str, object]] = []
+
+    def _type_cli(text: list[str], **kwargs: object) -> None:
+        calls.append({"text": text, **kwargs})
+
+    monkeypatch.setattr(cli_main, "type_cli", _type_cli)
+    monkeypatch.setattr(sys, "argv", ["keymasq", "type", "--no-unicode", "café"])
+
+    cli_main.main()
+    assert calls[0]["use_unicode_input"] is False
 
 
 def test_cli_main_play_routes_json_input_to_helper(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -200,3 +215,44 @@ def test_cli_main_play_routes_json_input_to_helper(monkeypatch: pytest.MonkeyPat
             "json_output": True,
         }
     ]
+
+
+def test_cli_main_macros_create_routes_to_helper(monkeypatch: pytest.MonkeyPatch) -> None:
+    from keymasq.cli import __main__ as cli_main
+
+    calls: list[dict[str, object]] = []
+
+    def _create_macro(name: str, json_parts: list[str], **kwargs: object) -> None:
+        calls.append({"name": name, "json_parts": json_parts, **kwargs})
+
+    monkeypatch.setattr(cli_main, "create_macro_cli", _create_macro)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["keymasq", "macros", "create", "--force", "stored", '{"events":[]}'],
+    )
+
+    cli_main.main()
+    assert calls == [
+        {
+            "name": "stored",
+            "json_parts": ['{"events":[]}'],
+            "force": True,
+            "json_output": False,
+        }
+    ]
+
+
+def test_cli_main_macros_delete_routes_to_helper(monkeypatch: pytest.MonkeyPatch) -> None:
+    from keymasq.cli import __main__ as cli_main
+
+    calls: list[dict[str, object]] = []
+
+    def _delete_macro(name: str, **kwargs: object) -> None:
+        calls.append({"name": name, **kwargs})
+
+    monkeypatch.setattr(cli_main, "delete_macro_cli", _delete_macro)
+    monkeypatch.setattr(sys, "argv", ["keymasq", "macros", "delete", "stored"])
+
+    cli_main.main()
+    assert calls == [{"name": "stored", "json_output": False}]

--- a/tests/test_entrypoints_and_cli.py
+++ b/tests/test_entrypoints_and_cli.py
@@ -92,6 +92,42 @@ def test_cli_main_version_uses_package_version(
     assert capsys.readouterr().out.strip() == "keymasq 9.9.9"
 
 
+def test_cli_main_type_help_includes_inline_controls_and_docs(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    from keymasq.cli import __main__ as cli_main
+
+    monkeypatch.setattr(cli_main, "__version__", "1.2.3")
+    monkeypatch.setattr(sys, "argv", ["keymasq", "type", "--help"])
+
+    with pytest.raises(SystemExit) as excinfo:
+        cli_main.main()
+
+    assert excinfo.value.code == 0
+    out = capsys.readouterr().out
+    assert "<tab>, <enter>, <wait:MS>, <wait:MIN:MAX>" in out
+    assert "https://keymasq.tools/docs/1.2.3/CLI.md" in out
+
+
+def test_cli_main_play_help_includes_compact_tokens_and_docs(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    from keymasq.cli import __main__ as cli_main
+
+    monkeypatch.setattr(cli_main, "__version__", "1.2.3")
+    monkeypatch.setattr(sys, "argv", ["keymasq", "play", "--help"])
+
+    with pytest.raises(SystemExit) as excinfo:
+        cli_main.main()
+
+    assert excinfo.value.code == 0
+    out = capsys.readouterr().out
+    assert "move_abs:X:Y, move_rel:DX:DY, wait:MS, wait:MIN:MAX" in out
+    assert "https://keymasq.tools/docs/1.2.3/CLI.md" in out
+
+
 def test_keymasqd_script_entrypoint_calls_daemon_main(monkeypatch: pytest.MonkeyPatch) -> None:
     called: list[str] = []
     monkeypatch.setitem(


### PR DESCRIPTION
## Summary
- Added top-level `keymasq type` and `keymasq play` commands for compiling and playing ad-hoc macros from text, compact CLI tokens, stdin, or canonical macro JSON.
- Moved type/play macro compilation into `keymasq/common/macro_compile.py` and reused it from the GTK type macro flow so CLI and GUI share normalization, Unicode typing, waits, and event-building behavior.
- Added readable type controls for `<tab>`, `<enter>`, `<wait:MS>`, `<wait:MIN:MAX>`, plus the literal `<` escape via `\<`; Unicode typing is attempted by default with `--no-unicode` as the opt-out.
- Added compact play grammar support for taps, explicit down/up states, fixed/random waits, absolute/relative pointer moves, and automatic release of held keys/buttons at macro end.
- Added `macros create` and `macros delete`, including stdin JSON input and `--force` overwrite support, so `--print-json` output can be piped directly into stored macros.
- Added session/daemon support for playing ad-hoc macro payloads and changed `keymasqd` to keep its private output uinput devices available for daemon lifetime.
- Refactored compiler/editor/runtime pointer moves to semantic macro actions (`mouse_move_abs` / `mouse_move_rel`) instead of synthetic multi-event REL encodings.
- Documented the new CLI workflow, compact token grammar, type controls, macro storage pipeline, and JSON event shape in `docs/CLI.md`.

## Testing
- Added coverage for shared macro compilation in `tests/common/test_macro_compile.py`.
- Added CLI helper and entrypoint coverage in `tests/test_cli_commands_helpers.py` and `tests/test_entrypoints_and_cli.py`.
- Added session command coverage in `tests/session/test_session_manager_command_runtime.py`.
- Added daemon/runtime/editor coverage for output-device initialization, ad-hoc playback, macro move actions, and parser reconstruction.
- `nix develop -c ./scripts/check.sh full` (`ruff: ok`, `basedpyright: ok`, `pytest: ok - 863 passed, 23 skipped`)
