### PR TITLE
Add device renaming from device tabs

### DIFF
--- a/docs/PROFILES.md
+++ b/docs/PROFILES.md
@@ -264,6 +264,8 @@ In the GUI:
 - enabling or disabling a profile affects every device layer in that profile
 - active-state displays show the active profiles contributing to that device
 - `Passthrough` removes the mapping from the selected profile so lower profiles can still apply one
+- right-clicking the device name in a device tab lets you rename the hardware
+  definition; this updates the device tab and saved hardware config
 - deleting a button from the device tab removes it from the hardware config and clears saved mappings for that button across profiles
 
 Deleting a hardware definition does not delete global profiles. Any layers for that hardware remain in the profile file and stay dormant until that hardware exists again.

--- a/docs/PROFILES.md
+++ b/docs/PROFILES.md
@@ -264,8 +264,8 @@ In the GUI:
 - enabling or disabling a profile affects every device layer in that profile
 - active-state displays show the active profiles contributing to that device
 - `Passthrough` removes the mapping from the selected profile so lower profiles can still apply one
-- right-clicking the device name in a device tab lets you rename the hardware
-  definition; this updates the device tab and saved hardware config
+- right-clicking the device name in a device tab lets you edit the saved display
+  name; hardware IDs, mappings, and device identity are unchanged
 - deleting a button from the device tab removes it from the hardware config and clears saved mappings for that button across profiles
 
 Deleting a hardware definition does not delete global profiles. Any layers for that hardware remain in the profile file and stay dormant until that hardware exists again.

--- a/keymasq/gui/widgets/device_tab.py
+++ b/keymasq/gui/widgets/device_tab.py
@@ -144,19 +144,12 @@ class DeviceTab(ProfileManagedTab):
         return self._selected_profile.config.get_layer(self.device.hardware_id)
 
     def _append_profile_settings_rows(self, settings_grid: Gtk.Grid, row: int) -> int:
-        iface_count = len(self.device.evdev_devices)
-        device_name = self.device.name
-
         grab_label = Gtk.Label(label="Grab Mode")
         grab_label.set_halign(Gtk.Align.START)
         grab_label.set_valign(Gtk.Align.CENTER)
         settings_grid.attach(grab_label, 0, row, 1, 1)
 
-        if iface_count > 1:
-            grab_text = f"Always grab all {iface_count} interfaces of {device_name}"
-        else:
-            grab_text = f"Always grab {device_name}"
-        self.always_grab_check = Gtk.CheckButton(label=grab_text)
+        self.always_grab_check = Gtk.CheckButton(label=self._device_grab_label_text())
         self.always_grab_check.set_active(False)
         self.always_grab_check.set_tooltip_text(
             "Grab all device interfaces even if not all are used. "
@@ -205,10 +198,17 @@ class DeviceTab(ProfileManagedTab):
 
         name_row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=8)
 
-        name_label = Gtk.Label(label=self.device.name)
-        name_label.add_css_class("title-2")
-        name_label.set_halign(Gtk.Align.START)
-        name_row.append(name_label)
+        self.device_name_label = Gtk.Label(label=self.device.name)
+        self.device_name_label.add_css_class("title-2")
+        self.device_name_label.set_halign(Gtk.Align.START)
+        self.device_name_label.set_ellipsize(Pango.EllipsizeMode.END)
+        if not self.demo_mode:
+            self.device_name_label.set_tooltip_text("Right-click to rename device")
+            name_right_click = Gtk.GestureClick()
+            name_right_click.set_button(Gdk.BUTTON_SECONDARY)
+            name_right_click.connect("pressed", self._on_device_name_right_clicked)
+            self.device_name_label.add_controller(name_right_click)
+        name_row.append(self.device_name_label)
 
         if not self.demo_mode:
             delete_btn = Gtk.Button(icon_name="user-trash-symbolic")
@@ -237,6 +237,82 @@ class DeviceTab(ProfileManagedTab):
         self.append(header_box)
 
         self.set_focusable(True)
