### PR TITLE
feat: Add OpenRazer device control actions (DPI, polling rate)

### DIFF
--- a/docs/ACTIONS.md
+++ b/docs/ACTIONS.md
@@ -259,6 +259,27 @@ Super keys have two modes:
 
 ![Super Keys tab — choose a saved super key action](assets/screenshots/key_selector_superkeys.png)
 
+## OpenRazer
+
+Set OpenRazer device settings from a mapping, combo, super key action, or
+macro. Keymasq talks to the OpenRazer daemon over the session D-Bus service
+`org.razer`; it does not require an OpenRazer Python package.
+
+Supported settings:
+
+| Setting | What it does |
+|---|---|
+| **DPI** | Set one DPI value for both axes, or use Split mode to set X and Y separately. Devices that expose only one DPI value use OpenRazer's `setDPI(x, 0)` form. |
+| **Polling Rate** | Set an explicit polling rate. The GUI offers OpenRazer-reported templates when available, otherwise 125/500/1000 Hz, while still allowing a custom value. |
+
+OpenRazer actions target an explicit OpenRazer device by serial. This avoids
+ambiguous behavior when an action is triggered by another input device or from
+a macro.
+
+OpenRazer availability is checked lazily and refreshed when D-Bus reports that
+`org.razer` appears or disappears, so Keymasq can start before OpenRazer and
+still discover it later.
+
 ## Macro
 
 Trigger macro recording controls or play a saved macro.
@@ -319,8 +340,8 @@ Rapidfire and tap are **mutually exclusive** — enabling one disables the
 other.
 
 They are available for: Keyboard, Mouse, Navigation, Media, Gamepad, and Mouse Move
-actions. They are not available for: Special, Super Keys, Macro, Profile, or
-Compositor actions.
+actions. They are not available for: Special, Super Keys, Macro, Profile,
+Compositor, or OpenRazer actions.
 
 ### Rapidfire
 

--- a/docs/MACROS.md
+++ b/docs/MACROS.md
@@ -282,6 +282,7 @@ You can:
 - Change which key or button an event uses.
 - Insert wait controls.
 - Insert compositor actions.
+- Insert OpenRazer actions.
 - Use timing tools to trim, scale, or adjust gaps.
 
 ### Event Types
@@ -299,6 +300,7 @@ The editor lets you insert several kinds of events into the timeline:
 | **Exec (synchronous)** | Run an external program and wait for it to finish before the macro continues. Macro playback is paused until the process exits. |
 | **Exec (asynchronous)** | Fire-and-forget an external program. The macro continues immediately — the launched process runs independently. |
 | **Compositor action** | Send a compositor dispatch through the active session listener. This uses the same Hyprland, Niri, KDE, or GNOME action picker as normal mappings. |
+| **OpenRazer action** | Set DPI or polling rate through the OpenRazer D-Bus service. |
 
 Exec events are powerful but be cautious: a synchronous exec that hangs will
 stall the macro indefinitely. Prefer asynchronous exec for anything that
@@ -307,6 +309,10 @@ doesn't need to gate later events.
 Compositor events fire at their timestamp and macro playback continues
 immediately. They are available only when the current session has a supported
 compositor listener with compositor dispatch enabled.
+
+OpenRazer events use the same session-side action path as normal OpenRazer
+mappings, but macro OpenRazer events always target an explicit OpenRazer
+device selected in the macro editor.
 
 Playback errors are silent — if a macro fails mid-sequence (for example, the
 target device is gone), the GUI won't notify you.

--- a/keymasq/common/models.py
+++ b/keymasq/common/models.py
@@ -29,6 +29,7 @@ class ActionType(Enum):
     PROFILE_ENABLE = "profile_enable"
     PROFILE_DISABLE = "profile_disable"
     PROFILE_TOGGLE = "profile_toggle"
+    OPENRAZER = "openrazer"
 
 
 class SuperkeyMode(Enum):
@@ -53,6 +54,7 @@ SUPERKEY_ACTION_TYPES = frozenset(
         ActionType.PROFILE_ENABLE,
         ActionType.PROFILE_DISABLE,
         ActionType.PROFILE_TOGGLE,
+        ActionType.OPENRAZER,
     }
 )
 
@@ -70,9 +72,9 @@ DEFAULT_RAPIDFIRE_HOLD_MS = 20
 DEFAULT_RAPIDFIRE_WAIT_MS = 20
 MIN_RAPIDFIRE_HOLD_MS = 0
 MIN_RAPIDFIRE_WAIT_MS = 1
-
 MACRO_LOOP_STOP_BEHAVIORS = frozenset({"finish_run", "cancel_run"})
 DEFAULT_MACRO_LOOP_STOP_BEHAVIOR = "finish_run"
+OPENRAZER_DEFAULT_POLL_RATE_TEMPLATES = (125, 500, 1000)
 
 
 class DeviceType(Enum):
@@ -239,6 +241,12 @@ class MappingAction:
     move_y: int = 0
     move_speed: float = 1.0
     move_jitter: float = 0.3
+    openrazer_setting: str | None = None
+    openrazer_device: str = "serial"
+    openrazer_serial: str | None = None
+    openrazer_dpi_x: int = 0
+    openrazer_dpi_y: int = 0
+    openrazer_poll_rate: int = 0
 
     rapidfire_enabled: bool = False
     rapidfire_hold_ms: int = DEFAULT_RAPIDFIRE_HOLD_MS
@@ -282,6 +290,12 @@ class SuperkeyAction:
     compositor_args: str | None = None
     move_x: int = 0
     move_y: int = 0
+    openrazer_setting: str | None = None
+    openrazer_device: str = "serial"
+    openrazer_serial: str | None = None
+    openrazer_dpi_x: int = 0
+    openrazer_dpi_y: int = 0
+    openrazer_poll_rate: int = 0
 
     rapidfire_enabled: bool = False
     rapidfire_hold_ms: int = DEFAULT_RAPIDFIRE_HOLD_MS
