### PR TITLE
Add compositor action support to macro timelines

### DIFF
--- a/docs/MACROS.md
+++ b/docs/MACROS.md
@@ -281,6 +281,7 @@ You can:
 - Move events forward or backward in time.
 - Change which key or button an event uses.
 - Insert wait controls.
+- Insert compositor actions.
 - Use timing tools to trim, scale, or adjust gaps.
 
 ### Event Types
@@ -297,10 +298,15 @@ The editor lets you insert several kinds of events into the timeline:
 | **Wait (random)** | Pause macro playback for a random duration in a configured range. The editor stores it at its timestamp and does not estimate the eventual delay. |
 | **Exec (synchronous)** | Run an external program and wait for it to finish before the macro continues. Macro playback is paused until the process exits. |
 | **Exec (asynchronous)** | Fire-and-forget an external program. The macro continues immediately — the launched process runs independently. |
+| **Compositor action** | Send a compositor dispatch through the active session listener. This uses the same Hyprland, Niri, KDE, or GNOME action picker as normal mappings. |
 
 Exec events are powerful but be cautious: a synchronous exec that hangs will
 stall the macro indefinitely. Prefer asynchronous exec for anything that
 doesn't need to gate later events.
+
+Compositor events fire at their timestamp and macro playback continues
+immediately. They are available only when the current session has a supported
+compositor listener with compositor dispatch enabled.
 
 Playback errors are silent — if a macro fails mid-sequence (for example, the
 target device is gone), the GUI won't notify you.

--- a/keymasq/gui/widgets/compositor_actions/__init__.py
+++ b/keymasq/gui/widgets/compositor_actions/__init__.py
@@ -16,12 +16,14 @@ def build_compositor_action_pages(
     current_action: MappingAction | None,
     on_selected: Callable[[MappingAction], None],
     status: Mapping[str, object] | None = None,
+    submit_label: str | None = None,
 ):
     return build_compositor_action_pages_for_definitions(
         COMPOSITOR_ACTION_DEFINITIONS,
         current_action,
         on_selected,
         status,
+        submit_label,
     )
 
 

--- a/keymasq/gui/widgets/compositor_actions/core.py
+++ b/keymasq/gui/widgets/compositor_actions/core.py
@@ -50,10 +50,12 @@ class _CompositorDispatchPage(Gtk.Box):
         definition: CompositorActionDefinition,
         current_action: MappingAction | None,
         on_selected: Callable[[MappingAction], None],
+        submit_label: str | None = None,
     ) -> None:
         super().__init__(orientation=Gtk.Orientation.VERTICAL, spacing=12)
         self._definition = definition
         self._on_selected = on_selected
+        self._submit_label = submit_label
         self._dispatcher, self._args = definition.extract_fields(current_action)
         self._build_ui()
 
@@ -134,7 +136,9 @@ class _CompositorDispatchPage(Gtk.Box):
         self._hint_label.set_halign(Gtk.Align.START)
         self.append(self._hint_label)
 
-        self._map_btn = Gtk.Button(label=f"Map {self._definition.title} Action")
+        self._map_btn = Gtk.Button(
+            label=self._submit_label or f"Map {self._definition.title} Action"
+        )
         self._map_btn.add_css_class("suggested-action")
         self._map_btn.set_halign(Gtk.Align.START)
         self._map_btn.connect("clicked", self._on_map_clicked)
@@ -213,6 +217,7 @@ def build_compositor_action_pages_for_definitions(
     current_action: MappingAction | None,
     on_selected: Callable[[MappingAction], None],
     status: Mapping[str, object] | None = None,
+    submit_label: str | None = None,
 ) -> list[CompositorActionPage]:
     resolved_status = dict(status or {})
     pages: list[CompositorActionPage] = []
@@ -223,7 +228,12 @@ def build_compositor_action_pages_for_definitions(
             CompositorActionPage(
                 page_id=definition.page_id,
                 title=definition.title,
-                widget=_CompositorDispatchPage(definition, current_action, on_selected),
+                widget=_CompositorDispatchPage(
+                    definition,
+                    current_action,
+                    on_selected,
+                    submit_label,
+                ),
             )
         )
     return pages

