### PR TITLE
Hide the OpenRazer tab until devices are detected

### DIFF
--- a/keymasq/gui/widgets/key_selector_dialog.py
+++ b/keymasq/gui/widgets/key_selector_dialog.py
@@ -397,6 +397,7 @@ class KeySelectorDialog(Adw.Dialog):
         self._openrazer_poll_rates: list[int] = []
         self._openrazer_status_requested = False
         self._openrazer_poll_template_updating = False
+        self._openrazer_tab: Gtk.Widget | None = None
         self.openrazer_map_btn: Gtk.Button | None = None
         self.openrazer_poll_template_dropdown: Gtk.DropDown | None = None
         self._exec_cmd: str = ""
@@ -486,7 +487,6 @@ class KeySelectorDialog(Adw.Dialog):
         self.stack.add_titled(self._build_navigation_tab(), "navigation", "Navigation")
         self.stack.add_titled(self._build_media_tab(), "media", "Media")
         self.stack.add_titled(self._build_mouse_tab(), "mouse", "Mouse")
-        self.stack.add_titled(self._build_openrazer_tab(), "openrazer", "OpenRazer")
         for page in self._compositor_action_pages:
             self.stack.add_titled(page.widget, page.page_id, page.title)
         self.stack.add_titled(self._build_gamepad_tab(), "gamepad", "Gamepad")
@@ -496,6 +496,7 @@ class KeySelectorDialog(Adw.Dialog):
         self.stack.add_titled(self._build_profile_tab(), "profile", "Profile")
 
         self._set_initial_tab()
+        self._refresh_openrazer_status(force=False)
 
         frame = Gtk.Frame()
         frame.set_vexpand(True)
@@ -924,7 +925,12 @@ class KeySelectorDialog(Adw.Dialog):
         box.set_margin_end(16)
 
         header = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=8)
-        self.openrazer_status_label = Gtk.Label(label="Checking OpenRazer...")
+        status_text = (
+            f"OpenRazer ready ({len(self._openrazer_devices)} device(s))"
+            if self._openrazer_available
+            else "Checking OpenRazer..."
+        )
+        self.openrazer_status_label = Gtk.Label(label=status_text)
         self.openrazer_status_label.add_css_class("dim-label")
         self.openrazer_status_label.set_halign(Gtk.Align.START)
         self.openrazer_status_label.set_hexpand(True)
@@ -1057,7 +1063,8 @@ class KeySelectorDialog(Adw.Dialog):
 
     def _refresh_openrazer_status(self, *, force: bool) -> None:
         self._openrazer_status_requested = True