@@ -323,6 +337,12 @@ SUPERKEY_ACTION_SHARED_FIELDS = (
     "compositor_args",
     "move_x",
     "move_y",
+    "openrazer_setting",
+    "openrazer_device",
+    "openrazer_serial",
+    "openrazer_dpi_x",
+    "openrazer_dpi_y",
+    "openrazer_poll_rate",
     "rapidfire_enabled",
     "rapidfire_hold_ms",
     "rapidfire_wait_ms",

--- a/keymasq/gui/widgets/action_labels.py
+++ b/keymasq/gui/widgets/action_labels.py
@@ -61,6 +61,8 @@ def describe_mapping_action_compact(
         parts.append(f"🗂 disable {action.profile_name or '?'}")
     elif action.action_type == ActionType.PROFILE_TOGGLE:
         parts.append(f"🗂 toggle {action.profile_name or '?'}")
+    elif action.action_type == ActionType.OPENRAZER:
+        parts.append(_describe_openrazer_compact(action))
     elif action.action_type == ActionType.SUPPRESS:
         parts.append("× suppress")
     elif action.action_type == ActionType.PASSTHROUGH:
@@ -135,4 +137,32 @@ def describe_mapping_action_verbose(
         return f"Disable Profile → {action.profile_name or '?'}"
     if action.action_type == ActionType.PROFILE_TOGGLE:
         return f"Toggle Profile → {action.profile_name or '?'}"
+    if action.action_type == ActionType.OPENRAZER:
+        return describe_openrazer_action(action)
     return action.action_type.value
+
+
+def _describe_openrazer_compact(action: MappingAction) -> str:
+    setting = action.openrazer_setting or "setting"
+    if setting == "dpi":
+        if action.openrazer_dpi_x == action.openrazer_dpi_y:
+            return f"Razer DPI {action.openrazer_dpi_x}"
+        return f"Razer DPI {action.openrazer_dpi_x}/{action.openrazer_dpi_y}"
+    if setting == "poll_rate":
+        return f"Razer poll {action.openrazer_poll_rate}Hz"
+    return f"Razer {setting}"
+
+
+def describe_openrazer_action(action: MappingAction) -> str:
+    device = action.openrazer_serial or "device"
+    setting = action.openrazer_setting or "setting"
+    if setting == "dpi":
+        if action.openrazer_dpi_x == action.openrazer_dpi_y:
+            return f"OpenRazer DPI ({device}) -> {action.openrazer_dpi_x}"
+        return (
+            f"OpenRazer DPI ({device}) -> "
+            f"{action.openrazer_dpi_x}, {action.openrazer_dpi_y}"
+        )
+    if setting == "poll_rate":
+        return f"OpenRazer Poll Rate ({device}) -> {action.openrazer_poll_rate} Hz"
+    return f"OpenRazer -> {setting}"

--- a/keymasq/gui/widgets/combo_editor_dialog.py
+++ b/keymasq/gui/widgets/combo_editor_dialog.py
@@ -156,6 +156,8 @@ def combo_action_label(action: MappingAction | None) -> str:
         dispatcher = action.compositor_dispatcher or "Compositor"
         args = str(action.compositor_args or "").strip()
         return f"{dispatcher} {args}".strip()
+    if action.action_type == ActionType.OPENRAZER:
+        return describe_mapping_action_compact(action)
     if action.action_type == ActionType.SUPPRESS:
         return "Suppress"
     if action.action_type == ActionType.MACRO:

--- a/keymasq/gui/widgets/key_selector_dialog.py
+++ b/keymasq/gui/widgets/key_selector_dialog.py
@@ -954,7 +954,7 @@ class KeySelectorDialog(Adw.Dialog):
         self.openrazer_device_model = Gtk.StringList()
         self.openrazer_device_dropdown = Gtk.DropDown(model=self.openrazer_device_model)
         self.openrazer_device_dropdown.set_hexpand(True)
-        form.attach(self.openrazer_device_dropdown, 1, row, 3, 1)
+        form.attach(self.openrazer_device_dropdown, 1, row, 1, 1)
 
         row += 1
         setting_label = form_label("Setting:")
@@ -966,6 +966,7 @@ class KeySelectorDialog(Adw.Dialog):
         self.openrazer_setting_dropdown.set_selected(
             1 if self._openrazer_setting == "poll_rate" else 0
         )
+        self.openrazer_setting_dropdown.set_halign(Gtk.Align.START)
         form.attach(self.openrazer_setting_dropdown, 1, row, 1, 1)
 
         row += 1
@@ -976,46 +977,56 @@ class KeySelectorDialog(Adw.Dialog):
             self.openrazer_dpi_mode_model.append(label)
         self.openrazer_dpi_mode_dropdown = Gtk.DropDown(model=self.openrazer_dpi_mode_model)
         self.openrazer_dpi_mode_dropdown.set_selected(1 if self._openrazer_split_dpi else 0)
+        self.openrazer_dpi_mode_dropdown.set_halign(Gtk.Align.START)
         form.attach(self.openrazer_dpi_mode_dropdown, 1, row, 1, 1)
 
         row += 1
         self.openrazer_dpi_x_label = form_label("Value:")
         form.attach(self.openrazer_dpi_x_label, 0, row, 1, 1)
+        dpi_value_row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=8)
+        dpi_value_row.set_halign(Gtk.Align.START)
         self.openrazer_dpi_x_spin = Gtk.SpinButton()
         self.openrazer_dpi_x_spin.set_adjustment(
             Gtk.Adjustment(value=self._openrazer_dpi_x, lower=1, upper=60000, step_increment=50)
         )
         self.openrazer_dpi_x_spin.set_digits(0)
         self.openrazer_dpi_x_spin.set_width_chars(7)
-        form.attach(self.openrazer_dpi_x_spin, 1, row, 1, 1)
-        self.openrazer_dpi_y_label = form_label("Y:")
-        form.attach(self.openrazer_dpi_y_label, 2, row, 1, 1)
+        dpi_value_row.append(self.openrazer_dpi_x_spin)
+        self.openrazer_dpi_y_label = Gtk.Label(label="Y:")
+        self.openrazer_dpi_y_label.set_margin_start(8)
+        dpi_value_row.append(self.openrazer_dpi_y_label)
         self.openrazer_dpi_y_spin = Gtk.SpinButton()
         self.openrazer_dpi_y_spin.set_adjustment(
             Gtk.Adjustment(value=self._openrazer_dpi_y, lower=0, upper=60000, step_increment=50)
         )
         self.openrazer_dpi_y_spin.set_digits(0)
         self.openrazer_dpi_y_spin.set_width_chars(7)
-        form.attach(self.openrazer_dpi_y_spin, 3, row, 1, 1)
+        dpi_value_row.append(self.openrazer_dpi_y_spin)
+        self._openrazer_dpi_value_row = dpi_value_row
+        form.attach(dpi_value_row, 1, row, 1, 1)
 
         row += 1
         self.openrazer_poll_label = form_label("Rate:")
         form.attach(self.openrazer_poll_label, 0, row, 1, 1)
+        poll_row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=8)
+        poll_row.set_halign(Gtk.Align.START)
         self.openrazer_poll_spin = Gtk.SpinButton()
         self.openrazer_poll_spin.set_adjustment(
             Gtk.Adjustment(value=self._openrazer_poll_rate, lower=1, upper=8000, step_increment=125)
         )
         self.openrazer_poll_spin.set_digits(0)
         self.openrazer_poll_spin.set_width_chars(7)
-        form.attach(self.openrazer_poll_spin, 1, row, 1, 1)
+        poll_row.append(self.openrazer_poll_spin)
         self.openrazer_poll_suffix = Gtk.Label(label="Hz")
-        self.openrazer_poll_suffix.set_halign(Gtk.Align.START)
-        form.attach(self.openrazer_poll_suffix, 2, row, 1, 1)
+        poll_row.append(self.openrazer_poll_suffix)
         self.openrazer_poll_model = Gtk.StringList()
         poll_template_dropdown = Gtk.DropDown(model=self.openrazer_poll_model)
+        poll_template_dropdown.set_margin_start(8)
         poll_template_dropdown.connect("notify::selected", self._on_openrazer_poll_template_changed)
         self.openrazer_poll_template_dropdown = poll_template_dropdown
-        form.attach(poll_template_dropdown, 3, row, 1, 1)
+        poll_row.append(poll_template_dropdown)
+        self._openrazer_poll_row = poll_row
+        form.attach(poll_row, 1, row, 1, 1)
 
         row += 1
         openrazer_map_btn = Gtk.Button(label="Map OpenRazer Action")
@@ -1023,7 +1034,7 @@ class KeySelectorDialog(Adw.Dialog):
         openrazer_map_btn.set_halign(Gtk.Align.START)
         openrazer_map_btn.connect("clicked", self._on_openrazer_map_clicked)
         self.openrazer_map_btn = openrazer_map_btn
-        form.attach(openrazer_map_btn, 1, row, 3, 1)
+        form.attach(openrazer_map_btn, 1, row, 1, 1)
 
         self.openrazer_device_dropdown.connect(
             "notify::selected",
@@ -1188,14 +1199,11 @@ class KeySelectorDialog(Adw.Dialog):
         self.openrazer_dpi_mode_dropdown.set_visible(is_dpi)
         self.openrazer_dpi_x_label.set_label("X:" if split else "Value:")
         self.openrazer_dpi_x_label.set_visible(is_dpi)
-        self.openrazer_dpi_x_spin.set_visible(is_dpi)
-        self.openrazer_dpi_y_label.set_visible(is_dpi and split)
-        self.openrazer_dpi_y_spin.set_visible(is_dpi and split)
+        self._openrazer_dpi_value_row.set_visible(is_dpi)
+        self.openrazer_dpi_y_label.set_visible(split)
+        self.openrazer_dpi_y_spin.set_visible(split)
         self.openrazer_poll_label.set_visible(not is_dpi)
-        self.openrazer_poll_spin.set_visible(not is_dpi)
-        self.openrazer_poll_suffix.set_visible(not is_dpi)
-        if self.openrazer_poll_template_dropdown is not None:
-            self.openrazer_poll_template_dropdown.set_visible(not is_dpi)
+        self._openrazer_poll_row.set_visible(not is_dpi)
 
     def _on_openrazer_map_clicked(self, _btn: Gtk.Button) -> None:
         setting = "poll_rate" if int(self.openrazer_setting_dropdown.get_selected()) == 1 else "dpi"

--- a/keymasq/gui/widgets/key_selector_dialog.py
+++ b/keymasq/gui/widgets/key_selector_dialog.py
@@ -1,4 +1,5 @@
 import logging
+from typing import cast
 
 import evdev
 import gi
@@ -50,6 +51,12 @@ from keymasq.session.compositor import detect_compositor_sync
 from keymasq.session.superkeys import SuperkeyManager
 
 log = logging.getLogger("keymasq.gui.widgets.key_selector_dialog")
+
+type IntLike = int | float | str | bytes
+
+
+def _int_value(value: object, default: int = 0) -> int:
+    return default if value is None else int(cast(IntLike, value))
 
 KEYBOARD_LAYOUT = [
     ["Esc", "F1", "F2", "F3", "F4", "F5", "F6", "F7", "F8", "F9", "F10", "F11", "F12"],
@@ -261,6 +268,7 @@ ACTION_DOC_LINKS = {
     "navigation": ("navigation", "Navigation"),
     "media": ("media", "Media"),
     "mouse": ("mouse", "Mouse"),
+    "openrazer": ("openrazer", "OpenRazer"),
     "gamepad": ("gamepad", "Gamepad"),
     "hyprland": ("hyprland", "Hyprland"),
     "niri": ("niri", "Niri"),
@@ -378,6 +386,19 @@ class KeySelectorDialog(Adw.Dialog):
         self._selected_profile_action: str = "toggle"
         self._selected_profile_name: str = ""
         self._profile_name_items: list[str] = []
+        self._openrazer_devices: list[dict[str, object]] = []
+        self._openrazer_available = False
+        self._openrazer_serial = ""
+        self._openrazer_setting = "dpi"
+        self._openrazer_split_dpi = False
+        self._openrazer_dpi_x = 1600
+        self._openrazer_dpi_y = 1600
+        self._openrazer_poll_rate = 1000
+        self._openrazer_poll_rates: list[int] = []
+        self._openrazer_status_requested = False
+        self._openrazer_poll_template_updating = False
+        self.openrazer_map_btn: Gtk.Button | None = None
+        self.openrazer_poll_template_dropdown: Gtk.DropDown | None = None
         self._exec_cmd: str = ""
         self._mouse_move_x: int = 0
         self._mouse_move_y: int = 0
@@ -425,6 +446,15 @@ class KeySelectorDialog(Adw.Dialog):
                 self._mouse_move_y = int(current_action.move_y)
                 if current_action.action_type == ActionType.MOUSE_MOVE_ABS:
                     self._mouse_move_mode = "abs"
+            elif current_action.action_type == ActionType.OPENRAZER:
+                self._openrazer_serial = str(current_action.openrazer_serial or "")
+                self._openrazer_setting = str(current_action.openrazer_setting or "dpi")
+                self._openrazer_dpi_x = int(current_action.openrazer_dpi_x or 1600)
+                self._openrazer_dpi_y = int(
+                    current_action.openrazer_dpi_y or self._openrazer_dpi_x
+                )
+                self._openrazer_split_dpi = self._openrazer_dpi_y != self._openrazer_dpi_x
+                self._openrazer_poll_rate = int(current_action.openrazer_poll_rate or 1000)
         if not self._allow_rapidfire:
             self._rapidfire_enabled = False
         if not self._allow_tap:
@@ -456,6 +486,7 @@ class KeySelectorDialog(Adw.Dialog):
         self.stack.add_titled(self._build_navigation_tab(), "navigation", "Navigation")
         self.stack.add_titled(self._build_media_tab(), "media", "Media")
         self.stack.add_titled(self._build_mouse_tab(), "mouse", "Mouse")
+        self.stack.add_titled(self._build_openrazer_tab(), "openrazer", "OpenRazer")
         for page in self._compositor_action_pages:
             self.stack.add_titled(page.widget, page.page_id, page.title)
         self.stack.add_titled(self._build_gamepad_tab(), "gamepad", "Gamepad")
@@ -885,6 +916,313 @@ class KeySelectorDialog(Adw.Dialog):
 
         return box
 
+    def _build_openrazer_tab(self) -> Gtk.Widget:
+        box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=12)
+        box.set_margin_top(16)
+        box.set_margin_bottom(16)
+        box.set_margin_start(16)
+        box.set_margin_end(16)
+
+        header = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=8)
+        self.openrazer_status_label = Gtk.Label(label="Checking OpenRazer...")
+        self.openrazer_status_label.add_css_class("dim-label")
+        self.openrazer_status_label.set_halign(Gtk.Align.START)
+        self.openrazer_status_label.set_hexpand(True)
+        header.append(self.openrazer_status_label)
+        refresh_btn = Gtk.Button(label="Refresh")
+        refresh_btn.add_css_class("flat")
+        refresh_btn.connect("clicked", self._on_openrazer_refresh_clicked)
+        header.append(refresh_btn)
+        box.append(header)
+
+        form = Gtk.Grid()
+        form.set_row_spacing(10)
+        form.set_column_spacing(10)
+        form.set_hexpand(True)
+        box.append(form)
+
+        def form_label(text: str) -> Gtk.Label:
+            label = Gtk.Label(label=text)
+            label.set_xalign(1.0)
+            label.set_halign(Gtk.Align.END)
+            label.set_width_chars(8)
+            return label
+
+        row = 0
+        device_label = form_label("Device:")
+        form.attach(device_label, 0, row, 1, 1)
+        self.openrazer_device_model = Gtk.StringList()
+        self.openrazer_device_dropdown = Gtk.DropDown(model=self.openrazer_device_model)
+        self.openrazer_device_dropdown.set_hexpand(True)
+        form.attach(self.openrazer_device_dropdown, 1, row, 3, 1)
+
+        row += 1
+        setting_label = form_label("Setting:")
+        form.attach(setting_label, 0, row, 1, 1)
+        self.openrazer_setting_model = Gtk.StringList()
+        self.openrazer_setting_model.append("DPI")
+        self.openrazer_setting_model.append("Polling Rate")
+        self.openrazer_setting_dropdown = Gtk.DropDown(model=self.openrazer_setting_model)
+        self.openrazer_setting_dropdown.set_selected(
+            1 if self._openrazer_setting == "poll_rate" else 0
+        )
+        form.attach(self.openrazer_setting_dropdown, 1, row, 1, 1)
+
+        row += 1
+        self.openrazer_dpi_mode_label = form_label("DPI:")
+        form.attach(self.openrazer_dpi_mode_label, 0, row, 1, 1)
+        self.openrazer_dpi_mode_model = Gtk.StringList()
+        for label in ("Both", "Split"):
+            self.openrazer_dpi_mode_model.append(label)
+        self.openrazer_dpi_mode_dropdown = Gtk.DropDown(model=self.openrazer_dpi_mode_model)
+        self.openrazer_dpi_mode_dropdown.set_selected(1 if self._openrazer_split_dpi else 0)
+        form.attach(self.openrazer_dpi_mode_dropdown, 1, row, 1, 1)
+
+        row += 1
+        self.openrazer_dpi_x_label = form_label("Value:")
+        form.attach(self.openrazer_dpi_x_label, 0, row, 1, 1)
+        self.openrazer_dpi_x_spin = Gtk.SpinButton()
+        self.openrazer_dpi_x_spin.set_adjustment(
+            Gtk.Adjustment(value=self._openrazer_dpi_x, lower=1, upper=60000, step_increment=50)
+        )
+        self.openrazer_dpi_x_spin.set_digits(0)
+        self.openrazer_dpi_x_spin.set_width_chars(7)
+        form.attach(self.openrazer_dpi_x_spin, 1, row, 1, 1)
+        self.openrazer_dpi_y_label = form_label("Y:")
+        form.attach(self.openrazer_dpi_y_label, 2, row, 1, 1)
+        self.openrazer_dpi_y_spin = Gtk.SpinButton()
+        self.openrazer_dpi_y_spin.set_adjustment(
+            Gtk.Adjustment(value=self._openrazer_dpi_y, lower=0, upper=60000, step_increment=50)
+        )
+        self.openrazer_dpi_y_spin.set_digits(0)
+        self.openrazer_dpi_y_spin.set_width_chars(7)
+        form.attach(self.openrazer_dpi_y_spin, 3, row, 1, 1)
+
+        row += 1
+        self.openrazer_poll_label = form_label("Rate:")
+        form.attach(self.openrazer_poll_label, 0, row, 1, 1)
+        self.openrazer_poll_spin = Gtk.SpinButton()
+        self.openrazer_poll_spin.set_adjustment(
+            Gtk.Adjustment(value=self._openrazer_poll_rate, lower=1, upper=8000, step_increment=125)
+        )
+        self.openrazer_poll_spin.set_digits(0)
+        self.openrazer_poll_spin.set_width_chars(7)
+        form.attach(self.openrazer_poll_spin, 1, row, 1, 1)
+        self.openrazer_poll_suffix = Gtk.Label(label="Hz")
+        self.openrazer_poll_suffix.set_halign(Gtk.Align.START)
+        form.attach(self.openrazer_poll_suffix, 2, row, 1, 1)
+        self.openrazer_poll_model = Gtk.StringList()
+        poll_template_dropdown = Gtk.DropDown(model=self.openrazer_poll_model)
+        poll_template_dropdown.connect("notify::selected", self._on_openrazer_poll_template_changed)
+        self.openrazer_poll_template_dropdown = poll_template_dropdown
+        form.attach(poll_template_dropdown, 3, row, 1, 1)
+
+        row += 1
+        openrazer_map_btn = Gtk.Button(label="Map OpenRazer Action")
+        openrazer_map_btn.add_css_class("suggested-action")
+        openrazer_map_btn.set_halign(Gtk.Align.START)
+        openrazer_map_btn.connect("clicked", self._on_openrazer_map_clicked)
+        self.openrazer_map_btn = openrazer_map_btn
+        form.attach(openrazer_map_btn, 1, row, 3, 1)
+
+        self.openrazer_device_dropdown.connect(
+            "notify::selected",
+            self._on_openrazer_device_changed,
+        )
+        self.openrazer_setting_dropdown.connect(
+            "notify::selected",
+            self._on_openrazer_setting_changed,
+        )
+        self.openrazer_dpi_mode_dropdown.connect(
+            "notify::selected",
+            self._on_openrazer_dpi_mode_changed,
+        )
+        self._populate_openrazer_poll_rates(self._openrazer_poll_rates, self._openrazer_poll_rate)
+        self._update_openrazer_setting_visibility()
+        return box
+
+    def _on_openrazer_refresh_clicked(self, _btn: Gtk.Button) -> None:
+        self._refresh_openrazer_status(force=True)
+
+    def _refresh_openrazer_status(self, *, force: bool) -> None:
+        self._openrazer_status_requested = True
+        self.openrazer_status_label.set_label("Checking OpenRazer...")
+        command = "refresh_openrazer" if force else "get_openrazer_status"
+        session_request_async(
+            {"command": command, "force": force},
+            self._on_openrazer_status_loaded,
+            timeout=2.0,
+        )
+
+    def _on_openrazer_status_loaded(self, response: dict | None) -> bool:
+        if not response or response.get("status") != "ok":
+            self._openrazer_available = False
+            self._openrazer_devices = []
+            self.openrazer_status_label.set_label("OpenRazer unavailable")
+            self._populate_openrazer_devices()
+            return False
+        self._openrazer_available = bool(response.get("available", False))
+        devices = response.get("devices", [])
+        self._openrazer_devices = [
+            dict(item) for item in devices if isinstance(item, dict)
+        ]
+        if self._openrazer_available:
+            self.openrazer_status_label.set_label(
+                f"OpenRazer ready ({len(self._openrazer_devices)} device(s))"
+            )
+        else:
+            message = str(response.get("last_error", "") or "OpenRazer unavailable")
+            self.openrazer_status_label.set_label(message)
+        self._populate_openrazer_devices()
+        return False
+
+    def _populate_openrazer_devices(self) -> None:
+        self.openrazer_device_model.splice(0, self.openrazer_device_model.get_n_items(), [])
+        if not self._openrazer_devices:
+            self.openrazer_device_model.append("No OpenRazer device available")
+            self.openrazer_device_dropdown.set_selected(0)
+            self.openrazer_device_dropdown.set_sensitive(False)
+            self._openrazer_serial = ""
+            self._populate_openrazer_poll_rates([], self._openrazer_poll_rate)
+            if self.openrazer_map_btn is not None:
+                self.openrazer_map_btn.set_sensitive(False)
+            return
+        self.openrazer_device_dropdown.set_sensitive(True)
+        if self.openrazer_map_btn is not None:
+            self.openrazer_map_btn.set_sensitive(True)
+        selected_index = 0
+        for index, device in enumerate(self._openrazer_devices):
+            serial = str(device.get("serial", "") or "")
+            name = str(device.get("name", "") or serial)
+            hardware_id = str(device.get("hardware_id", "") or "")
+            self.openrazer_device_model.append(f"{name} ({hardware_id})")
+            if serial and serial == self._openrazer_serial:
+                selected_index = index
+        self.openrazer_device_dropdown.set_selected(selected_index)
+        self._on_openrazer_device_changed(self.openrazer_device_dropdown, None)
+
+    def _on_openrazer_device_changed(self, dropdown: Gtk.DropDown, _pspec=None) -> None:
+        index = int(dropdown.get_selected())
+        if 0 <= index < len(self._openrazer_devices):
+            device = self._openrazer_devices[index]
+            self._openrazer_serial = str(device.get("serial", "") or "")
+            dpi = device.get("dpi")
+            if isinstance(dpi, list) and dpi:
+                dpi_x = _int_value(dpi[0])
+                dpi_y = _int_value(dpi[1]) if len(dpi) > 1 else dpi_x
+                self.openrazer_dpi_x_spin.set_value(dpi_x)
+                self.openrazer_dpi_y_spin.set_value(dpi_y)
+                self.openrazer_dpi_mode_dropdown.set_selected(
+                    1 if dpi_y > 0 and dpi_y != dpi_x else 0
+                )
+            poll_rate = device.get("poll_rate")
+            if poll_rate is not None:
+                self._openrazer_poll_rate = _int_value(poll_rate)
+                self.openrazer_poll_spin.set_value(self._openrazer_poll_rate)
+            self._populate_openrazer_poll_rates(
+                self._openrazer_poll_rate_values(device),
+                self._openrazer_poll_rate,
+            )
+        else:
+            self._openrazer_serial = ""
+            self._populate_openrazer_poll_rates([], self._openrazer_poll_rate)
+
+    def _openrazer_poll_rate_values(self, device: dict[str, object]) -> list[int]:
+        values = device.get("poll_rate_templates", device.get("supported_poll_rates"))
+        if isinstance(values, list | tuple):
+            rates = sorted({_int_value(value) for value in values if _int_value(value) > 0})
+            if rates:
+                return rates
+        return []
+
+    def _populate_openrazer_poll_rates(self, rates: list[int], selected_rate: int) -> None:
+        deduped = sorted({int(rate) for rate in rates if int(rate) > 0})
+        self._openrazer_poll_rates = deduped
+        self.openrazer_poll_model.splice(0, self.openrazer_poll_model.get_n_items(), [])
+        selected_index = 0
+        if not deduped:
+            self.openrazer_poll_model.append("Templates unavailable")
+            if self.openrazer_poll_template_dropdown is not None:
+                self.openrazer_poll_template_dropdown.set_sensitive(False)
+                self._openrazer_poll_template_updating = True
+                self.openrazer_poll_template_dropdown.set_selected(0)
+                self._openrazer_poll_template_updating = False
+            return
+        if self.openrazer_poll_template_dropdown is not None:
+            self.openrazer_poll_template_dropdown.set_sensitive(True)
+        for index, rate in enumerate(deduped):
+            self.openrazer_poll_model.append(f"{rate} Hz")
+            if rate == selected_rate:
+                selected_index = index
+        if self.openrazer_poll_template_dropdown is not None:
+            self._openrazer_poll_template_updating = True
+            self.openrazer_poll_template_dropdown.set_selected(selected_index)
+            self._openrazer_poll_template_updating = False
+
+    def _selected_openrazer_poll_rate(self) -> int:
+        return int(self.openrazer_poll_spin.get_value())
+
+    def _on_openrazer_poll_template_changed(
+        self,
+        dropdown: Gtk.DropDown,
+        _pspec=None,
+    ) -> None:
+        if self._openrazer_poll_template_updating:
+            return
+        index = int(dropdown.get_selected())
+        if 0 <= index < len(self._openrazer_poll_rates):
+            self.openrazer_poll_spin.set_value(self._openrazer_poll_rates[index])
+
+    def _on_openrazer_setting_changed(self, dropdown: Gtk.DropDown, _pspec=None) -> None:
+        self._openrazer_setting = "poll_rate" if int(dropdown.get_selected()) == 1 else "dpi"
+        self._update_openrazer_setting_visibility()
+
+    def _on_openrazer_dpi_mode_changed(self, dropdown: Gtk.DropDown, _pspec=None) -> None:
+        self._openrazer_split_dpi = int(dropdown.get_selected()) == 1
+        self._update_openrazer_setting_visibility()
+
+    def _update_openrazer_setting_visibility(self) -> None:
+        is_dpi = self._openrazer_setting == "dpi"
+        split = int(self.openrazer_dpi_mode_dropdown.get_selected()) == 1
+        self.openrazer_dpi_mode_label.set_visible(is_dpi)
+        self.openrazer_dpi_mode_dropdown.set_visible(is_dpi)
+        self.openrazer_dpi_x_label.set_label("X:" if split else "Value:")
+        self.openrazer_dpi_x_label.set_visible(is_dpi)
+        self.openrazer_dpi_x_spin.set_visible(is_dpi)
+        self.openrazer_dpi_y_label.set_visible(is_dpi and split)
+        self.openrazer_dpi_y_spin.set_visible(is_dpi and split)
+        self.openrazer_poll_label.set_visible(not is_dpi)
+        self.openrazer_poll_spin.set_visible(not is_dpi)
+        self.openrazer_poll_suffix.set_visible(not is_dpi)
+        if self.openrazer_poll_template_dropdown is not None:
+            self.openrazer_poll_template_dropdown.set_visible(not is_dpi)
+
+    def _on_openrazer_map_clicked(self, _btn: Gtk.Button) -> None:
+        setting = "poll_rate" if int(self.openrazer_setting_dropdown.get_selected()) == 1 else "dpi"
+        poll_rate = self._selected_openrazer_poll_rate()
+        if not self._openrazer_serial:
+            return
+        if setting == "poll_rate" and poll_rate <= 0:
+            return
+        dpi_x = int(self.openrazer_dpi_x_spin.get_value())
+        dpi_y = (
+            int(self.openrazer_dpi_y_spin.get_value())
+            if int(self.openrazer_dpi_mode_dropdown.get_selected()) == 1
+            else dpi_x
+        )
+        self._warn_and_clear_unsupported_rapidfire(ActionType.OPENRAZER)
+        action = MappingAction(
+            action_type=ActionType.OPENRAZER,
+            openrazer_setting=setting,
+            openrazer_device="serial",
+            openrazer_serial=self._openrazer_serial or None,
+            openrazer_dpi_x=dpi_x,
+            openrazer_dpi_y=dpi_y,
+            openrazer_poll_rate=poll_rate,
+        )
+        self.emit("key-selected", action)
+        self.close()
+
     def _build_gamepad_tab(self) -> Gtk.Widget:
         return build_shared_gamepad_tab(self)
 
@@ -1009,6 +1347,7 @@ class KeySelectorDialog(Adw.Dialog):
         is_macro = child_name == "macro"
         is_profile = child_name == "profile"
         is_exec = child_name == "exec"
+        is_openrazer = child_name == "openrazer"
         is_compositor_action = child_name in self._compositor_action_page_ids
         has_options = self._allow_rapidfire or self._allow_tap
         options_enabled = (
@@ -1017,6 +1356,7 @@ class KeySelectorDialog(Adw.Dialog):
             and not is_macro
             and not is_profile
             and not is_exec
+            and not is_openrazer
             and not is_compositor_action
         )
         self.options_box.set_sensitive(options_enabled and has_options)
@@ -1026,6 +1366,7 @@ class KeySelectorDialog(Adw.Dialog):
             and not is_macro
             and not is_profile
             and not is_exec
+            and not is_openrazer
             and not is_compositor_action
         )
         self.map_btn.set_visible(is_superkey or is_macro or is_profile)
@@ -1037,6 +1378,8 @@ class KeySelectorDialog(Adw.Dialog):
             self.map_btn.set_sensitive(bool(self._selected_profile_name))
         else:
             self.map_btn.set_sensitive(False)
+        if is_openrazer and not self._openrazer_status_requested:
+            self._refresh_openrazer_status(force=False)
         self._update_actions_docs_button()
 
     def _active_actions_docs_link(self) -> tuple[str, str] | None:
@@ -1803,6 +2146,7 @@ class KeySelectorDialog(Adw.Dialog):
             ActionType.PROFILE_ENABLE: "profile",
             ActionType.PROFILE_DISABLE: "profile",
             ActionType.PROFILE_TOGGLE: "profile",
+            ActionType.OPENRAZER: "openrazer",
         }
         name = compositor_tab or tab_map.get(self._current_action.action_type)
         if name == "superkey" and not self._allow_superkey:

--- a/keymasq/gui/widgets/macro_editor_dialog.py
+++ b/keymasq/gui/widgets/macro_editor_dialog.py
@@ -27,6 +27,7 @@ from keymasq.gui.session_client import (
     session_request_async,
 )
 from keymasq.gui.session_reload import notify_session_reload_async
+from keymasq.gui.widgets.action_labels import describe_openrazer_action
 from keymasq.gui.widgets.compositor_actions import (
     build_compositor_action_pages,
     describe_compositor_action,
@@ -169,7 +170,7 @@ class EditableMove:
 
 @dataclass
 class EditableControl:
-    mode: str  # wait | wait_random | exec_sync | exec_async | compositor_dispatch
+    mode: str  # wait | wait_random | exec_sync | exec_async | compositor_dispatch | openrazer
     t_us: int
     duration_us: int = 0
     min_us: int = 0
@@ -180,6 +181,12 @@ class EditableControl:
     compositor_id: str = ""
     compositor_dispatcher: str = ""
     compositor_args: str = ""
+    openrazer_setting: str = ""
+    openrazer_device: str = "serial"
+    openrazer_serial: str = ""
+    openrazer_dpi_x: int = 0
+    openrazer_dpi_y: int = 0
+    openrazer_poll_rate: int = 0
 
 
 def _control_to_compositor_action(control: EditableControl) -> MappingAction:
@@ -200,6 +207,31 @@ def _describe_compositor_control(control: EditableControl) -> str:
     args = str(control.compositor_args or "").strip()
     suffix = f" {args}" if args else ""
     return f"Compositor -> {dispatcher}{suffix}"
+
+
+def _control_to_openrazer_action(control: EditableControl) -> MappingAction:
+    return MappingAction(
+        action_type=ActionType.OPENRAZER,
+        openrazer_setting=control.openrazer_setting,
+        openrazer_device="serial",
+        openrazer_serial=control.openrazer_serial or None,
+        openrazer_dpi_x=int(control.openrazer_dpi_x),
+        openrazer_dpi_y=int(control.openrazer_dpi_y),
+        openrazer_poll_rate=int(control.openrazer_poll_rate),
+    )
+
+
+def _describe_openrazer_control(control: EditableControl) -> str:
+    return describe_openrazer_action(_control_to_openrazer_action(control))
+
+
+def _openrazer_poll_rate_values(device: dict[str, object]) -> list[int]:
+    values = device.get("poll_rate_templates", device.get("supported_poll_rates"))
+    if isinstance(values, list | tuple):
+        rates = sorted({int(value) for value in values if int(value) > 0})
+        if rates:
+            return rates
+    return []
 
 
 def parse_events(
@@ -243,21 +275,28 @@ def parse_events(
             )
             continue
         if macro_action:
-            control_events.append(
-                EditableControl(
-                    mode=macro_action,
-                    t_us=int(ev.get("t_us", 0)),
-                    duration_us=int(ev.get("duration_us", 0) or 0),
-                    min_us=int(ev.get("min_us", 0) or 0),
-                    max_us=int(ev.get("max_us", 0) or 0),
-                    command=str(ev.get("command", "") or ""),
-                    timeout_ms=int(ev.get("timeout_ms", 30000) or 30000),
-                    inhibit_mouse=bool(ev.get("inhibit_mouse", False)),
-                    compositor_id=str(ev.get("compositor", "") or ""),
-                    compositor_dispatcher=str(ev.get("dispatcher", "") or ""),
-                    compositor_args=str(ev.get("args", "") or ""),
-                )
+            control = EditableControl(
+                mode=macro_action,
+                t_us=int(ev.get("t_us", 0)),
+                duration_us=int(ev.get("duration_us", 0) or 0),
+                min_us=int(ev.get("min_us", 0) or 0),
+                max_us=int(ev.get("max_us", 0) or 0),
+                command=str(ev.get("command", "") or ""),
+                timeout_ms=int(ev.get("timeout_ms", 30000) or 30000),
+                inhibit_mouse=bool(ev.get("inhibit_mouse", False)),
+                compositor_id=str(ev.get("compositor", "") or ""),
+                compositor_dispatcher=str(ev.get("dispatcher", "") or ""),
+                compositor_args=str(ev.get("args", "") or ""),
+                openrazer_setting=str(ev.get("setting", "") or ""),
+                openrazer_device="serial",
+                openrazer_serial=str(ev.get("serial", "") or ""),
+                openrazer_dpi_x=int(ev.get("dpi_x", 0) or 0),
+                openrazer_dpi_y=int(ev.get("dpi_y", ev.get("dpi_x", 0)) or 0),
+                openrazer_poll_rate=int(ev.get("poll_rate", 0) or 0),
             )
+            if macro_action == "openrazer" and control.openrazer_dpi_y <= 0:
+                control.openrazer_dpi_y = control.openrazer_dpi_x
+            control_events.append(control)
             continue
 
         if ev["type"] == ev_key:
@@ -376,6 +415,13 @@ def reconstruct_events(
                 event["compositor"] = str(control.compositor_id)
             event["dispatcher"] = str(control.compositor_dispatcher)
             event["args"] = str(control.compositor_args)
+        elif control.mode == "openrazer":
+            event["setting"] = str(control.openrazer_setting)
+            event["device"] = "serial"
+            event["serial"] = str(control.openrazer_serial)
+            event["dpi_x"] = int(control.openrazer_dpi_x)
+            event["dpi_y"] = int(control.openrazer_dpi_y)
+            event["poll_rate"] = int(control.openrazer_poll_rate)
         raw.append(event)
 
     raw.extend(passthrough_events)
@@ -1452,6 +1498,17 @@ class TimelineWidget(Gtk.DrawingArea):
             compositor_btn.connect("clicked", _insert_compositor)
             box.append(compositor_btn)
 
+            if self._editor._openrazer_available and self._editor._openrazer_devices:
+                openrazer_btn = Gtk.Button(label=f"Insert OpenRazer Action at {t_label}")
+                openrazer_btn.add_css_class("flat")
+
+                def _insert_openrazer(_b, _t=t_us, _p=popover):
+                    _p.popdown()
+                    self._editor._present_openrazer_action_dialog(default_t_us=_t)
+
+                openrazer_btn.connect("clicked", _insert_openrazer)
+                box.append(openrazer_btn)
+
         if box.get_first_child():
             box.append(Gtk.Separator())
 
@@ -1615,6 +1672,8 @@ class MacroEditorDialog(Adw.Dialog):
             "listener_name": None,
             "compositor_dispatch_available": False,
         }
+        self._openrazer_available: bool = False
+        self._openrazer_devices: list[dict[str, object]] = []
         self._initial_macro_data: dict = {}
         self._macro_exists = False
 
@@ -1692,6 +1751,13 @@ class MacroEditorDialog(Adw.Dialog):
         except Exception:
             timeout_max = 30000
 
+        openrazer_status: dict[str, object] = {}
+        try:
+            status = session_request({"command": "get_openrazer_status"}) or {}
+            openrazer_status = dict(status)
+        except Exception:
+            openrazer_status = {}
+
         macro: dict | None = None
         try:
             response = session_request({"command": "get_macro", "name": self._macro_name}) or {}
@@ -1704,6 +1770,7 @@ class MacroEditorDialog(Adw.Dialog):
         return {
             "timeout_max": max(1, timeout_max),
             "compositor_status": compositor_status,
+            "openrazer_status": openrazer_status,
             "macro": macro,
         }
 
@@ -1715,6 +1782,7 @@ class MacroEditorDialog(Adw.Dialog):
         self._compositor_action_status = self._resolve_compositor_action_status(
             payload.get("compositor_status")
         )
+        self._apply_openrazer_status(payload.get("openrazer_status"))
 
         timeout_adjustment = self._control_timeout_spin.get_adjustment()
         timeout_adjustment.set_upper(self._macro_exec_timeout_max_ms)
@@ -1730,6 +1798,17 @@ class MacroEditorDialog(Adw.Dialog):
             self._initial_macro_data = copy.deepcopy(macro)
             self._refresh_loaded_macro_state()
         return False
+
+    def _apply_openrazer_status(self, status: object) -> None:
+        if not isinstance(status, dict) or status.get("status") != "ok":
+            self._openrazer_available = False
+            self._openrazer_devices = []
+            return
+        self._openrazer_available = bool(status.get("available", False))
+        devices = status.get("devices", [])
+        self._openrazer_devices = [
+            dict(item) for item in devices if isinstance(item, dict)
+        ]
 
     def _refresh_loaded_macro_state(self) -> None:
         self._update_stats()
@@ -3225,10 +3304,19 @@ class MacroEditorDialog(Adw.Dialog):
         if isinstance(selected_obj, EditableControl):
             control = selected_obj
             is_compositor = control.mode == "compositor_dispatch"
-            self._prop_title.set_label("Compositor Action" if is_compositor else "Control")
+            is_openrazer = control.mode == "openrazer"
+            self._prop_title.set_label(
+                "Compositor Action"
+                if is_compositor
+                else "OpenRazer Action"
+                if is_openrazer
+                else "Control"
+            )
             self._key_info_label.set_label(
                 _describe_compositor_control(control)
                 if is_compositor
+                else _describe_openrazer_control(control)
+                if is_openrazer
                 else control.mode.replace("_", " ").title()
             )
             self._press_label.set_label("At:")
@@ -3238,8 +3326,10 @@ class MacroEditorDialog(Adw.Dialog):
             self._release_label.set_visible(False)
             self._release_spin.set_visible(False)
             self._release_unit_label.set_visible(False)
-            self._change_key_btn.set_visible(is_compositor)
-            self._change_key_btn.set_label("Change Action..." if is_compositor else "Change Key...")
+            self._change_key_btn.set_visible(is_compositor or is_openrazer)
+            self._change_key_btn.set_label(
+                "Change Action..." if is_compositor or is_openrazer else "Change Key..."
+            )
             self._move_row.set_visible(False)
             self._control_row.set_visible(True)
 
@@ -3474,6 +3564,9 @@ class MacroEditorDialog(Adw.Dialog):
         ev = self._timeline._selected
         if isinstance(ev, EditableControl) and ev.mode == "compositor_dispatch":
             self._present_compositor_action_dialog(control=ev)
+            return
+        if isinstance(ev, EditableControl) and ev.mode == "openrazer":
+            self._present_openrazer_action_dialog(control=ev)
             return
         if ev is None or isinstance(ev, (EditableMove, EditableControl, dict)):
             return
@@ -3859,6 +3952,274 @@ class MacroEditorDialog(Adw.Dialog):
         close_btn = Gtk.Button(label="Close")
         close_btn.connect("clicked", self._on_close_dialog_clicked, dialog)
         footer.append(close_btn)
+        box.append(footer)
+
+        dialog.set_child(box)
+        dialog.present(self._parent)
+
+    def _present_openrazer_action_dialog(
+        self,
+        default_t_us: int | None = None,
+        control: EditableControl | None = None,
+    ) -> None:
+        title = "Edit OpenRazer Action" if control is not None else "Insert OpenRazer Action"
+        dialog = Adw.Dialog(title=title, content_width=520, content_height=360)
+
+        box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=10)
+        box.set_margin_top(12)
+        box.set_margin_bottom(12)
+        box.set_margin_start(12)
+        box.set_margin_end(12)
+
+        form = Gtk.Grid()
+        form.set_row_spacing(10)
+        form.set_column_spacing(10)
+        form.set_hexpand(True)
+        box.append(form)
+
+        def form_label(text: str) -> Gtk.Label:
+            label = Gtk.Label(label=text)
+            label.set_xalign(1.0)
+            label.set_halign(Gtk.Align.END)
+            label.set_width_chars(8)
+            return label
+
+        row = 0
+        form.attach(form_label("At (ms):"), 0, row, 1, 1)
+        at_value_us = control.t_us if control is not None else (default_t_us or 0)
+        at_spin = Gtk.SpinButton()
+        at_spin.set_adjustment(
+            Gtk.Adjustment(value=at_value_us / 1000, lower=0, upper=3600000, step_increment=1)
+        )
+        at_spin.set_digits(0)
+        at_spin.set_width_chars(8)
+        form.attach(at_spin, 1, row, 1, 1)
+
+        row += 1
+        form.attach(form_label("Device:"), 0, row, 1, 1)
+        device_options: list[tuple[str, str, list[int]]] = []
+        for device in self._openrazer_devices:
+            serial = str(device.get("serial", "") or "")
+            if not serial:
+                continue
+            name = str(device.get("name", "") or serial)
+            hardware_id = str(device.get("hardware_id", "") or "")
+            suffix = f" ({hardware_id})" if hardware_id else ""
+            device_options.append(
+                (
+                    f"{name}{suffix}",
+                    serial,
+                    _openrazer_poll_rate_values(device),
+                )
+            )
+        device_model = Gtk.StringList()
+        selected_device = 0
+        for index, (label, serial, _rates) in enumerate(device_options):
+            device_model.append(label)
+            if (
+                control is not None
+                and control.openrazer_serial
+                and serial == control.openrazer_serial
+            ):
+                selected_device = index
+        if not device_options:
+            device_model.append("No OpenRazer device available")
+        device_dropdown = Gtk.DropDown(model=device_model)
+        device_dropdown.set_hexpand(True)
+        device_dropdown.set_selected(selected_device)
+        form.attach(device_dropdown, 1, row, 3, 1)
+
+        row += 1
+        form.attach(form_label("Setting:"), 0, row, 1, 1)
+        setting_model = Gtk.StringList()
+        setting_model.append("DPI")
+        setting_model.append("Polling Rate")
+        setting_dropdown = Gtk.DropDown(model=setting_model)
+        setting_dropdown.set_selected(
+            1 if control is not None and control.openrazer_setting == "poll_rate" else 0
+        )
+        form.attach(setting_dropdown, 1, row, 1, 1)
+
+        row += 1
+        dpi_mode_label = form_label("DPI:")
+        form.attach(dpi_mode_label, 0, row, 1, 1)
+        dpi_mode_model = Gtk.StringList()
+        for label in ("Both", "Split"):
+            dpi_mode_model.append(label)
+        dpi_mode_dropdown = Gtk.DropDown(model=dpi_mode_model)
+        split_dpi = (
+            control is not None
+            and int(control.openrazer_dpi_y) != int(control.openrazer_dpi_x)
+        )
+        dpi_mode_dropdown.set_selected(1 if split_dpi else 0)
+        form.attach(dpi_mode_dropdown, 1, row, 1, 1)
+
+        row += 1
+        dpi_x_label = form_label("X:" if split_dpi else "Value:")
+        form.attach(dpi_x_label, 0, row, 1, 1)
+        dpi_x_spin = Gtk.SpinButton()
+        dpi_x_spin.set_adjustment(
+            Gtk.Adjustment(
+                value=control.openrazer_dpi_x if control is not None else 1600,
+                lower=1,
+                upper=60000,
+                step_increment=50,
+            )
+        )
+        dpi_x_spin.set_digits(0)
+        dpi_x_spin.set_width_chars(7)
+        form.attach(dpi_x_spin, 1, row, 1, 1)
+        dpi_y_label = form_label("Y:")
+        form.attach(dpi_y_label, 2, row, 1, 1)
+        dpi_y_spin = Gtk.SpinButton()
+        dpi_y_spin.set_adjustment(
+            Gtk.Adjustment(
+                value=control.openrazer_dpi_y if control is not None else 1600,
+                lower=0,
+                upper=60000,
+                step_increment=50,
+            )
+        )
+        dpi_y_spin.set_digits(0)
+        dpi_y_spin.set_width_chars(7)
+        form.attach(dpi_y_spin, 3, row, 1, 1)
+
+        row += 1
+        poll_label = form_label("Rate:")
+        form.attach(poll_label, 0, row, 1, 1)
+        poll_spin = Gtk.SpinButton()
+        poll_spin.set_adjustment(
+            Gtk.Adjustment(
+                value=control.openrazer_poll_rate if control is not None else 1000,
+                lower=1,
+                upper=8000,
+                step_increment=125,
+            )
+        )
+        poll_spin.set_digits(0)
+        poll_spin.set_width_chars(7)
+        form.attach(poll_spin, 1, row, 1, 1)
+        poll_suffix = Gtk.Label(label="Hz")
+        poll_suffix.set_halign(Gtk.Align.START)
+        form.attach(poll_suffix, 2, row, 1, 1)
+        poll_model = Gtk.StringList()
+        poll_dropdown = Gtk.DropDown(model=poll_model)
+        form.attach(poll_dropdown, 3, row, 1, 1)
+
+        poll_rates: list[int] = []
+        poll_template_updating = False
+
+        def populate_poll_rates(rates: list[int], selected_rate: int) -> None:
+            nonlocal poll_rates, poll_template_updating
+            deduped = sorted({int(rate) for rate in rates if int(rate) > 0})
+
+            poll_rates = deduped
+            poll_model.splice(0, poll_model.get_n_items(), [])
+            selected_index = 0
+            if not deduped:
+                poll_model.append("Templates unavailable")
+                poll_dropdown.set_sensitive(False)
+                poll_template_updating = True
+                poll_dropdown.set_selected(0)
+                poll_template_updating = False
+                return
+            poll_dropdown.set_sensitive(True)
+            for index, rate in enumerate(deduped):
+                poll_model.append(f"{rate} Hz")
+                if rate == selected_rate:
+                    selected_index = index
+            poll_template_updating = True
+            poll_dropdown.set_selected(selected_index)
+            poll_template_updating = False
+
+        def selected_poll_rate() -> int:
+            return int(poll_spin.get_value())
+
+        def selected_device_rates() -> list[int]:
+            index = int(device_dropdown.get_selected())
+            if 0 <= index < len(device_options):
+                return device_options[index][2]
+            return []
+
+        def on_device_changed(*_args: object) -> None:
+            populate_poll_rates(selected_device_rates(), selected_poll_rate())
+
+        def on_poll_template_changed(dropdown: Gtk.DropDown, *_args: object) -> None:
+            if poll_template_updating:
+                return
+            index = int(dropdown.get_selected())
+            if 0 <= index < len(poll_rates):
+                poll_spin.set_value(poll_rates[index])
+
+        def update_visibility(*_args) -> None:
+            is_dpi = int(setting_dropdown.get_selected()) == 0
+            split = int(dpi_mode_dropdown.get_selected()) == 1
+            dpi_mode_label.set_visible(is_dpi)
+            dpi_mode_dropdown.set_visible(is_dpi)
+            dpi_x_label.set_label("X:" if split else "Value:")
+            dpi_x_label.set_visible(is_dpi)
+            dpi_x_spin.set_visible(is_dpi)
+            dpi_y_label.set_visible(is_dpi and split)
+            dpi_y_spin.set_visible(is_dpi and split)
+            poll_label.set_visible(not is_dpi)
+            poll_spin.set_visible(not is_dpi)
+            poll_dropdown.set_visible(not is_dpi)
+            poll_suffix.set_visible(not is_dpi)
+
+        setting_dropdown.connect("notify::selected", update_visibility)
+        dpi_mode_dropdown.connect("notify::selected", update_visibility)
+        device_dropdown.connect("notify::selected", on_device_changed)
+        poll_dropdown.connect("notify::selected", on_poll_template_changed)
+        populate_poll_rates(
+            selected_device_rates(),
+            int(control.openrazer_poll_rate if control is not None else 1000),
+        )
+        update_visibility()
+
+        footer = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=8)
+        footer.set_halign(Gtk.Align.END)
+        close_btn = Gtk.Button(label="Close")
+        close_btn.connect("clicked", self._on_close_dialog_clicked, dialog)
+        footer.append(close_btn)
+        apply_btn = Gtk.Button(label="Apply" if control is not None else "Insert")
+        apply_btn.add_css_class("suggested-action")
+        apply_btn.set_sensitive(bool(device_options))
+
+        def on_apply(_btn) -> None:
+            target = control or EditableControl(mode="openrazer", t_us=0)
+            target.mode = "openrazer"
+            target.t_us = max(0, int(at_spin.get_value() * 1000))
+            target.openrazer_setting = (
+                "poll_rate" if int(setting_dropdown.get_selected()) == 1 else "dpi"
+            )
+            selected_index = int(device_dropdown.get_selected())
+            serial = (
+                device_options[selected_index][1]
+                if 0 <= selected_index < len(device_options)
+                else ""
+            )
+            if not serial:
+                return
+            poll_rate = selected_poll_rate()
+            if int(setting_dropdown.get_selected()) == 1 and poll_rate <= 0:
+                return
+            target.openrazer_device = "serial"
+            target.openrazer_serial = serial
+            target.openrazer_dpi_x = int(dpi_x_spin.get_value())
+            target.openrazer_dpi_y = (
+                int(dpi_y_spin.get_value())
+                if int(dpi_mode_dropdown.get_selected()) == 1
+                else target.openrazer_dpi_x
+            )
+            target.openrazer_poll_rate = poll_rate
+            if control is None:
+                self._insert_control_event(target)
+            else:
+                self._refresh_after_control_change(target)
+            dialog.close()
+
+        apply_btn.connect("clicked", on_apply)
+        footer.append(apply_btn)
         box.append(footer)
 
         dialog.set_child(box)

--- a/keymasq/gui/widgets/macro_editor_dialog.py
+++ b/keymasq/gui/widgets/macro_editor_dialog.py
@@ -1063,6 +1063,9 @@ class TimelineWidget(Gtk.DrawingArea):
             elif control.mode == "compositor_dispatch":
                 cr.set_source_rgba(0.70, 0.45, 1.00, 0.95)
                 label = "C"
+            elif control.mode == "openrazer":
+                cr.set_source_rgba(0.55, 0.95, 0.62, 0.95)
+                label = "OR"
             else:
                 cr.set_source_rgba(0.65, 0.65, 0.65, 0.95)
                 label = "?"

--- a/keymasq/gui/widgets/macro_editor_dialog.py
+++ b/keymasq/gui/widgets/macro_editor_dialog.py
@@ -3996,6 +3996,7 @@ class MacroEditorDialog(Adw.Dialog):
         )
         at_spin.set_digits(0)
         at_spin.set_width_chars(8)
