### PR TITLE
Parent superkey dialogs to the main window

### DIFF
--- a/keymasq/gui/application.py
+++ b/keymasq/gui/application.py
@@ -101,7 +101,7 @@ class Application(Adw.Application):
         dialog = SuperkeyDialog(self.window, self.window.profile_manager)
         dialog.connect("superkey-saved", self._on_superkey_changed)
         dialog.connect("superkey-deleted", self._on_superkey_changed)
-        dialog.present()
+        dialog.present(self.window)
 
     def _on_superkey_changed(self, dialog, name: str) -> None:
         notify_session_reload_async()

--- a/keymasq/gui/style.css
+++ b/keymasq/gui/style.css
@@ -165,3 +165,23 @@ button.actions-docs-button {
   opacity: 1;
   border-color: @accent_color;
 }
+
+.superkey-add-row {
+  border: 1.5px solid transparent;
+  border-radius: 8px;
+  padding: 10px 16px;
+  opacity: 0.65;
+  background: transparent;
+  min-height: 0;
+}
+
+.superkey-add-row:hover {
+  opacity: 1;
+  border-color: @accent_color;
+  background: alpha(@accent_color, 0.08);
+}
+
+.superkey-add-row:selected {
+  opacity: 1;
+  border-color: @accent_color;
+}

--- a/keymasq/gui/widgets/key_selector_dialog.py
+++ b/keymasq/gui/widgets/key_selector_dialog.py
@@ -280,8 +280,10 @@ _compact_tabs_css_installed = False
 
 def _docs_version() -> str:
     version = __version__.strip()
-    if not version or "dev" in version:
+    if not version:
         return "latest"
+    if "dev" in version:
+        return "master"
     return version
 
 

--- a/keymasq/gui/widgets/superkey_dialog.py
+++ b/keymasq/gui/widgets/superkey_dialog.py
@@ -1,3 +1,4 @@
+import logging
 from collections.abc import Sequence
 
 import gi
@@ -7,6 +8,7 @@ gi.require_version("Adw", "1")
 
 from gi.repository import Adw, Gdk, GObject, Gtk  # pyright: ignore[reportAttributeAccessIssue]
 
+from keymasq import __version__
 from keymasq.common.models import (
     ActionType,
     MappingAction,
@@ -19,6 +21,21 @@ from keymasq.common.models import (
 from keymasq.gui.widgets.action_labels import describe_mapping_action_verbose
 from keymasq.session.profiles import ProfileManager
 from keymasq.session.superkeys import SuperkeyManager
+
+log = logging.getLogger("keymasq.gui.widgets.superkey_dialog")
+
+
+def _docs_version() -> str:
+    version = __version__.strip()
+    if not version:
+        return "latest"
+    if "dev" in version:
+        return "master"
+    return version
+
+
+def _superkeys_docs_url() -> str:
+    return f"https://keymasq.tools/docs/{_docs_version()}/SUPERKEYS/"
 
 
 def _append_action_state_markers(label: str, action: object) -> str:
@@ -390,6 +407,7 @@ class SuperkeyDialog(Adw.Dialog):
         self._current_config: SuperkeyConfig | None = None
         self._modified = False
         self._mode_items = [SuperkeyMode.PATTERN, SuperkeyMode.OVERLOAD]
+        self.new_superkey_row: Gtk.ListBoxRow | None = None
 
         self._build_ui()
         self._load_superkeys()
@@ -439,19 +457,16 @@ class SuperkeyDialog(Adw.Dialog):
 
         box.append(scrolled)
 
-        btn_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=6)
+        footer = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=6)
 
-        new_btn = Gtk.Button(label="New")
-        new_btn.connect("clicked", self._on_new_clicked)
-        btn_box.append(new_btn)
+        self.superkeys_docs_btn = Gtk.Button(label="?")
+        self.superkeys_docs_btn.add_css_class("flat")
+        self.superkeys_docs_btn.add_css_class("actions-docs-button")
+        self.superkeys_docs_btn.set_tooltip_text("Open Super Keys documentation")
+        self.superkeys_docs_btn.connect("clicked", self._on_superkeys_docs_clicked)
+        footer.append(self.superkeys_docs_btn)
 
