### PR TITLE
Improve macro recording start time and behaviour

### DIFF
--- a/keymasq/session/manager/commands.py
+++ b/keymasq/session/manager/commands.py
@@ -518,6 +518,8 @@ async def _handle_capture_commands(
             include_grabbed=True,
         )
         manager.recording_state.devices_cache = devices
+        manager.recording_state.devices_cache_ready = True
+        runtime_recording.update_selected_recording_devices_cache(manager)
         return {"status": "ok", "devices": devices}
 
     if command == "begin_capture":

--- a/keymasq/session/manager/core.py
+++ b/keymasq/session/manager/core.py
@@ -429,6 +429,7 @@ class SessionManager:
                 except Exception as e:
                     log.error(f"Failed to activate initial profiles: {e}")
                     traceback.print_exc()
+                await runtime_recording.refresh_recording_devices_cache(self)
 
                 await self.client.wait_disconnected()
 
@@ -448,6 +449,9 @@ class SessionManager:
                 self.profile_state.last_sent_combo_signature = ""
                 self.profile_state.active_profile_names.clear()
                 self.profile_state.resolved_devices.clear()
+                self.recording_state.devices_cache.clear()
+                self.recording_state.selected_devices_cache.clear()
+                self.recording_state.devices_cache_ready = False
 
                 if was_connected:
                     self._broadcast_keymasqd_status(False)

--- a/keymasq/session/manager/events.py
+++ b/keymasq/session/manager/events.py
@@ -398,6 +398,7 @@ async def on_device_connected(manager: "SessionManager", device_info: JsonObject
         TOPOLOGY_REFRESH_DEBOUNCE_S,
         TOPOLOGY_REFRESH_RETRY_S,
     )
+    asyncio.create_task(_refresh_recording_devices_cache_after_topology(manager))
 
 
 async def on_device_disconnected(manager: "SessionManager", device_info: JsonObject) -> None:
@@ -419,6 +420,12 @@ async def on_device_disconnected(manager: "SessionManager", device_info: JsonObj
         TOPOLOGY_REFRESH_DEBOUNCE_S,
         TOPOLOGY_REFRESH_RETRY_S,
     )
+    asyncio.create_task(_refresh_recording_devices_cache_after_topology(manager))
+
+
+async def _refresh_recording_devices_cache_after_topology(manager: "SessionManager") -> None:
+    await asyncio.sleep(TOPOLOGY_REFRESH_DEBOUNCE_S + 0.1)
+    await runtime_recording.refresh_recording_devices_cache(manager)
 
 
 def device_name_for_hardware(manager: "SessionManager", hardware_id: str) -> str:

--- a/keymasq/session/manager/recording.py
+++ b/keymasq/session/manager/recording.py
@@ -894,6 +894,7 @@ def update_recording_settings(manager: "SessionManager", request: JsonObject) ->
             settings["device_overrides"] = {
                 str(recording_id): bool(enabled) for recording_id, enabled in overrides.items()
             }
+    update_selected_recording_devices_cache(manager)
     queue_recording_settings_save(manager, dict(settings))
 
 