+        at_spin.set_halign(Gtk.Align.START)
         form.attach(at_spin, 1, row, 1, 1)
 
         row += 1
@@ -4030,7 +4031,7 @@ class MacroEditorDialog(Adw.Dialog):
         device_dropdown = Gtk.DropDown(model=device_model)
         device_dropdown.set_hexpand(True)
         device_dropdown.set_selected(selected_device)
-        form.attach(device_dropdown, 1, row, 3, 1)
+        form.attach(device_dropdown, 1, row, 1, 1)
 
         row += 1
         form.attach(form_label("Setting:"), 0, row, 1, 1)
@@ -4041,6 +4042,7 @@ class MacroEditorDialog(Adw.Dialog):
         setting_dropdown.set_selected(
             1 if control is not None and control.openrazer_setting == "poll_rate" else 0
         )
+        setting_dropdown.set_halign(Gtk.Align.START)
         form.attach(setting_dropdown, 1, row, 1, 1)
 
         row += 1
@@ -4055,11 +4057,14 @@ class MacroEditorDialog(Adw.Dialog):
             and int(control.openrazer_dpi_y) != int(control.openrazer_dpi_x)
         )
         dpi_mode_dropdown.set_selected(1 if split_dpi else 0)
+        dpi_mode_dropdown.set_halign(Gtk.Align.START)
         form.attach(dpi_mode_dropdown, 1, row, 1, 1)
 
         row += 1
         dpi_x_label = form_label("X:" if split_dpi else "Value:")
         form.attach(dpi_x_label, 0, row, 1, 1)
