### PR TITLE
Store macros as compressed files with pending recording spool

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -171,7 +171,9 @@ keymasq macros cancel
 
 `macros create` reads macro JSON from stdin when no JSON argument is provided.
 It accepts either a macro object with an `events` field or a raw event list. The
-CLI-provided name is always used for the stored macro.
+CLI-provided name is always used for the stored macro. This JSON is the CLI
+interchange format; stored macros are written by keymasqd as compressed
+`.kmacro.xz` files.
 
 ```bash
 keymasq type "test123üäß<tab><wait:20>12345<tab><wait:20>" --print-json \

--- a/docs/MACROS.md
+++ b/docs/MACROS.md
@@ -341,14 +341,21 @@ quick operations — use the GUI for creating and editing.
 
 | Command | What it does |
 |---|---|
-| `keymasq macro list` | Show all saved macros with basic info. |
-| `keymasq macro play <name>` | Play a macro by name. |
-| `keymasq macro cancel` | Stop all currently running macros. |
+| `keymasq macros list` | Show all saved macros with basic info. |
+| `keymasq macros play <name>` | Play a macro by name. |
+| `keymasq macros cancel` | Stop all currently running macros. |
 
 ## Storage
 
 Macros are stored in `/var/lib/keymasq/macros/`, owned by the `keymasq`
-system user. Do not edit these files by hand — use the GUI or CLI instead.
+system user. Persistent macros use compressed `.kmacro.xz` files. Do not edit
+these files by hand — use the GUI or CLI instead.
+
+During live recording, Keymasq keeps the unsaved recording inside keymasqd and
+spills long recordings to daemon-owned temporary files instead of sending the
+full event list through the session. Saving the dialog finalizes that pending
+recording into compressed macro storage; discarding it removes the temporary
+recording.
 
 ### Deleting Macros
 
@@ -371,8 +378,9 @@ could be misused as a keylogger.
   background without your knowledge.
 
 - **Macros are stored in `/var/lib/keymasq/macros/`**, owned by the `keymasq`
-  system user, not mixed into your profile files. The GUI asks Keymasq to save
-  or play them; it does not write files there directly.
+  system user, not mixed into your profile files. They are compressed on disk.
+  The GUI asks Keymasq to save or play them; it does not write files there
+  directly.
 
 **Optional security settings** (in `/etc/keymasq/security.toml`). Most users
 do not need to change these — they are intended for system administrators:

--- a/keymasq/common/ipc.py
+++ b/keymasq/common/ipc.py
@@ -37,6 +37,8 @@ class CommandType(Enum):
     MACRO_UPDATE = "macro_update"
     MACRO_RENAME = "macro_rename"
     MACRO_DELETE = "macro_delete"
+    MACRO_SAVE_RECORDING = "macro_save_recording"
+    MACRO_DISCARD_RECORDING = "macro_discard_recording"
     MACRO_PLAY_BY_NAME = "macro_play_by_name"
     CANCEL_MACRO_PLAYBACK = "cancel_macro_playback"
     MACRO_EXEC_COMPLETE = "macro_exec_complete"

--- a/keymasq/gui/widgets/macro_manager_dialog.py
+++ b/keymasq/gui/widgets/macro_manager_dialog.py
@@ -533,7 +533,7 @@ class MacroManagerDialog(Adw.Dialog):
     def _is_stop_recording_success(self, result: dict) -> bool:
         if result.get("status") == "error":
             return False
-        return isinstance(result.get("events"), list) and "duration_ms" in result
+        return bool(result.get("pending_recording_id")) and "duration_ms" in result
 
     def _on_recording_started(self, data: dict) -> None:
         self._recording_active = True

--- a/keymasq/keymasqd/daemon.py
+++ b/keymasq/keymasqd/daemon.py
@@ -58,6 +58,8 @@ class _GrabbedDeviceRef(Protocol):
 class _DaemonDeviceManager(Protocol):
     broadcast_callback: object | None
     recording_manager: object | None
+    macro_store: object | None
+    macro_exec_timeout_max_ms: int
     grabbed_devices: dict[str, list[_GrabbedDeviceRef]]
 
     def initialize_output_devices(self) -> None: ...
@@ -217,6 +219,9 @@ class Daemon:
         RUN_DIR.mkdir(parents=True, exist_ok=True)
         self._secure_run_dir()
         self.security_policy = load_security_policy(SECURITY_POLICY_PATH)
+        self.device_manager.macro_exec_timeout_max_ms = int(
+            self.security_policy.macro_exec_timeout_max_ms
+        )
         await asyncio.to_thread(self._prepare_macro_store)
         log.info(
             "Security policy loaded from %s",
@@ -237,6 +242,7 @@ class Daemon:
         self.device_manager.broadcast_callback = self.socket_server.broadcast_event
         self.recording_manager.broadcast_callback = self.socket_server.broadcast_event
         self.device_manager.recording_manager = self.recording_manager
+        self.device_manager.macro_store = self.macro_store
 
         loop = asyncio.get_event_loop()
         for sig in (signal.SIGTERM, signal.SIGINT):
@@ -415,6 +421,7 @@ class Daemon:
             CommandType.MACRO_GET,
             CommandType.MACRO_CREATE,
             CommandType.MACRO_UPDATE,
+            CommandType.MACRO_SAVE_RECORDING,
         }
 
         requires_unlock = command_type in tier1_commands

--- a/keymasq/keymasqd/daemon.py
+++ b/keymasq/keymasqd/daemon.py
@@ -146,6 +146,10 @@ class _DaemonRecordingManager(Protocol):
 
     async def stop(self) -> JsonObject: ...
 
+    async def discard_all_pending_recordings(self) -> None: ...
+
+    def cleanup_spool_dir(self, *, older_than_s: float | None = None) -> None: ...
+
 
 class _DaemonMacroStore(Protocol):
     def ensure(self) -> None: ...
@@ -285,6 +289,7 @@ class Daemon:
     def _prepare_macro_store(self) -> None:
         self.macro_store.ensure()
         self._register_internal_macros()
+        self.recording_manager.cleanup_spool_dir()
 
     def _register_internal_macros(self) -> None:
         ev_rel = 2
@@ -674,6 +679,7 @@ class Daemon:
     async def _on_client_disconnect(self) -> None:
         log.info("Client disconnected, clearing runtime unlocks and releasing all devices")
         await asyncio.to_thread(self._clear_all_runtime_unlocks, reason="session_disconnect")
+        await self.recording_manager.discard_all_pending_recordings()
         await self.device_manager.release_all_devices()
 
     def _secure_run_dir(self) -> None:

--- a/keymasq/keymasqd/daemon_device_commands.py
+++ b/keymasq/keymasqd/daemon_device_commands.py
@@ -51,6 +51,8 @@ class _DeviceCommandManager(Protocol):
 class _DeviceCommandMacroStore(Protocol):
     def get(self, name: str) -> JsonObject: ...
 
+    def get_meta(self, name: str) -> JsonObject: ...
+
 
 class _DeviceCommandDaemon(Protocol):
     device_manager: _DeviceCommandManager

--- a/keymasq/keymasqd/daemon_macro_commands.py
+++ b/keymasq/keymasqd/daemon_macro_commands.py
@@ -1,4 +1,6 @@
 import asyncio
+from collections.abc import Iterable
+from datetime import datetime
 from typing import Protocol, cast
 
 from keymasq.common.ipc import CommandType
@@ -14,6 +16,8 @@ from keymasq.keymasqd.daemon_helpers import (
     json_object_list,
     str_value,
 )
+
+type MacroEvent = dict[str, object]
 
 
 class _MacroCommandDeviceManager(Protocol):
@@ -44,6 +48,8 @@ class _MacroCommandDeviceManager(Protocol):
 class _MacroDefinitionStore(Protocol):
     def get(self, name: str) -> JsonObject: ...
 
+    def get_meta(self, name: str) -> JsonObject: ...
+
 
 class _MacroCommandStore(_MacroDefinitionStore, Protocol):
 
@@ -59,10 +65,34 @@ class _MacroCommandStore(_MacroDefinitionStore, Protocol):
 
     def delete(self, name: str, expected_revision: int | None) -> None: ...
 
+    def create_from_events(
+        self,
+        payload: JsonObject,
+        events: Iterable[MacroEvent],
+        *,
+        return_full: bool = False,
+    ) -> JsonObject: ...
+
+
+class _MacroCommandRecordingManager(Protocol):
+    def pending_recording(self, recording_id: str) -> object: ...
+
+    def discard_pending_recording(self, recording_id: str) -> None: ...
+
+
+class _PendingRecording(Protocol):
+    recording_id: str
+    duration_ms: int
+    device_types: list[str]
+    event_count: int
+
+    def iter_events(self) -> Iterable[MacroEvent]: ...
+
 
 class _MacroCommandDaemon(Protocol):
     device_manager: _MacroCommandDeviceManager
     macro_store: _MacroCommandStore
+    recording_manager: _MacroCommandRecordingManager
 
 
 MacroCommandDaemon = _MacroCommandDaemon
@@ -125,6 +155,14 @@ async def handle_macro_command(
         await asyncio.to_thread(daemon.macro_store.delete, name, revision)
         return {"status": "ok"}
 
+    if command_type == CommandType.MACRO_SAVE_RECORDING:
+        return await save_pending_recording(daemon, data)
+
+    if command_type == CommandType.MACRO_DISCARD_RECORDING:
+        recording_id = str_value(data.get("pending_recording_id", ""))
+        await asyncio.to_thread(daemon.recording_manager.discard_pending_recording, recording_id)
+        return {"status": "ok"}
+
     if command_type == CommandType.MACRO_PLAY_BY_NAME:
         return await play_macro_by_name(daemon, data)
 
@@ -137,6 +175,45 @@ async def handle_macro_command(
         return daemon.device_manager.complete_macro_exec_wait(wait_id, returncode)
 
     return None
+
+
+async def save_pending_recording(
+    daemon: _MacroCommandDaemon,
+    data: JsonObject,
+) -> JsonObject:
+    return await asyncio.to_thread(_save_pending_recording_sync, daemon, data)
+
+
+def _save_pending_recording_sync(
+    daemon: _MacroCommandDaemon,
+    data: JsonObject,
+) -> JsonObject:
+    recording_id = str_value(data.get("pending_recording_id", ""))
+    name = str_value(data.get("name", ""))
+    if not recording_id:
+        raise ValueError("pending_recording_id required")
+    if not name:
+        raise ValueError("name required")
+
+    snapshot = cast(_PendingRecording, daemon.recording_manager.pending_recording(recording_id))
+    payload: JsonObject = {
+        "name": name,
+        "created_at": datetime.now().isoformat(),
+        "duration_ms": int(snapshot.duration_ms),
+        "device_types": list(snapshot.device_types),
+        "event_count": int(snapshot.event_count),
+        "move_to_start": bool(data.get("move_to_start", False)),
+        "start_x": int_like(data.get("start_x", 0), 0),
+        "start_y": int_like(data.get("start_y", 0), 0),
+        "block_mouse_movement": bool(data.get("block_mouse_movement", False)),
+    }
+    macro = daemon.macro_store.create_from_events(
+        payload,
+        snapshot.iter_events(),
+        return_full=False,
+    )
+    daemon.recording_manager.discard_pending_recording(recording_id)
+    return {"macro": macro}
 
 
 async def play_macro_from_payload(daemon: _MacroCommandDaemon, data: JsonObject) -> JsonObject:
@@ -153,8 +230,7 @@ async def play_macro_from_payload(daemon: _MacroCommandDaemon, data: JsonObject)
     block_mouse_movement = bool(data.get("block_mouse_movement", False))
 
     if macro_name and not macro_events:
-        macro_data = await asyncio.to_thread(daemon.macro_store.get, macro_name)
-        macro_events = json_object_list(macro_data.get("events", []))
+        macro_data = await asyncio.to_thread(_load_macro_meta_sync, daemon.macro_store, macro_name)
         loop_mode = str_value(macro_data.get("loop_mode", loop_mode), loop_mode) or loop_mode
         loop_count = int_like(macro_data.get("loop_count", loop_count), loop_count)
         loop_stop_behavior = normalize_macro_loop_stop_behavior(
@@ -188,9 +264,9 @@ async def play_macro_from_payload(daemon: _MacroCommandDaemon, data: JsonObject)
 
 async def play_macro_by_name(daemon: _MacroCommandDaemon, data: JsonObject) -> JsonObject:
     name = str_value(data.get("name", ""))
-    macro_data = await asyncio.to_thread(daemon.macro_store.get, name)
+    macro_data = await asyncio.to_thread(_load_macro_meta_sync, daemon.macro_store, name)
     return await daemon.device_manager.play_macro(
-        macro_events=json_object_list(macro_data.get("events", [])),
+        macro_events=[],
         macro_name=name,
         replay_mouse_movement=bool(data.get("replay_mouse_movement", True)),
         replay_mouse_clicks=bool(data.get("replay_mouse_clicks", True)),
@@ -216,7 +292,7 @@ async def load_macro_definitions(
 
     async def load_macro(name: str) -> tuple[str, JsonObject | None]:
         try:
-            macro = await asyncio.to_thread(macro_store.get, name)
+            macro = await asyncio.to_thread(_load_macro_meta_sync, macro_store, name)
         except Exception:
             return name, None
         return name, macro
@@ -225,9 +301,15 @@ async def load_macro_definitions(
     return {name: macro for name, macro in loaded if isinstance(macro, dict)}
 
 
+def _load_macro_meta_sync(macro_store: _MacroDefinitionStore, name: str) -> JsonObject:
+    get_meta = getattr(macro_store, "get_meta", None)
+    if callable(get_meta):
+        return cast(JsonObject, get_meta(name))
+    return macro_store.get(name)
+
+
 def apply_macro_definition(action_data: JsonObject, macro: JsonObject) -> JsonObject:
     updated: JsonObject = dict(action_data)
-    updated["macro_events"] = json_object_list(macro.get("events", []))
     updated["macro_loop_mode"] = str_value(macro.get("loop_mode", "none"), "none") or "none"
     updated["macro_loop_count"] = int_like(macro.get("loop_count", 1), 1)
     updated["macro_loop_stop_behavior"] = normalize_macro_loop_stop_behavior(

--- a/keymasq/keymasqd/daemon_macro_commands.py
+++ b/keymasq/keymasqd/daemon_macro_commands.py
@@ -75,9 +75,16 @@ class _MacroCommandStore(_MacroDefinitionStore, Protocol):
 
 
 class _MacroCommandRecordingManager(Protocol):
-    def pending_recording(self, recording_id: str) -> object: ...
+    async def claim_pending_recording(self, recording_id: str) -> object: ...
 
-    def discard_pending_recording(self, recording_id: str) -> None: ...
+    async def release_pending_recording_claim(
+        self,
+        recording_id: str,
+        *,
+        saved: bool,
+    ) -> None: ...
+
+    async def discard_pending_recording(self, recording_id: str) -> None: ...
 
 
 class _PendingRecording(Protocol):
@@ -160,7 +167,7 @@ async def handle_macro_command(
 
     if command_type == CommandType.MACRO_DISCARD_RECORDING:
         recording_id = str_value(data.get("pending_recording_id", ""))
-        await asyncio.to_thread(daemon.recording_manager.discard_pending_recording, recording_id)
+        await daemon.recording_manager.discard_pending_recording(recording_id)
         return {"status": "ok"}
 
     if command_type == CommandType.MACRO_PLAY_BY_NAME:
@@ -181,21 +188,36 @@ async def save_pending_recording(
     daemon: _MacroCommandDaemon,
     data: JsonObject,
 ) -> JsonObject:
-    return await asyncio.to_thread(_save_pending_recording_sync, daemon, data)
+    recording_id = str_value(data.get("pending_recording_id", ""))
+    if not recording_id:
+        raise ValueError("pending_recording_id required")
+    if not str_value(data.get("name", "")):
+        raise ValueError("name required")
+    snapshot = cast(
+        _PendingRecording,
+        await daemon.recording_manager.claim_pending_recording(recording_id),
+    )
+    saved = False
+    try:
+        result = await asyncio.to_thread(_save_pending_recording_sync, daemon, data, snapshot)
+        saved = True
+        return result
+    finally:
+        await daemon.recording_manager.release_pending_recording_claim(
+            recording_id,
+            saved=saved,
+        )
 
 
 def _save_pending_recording_sync(
     daemon: _MacroCommandDaemon,
     data: JsonObject,
+    snapshot: _PendingRecording,
 ) -> JsonObject:
-    recording_id = str_value(data.get("pending_recording_id", ""))
     name = str_value(data.get("name", ""))
-    if not recording_id:
-        raise ValueError("pending_recording_id required")
     if not name:
         raise ValueError("name required")
 
-    snapshot = cast(_PendingRecording, daemon.recording_manager.pending_recording(recording_id))
     payload: JsonObject = {
         "name": name,
         "created_at": datetime.now().isoformat(),
@@ -212,7 +234,6 @@ def _save_pending_recording_sync(
         snapshot.iter_events(),
         return_full=False,
     )
-    daemon.recording_manager.discard_pending_recording(recording_id)
     return {"macro": macro}
 
 

--- a/keymasq/keymasqd/device_manager.py
+++ b/keymasq/keymasqd/device_manager.py
@@ -3,7 +3,7 @@ import contextlib
 import errno
 import logging
 from collections import deque
-from collections.abc import AsyncIterator, Awaitable, Callable, Sequence
+from collections.abc import AsyncIterator, Awaitable, Callable, Iterator, Sequence
 from dataclasses import dataclass, field
 from typing import Any, Protocol, cast
 
@@ -280,6 +280,8 @@ class DeviceManager:
         self.output_state = OutputRuntimeState()
         self.cursor_position_state = CursorPositionRuntimeState()
         self.recording_manager: RecordingManager | None = None
+        self.macro_store: Any | None = None
+        self.macro_exec_timeout_max_ms = 30000
         self.macro_state = MacroRuntimeState()
         self._op_lock = asyncio.Lock()
         self.diagnostics_state = DiagnosticsState()
@@ -711,7 +713,10 @@ class DeviceManager:
         source_device: str = "",
         source_button: str = "",
         trigger_value: int = 1,
+        macro_event_source: runtime_macros.MacroEventSource | None = None,
     ) -> JsonObject:
+        if macro_event_source is None and macro_name and not macro_events:
+            macro_event_source = await self._stored_macro_event_source(macro_name)
         return await runtime_macros.play_macro(
             self,
             macro_events,
@@ -730,6 +735,33 @@ class DeviceManager:
             source_button,
             trigger_value,
             deps=_macro_runtime_deps(),
+            macro_event_source=macro_event_source,
+        )
+
+    async def _stored_macro_event_source(
+        self,
+        macro_name: str,
+    ) -> runtime_macros.MacroEventSource | None:
+        store = self.macro_store
+        if store is None:
+            return None
+        get_meta = getattr(store, "get_meta", None)
+        iter_events = getattr(store, "iter_events", None)
+        if not callable(get_meta) or not callable(iter_events):
+            return None
+
+        meta_raw = await asyncio.to_thread(get_meta, macro_name)
+        if not isinstance(meta_raw, dict):
+            return None
+        meta = cast(JsonObject, meta_raw)
+
+        def iter_stored_events() -> Iterator[JsonObject]:
+            return cast(Iterator[JsonObject], iter_events(macro_name))
+
+        return runtime_macros.MacroEventSource(
+            event_count=_int_value(meta.get("event_count"), 0),
+            duration_us=_int_value(meta.get("duration_ms"), 0) * 1000,
+            iter_events=iter_stored_events,
         )
 
     def set_cursor_position_backend(self, enabled: bool) -> JsonObject:

--- a/keymasq/keymasqd/macro_file.py
+++ b/keymasq/keymasqd/macro_file.py
@@ -1,0 +1,213 @@
+import io
+import json
+import lzma
+from collections.abc import Iterable, Iterator
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import cast
+
+from keymasq.common.models import DEFAULT_MACRO_LOOP_STOP_BEHAVIOR
+
+MACRO_FILE_SUFFIX = ".kmacro.xz"
+MACRO_FILE_FORMAT = "keymasq-macro"
+MACRO_FILE_VERSION = 1
+
+type JsonObject = dict[str, object]
+type MacroEvent = dict[str, object]
+
+
+@dataclass(frozen=True)
+class MacroFileMeta:
+    name: str
+    duration_ms: int = 0
+    device_types: list[str] = field(default_factory=list)
+    event_count: int = 0
+    created_at: str = ""
+    revision: int = 1
+    move_to_start: bool = False
+    start_x: int = 0
+    start_y: int = 0
+    block_mouse_movement: bool = False
+    loop_mode: str = "none"
+    loop_count: int = 1
+    loop_stop_behavior: str = DEFAULT_MACRO_LOOP_STOP_BEHAVIOR
+
+    @classmethod
+    def from_payload(cls, payload: JsonObject, *, name: str | None = None) -> "MacroFileMeta":
+        return cls(
+            name=name or _payload_str(payload, "name"),
+            duration_ms=_payload_int(payload, "duration_ms", 0),
+            device_types=_payload_str_list(payload, "device_types"),
+            event_count=_payload_int(payload, "event_count", _event_count(payload)),
+            created_at=_payload_str(payload, "created_at", datetime.now().isoformat()),
+            revision=_payload_int(payload, "revision", 1),
+            move_to_start=bool(payload.get("move_to_start", False)),
+            start_x=_payload_int(payload, "start_x", 0),
+            start_y=_payload_int(payload, "start_y", 0),
+            block_mouse_movement=bool(payload.get("block_mouse_movement", False)),
+            loop_mode=_payload_str(payload, "loop_mode", "none") or "none",
+            loop_count=_payload_int(payload, "loop_count", 1),
+            loop_stop_behavior=_payload_str(
+                payload,
+                "loop_stop_behavior",
+                DEFAULT_MACRO_LOOP_STOP_BEHAVIOR,
+            )
+            or DEFAULT_MACRO_LOOP_STOP_BEHAVIOR,
+        )
+
+    def to_payload(self) -> JsonObject:
+        return {
+            "name": self.name,
+            "duration_ms": int(self.duration_ms),
+            "device_types": list(self.device_types),
+            "event_count": int(self.event_count),
+            "created_at": self.created_at,
+            "revision": int(self.revision),
+            "move_to_start": bool(self.move_to_start),
+            "start_x": int(self.start_x),
+            "start_y": int(self.start_y),
+            "block_mouse_movement": bool(self.block_mouse_movement),
+            "loop_mode": self.loop_mode,
+            "loop_count": int(self.loop_count),
+            "loop_stop_behavior": self.loop_stop_behavior,
+        }
+
+    def to_record(self) -> JsonObject:
+        return {
+            "format": MACRO_FILE_FORMAT,
+            "version": MACRO_FILE_VERSION,
+            **self.to_payload(),
+        }
+
+
+def read_macro_meta(path: Path) -> MacroFileMeta:
+    with _open_text(path, "rb") as f:
+        first_line = f.readline()
+    if not first_line:
+        raise ValueError("Empty macro file")
+    record = _json_object(json.loads(first_line))
+    _validate_meta_record(record)
+    return MacroFileMeta.from_payload(record)
+
+
+def iter_macro_events(path: Path) -> Iterator[MacroEvent]:
+    with _open_text(path, "rb") as f:
+        first_line = f.readline()
+        if not first_line:
+            raise ValueError("Empty macro file")
+        _validate_meta_record(_json_object(json.loads(first_line)))
+        for line in f:
+            stripped = line.strip()
+            if not stripped:
+                continue
+            event = _json_object(json.loads(stripped))
+            yield event
+
+
+def load_macro(path: Path) -> JsonObject:
+    meta = read_macro_meta(path)
+    payload = meta.to_payload()
+    payload["events"] = list(iter_macro_events(path))
+    return payload
+
+
+def write_macro(path: Path, meta: MacroFileMeta, events: Iterable[MacroEvent]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = path.with_suffix(path.suffix + ".tmp")
+    try:
+        with _open_text(tmp_path, "wb") as f:
+            f.write(_json_line(meta.to_record()))
+            for event in events:
+                f.write(_json_line(event))
+        tmp_path.chmod(0o600)
+        tmp_path.replace(path)
+        path.chmod(0o600)
+    except Exception:
+        tmp_path.unlink(missing_ok=True)
+        raise
+
+
+def macro_payload_from_events(
+    payload: JsonObject,
+    events: list[MacroEvent],
+    *,
+    name: str | None = None,
+    revision: int | None = None,
+    created_at: str | None = None,
+) -> JsonObject:
+    data = dict(payload)
+    data["events"] = events
+    if name is not None:
+        data["name"] = name
+    if revision is not None:
+        data["revision"] = int(revision)
+    if created_at is not None:
+        data["created_at"] = created_at
+    data["event_count"] = len(events)
+    if "duration_ms" not in data:
+        data["duration_ms"] = _duration_ms(events)
+    if "device_types" not in data:
+        data["device_types"] = _device_types(events)
+    return data
+
+
+def _open_text(path: Path, mode: str) -> io.TextIOWrapper:
+    raw = lzma.LZMAFile(path, mode)
+    return io.TextIOWrapper(raw, encoding="utf-8", newline="\n")
+
+
+def _json_line(value: JsonObject) -> str:
+    return json.dumps(value, separators=(",", ":")) + "\n"
+
+
+def _json_object(value: object) -> JsonObject:
+    if not isinstance(value, dict):
+        raise ValueError("Expected JSON object")
+    return cast(JsonObject, value)
+
+
+def _validate_meta_record(record: JsonObject) -> None:
+    if record.get("format") != MACRO_FILE_FORMAT:
+        raise ValueError("Unsupported macro file format")
+    if record.get("version") != MACRO_FILE_VERSION:
+        raise ValueError("Unsupported macro file version")
+
+
+def _payload_str(payload: JsonObject, key: str, default: str = "") -> str:
+    value = payload.get(key, default)
+    return value if isinstance(value, str) else default
+
+
+def _payload_int(payload: JsonObject, key: str, default: int) -> int:
+    value = payload.get(key, default)
+    try:
+        return int(cast(int | float | str, value))
+    except (TypeError, ValueError):
+        return default
+
+
+def _payload_str_list(payload: JsonObject, key: str) -> list[str]:
+    value = payload.get(key, [])
+    if not isinstance(value, list):
+        return []
+    items = cast(list[object], value)
+    return [str(item) for item in items if str(item)]
+
+
+def _event_count(payload: JsonObject) -> int:
+    events = payload.get("events")
+    return len(cast(list[object], events)) if isinstance(events, list) else 0
+
+
+def _event_t_us(event: MacroEvent) -> int:
+    value = event.get("t_us", 0)
+    return value if isinstance(value, int) else 0
+
+
+def _duration_ms(events: list[MacroEvent]) -> int:
+    return max((_event_t_us(event) for event in events), default=0) // 1000
+
+
+def _device_types(events: list[MacroEvent]) -> list[str]:
+    return sorted({str(event.get("device_type", "other")) for event in events})

--- a/keymasq/keymasqd/macro_store.py
+++ b/keymasq/keymasqd/macro_store.py
@@ -1,19 +1,23 @@
-import json
 import os
 import re
+from collections.abc import Iterable, Iterator
 from datetime import datetime
 from pathlib import Path
 from typing import cast
 
+from keymasq.keymasqd.macro_file import (
+    MACRO_FILE_SUFFIX,
+    MacroFileMeta,
+    iter_macro_events,
+    load_macro,
+    macro_payload_from_events,
+    read_macro_meta,
+    write_macro,
+)
+
 INTERNAL_MACRO_PREFIX = "__"
 type MacroEvent = dict[str, object]
 type MacroPayload = dict[str, object]
-
-
-def _as_macro_payload(value: object) -> MacroPayload:
-    if not isinstance(value, dict):
-        raise ValueError("Invalid macro payload")
-    return cast(MacroPayload, value)
 
 
 def _payload_str(payload: MacroPayload, key: str, default: str = "") -> str:
@@ -23,7 +27,10 @@ def _payload_str(payload: MacroPayload, key: str, default: str = "") -> str:
 
 def _payload_int(payload: MacroPayload, key: str, default: int) -> int:
     value = payload.get(key, default)
-    return value if isinstance(value, int) else default
+    try:
+        return int(cast(int | float | str, value))
+    except (TypeError, ValueError):
+        return default
 
 
 def _payload_list(payload: MacroPayload, key: str) -> list[object]:
@@ -32,27 +39,16 @@ def _payload_list(payload: MacroPayload, key: str) -> list[object]:
 
 
 class MacroStore:
-    """Central store for macro data, persisted as JSON files.
+    """Central store for macro data, persisted as compressed JSONL files.
 
-    Each macro is a JSON file under ``base_dir`` containing:
+    Persistent macros are stored as ``*.kmacro.xz`` files under ``base_dir``.
+    The first JSONL record contains macro metadata; each following record is
+    one macro event. Stored playback can iterate event records without loading
+    the full macro into memory. GUI/editor operations may still call ``get()``
+    to load a complete canonical macro payload.
 
-    - ``name``                  – unique identifier used by profiles and the CLI.
-    - ``events``                – recorded input events (evdev-format list).
-    - ``duration_ms``           – total duration in milliseconds.
-    - ``device_types``          – which device types are involved (keyboard, mouse, etc.).
-    - ``move_to_start``         – whether to reposition the cursor before playback.
-    - ``start_x`` / ``start_y`` – cursor position at the start of recording.
-    - ``block_mouse_movement``  – whether to suppress mouse movement during playback.
-    - ``loop_stop_behavior`` – whether Hold/Toggle stop input finishes or
-      cancels the current run.
-    - ``revision``              – version counter for optimistic concurrency.
-    - ``created_at``            – ISO timestamp of initial creation.
-
-    Editor metadata (such as gap notes) may also be stored to support
-    non-destructive editing in the GUI.
-
-    Internal macros (names prefixed with ``__``) are registered in memory
-    and are not written to disk.
+    Internal macros (names prefixed with ``__``) are registered in memory and
+    are not written to disk.
     """
 
     def __init__(self, base_dir: Path) -> None:
@@ -62,12 +58,11 @@ class MacroStore:
     def register_internal(self, name: str, events: list[MacroEvent], **extra: object) -> None:
         if not name.startswith(INTERNAL_MACRO_PREFIX):
             raise ValueError(f"Internal macro names must start with {INTERNAL_MACRO_PREFIX}")
-        self._internal_macros[name] = {
-            "name": name,
-            "events": events,
-            "internal": True,
-            **extra,
-        }
+        self._internal_macros[name] = macro_payload_from_events(
+            {"name": name, "internal": True, **extra},
+            events,
+            name=name,
+        )
 
     def is_internal(self, name: str) -> bool:
         return name in self._internal_macros
@@ -79,22 +74,12 @@ class MacroStore:
     def list_meta(self) -> list[MacroPayload]:
         self.ensure()
         macros: list[MacroPayload] = []
-        for path in sorted(self.base_dir.glob("*.json")):
+        for path in sorted(self.base_dir.glob(f"*{MACRO_FILE_SUFFIX}")):
             try:
-                data = _as_macro_payload(json.loads(path.read_text()))
-                name = _payload_str(data, "name", path.stem)
-                if name.startswith(INTERNAL_MACRO_PREFIX):
+                meta = read_macro_meta(path)
+                if meta.name.startswith(INTERNAL_MACRO_PREFIX):
                     continue
-                macros.append(
-                    {
-                        "name": name,
-                        "duration_ms": _payload_int(data, "duration_ms", 0),
-                        "device_types": _payload_list(data, "device_types"),
-                        "created_at": _payload_str(data, "created_at"),
-                        "event_count": len(_payload_list(data, "events")),
-                        "revision": _payload_int(data, "revision", 1),
-                    }
-                )
+                macros.append(meta.to_payload())
             except Exception:
                 continue
         return macros
@@ -105,31 +90,60 @@ class MacroStore:
         path = self._macro_path(name)
         if not path.exists():
             raise FileNotFoundError(f"Macro '{name}' not found")
-        data = _as_macro_payload(json.loads(path.read_text()))
-        data["revision"] = _payload_int(data, "revision", 1)
-        return data
+        return load_macro(path)
+
+    def get_meta(self, name: str) -> MacroPayload:
+        if name in self._internal_macros:
+            data = self._internal_macros[name]
+            return {
+                "name": _payload_str(data, "name", name),
+                "duration_ms": _payload_int(data, "duration_ms", 0),
+                "device_types": _payload_list(data, "device_types"),
+                "created_at": _payload_str(data, "created_at"),
+                "event_count": _payload_int(
+                    data,
+                    "event_count",
+                    len(_payload_list(data, "events")),
+                ),
+                "revision": _payload_int(data, "revision", 1),
+                "move_to_start": bool(data.get("move_to_start", False)),
+                "start_x": _payload_int(data, "start_x", 0),
+                "start_y": _payload_int(data, "start_y", 0),
+                "block_mouse_movement": bool(data.get("block_mouse_movement", False)),
+                "loop_mode": _payload_str(data, "loop_mode", "none") or "none",
+                "loop_count": _payload_int(data, "loop_count", 1),
+                "loop_stop_behavior": _payload_str(data, "loop_stop_behavior", "finish_run"),
+            }
+        path = self._macro_path(name)
+        if not path.exists():
+            raise FileNotFoundError(f"Macro '{name}' not found")
+        return read_macro_meta(path).to_payload()
+
+    def iter_events(self, name: str) -> Iterator[MacroEvent]:
+        if name in self._internal_macros:
+            events = _payload_events(self._internal_macros[name])
+            return iter(events)
+        path = self._macro_path(name)
+        if not path.exists():
+            raise FileNotFoundError(f"Macro '{name}' not found")
+        return iter_macro_events(path)
 
     def create(self, payload: MacroPayload) -> MacroPayload:
-        self.ensure()
-        raw_name = _payload_str(payload, "name")
-        if raw_name.startswith(INTERNAL_MACRO_PREFIX):
-            raise ValueError(f"Macro names starting with {INTERNAL_MACRO_PREFIX} are reserved")
-        name = self._sanitize_name(raw_name)
-        if not name:
-            raise ValueError("Invalid macro name")
+        events = _payload_events(payload)
+        return self._create_from_events(
+            macro_payload_from_events(payload, events),
+            events,
+            return_full=True,
+        )
 
-        path = self._macro_path(name)
-        if path.exists():
-            raise FileExistsError(f"Macro '{name}' already exists")
-
-        now = datetime.now().isoformat()
-        data: MacroPayload = dict(payload)
-        data["name"] = name
-        data["created_at"] = _payload_str(payload, "created_at", now) or now
-        data["revision"] = _payload_int(payload, "revision", 1)
-
-        self._write_atomic(path, data)
-        return self.get(name)
+    def create_from_events(
+        self,
+        payload: MacroPayload,
+        events: Iterable[MacroEvent],
+        *,
+        return_full: bool = False,
+    ) -> MacroPayload:
+        return self._create_from_events(payload, events, return_full=return_full)
 
     def update(
         self, name: str, payload: MacroPayload, expected_revision: int | None
@@ -150,7 +164,8 @@ class MacroStore:
             data[key] = value
 
         data["revision"] = current_revision + 1
-        self._write_atomic(self._macro_path(name), data)
+        data["event_count"] = len(_payload_events(data))
+        self._write_payload(self._macro_path(name), data)
         return self.get(name)
 
     def rename(self, old_name: str, new_name: str, expected_revision: int | None) -> MacroPayload:
@@ -176,14 +191,15 @@ class MacroStore:
 
         current["name"] = safe_new
         current["revision"] = current_revision + 1
-        self._write_atomic(new_path, current)
+        current["event_count"] = len(_payload_events(current))
+        self._write_payload(new_path, current)
         old_path.unlink(missing_ok=True)
         return self.get(safe_new)
 
     def delete(self, name: str, expected_revision: int | None) -> None:
         if name in self._internal_macros:
             raise PermissionError(f"Cannot delete internal macro '{name}'")
-        current = self.get(name)
+        current = self.get_meta(name)
         current_revision = _payload_int(current, "revision", 1)
         if expected_revision is not None and expected_revision != current_revision:
             raise ValueError(
@@ -191,19 +207,50 @@ class MacroStore:
             )
         self._macro_path(name).unlink(missing_ok=True)
 
+    def _create_from_events(
+        self,
+        payload: MacroPayload,
+        events: Iterable[MacroEvent],
+        *,
+        return_full: bool,
+    ) -> MacroPayload:
+        self.ensure()
+        raw_name = _payload_str(payload, "name")
+        if raw_name.startswith(INTERNAL_MACRO_PREFIX):
+            raise ValueError(f"Macro names starting with {INTERNAL_MACRO_PREFIX} are reserved")
+        name = self._sanitize_name(raw_name)
+        if not name:
+            raise ValueError("Invalid macro name")
+
+        path = self._macro_path(name)
+        if path.exists():
+            raise FileExistsError(f"Macro '{name}' already exists")
+
+        data = dict(payload)
+        data["name"] = name
+        data["created_at"] = _payload_str(payload, "created_at", datetime.now().isoformat())
+        data["revision"] = _payload_int(payload, "revision", 1)
+
+        meta = MacroFileMeta.from_payload(data, name=name)
+        write_macro(path, meta, events)
+        return self.get(name) if return_full else meta.to_payload()
+
     def _macro_path(self, name: str) -> Path:
         safe = self._sanitize_name(name)
         if not safe:
             raise ValueError("Invalid macro name")
-        return self.base_dir / f"{safe}.json"
+        return self.base_dir / f"{safe}{MACRO_FILE_SUFFIX}"
 
     def _sanitize_name(self, name: str) -> str:
         return re.sub(r"[^a-zA-Z0-9_.-]", "_", name).strip("._")
 
-    def _write_atomic(self, path: Path, data: MacroPayload) -> None:
-        path.parent.mkdir(parents=True, exist_ok=True)
-        tmp_path = path.with_suffix(path.suffix + ".tmp")
-        tmp_path.write_text(json.dumps(data))
-        os.chmod(tmp_path, 0o600)
-        os.replace(tmp_path, path)
-        os.chmod(path, 0o600)
+    def _write_payload(self, path: Path, data: MacroPayload) -> None:
+        events = _payload_events(data)
+        payload = macro_payload_from_events(data, events)
+        meta = MacroFileMeta.from_payload(payload)
+        write_macro(path, meta, events)
+
+
+def _payload_events(payload: MacroPayload) -> list[MacroEvent]:
+    events = _payload_list(payload, "events")
+    return [cast(MacroEvent, event) for event in events if isinstance(event, dict)]

--- a/keymasq/keymasqd/macro_store.py
+++ b/keymasq/keymasqd/macro_store.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import re
 from collections.abc import Iterable, Iterator
@@ -5,6 +6,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import cast
 
+from keymasq.common.models import DEFAULT_MACRO_LOOP_STOP_BEHAVIOR
 from keymasq.keymasqd.macro_file import (
     MACRO_FILE_SUFFIX,
     MacroFileMeta,
@@ -16,6 +18,7 @@ from keymasq.keymasqd.macro_file import (
 )
 
 INTERNAL_MACRO_PREFIX = "__"
+log = logging.getLogger("keymasqd.macros")
 type MacroEvent = dict[str, object]
 type MacroPayload = dict[str, object]
 
@@ -80,7 +83,8 @@ class MacroStore:
                 if meta.name.startswith(INTERNAL_MACRO_PREFIX):
                     continue
                 macros.append(meta.to_payload())
-            except Exception:
+            except Exception as exc:
+                log.warning("Skipping unreadable macro file %s: %s", path, exc)
                 continue
         return macros
 
@@ -112,7 +116,11 @@ class MacroStore:
                 "block_mouse_movement": bool(data.get("block_mouse_movement", False)),
                 "loop_mode": _payload_str(data, "loop_mode", "none") or "none",
                 "loop_count": _payload_int(data, "loop_count", 1),
-                "loop_stop_behavior": _payload_str(data, "loop_stop_behavior", "finish_run"),
+                "loop_stop_behavior": _payload_str(
+                    data,
+                    "loop_stop_behavior",
+                    DEFAULT_MACRO_LOOP_STOP_BEHAVIOR,
+                ),
             }
         path = self._macro_path(name)
         if not path.exists():

--- a/keymasq/keymasqd/recording.py
+++ b/keymasq/keymasqd/recording.py
@@ -1,5 +1,6 @@
 import asyncio
 from collections.abc import AsyncIterator, Awaitable, Callable
+from pathlib import Path
 from typing import Protocol, cast
 
 import evdev
@@ -11,6 +12,8 @@ from keymasq.common.devices import (
     resolve_stable_path,
 )
 from keymasq.common.ipc import CommandType
+from keymasq.common.paths import STATE_DIR
+from keymasq.keymasqd.recording_spool import RecordingSnapshot, RecordingSpool
 
 type RecordingEvent = dict[str, object]
 type RecordingPayload = dict[str, object]
@@ -23,20 +26,19 @@ class _RecordingInputDevice(Protocol):
     def async_read_loop(self) -> AsyncIterator[evdev.InputEvent]: ...
 
 
-def _event_time_us(event: RecordingEvent) -> int:
-    value = event.get("t_us", 0)
-    return value if isinstance(value, int) else 0
-
-
 class RecordingManager:
     def __init__(
         self,
         broadcast_callback: (
             Callable[[CommandType, RecordingPayload], Awaitable[None]] | None
         ) = None,
+        *,
+        spool_dir: Path | None = None,
     ) -> None:
         self.broadcast_callback = broadcast_callback
-        self._events: list[RecordingEvent] = []
+        self._spool_dir = spool_dir or STATE_DIR / "recording-spool"
+        self._spool: RecordingSpool | None = None
+        self._pending_recordings: dict[str, RecordingSnapshot] = {}
         self._start_time_us: int | None = None
         self._extra_devices: list[_RecordingInputDevice] = []
         self._monitoring_tasks: list[asyncio.Task[None]] = []
@@ -61,9 +63,12 @@ class RecordingManager:
         include_mouse_movement: bool = False,
         include_mouse_clicks: bool = False,
     ) -> RecordingPayload:
-        await self.stop()
+        previous = await self.stop()
+        pending_id = previous.get("pending_recording_id")
+        if isinstance(pending_id, str) and pending_id:
+            self.discard_pending_recording(pending_id)
 
-        self._events = []
+        self._spool = RecordingSpool(self._spool_dir)
         self._start_time_us = None
         self._extra_devices = []
         self._monitoring_tasks = []
@@ -127,7 +132,11 @@ class RecordingManager:
             self._start_time_us = event_ts_us
 
         t_us = max(0, event_ts_us - self._start_time_us)
-        self._events.append(
+        spool = self._spool
+        if spool is None:
+            return
+
+        spool.append(
             {
                 "device_type": device_type,
                 "type": event.type,
@@ -166,24 +175,39 @@ class RecordingManager:
         self._extra_devices = []
         self._record_grabbed_source_keys = set()
 
-        duration_ms = int(_event_time_us(self._events[-1]) / 1000) if self._events else 0
-        device_types = sorted({str(event.get("device_type", "other")) for event in self._events})
+        spool = self._spool
+        self._spool = None
+        if spool is None:
+            return {"status": "ok"}
+
+        snapshot = await spool.finish()
+        self._pending_recordings[snapshot.recording_id] = snapshot
 
         payload: RecordingPayload = {
-            "duration_ms": duration_ms,
-            "device_types": device_types,
-            "events": list(self._events),
+            "pending_recording_id": snapshot.recording_id,
+            "duration_ms": snapshot.duration_ms,
+            "device_types": snapshot.device_types,
+            "event_count": snapshot.event_count,
         }
 
         if was_recording and self.broadcast_callback:
             await self.broadcast_callback(CommandType.RECORDING_STOPPED, payload)
 
         return {
-            "duration_ms": duration_ms,
-            "device_types": device_types,
-            "event_count": len(self._events),
-            "events": list(self._events),
+            "status": "ok",
+            **payload,
         }
+
+    def pending_recording(self, recording_id: str) -> RecordingSnapshot:
+        snapshot = self._pending_recordings.get(recording_id)
+        if snapshot is None:
+            raise FileNotFoundError("Pending recording not found")
+        return snapshot
+
+    def discard_pending_recording(self, recording_id: str) -> None:
+        snapshot = self._pending_recordings.pop(recording_id, None)
+        if snapshot is not None:
+            snapshot.cleanup()
 
     async def _monitor_progress(self) -> None:
         while not self._stopped:
@@ -191,11 +215,13 @@ class RecordingManager:
             if self._stopped or not self.broadcast_callback:
                 continue
 
-            duration_ms = int(_event_time_us(self._events[-1]) / 1000) if self._events else 0
+            spool = self._spool
+            duration_ms = spool.duration_ms if spool is not None else 0
+            event_count = spool.event_count if spool is not None else 0
             await self.broadcast_callback(
                 CommandType.RECORDING_PROGRESS,
                 {
-                    "event_count": len(self._events),
+                    "event_count": event_count,
                     "duration_ms": duration_ms,
                 },
         )

--- a/keymasq/keymasqd/recording.py
+++ b/keymasq/keymasqd/recording.py
@@ -1,5 +1,6 @@
 import asyncio
 from collections.abc import AsyncIterator, Awaitable, Callable
+from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Protocol, cast
 
@@ -18,6 +19,7 @@ from keymasq.keymasqd.recording_spool import RecordingSnapshot, RecordingSpool
 type RecordingEvent = dict[str, object]
 type RecordingPayload = dict[str, object]
 type RecordingDevice = dict[str, object]
+PENDING_RECORDING_TTL_S = 30 * 60
 
 
 class _RecordingInputDevice(Protocol):
@@ -39,6 +41,11 @@ class RecordingManager:
         self._spool_dir = spool_dir or STATE_DIR / "recording-spool"
         self._spool: RecordingSpool | None = None
         self._pending_recordings: dict[str, RecordingSnapshot] = {}
+        self._pending_recording_created_at: dict[str, float] = {}
+        self._claimed_recordings: dict[str, RecordingSnapshot] = {}
+        self._claimed_recording_created_at: dict[str, float] = {}
+        self._claimed_recording_discard_requested: set[str] = set()
+        self._pending_recording_lock = asyncio.Lock()
         self._start_time_us: int | None = None
         self._extra_devices: list[_RecordingInputDevice] = []
         self._monitoring_tasks: list[asyncio.Task[None]] = []
@@ -63,10 +70,11 @@ class RecordingManager:
         include_mouse_movement: bool = False,
         include_mouse_clicks: bool = False,
     ) -> RecordingPayload:
+        await self.discard_expired_pending_recordings()
         previous = await self.stop()
         pending_id = previous.get("pending_recording_id")
         if isinstance(pending_id, str) and pending_id:
-            self.discard_pending_recording(pending_id)
+            await self.discard_pending_recording(pending_id)
 
         self._spool = RecordingSpool(self._spool_dir)
         self._start_time_us = None
@@ -176,12 +184,22 @@ class RecordingManager:
         self._record_grabbed_source_keys = set()
 
         spool = self._spool
-        self._spool = None
         if spool is None:
             return {"status": "ok"}
 
-        snapshot = await spool.finish()
-        self._pending_recordings[snapshot.recording_id] = snapshot
+        try:
+            snapshot = await spool.finish()
+        except Exception:
+            await spool.discard()
+            raise
+        finally:
+            self._spool = None
+
+        async with self._pending_recording_lock:
+            self._pending_recordings[snapshot.recording_id] = snapshot
+            self._pending_recording_created_at[snapshot.recording_id] = (
+                asyncio.get_running_loop().time()
+            )
 
         payload: RecordingPayload = {
             "pending_recording_id": snapshot.recording_id,
@@ -198,16 +216,120 @@ class RecordingManager:
             **payload,
         }
 
-    def pending_recording(self, recording_id: str) -> RecordingSnapshot:
-        snapshot = self._pending_recordings.get(recording_id)
-        if snapshot is None:
-            raise FileNotFoundError("Pending recording not found")
-        return snapshot
+    async def pending_recording(self, recording_id: str) -> RecordingSnapshot:
+        async with self._pending_recording_lock:
+            snapshot = self._pending_recordings.get(recording_id)
+            if snapshot is None:
+                raise FileNotFoundError("Pending recording not found")
+            return snapshot
 
-    def discard_pending_recording(self, recording_id: str) -> None:
-        snapshot = self._pending_recordings.pop(recording_id, None)
-        if snapshot is not None:
+    async def claim_pending_recording(self, recording_id: str) -> RecordingSnapshot:
+        async with self._pending_recording_lock:
+            snapshot = self._pending_recordings.pop(recording_id, None)
+            created_at = self._pending_recording_created_at.pop(recording_id, None)
+            if snapshot is None:
+                raise FileNotFoundError("Pending recording not found")
+            self._claimed_recordings[recording_id] = snapshot
+            self._claimed_recording_created_at[recording_id] = (
+                created_at
+                if created_at is not None
+                else asyncio.get_running_loop().time()
+            )
+            self._claimed_recording_discard_requested.discard(recording_id)
+            return snapshot
+
+    async def release_pending_recording_claim(
+        self,
+        recording_id: str,
+        *,
+        saved: bool,
+    ) -> None:
+        cleanup_snapshot: RecordingSnapshot | None = None
+        async with self._pending_recording_lock:
+            snapshot = self._claimed_recordings.pop(recording_id, None)
+            created_at = self._claimed_recording_created_at.pop(recording_id, None)
+            discard_requested = recording_id in self._claimed_recording_discard_requested
+            self._claimed_recording_discard_requested.discard(recording_id)
+            if snapshot is None:
+                return
+            if saved or discard_requested:
+                cleanup_snapshot = snapshot
+            else:
+                self._pending_recordings[recording_id] = snapshot
+                self._pending_recording_created_at[recording_id] = (
+                    created_at
+                    if created_at is not None
+                    else asyncio.get_running_loop().time()
+                )
+
+        if cleanup_snapshot is not None:
+            cleanup_snapshot.cleanup()
+
+    async def discard_pending_recording(self, recording_id: str) -> None:
+        cleanup_snapshot: RecordingSnapshot | None = None
+        async with self._pending_recording_lock:
+            snapshot = self._pending_recordings.pop(recording_id, None)
+            self._pending_recording_created_at.pop(recording_id, None)
+            if snapshot is not None:
+                cleanup_snapshot = snapshot
+            elif recording_id in self._claimed_recordings:
+                self._claimed_recording_discard_requested.add(recording_id)
+
+        if cleanup_snapshot is not None:
+            cleanup_snapshot.cleanup()
+
+    async def discard_all_pending_recordings(self) -> None:
+        snapshots = await self._pop_all_pending_recordings()
+        for snapshot in snapshots:
             snapshot.cleanup()
+
+    async def discard_expired_pending_recordings(
+        self,
+        *,
+        ttl_s: float = PENDING_RECORDING_TTL_S,
+    ) -> None:
+        now = asyncio.get_running_loop().time()
+        expired_ids: list[str] = []
+        async with self._pending_recording_lock:
+            for recording_id, created_at in self._pending_recording_created_at.items():
+                if now - created_at >= max(0.0, float(ttl_s)):
+                    expired_ids.append(recording_id)
+            snapshots = [
+                self._pending_recordings.pop(recording_id)
+                for recording_id in expired_ids
+                if recording_id in self._pending_recordings
+            ]
+            for recording_id in expired_ids:
+                self._pending_recording_created_at.pop(recording_id, None)
+
+        for snapshot in snapshots:
+            snapshot.cleanup()
+
+    def cleanup_spool_dir(self, *, older_than_s: float | None = None) -> None:
+        if not self._spool_dir.exists():
+            return
+        cutoff = (
+            datetime.now() - timedelta(seconds=max(0.0, float(older_than_s)))
+            if older_than_s is not None
+            else None
+        )
+        for path in self._spool_dir.glob("recording-*.jsonl"):
+            try:
+                if cutoff is not None:
+                    mtime = datetime.fromtimestamp(path.stat().st_mtime)
+                    if mtime > cutoff:
+                        continue
+                path.unlink(missing_ok=True)
+            except OSError:
+                continue
+
+    async def _pop_all_pending_recordings(self) -> list[RecordingSnapshot]:
+        async with self._pending_recording_lock:
+            snapshots = list(self._pending_recordings.values())
+            self._pending_recordings.clear()
+            self._pending_recording_created_at.clear()
+            self._claimed_recording_discard_requested.update(self._claimed_recordings)
+            return snapshots
 
     async def _monitor_progress(self) -> None:
         while not self._stopped:

--- a/keymasq/keymasqd/recording_spool.py
+++ b/keymasq/keymasqd/recording_spool.py
@@ -88,25 +88,29 @@ class RecordingSpool:
             self._queue_memory_chunk()
 
     async def finish(self) -> RecordingSnapshot:
-        if self._fatal_error is not None:
-            raise RuntimeError(
-                f"Recording spool failed: {self._fatal_error}"
-            ) from self._fatal_error
+        try:
+            while True:
+                if self._fatal_error is not None:
+                    raise RuntimeError(
+                        f"Recording spool failed: {self._fatal_error}"
+                    ) from self._fatal_error
 
-        while True:
-            task = self._flush_task
-            if task is not None:
-                await task
+                task = self._flush_task
+                if task is not None:
+                    await task
 
-            if self._fatal_error is not None:
-                raise RuntimeError(
-                    f"Recording spool failed: {self._fatal_error}"
-                ) from self._fatal_error
+                if self._fatal_error is not None:
+                    raise RuntimeError(
+                        f"Recording spool failed: {self._fatal_error}"
+                    ) from self._fatal_error
 
-            if self._spool_path is not None and self._memory_events:
-                self._queue_memory_chunk()
-                continue
-            break
+                if self._spool_path is not None and self._memory_events:
+                    self._queue_memory_chunk()
+                    continue
+                break
+        except Exception:
+            await self.discard()
+            raise
 
         snapshot = RecordingSnapshot(
             recording_id=uuid.uuid4().hex,

--- a/keymasq/keymasqd/recording_spool.py
+++ b/keymasq/keymasqd/recording_spool.py
@@ -1,0 +1,207 @@
+import asyncio
+import json
+import os
+import tempfile
+import uuid
+from collections import deque
+from collections.abc import Iterator
+from dataclasses import dataclass
+from pathlib import Path
+from typing import cast
+
+type RecordingEvent = dict[str, object]
+
+DEFAULT_MEMORY_EVENT_LIMIT = 8192
+DEFAULT_MEMORY_BYTE_LIMIT = 2 * 1024 * 1024
+DEFAULT_MAX_PENDING_FLUSH_CHUNKS = 8
+
+
+@dataclass(frozen=True)
+class RecordingSnapshot:
+    recording_id: str
+    duration_ms: int
+    device_types: list[str]
+    event_count: int
+    spool_path: Path | None
+    memory_events: tuple[RecordingEvent, ...]
+
+    def iter_events(self) -> Iterator[RecordingEvent]:
+        if self.spool_path is not None:
+            with self.spool_path.open("r", encoding="utf-8") as f:
+                for line in f:
+                    stripped = line.strip()
+                    if not stripped:
+                        continue
+                    value = json.loads(stripped)
+                    if isinstance(value, dict):
+                        yield cast(RecordingEvent, value)
+        yield from self.memory_events
+
+    def cleanup(self) -> None:
+        if self.spool_path is not None:
+            self.spool_path.unlink(missing_ok=True)
+
+
+class RecordingSpool:
+    """Bounded recording event buffer with asynchronous uncompressed spill files."""
+
+    def __init__(
+        self,
+        spool_dir: Path,
+        *,
+        memory_event_limit: int = DEFAULT_MEMORY_EVENT_LIMIT,
+        memory_byte_limit: int = DEFAULT_MEMORY_BYTE_LIMIT,
+        max_pending_flush_chunks: int = DEFAULT_MAX_PENDING_FLUSH_CHUNKS,
+    ) -> None:
+        self.spool_dir = spool_dir
+        self.memory_event_limit = max(1, int(memory_event_limit))
+        self.memory_byte_limit = max(1, int(memory_byte_limit))
+        self.max_pending_flush_chunks = max(1, int(max_pending_flush_chunks))
+        self._memory_events: list[RecordingEvent] = []
+        self._memory_bytes = 0
+        self._pending_flush_chunks: deque[list[RecordingEvent]] = deque()
+        self._flush_task: asyncio.Task[None] | None = None
+        self._spool_path: Path | None = None
+        self._fatal_error: BaseException | None = None
+        self.event_count = 0
+        self.duration_ms = 0
+        self.device_types: set[str] = set()
+
+    @property
+    def failed(self) -> BaseException | None:
+        return self._fatal_error
+
+    def append(self, event: RecordingEvent) -> None:
+        if self._fatal_error is not None:
+            return
+
+        self._memory_events.append(event)
+        self._memory_bytes += _estimate_event_bytes(event)
+        self.event_count += 1
+        self.duration_ms = int(_event_t_us(event) / 1000)
+        self.device_types.add(str(event.get("device_type", "other")))
+
+        if (
+            len(self._memory_events) >= self.memory_event_limit
+            or self._memory_bytes >= self.memory_byte_limit
+        ):
+            self._queue_memory_chunk()
+
+    async def finish(self) -> RecordingSnapshot:
+        if self._fatal_error is not None:
+            raise RuntimeError(
+                f"Recording spool failed: {self._fatal_error}"
+            ) from self._fatal_error
+
+        while True:
+            task = self._flush_task
+            if task is not None:
+                await task
+
+            if self._fatal_error is not None:
+                raise RuntimeError(
+                    f"Recording spool failed: {self._fatal_error}"
+                ) from self._fatal_error
+
+            if self._spool_path is not None and self._memory_events:
+                self._queue_memory_chunk()
+                continue
+            break
+
+        snapshot = RecordingSnapshot(
+            recording_id=uuid.uuid4().hex,
+            duration_ms=int(self.duration_ms),
+            device_types=sorted(self.device_types),
+            event_count=int(self.event_count),
+            spool_path=self._spool_path,
+            memory_events=tuple(self._memory_events),
+        )
+        self._memory_events = []
+        self._memory_bytes = 0
+        self._spool_path = None
+        return snapshot
+
+    async def discard(self) -> None:
+        self._memory_events = []
+        self._memory_bytes = 0
+        self._pending_flush_chunks.clear()
+        task = self._flush_task
+        if task is not None:
+            await task
+        self._flush_task = None
+        if self._spool_path is not None:
+            self._spool_path.unlink(missing_ok=True)
+            self._spool_path = None
+
+    def _queue_memory_chunk(self) -> None:
+        if not self._memory_events:
+            return
+        if len(self._pending_flush_chunks) >= self.max_pending_flush_chunks:
+            self._fatal_error = MemoryError("Recording spool writer fell behind")
+            return
+        self._pending_flush_chunks.append(self._memory_events)
+        self._memory_events = []
+        self._memory_bytes = 0
+        self._ensure_flush_task()
+
+    def _ensure_flush_task(self) -> None:
+        if self._flush_task is not None and not self._flush_task.done():
+            return
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError as exc:
+            self._fatal_error = exc
+            return
+        self._flush_task = loop.create_task(self._flush_pending_chunks())
+
+    async def _flush_pending_chunks(self) -> None:
+        try:
+            while self._pending_flush_chunks:
+                chunk = self._pending_flush_chunks.popleft()
+                await asyncio.to_thread(self._write_chunk, chunk)
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            self._fatal_error = exc
+        finally:
+            if self._flush_task is asyncio.current_task():
+                self._flush_task = None
+            if self._pending_flush_chunks and self._fatal_error is None:
+                self._ensure_flush_task()
+
+    def _write_chunk(self, chunk: list[RecordingEvent]) -> None:
+        path = self._ensure_spool_path()
+        with path.open("a", encoding="utf-8") as f:
+            for event in chunk:
+                f.write(json.dumps(event, separators=(",", ":")))
+                f.write("\n")
+
+    def _ensure_spool_path(self) -> Path:
+        if self._spool_path is not None:
+            return self._spool_path
+
+        self.spool_dir.mkdir(parents=True, exist_ok=True)
+        os.chmod(self.spool_dir, 0o700)
+        fd, raw_path = tempfile.mkstemp(
+            prefix="recording-",
+            suffix=".jsonl",
+            dir=self.spool_dir,
+            text=True,
+        )
+        os.close(fd)
+        path = Path(raw_path)
+        path.chmod(0o600)
+        self._spool_path = path
+        return path
+
+
+def _event_t_us(event: RecordingEvent) -> int:
+    value = event.get("t_us", 0)
+    return value if isinstance(value, int) else 0
+
+
+def _estimate_event_bytes(event: RecordingEvent) -> int:
+    size = 64
+    for key, value in event.items():
+        size += len(str(key)) + len(str(value)) + 8
+    return size

--- a/keymasq/keymasqd/runtime/macros.py
+++ b/keymasq/keymasqd/runtime/macros.py
@@ -2,7 +2,7 @@ import contextlib
 import logging
 import random
 import uuid
-from collections.abc import Callable
+from collections.abc import AsyncIterator, Callable, Iterator
 from dataclasses import dataclass
 from typing import Any
 
@@ -16,6 +16,7 @@ type JsonObject = dict[str, object]
 type IntValueFn = Callable[[object, int], int]
 type StrValueFn = Callable[[object, str], str]
 type _MacroManager = Any
+type MacroEventIteratorFactory = Callable[[], Iterator[dict[str, object]]]
 
 
 @dataclass(frozen=True)
@@ -26,6 +27,25 @@ class MacroRuntimeDeps:
     log: logging.Logger
     int_value_fn: IntValueFn
     str_value_fn: StrValueFn
+
+
+@dataclass(frozen=True)
+class MacroEventSource:
+    event_count: int
+    duration_us: int
+    iter_events: MacroEventIteratorFactory
+
+
+def list_macro_event_source(
+    macro_events: list[dict[str, object]],
+    *,
+    int_value_fn: IntValueFn,
+) -> MacroEventSource:
+    return MacroEventSource(
+        event_count=len(macro_events),
+        duration_us=max((int_value_fn(ev.get("t_us"), 0) for ev in macro_events), default=0),
+        iter_events=lambda: iter(macro_events),
+    )
 
 
 async def play_macro(
@@ -47,6 +67,7 @@ async def play_macro(
     trigger_value: int,
     *,
     deps: MacroRuntimeDeps,
+    macro_event_source: MacroEventSource | None = None,
 ) -> dict[str, object]:
     asyncio_mod = deps.asyncio_mod
     if not (
@@ -128,6 +149,8 @@ async def play_macro(
             manager,
             instance_id=instance_id,
             macro_events=macro_events,
+            macro_event_source=macro_event_source
+            or list_macro_event_source(macro_events, int_value_fn=deps.int_value_fn),
             macro_name=macro_name,
             replay_mouse_movement=replay_mouse_movement,
             replay_mouse_clicks=replay_mouse_clicks,
@@ -284,6 +307,7 @@ async def play_macro_task(
     block_mouse_movement: bool,
     *,
     deps: MacroRuntimeDeps,
+    macro_event_source: MacroEventSource | None = None,
 ) -> None:
     asyncio_mod = deps.asyncio_mod
     evdev_mod = deps.evdev_mod
@@ -291,14 +315,17 @@ async def play_macro_task(
     str_value_fn = deps.str_value_fn
     uinput_writer = deps.uinput_writer
     mouse_btn_codes = frozenset(range(0x110, 0x118))
+    if macro_event_source is None:
+        macro_event_source = list_macro_event_source(
+            macro_events,
+            int_value_fn=int_value_fn,
+        )
 
     if manager.verbosity >= 1:
         deps.log.debug("Macro playback started: %s", macro_name or "<unnamed>")
 
     speed_factor = max(0.01, speed)
-    macro_duration_us = (
-        max(int_value_fn(ev.get("t_us"), 0) for ev in macro_events) if macro_events else 0
-    )
+    macro_duration_us = int(macro_event_source.duration_us)
     suppression_timeout_s = max(2.0, (macro_duration_us / speed_factor) / 1_000_000.0 + 1.0)
     event_loop = asyncio_mod.get_running_loop()
     try:
@@ -333,11 +360,16 @@ async def play_macro_task(
             # sequential semantics.
             iteration_anchor = event_loop.time()
             timeline_offset_s = 0.0
-            for idx, ev in enumerate(macro_events):
+            idx = 0
+            async for ev in iter_macro_source_events(
+                macro_event_source,
+                deps=deps,
+            ):
                 if instance_id in manager.macro_state.cancel_instance_ids:
                     break
                 if (idx & 127) == 127:
                     await asyncio_mod.sleep(0)
+                idx += 1
 
                 t_us = int_value_fn(ev.get("t_us"), 0)
                 deadline = (
@@ -438,7 +470,7 @@ async def play_macro_task(
                     elif event_value == 0:
                         track_macro_key_release(manager, instance_id, output_class, event_code)
 
-            if not macro_events and loop_mode in {"hold", "toggle"}:
+            if macro_event_source.event_count <= 0 and loop_mode in {"hold", "toggle"}:
                 await asyncio_mod.sleep(0.01)
             else:
                 await asyncio_mod.sleep(0)
@@ -468,6 +500,35 @@ async def play_macro_task(
             release_macro_mouse_inhibit(manager)
         if manager.verbosity >= 1:
             deps.log.debug("Macro playback finished: %s", macro_name or "<unnamed>")
+
+
+class _MacroBatchReader:
+    def __init__(self, source: MacroEventSource, batch_size: int = 128) -> None:
+        self._iterator = source.iter_events()
+        self._batch_size = max(1, int(batch_size))
+
+    def next_batch(self) -> list[dict[str, object]]:
+        batch: list[dict[str, object]] = []
+        for _ in range(self._batch_size):
+            try:
+                batch.append(next(self._iterator))
+            except StopIteration:
+                break
+        return batch
+
+
+async def iter_macro_source_events(
+    source: MacroEventSource,
+    *,
+    deps: MacroRuntimeDeps,
+) -> AsyncIterator[dict[str, object]]:
+    reader = _MacroBatchReader(source)
+    while True:
+        batch = await deps.asyncio_mod.to_thread(reader.next_batch)
+        if not batch:
+            break
+        for event in batch:
+            yield event
 
 
 def _is_wheel_event(event_type: int, event_code: int, *, evdev_mod: Any) -> bool:
@@ -627,6 +688,10 @@ async def run_macro_control_action(
             return 0.0
 
         timeout_ms = max(1, int_value_fn(ev.get("timeout_ms"), 30000))
+        timeout_limit = getattr(manager, "macro_exec_timeout_max_ms", None)
+        if timeout_limit is not None:
+            with contextlib.suppress(TypeError, ValueError):
+                timeout_ms = min(timeout_ms, max(1, int(timeout_limit)))
         inhibit_mouse = bool(ev.get("inhibit_mouse", False))
         loop = asyncio_mod.get_running_loop()
         started_at = loop.time()

--- a/keymasq/session/manager/commands.py
+++ b/keymasq/session/manager/commands.py
@@ -285,6 +285,18 @@ async def _handle_recording_commands(
                 "error_code": "stale_pending_macro_save",
                 "message": "Pending recording has already changed.",
             }
+        pending_data = manager.recording_state.pending_data or {}
+        pending_recording_id = str_value(pending_data.get("pending_recording_id"), "")
+        if pending_recording_id:
+            try:
+                await manager.client.send_command(
+                    Command(
+                        command=CommandType.MACRO_DISCARD_RECORDING,
+                        data={"pending_recording_id": pending_recording_id},
+                    )
+                )
+            except Exception:
+                pass
         runtime_recording.clear_pending_macro_save(manager)
         return {"status": "ok"}
 
@@ -403,41 +415,16 @@ async def _handle_macro_commands(
     if command == "play_macro":
         name = str_value(request.get("name"), "")
         try:
-            get_result = await manager.client.send_command(
-                Command(command=CommandType.MACRO_GET, data={"name": name})
-            )
-        except Exception:
-            return {"status": "error", "message": "Daemon unavailable"}
-
-        get_result_data = json_object(get_result.data)
-        if get_result.status != "ok" or get_result_data is None:
-            return {"status": "error", "message": get_result.error or "Macro not found"}
-
-        macro = json_object(get_result_data.get("macro"))
-        if macro is None:
-            return {"status": "error", "message": "Macro not found"}
-
-        macro = runtime_recording.sanitize_macro_for_policy(manager, macro)
-        named_payload: JsonObject = {
-            "macro_name": str(macro.get("name", name) or name),
-            "macro_events": macro.get("events", []),
-            "replay_mouse_movement": request.get("replay_mouse_movement", True),
-            "replay_mouse_clicks": request.get("replay_mouse_clicks", True),
-            "speed": float_value(request.get("speed"), 1.0),
-            "loop_mode": str(macro.get("loop_mode", "none") or "none"),
-            "loop_count": int_value(macro.get("loop_count"), 1),
-            "loop_stop_behavior": normalize_macro_loop_stop_behavior(
-                macro.get("loop_stop_behavior")
-            ),
-            "move_to_start": bool(macro.get("move_to_start", False)),
-            "start_x": int_value(macro.get("start_x"), 0),
-            "start_y": int_value(macro.get("start_y"), 0),
-            "block_mouse_movement": bool(macro.get("block_mouse_movement", False)),
-        }
-
-        try:
             result = await manager.client.send_command(
-                Command(command=CommandType.PLAY_MACRO, data=named_payload)
+                Command(
+                    command=CommandType.MACRO_PLAY_BY_NAME,
+                    data={
+                        "name": name,
+                        "replay_mouse_movement": request.get("replay_mouse_movement", True),
+                        "replay_mouse_clicks": request.get("replay_mouse_clicks", True),
+                        "speed": float_value(request.get("speed"), 1.0),
+                    },
+                )
             )
         except Exception:
             return {"status": "error", "message": "Daemon unavailable"}

--- a/keymasq/session/manager/core.py
+++ b/keymasq/session/manager/core.py
@@ -297,7 +297,7 @@ class SessionManager:
         except Exception as e:
             log.debug(f"Session client error: {e}")
         finally:
-            runtime_recording.clear_pending_macro_save_if_writer(self, writer)
+            await runtime_recording.discard_pending_macro_save_if_writer(self, writer)
             await runtime_recording.clear_recording_refresh_owner_if_writer(self, peer, writer)
             self.session_clients.discard(writer)
             self.session_client_peers.pop(writer, None)

--- a/keymasq/session/manager/events.py
+++ b/keymasq/session/manager/events.py
@@ -117,7 +117,7 @@ async def handle_event(
                 "event": "recording_stopped",
                 "pending_save_token": pending_save_token,
                 "duration_ms": recording_data.get("duration_ms", 0),
-                "event_count": len(_json_list(recording_data.get("events"))),
+                "event_count": _int_value(recording_data.get("event_count"), 0),
                 "device_types": recording_data.get("device_types", []),
                 "start_x": recording_data.get("start_x"),
                 "start_y": recording_data.get("start_y"),

--- a/keymasq/session/manager/recording.py
+++ b/keymasq/session/manager/recording.py
@@ -180,6 +180,32 @@ def clear_pending_macro_save_if_writer(
         clear_pending_macro_save(manager)
 
 
+async def discard_pending_macro_save_if_writer(
+    manager: "SessionManager",
+    writer: asyncio.StreamWriter,
+) -> None:
+    state = manager.recording_state
+    if not has_pending_macro_save(manager):
+        return
+    owner_writer_id = state.pending_save_owner_writer_id
+    if owner_writer_id != id(writer) and owner_writer_id is not None:
+        return
+
+    pending_data = state.pending_data or {}
+    pending_recording_id = str_value(pending_data.get("pending_recording_id"), "")
+    if pending_recording_id:
+        try:
+            await manager.client.send_command(
+                Command(
+                    command=CommandType.MACRO_DISCARD_RECORDING,
+                    data={"pending_recording_id": pending_recording_id},
+                )
+            )
+        except Exception:
+            pass
+    clear_pending_macro_save(manager)
+
+
 def pending_macro_save_token_matches(
     manager: "SessionManager",
     token: str,
@@ -722,8 +748,11 @@ async def stop_recording(
                 recording_data["move_to_start"] = True
             if has_pending_macro_save(manager):
                 manager.recording_state.pending_data = recording_data
+                pending_save_token = str(manager.recording_state.pending_save_token or "")
             else:
-                begin_pending_macro_save(manager, recording_data)
+                pending_save_token = begin_pending_macro_save(manager, recording_data)
+            if pending_save_token:
+                recording_data["pending_save_token"] = pending_save_token
             manager.recording_state.active = False
             manager.recording_state.start_cursor = None
             return {"status": "ok", **recording_data}
@@ -744,20 +773,7 @@ async def play_macro_trigger(manager: "SessionManager", data: JsonObject) -> Non
         macro_events = json_list(data.get("macro_events"))
 
         macro: JsonObject | None = None
-        if macro_name and not macro_events:
-            get_result = await manager.client.send_command(
-                Command(command=CommandType.MACRO_GET, data={"name": macro_name})
-            )
-            get_result_data = json_object(get_result.data)
-            if get_result.status != "ok" or get_result_data is None:
-                return
-            macro = json_object(get_result_data.get("macro"))
-            if macro is None:
-                return
-            macro = sanitize_macro_for_policy(manager, macro)
-            macro_name = str(macro.get("name", macro_name) or macro_name)
-            macro_events = json_list(macro.get("events"))
-        elif macro_events:
+        if macro_events:
             macro = sanitize_macro_for_policy(
                 manager,
                 {"events": macro_events},
@@ -1196,12 +1212,14 @@ async def save_recording(
         raise ValueError("Invalid macro name")
 
     data: JsonObject = manager.recording_state.pending_data or {}
+    pending_recording_id = str_value(data.get("pending_recording_id"), "")
+    if not pending_recording_id:
+        return {"status": "error", "message": "No pending recording"}
+
     macro: JsonObject = {
         "name": safe_name,
         "created_at": datetime.now().isoformat(),
-        "duration_ms": int_value(data.get("duration_ms"), 0),
-        "device_types": json_list(data.get("device_types")),
-        "events": json_list(data.get("events")),
+        "pending_recording_id": pending_recording_id,
         "move_to_start": bool(move_to_start),
         "start_x": int(start_x),
         "start_y": int(start_y),
@@ -1209,7 +1227,7 @@ async def save_recording(
     }
     try:
         result = await manager.client.send_command(
-            Command(command=CommandType.MACRO_CREATE, data={"macro": macro})
+            Command(command=CommandType.MACRO_SAVE_RECORDING, data=macro)
         )
     except Exception:
         return {"status": "error", "message": "Daemon unavailable"}

--- a/tests/keymasqd/daemon_support.py
+++ b/tests/keymasqd/daemon_support.py
@@ -47,11 +47,17 @@ def daemon_testbed(monkeypatch):
     recording_manager = SimpleNamespace(
         start=AsyncMock(return_value={"recording": "started"}),
         stop=AsyncMock(return_value={"recording": "stopped"}),
+        claim_pending_recording=AsyncMock(),
+        release_pending_recording_claim=AsyncMock(return_value=None),
+        discard_pending_recording=AsyncMock(return_value=None),
+        discard_all_pending_recordings=AsyncMock(return_value=None),
+        cleanup_spool_dir=Mock(return_value=None),
     )
     macro_store = SimpleNamespace(
         get=Mock(return_value={"events": []}),
         list_meta=Mock(return_value=[]),
         create=Mock(return_value={"name": "new"}),
+        create_from_events=Mock(return_value={"name": "new"}),
         update=Mock(return_value={"name": "updated"}),
         rename=Mock(return_value={"name": "renamed"}),
         delete=Mock(return_value=None),

--- a/tests/keymasqd/test_daemon_capture_commands.py
+++ b/tests/keymasqd/test_daemon_capture_commands.py
@@ -28,7 +28,7 @@ async def test_macro_play_by_name_loads_store_and_forwards_runtime_options(daemo
     assert result == {"played": True}
     macro_store.get.assert_called_once_with("combo")
     device_manager.play_macro.assert_awaited_once_with(
-        macro_events=[{"type": 1, "code": 30, "value": 1, "t_us": 0}],
+        macro_events=[],
         macro_name="combo",
         replay_mouse_movement=False,
         replay_mouse_clicks=True,

--- a/tests/keymasqd/test_daemon_capture_commands.py
+++ b/tests/keymasqd/test_daemon_capture_commands.py
@@ -44,6 +44,44 @@ async def test_macro_play_by_name_loads_store_and_forwards_runtime_options(daemo
 
 
 @pytest.mark.asyncio
+async def test_macro_save_recording_claims_snapshot_before_streaming(daemon_testbed):
+    daemon, _device_manager, recording_manager, macro_store, _capture_manager = daemon_testbed
+    stored_events: list[dict[str, object]] = []
+
+    class Snapshot:
+        recording_id = "recording-1"
+        duration_ms = 5
+        device_types = ["keyboard"]
+        event_count = 1
+
+        def iter_events(self):
+            yield {"type": 1, "code": 30, "value": 1, "t_us": 0}
+
+    def create_from_events(payload, events, *, return_full: bool = False):
+        assert payload["name"] == "saved"
+        assert return_full is False
+        stored_events.extend(events)
+        return {"name": payload["name"]}
+
+    recording_manager.claim_pending_recording.return_value = Snapshot()
+    macro_store.create_from_events.side_effect = create_from_events
+
+    result = await daemon._handle_command(
+        CommandType.MACRO_SAVE_RECORDING,
+        {"pending_recording_id": "recording-1", "name": "saved"},
+    )
+
+    assert result == {"macro": {"name": "saved"}}
+    recording_manager.claim_pending_recording.assert_awaited_once_with("recording-1")
+    recording_manager.release_pending_recording_claim.assert_awaited_once_with(
+        "recording-1",
+        saved=True,
+    )
+    recording_manager.discard_pending_recording.assert_not_awaited()
+    assert stored_events == [{"type": 1, "code": 30, "value": 1, "t_us": 0}]
+
+
+@pytest.mark.asyncio
 async def test_start_recording_resolves_recording_ids_before_start(daemon_testbed):
     daemon, device_manager, recording_manager, _macro_store, _capture_manager = daemon_testbed
     selected = {
@@ -311,6 +349,7 @@ async def test_start_offloads_macro_store_prep_to_thread(
     assert to_thread_calls[0][0].__name__ == "_prepare_macro_store"
     macro_store.ensure.assert_called_once()
     macro_store.register_internal.assert_called_once()
+    recording_manager.cleanup_spool_dir.assert_called_once()
     device_manager.initialize_output_devices.assert_called_once()
     device_manager.shutdown_output_devices.assert_called_once()
     device_manager.start_topology_watcher.assert_awaited_once()

--- a/tests/keymasqd/test_daemon_macro_resolution.py
+++ b/tests/keymasqd/test_daemon_macro_resolution.py
@@ -27,7 +27,7 @@ async def test_resolve_mapping_macros_loads_macro_definition(daemon_testbed):
     )
 
     action = cast(dict[str, object], resolved["btn_side"])
-    assert action["macro_events"] == [{"type": 1, "code": 30, "value": 1, "t_us": 0}]
+    assert "macro_events" not in action
     assert action["macro_loop_mode"] == "count"
     assert action["macro_loop_count"] == 3
     assert action["macro_loop_stop_behavior"] == "cancel_run"
@@ -69,7 +69,7 @@ async def test_resolve_mapping_macros_loads_macro_definition_inside_superkey(dae
     action = cast(dict[str, object], resolved["btn_side"])
     superkey = cast(dict[str, object], action["superkey"])
     hold_action = cast(dict[str, object], cast(list[object], superkey["hold_actions"])[0])
-    assert hold_action["macro_events"] == [{"type": 1, "code": 30, "value": 1, "t_us": 0}]
+    assert "macro_events" not in hold_action
     assert hold_action["macro_loop_mode"] == "count"
     assert hold_action["macro_loop_count"] == 3
     assert hold_action["macro_loop_stop_behavior"] == "cancel_run"
@@ -164,7 +164,7 @@ async def test_handle_command_set_mapping_resolves_macro_values(daemon_testbed):
         device_manager.set_mapping.await_args.kwargs["mapping"],
     )
     resolved = sent_mapping["btn_side"]
-    assert resolved["macro_events"] == [{"type": 1, "code": 30, "value": 1, "t_us": 0}]
+    assert "macro_events" not in resolved
     assert resolved["macro_loop_mode"] == "count"
     assert resolved["macro_loop_count"] == 2
 
@@ -209,9 +209,7 @@ async def test_handle_command_set_combos_resolves_macro_values(daemon_testbed):
 
     sent_combos = cast(list[dict[str, object]], device_manager.set_combos.await_args.args[0])
     first_action = cast(dict[str, object], sent_combos[0]["action"])
-    assert first_action["macro_events"] == [
-        {"type": 1, "code": 30, "value": 1, "t_us": 0}
-    ]
+    assert "macro_events" not in first_action
     assert first_action["macro_loop_mode"] == "count"
     assert first_action["macro_loop_count"] == 4
 
@@ -266,7 +264,7 @@ async def test_handle_command_set_combos_resolves_macro_values_inside_superkey(d
     combo_action = cast(dict[str, object], sent_combos[0]["action"])
     superkey = cast(dict[str, object], combo_action["superkey"])
     hold_action = cast(dict[str, object], cast(list[object], superkey["hold_actions"])[0])
-    assert hold_action["macro_events"] == [{"type": 1, "code": 30, "value": 1, "t_us": 0}]
+    assert "macro_events" not in hold_action
     assert hold_action["macro_loop_mode"] == "hold"
     assert hold_action["macro_loop_count"] == 5
     assert hold_action["macro_loop_stop_behavior"] == "cancel_run"

--- a/tests/keymasqd/test_daemon_runtime_unlock.py
+++ b/tests/keymasqd/test_daemon_runtime_unlock.py
@@ -88,7 +88,7 @@ async def test_client_disconnect_clears_owned_and_unowned_runtime_unlocks(
     monkeypatch,
     tmp_path: Path,
 ):
-    daemon, device_manager, _recording_manager, _macro_store, _capture_manager = daemon_testbed
+    daemon, device_manager, recording_manager, _macro_store, _capture_manager = daemon_testbed
     owned_uid = 5555
     stray_uid = 7777
     runtime_dir = tmp_path / "runtime-unlocks"
@@ -112,4 +112,5 @@ async def test_client_disconnect_clears_owned_and_unowned_runtime_unlocks(
     assert daemon._unlock_cache[stray_uid] == (500.0, False, 0, "none")
     assert not (runtime_dir / f"recording-unlock-{owned_uid}").exists()
     assert not (runtime_dir / f"recording-unlock-{stray_uid}").exists()
+    recording_manager.discard_all_pending_recordings.assert_awaited_once()
     device_manager.release_all_devices.assert_awaited_once()

--- a/tests/keymasqd/test_macro_backend_recording.py
+++ b/tests/keymasqd/test_macro_backend_recording.py
@@ -2,12 +2,13 @@
 from tests.keymasqd.macro_backend_support import *
 
 
-def _recorded_events(
+async def _recorded_events(
     recorder: RecordingManager,
     result: dict[str, object],
 ) -> list[dict[str, object]]:
     recording_id = str(result.get("pending_recording_id", ""))
-    return list(recorder.pending_recording(recording_id).iter_events())
+    snapshot = await recorder.pending_recording(recording_id)
+    return list(snapshot.iter_events())
 
 
 @pytest.mark.asyncio
@@ -24,7 +25,7 @@ async def test_recording_manager_uses_relative_timestamps() -> None:
     result = await recorder.stop()
 
     assert result["event_count"] == 2
-    events = _recorded_events(recorder, result)
+    events = await _recorded_events(recorder, result)
     assert events[0]["t_us"] == 0
     assert events[1]["t_us"] == 400
 
@@ -45,7 +46,7 @@ async def test_recording_manager_drops_msc_and_syn_events() -> None:
     recorder.record_event("keyboard", key_up)
 
     result = await recorder.stop()
-    events = _recorded_events(recorder, result)
+    events = await _recorded_events(recorder, result)
 
     assert result["event_count"] == 2
     assert all(event["type"] == evdev.ecodes.EV_KEY for event in events)

--- a/tests/keymasqd/test_macro_backend_recording.py
+++ b/tests/keymasqd/test_macro_backend_recording.py
@@ -1,6 +1,15 @@
 # ruff: noqa: F403, F405, I001
 from tests.keymasqd.macro_backend_support import *
 
+
+def _recorded_events(
+    recorder: RecordingManager,
+    result: dict[str, object],
+) -> list[dict[str, object]]:
+    recording_id = str(result.get("pending_recording_id", ""))
+    return list(recorder.pending_recording(recording_id).iter_events())
+
+
 @pytest.mark.asyncio
 async def test_recording_manager_uses_relative_timestamps() -> None:
     recorder = RecordingManager(broadcast_callback=AsyncMock())
@@ -15,8 +24,9 @@ async def test_recording_manager_uses_relative_timestamps() -> None:
     result = await recorder.stop()
 
     assert result["event_count"] == 2
-    assert recorder._events[0]["t_us"] == 0
-    assert recorder._events[1]["t_us"] == 400
+    events = _recorded_events(recorder, result)
+    assert events[0]["t_us"] == 0
+    assert events[1]["t_us"] == 400
 
 
 @pytest.mark.asyncio
@@ -35,7 +45,7 @@ async def test_recording_manager_drops_msc_and_syn_events() -> None:
     recorder.record_event("keyboard", key_up)
 
     result = await recorder.stop()
-    events = cast(list[dict[str, object]], result["events"])
+    events = _recorded_events(recorder, result)
 
     assert result["event_count"] == 2
     assert all(event["type"] == evdev.ecodes.EV_KEY for event in events)

--- a/tests/session/test_session_manager_command_runtime.py
+++ b/tests/session/test_session_manager_command_runtime.py
@@ -395,9 +395,10 @@ async def test_handle_session_request_create_macro_broadcasts_saved_event() -> N
 async def test_save_recording_clears_pending_macro_save_state() -> None:
     manager = SessionManager()
     manager.recording_state.pending_data = {
+        "pending_recording_id": "recording-1",
         "duration_ms": 10,
         "device_types": ["keyboard"],
-        "events": [{"type": 1, "code": 30, "value": 1, "t_us": 0}],
+        "event_count": 1,
     }
     manager.recording_state.pending_save_token = "pending-1"
     manager.recording_state.pending_save_owner_writer_id = 123
@@ -419,6 +420,9 @@ async def test_save_recording_clears_pending_macro_save_state() -> None:
     )
 
     assert result == {"status": "ok", "name": "Saved"}
+    sent_command = manager.client.send_command.await_args.args[0]
+    assert sent_command.command == CommandType.MACRO_SAVE_RECORDING
+    assert sent_command.data["pending_recording_id"] == "recording-1"
     assert manager.recording_state.pending_data is None
     assert manager.recording_state.pending_save_token is None
     assert manager.recording_state.pending_save_owner_writer_id is None

--- a/tests/test_macro_store.py
+++ b/tests/test_macro_store.py
@@ -18,6 +18,9 @@ def test_macro_store_crud_and_revision(tmp_path: Path) -> None:
     )
     assert created["name"] == "combo"
     assert created["revision"] == 1
+    assert not (tmp_path / "macros" / "combo.json").exists()
+    assert (tmp_path / "macros" / "combo.kmacro.xz").exists()
+    assert list(store.iter_events("combo")) == [{"type": 1, "code": 30, "value": 1, "t_us": 0}]
 
     updated = store.update("combo", {"duration_ms": 20}, expected_revision=1)
     assert updated["duration_ms"] == 20
@@ -40,3 +43,29 @@ def test_macro_store_revision_conflict(tmp_path: Path) -> None:
 
     with pytest.raises(ValueError):
         store.update("macro_a", {"duration_ms": 10}, expected_revision=7)
+
+
+def test_macro_store_create_from_events_returns_metadata_without_loading_full_payload(
+    tmp_path: Path,
+) -> None:
+    store = MacroStore(tmp_path / "macros")
+    events = (
+        {"device_type": "keyboard", "type": 1, "code": code, "value": 1, "t_us": code}
+        for code in range(3)
+    )
+
+    created = store.create_from_events(
+        {
+            "name": "streamed",
+            "duration_ms": 1,
+            "device_types": ["keyboard"],
+            "event_count": 3,
+        },
+        events,
+        return_full=False,
+    )
+
+    assert created["name"] == "streamed"
+    assert created["event_count"] == 3
+    assert "events" not in created
+    assert [event["code"] for event in store.iter_events("streamed")] == [0, 1, 2]

--- a/tests/test_macro_store.py
+++ b/tests/test_macro_store.py
@@ -1,7 +1,9 @@
+import logging
 from pathlib import Path
 
 import pytest
 
+from keymasq.common.models import DEFAULT_MACRO_LOOP_STOP_BEHAVIOR
 from keymasq.keymasqd.macro_store import MacroStore
 
 
@@ -69,3 +71,28 @@ def test_macro_store_create_from_events_returns_metadata_without_loading_full_pa
     assert created["event_count"] == 3
     assert "events" not in created
     assert [event["code"] for event in store.iter_events("streamed")] == [0, 1, 2]
+
+
+def test_macro_store_internal_meta_uses_shared_loop_stop_default(tmp_path: Path) -> None:
+    store = MacroStore(tmp_path / "macros")
+    store.register_internal("__internal", [{"type": 1, "code": 30, "value": 1, "t_us": 0}])
+
+    meta = store.get_meta("__internal")
+
+    assert meta["loop_stop_behavior"] == DEFAULT_MACRO_LOOP_STOP_BEHAVIOR
+
+
+def test_macro_store_list_meta_logs_unreadable_files(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    macro_dir = tmp_path / "macros"
+    macro_dir.mkdir()
+    (macro_dir / "broken.kmacro.xz").write_text("not xz")
+    store = MacroStore(macro_dir)
+
+    with caplog.at_level(logging.WARNING, logger="keymasqd.macros"):
+        assert store.list_meta() == []
+
+    assert "Skipping unreadable macro file" in caplog.text
+    assert "broken.kmacro.xz" in caplog.text

--- a/tests/test_recording_extended.py
+++ b/tests/test_recording_extended.py
@@ -1,3 +1,4 @@
+import asyncio
 from pathlib import Path
 from unittest.mock import AsyncMock
 
@@ -5,15 +6,16 @@ import evdev
 import pytest
 
 from keymasq.keymasqd.recording import RecordingManager
-from keymasq.keymasqd.recording_spool import RecordingSpool
+from keymasq.keymasqd.recording_spool import RecordingSnapshot, RecordingSpool
 
 
-def _recorded_events(
+async def _recorded_events(
     recorder: RecordingManager,
     result: dict[str, object],
 ) -> list[dict[str, object]]:
     recording_id = str(result.get("pending_recording_id", ""))
-    return list(recorder.pending_recording(recording_id).iter_events())
+    snapshot = await recorder.pending_recording(recording_id)
+    return list(snapshot.iter_events())
 
 
 @pytest.mark.asyncio
@@ -40,7 +42,7 @@ async def test_recording_event_filtering_for_mouse_controls():
     recorder.record_event("keyboard", keyboard)
 
     result = await recorder.stop()
-    events = _recorded_events(recorder, result)
+    events = await _recorded_events(recorder, result)
 
     assert result["event_count"] == 1
     assert events[0]["type"] == evdev.ecodes.EV_KEY
@@ -72,7 +74,7 @@ async def test_recording_keeps_wheel_events_without_mouse_movement_enabled() -> 
     )
 
     result = await recorder.stop()
-    events = _recorded_events(recorder, result)
+    events = await _recorded_events(recorder, result)
 
     assert [event["code"] for event in events] == [
         evdev.ecodes.REL_WHEEL,
@@ -96,7 +98,7 @@ async def test_recording_callback_fires_on_start_and_stop(monkeypatch):
     assert stop_result["event_count"] == 1
     assert callback.await_args_list[1].args[0].value == "recording_stopped"
     assert "events" not in callback.await_args_list[1].args[1]
-    assert _recorded_events(recorder, stop_result)[0]["code"] == evdev.ecodes.KEY_A
+    assert (await _recorded_events(recorder, stop_result))[0]["code"] == evdev.ecodes.KEY_A
 
 
 @pytest.mark.asyncio
@@ -181,7 +183,7 @@ async def test_recording_classifies_combo_device_events_per_event_type() -> None
     )
 
     result = await recorder.stop()
-    events = _recorded_events(recorder, result)
+    events = await _recorded_events(recorder, result)
 
     assert [event["device_type"] for event in events] == ["keyboard", "mouse"]
 
@@ -208,3 +210,160 @@ async def test_recording_spool_spills_past_memory_event_limit(tmp_path: Path) ->
     assert [event["code"] for event in snapshot.iter_events()] == [0, 1, 2]
     snapshot.cleanup()
     assert not snapshot.spool_path.exists()
+
+
+@pytest.mark.asyncio
+async def test_pending_recording_claim_prevents_concurrent_discard(tmp_path: Path) -> None:
+    recorder = RecordingManager(spool_dir=tmp_path)
+    path = tmp_path / "recording-test.jsonl"
+    path.write_text('{"t_us":0}\n')
+    snapshot = RecordingSnapshot(
+        recording_id="recording-1",
+        duration_ms=0,
+        device_types=["keyboard"],
+        event_count=1,
+        spool_path=path,
+        memory_events=(),
+    )
+    recorder._pending_recordings[snapshot.recording_id] = snapshot
+
+    claimed = await recorder.claim_pending_recording(snapshot.recording_id)
+    await recorder.discard_pending_recording(snapshot.recording_id)
+
+    assert claimed is snapshot
+    assert path.exists()
+    assert list(claimed.iter_events()) == [{"t_us": 0}]
+    await recorder.release_pending_recording_claim(snapshot.recording_id, saved=True)
+    assert not path.exists()
+
+
+@pytest.mark.asyncio
+async def test_pending_recording_claim_restores_on_failed_save(tmp_path: Path) -> None:
+    recorder = RecordingManager(spool_dir=tmp_path)
+    path = tmp_path / "recording-test.jsonl"
+    path.write_text('{"t_us":0}\n')
+    snapshot = RecordingSnapshot(
+        recording_id="recording-1",
+        duration_ms=0,
+        device_types=["keyboard"],
+        event_count=1,
+        spool_path=path,
+        memory_events=(),
+    )
+    recorder._pending_recordings[snapshot.recording_id] = snapshot
+
+    claimed = await recorder.claim_pending_recording(snapshot.recording_id)
+    await recorder.release_pending_recording_claim(snapshot.recording_id, saved=False)
+
+    assert claimed is snapshot
+    assert await recorder.pending_recording(snapshot.recording_id) is snapshot
+    assert path.exists()
+    await recorder.discard_pending_recording(snapshot.recording_id)
+    assert not path.exists()
+
+
+@pytest.mark.asyncio
+async def test_pending_recording_claim_honors_discard_on_failed_save(tmp_path: Path) -> None:
+    recorder = RecordingManager(spool_dir=tmp_path)
+    path = tmp_path / "recording-test.jsonl"
+    path.write_text('{"t_us":0}\n')
+    snapshot = RecordingSnapshot(
+        recording_id="recording-1",
+        duration_ms=0,
+        device_types=["keyboard"],
+        event_count=1,
+        spool_path=path,
+        memory_events=(),
+    )
+    recorder._pending_recordings[snapshot.recording_id] = snapshot
+
+    await recorder.claim_pending_recording(snapshot.recording_id)
+    await recorder.discard_pending_recording(snapshot.recording_id)
+    await recorder.release_pending_recording_claim(snapshot.recording_id, saved=False)
+
+    assert not path.exists()
+    with pytest.raises(FileNotFoundError):
+        await recorder.pending_recording(snapshot.recording_id)
+
+
+@pytest.mark.asyncio
+async def test_recording_spool_finish_cleans_spool_file_on_fatal_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    spool = RecordingSpool(tmp_path, memory_event_limit=1)
+
+    def fail_write(_chunk: list[dict[str, object]]) -> None:
+        path = spool._ensure_spool_path()
+        path.write_text('{"t_us":0}\n', encoding="utf-8")
+        raise OSError("disk full")
+
+    monkeypatch.setattr(spool, "_write_chunk", fail_write)
+    spool.append(
+        {
+            "device_type": "keyboard",
+            "type": evdev.ecodes.EV_KEY,
+            "code": 1,
+            "value": 1,
+            "t_us": 0,
+        }
+    )
+
+    with pytest.raises(RuntimeError):
+        await spool.finish()
+
+    assert list(tmp_path.glob("recording-*.jsonl")) == []
+
+
+@pytest.mark.asyncio
+async def test_recording_manager_discards_expired_pending_recordings(tmp_path: Path) -> None:
+    recorder = RecordingManager(spool_dir=tmp_path)
+    expired_path = tmp_path / "recording-expired.jsonl"
+    fresh_path = tmp_path / "recording-fresh.jsonl"
+    expired_path.write_text('{"t_us":0}\n', encoding="utf-8")
+    fresh_path.write_text('{"t_us":1}\n', encoding="utf-8")
+    expired = RecordingSnapshot(
+        recording_id="expired",
+        duration_ms=0,
+        device_types=[],
+        event_count=1,
+        spool_path=expired_path,
+        memory_events=(),
+    )
+    fresh = RecordingSnapshot(
+        recording_id="fresh",
+        duration_ms=0,
+        device_types=[],
+        event_count=1,
+        spool_path=fresh_path,
+        memory_events=(),
+    )
+    now = asyncio.get_running_loop().time()
+    recorder._pending_recordings = {
+        expired.recording_id: expired,
+        fresh.recording_id: fresh,
+    }
+    recorder._pending_recording_created_at = {
+        expired.recording_id: now - 10,
+        fresh.recording_id: now,
+    }
+
+    await recorder.discard_expired_pending_recordings(ttl_s=5)
+
+    assert not expired_path.exists()
+    assert fresh_path.exists()
+    assert await recorder.pending_recording(fresh.recording_id) is fresh
+    fresh.cleanup()
+
+
+def test_recording_manager_startup_spool_cleanup(tmp_path: Path) -> None:
+    recorder = RecordingManager(spool_dir=tmp_path)
+    stale = tmp_path / "recording-stale.jsonl"
+    other = tmp_path / "other.jsonl"
+    stale.write_text("{}\n")
+    other.write_text("{}\n")
+
+    recorder.cleanup_spool_dir()
+
+    assert not stale.exists()
+    assert other.exists()

--- a/tests/test_recording_extended.py
+++ b/tests/test_recording_extended.py
@@ -1,10 +1,19 @@
-from typing import cast
+from pathlib import Path
 from unittest.mock import AsyncMock
 
 import evdev
 import pytest
 
 from keymasq.keymasqd.recording import RecordingManager
+from keymasq.keymasqd.recording_spool import RecordingSpool
+
+
+def _recorded_events(
+    recorder: RecordingManager,
+    result: dict[str, object],
+) -> list[dict[str, object]]:
+    recording_id = str(result.get("pending_recording_id", ""))
+    return list(recorder.pending_recording(recording_id).iter_events())
 
 
 @pytest.mark.asyncio
@@ -31,7 +40,7 @@ async def test_recording_event_filtering_for_mouse_controls():
     recorder.record_event("keyboard", keyboard)
 
     result = await recorder.stop()
-    events = cast(list[dict[str, object]], result["events"])
+    events = _recorded_events(recorder, result)
 
     assert result["event_count"] == 1
     assert events[0]["type"] == evdev.ecodes.EV_KEY
@@ -63,7 +72,7 @@ async def test_recording_keeps_wheel_events_without_mouse_movement_enabled() -> 
     )
 
     result = await recorder.stop()
-    events = cast(list[dict[str, object]], result["events"])
+    events = _recorded_events(recorder, result)
 
     assert [event["code"] for event in events] == [
         evdev.ecodes.REL_WHEEL,
@@ -86,7 +95,8 @@ async def test_recording_callback_fires_on_start_and_stop(monkeypatch):
     assert callback.await_count == 2
     assert stop_result["event_count"] == 1
     assert callback.await_args_list[1].args[0].value == "recording_stopped"
-    assert callback.await_args_list[1].args[1]["events"][0]["code"] == evdev.ecodes.KEY_A
+    assert "events" not in callback.await_args_list[1].args[1]
+    assert _recorded_events(recorder, stop_result)[0]["code"] == evdev.ecodes.KEY_A
 
 
 @pytest.mark.asyncio
@@ -132,10 +142,19 @@ async def test_recording_event_filters_sync_and_msc_events() -> None:
 async def test_recording_progress_reports_latest_event() -> None:
     callback = AsyncMock()
     recorder = RecordingManager(broadcast_callback=callback)
-    recorder._stopped = False
-    recorder._events = [
-        {"device_type": "keyboard", "type": 1, "code": 30, "value": 1, "t_us": 2500}
-    ]
+    await recorder.start([])
+    if recorder._progress_task:
+        recorder._progress_task.cancel()
+        recorder._progress_task = None
+    recorder.record_event(
+        "keyboard",
+        evdev.InputEvent(1, 0, evdev.ecodes.EV_KEY, evdev.ecodes.KEY_A, 1),
+    )
+    recorder.record_event(
+        "keyboard",
+        evdev.InputEvent(1, 2500, evdev.ecodes.EV_KEY, evdev.ecodes.KEY_A, 0),
+    )
+    callback.reset_mock()
     callback.side_effect = lambda *_args: setattr(recorder, "_stopped", True)
 
     with pytest.MonkeyPatch.context() as monkeypatch:
@@ -144,7 +163,7 @@ async def test_recording_progress_reports_latest_event() -> None:
 
     callback.assert_awaited_once()
     assert callback.await_args.args[0].value == "recording_progress"
-    assert callback.await_args.args[1] == {"event_count": 1, "duration_ms": 2}
+    assert callback.await_args.args[1] == {"event_count": 2, "duration_ms": 2}
 
 
 @pytest.mark.asyncio
@@ -162,6 +181,30 @@ async def test_recording_classifies_combo_device_events_per_event_type() -> None
     )
 
     result = await recorder.stop()
-    events = cast(list[dict[str, object]], result["events"])
+    events = _recorded_events(recorder, result)
 
     assert [event["device_type"] for event in events] == ["keyboard", "mouse"]
+
+
+@pytest.mark.asyncio
+async def test_recording_spool_spills_past_memory_event_limit(tmp_path: Path) -> None:
+    spool = RecordingSpool(tmp_path, memory_event_limit=2)
+    for code in range(3):
+        spool.append(
+            {
+                "device_type": "keyboard",
+                "type": evdev.ecodes.EV_KEY,
+                "code": code,
+                "value": 1,
+                "t_us": code * 1000,
+            }
+        )
+
+    snapshot = await spool.finish()
+
+    assert snapshot.spool_path is not None
+    assert snapshot.memory_events == ()
+    assert snapshot.event_count == 3
+    assert [event["code"] for event in snapshot.iter_events()] == [0, 1, 2]
+    snapshot.cleanup()
+    assert not snapshot.spool_path.exists()

--- a/tests/test_session_manager_events.py
+++ b/tests/test_session_manager_events.py
@@ -222,13 +222,11 @@ async def test_handle_event_macro_trigger_forwards_full_playback_payload() -> No
 
     await asyncio.sleep(0)
 
-    get_call, play_call = manager.client.send_command.await_args_list
-    assert get_call.args[0].command == CommandType.MACRO_GET
-    assert get_call.args[0].data == {"name": "demo"}
+    (play_call,) = manager.client.send_command.await_args_list
     assert play_call.args[0].command == CommandType.PLAY_MACRO
     assert play_call.args[0].data == {
         "macro_name": "demo",
-        "macro_events": [{"type": 1, "code": 30, "value": 1, "t_us": 0}],
+        "macro_events": [],
         "replay_mouse_movement": False,
         "replay_mouse_clicks": False,
         "speed": 2.5,


### PR DESCRIPTION
## Summary
- Switched persistent macro storage from JSON files to compressed `.kmacro.xz` records with explicit metadata and streamed event loading.
- Added pending recording spooling so long live recordings stay on the daemon side until the user saves or discards them.
- Updated daemon, session, and GUI macro flows to work with recording IDs and metadata-only macro resolution.
- Refreshed macro-related docs and CLI wording to match the new storage and command behavior.
- Extended tests around macro storage, recording lifecycle, daemon commands, and session events.

## Testing
- Not run
- Expected checks: `./scripts/check.sh full`
- Expected coverage areas: macro store read/write, pending recording save/discard, macro playback by name, and session command/event handling