-        self.delete_btn = Gtk.Button(label="Delete")
-        self.delete_btn.set_sensitive(False)
-        self.delete_btn.add_css_class("destructive-action")
-        self.delete_btn.connect("clicked", self._on_delete_clicked)
-        btn_box.append(self.delete_btn)
-
-        box.append(btn_box)
+        box.append(footer)
         return box
 
     def _build_right_panel(self) -> Gtk.Widget:
@@ -556,37 +571,37 @@ class SuperkeyDialog(Adw.Dialog):
         self.editor_box.append(self.timing_group)
         self.right_box.append(self.editor_box)
 
-        btn_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=8)
-        btn_box.set_halign(Gtk.Align.END)
-        btn_box.set_margin_top(12)
+        footer = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=12)
+        footer.set_hexpand(True)
+        footer.set_margin_top(12)
 
-        top_row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=12)
-        top_row.set_halign(Gtk.Align.END)
+        self.delete_btn = Gtk.Button(label="Delete")
+        self.delete_btn.set_sensitive(False)
+        self.delete_btn.add_css_class("destructive-action")
+        self.delete_btn.connect("clicked", self._on_delete_clicked)
+        footer.append(self.delete_btn)
 
-        self.revert_btn = Gtk.Button(label="Revert")
-        self.revert_btn.set_sensitive(False)
-        self.revert_btn.connect("clicked", self._on_revert_clicked)
-        top_row.append(self.revert_btn)
+        footer_spacer = Gtk.Box()
+        footer_spacer.set_hexpand(True)
+        footer.append(footer_spacer)
 
         self.save_btn = Gtk.Button(label="Save")
         self.save_btn.add_css_class("suggested-action")
         self.save_btn.set_sensitive(False)
         self.save_btn.connect("clicked", self._on_save_clicked)
-        top_row.append(self.save_btn)
+        footer.append(self.save_btn)
 
-        btn_box.append(top_row)
-
-        bottom_row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=12)
-        bottom_row.set_halign(Gtk.Align.END)
+        self.revert_btn = Gtk.Button(label="Revert")
+        self.revert_btn.set_sensitive(False)
+        self.revert_btn.connect("clicked", self._on_revert_clicked)
+        footer.append(self.revert_btn)
 
         close_btn = Gtk.Button(label="Close")
         close_btn.connect("clicked", self._on_close_clicked)
-        bottom_row.append(close_btn)
+        footer.append(close_btn)
         self.close_btn = close_btn
 
-        btn_box.append(bottom_row)
-
-        self.right_box.append(btn_box)
+        self.right_box.append(footer)
         self._update_mode_visibility()
         return self.right_box
 
@@ -641,6 +656,27 @@ class SuperkeyDialog(Adw.Dialog):
         row.add_suffix(clear_btn)
         return row
 
+    def _build_new_superkey_row(self) -> Gtk.ListBoxRow:
+        row = Gtk.ListBoxRow()
+        row._is_new_superkey = True
+        row.add_css_class("superkey-add-row")
+        row.set_tooltip_text("Add a new Super Key")
+        label = Gtk.Label(label="+ Add", xalign=0)
+        label.add_css_class("dim-label")
+        row.set_child(label)
+        return row
+
+    def _build_saved_superkey_row(self, name: str) -> Gtk.ListBoxRow:
+        row = Gtk.ListBoxRow()
+        row._superkey_name = name
+        label = Gtk.Label(label=name, xalign=0)
+        label.set_margin_start(6)
+        label.set_margin_end(6)
+        label.set_margin_top(6)
+        label.set_margin_bottom(6)
+        row.set_child(label)
+        return row
+
     def _current_mode(self) -> SuperkeyMode:
         return self._mode_items[self.mode_dropdown.get_selected()]
 
@@ -658,22 +694,15 @@ class SuperkeyDialog(Adw.Dialog):
 
         names = self.manager.list_superkeys()
         for name in names:
-            label = Gtk.Label(label=name, xalign=0)
-            label.set_margin_start(6)
-            label.set_margin_end(6)
-            label.set_margin_top(6)
-            label.set_margin_bottom(6)
-            self.list_box.append(label)
+            self.list_box.append(self._build_saved_superkey_row(name))
+
+        self.new_superkey_row = self._build_new_superkey_row()
+        self.list_box.append(self.new_superkey_row)
 
         if names:
             self.list_box.select_row(self.list_box.get_row_at_index(0))
         else:
