### PR TITLE
Ability to run macros on profile activation and deactivation

### DIFF
--- a/docs/PROFILES.md
+++ b/docs/PROFILES.md
@@ -199,6 +199,8 @@ enabled = true
 is_permanent = false
 priority = 50
 notify_on_activation = true
+activation_macro = "game_enter"
+deactivation_macro = "game_leave"
 created_at = "2026-03-09T12:34:56"
 
 [[profile.window_rules]]
@@ -223,6 +225,12 @@ always_grab_all = true
 action = "exec"
 cmd = "playerctl play-pause"
 ```
+
+`activation_macro` and `deactivation_macro` are optional stored macro names.
+When set, `keymasq-session` asks `keymasqd` to play the macro after the global
+active profile set changes. They fire once when a profile enters or leaves the
+active set, not on unchanged reevaluations, device reconnects, or mapping-only
+refreshes.
 
 ## Common Patterns
 

--- a/keymasq/common/models.py
+++ b/keymasq/common/models.py
@@ -500,6 +500,8 @@ class ProfileConfig:
     is_permanent: bool = False
     priority: int = 0
     notify_on_activation: bool = True
+    activation_macro_name: str | None = None
+    deactivation_macro_name: str | None = None
     window_rules: list[WindowRule] = field(default_factory=list)
     device_layers: dict[str, DeviceProfileLayer] = field(default_factory=dict)
     combos: list[ComboConfig] = field(default_factory=list)

--- a/keymasq/gui/widgets/profile_managed_tab.py
+++ b/keymasq/gui/widgets/profile_managed_tab.py
@@ -49,6 +49,9 @@ class ProfileManagedTab(Gtk.Box):
         self._window_rule_capture_timeout_id = 0
         self._window_rule_capture_generation = 0
         self._window_rules_target_profile_name: str | None = None
+        self._profile_lifecycle_macro_names: list[str] = []
+        self._profile_lifecycle_macro_options: list[str] = [""]
+        self._suspend_lifecycle_macro_signal = False
 
         self.set_margin_top(12)
         self.set_margin_bottom(12)
@@ -210,6 +213,44 @@ class ProfileManagedTab(Gtk.Box):
         self.notify_check.connect("toggled", self._on_notify_toggled)
         settings_grid.attach(self.notify_check, 1, row, 1, 1)
 
+        row += 1
+
+        activation_macro_label = Gtk.Label(label="Activation Macro")
+        activation_macro_label.set_halign(Gtk.Align.START)
+        activation_macro_label.set_valign(Gtk.Align.CENTER)
+        settings_grid.attach(activation_macro_label, 0, row, 1, 1)
+
+        self.activation_macro_dropdown = Gtk.DropDown()
+        self.activation_macro_dropdown.set_hexpand(True)
+        self.activation_macro_dropdown.set_tooltip_text("Macro to play when this profile activates")
+        self.activation_macro_dropdown.connect(
+            "notify::selected",
+            self._on_activation_macro_changed,
+        )
+        settings_grid.attach(self.activation_macro_dropdown, 1, row, 1, 1)
+
+        row += 1
+
+        deactivation_macro_label = Gtk.Label(label="Deactivation Macro")
+        deactivation_macro_label.set_halign(Gtk.Align.START)
+        deactivation_macro_label.set_valign(Gtk.Align.CENTER)
+        settings_grid.attach(deactivation_macro_label, 0, row, 1, 1)
+
+        self.deactivation_macro_dropdown = Gtk.DropDown()
+        self.deactivation_macro_dropdown.set_hexpand(True)
+        self.deactivation_macro_dropdown.set_tooltip_text(
+            "Macro to play when this profile deactivates"
+        )
+        self.deactivation_macro_dropdown.connect(
+            "notify::selected",
+            self._on_deactivation_macro_changed,
+        )
+        settings_grid.attach(self.deactivation_macro_dropdown, 1, row, 1, 1)
+
+        self._refresh_lifecycle_macro_dropdowns()
+        if self.profile_manager is not None:
+            session_request_async({"command": "list_macros"}, self._on_lifecycle_macros_loaded)
+
         row = self._append_profile_settings_rows(settings_grid, row + 1)
         _ = row
 
@@ -321,6 +362,8 @@ class ProfileManagedTab(Gtk.Box):
             is_permanent=self._selected_profile.config.is_permanent,
             priority=self.profile_manager.get_next_priority(),
             notify_on_activation=self._selected_profile.config.notify_on_activation,
+            activation_macro_name=self._selected_profile.config.activation_macro_name,
+            deactivation_macro_name=self._selected_profile.config.deactivation_macro_name,
             window_rules=copy.deepcopy(self._selected_profile.config.window_rules),
             device_layers=copy.deepcopy(self._selected_profile.config.device_layers),
             combos=copy.deepcopy(self._selected_profile.config.combos),
@@ -417,6 +460,89 @@ class ProfileManagedTab(Gtk.Box):
         if not self._selected_profile:
             return
         self._selected_profile.config.notify_on_activation = check.get_active()
+        self._save_profile()
+
+    def _on_lifecycle_macros_loaded(self, result: dict | None) -> bool:
+        macros = (result or {}).get("macros", [])
+        names: list[str] = []
+        if isinstance(macros, list):
+            for macro in macros:
+                if not isinstance(macro, dict):
+                    continue
+                name = str(macro.get("name", "") or "").strip()
+                if name:
+                    names.append(name)
+        self._profile_lifecycle_macro_names = sorted(set(names), key=str.casefold)
+        self._refresh_lifecycle_macro_dropdowns()
+        return False
+
+    def _refresh_lifecycle_macro_dropdowns(self) -> None:
+        selected_names = []
+        if self._selected_profile:
+            selected_names = [
+                self._selected_profile.config.activation_macro_name or "",
+                self._selected_profile.config.deactivation_macro_name or "",
+            ]
+        options = [""]
+        for name in self._profile_lifecycle_macro_names + selected_names:
+            if name and name not in options:
+                options.append(name)
+        self._profile_lifecycle_macro_options = options
+
+        activation_model = Gtk.StringList()
+        deactivation_model = Gtk.StringList()
+        for name in options:
+            label = name or "None"
+            activation_model.append(label)
+            deactivation_model.append(label)
+
+        self._suspend_lifecycle_macro_signal = True
+        try:
+            self.activation_macro_dropdown.set_model(activation_model)
+            self.deactivation_macro_dropdown.set_model(deactivation_model)
+            self._select_lifecycle_macro(
+                self.activation_macro_dropdown,
+                self._selected_profile.config.activation_macro_name
+                if self._selected_profile
+                else None,
+            )
+            self._select_lifecycle_macro(
+                self.deactivation_macro_dropdown,
+                self._selected_profile.config.deactivation_macro_name
+                if self._selected_profile
+                else None,
+            )
+        finally:
+            self._suspend_lifecycle_macro_signal = False
+
+    def _select_lifecycle_macro(self, dropdown: Gtk.DropDown, macro_name: str | None) -> None:
+        selected_name = macro_name or ""
+        try:
+            index = self._profile_lifecycle_macro_options.index(selected_name)
+        except ValueError:
+            index = 0
+        dropdown.set_selected(index)
+
+    def _lifecycle_macro_name_for_dropdown(self, dropdown: Gtk.DropDown) -> str | None:
+        selected = dropdown.get_selected()
+        if selected >= len(self._profile_lifecycle_macro_options):
+            return None
+        return self._profile_lifecycle_macro_options[selected] or None
+
+    def _on_activation_macro_changed(self, dropdown: Gtk.DropDown, _param) -> None:
+        if self._suspend_lifecycle_macro_signal or not self._selected_profile:
+            return
+        self._selected_profile.config.activation_macro_name = (
+            self._lifecycle_macro_name_for_dropdown(dropdown)
+        )
+        self._save_profile()
+
+    def _on_deactivation_macro_changed(self, dropdown: Gtk.DropDown, _param) -> None:
+        if self._suspend_lifecycle_macro_signal or not self._selected_profile:
+            return
+        self._selected_profile.config.deactivation_macro_name = (
+            self._lifecycle_macro_name_for_dropdown(dropdown)
+        )
         self._save_profile()
 
     def _on_edit_window_rules(self, _button: Gtk.Button) -> None:
@@ -1051,6 +1177,7 @@ class ProfileManagedTab(Gtk.Box):
         self.notify_check.set_active(config.notify_on_activation)
         self.notify_check.handler_unblock_by_func(self._on_notify_toggled)
 
+        self._refresh_lifecycle_macro_dropdowns()
         self._update_rules_label()
         self.window_rules_box.set_sensitive(not config.is_permanent)
         self._update_extra_profile_settings()

--- a/keymasq/gui/widgets/profile_managed_tab.py
+++ b/keymasq/gui/widgets/profile_managed_tab.py
@@ -52,6 +52,12 @@ class ProfileManagedTab(Gtk.Box):
         self._profile_lifecycle_macro_names: list[str] = []
         self._profile_lifecycle_macro_options: list[str] = [""]
         self._suspend_lifecycle_macro_signal = False
+        self._registered_macro_event_handlers = False
+        if self.main_window is not None and hasattr(self.main_window, "register_event_handler"):
+            self.main_window.register_event_handler("macro_saved", self._on_macro_list_changed)
+            self.main_window.register_event_handler("macro_deleted", self._on_macro_list_changed)
+            self._registered_macro_event_handlers = True
+        self.connect("destroy", self._on_profile_managed_destroy)
 
         self.set_margin_top(12)
         self.set_margin_bottom(12)
@@ -248,8 +254,7 @@ class ProfileManagedTab(Gtk.Box):
         settings_grid.attach(self.deactivation_macro_dropdown, 1, row, 1, 1)
 
         self._refresh_lifecycle_macro_dropdowns()
-        if self.profile_manager is not None:
-            session_request_async({"command": "list_macros"}, self._on_lifecycle_macros_loaded)
+        self._load_lifecycle_macros()
 
         row = self._append_profile_settings_rows(settings_grid, row + 1)
         _ = row
@@ -475,6 +480,22 @@ class ProfileManagedTab(Gtk.Box):
         self._profile_lifecycle_macro_names = sorted(set(names), key=str.casefold)
         self._refresh_lifecycle_macro_dropdowns()
         return False
+
+    def _load_lifecycle_macros(self) -> None:
+        if self.profile_manager is None or self.demo_mode:
+            return
+        session_request_async({"command": "list_macros"}, self._on_lifecycle_macros_loaded)
+
+    def _on_macro_list_changed(self, _event: dict) -> None:
+        self._load_lifecycle_macros()
+
+    def _on_profile_managed_destroy(self, _widget) -> None:
+        if not self._registered_macro_event_handlers:
+            return
+        if self.main_window is not None and hasattr(self.main_window, "unregister_event_handler"):
+            self.main_window.unregister_event_handler("macro_saved", self._on_macro_list_changed)
+            self.main_window.unregister_event_handler("macro_deleted", self._on_macro_list_changed)
+        self._registered_macro_event_handlers = False
 
     def _refresh_lifecycle_macro_dropdowns(self) -> None:
         selected_names = []

--- a/keymasq/session/manager/commands.py
+++ b/keymasq/session/manager/commands.py
@@ -426,6 +426,7 @@ async def _handle_macro_commands(
         if result.status != "ok":
             return {"status": "error", "message": result.error or "Failed to delete macro"}
         await runtime_profiles.refresh_macro_bindings(manager)
+        manager.broadcast_to_session_clients({"event": "macro_deleted", "name": name})
         return {"status": "ok"}
 
     if command == "rename_macro":
@@ -446,7 +447,14 @@ async def _handle_macro_commands(
         await runtime_profiles.refresh_macro_bindings(manager)
         result_data = json_object(result.data)
         if result_data is not None:
-            return {"status": "ok", "macro": result_data.get("macro")}
+            renamed = json_object(result_data.get("macro")) or {}
+            manager.broadcast_to_session_clients(
+                {"event": "macro_deleted", "name": str_value(request.get("old"), "")}
+            )
+            manager.broadcast_to_session_clients(
+                {"event": "macro_saved", "name": str_value(renamed.get("name"), "")}
+            )
+            return {"status": "ok", "macro": renamed}
         return {"status": "ok"}
 
     if command == "play_macro":

--- a/keymasq/session/manager/profiles.py
+++ b/keymasq/session/manager/profiles.py
@@ -6,7 +6,7 @@ from datetime import datetime
 from typing import TYPE_CHECKING
 
 from keymasq.common.ipc import Command, CommandType
-from keymasq.common.models import ActionType, HardwareConfig
+from keymasq.common.models import ActionType, HardwareConfig, ProfileConfig
 from keymasq.session.profiles import ResolvedCombo, ResolvedDeviceProfile
 
 from . import payloads as runtime_payloads
@@ -221,6 +221,7 @@ async def reevaluate_profiles(manager: "SessionManager") -> None:
         manager.compositor_state.compositor_capabilities,
         hardware_ids=hardware_ids,
     )
+    old_active_profile_names = list(manager.profile_state.active_profile_names)
     manager.profile_state.active_profile_names = [
         profile.name for profile in resolved.active_profiles
     ]
@@ -249,6 +250,80 @@ async def reevaluate_profiles(manager: "SessionManager") -> None:
     manager.broadcast_to_session_clients(
         {"event": "profiles_changed", **build_active_profiles_payload(manager)}
     )
+    await play_profile_lifecycle_macros(
+        manager,
+        old_active_profile_names,
+        resolved.active_profiles,
+    )
+
+
+async def play_profile_lifecycle_macros(
+    manager: "SessionManager",
+    old_active_profile_names: list[str],
+    new_active_profiles: list[ProfileConfig],
+) -> None:
+    old_names = set(old_active_profile_names)
+    new_names = {profile.name for profile in new_active_profiles}
+
+    deactivated_names = [name for name in old_active_profile_names if name not in new_names]
+    activated_profiles = [
+        profile for profile in new_active_profiles if profile.name not in old_names
+    ]
+
+    for profile_name in deactivated_names:
+        profile_info = manager.profiles.get_profile(profile_name)
+        if profile_info is None:
+            continue
+        await play_profile_lifecycle_macro(
+            manager,
+            profile_info.config.deactivation_macro_name,
+            profile_name=profile_name,
+            transition="deactivation",
+        )
+
+    for profile in activated_profiles:
+        await play_profile_lifecycle_macro(
+            manager,
+            profile.activation_macro_name,
+            profile_name=profile.name,
+            transition="activation",
+        )
+
+
+async def play_profile_lifecycle_macro(
+    manager: "SessionManager",
+    macro_name: str | None,
+    *,
+    profile_name: str,
+    transition: str,
+) -> None:
+    if not macro_name:
+        return
+    try:
+        result = await manager.client.send_command(
+            Command(
+                command=CommandType.MACRO_PLAY_BY_NAME,
+                data={"name": macro_name},
+            )
+        )
+    except Exception as exc:
+        log.warning(
+            "Failed to play %s macro '%s' for profile '%s': %s",
+            transition,
+            macro_name,
+            profile_name,
+            exc,
+        )
+        return
+
+    if result.status != "ok":
+        log.warning(
+            "Failed to play %s macro '%s' for profile '%s': %s",
+            transition,
+            macro_name,
+            profile_name,
+            result.error or result.data or "playback failed",
+        )
 
 
 async def apply_resolved_device_profile(

--- a/keymasq/session/profiles.py
+++ b/keymasq/session/profiles.py
@@ -52,6 +52,13 @@ def _float_value(value: object, default: float) -> float:
     return default if value is None else float(cast(_FloatLike, value))
 
 
+def _optional_str(value: object) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
 @dataclass
 class ProfileInfo:
     path: Path
@@ -212,6 +219,8 @@ class ProfileManager:
             is_permanent=bool(profile.get("is_permanent", False)),
             priority=_int_value(profile.get("priority"), 0),
             notify_on_activation=bool(profile.get("notify_on_activation", True)),
+            activation_macro_name=_optional_str(profile.get("activation_macro")),
+            deactivation_macro_name=_optional_str(profile.get("deactivation_macro")),
             window_rules=window_rules,
             device_layers=device_layers,
             combos=self._parse_combos(data.get("combos", [])),
@@ -802,6 +811,11 @@ class ProfileManager:
             "notify_on_activation": config.notify_on_activation,
             "created_at": (config.created_at or datetime.now()).isoformat(),
         }
+
+        if config.activation_macro_name:
+            profile_data["activation_macro"] = config.activation_macro_name
+        if config.deactivation_macro_name:
+            profile_data["deactivation_macro"] = config.deactivation_macro_name
 
         if config.window_rules:
             profile_data["window_rules"] = [

--- a/tests/common/test_profile_manager.py
+++ b/tests/common/test_profile_manager.py
@@ -25,6 +25,27 @@ class TestProfileManager:
         assert profiles[0].config.name == sample_profile_config.name
         assert len(profiles[0].config.device_layers["1234:5678"].mappings) == 2
 
+    def test_save_and_load_profile_lifecycle_macros(self, temp_config_dir):
+        manager = ProfileManager()
+        manager.save_profile(
+            ProfileConfig(
+                name="Gaming",
+                enabled=True,
+                activation_macro_name="game_enter",
+                deactivation_macro_name="game_leave",
+            )
+        )
+
+        reloaded = ProfileManager()
+        profile = reloaded.get_profile("Gaming")
+
+        assert profile is not None
+        assert profile.config.activation_macro_name == "game_enter"
+        assert profile.config.deactivation_macro_name == "game_leave"
+        content = profile.path.read_text(encoding="utf-8")
+        assert 'activation_macro = "game_enter"' in content
+        assert 'deactivation_macro = "game_leave"' in content
+
     def test_multiple_profiles_global(self, temp_config_dir, sample_profile_config):
         manager = ProfileManager()
         manager.save_profile(sample_profile_config)

--- a/tests/gui/test_profile_dialogs_and_actions.py
+++ b/tests/gui/test_profile_dialogs_and_actions.py
@@ -58,6 +58,54 @@ class TestButtonWidget:
         assert button.evdev == "btn_left"
         assert button.zone == "left"
 
+
+class TestProfileManagedTab:
+    def test_lifecycle_macro_dropdown_reloads_on_macro_saved_event(self, monkeypatch):
+        from keymasq.gui.widgets import profile_managed_tab as profile_managed_tab_module
+        from keymasq.gui.widgets.profile_managed_tab import ProfileManagedTab
+
+        class ProfileManagerStub:
+            def list_profiles(self):
+                return []
+
+        class Parent:
+            def __init__(self):
+                self.handlers = {}
+                self._selected_profile_name = None
+
+            def register_event_handler(self, event_type, callback):
+                self.handlers.setdefault(event_type, []).append(callback)
+
+            def unregister_event_handler(self, event_type, callback):
+                self.handlers[event_type].remove(callback)
+
+        responses = [
+            {"status": "ok", "macros": []},
+            {"status": "ok", "macros": [{"name": "new_macro"}]},
+        ]
+        requests = []
+
+        def session_request_async(payload, callback, timeout=5.0):
+            _ = timeout
+            requests.append(payload)
+            callback(responses.pop(0))
+
+        monkeypatch.setattr(
+            profile_managed_tab_module,
+            "session_request_async",
+            session_request_async,
+        )
+
+        parent = Parent()
+        tab = ProfileManagedTab(ProfileManagerStub(), main_window=parent)
+        tab._setup_profile_selector()
+
+        parent.handlers["macro_saved"][0]({"event": "macro_saved", "name": "new_macro"})
+
+        assert requests == [{"command": "list_macros"}, {"command": "list_macros"}]
+        assert tab._profile_lifecycle_macro_options == ["", "new_macro"]
+
+
 class TestProfileActions:
     def test_action_types(self):
         from keymasq.common.models import ActionType

--- a/tests/session/test_session_manager_command_runtime.py
+++ b/tests/session/test_session_manager_command_runtime.py
@@ -616,6 +616,37 @@ async def test_handle_session_request_update_macro_refreshes_runtime_bindings() 
 
 
 @pytest.mark.asyncio
+async def test_handle_session_request_delete_macro_broadcasts_deleted_event() -> None:
+    manager = SessionManager()
+    manager.client.send_command = AsyncMock(return_value=Response(status="ok", data={}))
+    manager.broadcast_to_session_clients = Mock()  # type: ignore[method-assign]
+    refresh_macro_bindings = AsyncMock()
+    monkeypatch = pytest.MonkeyPatch()
+    monkeypatch.setattr(
+        session_profiles_module,
+        "refresh_macro_bindings",
+        refresh_macro_bindings,
+    )
+
+    peer = PeerCredentials(pid=1, uid=1000, gid=1000)
+    try:
+        result = await manager._handle_session_request(
+            {"command": "delete_macro", "name": "Speedrun"},
+            "client",
+            peer,
+            object(),
+        )
+    finally:
+        monkeypatch.undo()
+
+    assert result == {"status": "ok"}
+    refresh_macro_bindings.assert_awaited_once_with(manager)
+    manager.broadcast_to_session_clients.assert_called_once_with(  # type: ignore[attr-defined]
+        {"event": "macro_deleted", "name": "Speedrun"}
+    )
+
+
+@pytest.mark.asyncio
 async def test_capture_combo_session_command_round_trip() -> None:
     manager = SessionManager()
     manager.hardware.list_hardware_ids = lambda: ["1234:5678"]  # type: ignore[assignment]

--- a/tests/session/test_session_manager_profile_resolution.py
+++ b/tests/session/test_session_manager_profile_resolution.py
@@ -283,3 +283,57 @@ async def test_reevaluate_profiles_broadcast_omits_window_state() -> None:
     assert "devices" in payload
     assert "window" not in payload
 
+
+@pytest.mark.asyncio
+async def test_reevaluate_profiles_plays_lifecycle_macros_once_per_transition(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = SessionManager()
+    desktop = ProfileConfig(
+        name="Desktop",
+        enabled=True,
+        is_permanent=True,
+        activation_macro_name="desktop_enter",
+        deactivation_macro_name="desktop_leave",
+    )
+    gaming = ProfileConfig(
+        name="Gaming",
+        enabled=True,
+        activation_macro_name="gaming_enter",
+        deactivation_macro_name="gaming_leave",
+    )
+    profiles_by_name = {
+        desktop.name: SimpleNamespace(config=desktop),
+        gaming.name: SimpleNamespace(config=gaming),
+    }
+    resolved_profiles = [
+        ResolvedProfiles(active_profiles=[desktop], devices={}, combos=[]),
+        ResolvedProfiles(active_profiles=[desktop], devices={}, combos=[]),
+        ResolvedProfiles(active_profiles=[gaming], devices={}, combos=[]),
+        ResolvedProfiles(active_profiles=[], devices={}, combos=[]),
+    ]
+
+    manager.hardware.list_hardware_ids = lambda: []  # type: ignore[assignment]
+    manager.profiles.get_profile = lambda name: profiles_by_name.get(name)  # type: ignore[assignment]
+    manager.profiles.resolve_active_profiles = Mock(  # type: ignore[assignment]
+        side_effect=resolved_profiles
+    )
+    manager.client.send_command = AsyncMock(return_value=Response(status="ok", data={}))
+    monkeypatch.setattr(session_profiles_module, "update_combos", AsyncMock())
+
+    for _ in resolved_profiles:
+        await session_profiles_module.reevaluate_profiles(manager)
+
+    sent = manager.client.send_command.await_args_list
+    assert [call.args[0].command for call in sent] == [
+        CommandType.MACRO_PLAY_BY_NAME,
+        CommandType.MACRO_PLAY_BY_NAME,
+        CommandType.MACRO_PLAY_BY_NAME,
+        CommandType.MACRO_PLAY_BY_NAME,
+    ]
+    assert [call.args[0].data["name"] for call in sent] == [
+        "desktop_enter",
+        "desktop_leave",
+        "gaming_enter",
+        "gaming_leave",
+    ]


### PR DESCRIPTION
## Summary
- Add `activation_macro_name` and `deactivation_macro_name` fields to `ProfileConfig` model
- Play the configured macro via `MACRO_PLAY_BY_NAME` when a profile enters or leaves the active set
- Fire macros once per transition, not on unchanged reevaluations or device reconnects
- Provide dropdown selectors in the GUI profile settings tab, populated from stored macros
- Save/load the new fields as `activation_macro` / `deactivation_macro` in TOML profile files
- Update profile docs with behavior semantics

## Testing
- Added `test_save_and_load_profile_lifecycle_macros` — verifies round-trip save/load of macro names and TOML serialization
- Added `test_reevaluate_profiles_plays_lifecycle_macros_once_per_transition` — verifies correct macro playback on activation/deactivation across multiple reevaluation cycles
- Manually verified GUI dropdown shows available macros and persists selection
- Existing profile resolution and round-robin tests pass with no regression