### PR TITLE
Select newly created profiles and reload session

### DIFF
--- a/keymasq/gui/widgets/profile_managed_tab.py
+++ b/keymasq/gui/widgets/profile_managed_tab.py
@@ -1063,9 +1063,9 @@ class ProfileManagedTab(Gtk.Box):
         dialog.present()
 
     def _on_profile_created(self, _dialog, profile_name: str) -> None:
-        self._refresh_other_profile_tabs(preferred_profile_name=profile_name)
-        self.refresh_profiles(preferred_profile_name=profile_name, publish_selection=False)
+        self.refresh_profiles(preferred_profile_name=profile_name)
         self.settings_frame.set_expanded(True)
+        notify_session_reload_async()
 
     def _save_specific_profile(self, profile: ProfileInfo | None) -> bool:
         if profile is None or self.profile_manager is None or self.demo_mode:

--- a/keymasq/gui/widgets/profile_managed_tab.py
+++ b/keymasq/gui/widgets/profile_managed_tab.py
@@ -1063,6 +1063,11 @@ class ProfileManagedTab(Gtk.Box):
         dialog.present()
 
     def _on_profile_created(self, _dialog, profile_name: str) -> None:
+        root = self.main_window or self.get_root()
+        if root and hasattr(root, "_set_selected_profile_name"):
+            root._set_selected_profile_name(profile_name)
+        if self.profile_manager is not None:
+            self.profile_manager.reload()
         self.refresh_profiles(preferred_profile_name=profile_name)
         self.settings_frame.set_expanded(True)
         notify_session_reload_async()

--- a/tests/gui/test_main_window.py
+++ b/tests/gui/test_main_window.py
@@ -240,6 +240,46 @@ class TestMainWindow:
         assert tab2._selected_profile is not None
         assert tab2._selected_profile.config.name == "Desktop"
 
+    def test_created_profile_is_selected_and_reloaded(self, temp_config_dir, monkeypatch):
+        from keymasq.common.models import ButtonDefinition, HardwareConfig, ProfileConfig
+        from keymasq.gui.widgets import profile_managed_tab as profile_tab_module
+        from keymasq.gui.window import MainWindow
+
+        reload_calls = []
+        monkeypatch.setattr(
+            profile_tab_module,
+            "notify_session_reload_async",
+            lambda *args, **kwargs: reload_calls.append((args, kwargs)),
+        )
+
+        window = MainWindow(demo_mode=True)
+        device = HardwareConfig(
+            vendor_id="2234",
+            product_id="6678",
+            name="Mouse One",
+            evdev_devices=[],
+            buttons=[ButtonDefinition(id="btn_back", label="Back", evdev="btn_side")],
+        )
+        window._add_device_tab(device)
+        window.profile_manager.save_profile(
+            ProfileConfig(name="Gaming", enabled=True, is_permanent=True)
+        )
+
+        tab = window.stack.get_page(
+            window.stack.get_child_by_name(device.hardware_id)
+        ).get_child()
+
+        tab._on_profile_created(None, "Gaming")
+
+        assert reload_calls
+        assert window._selected_profile_name == "Gaming"
+        assert tab._selected_profile is not None
+        assert tab._selected_profile.config.name == "Gaming"
+        assert tab.settings_frame.get_expanded() is True
+        assert window.combo_tab is not None
+        assert window.combo_tab._selected_profile is not None
+        assert window.combo_tab._selected_profile.config.name == "Gaming"
+
     def test_main_window_update_device_display_name_updates_stack_page(self, temp_config_dir):
         from keymasq.common.models import ButtonDefinition, HardwareConfig
         from keymasq.gui.window import MainWindow

--- a/tests/gui/test_main_window.py
+++ b/tests/gui/test_main_window.py
@@ -244,6 +244,7 @@ class TestMainWindow:
         from keymasq.common.models import ButtonDefinition, HardwareConfig, ProfileConfig
         from keymasq.gui.widgets import profile_managed_tab as profile_tab_module
         from keymasq.gui.window import MainWindow
+        from keymasq.session.profiles import ProfileManager
 
         reload_calls = []
         monkeypatch.setattr(
@@ -261,7 +262,10 @@ class TestMainWindow:
             buttons=[ButtonDefinition(id="btn_back", label="Back", evdev="btn_side")],
         )
         window._add_device_tab(device)
-        window.profile_manager.save_profile(
+        original_profile_manager = window.profile_manager
+        window._set_profile_manager(ProfileManager(auto_create_default_if_empty=True))
+        assert window.profile_manager.get_profile("Gaming") is None
+        original_profile_manager.save_profile(
             ProfileConfig(name="Gaming", enabled=True, is_permanent=True)
         )
 


### PR DESCRIPTION
## Summary
- Updates profile creation flow to immediately select the new profile in the GUI.
- Triggers a session reload after creation so the runtime picks up the new profile state.
- Adds GUI coverage for selection sync, combo-tab refresh, and reload notification behavior.

## Testing
- `Not run` (PR content only).
- Added/updated test coverage in `tests/gui/test_main_window.py` for created-profile selection and reload notification.