-            self.list_box.select_row(None)
-            self._current_config = None
-            self.editor_box.set_sensitive(False)
-            self.delete_btn.set_sensitive(False)
-            self._modified = False
-            self._update_buttons()
+            self.list_box.select_row(self.new_superkey_row)
 
     def _on_superkey_selected(self, _list_box, row) -> None:
         if row is None:
@@ -684,8 +713,18 @@ class SuperkeyDialog(Adw.Dialog):
             self._update_buttons()
             return
 
-        label = row.get_child()
-        name = label.get_label()
+        if getattr(row, "_is_new_superkey", False):
+            self._begin_new_superkey()
+            return
+
+        name = getattr(row, "_superkey_name", None)
+        if not name:
+            self._current_config = None
+            self.editor_box.set_sensitive(False)
+            self.delete_btn.set_sensitive(False)
+            self._modified = False
+            self._update_buttons()
+            return
         self._current_config = self.manager.get_superkey(name)
         if self._current_config:
             self._populate_editor()
@@ -801,8 +840,7 @@ class SuperkeyDialog(Adw.Dialog):
         self.revert_btn.set_sensitive(self._modified)
         self.save_btn.set_sensitive(self._modified)
 
-    def _on_new_clicked(self, _button) -> None:
-        self.list_box.select_row(None)
+    def _begin_new_superkey(self) -> None:
         self._current_config = SuperkeyConfig(name="New Super Key")
         self._populate_editor()
         self.editor_box.set_sensitive(True)
@@ -810,6 +848,15 @@ class SuperkeyDialog(Adw.Dialog):
         self._modified = True
         self._update_buttons()
         self.name_entry.grab_focus()
+
+    def _on_new_clicked(self, _button) -> None:
+        if (
+            self.new_superkey_row is not None
+            and self.list_box.get_selected_row() is not self.new_superkey_row
+        ):
+            self.list_box.select_row(self.new_superkey_row)
+        else:
+            self._begin_new_superkey()
 
     def start_new_superkey(self) -> None:
         self._on_new_clicked(None)
@@ -896,8 +943,7 @@ class SuperkeyDialog(Adw.Dialog):
             row = self.list_box.get_row_at_index(idx)
             if row is None:
                 break
-            label = row.get_child()
-            if label and label.get_label() == name:
+            if getattr(row, "_superkey_name", None) == name:
                 self.list_box.select_row(row)
                 break
             idx += 1
@@ -937,3 +983,11 @@ class SuperkeyDialog(Adw.Dialog):
 
     def _on_close_clicked(self, _button: Gtk.Button) -> None:
         self.close()
+
+    def _on_superkeys_docs_clicked(self, _button: Gtk.Button) -> None:
+        url = _superkeys_docs_url()
+        try:
+            launcher = Gtk.UriLauncher.new(url)
+            launcher.launch(None, None, None)
+        except Exception as exc:
+            log.warning("Could not open Super Keys documentation %s: %s", url, exc)

--- a/keymasq/gui/widgets/superkey_dialog.py
+++ b/keymasq/gui/widgets/superkey_dialog.py
@@ -282,7 +282,7 @@ class ActionListDialog(Adw.Dialog):
                 allow_macro_options=True,
             )
             dialog.connect("key-selected", self._on_pattern_action_selected, index)
-            dialog.present()
+            dialog.present(self._parent)
             return
 
         from keymasq.gui.widgets.key_selector_dialog import KeySelectorDialog
@@ -297,7 +297,7 @@ class ActionListDialog(Adw.Dialog):
             allow_superkey=False,
         )
         dialog.connect("key-selected", self._on_mapping_action_selected, index)
-        dialog.present()
+        dialog.present(self._parent)
 
     def _on_add_clicked(self, _button: Gtk.Button) -> None:
         self._open_child_editor()
@@ -918,7 +918,7 @@ class SuperkeyDialog(Adw.Dialog):
             action_key=row._action_key,
         )
         dialog.connect("actions-selected", self._on_actions_selected, row)
-        dialog.present()
+        dialog.present(self._parent)
 
     def _on_actions_selected(self, _dialog, actions: list[object], row: Adw.ActionRow) -> None:
         row._action_items = list(actions)

