### PR TITLE
Clamp rapidfire timings and allow zero-hold pulses

### DIFF
--- a/docs/ACTIONS.md
+++ b/docs/ACTIONS.md
@@ -311,8 +311,10 @@ This continues for as long as the key is physically held down.
 
 | Setting | What it controls | Default | Range |
 |---|---|---|---|
-| **Hold (ms)** | How long each pulse is held. | 20 ms | 10–1000 ms |
-| **Wait (ms)** | Pause between pulses. | 20 ms | 10–1000 ms |
+| **Hold (ms)** | How long each pulse is held. | 20 ms | 0–1000 ms |
+| **Wait (ms)** | Pause between pulses. | 20 ms | 1–1000 ms |
+
+`0 ms` hold with `1 ms` wait is the fastest supported rapidfire pattern.
 
 **Use cases:** auto-fire in games, Linux autoclicker setups, repeated key
 presses, and continuous mouse movement.

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -58,6 +58,53 @@ processing. Disable when done:
 keymasq diagnostics off
 ```
 
+## Rapidfire Throughput
+
+You can measure rapidfire output rate externally on the Keymasq virtual output
+device with `evtest` and `pv`.
+
+First, identify the relevant Keymasq virtual device:
+
+```bash
+sudo evtest
+```
+
+Then count emitted key state changes on that device:
+
+```bash
+sudo evtest /dev/input/eventX \
+  | rg --line-buffered 'EV_KEY.*value [01]' \
+  | pv -l -i 1 > /dev/null
+```
+
+This reports total press and release events per second. If you only want
+activation rate, count key-down events only:
+
+```bash
+sudo evtest /dev/input/eventX \
+  | rg --line-buffered 'EV_KEY.*value 1' \
+  | pv -l -i 1 > /dev/null
+```
+
+### Informal Result
+
+On one local test system, six concurrent rapidfire mouse-button mappings
+reached roughly **2.8k mouse events/sec** on the `keymasq-mouse` virtual
+device while using about **11% of one CPU core**.
+
+That is an informal measurement, not a guaranteed minimum or maximum across
+systems. It is included here as a practical data point showing that very fast
+rapidfire settings do not immediately hit an obvious Python-side throughput
+limit.
+
+### Caveat
+
+Multiple rapidfire mappings targeting the same logical output, such as several
+`BTN_LEFT` mappings, do not necessarily scale linearly. Those mappings all
+share one output code, so their press and release streams can overlap. Mixed
+outputs such as `BTN_LEFT` and `BTN_RIGHT` can scale more cleanly because they
+do not collapse onto the same logical button state.
+
 ## Detailed Benchmarks
 
 For methodology and full results, see:

--- a/flake.nix
+++ b/flake.nix
@@ -367,7 +367,8 @@
               pkgs.nodejs
               pkgs.cloc
               pkgs.glow
-	      pkgs.slurp
+              pkgs.slurp
+              pkgs.pv
               # GitHub Actions
               pkgs.gh           # GitHub CLI - manage workflows, PRs, releases
               pkgs.act          # run GitHub Actions locally

--- a/keymasq/common/models.py
+++ b/keymasq/common/models.py
@@ -64,6 +64,11 @@ RAPIDFIRE_ACTION_TYPES = frozenset(
     }
 )
 
+DEFAULT_RAPIDFIRE_HOLD_MS = 20
+DEFAULT_RAPIDFIRE_WAIT_MS = 20
+MIN_RAPIDFIRE_HOLD_MS = 0
+MIN_RAPIDFIRE_WAIT_MS = 1
+
 MACRO_LOOP_STOP_BEHAVIORS = frozenset({"finish_run", "cancel_run"})
 DEFAULT_MACRO_LOOP_STOP_BEHAVIOR = "finish_run"
 
@@ -98,6 +103,14 @@ def action_type_supports_rapidfire(action_type: ActionType) -> bool:
     return action_type in RAPIDFIRE_ACTION_TYPES
 
 
+def clamp_rapidfire_hold_ms(rapidfire_hold_ms: int) -> int:
+    return max(MIN_RAPIDFIRE_HOLD_MS, int(rapidfire_hold_ms))
+
+
+def clamp_rapidfire_wait_ms(rapidfire_wait_ms: int) -> int:
+    return max(MIN_RAPIDFIRE_WAIT_MS, int(rapidfire_wait_ms))
+
+
 def normalize_rapidfire_fields(
     action_type: ActionType,
     *,
@@ -106,8 +119,12 @@ def normalize_rapidfire_fields(
     rapidfire_wait_ms: int,
 ) -> tuple[bool, int, int]:
     if not action_type_supports_rapidfire(action_type):
-        return False, 20, 20
-    return rapidfire_enabled, rapidfire_hold_ms, rapidfire_wait_ms
+        return False, DEFAULT_RAPIDFIRE_HOLD_MS, DEFAULT_RAPIDFIRE_WAIT_MS
+    return (
+        rapidfire_enabled,
+        clamp_rapidfire_hold_ms(rapidfire_hold_ms),
+        clamp_rapidfire_wait_ms(rapidfire_wait_ms),
+    )
 
 
 def resolve_rapidfire_fields(
@@ -143,8 +160,8 @@ def parse_rapidfire_fields(
     return resolve_rapidfire_fields(
         action_type,
         rapidfire_enabled=bool(rapidfire_enabled),
-        rapidfire_hold_ms=int_value(rapidfire_hold_ms, 20),
-        rapidfire_wait_ms=int_value(rapidfire_wait_ms, 20),
+        rapidfire_hold_ms=int_value(rapidfire_hold_ms, DEFAULT_RAPIDFIRE_HOLD_MS),
+        rapidfire_wait_ms=int_value(rapidfire_wait_ms, DEFAULT_RAPIDFIRE_WAIT_MS),
     )
 
 
@@ -222,11 +239,22 @@ class MappingAction:
     move_jitter: float = 0.3
 
     rapidfire_enabled: bool = False
-    rapidfire_hold_ms: int = 20
-    rapidfire_wait_ms: int = 20
+    rapidfire_hold_ms: int = DEFAULT_RAPIDFIRE_HOLD_MS
+    rapidfire_wait_ms: int = DEFAULT_RAPIDFIRE_WAIT_MS
 
     tap_enabled: bool = False
     tap_hold_ms: int = 10
+
+    def __post_init__(self) -> None:
+        rapidfire_enabled, rapidfire_hold_ms, rapidfire_wait_ms = normalize_rapidfire_fields(
+            self.action_type,
+            rapidfire_enabled=bool(self.rapidfire_enabled),
+            rapidfire_hold_ms=int(self.rapidfire_hold_ms),
+            rapidfire_wait_ms=int(self.rapidfire_wait_ms),
+        )
+        self.rapidfire_enabled = rapidfire_enabled
+        self.rapidfire_hold_ms = rapidfire_hold_ms
+        self.rapidfire_wait_ms = rapidfire_wait_ms
 
 
 @dataclass
@@ -254,11 +282,22 @@ class SuperkeyAction:
     move_y: int = 0
 
     rapidfire_enabled: bool = False
-    rapidfire_hold_ms: int = 20
-    rapidfire_wait_ms: int = 20
+    rapidfire_hold_ms: int = DEFAULT_RAPIDFIRE_HOLD_MS
+    rapidfire_wait_ms: int = DEFAULT_RAPIDFIRE_WAIT_MS
 
     def is_valid(self) -> bool:
         return self.action_type in SUPERKEY_ACTION_TYPES
+
+    def __post_init__(self) -> None:
+        rapidfire_enabled, rapidfire_hold_ms, rapidfire_wait_ms = normalize_rapidfire_fields(
+            self.action_type,
+            rapidfire_enabled=bool(self.rapidfire_enabled),
+            rapidfire_hold_ms=int(self.rapidfire_hold_ms),
+            rapidfire_wait_ms=int(self.rapidfire_wait_ms),
+        )
+        self.rapidfire_enabled = rapidfire_enabled
+        self.rapidfire_hold_ms = rapidfire_hold_ms
+        self.rapidfire_wait_ms = rapidfire_wait_ms
 
 
 SUPERKEY_ACTION_SHARED_FIELDS = (

--- a/keymasq/gui/widgets/key_selector_dialog.py
+++ b/keymasq/gui/widgets/key_selector_dialog.py
@@ -15,6 +15,8 @@ from gi.repository import (  # pyright: ignore[reportAttributeAccessIssue]
 )
 
 from keymasq.common.models import (
+    MIN_RAPIDFIRE_HOLD_MS,
+    MIN_RAPIDFIRE_WAIT_MS,
     ActionType,
     MappingAction,
     SuperkeyAction,
@@ -814,7 +816,10 @@ class KeySelectorDialog(Adw.Dialog):
 
         self.hold_spin = Gtk.SpinButton()
         hold_adj = Gtk.Adjustment(
-            value=self._rapidfire_hold, lower=10, upper=1000, step_increment=10
+            value=self._rapidfire_hold,
+            lower=MIN_RAPIDFIRE_HOLD_MS,
+            upper=1000,
+            step_increment=1,
         )
         self.hold_spin.set_adjustment(hold_adj)
         row1.append(self.hold_spin)
@@ -827,7 +832,10 @@ class KeySelectorDialog(Adw.Dialog):
 
         self.wait_spin = Gtk.SpinButton()
         wait_adj = Gtk.Adjustment(
-            value=self._rapidfire_wait, lower=10, upper=1000, step_increment=10
+            value=self._rapidfire_wait,
+            lower=MIN_RAPIDFIRE_WAIT_MS,
+            upper=1000,
+            step_increment=1,
         )
         self.wait_spin.set_adjustment(wait_adj)
         row1.append(self.wait_spin)
@@ -1852,7 +1860,10 @@ class SuperkeyActionDialog(Adw.Dialog):
 
             self.hold_spin = Gtk.SpinButton()
             hold_adj = Gtk.Adjustment(
-                value=self._rapidfire_hold, lower=10, upper=1000, step_increment=10
+                value=self._rapidfire_hold,
+                lower=MIN_RAPIDFIRE_HOLD_MS,
+                upper=1000,
+                step_increment=1,
             )
             self.hold_spin.set_adjustment(hold_adj)
             row.append(self.hold_spin)
@@ -1865,7 +1876,10 @@ class SuperkeyActionDialog(Adw.Dialog):
 
             self.wait_spin = Gtk.SpinButton()
             wait_adj = Gtk.Adjustment(
-                value=self._rapidfire_wait, lower=10, upper=1000, step_increment=10
+                value=self._rapidfire_wait,
+                lower=MIN_RAPIDFIRE_WAIT_MS,
+                upper=1000,
+                step_increment=1,
             )
             self.wait_spin.set_adjustment(wait_adj)
             row.append(self.wait_spin)

--- a/keymasq/keymasqd/runtime/combos.py
+++ b/keymasq/keymasqd/runtime/combos.py
@@ -17,6 +17,8 @@ from keymasq.common.models import (
     ActionType,
     MappingAction,
     SuperkeyMode,
+    clamp_rapidfire_hold_ms,
+    clamp_rapidfire_wait_ms,
     combo_effective_superkey_config,
 )
 from keymasq.keymasqd.combo_engine import (
@@ -1410,11 +1412,11 @@ async def combo_rapidfire_key(
             if not started_set:
                 mark_combo_action_started(started)
                 started_set = True
-            await deps.asyncio_mod.sleep(max(0.001, hold_ms / 1000.0))
+            await deps.asyncio_mod.sleep(clamp_rapidfire_hold_ms(hold_ms) / 1000.0)
             if not _combo_action_active(manager, combo_id):
                 break
             write_combo_key(uinput_dev, code, 0, deps=deps)
-            await deps.asyncio_mod.sleep(max(0.001, wait_ms / 1000.0))
+            await deps.asyncio_mod.sleep(clamp_rapidfire_wait_ms(wait_ms) / 1000.0)
     except deps.asyncio_mod.CancelledError:
         raise
     finally:
@@ -1493,8 +1495,8 @@ async def combo_rapidfire_relative(
         await rapidfire_relative_pulses(
             emit_pulse=emit_started_pulse,
             is_active=lambda: _combo_action_active(manager, combo_id),
-            hold_s=max(0.001, hold_ms / 1000.0),
-            wait_s=max(0.001, wait_ms / 1000.0),
+            hold_s=clamp_rapidfire_hold_ms(hold_ms) / 1000.0,
+            wait_s=clamp_rapidfire_wait_ms(wait_ms) / 1000.0,
             asyncio_mod=deps.asyncio_mod,
         )
     except deps.asyncio_mod.CancelledError:
@@ -1527,7 +1529,7 @@ async def combo_rapidfire_trigger(
             if not started_set:
                 mark_combo_action_started(started)
                 started_set = True
-            await deps.asyncio_mod.sleep(max(0.001, hold_ms / 1000.0))
+            await deps.asyncio_mod.sleep(clamp_rapidfire_hold_ms(hold_ms) / 1000.0)
             if not _combo_action_active(manager, combo_id):
                 break
             write_combo_trigger(
@@ -1536,7 +1538,7 @@ async def combo_rapidfire_trigger(
                 0,
                 deps=deps,
             )
-            await deps.asyncio_mod.sleep(max(0.001, wait_ms / 1000.0))
+            await deps.asyncio_mod.sleep(clamp_rapidfire_wait_ms(wait_ms) / 1000.0)
     except deps.asyncio_mod.CancelledError:
         raise
     finally:

--- a/keymasq/keymasqd/runtime/grabbed_device_repeat.py
+++ b/keymasq/keymasqd/runtime/grabbed_device_repeat.py
@@ -4,7 +4,11 @@ from typing import cast
 
 import evdev
 
-from keymasq.common.models import MappingAction
+from keymasq.common.models import (
+    MappingAction,
+    clamp_rapidfire_hold_ms,
+    clamp_rapidfire_wait_ms,
+)
 from keymasq.keymasqd.runtime.grabbed_device_outputs import (
     emit_configured_mouse_move,
     ensure_key_released,
@@ -136,8 +140,8 @@ async def rapidfire_trigger(
     evdev_mod: EvdevModule,
     uinput_writer: UInputWriter,
 ) -> None:
-    hold = hold_ms / 1000.0
-    wait = wait_ms / 1000.0
+    hold = clamp_rapidfire_hold_ms(hold_ms) / 1000.0
+    wait = clamp_rapidfire_wait_ms(wait_ms) / 1000.0
     task = asyncio_mod.current_task()
     pressed = False
 
@@ -213,8 +217,8 @@ async def rapidfire_key(
     *,
     asyncio_mod: AsyncioModule,
 ) -> None:
-    hold = hold_ms / 1000.0
-    wait = wait_ms / 1000.0
+    hold = clamp_rapidfire_hold_ms(hold_ms) / 1000.0
+    wait = clamp_rapidfire_wait_ms(wait_ms) / 1000.0
     task = asyncio_mod.current_task()
     pressed = False
 
@@ -303,8 +307,8 @@ async def rapidfire_relative(
     *,
     asyncio_mod: AsyncioModule,
 ) -> None:
-    hold = hold_ms / 1000.0
-    wait = wait_ms / 1000.0
+    hold = clamp_rapidfire_hold_ms(hold_ms) / 1000.0
+    wait = clamp_rapidfire_wait_ms(wait_ms) / 1000.0
     task = asyncio_mod.current_task()
 
     try:
@@ -370,8 +374,8 @@ async def rapidfire_move(
     *,
     asyncio_mod: AsyncioModule,
 ) -> None:
-    hold = hold_ms / 1000.0
-    wait = wait_ms / 1000.0
+    hold = clamp_rapidfire_hold_ms(hold_ms) / 1000.0
+    wait = clamp_rapidfire_wait_ms(wait_ms) / 1000.0
     task = asyncio_mod.current_task()
 
     try:

--- a/keymasq/keymasqd/superkey_state.py
+++ b/keymasq/keymasqd/superkey_state.py
@@ -12,6 +12,8 @@ from keymasq.common.models import (
     ActionType,
     MappingAction,
     SuperkeyMode,
+    clamp_rapidfire_hold_ms,
+    clamp_rapidfire_wait_ms,
     superkey_action_shared_kwargs,
 )
 from keymasq.keymasqd.output_helpers import emit_mouse_move, get_trigger_axis, resolve_output_code
@@ -63,6 +65,10 @@ class SuperkeyActionData:
     rapidfire_enabled: bool = False
     rapidfire_hold_ms: int = 20
     rapidfire_wait_ms: int = 20
+
+    def __post_init__(self) -> None:
+        self.rapidfire_hold_ms = clamp_rapidfire_hold_ms(self.rapidfire_hold_ms)
+        self.rapidfire_wait_ms = clamp_rapidfire_wait_ms(self.rapidfire_wait_ms)
 
 
 @dataclass
@@ -272,8 +278,8 @@ class SuperkeyMachine:
             await self._execute_actions_up(self.config.tap_hold_actions)
 
     async def _rapidfire_loop(self, action: SuperkeyActionData) -> None:
-        hold = action.rapidfire_hold_ms / 1000.0
-        wait = action.rapidfire_wait_ms / 1000.0
+        hold = clamp_rapidfire_hold_ms(action.rapidfire_hold_ms) / 1000.0
+        wait = clamp_rapidfire_wait_ms(action.rapidfire_wait_ms) / 1000.0
         mouse_target = (
             self._resolve_mouse_target(action.target) if action.action_type == "mouse" else None
         )

--- a/tests/common/test_mapping_and_profile_state.py
+++ b/tests/common/test_mapping_and_profile_state.py
@@ -22,6 +22,19 @@ class TestMappingAction:
         assert action.rapidfire_hold_ms == 50
         assert action.rapidfire_wait_ms == 30
 
+    def test_rapidfire_clamps_to_fastest_supported_pattern(self):
+        action = MappingAction(
+            action_type=ActionType.KEYBOARD,
+            target="key_a",
+            rapidfire_enabled=True,
+            rapidfire_hold_ms=-5,
+            rapidfire_wait_ms=0,
+        )
+
+        assert action.rapidfire_enabled is True
+        assert action.rapidfire_hold_ms == 0
+        assert action.rapidfire_wait_ms == 1
+
     def test_mouse_action(self):
         action = MappingAction(action_type=ActionType.MOUSE, target="btn_left")
 


### PR DESCRIPTION
## Summary
- Allow rapidfire actions to use a `0 ms` hold while keeping wait times clamped to a minimum of `1 ms`.
- Normalize rapidfire timing fields in mapping, superkey, combo, and grabbed-device runtimes so invalid values are clamped consistently.
- Update the key selector dialogs and docs to reflect the new supported ranges.
- Add coverage for the fastest supported rapidfire pattern and field clamping behavior.

## Testing
- Not run (PR content only).
- Covered by existing unit test update: `tests/common/test_mapping_and_profile_state.py`.
- Behavior touched across common models, GUI widgets, and keymasqd runtime paths; broader `./scripts/check.sh full` would be the relevant verification step.