@@ -1006,20 +1007,9 @@ async def start_recording(
     record_start_position = settings.get("record_start_position", False)
     device_types = ["keyboard", "gamepad", "mouse"]
 
-    devices: list[JsonObject]
-    if manager.recording_state.devices_cache:
-        devices = list(manager.recording_state.devices_cache)
-    else:
-        try:
-            devices = await asyncio.wait_for(
-                get_devices_for_recording(manager, device_types, include_grabbed=True),
-                timeout=1.5,
-            )
-        except Exception:
-            devices = []
-
-    overrides = json_object(settings.get("device_overrides")) or {}
-    devices = [d for d in devices if _recording_device_enabled(d, overrides)]
+    if not manager.recording_state.devices_cache_ready:
+        log.debug("Recording start using empty/uninitialized recording device cache")
+    devices = list(manager.recording_state.selected_devices_cache)
     recording_ids = list(
         dict.fromkeys(
             recording_id
@@ -1030,7 +1020,7 @@ async def start_recording(
     log.debug(
         "recording start device selection: types=%s overrides=%r recording_ids=%s devices=%s",
         device_types,
-        overrides,
+        json_object(settings.get("device_overrides")) or {},
         recording_ids,
         [str(d.get("path", "")) for d in devices],
     )
@@ -1063,7 +1053,7 @@ async def start_recording(
             Command(
                 command=CommandType.START_RECORDING,
                 data={
-                    "recording_ids": recording_ids,
+                    "devices": devices,
                     "include_mouse_movement": include_mouse_movement,
                     "include_mouse_clicks": include_mouse_clicks,
                     "start_x": start_x,
@@ -1099,8 +1089,19 @@ async def refresh_recording_devices_cache(manager: "SessionManager") -> None:
             include_grabbed=True,
         )
         manager.recording_state.devices_cache = devices
+        manager.recording_state.devices_cache_ready = True
+        update_selected_recording_devices_cache(manager)
     except Exception:
         pass
+
+
+def update_selected_recording_devices_cache(manager: "SessionManager") -> None:
+    overrides = json_object(manager.recording_state.settings.get("device_overrides")) or {}
+    manager.recording_state.selected_devices_cache = [
+        d
+        for d in manager.recording_state.devices_cache
+        if _recording_device_enabled(d, overrides)
+    ]
 
 
 def _recording_device_types(device: JsonObject) -> list[str]:

--- a/keymasq/session/manager/state.py
+++ b/keymasq/session/manager/state.py
@@ -45,6 +45,8 @@ class RecordingRuntimeState:
     settings_pending_save: JsonObject | None = None
     settings_save_task: object | None = None
     devices_cache: list[JsonObject] = field(default_factory=list)
+    selected_devices_cache: list[JsonObject] = field(default_factory=list)
+    devices_cache_ready: bool = False
 
 
 @dataclass

--- a/tests/session/test_session_manager_recording_settings.py
+++ b/tests/session/test_session_manager_recording_settings.py
@@ -1,6 +1,7 @@
 # ruff: noqa: F403, F405, I001
 import logging
 import tomllib
+from typing import cast
 
 from tests.session.profile_support import *
 
@@ -120,7 +121,7 @@ def test_recording_settings_save_logs_errors(tmp_path, caplog, monkeypatch) -> N
 
 
 @pytest.mark.asyncio
-async def test_start_recording_sends_recording_ids_from_cache() -> None:
+async def test_start_recording_sends_selected_devices_from_cache() -> None:
     manager = SessionManager()
     sent_commands: list[CommandType] = []
     sent_payloads: list[dict[str, object]] = []
@@ -160,12 +161,22 @@ async def test_start_recording_sends_recording_ids_from_cache() -> None:
             "device_types": ["keyboard"],
         },
     ]
+    session_recording_module.update_selected_recording_devices_cache(manager)
 
     result = await session_recording_module.start_recording(manager)
 
     assert result == {"status": "ok"}
     assert sent_commands == [CommandType.START_RECORDING]
-    assert sent_payloads[0]["recording_ids"] == ["keymasq:passthrough:1234:5678:kbd"]
+    assert sent_payloads[0]["devices"] == [
+        {
+            "path": "/dev/input/event20",
+            "recording_id": "keymasq:passthrough:1234:5678:kbd",
+            "recording_kind": "keymasq_passthrough",
+            "device_type": "keyboard",
+            "device_types": ["keyboard"],
+        }
+    ]
+    assert "recording_ids" not in sent_payloads[0]
 
 
 @pytest.mark.asyncio
@@ -208,14 +219,60 @@ async def test_start_recording_defaults_to_recommended_sources_only() -> None:
             "device_types": ["keyboard"],
         },
     ]
+    session_recording_module.update_selected_recording_devices_cache(manager)
 
     result = await session_recording_module.start_recording(manager)
 
     assert result == {"status": "ok"}
-    assert sent_payloads[0]["recording_ids"] == [
+    sent_devices = cast(list[dict[str, object]], sent_payloads[0]["devices"])
+    assert [device["recording_id"] for device in sent_devices] == [
         "keymasq:output:keyboard",
         "keymasq:passthrough:1234:5678:mouse",
     ]
+
+
+@pytest.mark.asyncio
+async def test_update_recording_settings_recomputes_selected_devices_cache() -> None:
+    manager = SessionManager()
+    manager.recording_state.settings = {
+        "include_mouse_movement": False,
+        "include_mouse_clicks": False,
+        "record_start_position": False,
+        "device_overrides": {},
+    }
+    manager.recording_state.devices_cache = [
+        {
+            "path": "/dev/input/event20",
+            "recording_id": "keymasq:output:keyboard",
+            "recording_kind": "keymasq_output",
+            "device_type": "keyboard",
+            "device_types": ["keyboard"],
+        },
+        {
+            "path": "/dev/input/event21",
+            "recording_id": "physical:/dev/input/by-id/raw-mouse",
+            "recording_kind": "physical",
+            "device_type": "mouse",
+            "device_types": ["mouse"],
+        },
+    ]
+    session_recording_module.update_selected_recording_devices_cache(manager)
+    assert [
+        device["recording_id"] for device in manager.recording_state.selected_devices_cache
+    ] == ["keymasq:output:keyboard"]
+
+    session_recording_module.update_recording_settings(
+        manager,
+        {"device_overrides": {"physical:/dev/input/by-id/raw-mouse": True}},
+    )
+
+    assert [
+        device["recording_id"] for device in manager.recording_state.selected_devices_cache
+    ] == ["keymasq:output:keyboard", "physical:/dev/input/by-id/raw-mouse"]
+
+    save_task = cast(asyncio.Task[None] | None, manager.recording_state.settings_save_task)
+    if save_task is not None:
+        await save_task
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Introduce `devices_cache_ready` flag to track cache initialization
- Add `selected_devices_cache` for pre-filtered list of enabled devices
- Populate caches eagerly after profile activation and topology changes
- Recompute `selected_devices_cache` on every recording settings update
- Send full device objects (not just `recording_ids`) in `START_RECORDING` command
- Clear caches on daemon disconnect to prevent stale data

## Testing

- Updated `test_start_recording_sends_selected_devices_from_cache` to assert `devices` payload instead of `recording_ids`
- Updated `test_start_recording_defaults_to_recommended_sources_only` to check `devices` content
- Added `test_update_recording_settings_recomputes_selected_devices_cache` to verify cache recomputation