+        dpi_value_row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=8)
+        dpi_value_row.set_halign(Gtk.Align.START)
         dpi_x_spin = Gtk.SpinButton()
         dpi_x_spin.set_adjustment(
             Gtk.Adjustment(
@@ -4071,9 +4076,10 @@ class MacroEditorDialog(Adw.Dialog):
         )
         dpi_x_spin.set_digits(0)
         dpi_x_spin.set_width_chars(7)
-        form.attach(dpi_x_spin, 1, row, 1, 1)
-        dpi_y_label = form_label("Y:")
-        form.attach(dpi_y_label, 2, row, 1, 1)
+        dpi_value_row.append(dpi_x_spin)
+        dpi_y_label = Gtk.Label(label="Y:")
+        dpi_y_label.set_margin_start(8)
+        dpi_value_row.append(dpi_y_label)
         dpi_y_spin = Gtk.SpinButton()
         dpi_y_spin.set_adjustment(
             Gtk.Adjustment(
@@ -4085,11 +4091,14 @@ class MacroEditorDialog(Adw.Dialog):
         )
         dpi_y_spin.set_digits(0)
         dpi_y_spin.set_width_chars(7)
-        form.attach(dpi_y_spin, 3, row, 1, 1)
+        dpi_value_row.append(dpi_y_spin)
+        form.attach(dpi_value_row, 1, row, 1, 1)
 
         row += 1
         poll_label = form_label("Rate:")
         form.attach(poll_label, 0, row, 1, 1)
+        poll_row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=8)
+        poll_row.set_halign(Gtk.Align.START)
         poll_spin = Gtk.SpinButton()
         poll_spin.set_adjustment(
             Gtk.Adjustment(
@@ -4101,13 +4110,14 @@ class MacroEditorDialog(Adw.Dialog):
         )
         poll_spin.set_digits(0)
         poll_spin.set_width_chars(7)
-        form.attach(poll_spin, 1, row, 1, 1)
+        poll_row.append(poll_spin)
         poll_suffix = Gtk.Label(label="Hz")
-        poll_suffix.set_halign(Gtk.Align.START)
-        form.attach(poll_suffix, 2, row, 1, 1)
+        poll_row.append(poll_suffix)
         poll_model = Gtk.StringList()
         poll_dropdown = Gtk.DropDown(model=poll_model)
-        form.attach(poll_dropdown, 3, row, 1, 1)
+        poll_dropdown.set_margin_start(8)
+        poll_row.append(poll_dropdown)
+        form.attach(poll_row, 1, row, 1, 1)
 
         poll_rates: list[int] = []
         poll_template_updating = False
@@ -4161,13 +4171,11 @@ class MacroEditorDialog(Adw.Dialog):
             dpi_mode_dropdown.set_visible(is_dpi)
             dpi_x_label.set_label("X:" if split else "Value:")
             dpi_x_label.set_visible(is_dpi)
-            dpi_x_spin.set_visible(is_dpi)
-            dpi_y_label.set_visible(is_dpi and split)
-            dpi_y_spin.set_visible(is_dpi and split)
+            dpi_value_row.set_visible(is_dpi)
+            dpi_y_label.set_visible(split)
+            dpi_y_spin.set_visible(split)
             poll_label.set_visible(not is_dpi)
-            poll_spin.set_visible(not is_dpi)
-            poll_dropdown.set_visible(not is_dpi)
-            poll_suffix.set_visible(not is_dpi)
+            poll_row.set_visible(not is_dpi)
 
         setting_dropdown.connect("notify::selected", update_visibility)
         dpi_mode_dropdown.connect("notify::selected", update_visibility)

--- a/keymasq/keymasqd/runtime/action_runner.py
+++ b/keymasq/keymasqd/runtime/action_runner.py
@@ -82,6 +82,20 @@ def build_action_trigger_payload(
             "source_button": source_button,
         }
 
+    if action.action_type == ActionType.OPENRAZER:
+        payload: JsonObject = {
+            "action_type": "openrazer",
+            "setting": action.openrazer_setting or "",
+            "device": "serial",
+            "serial": action.openrazer_serial or "",
+            "dpi_x": int(action.openrazer_dpi_x),
+            "dpi_y": int(action.openrazer_dpi_y),
+            "poll_rate": int(action.openrazer_poll_rate),
+            "source_device": source_device,
+            "source_button": source_button,
+        }
+        return payload
+
     return None
 
 

--- a/keymasq/keymasqd/runtime/actions.py
+++ b/keymasq/keymasqd/runtime/actions.py
@@ -86,6 +86,11 @@ def parse_action(
             action_type.value,
         )
 
+    openrazer_dpi_x = int_value(action_data.get("dpi_x"), 0)
+    openrazer_dpi_y = int_value(action_data.get("dpi_y"), openrazer_dpi_x)
+    if openrazer_dpi_y <= 0:
+        openrazer_dpi_y = openrazer_dpi_x
+
     return MappingAction(
         action_type=action_type,
         target=optional_str(target),
@@ -115,6 +120,12 @@ def parse_action(
         move_y=int_value(action_data.get("y"), 0),
         move_speed=float_value(action_data.get("speed"), 1.0),
         move_jitter=float_value(action_data.get("jitter"), 0.3),
+        openrazer_setting=optional_str(action_data.get("setting")),
+        openrazer_device=str_value(action_data.get("device"), "serial") or "serial",
+        openrazer_serial=optional_str(action_data.get("serial")),
+        openrazer_dpi_x=openrazer_dpi_x,
+        openrazer_dpi_y=openrazer_dpi_y,
+        openrazer_poll_rate=int_value(action_data.get("poll_rate"), 0),
         rapidfire_enabled=rapidfire_enabled,
         rapidfire_hold_ms=rapidfire_hold_ms,
         rapidfire_wait_ms=rapidfire_wait_ms,
@@ -358,6 +369,11 @@ def parse_superkey_action(
             action_type.value,
         )
 
+    openrazer_dpi_x = int_value(action.get("dpi_x"), 0)
+    openrazer_dpi_y = int_value(action.get("dpi_y"), openrazer_dpi_x)
+    if openrazer_dpi_y <= 0:
+        openrazer_dpi_y = openrazer_dpi_x
+
     return SuperkeyActionData(
         action_type=action_type.value,
         target=optional_str(action.get("target")),
@@ -384,6 +400,12 @@ def parse_superkey_action(
         compositor_args=optional_str(action.get("args")),
         move_x=int_value(action.get("x"), 0),
         move_y=int_value(action.get("y"), 0),
+        openrazer_setting=optional_str(action.get("setting")),
+        openrazer_device=str_value(action.get("device"), "serial") or "serial",
+        openrazer_serial=optional_str(action.get("serial")),
+        openrazer_dpi_x=openrazer_dpi_x,
+        openrazer_dpi_y=openrazer_dpi_y,
+        openrazer_poll_rate=int_value(action.get("poll_rate"), 0),
         rapidfire_enabled=rapidfire_enabled,
         rapidfire_hold_ms=rapidfire_hold_ms,
         rapidfire_wait_ms=rapidfire_wait_ms,

--- a/keymasq/keymasqd/runtime/grabbed_device_actions.py
+++ b/keymasq/keymasqd/runtime/grabbed_device_actions.py
@@ -249,6 +249,7 @@ async def execute_action(
         ActionType.PROFILE_ENABLE,
         ActionType.PROFILE_DISABLE,
         ActionType.PROFILE_TOGGLE,
+        ActionType.OPENRAZER,
     ):
         if event.value == 1:
             dispatch_action_trigger(
@@ -259,7 +260,7 @@ async def execute_action(
                     source_button=event_name,
                 ),
                 fire_and_observe_fn=fire_and_observe_fn,
-                label=f"profile action {event_name}",
+                label=f"{action.action_type.value} action {event_name}",
             )
 
     elif action.action_type == ActionType.MACRO:

--- a/keymasq/keymasqd/runtime/macros.py
+++ b/keymasq/keymasqd/runtime/macros.py
@@ -770,6 +770,26 @@ async def run_macro_control_action(
             )
         return 0.0
 
+    if action_type == "openrazer":
+        setting = str_value_fn(ev.get("setting"), "").strip()
+        serial = str_value_fn(ev.get("serial"), "").strip()
+        if not setting or not serial:
+            return 0.0
+        if manager.broadcast_callback:
+            await manager.broadcast_callback(
+                CommandType.ACTION_TRIGGER,
+                {
+                    "action_type": "openrazer",
+                    "setting": setting,
+                    "device": "serial",
+                    "serial": serial,
+                    "dpi_x": int_value_fn(ev.get("dpi_x"), 0),
+                    "dpi_y": int_value_fn(ev.get("dpi_y"), 0),
+                    "poll_rate": int_value_fn(ev.get("poll_rate"), 0),
+                },
+            )
+        return 0.0
+
     return 0.0
 
 

--- a/keymasq/keymasqd/superkey_state.py
+++ b/keymasq/keymasqd/superkey_state.py
@@ -62,6 +62,12 @@ class SuperkeyActionData:
     compositor_args: str | None = None
     move_x: int = 0
     move_y: int = 0
+    openrazer_setting: str | None = None
+    openrazer_device: str = "serial"
+    openrazer_serial: str | None = None
+    openrazer_dpi_x: int = 0
+    openrazer_dpi_y: int = 0
+    openrazer_poll_rate: int = 0
     rapidfire_enabled: bool = False
     rapidfire_hold_ms: int = 20
     rapidfire_wait_ms: int = 20
@@ -445,6 +451,7 @@ class SuperkeyMachine:
             "profile_enable",
             "profile_disable",
             "profile_toggle",
+            "openrazer",
         ):
             return
 
@@ -518,6 +525,7 @@ class SuperkeyMachine:
             "profile_enable",
             "profile_disable",
             "profile_toggle",
+            "openrazer",
         }:
             return None
         return build_action_trigger_payload(

--- a/keymasq/session/manager/commands.py
+++ b/keymasq/session/manager/commands.py
@@ -7,6 +7,7 @@ from keymasq.common.models import normalize_macro_loop_stop_behavior
 from keymasq.common.security import PeerCredentials, command_allowed
 
 from . import compositor as runtime_compositor
+from . import openrazer as runtime_openrazer
 from . import profiles as runtime_profiles
 from . import recording as runtime_recording
 from .common import (
@@ -62,6 +63,10 @@ async def handle_session_request(
         peer,
         writer,
     )
+    if result is not None:
+        return result
+
+    result = await _handle_openrazer_commands(manager, command, request)
     if result is not None:
         return result
 
@@ -172,6 +177,7 @@ async def _handle_compositor_commands(
         compositor_details = cast(dict[str, object], compositor_status["details"])
         policy = manager.security_policy
         profile_payload = runtime_profiles.build_active_profiles_payload(manager)
+        openrazer_status = runtime_openrazer.openrazer_status(manager)
         status_payload: JsonObject = {
             "status": "ok",
             "keymasqd_connected": manager.connected,
@@ -186,6 +192,9 @@ async def _handle_compositor_commands(
             "macro_exec_timeout_max_ms": int(policy.macro_exec_timeout_max_ms),
             "gui_allow_left_right_click_remap": bool(policy.gui_allow_left_right_click_remap),
             "emergency_cancel_combo_enabled": bool(policy.emergency_cancel_combo_enabled),
+            "openrazer_available": bool(openrazer_status.get("available", False)),
+            "openrazer_devices": openrazer_status.get("devices", []),
+            "openrazer_last_error": openrazer_status.get("last_error", ""),
             **runtime_recording.serialize_recording_unlock_state(
                 manager,
                 unlock_status,
@@ -198,6 +207,23 @@ async def _handle_compositor_commands(
         if command_allowed("get_active_window", policy.session_command_acl, client_class):
             status_payload["window"] = manager.compositor_state.current_window
         return status_payload
+
+    return None
+
+
+async def _handle_openrazer_commands(
+    manager: "SessionManager",
+    command: str,
+    request: JsonObject,
+) -> JsonObject | None:
+    if command == "get_openrazer_status":
+        return await runtime_openrazer.refresh_openrazer(manager)
+
+    if command == "refresh_openrazer":
+        return await runtime_openrazer.refresh_openrazer(
+            manager,
+            force=bool(request.get("force", True)),
+        )
 
     return None
 

--- a/keymasq/session/manager/core.py
+++ b/keymasq/session/manager/core.py
@@ -45,6 +45,7 @@ from .state import (
     CaptureRuntimeState,
     CompositorRuntimeState,
     ExecRuntimeState,
+    OpenRazerRuntimeState,
     ProfileRuntimeState,
     RecordingRuntimeState,
     UnlockRuntimeState,
@@ -90,6 +91,7 @@ class SessionManager:
         self.capture_state = CaptureRuntimeState()
 
         self.exec_state = ExecRuntimeState()
+        self.openrazer_state = OpenRazerRuntimeState()
         self.recording_state = RecordingRuntimeState()
         self.unlock_state = UnlockRuntimeState()
         runtime_recording.load_recording_settings_from_disk(self)
@@ -129,6 +131,9 @@ class SessionManager:
         self.compositor_state.supervisor_task = asyncio.create_task(
             runtime_compositor.compositor_supervisor_loop(self)
         )
+        from . import openrazer as runtime_openrazer
+
+        await runtime_openrazer.start_openrazer_monitor(self)
 
         try:
             await self._shutdown_event.wait()
@@ -149,6 +154,10 @@ class SessionManager:
             with contextlib.suppress(asyncio.CancelledError, Exception):
                 await self.compositor_state.supervisor_task
             self.compositor_state.supervisor_task = None
+
+        from . import openrazer as runtime_openrazer
+
+        await runtime_openrazer.stop_openrazer_monitor(self)
 
         topology_task = self.profile_state.topology_refresh_task
         if topology_task:

--- a/keymasq/session/manager/events.py
+++ b/keymasq/session/manager/events.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING
 from keymasq.common.ipc import Command, CommandType
 
 from . import compositor as runtime_compositor
+from . import openrazer as runtime_openrazer
 from . import profiles as runtime_profiles
 from . import recording as runtime_recording
 from .common import JsonObject
@@ -69,6 +70,8 @@ async def handle_event(
             asyncio.create_task(
                 runtime_compositor.handle_compositor_dispatch_trigger(manager, data)
             )
+        elif action_type_str == "openrazer":
+            asyncio.create_task(runtime_openrazer.handle_openrazer_action(manager, data))
         elif action_type_str == "macro":
             asyncio.create_task(runtime_recording.play_macro_trigger(manager, data))
         return

--- a/keymasq/session/manager/openrazer.py
+++ b/keymasq/session/manager/openrazer.py
@@ -1,0 +1,433 @@
+import asyncio
+import logging
+import time
+from collections.abc import Sequence
+from typing import TYPE_CHECKING, Any, cast
+
+from dbus_next.constants import MessageType
+from dbus_next.message import Message
+
+from keymasq.common.models import OPENRAZER_DEFAULT_POLL_RATE_TEMPLATES
+from keymasq.session.dbus import DBUS_INTERFACE, DBUS_PATH, DBUS_SERVICE
+
+from .common import JsonObject, int_value, str_value
+
+if TYPE_CHECKING:
+    from .core import SessionManager
+
+log = logging.getLogger("keymasq-session.openrazer")
+
+OPENRAZER_SERVICE = "org.razer"
+OPENRAZER_ROOT_PATH = "/org/razer"
+OPENRAZER_DEVICES_INTERFACE = "razer.devices"
+OPENRAZER_MISC_INTERFACE = "razer.device.misc"
+OPENRAZER_DPI_INTERFACE = "razer.device.dpi"
+
+PROBE_FRESH_S = 2.0
+READY_STALE_S = 30.0
+ACTION_RETRY_INITIAL_S = 5.0
+ACTION_RETRY_MAX_S = 30.0
+DBUS_CALL_TIMEOUT_S = 0.8
+
+
+async def start_openrazer_monitor(manager: "SessionManager") -> None:
+    await install_name_owner_watch(manager)
+
+
+async def stop_openrazer_monitor(manager: "SessionManager") -> None:
+    state = manager.openrazer_state
+    handler = state.watcher_handler
+    if handler is not None:
+        try:
+            bus = await manager.dbus.bus()
+            remove = getattr(bus, "remove_message_handler", None)
+            if callable(remove):
+                remove(handler)
+        except Exception:
+            pass
+    state.watcher_handler = None
+    state.watcher_installed = False
+
+
+async def install_name_owner_watch(manager: "SessionManager") -> None:
+    state = manager.openrazer_state
+    if state.watcher_installed:
+        return
+
+    try:
+        bus = await manager.dbus.bus()
+        match_rule = (
+            "type='signal',sender='org.freedesktop.DBus',"
+            "interface='org.freedesktop.DBus',member='NameOwnerChanged',arg0='org.razer'"
+        )
+        reply = await bus.call(
+            Message(
+                destination=DBUS_SERVICE,
+                path=DBUS_PATH,
+                interface=DBUS_INTERFACE,
+                member="AddMatch",
+                signature="s",
+                body=[match_rule],
+            )
+        )
+        if reply is not None and reply.message_type == MessageType.ERROR:
+            raise RuntimeError(str(reply.body[0]) if reply.body else "AddMatch failed")
+
+        def _on_message(message: Message) -> bool | None:
+            if (
+                message.message_type != MessageType.SIGNAL
+                or message.interface != DBUS_INTERFACE
+                or message.member != "NameOwnerChanged"
+                or not message.body
+                or message.body[0] != OPENRAZER_SERVICE
+            ):
+                return None
+            new_owner = str(message.body[2]) if len(message.body) >= 3 else ""
+            if new_owner:
+                asyncio.create_task(refresh_openrazer(manager, force=True))
+            else:
+                mark_openrazer_unavailable(manager, "OpenRazer daemon disconnected")
+            return None
+
+        add = getattr(bus, "add_message_handler", None)
+        if callable(add):
+            add(_on_message)
+            state.watcher_handler = _on_message
+            state.watcher_installed = True
+    except Exception as exc:
+        log.debug("OpenRazer DBus name watch unavailable: %s", exc)
+
+
+def openrazer_status(manager: "SessionManager") -> JsonObject:
+    state = manager.openrazer_state
+    return {
+        "status": "ok",
+        "available": bool(state.available),
+        "devices": list(state.devices.values()),
+        "last_error": state.last_error,
+        "last_probe_s": state.last_probe_s,
+        "next_retry_s": state.next_retry_s,
+    }
+
+
+async def refresh_openrazer(
+    manager: "SessionManager",
+    *,
+    force: bool = False,
+) -> JsonObject:
+    state = manager.openrazer_state
+    now = time.monotonic()
+    if not force:
+        if state.available and now - state.last_probe_s < READY_STALE_S:
+            return openrazer_status(manager)
+        if now < state.next_retry_s:
+            return openrazer_status(manager)
+        if now - state.last_probe_s < PROBE_FRESH_S:
+            return openrazer_status(manager)
+
+    async with state.refresh_lock:
+        now = time.monotonic()
+        if not force:
+            if state.available and now - state.last_probe_s < READY_STALE_S:
+                return openrazer_status(manager)
+            if now < state.next_retry_s:
+                return openrazer_status(manager)
+            if now - state.last_probe_s < PROBE_FRESH_S:
+                return openrazer_status(manager)
+
+        state.last_probe_s = now
+        try:
+            has_owner = await manager.dbus.name_has_owner(
+                OPENRAZER_SERVICE,
+                timeout=DBUS_CALL_TIMEOUT_S,
+            )
+            if not has_owner:
+                _record_probe_failure(manager, "OpenRazer daemon is not running")
+                return openrazer_status(manager)
+
+            devices = await _load_openrazer_devices(manager)
+            state.available = True
+            state.devices = devices
+            state.last_error = ""
+            state.retry_delay_s = ACTION_RETRY_INITIAL_S
+            state.next_retry_s = 0.0
+            return openrazer_status(manager)
+        except Exception as exc:
+            log.debug("OpenRazer probe failed: %s", exc)
+            _record_probe_failure(manager, str(exc).strip() or exc.__class__.__name__)
+            return openrazer_status(manager)
+
+
+def _record_probe_failure(manager: "SessionManager", message: str) -> None:
+    state = manager.openrazer_state
+    now = time.monotonic()
+    state.available = False
+    state.devices = {}
+    state.last_error = message
+    state.next_retry_s = now + state.retry_delay_s
+    state.retry_delay_s = min(state.retry_delay_s * 2, ACTION_RETRY_MAX_S)
+
+
+def mark_openrazer_unavailable(manager: "SessionManager", message: str) -> None:
+    state = manager.openrazer_state
+    state.available = False
+    state.devices = {}
+    state.last_error = message
+    state.next_retry_s = 0.0
+
+
+async def _load_openrazer_devices(manager: "SessionManager") -> dict[str, JsonObject]:
+    devices_iface = await manager.dbus.get_interface(
+        OPENRAZER_SERVICE,
+        OPENRAZER_ROOT_PATH,
+        OPENRAZER_DEVICES_INTERFACE,
+    )
+    serials_raw = await _call_dbus(devices_iface.call_get_devices())
+    serials = [str(serial) for serial in cast(list[object], serials_raw or [])]
+
+    devices: dict[str, JsonObject] = {}
+    for serial in serials:
+        path = _device_path(serial)
+        try:
+            devices[serial] = await _load_device(manager, serial, path)
+        except Exception as exc:
+            log.debug("Skipping OpenRazer device %s: %s", serial, exc)
+    return devices
+
+
+async def _load_device(manager: "SessionManager", serial: str, path: str) -> JsonObject:
+    features = await _device_features(manager, path)
+    misc_iface = await manager.dbus.get_interface(
+        OPENRAZER_SERVICE,
+        path,
+        OPENRAZER_MISC_INTERFACE,
+    )
+
+    vid_pid = await _optional_call(misc_iface, "call_get_vid_pid")
+    vendor_id = ""
+    product_id = ""
+    vid_pid_values = _object_sequence(vid_pid)
+    if len(vid_pid_values) >= 2:
+        vendor_id = f"{int_value(vid_pid_values[0]):04x}"
+        product_id = f"{int_value(vid_pid_values[1]):04x}"
+
+    name = await _optional_call(misc_iface, "call_get_device_name")
+    device_type = await _optional_call(misc_iface, "call_get_device_type")
+    device: JsonObject = {
+        "serial": serial,
+        "name": str(name or serial),
+        "device_type": str(device_type or ""),
+        "vendor_id": vendor_id,
+        "product_id": product_id,
+        "hardware_id": f"{vendor_id}:{product_id}" if vendor_id and product_id else "",
+        "has_dpi": _has_methods(features, OPENRAZER_DPI_INTERFACE, {"getDPI", "setDPI"}),
+        "has_available_dpi": _has_methods(features, OPENRAZER_DPI_INTERFACE, {"availableDPI"}),
+        "has_poll_rate": _has_methods(
+            features,
+            OPENRAZER_MISC_INTERFACE,
+            {"getPollRate", "setPollRate"},
+        ),
+        "has_supported_poll_rates": _has_methods(
+            features,
+            OPENRAZER_MISC_INTERFACE,
+            {"getSupportedPollRates"},
+        ),
+    }
+
+    if bool(device["has_dpi"]):
+        dpi_iface = await manager.dbus.get_interface(
+            OPENRAZER_SERVICE,
+            path,
+            OPENRAZER_DPI_INTERFACE,
+        )
+        dpi = await _optional_call(dpi_iface, "call_get_dpi")
+        dpi_values = _object_sequence(dpi)
+        if dpi_values:
+            device["dpi"] = [
+                int_value(dpi_values[0]),
+                int_value(dpi_values[1]) if len(dpi_values) > 1 else 0,
+            ]
+        max_dpi = await _optional_call(dpi_iface, "call_max_dpi")
+        if max_dpi is not None:
+            device["max_dpi"] = int_value(max_dpi)
+        available_dpi = await _optional_call(dpi_iface, "call_available_dpi")
+        if isinstance(available_dpi, list | tuple):
+            available_values = cast(Sequence[object], available_dpi)
+            device["available_dpi"] = [int_value(value) for value in available_values]
+
+    if bool(device["has_poll_rate"]):
+        poll_rate = await _optional_call(misc_iface, "call_get_poll_rate")
+        if poll_rate is not None:
+            device["poll_rate"] = int_value(poll_rate)
+        supported = await _optional_call(misc_iface, "call_get_supported_poll_rates")
+        if isinstance(supported, list | tuple):
+            supported_values = cast(Sequence[object], supported)
+            device["supported_poll_rates"] = [int_value(value) for value in supported_values]
+            templates = sorted(
+                {int_value(value) for value in supported_values if int_value(value) > 0}
+            )
+            if templates:
+                device["poll_rate_templates"] = templates
+                device["poll_rate_templates_source"] = "openrazer"
+            else:
+                device["poll_rate_templates"] = list(OPENRAZER_DEFAULT_POLL_RATE_TEMPLATES)
+                device["poll_rate_templates_source"] = "default"
+        else:
+            device["poll_rate_templates"] = list(OPENRAZER_DEFAULT_POLL_RATE_TEMPLATES)
+            device["poll_rate_templates_source"] = "default"
+
+    return device
+
+
+async def _device_features(manager: "SessionManager", path: str) -> dict[str, set[str]]:
+    introspection = await manager.dbus.introspect(OPENRAZER_SERVICE, path)
+    features: dict[str, set[str]] = {}
+    for interface in getattr(introspection, "interfaces", []):
+        name = str(getattr(interface, "name", "") or "")
+        if not name:
+            continue
+        features[name] = {
+            str(getattr(method, "name", "") or "")
+            for method in getattr(interface, "methods", [])
+            if getattr(method, "name", None)
+        }
+    return features
+
+
+def _has_methods(features: dict[str, set[str]], interface: str, methods: set[str]) -> bool:
+    available = features.get(interface, set())
+    return methods.issubset(available)
+
+
+async def handle_openrazer_action(manager: "SessionManager", data: JsonObject) -> JsonObject:
+    status = await refresh_openrazer(manager)
+    if not bool(status.get("available")):
+        message = str_value(status.get("last_error"), "OpenRazer unavailable")
+        log.warning("OpenRazer action skipped: %s", message)
+        return {"status": "error", "message": message}
+
+    try:
+        serial = _resolve_action_serial(manager, data)
+        setting = str_value(data.get("setting"), "").strip().lower()
+        if setting == "dpi":
+            return await _apply_dpi_action(manager, serial, data)
+        if setting == "poll_rate":
+            return await _apply_poll_rate_action(manager, serial, data)
+        return {"status": "error", "message": f"unsupported OpenRazer setting '{setting}'"}
+    except Exception as exc:
+        message = str(exc).strip() or exc.__class__.__name__
+        log.warning("OpenRazer action failed: %s", message)
+        return {"status": "error", "message": message}
+
+
+def _resolve_action_serial(manager: "SessionManager", data: JsonObject) -> str:
+    serial = str_value(data.get("serial"), "").strip()
+    if not serial:
+        raise ValueError("OpenRazer action requires a device serial")
+    if serial in manager.openrazer_state.devices:
+        return serial
+    raise ValueError(f"OpenRazer device serial '{serial}' is not available")
+
+
+async def _apply_dpi_action(
+    manager: "SessionManager",
+    serial: str,
+    data: JsonObject,
+) -> JsonObject:
+    device = _device(manager, serial)
+    if not bool(device.get("has_dpi")):
+        raise ValueError(f"OpenRazer device '{serial}' does not support DPI changes")
+
+    dpi_iface = await manager.dbus.get_interface(
+        OPENRAZER_SERVICE,
+        _device_path(serial),
+        OPENRAZER_DPI_INTERFACE,
+    )
+    current_raw = await _call_dbus(dpi_iface.call_get_dpi())
+    current = [int_value(value) for value in _object_sequence(current_raw)]
+    if not current:
+        current = [0, 0]
+    if len(current) == 1:
+        current.append(0)
+
+    requested_x = int_value(data.get("dpi_x"), 0)
+    requested_y = int_value(data.get("dpi_y"), requested_x)
+    if requested_y <= 0:
+        requested_y = requested_x
+    single_axis = bool(device.get("has_available_dpi")) or int(current[1]) == 0
+    dpi_x, dpi_y = requested_x, 0 if single_axis else requested_y
+
+    _validate_dpi(device, dpi_x, dpi_y)
+    await _call_dbus(dpi_iface.call_set_dpi(dpi_x, dpi_y))
+    device["dpi"] = [dpi_x, dpi_y]
+    return {"status": "ok", "serial": serial, "setting": "dpi", "dpi": [dpi_x, dpi_y]}
+
+
+async def _apply_poll_rate_action(
+    manager: "SessionManager",
+    serial: str,
+    data: JsonObject,
+) -> JsonObject:
+    device = _device(manager, serial)
+    if not bool(device.get("has_poll_rate")):
+        raise ValueError(f"OpenRazer device '{serial}' does not support polling rate changes")
+    poll_rate = int_value(data.get("poll_rate"), 0)
+    if poll_rate <= 0:
+        raise ValueError("poll rate must be positive")
+
+    misc_iface = await manager.dbus.get_interface(
+        OPENRAZER_SERVICE,
+        _device_path(serial),
+        OPENRAZER_MISC_INTERFACE,
+    )
+    await _call_dbus(misc_iface.call_set_poll_rate(poll_rate))
+    device["poll_rate"] = poll_rate
+    return {"status": "ok", "serial": serial, "setting": "poll_rate", "poll_rate": poll_rate}
+
+
+def _validate_dpi(device: JsonObject, dpi_x: int, dpi_y: int) -> None:
+    if dpi_x <= 0:
+        raise ValueError("DPI must be positive")
+    if dpi_y < 0:
+        raise ValueError("DPI Y cannot be negative")
+    available = _int_list(device.get("available_dpi"))
+    if available and dpi_x not in available:
+        raise ValueError(f"DPI {dpi_x} is not one of the available values: {available}")
+    max_dpi = int_value(device.get("max_dpi"), 0)
+    if max_dpi > 0 and (dpi_x > max_dpi or dpi_y > max_dpi):
+        raise ValueError(f"DPI exceeds device maximum {max_dpi}")
+
+
+def _device(manager: "SessionManager", serial: str) -> JsonObject:
+    device = manager.openrazer_state.devices.get(serial)
+    if device is None:
+        raise ValueError(f"OpenRazer device serial '{serial}' is not available")
+    return device
+
+
+def _device_path(serial: str) -> str:
+    return f"{OPENRAZER_ROOT_PATH}/device/{serial}"
+
+
+def _int_list(value: object) -> list[int]:
+    return [int_value(item) for item in _object_sequence(value)]
+
+
+def _object_sequence(value: object) -> Sequence[object]:
+    if not isinstance(value, list | tuple):
+        return ()
+    return cast(Sequence[object], value)
+
+
+async def _optional_call(iface: object, method_name: str) -> object | None:
+    method = getattr(iface, method_name, None)
+    if not callable(method):
+        return None
+    try:
+        return await _call_dbus(method())
+    except Exception:
+        return None
+
+
+async def _call_dbus(awaitable: Any) -> object:
+    return await asyncio.wait_for(awaitable, timeout=DBUS_CALL_TIMEOUT_S)

--- a/keymasq/session/manager/openrazer.py
+++ b/keymasq/session/manager/openrazer.py
@@ -22,6 +22,10 @@ OPENRAZER_ROOT_PATH = "/org/razer"
 OPENRAZER_DEVICES_INTERFACE = "razer.devices"
 OPENRAZER_MISC_INTERFACE = "razer.device.misc"
 OPENRAZER_DPI_INTERFACE = "razer.device.dpi"
+OPENRAZER_NAME_OWNER_MATCH_RULE = (
+    "type='signal',sender='org.freedesktop.DBus',"
+    "interface='org.freedesktop.DBus',member='NameOwnerChanged',arg0='org.razer'"
+)
 
 PROBE_FRESH_S = 2.0
 READY_STALE_S = 30.0
@@ -37,6 +41,7 @@ async def start_openrazer_monitor(manager: "SessionManager") -> None:
 async def stop_openrazer_monitor(manager: "SessionManager") -> None:
     state = manager.openrazer_state
     handler = state.watcher_handler
+    match_rule = state.watcher_match_rule
     if handler is not None:
         try:
             bus = await manager.dbus.bus()
@@ -45,7 +50,25 @@ async def stop_openrazer_monitor(manager: "SessionManager") -> None:
                 remove(handler)
         except Exception:
             pass
+    if match_rule:
+        try:
+            bus = await manager.dbus.bus()
+            reply = await bus.call(
+                Message(
+                    destination=DBUS_SERVICE,
+                    path=DBUS_PATH,
+                    interface=DBUS_INTERFACE,
+                    member="RemoveMatch",
+                    signature="s",
+                    body=[match_rule],
+                )
+            )
+            if reply is not None and reply.message_type == MessageType.ERROR:
+                raise RuntimeError(str(reply.body[0]) if reply.body else "RemoveMatch failed")
+        except Exception as exc:
+            log.debug("OpenRazer DBus name watch cleanup failed: %s", exc)
     state.watcher_handler = None
+    state.watcher_match_rule = None
     state.watcher_installed = False
 
 
@@ -56,10 +79,9 @@ async def install_name_owner_watch(manager: "SessionManager") -> None:
 
     try:
         bus = await manager.dbus.bus()
-        match_rule = (
-            "type='signal',sender='org.freedesktop.DBus',"
-            "interface='org.freedesktop.DBus',member='NameOwnerChanged',arg0='org.razer'"
-        )
+        add = getattr(bus, "add_message_handler", None)
+        if not callable(add):
+            return
         reply = await bus.call(
             Message(
                 destination=DBUS_SERVICE,
@@ -67,7 +89,7 @@ async def install_name_owner_watch(manager: "SessionManager") -> None:
                 interface=DBUS_INTERFACE,
                 member="AddMatch",
                 signature="s",
-                body=[match_rule],
+                body=[OPENRAZER_NAME_OWNER_MATCH_RULE],
             )
         )
         if reply is not None and reply.message_type == MessageType.ERROR:
@@ -89,11 +111,10 @@ async def install_name_owner_watch(manager: "SessionManager") -> None:
                 mark_openrazer_unavailable(manager, "OpenRazer daemon disconnected")
             return None
 
-        add = getattr(bus, "add_message_handler", None)
-        if callable(add):
-            add(_on_message)
-            state.watcher_handler = _on_message
-            state.watcher_installed = True
+        add(_on_message)
+        state.watcher_handler = _on_message
+        state.watcher_match_rule = OPENRAZER_NAME_OWNER_MATCH_RULE
+        state.watcher_installed = True
     except Exception as exc:
         log.debug("OpenRazer DBus name watch unavailable: %s", exc)
 
@@ -345,6 +366,7 @@ async def _apply_dpi_action(
     )
     current_raw = await _call_dbus(dpi_iface.call_get_dpi())
     current = [int_value(value) for value in _object_sequence(current_raw)]
+    single_axis = len(current) < 2 or int(current[1]) == 0
     if not current:
         current = [0, 0]
     if len(current) == 1:
@@ -354,7 +376,6 @@ async def _apply_dpi_action(
     requested_y = int_value(data.get("dpi_y"), requested_x)
     if requested_y <= 0:
         requested_y = requested_x
-    single_axis = bool(device.get("has_available_dpi")) or int(current[1]) == 0
     dpi_x, dpi_y = requested_x, 0 if single_axis else requested_y
 
     _validate_dpi(device, dpi_x, dpi_y)
@@ -393,8 +414,10 @@ def _validate_dpi(device: JsonObject, dpi_x: int, dpi_y: int) -> None:
     available = _int_list(device.get("available_dpi"))
     if available and dpi_x not in available:
         raise ValueError(f"DPI {dpi_x} is not one of the available values: {available}")
+    if available and dpi_y > 0 and dpi_y not in available:
+        raise ValueError(f"DPI Y {dpi_y} is not one of the available values: {available}")
     max_dpi = int_value(device.get("max_dpi"), 0)
-    if max_dpi > 0 and (dpi_x > max_dpi or dpi_y > max_dpi):
+    if max_dpi > 0 and (dpi_x > max_dpi or (dpi_y > 0 and dpi_y > max_dpi)):
         raise ValueError(f"DPI exceeds device maximum {max_dpi}")
 
 

--- a/keymasq/session/manager/payloads.py
+++ b/keymasq/session/manager/payloads.py
@@ -175,6 +175,10 @@ def action_signature_payload(
         data["args"] = action.compositor_args or ""
         return data
 
+    if action_type == "openrazer":
+        data.update(openrazer_action_payload(action))
+        return data
+
     if action_type in (
         "start_macro_recording",
         "stop_macro_recording",
@@ -288,6 +292,8 @@ def profile_to_mapping(
                 action_data["compositor"] = action.compositor_id
             action_data["dispatcher"] = action.compositor_dispatcher or ""
             action_data["args"] = action.compositor_args or ""
+        elif action.action_type.value == "openrazer":
+            action_data.update(openrazer_action_payload(action))
         elif action.action_type.value in (
             "start_macro_recording",
             "stop_macro_recording",
@@ -429,6 +435,10 @@ def combo_action_to_payload(
             action_data["compositor"] = action.compositor_id
         action_data["dispatcher"] = dispatcher
         action_data["args"] = action.compositor_args or ""
+        return action_data
+
+    if action_type == "openrazer":
+        action_data.update(openrazer_action_payload(action))
         return action_data
 
     if action_type in (
@@ -679,6 +689,10 @@ def serialize_overload_action(
         action_data["args"] = action.compositor_args or ""
         return action_data
 
+    if action_type == "openrazer":
+        action_data.update(openrazer_action_payload(action))
+        return action_data
+
     if action_type in (
         "start_macro_recording",
         "stop_macro_recording",
@@ -725,6 +739,17 @@ def _allocate_superkey_exec_ref(
     if track_combo_refs:
         manager.exec_state.combo_superkey_exec_refs.add(exec_ref)
     return exec_ref
+
+
+def openrazer_action_payload(action: MappingAction) -> dict[str, object]:
+    return {
+        "setting": action.openrazer_setting or "",
+        "device": "serial",
+        "serial": action.openrazer_serial or "",
+        "dpi_x": int(action.openrazer_dpi_x),
+        "dpi_y": int(action.openrazer_dpi_y),
+        "poll_rate": int(action.openrazer_poll_rate),
+    }
 
 
 def mapping_log_view(mapping: JsonObject) -> JsonObject:

--- a/keymasq/session/manager/state.py
+++ b/keymasq/session/manager/state.py
@@ -80,6 +80,19 @@ class ExecRuntimeState:
 
 
 @dataclass
+class OpenRazerRuntimeState:
+    available: bool = False
+    devices: dict[str, JsonObject] = field(default_factory=dict)
+    last_probe_s: float = 0.0
+    retry_delay_s: float = 5.0
+    next_retry_s: float = 0.0
+    last_error: str = ""
+    watcher_installed: bool = False
+    watcher_handler: object | None = None
+    refresh_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+
+
+@dataclass
 class CompositorRuntimeState:
     current_window: JsonObject = field(default_factory=dict)
     window_listener: WindowListener | None = None

--- a/keymasq/session/manager/state.py
+++ b/keymasq/session/manager/state.py
@@ -89,6 +89,7 @@ class OpenRazerRuntimeState:
     last_error: str = ""
     watcher_installed: bool = False
     watcher_handler: object | None = None
+    watcher_match_rule: str | None = None
     refresh_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
 
 

--- a/keymasq/session/profiles.py
+++ b/keymasq/session/profiles.py
@@ -344,6 +344,23 @@ class ProfileManager:
                 compositor_args=str(action_data.get("args", "") or ""),
             )
 
+        if action_type == ActionType.OPENRAZER:
+            dpi_x = _int_value(action_data.get("dpi_x"), 0)
+            dpi_y = _int_value(action_data.get("dpi_y"), dpi_x)
+            if dpi_x <= 0:
+                dpi_x = dpi_y
+            if dpi_y <= 0:
+                dpi_y = dpi_x
+            return MappingAction(
+                action_type=action_type,
+                openrazer_setting=str(action_data.get("setting", "") or "") or None,
+                openrazer_device=str(action_data.get("device", "serial") or "serial"),
+                openrazer_serial=str(action_data.get("serial", "") or "") or None,
+                openrazer_dpi_x=dpi_x,
+                openrazer_dpi_y=dpi_y,
+                openrazer_poll_rate=_int_value(action_data.get("poll_rate"), 0),
+            )
+
         (
             rapidfire_enabled,
             rapidfire_hold_ms,
@@ -425,6 +442,14 @@ class ProfileManager:
                 action_data["compositor"] = action.compositor_id
             action_data["dispatcher"] = action.compositor_dispatcher or ""
             action_data["args"] = action.compositor_args or ""
+        if action.action_type == ActionType.OPENRAZER:
+            action_data["setting"] = action.openrazer_setting or ""
+            action_data["device"] = "serial"
+            if action.openrazer_serial:
+                action_data["serial"] = action.openrazer_serial
+            action_data["dpi_x"] = int(action.openrazer_dpi_x)
+            action_data["dpi_y"] = int(action.openrazer_dpi_y)
+            action_data["poll_rate"] = int(action.openrazer_poll_rate)
         (
             rapidfire_enabled,
             rapidfire_hold_ms,

--- a/keymasq/session/superkeys.py
+++ b/keymasq/session/superkeys.py
@@ -241,6 +241,23 @@ class SuperkeyManager:
                 compositor_args=str(action_data.get("args", "") or ""),
             )
 
+        if action_type == ActionType.OPENRAZER:
+            dpi_x = _int_value(action_data.get("dpi_x"), 0)
+            dpi_y = _int_value(action_data.get("dpi_y"), dpi_x)
+            if dpi_x <= 0:
+                dpi_x = dpi_y
+            if dpi_y <= 0:
+                dpi_y = dpi_x
+            return MappingAction(
+                action_type=action_type,
+                openrazer_setting=str(action_data.get("setting", "") or "") or None,
+                openrazer_device=str(action_data.get("device", "serial") or "serial"),
+                openrazer_serial=str(action_data.get("serial", "") or "") or None,
+                openrazer_dpi_x=dpi_x,
+                openrazer_dpi_y=dpi_y,
+                openrazer_poll_rate=_int_value(action_data.get("poll_rate"), 0),
+            )
+
         if action_type in (ActionType.MOUSE_MOVE_REL, ActionType.MOUSE_MOVE_ABS):
             return MappingAction(
                 action_type=action_type,
@@ -399,6 +416,14 @@ class SuperkeyManager:
                 action_data["compositor"] = action.compositor_id
             action_data["dispatcher"] = action.compositor_dispatcher or ""
             action_data["args"] = action.compositor_args or ""
+        if action.action_type == ActionType.OPENRAZER:
+            action_data["setting"] = action.openrazer_setting or ""
+            action_data["device"] = "serial"
+            if action.openrazer_serial:
+                action_data["serial"] = action.openrazer_serial
+            action_data["dpi_x"] = int(action.openrazer_dpi_x)
+            action_data["dpi_y"] = int(action.openrazer_dpi_y)
+            action_data["poll_rate"] = int(action.openrazer_poll_rate)
         (
             rapidfire_enabled,
             rapidfire_hold_ms,

--- a/tests/keymasqd/test_device_manager_core.py
+++ b/tests/keymasqd/test_device_manager_core.py
@@ -750,6 +750,43 @@ class TestMacroControlActions:
         assert result == 0.0
 
     @pytest.mark.asyncio
+    async def test_run_macro_control_action_openrazer_broadcasts(self):
+        manager = DeviceManager()
+
+        callback = AsyncMock()
+
+        async def cb(command, data):
+            await callback(command, data)
+
+        manager.broadcast_callback = cb
+
+        result = await _runtime_run_macro_control_action(
+            manager,
+            {
+                "macro_action": "openrazer",
+                "setting": "dpi",
+                "device": "serial",
+                "serial": "ABC123",
+                "dpi_x": 1600,
+                "dpi_y": 1200,
+            },
+        )
+
+        callback.assert_awaited_once()
+        called_command, called_data = callback.await_args.args
+        assert called_command == CommandType.ACTION_TRIGGER
+        assert called_data == {
+            "action_type": "openrazer",
+            "setting": "dpi",
+            "device": "serial",
+            "serial": "ABC123",
+            "dpi_x": 1600,
+            "dpi_y": 1200,
+            "poll_rate": 0,
+        }
+        assert result == 0.0
+
+    @pytest.mark.asyncio
     async def test_run_macro_control_action_exec_sync_wait_id_and_cleanup(self, monkeypatch):
         manager = DeviceManager()
         clock = {"now": 30.0}

--- a/tests/session/test_openrazer.py
+++ b/tests/session/test_openrazer.py
@@ -64,14 +64,21 @@ class _FakeDBus:
         *,
         has_owner: bool = True,
         supported_poll_rates_method: bool = True,
+        bus: object | None = None,
     ) -> None:
         self.iface = iface
         self.has_owner = has_owner
         self.supported_poll_rates_method = supported_poll_rates_method
+        self.session_bus = bus
 
     async def name_has_owner(self, name: str, *, timeout: float = 0.6) -> bool:
         assert name == openrazer.OPENRAZER_SERVICE
         return self.has_owner
+
+    async def bus(self):
+        if self.session_bus is None:
+            raise AssertionError("session bus not configured")
+        return self.session_bus
 
     async def get_interface(self, destination: str, path: str, interface: str):
         assert destination == openrazer.OPENRAZER_SERVICE
@@ -105,6 +112,22 @@ class _FakeDBus:
                 for interface_name, method_names in methods_by_interface.items()
             ]
         )
+
+
+class _FakeBus:
+    def __init__(self) -> None:
+        self.handlers: list[object] = []
+        self.calls: list[tuple[str, str]] = []
+
+    async def call(self, message):
+        self.calls.append((str(message.member), str(message.body[0])))
+        return None
+
+    def add_message_handler(self, handler) -> None:
+        self.handlers.append(handler)
+
+    def remove_message_handler(self, handler) -> None:
+        self.handlers.remove(handler)
 
 
 def _manager(fake_dbus: _FakeDBus):
@@ -163,6 +186,32 @@ async def test_refresh_openrazer_defaults_poll_templates_without_dbus_list() -> 
 
 
 @pytest.mark.asyncio
+async def test_openrazer_monitor_removes_dbus_match_rule_on_stop() -> None:
+    bus = _FakeBus()
+    manager = _manager(_FakeDBus(_FakeInterface(), bus=bus))
+
+    await openrazer.start_openrazer_monitor(manager)
+
+    assert manager.openrazer_state.watcher_installed is True
+    assert manager.openrazer_state.watcher_match_rule == openrazer.OPENRAZER_NAME_OWNER_MATCH_RULE
+    assert bus.calls == [
+        ("AddMatch", openrazer.OPENRAZER_NAME_OWNER_MATCH_RULE),
+    ]
+    assert len(bus.handlers) == 1
+
+    await openrazer.stop_openrazer_monitor(manager)
+
+    assert manager.openrazer_state.watcher_installed is False
+    assert manager.openrazer_state.watcher_handler is None
+    assert manager.openrazer_state.watcher_match_rule is None
+    assert bus.handlers == []
+    assert bus.calls == [
+        ("AddMatch", openrazer.OPENRAZER_NAME_OWNER_MATCH_RULE),
+        ("RemoveMatch", openrazer.OPENRAZER_NAME_OWNER_MATCH_RULE),
+    ]
+
+
+@pytest.mark.asyncio
 async def test_openrazer_action_sets_dpi_pair() -> None:
     iface = _FakeInterface()
     manager = _manager(_FakeDBus(iface))
@@ -185,6 +234,81 @@ async def test_openrazer_action_sets_dpi_pair() -> None:
         "dpi": [1600, 1200],
     }
     assert iface.set_dpi_calls == [(1600, 1200)]
+
+
+@pytest.mark.asyncio
+async def test_openrazer_action_keeps_split_dpi_when_available_dpi_exists() -> None:
+    iface = _FakeInterface()
+    manager = _manager(_FakeDBus(iface))
+    await openrazer.refresh_openrazer(manager, force=True)
+    manager.openrazer_state.devices["ABC123"]["has_available_dpi"] = True
+    manager.openrazer_state.devices["ABC123"]["available_dpi"] = [800, 1200, 1600]
+
+    result = await openrazer.handle_openrazer_action(
+        manager,
+        {
+            "setting": "dpi",
+            "serial": "ABC123",
+            "dpi_x": 1600,
+            "dpi_y": 1200,
+        },
+    )
+
+    assert result == {
+        "status": "ok",
+        "serial": "ABC123",
+        "setting": "dpi",
+        "dpi": [1600, 1200],
+    }
+    assert iface.set_dpi_calls == [(1600, 1200)]
+
+
+@pytest.mark.asyncio
+async def test_openrazer_action_uses_single_axis_dpi_when_device_reports_one_value() -> None:
+    iface = _FakeInterface()
+    iface.dpi = [800]
+    manager = _manager(_FakeDBus(iface))
+    await openrazer.refresh_openrazer(manager, force=True)
+
+    result = await openrazer.handle_openrazer_action(
+        manager,
+        {
+            "setting": "dpi",
+            "serial": "ABC123",
+            "dpi_x": 1600,
+            "dpi_y": 1200,
+        },
+    )
+
+    assert result == {
+        "status": "ok",
+        "serial": "ABC123",
+        "setting": "dpi",
+        "dpi": [1600, 0],
+    }
+    assert iface.set_dpi_calls == [(1600, 0)]
+
+
+@pytest.mark.asyncio
+async def test_openrazer_action_validates_available_dpi_y() -> None:
+    iface = _FakeInterface()
+    manager = _manager(_FakeDBus(iface))
+    await openrazer.refresh_openrazer(manager, force=True)
+    manager.openrazer_state.devices["ABC123"]["available_dpi"] = [800, 1600]
+
+    result = await openrazer.handle_openrazer_action(
+        manager,
+        {
+            "setting": "dpi",
+            "serial": "ABC123",
+            "dpi_x": 1600,
+            "dpi_y": 1200,
+        },
+    )
+
+    assert result["status"] == "error"
+    assert "DPI Y 1200" in str(result["message"])
+    assert iface.set_dpi_calls == []
 
 
 @pytest.mark.asyncio

--- a/tests/session/test_openrazer.py
+++ b/tests/session/test_openrazer.py
@@ -1,0 +1,247 @@
+from types import SimpleNamespace
+from typing import cast
+
+import pytest
+
+from keymasq.session.manager import openrazer
+from keymasq.session.manager.state import OpenRazerRuntimeState
+
+
+class _FakeInterface:
+    def __init__(self) -> None:
+        self.devices = ["ABC123"]
+        self.vid_pid = [0x1532, 0x0098]
+        self.name = "Razer Test Mouse"
+        self.device_type = "mouse"
+        self.dpi = [800, 1200]
+        self.max_dpi = 30000
+        self.available_dpi: list[int] = []
+        self.poll_rate = 1000
+        self.supported_poll_rates: list[int] | None = [125, 500, 1000]
+        self.set_dpi_calls: list[tuple[int, int]] = []
+        self.set_poll_rate_calls: list[int] = []
+
+    async def call_get_devices(self):
+        return self.devices
+
+    async def call_get_vid_pid(self):
+        return self.vid_pid
+
+    async def call_get_device_name(self):
+        return self.name
+
+    async def call_get_device_type(self):
+        return self.device_type
+
+    async def call_get_dpi(self):
+        return self.dpi
+
+    async def call_set_dpi(self, x: int, y: int):
+        self.set_dpi_calls.append((int(x), int(y)))
+        self.dpi = [int(x), int(y)]
+
+    async def call_max_dpi(self):
+        return self.max_dpi
+
+    async def call_available_dpi(self):
+        return self.available_dpi
+
+    async def call_get_poll_rate(self):
+        return self.poll_rate
+
+    async def call_set_poll_rate(self, rate: int):
+        self.set_poll_rate_calls.append(int(rate))
+        self.poll_rate = int(rate)
+
+    async def call_get_supported_poll_rates(self):
+        return self.supported_poll_rates
+
+
+class _FakeDBus:
+    def __init__(
+        self,
+        iface: _FakeInterface,
+        *,
+        has_owner: bool = True,
+        supported_poll_rates_method: bool = True,
+    ) -> None:
+        self.iface = iface
+        self.has_owner = has_owner
+        self.supported_poll_rates_method = supported_poll_rates_method
+
+    async def name_has_owner(self, name: str, *, timeout: float = 0.6) -> bool:
+        assert name == openrazer.OPENRAZER_SERVICE
+        return self.has_owner
+
+    async def get_interface(self, destination: str, path: str, interface: str):
+        assert destination == openrazer.OPENRAZER_SERVICE
+        return self.iface
+
+    async def introspect(self, destination: str, path: str):
+        assert destination == openrazer.OPENRAZER_SERVICE
+        misc_methods = [
+            "getVidPid",
+            "getDeviceName",
+            "getDeviceType",
+            "getPollRate",
+            "setPollRate",
+        ]
+        if self.supported_poll_rates_method:
+            misc_methods.append("getSupportedPollRates")
+        methods_by_interface = {
+            openrazer.OPENRAZER_MISC_INTERFACE: misc_methods,
+            openrazer.OPENRAZER_DPI_INTERFACE: [
+                "getDPI",
+                "setDPI",
+                "maxDPI",
+            ],
+        }
+        return SimpleNamespace(
+            interfaces=[
+                SimpleNamespace(
+                    name=interface_name,
+                    methods=[SimpleNamespace(name=name) for name in method_names],
+                )
+                for interface_name, method_names in methods_by_interface.items()
+            ]
+        )
+
+
+def _manager(fake_dbus: _FakeDBus):
+    return SimpleNamespace(
+        dbus=fake_dbus,
+        openrazer_state=OpenRazerRuntimeState(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_refresh_openrazer_loads_devices_without_openrazer_dependency() -> None:
+    iface = _FakeInterface()
+    manager = _manager(_FakeDBus(iface))
+
+    status = await openrazer.refresh_openrazer(manager, force=True)
+
+    assert status["available"] is True
+    assert status["devices"] == [
+        {
+            "serial": "ABC123",
+            "name": "Razer Test Mouse",
+            "device_type": "mouse",
+            "vendor_id": "1532",
+            "product_id": "0098",
+            "hardware_id": "1532:0098",
+            "has_dpi": True,
+            "has_available_dpi": False,
+            "has_poll_rate": True,
+            "has_supported_poll_rates": True,
+            "dpi": [800, 1200],
+            "max_dpi": 30000,
+            "available_dpi": [],
+            "poll_rate": 1000,
+            "supported_poll_rates": [125, 500, 1000],
+            "poll_rate_templates": [125, 500, 1000],
+            "poll_rate_templates_source": "openrazer",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_refresh_openrazer_defaults_poll_templates_without_dbus_list() -> None:
+    iface = _FakeInterface()
+    iface.supported_poll_rates = None
+    manager = _manager(_FakeDBus(iface, supported_poll_rates_method=False))
+
+    status = await openrazer.refresh_openrazer(manager, force=True)
+
+    assert status["available"] is True
+    devices = cast(list[dict[str, object]], status["devices"])
+    device = devices[0]
+    assert device["has_supported_poll_rates"] is False
+    assert "supported_poll_rates" not in device
+    assert device["poll_rate_templates"] == [125, 500, 1000]
+    assert device["poll_rate_templates_source"] == "default"
+
+
+@pytest.mark.asyncio
+async def test_openrazer_action_sets_dpi_pair() -> None:
+    iface = _FakeInterface()
+    manager = _manager(_FakeDBus(iface))
+    await openrazer.refresh_openrazer(manager, force=True)
+
+    result = await openrazer.handle_openrazer_action(
+        manager,
+        {
+            "setting": "dpi",
+            "serial": "ABC123",
+            "dpi_x": 1600,
+            "dpi_y": 1200,
+        },
+    )
+
+    assert result == {
+        "status": "ok",
+        "serial": "ABC123",
+        "setting": "dpi",
+        "dpi": [1600, 1200],
+    }
+    assert iface.set_dpi_calls == [(1600, 1200)]
+
+
+@pytest.mark.asyncio
+async def test_openrazer_action_sets_poll_rate() -> None:
+    iface = _FakeInterface()
+    manager = _manager(_FakeDBus(iface))
+    await openrazer.refresh_openrazer(manager, force=True)
+
+    result = await openrazer.handle_openrazer_action(
+        manager,
+        {
+            "setting": "poll_rate",
+            "serial": "ABC123",
+            "poll_rate": 500,
+        },
+    )
+
+    assert result == {
+        "status": "ok",
+        "serial": "ABC123",
+        "setting": "poll_rate",
+        "poll_rate": 500,
+    }
+    assert iface.set_poll_rate_calls == [500]
+
+
+@pytest.mark.asyncio
+async def test_openrazer_action_allows_custom_poll_rate() -> None:
+    iface = _FakeInterface()
+    manager = _manager(_FakeDBus(iface))
+    await openrazer.refresh_openrazer(manager, force=True)
+
+    result = await openrazer.handle_openrazer_action(
+        manager,
+        {
+            "setting": "poll_rate",
+            "serial": "ABC123",
+            "poll_rate": 2000,
+        },
+    )
+
+    assert result == {
+        "status": "ok",
+        "serial": "ABC123",
+        "setting": "poll_rate",
+        "poll_rate": 2000,
+    }
+    assert iface.set_poll_rate_calls == [2000]
+
+
+@pytest.mark.asyncio
+async def test_openrazer_unavailable_is_reported_without_importing_openrazer() -> None:
+    iface = _FakeInterface()
+    manager = _manager(_FakeDBus(iface, has_owner=False))
+
+    status = await openrazer.refresh_openrazer(manager, force=True)
+
+    assert status["available"] is False
+    assert status["devices"] == []
+    assert "not running" in str(status["last_error"])

--- a/tests/test_toml.py
+++ b/tests/test_toml.py
@@ -211,6 +211,40 @@ rapidfire_wait_ms = 60
         assert action.compositor_dispatcher == "focus_workspace"
         assert action.compositor_args == "name:web"
 
+    def test_profile_openrazer_roundtrip(self, temp_config_dir):
+        original = ProfileConfig(
+            name="Razer Profile",
+            enabled=True,
+            device_layers={
+                "1532:0098": DeviceProfileLayer(
+                    hardware_id="1532:0098",
+                    mappings={
+                        "btn_dpi": MappingAction(
+                            action_type=ActionType.OPENRAZER,
+                            openrazer_setting="dpi",
+                            openrazer_device="serial",
+                            openrazer_serial="ABC123",
+                            openrazer_dpi_x=1600,
+                            openrazer_dpi_y=1200,
+                        )
+                    },
+                )
+            },
+        )
+
+        manager = ProfileManager()
+        manager.save_profile(original)
+
+        loaded = manager.list_profiles()[0].config
+        action = loaded.device_layers["1532:0098"].mappings["btn_dpi"]
+
+        assert action.action_type == ActionType.OPENRAZER
+        assert action.openrazer_setting == "dpi"
+        assert action.openrazer_device == "serial"
+        assert action.openrazer_serial == "ABC123"
+        assert action.openrazer_dpi_x == 1600
+        assert action.openrazer_dpi_y == 1200
+
     def test_profile_with_window_rules(self, temp_config_dir):
         profile = ProfileConfig(
             name="Game Profile",


### PR DESCRIPTION
## Summary

- Add `ActionType.OPENRAZER` and corresponding `MappingAction` / `SuperkeyAction` fields for DPI (split or unified) and polling rate
- Create `session/manager/openrazer.py` — a D-Bus client for `org.razer` with lazy availability detection and device enumeration
- Add OpenRazer tab to `KeySelectorDialog` with device dropdown, DPI mode toggle, and polling rate template spinner
- Support OpenRazer actions in macro timeline — insert as an event type and edit via dedicated dialog
- Wire action execution through daemon (`action_runner.py`, `actions.py`, `macros.py`, `superkey_state.py`) as a session-side command
- Add compact/verbose labels in `action_labels.py` and combo action previews
- Update `docs/ACTIONS.md` and `docs/MACROS.md` with OpenRazer usage

## Testing

- `tests/session/test_openrazer.py` — D-Bus response parsing, device field mapping, availability refresh
- `tests/keymasqd/test_device_manager_core.py` — openrazer action dispatch through device manager
- `tests/test_toml.py` — TOML serialization/round-trip for OpenRazer action fields
- GUI tab device listing, DPI/polling controls, and state restore verified manually
- Macro editor insert, property panel, and event reconstruction verified manually
- Not run: integration test with physical Razer hardware