### PR TITLE
Switch symbolic icons to filled SVG paths

### DIFF
--- a/keymasq/gui/assets/keymasq-combos-symbolic.svg
+++ b/keymasq/gui/assets/keymasq-combos-symbolic.svg
@@ -1,9 +1,4 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">
-  <g fill="none" stroke="#d7d7db" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-    <rect x="4" y="7" width="7" height="7" rx="1.5"/>
-    <rect x="21" y="7" width="7" height="7" rx="1.5"/>
-    <rect x="12.5" y="18" width="7" height="7" rx="1.5"/>
-    <path d="M11 10.5h10"/>
-    <path d="M16 14v4"/>
-  </g>
+  <path fill="#d7d7db" d="M11 9.5h10v2H11Zm4 4.5h2v4h-2Z"/>
+  <path fill="#d7d7db" fill-rule="evenodd" d="M5.5 7h4A1.5 1.5 0 0 1 11 8.5v4A1.5 1.5 0 0 1 9.5 14h-4A1.5 1.5 0 0 1 4 12.5v-4A1.5 1.5 0 0 1 5.5 7ZM6 9v3h3V9H6Zm16.5-2h4A1.5 1.5 0 0 1 28 8.5v4a1.5 1.5 0 0 1-1.5 1.5h-4a1.5 1.5 0 0 1-1.5-1.5v-4A1.5 1.5 0 0 1 22.5 7ZM23 9v3h3V9h-3Zm-9 9h4a1.5 1.5 0 0 1 1.5 1.5v4A1.5 1.5 0 0 1 18 25h-4a1.5 1.5 0 0 1-1.5-1.5v-4A1.5 1.5 0 0 1 14 18Zm.5 2v3h3v-3h-3Z"/>
 </svg>

--- a/keymasq/gui/assets/keymasq-keyboard-symbolic.svg
+++ b/keymasq/gui/assets/keymasq-keyboard-symbolic.svg
@@ -1,14 +1,4 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">
-  <rect x="3.5" y="7" width="25" height="18" rx="2.5" fill="none" stroke="#d7d7db" stroke-width="2.2"/>
-  <g fill="#d7d7db">
-    <rect x="7" y="10.5" width="3" height="3" rx="0.7"/>
-    <rect x="12" y="10.5" width="3" height="3" rx="0.7"/>
-    <rect x="17" y="10.5" width="3" height="3" rx="0.7"/>
-    <rect x="22" y="10.5" width="3" height="3" rx="0.7"/>
-    <rect x="7" y="15.5" width="3" height="3" rx="0.7"/>
-    <rect x="12" y="15.5" width="3" height="3" rx="0.7"/>
-    <rect x="17" y="15.5" width="3" height="3" rx="0.7"/>
-    <rect x="22" y="15.5" width="3" height="3" rx="0.7"/>
-    <rect x="9" y="20.5" width="14" height="2.8" rx="1.2"/>
-  </g>
+  <path fill="#d7d7db" fill-rule="evenodd" d="M6 7h20a3 3 0 0 1 3 3v12a3 3 0 0 1-3 3H6a3 3 0 0 1-3-3V10a3 3 0 0 1 3-3Zm0 2a1 1 0 0 0-1 1v12a1 1 0 0 0 1 1h20a1 1 0 0 0 1-1V10a1 1 0 0 0-1-1H6Z"/>
+  <path fill="#d7d7db" d="M7 11h3v3H7Zm5 0h3v3h-3Zm5 0h3v3h-3Zm5 0h3v3h-3ZM7 16h3v3H7Zm5 0h3v3h-3Zm5 0h3v3h-3Zm5 0h3v3h-3ZM9 21h14v2H9Z"/>
 </svg>

--- a/tests/gui/test_icon_assets.py
+++ b/tests/gui/test_icon_assets.py
@@ -1,0 +1,16 @@
+from importlib import resources
+from xml.etree import ElementTree
+
+
+def test_custom_symbolic_icons_use_filled_paths() -> None:
+    assets = resources.files("keymasq").joinpath("gui/assets")
+
+    for icon_name in (
+        "keymasq-combos-symbolic.svg",
+        "keymasq-keyboard-symbolic.svg",
+        "keymasq-mouse-symbolic.svg",
+    ):
+        root = ElementTree.parse(assets.joinpath(icon_name)).getroot()
+        for element in root.iter():
+            assert element.get("stroke") is None, icon_name
+            assert element.get("fill") != "none", icon_name


### PR DESCRIPTION
## Summary
- Fixed custom GTK symbolic icons that rendered as solid white blobs on Ubuntu 26.04 / GTK 4.22.
- Confirmed the package was installing and registering the SVG assets correctly; the failure was GTK 4.22 rendering stroked symbolic SVGs with `fill="none"` as filled shapes.
- Converted the keyboard and combos symbolic icons to filled-path SVGs while preserving their intended visual shape.
- Added `tests/gui/test_icon_assets.py` to prevent custom symbolic icons from regressing back to `stroke` / `fill="none"` SVG markup.

## Result
- Patched an installed Keymasq copy in an Ubuntu 26.04 VM without rebuilding a package.
- Restarted the installed `/usr/bin/keymasq` GUI in the VM GNOME Wayland session.
- Verified in the live VM GUI that the keyboard and combo icons render correctly instead of appearing as white blobs.

## Testing
- Ran `nix develop -c ./scripts/check.sh gui`: `ruff`, `basedpyright`, and GUI pytest passed (`155 passed, 736 deselected`).
- In an Ubuntu 26.04 VM, verified GTK resolves the installed icons from `/usr/lib/python3/dist-packages/keymasq/gui/assets`.
- Rendered the patched installed SVGs through GTK 4.22 in the VM and confirmed the output matches the intended icon shapes.