-        self.openrazer_status_label.set_label("Checking OpenRazer...")
+        if hasattr(self, "openrazer_status_label"):
+            self.openrazer_status_label.set_label("Checking OpenRazer...")
         command = "refresh_openrazer" if force else "get_openrazer_status"
         session_request_async(
             {"command": command, "force": force},
@@ -1069,23 +1076,46 @@ class KeySelectorDialog(Adw.Dialog):
         if not response or response.get("status") != "ok":
             self._openrazer_available = False
             self._openrazer_devices = []
-            self.openrazer_status_label.set_label("OpenRazer unavailable")
-            self._populate_openrazer_devices()
+            if hasattr(self, "openrazer_status_label"):
+                self.openrazer_status_label.set_label("OpenRazer unavailable")
+                self._populate_openrazer_devices()
+            self._sync_openrazer_tab_visibility()
             return False
         self._openrazer_available = bool(response.get("available", False))
         devices = response.get("devices", [])
         self._openrazer_devices = [
             dict(item) for item in devices if isinstance(item, dict)
         ]
-        if self._openrazer_available:
+        if self._openrazer_available and hasattr(self, "openrazer_status_label"):
             self.openrazer_status_label.set_label(
                 f"OpenRazer ready ({len(self._openrazer_devices)} device(s))"
             )
-        else:
+        elif hasattr(self, "openrazer_status_label"):
             message = str(response.get("last_error", "") or "OpenRazer unavailable")
             self.openrazer_status_label.set_label(message)
-        self._populate_openrazer_devices()
+        self._sync_openrazer_tab_visibility()
+        if hasattr(self, "openrazer_device_model"):
+            self._populate_openrazer_devices()
         return False
+
+    def _sync_openrazer_tab_visibility(self) -> None:
+        should_show = self._openrazer_available and bool(self._openrazer_devices)
+        tab = self.stack.get_child_by_name("openrazer")
+        if should_show:
+            if tab is None:
+                self._openrazer_tab = self._build_openrazer_tab()
+                self.stack.add_titled(self._openrazer_tab, "openrazer", "OpenRazer")
+                if (
+                    self._current_action is not None
+                    and self._current_action.action_type == ActionType.OPENRAZER
+                ):
+                    self.stack.set_visible_child_name("openrazer")
+            return
+
+        if tab is not None:
+            if self.stack.get_visible_child_name() == "openrazer":
+                self.stack.set_visible_child_name("special")
+            self.stack.remove(tab)
 
     def _populate_openrazer_devices(self) -> None:
         self.openrazer_device_model.splice(0, self.openrazer_device_model.get_n_items(), [])
@@ -2159,7 +2189,7 @@ class KeySelectorDialog(Adw.Dialog):
         name = compositor_tab or tab_map.get(self._current_action.action_type)
         if name == "superkey" and not self._allow_superkey:
             return
-        if name:
+        if name and self.stack.get_child_by_name(name) is not None:
             self.stack.set_visible_child_name(name)
 
     def _resolve_compositor_action_status(

--- a/keymasq/gui/widgets/key_selector_dialog.py
+++ b/keymasq/gui/widgets/key_selector_dialog.py
@@ -54,6 +54,8 @@ log = logging.getLogger("keymasq.gui.widgets.key_selector_dialog")
 
 type IntLike = int | float | str | bytes
 
+OPENRAZER_STATUS_POLL_SECONDS = 5
+
 
 def _int_value(value: object, default: int = 0) -> int:
     return default if value is None else int(cast(IntLike, value))
@@ -396,6 +398,8 @@ class KeySelectorDialog(Adw.Dialog):
         self._openrazer_poll_rate = 1000
         self._openrazer_poll_rates: list[int] = []
         self._openrazer_status_requested = False
+        self._openrazer_status_inflight = False
+        self._openrazer_refresh_source_id = 0
         self._openrazer_poll_template_updating = False
         self._openrazer_tab: Gtk.Widget | None = None
         self.openrazer_map_btn: Gtk.Button | None = None
@@ -462,6 +466,7 @@ class KeySelectorDialog(Adw.Dialog):
             self._tap_enabled = False
 
         self._build_ui()
+        self.connect("closed", self._on_dialog_closed)
 
     def _build_ui(self):
         _ensure_compact_tabs_css()
@@ -497,6 +502,10 @@ class KeySelectorDialog(Adw.Dialog):
 
         self._set_initial_tab()
         self._refresh_openrazer_status(force=False)
+        self._openrazer_refresh_source_id = GLib.timeout_add_seconds(
+            OPENRAZER_STATUS_POLL_SECONDS,
+            self._poll_openrazer_status,
+        )
 
         frame = Gtk.Frame()
         frame.set_vexpand(True)
@@ -1062,6 +1071,9 @@ class KeySelectorDialog(Adw.Dialog):
         self._refresh_openrazer_status(force=True)
 
     def _refresh_openrazer_status(self, *, force: bool) -> None:
+        if self._openrazer_status_inflight:
+            return
+        self._openrazer_status_inflight = True
         self._openrazer_status_requested = True
         if hasattr(self, "openrazer_status_label"):
             self.openrazer_status_label.set_label("Checking OpenRazer...")
@@ -1073,6 +1085,7 @@ class KeySelectorDialog(Adw.Dialog):
         )
 
     def _on_openrazer_status_loaded(self, response: dict | None) -> bool:
+        self._openrazer_status_inflight = False
         if not response or response.get("status") != "ok":
             self._openrazer_available = False
             self._openrazer_devices = []
@@ -1116,6 +1129,17 @@ class KeySelectorDialog(Adw.Dialog):
             if self.stack.get_visible_child_name() == "openrazer":
                 self.stack.set_visible_child_name("special")
             self.stack.remove(tab)
+
+    def _poll_openrazer_status(self) -> bool:
+        if self._openrazer_refresh_source_id == 0:
+            return False
+        self._refresh_openrazer_status(force=True)
+        return True
+
+    def _on_dialog_closed(self, _dialog: Adw.Dialog) -> None:
+        if self._openrazer_refresh_source_id:
+            GLib.source_remove(self._openrazer_refresh_source_id)
+            self._openrazer_refresh_source_id = 0
 
     def _populate_openrazer_devices(self) -> None:
         self.openrazer_device_model.splice(0, self.openrazer_device_model.get_n_items(), [])

--- a/tests/gui/test_gui_device_tab_misc.py
+++ b/tests/gui/test_gui_device_tab_misc.py
@@ -663,6 +663,58 @@ def test_key_selector_dialog_profile_tab_populates_and_maps_selected_action(monk
     assert results[0].profile_name == "Gaming"
 
 
+def test_key_selector_dialog_hides_openrazer_tab_when_unavailable(monkeypatch):
+    from gi.repository import Gtk
+
+    from keymasq.gui.widgets import key_selector_dialog as dialog_module
+    from keymasq.gui.widgets.key_selector_dialog import KeySelectorDialog
+
+    def fake_session_request_async(payload, callback, timeout=5.0):
+        assert payload == {"command": "get_openrazer_status", "force": False}
+        callback({"status": "ok", "available": False, "devices": []})
+
+    monkeypatch.setattr(dialog_module, "session_request_async", fake_session_request_async)
+
+    dialog = KeySelectorDialog(Gtk.Box(), "Back")
+
+    assert dialog.stack.get_child_by_name("openrazer") is None
+
+
+def test_key_selector_dialog_shows_openrazer_tab_when_device_available(monkeypatch):
+    from gi.repository import Gtk
+
+    from keymasq.gui.widgets import key_selector_dialog as dialog_module
+    from keymasq.gui.widgets.key_selector_dialog import KeySelectorDialog
+
+    def fake_session_request_async(payload, callback, timeout=5.0):
+        assert payload == {"command": "get_openrazer_status", "force": False}
+        callback(
+            {
+                "status": "ok",
+                "available": True,
+                "devices": [
+                    {
+                        "serial": "ABC123",
+                        "name": "Razer Mouse",
+                        "hardware_id": "1532:0098",
+                        "dpi": [1600, 1600],
+                        "poll_rate": 1000,
+                        "poll_rate_templates": [125, 500, 1000],
+                    }
+                ],
+            }
+        )
+
+    monkeypatch.setattr(dialog_module, "session_request_async", fake_session_request_async)
+
+    dialog = KeySelectorDialog(Gtk.Box(), "Back")
+
+    assert dialog.stack.get_child_by_name("openrazer") is not None
+    assert dialog.openrazer_status_label.get_label() == "OpenRazer ready (1 device(s))"
+    assert dialog.openrazer_map_btn is not None
+    assert dialog.openrazer_map_btn.get_sensitive() is True
+
+
 def test_key_selector_dialog_only_shows_hyprland_dispatch_for_active_hyprland_listener():
     from gi.repository import Gtk
 
@@ -967,6 +1019,9 @@ def test_key_selector_dialog_repeated_delayed_capture_ignores_stale_response(mon
         return None
 
     def fake_session_request_async(payload, callback, timeout=5.0):
+        if payload == {"command": "get_openrazer_status", "force": False}:
+            callback({"status": "ok", "available": False, "devices": []})
+            return
         assert payload == {"command": "get_cursor_position"}
         requests.append(callback)
 

--- a/tests/gui/test_gui_device_tab_misc.py
+++ b/tests/gui/test_gui_device_tab_misc.py
@@ -715,6 +715,46 @@ def test_key_selector_dialog_shows_openrazer_tab_when_device_available(monkeypat
     assert dialog.openrazer_map_btn.get_sensitive() is True
 
 
+def test_key_selector_dialog_poll_adds_openrazer_tab_when_device_appears(monkeypatch):
+    from gi.repository import Gtk
+
+    from keymasq.gui.widgets import key_selector_dialog as dialog_module
+    from keymasq.gui.widgets.key_selector_dialog import KeySelectorDialog
+
+    responses = [
+        {"status": "ok", "available": False, "devices": []},
+        {
+            "status": "ok",
+            "available": True,
+            "devices": [
+                {
+                    "serial": "ABC123",
+                    "name": "Razer Mouse",
+                    "hardware_id": "1532:0098",
+                }
+            ],
+        },
+    ]
+
+    requests = [
+        {"command": "get_openrazer_status", "force": False},
+        {"command": "refresh_openrazer", "force": True},
+    ]
+
+    def fake_session_request_async(payload, callback, timeout=5.0):
+        assert payload == requests.pop(0)
+        callback(responses.pop(0))
+
+    monkeypatch.setattr(dialog_module, "session_request_async", fake_session_request_async)
+
+    dialog = KeySelectorDialog(Gtk.Box(), "Back")
+    assert dialog.stack.get_child_by_name("openrazer") is None
+
+    assert dialog._poll_openrazer_status() is True
+
+    assert dialog.stack.get_child_by_name("openrazer") is not None
+
+
 def test_key_selector_dialog_only_shows_hyprland_dispatch_for_active_hyprland_listener():
     from gi.repository import Gtk
 


### PR DESCRIPTION
## Summary
- Delay adding the OpenRazer tab in `KeySelectorDialog` until OpenRazer is available and at least one device is reported.
- Keep the status label and device list in sync with the tab’s visibility, and avoid switching to a tab that is no longer present.
- Add GUI coverage for the unavailable and available OpenRazer cases.

## Testing
- Added unit tests in `tests/gui/test_gui_device_tab_misc.py` for hiding the OpenRazer tab when no devices are available.
- Added unit tests in `tests/gui/test_gui_device_tab_misc.py` for showing the OpenRazer tab when a device is reported and verifying the status label/button state.
-  `./scripts/check.sh gui`