### PR TITLE
Fire exec actions as background tasks

### DIFF
--- a/docs/ACTIONS.md
+++ b/docs/ACTIONS.md
@@ -43,6 +43,7 @@ Use this to disable a key you never want to fire.
 
 Run a shell command when the key is pressed. The command runs inside your
 user session (delegated to keymasq-session, not the privileged daemon).
+Keymasq launches it in the background and continues handling later input.
 
 Enter the command text and click **Map**.
 

--- a/docs/COMBOS.md
+++ b/docs/COMBOS.md
@@ -270,7 +270,8 @@ editing combos.
 
 - **Command actions** run shell commands inside your user session (delegated
   to keymasq-session, not the privileged daemon). They still execute
-  automatically when the combo fires, so be mindful of what you put in them.
+  automatically when the combo fires, and Keymasq does not wait for them
+  before handling later input.
 - **Compositor dispatcher actions** can send commands to your compositor
   (e.g. Hyprland). These interact with your desktop environment directly, so
   review what they do before assigning them to a combo.

--- a/keymasq/session/manager/events.py
+++ b/keymasq/session/manager/events.py
@@ -37,20 +37,18 @@ async def handle_event(
                 ref_data = manager.exec_state.superkey_exec_refs.get(exec_ref)
                 if ref_data:
                     hardware_id, cmd = ref_data
-                    data["cmd"] = cmd
-                    data["hardware_id"] = hardware_id
-                    action_handler = manager.action_handler
-                    if action_handler is not None:
-                        await action_handler.handle_action(data)
+                    exec_data = dict(data)
+                    exec_data["cmd"] = cmd
+                    exec_data["hardware_id"] = hardware_id
+                    asyncio.create_task(handle_exec_trigger(manager, exec_data))
                 else:
                     log.warning("Unknown superkey exec_ref: %s", exec_ref)
             else:
                 cmd = manager.exec_state.exec_refs.get(exec_ref)
                 if cmd:
-                    data["cmd"] = cmd
-                    action_handler = manager.action_handler
-                    if action_handler is not None:
-                        await action_handler.handle_action(data)
+                    exec_data = dict(data)
+                    exec_data["cmd"] = cmd
+                    asyncio.create_task(handle_exec_trigger(manager, exec_data))
                 else:
                     log.warning("Unknown exec_ref: %s", exec_ref)
 

--- a/tests/test_session_manager_events.py
+++ b/tests/test_session_manager_events.py
@@ -133,24 +133,71 @@ async def test_handle_event_set_cursor_position_missing_request_id_is_one_way() 
 
 
 @pytest.mark.asyncio
-async def test_handle_event_exec_ref_runs_command_once() -> None:
+async def test_handle_event_exec_ref_schedules_command_without_blocking() -> None:
     manager = SessionManager()
     manager.exec_state.exec_refs[7] = "echo once"
-    manager.action_handler.execute_command = AsyncMock(return_value=0)
+    started = asyncio.Event()
+    finish = asyncio.Event()
 
-    await session_events_module.handle_event(
-        manager,
-        CommandType.ACTION_TRIGGER,
-        {
-            "action_type": "exec",
-            "exec_ref": 7,
-            "source_device": "1234:5678",
-            "source_button": "btn_side",
-        },
+    async def _execute_command(cmd: str) -> int:
+        started.set()
+        await finish.wait()
+        return 0
+
+    manager.action_handler.execute_command = AsyncMock(side_effect=_execute_command)
+
+    await asyncio.wait_for(
+        session_events_module.handle_event(
+            manager,
+            CommandType.ACTION_TRIGGER,
+            {
+                "action_type": "exec",
+                "exec_ref": 7,
+                "source_device": "1234:5678",
+                "source_button": "btn_side",
+            },
+        ),
+        timeout=1.0,
     )
 
-    await asyncio.sleep(0)
+    await asyncio.wait_for(started.wait(), timeout=1.0)
     manager.action_handler.execute_command.assert_awaited_once_with("echo once")
+    finish.set()
+    await asyncio.sleep(0)
+
+
+@pytest.mark.asyncio
+async def test_handle_event_superkey_exec_ref_schedules_command_without_blocking() -> None:
+    manager = SessionManager()
+    manager.exec_state.superkey_exec_refs[10000] = ("1234:5678", "echo super")
+    started = asyncio.Event()
+    finish = asyncio.Event()
+
+    async def _execute_command(cmd: str) -> int:
+        started.set()
+        await finish.wait()
+        return 0
+
+    manager.action_handler.execute_command = AsyncMock(side_effect=_execute_command)
+
+    await asyncio.wait_for(
+        session_events_module.handle_event(
+            manager,
+            CommandType.ACTION_TRIGGER,
+            {
+                "action_type": "exec",
+                "exec_ref": 10000,
+                "source_device": "1234:5678",
+                "source_button": "btn_side",
+            },
+        ),
+        timeout=1.0,
+    )
+
+    await asyncio.wait_for(started.wait(), timeout=1.0)
+    manager.action_handler.execute_command.assert_awaited_once_with("echo super")
+    finish.set()
+    await asyncio.sleep(0)
 
 
 @pytest.mark.asyncio
@@ -172,6 +219,51 @@ async def test_handle_event_macro_async_exec_uses_exec_trigger_path() -> None:
     await asyncio.sleep(0)
     manager.action_handler.handle_action.assert_not_awaited()
     manager.action_handler.execute_command_sync.assert_called_once_with("echo macro")
+
+
+@pytest.mark.asyncio
+async def test_handle_event_macro_sync_exec_waits_and_reports_completion() -> None:
+    manager = SessionManager()
+    started = asyncio.Event()
+    finish = asyncio.Event()
+    sent = asyncio.Event()
+    sent_commands = []
+
+    async def _execute_command(cmd: str) -> int:
+        started.set()
+        await finish.wait()
+        return 17
+
+    async def _send_command(command):
+        sent_commands.append(command)
+        sent.set()
+        return SimpleNamespace(status="ok", data={})
+
+    manager.action_handler.execute_command = AsyncMock(side_effect=_execute_command)
+    manager.client.send_command = AsyncMock(side_effect=_send_command)
+
+    await asyncio.wait_for(
+        session_events_module.handle_event(
+            manager,
+            CommandType.ACTION_TRIGGER,
+            {
+                "action_type": "exec",
+                "cmd": "echo macro",
+                "macro_exec_wait_id": "wait-1",
+            },
+        ),
+        timeout=1.0,
+    )
+
+    await asyncio.wait_for(started.wait(), timeout=1.0)
+    manager.client.send_command.assert_not_awaited()
+
+    finish.set()
+    await asyncio.wait_for(sent.wait(), timeout=1.0)
+
+    manager.action_handler.execute_command.assert_awaited_once_with("echo macro")
+    assert sent_commands[0].command == CommandType.MACRO_EXEC_COMPLETE
+    assert sent_commands[0].data == {"wait_id": "wait-1", "returncode": 17}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Exec actions (regular and superkey exec refs) are now launched via `asyncio.create_task` so the event handler does not block subsequent input processing.
- Documentation in `docs/ACTIONS.md` and `docs/COMBOS.md` updated to describe the fire-and-forget behavior.
- Refactored the single blocking exec test into three targeted tests: regular exec, superkey exec, and macro sync exec (which still waits and reports completion).

## Testing

- `test_handle_event_exec_ref_schedules_command_without_blocking` – confirmed exec ref triggers are scheduled as a background task and do not block.
- `test_handle_event_superkey_exec_ref_schedules_command_without_blocking` – confirmed superkey exec refs are also fire-and-forget.
- `test_handle_event_macro_sync_exec_waits_and_reports_completion` – confirmed macro sync exec still awaits the command and sends `MACRO_EXEC_COMPLETE` with the return code.
- Full test suite run: `check.sh full` passes.