--- a/keymasq/gui/widgets/macro_editor_dialog.py
+++ b/keymasq/gui/widgets/macro_editor_dialog.py
@@ -2256,29 +2256,12 @@ class MacroEditorDialog(Adw.Dialog):
         self._control_timeout_hint_label.set_halign(Gtk.Align.START)
         control_row.append(self._control_timeout_hint_label)
 
-        control_compositor_row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=8)
-        self._control_compositor_label = Gtk.Label()
-        self._control_compositor_label.add_css_class("dim-label")
-        self._control_compositor_label.set_halign(Gtk.Align.START)
-        self._control_compositor_label.set_hexpand(True)
-        control_compositor_row.append(self._control_compositor_label)
-        self._control_compositor_change_btn = Gtk.Button(label="Change Action...")
-        self._control_compositor_change_btn.add_css_class("flat")
-        self._control_compositor_change_btn.connect(
-            "clicked",
-            self._on_change_compositor_action_clicked,
-        )
-        control_compositor_row.append(self._control_compositor_change_btn)
-        control_row.append(control_compositor_row)
-
         panel.append(control_row)
         self._control_row = control_row
         self._control_ab_row = control_ab_row
         self._control_cmd_row = control_cmd_row
         self._control_sync_row = control_sync_row
-        self._control_compositor_row = control_compositor_row
         self._control_timeout_hint_label.set_visible(False)
-        self._control_compositor_row.set_visible(False)
         self._control_row.set_visible(False)
 
         # Action row
@@ -3255,7 +3238,8 @@ class MacroEditorDialog(Adw.Dialog):
             self._release_label.set_visible(False)
             self._release_spin.set_visible(False)
             self._release_unit_label.set_visible(False)
-            self._change_key_btn.set_visible(False)
+            self._change_key_btn.set_visible(is_compositor)
+            self._change_key_btn.set_label("Change Action..." if is_compositor else "Change Key...")
             self._move_row.set_visible(False)
             self._control_row.set_visible(True)
 
@@ -3271,7 +3255,6 @@ class MacroEditorDialog(Adw.Dialog):
                 self._control_cmd_row.set_visible(False)
                 self._control_sync_row.set_visible(False)
                 self._control_timeout_hint_label.set_visible(False)
-                self._control_compositor_row.set_visible(False)
 
                 if control.mode == "wait":
                     self._control_ab_row.set_visible(True)
@@ -3300,9 +3283,6 @@ class MacroEditorDialog(Adw.Dialog):
                     self._control_timeout_spin.set_value(max(1, int(control.timeout_ms)))
                     self._control_inhibit_check.set_active(bool(control.inhibit_mouse))
                     self._update_timeout_clamp_hint(int(control.timeout_ms))
-                elif control.mode == "compositor_dispatch":
-                    self._control_compositor_row.set_visible(True)
-                    self._control_compositor_label.set_label(_describe_compositor_control(control))
             finally:
                 self._updating_props = False
             self._move_capture_row.set_visible(False)
@@ -3492,6 +3472,9 @@ class MacroEditorDialog(Adw.Dialog):
 
     def _on_change_key_clicked(self, btn) -> None:
         ev = self._timeline._selected
+        if isinstance(ev, EditableControl) and ev.mode == "compositor_dispatch":
+            self._present_compositor_action_dialog(control=ev)
+            return
         if ev is None or isinstance(ev, (EditableMove, EditableControl, dict)):
             return
         assert isinstance(ev, EditableEvent)
@@ -3636,14 +3619,6 @@ class MacroEditorDialog(Adw.Dialog):
         if selected_obj.mode == "exec_sync":
             selected_obj.inhibit_mouse = bool(check.get_active())
             self._refresh_after_control_change(selected_obj)