+
+    def _device_grab_label_text(self) -> str:
+        iface_count = len(self.device.evdev_devices)
+        if iface_count > 1:
+            return f"Always grab all {iface_count} interfaces of {self.device.name}"
+        return f"Always grab {self.device.name}"
+
+    def _on_device_name_right_clicked(self, click, n_press, x, y) -> None:
+        if n_press != 1 or self.demo_mode:
+            return
+        self._show_device_rename_dialog()
+
+    def _show_device_rename_dialog(self) -> None:
+        dialog = Adw.Dialog(title="Rename Device", content_width=420, content_height=-1)
+        box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=12)
+        box.set_margin_top(16)
+        box.set_margin_bottom(16)
+        box.set_margin_start(16)
+        box.set_margin_end(16)
+
+        label = Gtk.Label(label=f"Rename '{self.device.name}'")
+        label.set_halign(Gtk.Align.START)
+        box.append(label)
+
+        entry = Gtk.Entry()
+        entry.set_text(self.device.name)
+        entry.set_activates_default(True)
+        box.append(entry)
+
+        btn_row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=8)
+        btn_row.set_halign(Gtk.Align.END)
+
+        cancel_btn = Gtk.Button(label="Cancel")
+        cancel_btn.connect("clicked", self._on_close_dialog_clicked, dialog)
+        btn_row.append(cancel_btn)
+
+        save_btn = Gtk.Button(label="Save")
+        save_btn.add_css_class("suggested-action")
+        save_btn.set_receives_default(True)
+
+        def on_save(_btn) -> None:
+            if self._rename_device(entry.get_text()):
+                dialog.close()
+
+        save_btn.connect("clicked", on_save)
+        btn_row.append(save_btn)
+
+        box.append(btn_row)
+        dialog.set_child(box)
+        dialog.present(self.get_root())
+
+    def _rename_device(self, new_name: str) -> bool:
+        new_name = new_name.strip()
+        if not new_name:
+            return False
+        if new_name == self.device.name:
+            return True
+
+        self.device.name = new_name
+        assert self.hardware_manager is not None
+        self.hardware_manager.save_hardware(self.device)
+        session_request_async({"command": "reload"}, lambda _result: False)
+        self._update_device_name_display()
+        self._notify_device_renamed()
+        return True
+
+    def _update_device_name_display(self) -> None:
+        self.device_name_label.set_text(self.device.name)
+        if hasattr(self, "always_grab_check"):
+            self.always_grab_check.set_label(self._device_grab_label_text())
+
+    def _notify_device_renamed(self) -> None:
+        target = self.main_window or self.get_root()
+        updater = getattr(target, "update_device_display_name", None)
+        if callable(updater):
+            updater(self.device.hardware_id, self.device.name)
 
     def _on_delete_device(self, button: Gtk.Button) -> None:
         dialog = Adw.Dialog(title="Delete Device", content_width=360, content_height=-1)

--- a/keymasq/gui/window.py
+++ b/keymasq/gui/window.py
@@ -904,6 +904,15 @@ class MainWindow(Adw.ApplicationWindow):
             )
             self._apply_profile_runtime_state_to_widget(self.combo_tab)
 
+    def update_device_display_name(self, hardware_id: str, name: str) -> None:
+        child = self.stack.get_child_by_name(hardware_id)
+        if child is None:
+            return
+
+        page = self.stack.get_page(child)
+        if page is not None:
+            page.set_title(name)
+
     def _queue_profile_reload(self) -> None:
         if self._destroyed:
             return

--- a/tests/gui/test_device_tab_widget.py
+++ b/tests/gui/test_device_tab_widget.py
@@ -339,6 +339,61 @@ class TestDeviceTabWidget:
         assert root.checked == 1
         assert closed == [True]
 