--- a/tests/gui/test_gui_demo_and_dialogs.py
+++ b/tests/gui/test_gui_demo_and_dialogs.py
@@ -627,6 +627,66 @@ class TestDialogConstruction:
         assert dialog._on_key_pressed(None, Gdk.KEY_Escape, 0, 0) is True
         assert closed == [True]
 
+    def test_application_presents_superkey_dialog_on_main_window(self, monkeypatch):
+        import keymasq.gui.application as application_module
+        import keymasq.gui.widgets.superkey_dialog as superkey_dialog_module
+
+        captured: dict[str, object] = {}
+        window = SimpleNamespace(profile_manager=object())
+
+        class DummySuperkeyDialog:
+            def __init__(self, parent, profile_manager):
+                captured["parent"] = parent
+                captured["profile_manager"] = profile_manager
+
+            def connect(self, signal_name, callback):
+                captured.setdefault("signals", []).append(signal_name)
+                captured["callback"] = callback
+
+            def present(self, parent):
+                captured["present_parent"] = parent
+
+        monkeypatch.setattr(superkey_dialog_module, "SuperkeyDialog", DummySuperkeyDialog)
+
+        app = application_module.Application(demo_mode=True)
+        app.window = window
+        app._open_superkey_dialog()
+
+        assert captured["parent"] is window
+        assert captured["profile_manager"] is window.profile_manager
+        assert captured["present_parent"] is window
+        assert captured["signals"] == ["superkey-saved", "superkey-deleted"]
+
+    def test_superkey_action_editor_presents_on_main_window(self, temp_config_dir, monkeypatch):
+        gi.require_version("Gtk", "4.0")
+        from gi.repository import Gtk
+
+        import keymasq.gui.widgets.superkey_dialog as superkey_dialog_module
+        from keymasq.gui.widgets.superkey_dialog import SuperkeyDialog
+
+        captured: dict[str, object] = {}
+        parent = Gtk.Window()
+
+        class DummyActionListDialog:
+            def __init__(self, *args, **kwargs):
+                captured["args"] = args
+                captured["kwargs"] = kwargs
+
+            def connect(self, signal_name, callback, row):
+                captured["signal_name"] = signal_name
+                captured["row"] = row
+
+            def present(self, parent):
+                captured["present_parent"] = parent
+
+        monkeypatch.setattr(superkey_dialog_module, "ActionListDialog", DummyActionListDialog)
+
+        dialog = SuperkeyDialog(parent)
+        dialog._on_edit_action_clicked(Gtk.Button(), dialog.tap_row)
+
+        assert captured["present_parent"] is parent
+        assert captured["signal_name"] == "actions-selected"
+
     def test_pattern_superkey_actions_use_shared_key_selector_dialog(self, monkeypatch):
         gi.require_version("Gtk", "4.0")
         from gi.repository import Gtk
@@ -637,8 +697,11 @@ class TestDialogConstruction:
 
         captured: dict[str, object] = {}
 
+        parent = Gtk.Window()
+
         class DummyDialog:
             def __init__(self, _parent, _label, current_action=None, **kwargs):
+                captured["parent"] = _parent
                 captured["current_action"] = current_action
                 captured["kwargs"] = kwargs
 
@@ -647,12 +710,13 @@ class TestDialogConstruction:
                 captured["callback"] = callback
                 captured["index"] = index
 
-            def present(self):
+            def present(self, parent):
                 captured["presented"] = True
+                captured["present_parent"] = parent
 
         monkeypatch.setattr(key_selector_dialog_module, "KeySelectorDialog", DummyDialog)
 