-
-    def _on_change_compositor_action_clicked(self, _btn: Gtk.Button) -> None:
-        selected_obj = self._timeline._selected
-        if not isinstance(selected_obj, EditableControl):
-            return
-        if selected_obj.mode != "compositor_dispatch":
-            return
-        self._present_compositor_action_dialog(control=selected_obj)
 
     # ------------------------------------------------------------------
     # Zoom

--- a/keymasq/gui/widgets/macro_editor_dialog.py
+++ b/keymasq/gui/widgets/macro_editor_dialog.py
@@ -14,6 +14,8 @@ from gi.repository import Adw, Gdk, GLib, Gtk  # pyright: ignore[reportAttribute
 
 from keymasq.common.models import (
     DEFAULT_MACRO_LOOP_STOP_BEHAVIOR,
+    ActionType,
+    MappingAction,
     normalize_macro_loop_stop_behavior,
 )
 from keymasq.common.slurp import get_slurp_capture
@@ -25,6 +27,10 @@ from keymasq.gui.session_client import (
     session_request_async,
 )
 from keymasq.gui.session_reload import notify_session_reload_async
+from keymasq.gui.widgets.compositor_actions import (
+    build_compositor_action_pages,
+    describe_compositor_action,
+)
 from keymasq.session.compositor import detect_compositor_sync
 
 # ---------------------------------------------------------------------------
@@ -163,7 +169,7 @@ class EditableMove:
 
 @dataclass
 class EditableControl:
-    mode: str  # wait | wait_random | exec_sync | exec_async
+    mode: str  # wait | wait_random | exec_sync | exec_async | compositor_dispatch
     t_us: int
     duration_us: int = 0
     min_us: int = 0
@@ -171,6 +177,29 @@ class EditableControl:
     command: str = ""
     timeout_ms: int = 30000
     inhibit_mouse: bool = False
+    compositor_id: str = ""
+    compositor_dispatcher: str = ""
+    compositor_args: str = ""
+
+
+def _control_to_compositor_action(control: EditableControl) -> MappingAction:
+    return MappingAction(
+        action_type=ActionType.COMPOSITOR_DISPATCH,
+        compositor_id=control.compositor_id or None,
+        compositor_dispatcher=control.compositor_dispatcher,
+        compositor_args=control.compositor_args,
+    )
+
+
+def _describe_compositor_control(control: EditableControl) -> str:
+    action = _control_to_compositor_action(control)
+    description = describe_compositor_action(action)
+    if description is not None:
+        return description
+    dispatcher = control.compositor_dispatcher or "dispatch"
+    args = str(control.compositor_args or "").strip()
+    suffix = f" {args}" if args else ""
+    return f"Compositor -> {dispatcher}{suffix}"
 
 
 def parse_events(
@@ -224,6 +253,9 @@ def parse_events(
                     command=str(ev.get("command", "") or ""),
                     timeout_ms=int(ev.get("timeout_ms", 30000) or 30000),
                     inhibit_mouse=bool(ev.get("inhibit_mouse", False)),
+                    compositor_id=str(ev.get("compositor", "") or ""),
+                    compositor_dispatcher=str(ev.get("dispatcher", "") or ""),
+                    compositor_args=str(ev.get("args", "") or ""),
                 )
             )
             continue