+    def test_device_tab_rename_device_updates_hardware_runtime_and_header(
+        self, temp_config_dir, monkeypatch
+    ):
+        from keymasq.common.models import ButtonDefinition, HardwareConfig
+        from keymasq.gui.widgets import device_tab as device_tab_module
+        from keymasq.gui.widgets.device_tab import DeviceTab
+        from keymasq.session.hardware import HardwareManager
+
+        class _MainWindow:
+            def __init__(self) -> None:
+                self.renamed: list[tuple[str, str]] = []
+
+            def update_device_display_name(self, hardware_id: str, name: str) -> None:
+                self.renamed.append((hardware_id, name))
+
+        device = HardwareConfig(
+            vendor_id="1234",
+            product_id="5678",
+            name="Test Mouse",
+            evdev_devices=[],
+            buttons=[ButtonDefinition(id="btn_back", label="Back", evdev="btn_side")],
+        )
+
+        hardware_manager = HardwareManager()
+        hardware_manager.save_hardware(device)
+        main_window = _MainWindow()
+        tab = DeviceTab(
+            device=device,
+            profile_manager=None,
+            hardware_manager=hardware_manager,
+            main_window=main_window,
+            demo_mode=False,
+        )
+
+        reload_requests: list[dict] = []
+        monkeypatch.setattr(
+            device_tab_module,
+            "session_request_async",
+            lambda payload, callback: reload_requests.append(payload),
+        )
+
+        assert tab._rename_device("  Work Mouse  ") is True
+
+        assert device.name == "Work Mouse"
+        reloaded = HardwareManager().get_hardware(device.hardware_id)
+        assert reloaded is not None
+        assert reloaded.name == "Work Mouse"
+        assert reload_requests == [{"command": "reload"}]
+        assert tab.device_name_label.get_text() == "Work Mouse"
+        assert tab.always_grab_check.get_label() == "Always grab Work Mouse"
+        assert main_window.renamed == [("1234:5678", "Work Mouse")]
+
+        assert tab._rename_device("   ") is False
+        assert reload_requests == [{"command": "reload"}]
+
     def test_device_tab_delete_button_updates_hardware_profiles_and_ui(
         self, temp_config_dir, monkeypatch
     ):

--- a/tests/gui/test_main_window.py
+++ b/tests/gui/test_main_window.py
@@ -240,6 +240,29 @@ class TestMainWindow:
         assert tab2._selected_profile is not None
         assert tab2._selected_profile.config.name == "Desktop"
 
+    def test_main_window_update_device_display_name_updates_stack_page(self, temp_config_dir):
+        from keymasq.common.models import ButtonDefinition, HardwareConfig
+        from keymasq.gui.window import MainWindow
+
+        window = MainWindow(demo_mode=True)
+        device = HardwareConfig(
+            vendor_id="1234",
+            product_id="5678",
+            name="Mouse One",
+            evdev_devices=[],
+            buttons=[ButtonDefinition(id="btn_back", label="Back", evdev="btn_side")],
+        )
+
+        window._add_device_tab(device)
+        child = window.stack.get_child_by_name(device.hardware_id)
+        assert child is not None
+        page = window.stack.get_page(child)
+        assert page.get_title() == "Mouse One"
+
+        window.update_device_display_name(device.hardware_id, "Desk Mouse")
+
+        assert page.get_title() == "Desk Mouse"
+
     def test_main_window_startup_probe_applies_compositor_state_and_devices(self, temp_config_dir):
         from keymasq.common.models import (
             ButtonDefinition,


### PR DESCRIPTION
## Summary
- Add right-click rename support on device names in device tabs.
- Persist renamed hardware definitions, refresh the UI label/grab text, and trigger a session reload so the new name is applied consistently.
- Update the main window stack page title when a device is renamed.
- Document the rename behavior in `docs/PROFILES.md` and add GUI tests covering rename flow and stack-page title updates.

## Testing
- `Not run` (changes were reviewed from the diff only).
- Added coverage in `tests/gui/test_device_tab_widget.py` for renaming, persistence, reload request emission, and UI text updates.
- Added coverage in `tests/gui/test_main_window.py` for updating the device tab title in the window stack.