-        dialog = ActionListDialog(Gtk.Window(), "Hold Actions", "pattern", action_key="hold")
+        dialog = ActionListDialog(parent, "Hold Actions", "pattern", action_key="hold")
         dialog._open_child_editor(
             SuperkeyAction(action_type=ActionType.PROFILE_TOGGLE, profile_name="Gaming"),
             2,
@@ -661,6 +725,8 @@ class TestDialogConstruction:
         current_action = captured["current_action"]
         assert captured["signal_name"] == "key-selected"
         assert captured["presented"] is True
+        assert captured["parent"] is parent
+        assert captured["present_parent"] is parent
         assert current_action.action_type == ActionType.PROFILE_TOGGLE
         assert current_action.profile_name == "Gaming"
         assert captured["kwargs"] == {

--- a/tests/gui/test_gui_demo_and_dialogs.py
+++ b/tests/gui/test_gui_demo_and_dialogs.py
@@ -600,7 +600,7 @@ class TestDialogConstruction:
         assert dialog.get_child() is not None
         assert dialog.right_box.get_parent() is not None
 
-    def test_superkey_dialog_empty_state_keeps_close_available(
+    def test_superkey_dialog_empty_state_starts_new_draft_and_keeps_close_available(
         self, temp_config_dir, monkeypatch
     ):
         gi.require_version("Gtk", "4.0")
@@ -615,8 +615,16 @@ class TestDialogConstruction:
         closed: list[bool] = []
         monkeypatch.setattr(dialog, "close", lambda: closed.append(True))
 
-        assert dialog.list_box.get_row_at_index(0) is None
-        assert dialog.editor_box.get_sensitive() is False
+        new_row = dialog.new_superkey_row
+        assert new_row is not None
+        assert new_row is dialog.new_superkey_row
+        assert getattr(new_row, "_is_new_superkey", False) is True
+        assert new_row.has_css_class("superkey-add-row") is True
+        assert new_row.get_tooltip_text() == "Add a new Super Key"
+        assert dialog.list_box.get_selected_row() is new_row
+        assert dialog.name_entry.get_text() == "New Super Key"
+        assert dialog.editor_box.get_sensitive() is True
+        assert dialog.delete_btn.get_sensitive() is False
         assert dialog.right_box.get_sensitive() is True
         assert dialog.close_btn.get_sensitive() is True
 
@@ -626,6 +634,33 @@ class TestDialogConstruction:
         closed.clear()
         assert dialog._on_key_pressed(None, Gdk.KEY_Escape, 0, 0) is True
         assert closed == [True]
+
+    def test_superkey_dialog_docs_button_links_to_superkeys_docs(
+        self, temp_config_dir, monkeypatch
+    ):
+        gi.require_version("Gtk", "4.0")
+        from gi.repository import Gtk
+
+        import keymasq.gui.widgets.superkey_dialog as superkey_dialog_module
+        from keymasq.gui.widgets.superkey_dialog import SuperkeyDialog
+
+        monkeypatch.setattr(superkey_dialog_module, "__version__", "1.2.3")
+
+        dialog = SuperkeyDialog(Gtk.Window())
+
+        assert dialog.superkeys_docs_btn.get_label() == "?"
+        assert (
+            dialog.superkeys_docs_btn.get_tooltip_text()
+            == "Open Super Keys documentation"
+        )
+        assert superkey_dialog_module._superkeys_docs_url() == (
+            "https://keymasq.tools/docs/1.2.3/SUPERKEYS/"
+        )
+
+        monkeypatch.setattr(superkey_dialog_module, "__version__", "1.2.3.dev1")
+        assert superkey_dialog_module._superkeys_docs_url() == (
+            "https://keymasq.tools/docs/master/SUPERKEYS/"
+        )
 
     def test_application_presents_superkey_dialog_on_main_window(self, monkeypatch):
         import keymasq.gui.application as application_module

--- a/tests/gui/test_gui_device_tab_misc.py
+++ b/tests/gui/test_gui_device_tab_misc.py
@@ -1102,3 +1102,8 @@ def test_key_selector_dialog_docs_button_tracks_visible_tab(monkeypatch: pytest.
     dialog.stack.set_visible_child_name("mouse")
 
     assert dialog.actions_docs_btn.get_tooltip_text() == "Open Mouse documentation"
+
+    monkeypatch.setattr(dialog_module, "__version__", "1.2.3.dev1")
+    assert dialog_module._actions_docs_url("mouse") == (
+        "https://keymasq.tools/docs/master/ACTIONS/#mouse"
+    )


### PR DESCRIPTION
## Summary
- Present the Super Key dialog and nested child editors from the main application window so transient dialogs are properly parented.
- Rework the Super Key dialog empty state into an explicit `+ Add` row that starts a new draft when selected.
- Add a Super Keys documentation button and align docs links with release vs. dev versions.
- Update dialog styling and test coverage for the new empty state, docs links, and parent-window presentation behavior.

## Testing
- Added GUI tests covering the Super Key empty state, docs button URL selection, and dialog parenting behavior.
- Added regression coverage for `ActionListDialog` and `KeySelectorDialog` presenting against their parent window.
- Ran command - nix develop -c ./scripts/check.sh gui