@@ -339,6 +371,11 @@ def reconstruct_events(
             if control.mode == "exec_sync":
                 event["timeout_ms"] = int(control.timeout_ms)
                 event["inhibit_mouse"] = bool(control.inhibit_mouse)
+        elif control.mode == "compositor_dispatch":
+            if control.compositor_id:
+                event["compositor"] = str(control.compositor_id)
+            event["dispatcher"] = str(control.compositor_dispatcher)
+            event["args"] = str(control.compositor_args)
         raw.append(event)
 
     raw.extend(passthrough_events)
@@ -974,9 +1011,15 @@ class TimelineWidget(Gtk.DrawingArea):
             elif control.mode == "exec_sync":
                 cr.set_source_rgba(1.00, 0.62, 0.12, 0.95)
                 label = "XS"
-            else:
+            elif control.mode == "exec_async":
                 cr.set_source_rgba(0.95, 0.50, 0.15, 0.95)
                 label = "XA"
+            elif control.mode == "compositor_dispatch":
+                cr.set_source_rgba(0.70, 0.45, 1.00, 0.95)
+                label = "C"
+            else:
+                cr.set_source_rgba(0.65, 0.65, 0.65, 0.95)
+                label = "?"
 
             size = 7.0
             cr.move_to(x, base_y - size)
@@ -1399,6 +1442,16 @@ class TimelineWidget(Gtk.DrawingArea):
             exec_async_btn.connect("clicked", _insert_exec_async)
             box.append(exec_async_btn)
 
+            compositor_btn = Gtk.Button(label=f"Insert Compositor Action at {t_label}")
+            compositor_btn.add_css_class("flat")
+
+            def _insert_compositor(_b, _t=t_us, _p=popover):
+                _p.popdown()
+                self._editor._present_compositor_action_dialog(default_t_us=_t)
+
+            compositor_btn.connect("clicked", _insert_compositor)
+            box.append(compositor_btn)
+
         if box.get_first_child():
             box.append(Gtk.Separator())
 
@@ -1469,7 +1522,12 @@ class TimelineWidget(Gtk.DrawingArea):
         if isinstance(ev, EditableControl):
             if box.get_first_child():
                 box.append(Gtk.Separator())
-            del_control_btn = Gtk.Button(label=f"Delete {ev.mode.replace('_', ' ').title()}")
+            label = (
+                "Compositor Action"
+                if ev.mode == "compositor_dispatch"
+                else ev.mode.replace("_", " ").title()
+            )
+            del_control_btn = Gtk.Button(label=f"Delete {label}")
             del_control_btn.add_css_class("flat")
             del_control_btn.add_css_class("destructive-action")
 
@@ -1552,6 +1610,11 @@ class MacroEditorDialog(Adw.Dialog):
         self._zoom_min_pps: float = 50.0
         self._zoom_max_pps: float = 4000.0
         self._macro_exec_timeout_max_ms: int = 30000
+        self._compositor_action_status: dict[str, bool | str | None] = {
+            "compositor_id": None,
+            "listener_name": None,
+            "compositor_dispatch_available": False,
+        }
         self._initial_macro_data: dict = {}
         self._macro_exists = False
 
@@ -1586,6 +1649,33 @@ class MacroEditorDialog(Adw.Dialog):
     # Data loading
     # ------------------------------------------------------------------
 
+    def _resolve_compositor_action_status(
+        self,
+        status: object | None = None,
+    ) -> dict[str, bool | str | None]:
+        resolved: dict[str, bool | str | None] = {
+            "compositor_id": None,
+            "listener_name": None,
+            "compositor_dispatch_available": False,
+        }
+        if isinstance(status, dict):
+            for key in resolved:
+                value = status.get(key)
+                if isinstance(value, (bool, str)) or value is None:
+                    resolved[key] = value
+            return resolved
+
+        root = self._parent.get_root() if hasattr(self._parent, "get_root") else None
+        get_status = getattr(root, "get_compositor_action_status", None)
+        if callable(get_status):
+            root_status = get_status()
+            if isinstance(root_status, dict):
+                for key in resolved:
+                    value = root_status.get(key)
+                    if isinstance(value, (bool, str)) or value is None:
+                        resolved[key] = value
+        return resolved
+
     def _load_initial_state_async(self) -> None:
         run_gui_task(
             self._load_initial_state,
@@ -1594,9 +1684,11 @@ class MacroEditorDialog(Adw.Dialog):
 
     def _load_initial_state(self) -> dict[str, object]:
         timeout_max = 30000
+        compositor_status: dict[str, object] = {}
         try:
             status = session_request({"command": "get_status"}) or {}
             timeout_max = int(status.get("macro_exec_timeout_max_ms", 30000) or 30000)
+            compositor_status = dict(status)
         except Exception:
             timeout_max = 30000
 
@@ -1611,6 +1703,7 @@ class MacroEditorDialog(Adw.Dialog):
 
         return {
             "timeout_max": max(1, timeout_max),
+            "compositor_status": compositor_status,
             "macro": macro,
         }
 
@@ -1619,6 +1712,9 @@ class MacroEditorDialog(Adw.Dialog):
         timeout_max_raw = payload.get("timeout_max", 30000)
         timeout_max = timeout_max_raw if isinstance(timeout_max_raw, int) else 30000
         self._macro_exec_timeout_max_ms = max(1, timeout_max)
+        self._compositor_action_status = self._resolve_compositor_action_status(
+            payload.get("compositor_status")
+        )
 
         timeout_adjustment = self._control_timeout_spin.get_adjustment()
         timeout_adjustment.set_upper(self._macro_exec_timeout_max_ms)
@@ -2160,12 +2256,29 @@ class MacroEditorDialog(Adw.Dialog):
         self._control_timeout_hint_label.set_halign(Gtk.Align.START)
         control_row.append(self._control_timeout_hint_label)
 
+        control_compositor_row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=8)
+        self._control_compositor_label = Gtk.Label()
+        self._control_compositor_label.add_css_class("dim-label")
+        self._control_compositor_label.set_halign(Gtk.Align.START)
+        self._control_compositor_label.set_hexpand(True)
+        control_compositor_row.append(self._control_compositor_label)
+        self._control_compositor_change_btn = Gtk.Button(label="Change Action...")
+        self._control_compositor_change_btn.add_css_class("flat")
+        self._control_compositor_change_btn.connect(
+            "clicked",
+            self._on_change_compositor_action_clicked,
+        )
+        control_compositor_row.append(self._control_compositor_change_btn)
+        control_row.append(control_compositor_row)
+
         panel.append(control_row)
         self._control_row = control_row
         self._control_ab_row = control_ab_row
         self._control_cmd_row = control_cmd_row
         self._control_sync_row = control_sync_row
+        self._control_compositor_row = control_compositor_row
         self._control_timeout_hint_label.set_visible(False)
+        self._control_compositor_row.set_visible(False)
         self._control_row.set_visible(False)
 
         # Action row
@@ -3128,8 +3241,13 @@ class MacroEditorDialog(Adw.Dialog):
             self._cancel_capture_selected_move("")
         if isinstance(selected_obj, EditableControl):
             control = selected_obj
-            self._prop_title.set_label("Control")
-            self._key_info_label.set_label(control.mode.replace("_", " ").title())
+            is_compositor = control.mode == "compositor_dispatch"
+            self._prop_title.set_label("Compositor Action" if is_compositor else "Control")
+            self._key_info_label.set_label(
+                _describe_compositor_control(control)
+                if is_compositor
+                else control.mode.replace("_", " ").title()
+            )
             self._press_label.set_label("At:")
             self._duration_text_label.set_visible(False)
             self._duration_spin.set_visible(False)
@@ -3153,6 +3271,7 @@ class MacroEditorDialog(Adw.Dialog):
                 self._control_cmd_row.set_visible(False)
                 self._control_sync_row.set_visible(False)
                 self._control_timeout_hint_label.set_visible(False)
+                self._control_compositor_row.set_visible(False)
 
                 if control.mode == "wait":
                     self._control_ab_row.set_visible(True)
@@ -3181,6 +3300,9 @@ class MacroEditorDialog(Adw.Dialog):
                     self._control_timeout_spin.set_value(max(1, int(control.timeout_ms)))
                     self._control_inhibit_check.set_active(bool(control.inhibit_mouse))
                     self._update_timeout_clamp_hint(int(control.timeout_ms))
+                elif control.mode == "compositor_dispatch":
+                    self._control_compositor_row.set_visible(True)
+                    self._control_compositor_label.set_label(_describe_compositor_control(control))
             finally:
                 self._updating_props = False
             self._move_capture_row.set_visible(False)
@@ -3515,6 +3637,14 @@ class MacroEditorDialog(Adw.Dialog):
             selected_obj.inhibit_mouse = bool(check.get_active())
             self._refresh_after_control_change(selected_obj)
 
+    def _on_change_compositor_action_clicked(self, _btn: Gtk.Button) -> None:
+        selected_obj = self._timeline._selected
+        if not isinstance(selected_obj, EditableControl):
+            return
+        if selected_obj.mode != "compositor_dispatch":
+            return
+        self._present_compositor_action_dialog(control=selected_obj)
+
     # ------------------------------------------------------------------
     # Zoom
     # ------------------------------------------------------------------
@@ -3677,6 +3807,87 @@ class MacroEditorDialog(Adw.Dialog):
         self._timeline._selected = control
         self._refresh_after_timing_edit()
         self._on_selection_changed(control)
+
+    def _present_compositor_action_dialog(
+        self,
+        default_t_us: int | None = None,
+        control: EditableControl | None = None,
+    ) -> None:
+        title = "Edit Compositor Action" if control is not None else "Insert Compositor Action"
+        dialog = Adw.Dialog(title=title, content_width=560, content_height=440)
+
+        box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=10)
+        box.set_margin_top(12)
+        box.set_margin_bottom(12)
+        box.set_margin_start(12)
+        box.set_margin_end(12)
+
+        at_row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=8)
+        at_row.append(Gtk.Label(label="At (ms):"))
+        at_value_us = control.t_us if control is not None else (default_t_us or 0)
+        at_spin = Gtk.SpinButton()
+        at_spin.set_adjustment(
+            Gtk.Adjustment(value=at_value_us / 1000, lower=0, upper=3600000, step_increment=1)
+        )
+        at_spin.set_digits(0)
+        at_spin.set_width_chars(8)
+        at_row.append(at_spin)
+        box.append(at_row)
+
+        current_action = _control_to_compositor_action(control) if control is not None else None
+
+        def on_selected(action: MappingAction) -> None:
+            dispatcher = str(action.compositor_dispatcher or "").strip()
+            if not dispatcher:
+                return
+            target = control or EditableControl(mode="compositor_dispatch", t_us=0)
+            target.t_us = max(0, int(at_spin.get_value() * 1000))
+            target.compositor_id = str(action.compositor_id or "")
+            target.compositor_dispatcher = dispatcher
+            target.compositor_args = str(action.compositor_args or "")
+            if control is None:
+                self._insert_control_event(target)
+            else:
+                self._refresh_after_control_change(target)
+            dialog.close()
+
+        status = self._resolve_compositor_action_status()
+        if not status.get("compositor_dispatch_available"):
+            status = self._resolve_compositor_action_status(self._compositor_action_status)
+        pages = build_compositor_action_pages(
+            current_action,
+            on_selected,
+            status,
+            "Apply" if control is not None else "Insert",
+        )
+
+        if pages:
+            stack = Gtk.Stack()
+            stack.set_vexpand(True)
+            for page in pages:
+                stack.add_titled(page.widget, page.page_id, page.title)
+            if len(pages) > 1:
+                switcher = Gtk.StackSwitcher()
+                switcher.set_stack(stack)
+                switcher.set_halign(Gtk.Align.CENTER)
+                box.append(switcher)
+            box.append(stack)
+        else:
+            message = Gtk.Label(label="Compositor actions are unavailable for this session.")
+            message.add_css_class("dim-label")
+            message.set_wrap(True)
+            message.set_halign(Gtk.Align.START)
+            box.append(message)
+
+        footer = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=8)
+        footer.set_halign(Gtk.Align.END)
+        close_btn = Gtk.Button(label="Close")
+        close_btn.connect("clicked", self._on_close_dialog_clicked, dialog)
+        footer.append(close_btn)
+        box.append(footer)
+
+        dialog.set_child(box)
+        dialog.present(self._parent)
 
     def _show_add_control_popover(
         self,

--- a/keymasq/keymasqd/runtime/macros.py
+++ b/keymasq/keymasqd/runtime/macros.py
@@ -754,6 +754,22 @@ async def run_macro_control_action(
                 release_macro_mouse_inhibit(manager)
         return max(0.0, loop.time() - started_at)
 
+    if action_type == "compositor_dispatch":
+        dispatcher = str_value_fn(ev.get("dispatcher"), "").strip()
+        if not dispatcher:
+            return 0.0
+        if manager.broadcast_callback:
+            await manager.broadcast_callback(
+                CommandType.ACTION_TRIGGER,
+                {
+                    "action_type": "compositor_dispatch",
+                    "compositor": str_value_fn(ev.get("compositor"), "").strip(),
+                    "dispatcher": dispatcher,
+                    "args": str_value_fn(ev.get("args"), "").strip(),
+                },
+            )
+        return 0.0
+
     return 0.0
 
 

--- a/tests/gui/test_macro_editor_dialog_widget.py
+++ b/tests/gui/test_macro_editor_dialog_widget.py
@@ -270,8 +270,9 @@ def test_macro_editor_compositor_control_selection_shows_action(monkeypatch) -> 
 
     assert dialog._prop_title.get_label() == "Compositor Action"
     assert dialog._press_spin.get_value_as_int() == 12
-    assert dialog._control_compositor_row.get_visible() is True
-    assert "workspace e+1" in dialog._control_compositor_label.get_label()
+    assert "workspace e+1" in dialog._key_info_label.get_label()
+    assert dialog._change_key_btn.get_visible() is True
+    assert dialog._change_key_btn.get_label() == "Change Action..."
     assert dialog._control_cmd_row.get_visible() is False
     assert dialog._control_sync_row.get_visible() is False
 

--- a/tests/gui/test_macro_editor_dialog_widget.py
+++ b/tests/gui/test_macro_editor_dialog_widget.py
@@ -194,6 +194,35 @@ def test_macro_editor_payload_includes_wait_controls(monkeypatch) -> None:
     ]
 
 
+def test_macro_editor_payload_includes_compositor_control(monkeypatch) -> None:
+    dialog = _build_macro_dialog(monkeypatch)
+    dialog._control_events = [
+        EditableControl(
+            mode="compositor_dispatch",
+            t_us=3000,
+            compositor_id="hyprland",
+            compositor_dispatcher="workspace",
+            compositor_args="e+1",
+        )
+    ]
+
+    payload = dialog._build_macro_payload("compositor_macro")
+
+    assert payload["events"] == [
+        {
+            "device_type": "macro",
+            "type": 0,
+            "code": 0,
+            "value": 0,
+            "t_us": 3000,
+            "macro_action": "compositor_dispatch",
+            "compositor": "hyprland",
+            "dispatcher": "workspace",
+            "args": "e+1",
+        }
+    ]
+
+
 def test_macro_editor_wait_controls_show_edit_fields(monkeypatch) -> None:
     dialog = _build_macro_dialog(monkeypatch)
 
@@ -224,6 +253,27 @@ def test_macro_editor_wait_controls_show_edit_fields(monkeypatch) -> None:
     assert dialog._control_b_label.get_label() == "Max (ms):"
     assert dialog._control_a_spin.get_value_as_int() == 10
     assert dialog._control_b_spin.get_value_as_int() == 80
+
+
+def test_macro_editor_compositor_control_selection_shows_action(monkeypatch) -> None:
+    dialog = _build_macro_dialog(monkeypatch)
+    control = EditableControl(
+        mode="compositor_dispatch",
+        t_us=12_000,
+        compositor_id="hyprland",
+        compositor_dispatcher="workspace",
+        compositor_args="e+1",
+    )
+    dialog._timeline._selected = control
+
+    dialog._on_selection_changed(control)
+
+    assert dialog._prop_title.get_label() == "Compositor Action"
+    assert dialog._press_spin.get_value_as_int() == 12
+    assert dialog._control_compositor_row.get_visible() is True
+    assert "workspace e+1" in dialog._control_compositor_label.get_label()
+    assert dialog._control_cmd_row.get_visible() is False
+    assert dialog._control_sync_row.get_visible() is False
 
 
 def test_macro_editor_abs_move_capture_updates_selected_move(monkeypatch) -> None:

--- a/tests/gui/test_macro_editor_parser.py
+++ b/tests/gui/test_macro_editor_parser.py
@@ -180,6 +180,37 @@ def test_parse_reconstruct_preserves_wait_controls() -> None:
     assert rebuilt == raw
 
 
+def test_parse_reconstruct_compositor_macro_action() -> None:
+    raw = [
+        {
+            "device_type": "macro",
+            "type": 0,
+            "code": 0,
+            "value": 0,
+            "t_us": 123000,
+            "macro_action": "compositor_dispatch",
+            "compositor": "hyprland",
+            "dispatcher": "workspace",
+            "args": "e+1",
+        }
+    ]
+
+    editable, rel_events, passthrough, synthetic_moves, control_events = parse_events(raw)
+    rebuilt = reconstruct_events(editable, rel_events, passthrough, synthetic_moves, control_events)
+
+    assert editable == []
+    assert rel_events == []
+    assert passthrough == []
+    assert synthetic_moves == []
+    assert len(control_events) == 1
+    control = control_events[0]
+    assert control.mode == "compositor_dispatch"
+    assert control.compositor_id == "hyprland"
+    assert control.compositor_dispatcher == "workspace"
+    assert control.compositor_args == "e+1"
+    assert rebuilt == raw
+
+
 def test_unmatched_key_press_is_classified_for_keyboard_track() -> None:
     raw = [
         {

--- a/tests/keymasqd/test_device_manager_core.py
+++ b/tests/keymasqd/test_device_manager_core.py
@@ -718,6 +718,38 @@ class TestMacroControlActions:
         assert result == 0.0
 
     @pytest.mark.asyncio
+    async def test_run_macro_control_action_compositor_dispatch_broadcasts(self):
+        manager = DeviceManager()
+
+        callback = AsyncMock()
+
+        async def cb(command, data):
+            await callback(command, data)
+
+        manager.broadcast_callback = cb
+
+        result = await _runtime_run_macro_control_action(
+            manager,
+            {
+                "macro_action": "compositor_dispatch",
+                "compositor": "hyprland",
+                "dispatcher": "workspace",
+                "args": "e+1",
+            },
+        )
+
+        callback.assert_awaited_once()
+        called_command, called_data = callback.await_args.args
+        assert called_command == CommandType.ACTION_TRIGGER
+        assert called_data == {
+            "action_type": "compositor_dispatch",
+            "compositor": "hyprland",
+            "dispatcher": "workspace",
+            "args": "e+1",
+        }
+        assert result == 0.0
+
+    @pytest.mark.asyncio
     async def test_run_macro_control_action_exec_sync_wait_id_and_cleanup(self, monkeypatch):
         manager = DeviceManager()
         clock = {"now": 30.0}


### PR DESCRIPTION
## Summary

- Adds a new "Compositor action" event type to the macro timeline editor
- Users can insert compositor dispatches (Hyprland, Niri, KDE, GNOME) into macro recordings
- Compositior events fire at their timestamp and continue immediately; playback uses the same compositor dispatch mechanism as normal mappings
- The daemon runtime broadcasts `compositor_dispatch` actions via `broadcast_callback` to the active session listener

## Testing

- Added `test_macro_editor_payload_includes_compositor_control` to verify payload serialisation of a compositor control event
- Added `test_macro_editor_compositor_control_selection_shows_action` to verify property panel shows compositor-specific fields when a compositor control is selected
- Added `test_parse_reconstruct_compositor_macro_action` to verify parse/reconstruct round-trip of compositor macro events
- Added `test_run_macro_control_action_compositor_dispatch_broadcasts` to verify the runtime broadcasts the dispatch via `broadcast_callback`
- Manual check: opened macro editor, inserted a compositor action, verified it appears on the timeline and in the property panel