### PR TITLE
Add tests for GUI and session manager payloads

### DIFF
--- a/tests/gui/test_action_labels.py
+++ b/tests/gui/test_action_labels.py
@@ -1,0 +1,112 @@
+# ruff: noqa: F403, F405, I001
+from tests.gui.support import *
+
+
+def test_action_labels_describe_all_mapping_action_types() -> None:
+    from keymasq.common.models import ActionType, MappingAction
+    from keymasq.gui.widgets.action_labels import (
+        describe_mapping_action_compact,
+        describe_mapping_action_verbose,
+    )
+
+    actions = [
+        MappingAction(action_type=ActionType.KEYBOARD, target="key_a"),
+        MappingAction(action_type=ActionType.MOUSE, target="btn_left"),
+        MappingAction(action_type=ActionType.MOUSE_MOVE_REL, move_x=4, move_y=-3),
+        MappingAction(action_type=ActionType.MOUSE_MOVE_ABS, move_x=100, move_y=200),
+        MappingAction(action_type=ActionType.GAMEPAD, target="btn_south"),
+        MappingAction(action_type=ActionType.EXEC, cmd="notify-send hi"),
+        MappingAction(
+            action_type=ActionType.COMPOSITOR_DISPATCH,
+            compositor_dispatcher="workspace",
+            compositor_args="2",
+        ),
+        MappingAction(action_type=ActionType.SUPERKEY, superkey_name="Nav"),
+        MappingAction(action_type=ActionType.MACRO, macro_name="paste"),
+        MappingAction(action_type=ActionType.START_MACRO_RECORDING),
+        MappingAction(action_type=ActionType.STOP_MACRO_RECORDING),
+        MappingAction(action_type=ActionType.CANCEL_MACRO_PLAYBACK),
+        MappingAction(action_type=ActionType.EMERGENCY_RESET),
+        MappingAction(action_type=ActionType.PROFILE_ENABLE, profile_name="Gaming"),
+        MappingAction(action_type=ActionType.PROFILE_DISABLE, profile_name="Work"),
+        MappingAction(action_type=ActionType.PROFILE_TOGGLE, profile_name="Streaming"),
+        MappingAction(action_type=ActionType.SUPPRESS),
+        MappingAction(action_type=ActionType.PASSTHROUGH),
+    ]
+
+    compact = [describe_mapping_action_compact(action) for action in actions]
+    verbose = [
+        describe_mapping_action_verbose(
+            action,
+            keyboard_label=lambda value: f"keyboard:{value}",
+            gamepad_label=lambda value: f"gamepad:{value}",
+        )
+        for action in actions
+    ]
+
+    assert compact == [
+        "→ key_a",
+        "→ btn_left",
+        "⇢ 4,-3",
+        "⌖ 100,200",
+        "🎮 btn_south",
+        "▶ notify-send hi",
+        "🪟 workspace 2",
+        "🌟S: Nav",
+        "🎬 paste",
+        "⏺ toggle recording",
+        "⏹ stop recording",
+        "⏹ cancel playback",
+        "⏹ emergency reset",
+        "🗂 enable Gaming",
+        "🗂 disable Work",
+        "🗂 toggle Streaming",
+        "× suppress",
+        "→ legacy passthrough",
+    ]
+    assert verbose == [
+        "Keyboard → keyboard:key_a",
+        "Mouse → btn_left",
+        "Mouse Move (rel) → 4, -3",
+        "Mouse Move (abs) → 100, 200",
+        "Gamepad → gamepad:btn_south",
+        "Exec → notify-send hi",
+        "Compositor → workspace 2",
+        "Super Key → Nav",
+        "Macro → paste",
+        "Toggle Macro Recording",
+        "Stop Macro Recording",
+        "Cancel Macro Playback",
+        "Emergency Runtime Reset",
+        "Enable Profile → Gaming",
+        "Disable Profile → Work",
+        "Toggle Profile → Streaming",
+        "Suppress",
+        "Legacy Passthrough",
+    ]
+
+
+def test_action_labels_include_state_flags_and_fallbacks() -> None:
+    from keymasq.common.models import ActionType, MappingAction
+    from keymasq.gui.widgets.action_labels import (
+        describe_mapping_action_compact,
+        describe_mapping_action_verbose,
+    )
+
+    action = MappingAction(
+        action_type=ActionType.KEYBOARD,
+        target="key_b",
+        rapidfire_enabled=True,
+        tap_enabled=True,
+    )
+
+    assert describe_mapping_action_compact(None) == "No action selected"
+    assert describe_mapping_action_verbose(None) == "No action selected"
+    assert describe_mapping_action_compact(action, include_state=True) == "→ key_b ⚡ ↓"
+    assert describe_mapping_action_verbose(
+        MappingAction(action_type=ActionType.KEYBOARD),
+        keyboard_label=lambda value: f"resolved:{value}",
+    ) == "Keyboard → resolved:?"
+    assert describe_mapping_action_verbose(
+        MappingAction(action_type=ActionType.EXEC)
+    ) == "Exec → ?"

--- a/tests/gui/test_application_and_reload.py
+++ b/tests/gui/test_application_and_reload.py
@@ -1,0 +1,148 @@
+# ruff: noqa: F403, F405, I001
+from tests.gui.support import *
+
+
+def test_application_dialog_actions_route_to_window_helpers(monkeypatch) -> None:
+    import keymasq.gui.application as application_module
+    import keymasq.gui.widgets.macro_manager_dialog as macro_manager_module
+    import keymasq.gui.widgets.superkey_dialog as superkey_module
+    from keymasq.gui.application import Application
+
+    class _Window:
+        def __init__(self) -> None:
+            self.profile_manager = object()
+            self.macro_dialogs: list[object | None] = []
+            self.recording_settings = 0
+
+        def set_macro_manager_dialog(self, dialog) -> None:
+            self.macro_dialogs.append(dialog)
+
+        def present_recording_settings_dialog(self) -> None:
+            self.recording_settings += 1
+
+    class _Dialog:
+        def __init__(self, *args) -> None:
+            self.args = args
+            self.connected: list[tuple[str, object]] = []
+            self.presented_with = None
+
+        def connect(self, signal_name: str, callback, *args) -> None:
+            self.connected.append((signal_name, callback))
+
+        def present(self, parent) -> None:
+            self.presented_with = parent
+
+    class _AboutDialog(_Dialog):
+        def __init__(self, **kwargs) -> None:
+            super().__init__(kwargs)
+            self.links: list[tuple[str, str]] = []
+
+        def add_link(self, label: str, url: str) -> None:
+            self.links.append((label, url))
+
+    reloads: list[bool] = []
+    monkeypatch.setattr(
+        application_module,
+        "notify_session_reload_async",
+        lambda: reloads.append(True),
+    )
+    monkeypatch.setattr(superkey_module, "SuperkeyDialog", _Dialog)
+    monkeypatch.setattr(macro_manager_module, "MacroManagerDialog", _Dialog)
+    monkeypatch.setattr(application_module.Adw, "AboutDialog", _AboutDialog)
+
+    app = Application()
+    app._open_superkey_dialog()
+
+    window = _Window()
+    app.window = window
+
+    app._open_superkey_dialog()
+    app._on_superkey_changed(None, "Nav")
+    app._on_macros(None, None)
+    app._on_record_macro(None, None)
+    app._on_about(None, None)
+    app._on_macro_manager_closed(None, window)
+
+    assert reloads == [True]
+    assert window.recording_settings == 1
+    assert isinstance(window.macro_dialogs[0], _Dialog)
+    assert window.macro_dialogs[-1] is None
+
+
+def test_application_activate_and_main_use_configured_entrypoints(monkeypatch) -> None:
+    import keymasq.gui.application as application_module
+    from keymasq.gui.application import Application
+
+    calls: list[str] = []
+
+    class _Window:
+        def __init__(self, application, demo_mode: bool) -> None:
+            calls.append(f"window:{demo_mode}")
+            self.application = application
+            self.present_count = 0
+
+        def present(self) -> None:
+            self.present_count += 1
+
+    monkeypatch.setattr(application_module, "ensure_config_dirs", lambda: calls.append("config"))
+    monkeypatch.setattr(application_module, "MainWindow", _Window)
+
+    app = Application(demo_mode=True)
+    app.do_activate()
+    app.do_activate()
+
+    assert calls == ["config", "window:True", "config"]
+    assert app.window.present_count == 2
+
+    class _App:
+        def __init__(self, demo_mode: bool = False) -> None:
+            calls.append(f"main:{demo_mode}")
+
+        def run(self) -> None:
+            calls.append("run")
+
+    monkeypatch.setattr(application_module, "Application", _App)
+    monkeypatch.setattr(
+        application_module.argparse.ArgumentParser,
+        "parse_known_args",
+        lambda self: (SimpleNamespace(demo=True), []),
+    )
+
+    application_module.main()
+
+    assert calls[-2:] == ["main:True", "run"]
+
+
+def test_session_reload_reports_sync_and_async_status(monkeypatch) -> None:
+    import keymasq.gui.session_reload as session_reload_module
+
+    monkeypatch.setattr(
+        session_reload_module,
+        "session_request",
+        lambda payload, timeout=5.0: {"status": "ok", "payload": payload},
+    )
+    assert session_reload_module.notify_session_reload(timeout=1.0) is True
+
+    def raise_request(_payload, timeout=5.0):
+        raise RuntimeError("daemon unavailable")
+
+    monkeypatch.setattr(session_reload_module, "session_request", raise_request)
+    assert session_reload_module.notify_session_reload() is False
+
+    callbacks: list[bool] = []
+
+    def fake_session_request_async(payload, callback, timeout=5.0):
+        callbacks.append(callback({"status": "ok"}))
+        callbacks.append(callback({"status": "error"}))
+
+    monkeypatch.setattr(
+        session_reload_module,
+        "session_request_async",
+        fake_session_request_async,
+    )
+    seen: list[bool] = []
+
+    session_reload_module.notify_session_reload_async(seen.append, timeout=2.0)
+
+    assert callbacks == [False, False]
+    assert seen == [True, False]

--- a/tests/gui/test_gui_demo_and_dialogs.py
+++ b/tests/gui/test_gui_demo_and_dialogs.py
@@ -1069,3 +1069,200 @@ class TestDialogConstruction:
         assert captured["signal_name"] == "closed"
         assert captured["callback"] == dialog._on_editor_closed
         assert captured["present_parent"] is parent
+
+    def test_macro_manager_initial_state_populates_macro_rows(self, monkeypatch):
+        gi.require_version("Gtk", "4.0")
+        from gi.repository import GLib, Gtk
+
+        from keymasq.gui.session_client import GuiTaskResult
+        from keymasq.gui.widgets.macro_manager_dialog import MacroManagerDialog
+
+        monkeypatch.setattr(GLib, "idle_add", lambda callback, *args: 0)
+        dialog = MacroManagerDialog(Gtk.Window())
+
+        result = GuiTaskResult(
+            value=(
+                {
+                    "recording_active": False,
+                    "recording_unlock_required": False,
+                    "recording_unlocked": False,
+                },
+                {
+                    "macros": [
+                        {
+                            "name": "short",
+                            "duration_us": 250_000,
+                            "device_types": ["keyboard", "mouse"],
+                            "event_count": 4,
+                        },
+                        {
+                            "name": "long",
+                            "duration_us": 1_500_000,
+                            "device_types": ["gamepad"],
+                            "event_count": 2,
+                        },
+                    ]
+                },
+            )
+        )
+
+        assert dialog._on_initial_state_loaded(result) is False
+        assert dialog._recording_unlocked is True
+        assert dialog._empty_label.get_visible() is False
+        assert dialog._listbox.get_first_child() is not None
+        assert dialog._record_btn.get_tooltip_text() == "Record a new macro"
+
+        dialog._on_macros_loaded({"macros": []})
+
+        assert dialog._empty_label.get_visible() is True
+
+    def test_macro_manager_duplicate_request_and_finish_paths(self, monkeypatch):
+        gi.require_version("Gtk", "4.0")
+        from gi.repository import GLib, Gtk
+
+        from keymasq.gui.session_client import GuiTaskResult
+        import keymasq.gui.widgets.macro_manager_dialog as macro_manager_dialog_module
+        from keymasq.gui.widgets.macro_manager_dialog import MacroManagerDialog
+
+        monkeypatch.setattr(GLib, "idle_add", lambda callback, *args: 0)
+        requests: list[dict] = []
+
+        def fake_session_request(payload):
+            requests.append(payload)
+            if payload["command"] == "get_macro":
+                return {
+                    "status": "ok",
+                    "macro": {
+                        "name": payload["name"],
+                        "revision": 9,
+                        "events": [{"t_us": 1}],
+                    },
+                }
+            if payload["command"] == "create_macro":
+                return {"status": "ok"}
+            return {"status": "error", "message": "unexpected"}
+
+        monkeypatch.setattr(macro_manager_dialog_module, "session_request", fake_session_request)
+        dialog = MacroManagerDialog(Gtk.Window())
+        dialog._macros = [{"name": "copy"}, {"name": "copy_1"}]
+
+        assert dialog._duplicate_macro_request("copy") == {"status": "ok"}
+
+        create_payload = requests[-1]
+        assert create_payload["command"] == "create_macro"
+        assert create_payload["macro"]["name"] == "copy_2"
+        assert "revision" not in create_payload["macro"]
+
+        loaded: list[bool] = []
+        monkeypatch.setattr(dialog, "_load_macros", lambda: loaded.append(True) or False)
+
+        assert dialog._on_duplicate_finished(GuiTaskResult(value={"status": "ok"})) is False
+        assert loaded == [True]
+
+    def test_macro_manager_create_and_record_button_paths(self, monkeypatch):
+        gi.require_version("Gtk", "4.0")
+        from gi.repository import GLib, Gtk
+
+        import keymasq.gui.widgets.macro_manager_dialog as macro_manager_dialog_module
+        from keymasq.gui.widgets.macro_manager_dialog import MacroManagerDialog
+
+        monkeypatch.setattr(GLib, "idle_add", lambda callback, *args: 0)
+        opened: list[str] = []
+        hook_requests: list[dict] = []
+
+        class Parent(Gtk.Window):
+            def present_unlock_dialog(self, on_success):
+                opened.append("unlock")
+                on_success()
+
+        def fake_session_request_async(payload, callback):
+            if payload["command"] == "get_status":
+                callback({"recording_unlock_required": True, "recording_unlocked": True})
+            elif payload["command"] == "list_macros":
+                callback({"macros": [{"name": "macro"}, {"name": "macro_1"}]})
+
+        def fake_session_request_with_hooks(payload, callback, on_done=None, **_kwargs):
+            hook_requests.append(payload)
+            callback({"status": "ok"})
+            if on_done:
+                on_done()
+
+        monkeypatch.setattr(
+            macro_manager_dialog_module,
+            "session_request_async",
+            fake_session_request_async,
+        )
+        monkeypatch.setattr(
+            macro_manager_dialog_module,
+            "session_request_with_hooks",
+            fake_session_request_with_hooks,
+        )
+
+        dialog = MacroManagerDialog(Parent())
+        opened_names: list[str] = []
+        monkeypatch.setattr(dialog, "_open_empty_macro_editor", opened_names.append)
+
+        dialog._recording_active = False
+        dialog._recording_unlocked = False
+        dialog._on_record_new(dialog._record_btn)
+        dialog._on_empty_macro_names_loaded({"macros": [{"name": "macro"}]})
+
+        assert opened == ["unlock"]
+        assert dialog._recording_unlocked is True
+        assert opened_names == ["macro_1"]
+
+        dialog._recording_active = False
+        dialog._recording_unlocked = True
+        dialog._on_record_new(dialog._record_btn)
+        dialog._recording_active = True
+        dialog._on_record_new(dialog._record_btn)
+
+        assert hook_requests == [
+            {"command": "start_recording"},
+            {"command": "stop_recording"},
+        ]
+
+    def test_type_macro_create_validates_and_submits_macro(self, monkeypatch):
+        gi.require_version("Gtk", "4.0")
+        from gi.repository import Gtk
+
+        import keymasq.gui.widgets.macro_manager_dialog as macro_manager_dialog_module
+        from keymasq.gui.widgets.macro_manager_dialog import TypeMacroDialog
+
+        requests: list[dict] = []
+        created: list[bool] = []
+
+        def fake_session_request_with_hooks(payload, callback, on_start=None, on_done=None):
+            requests.append(payload)
+            if on_start:
+                on_start()
+            callback({"status": "ok"})
+            if on_done:
+                on_done()
+
+        monkeypatch.setattr(
+            macro_manager_dialog_module,
+            "session_request_with_hooks",
+            fake_session_request_with_hooks,
+        )
+        dialog = TypeMacroDialog(Gtk.Window(), on_created=lambda: created.append(True))
+
+        dialog.name_entry.set_text("")
+        dialog._on_create(dialog._create_btn)
+        assert dialog.error_label.get_label() == "Macro name is required"
+
+        dialog.name_entry.set_text("bad name")
+        dialog._on_create(dialog._create_btn)
+        assert dialog.error_label.get_label() == "Only letters, numbers, underscores and hyphens"
+
+        dialog.name_entry.set_text("typed")
+        dialog.text_view.get_buffer().set_text("Hi")
+        dialog.down_spin.set_value(5)
+        dialog.pause_spin.set_value(7)
+        dialog._on_create(dialog._create_btn)
+
+        assert requests[0]["command"] == "create_macro"
+        assert requests[0]["macro"]["name"] == "typed"
+        assert requests[0]["macro"]["device_types"] == ["keyboard"]
+        assert requests[0]["macro"]["events"]
+        assert created == [True]

--- a/tests/gui/test_hardware_setup_dialog.py
+++ b/tests/gui/test_hardware_setup_dialog.py
@@ -507,3 +507,202 @@ def test_keyboard_device_tab_prepends_extra_buttons_section():
     assert isinstance(first_section, Gtk.Expander)
     assert first_section.get_label() == "Extra Buttons (2)"
     assert first_section.get_expanded() is True
+
+
+def test_hardware_setup_saves_standard_keyboard_template(monkeypatch):
+    gi.require_version("Gtk", "4.0")
+    from gi.repository import Gtk
+
+    from keymasq.common.models import DeviceType
+    from keymasq.gui.wizards.hardware_setup import HardwareSetupDialog
+
+    class _HardwareManager:
+        def __init__(self) -> None:
+            self.saved = []
+
+        def save_hardware(self, config) -> None:
+            self.saved.append(config)
+
+    monkeypatch.setattr(HardwareSetupDialog, "_detect_devices", lambda self: None)
+    hardware_manager = _HardwareManager()
+    dialog = HardwareSetupDialog(Gtk.Window(), hardware_manager)
+    dialog.selected_device = {
+        "vendor_id": "1234",
+        "product_id": "5678",
+        "name": "Keyboard",
+    }
+    dialog.discovered_interfaces = {
+        "kbd": {
+            "id": "kbd",
+            "stable_path": "/dev/input/by-id/test-kbd",
+            "device_types": ["keyboard"],
+        }
+    }
+    emitted = []
+    dialog.emit = lambda signal, config: emitted.append((signal, config))
+    dialog.close = lambda: None
+
+    dialog._save_keyboard_config()
+
+    saved = hardware_manager.saved[0]
+    assert saved.evdev_devices[0].device_type == DeviceType.KEYBOARD
+    assert saved.evdev_devices[0].id == "kbd"
+    assert saved.buttons[0].id == "key_esc"
+    assert saved.buttons[0].source == "kbd"
+    assert {button.id for button in saved.buttons} >= {
+        "key_space",
+        "key_leftctrl",
+        "key_rightmeta",
+        "key_f12",
+        "key_kpenter",
+    }
+    assert emitted == [("device-created", saved)]
+
+
+def test_hardware_setup_saves_mouse_keyboard_template_with_horizontal_wheel(monkeypatch):
+    gi.require_version("Gtk", "4.0")
+    import evdev
+    from gi.repository import Gtk
+
+    from keymasq.common.models import DeviceType
+    from keymasq.gui.wizards.hardware_setup import HardwareSetupDialog
+
+    class _HardwareManager:
+        def __init__(self) -> None:
+            self.saved = []
+
+        def save_hardware(self, config) -> None:
+            self.saved.append(config)
+
+    monkeypatch.setattr(HardwareSetupDialog, "_detect_devices", lambda self: None)
+    hardware_manager = _HardwareManager()
+    dialog = HardwareSetupDialog(Gtk.Window(), hardware_manager)
+    dialog.selected_device = {
+        "vendor_id": "1234",
+        "product_id": "5678",
+        "name": "Combo",
+    }
+    dialog.discovered_interfaces = {
+        "mouse": {
+            "id": "mouse",
+            "stable_path": "/dev/input/by-id/test-mouse",
+            "device_types": ["mouse"],
+            "capabilities": ["btn_left"],
+            "raw_capabilities": {evdev.ecodes.EV_REL: [evdev.ecodes.REL_HWHEEL]},
+        },
+        "kbd": {
+            "id": "kbd",
+            "stable_path": "/dev/input/by-id/test-kbd",
+            "device_types": ["keyboard"],
+            "capabilities": ["key_a"],
+        },
+    }
+    dialog.emit = lambda _signal, _config: None
+    dialog.close = lambda: None
+
+    dialog._save_mouse_keyboard_config()
+
+    saved = hardware_manager.saved[0]
+    assert [device.id for device in saved.evdev_devices] == ["mouse", "kbd"]
+    assert [device.device_type for device in saved.evdev_devices] == [
+        DeviceType.MOUSE,
+        DeviceType.KEYBOARD,
+    ]
+    by_id = {button.id: button for button in saved.buttons}
+    assert by_id["btn_left"].source == "mouse"
+    assert by_id["wheel_left"].source == "mouse"
+    assert by_id["wheel_right"].source == "mouse"
+    assert by_id["key_a"].source == "kbd"
+
+
+def test_hardware_setup_capture_flow_records_buttons_and_saves(monkeypatch):
+    gi.require_version("Gtk", "4.0")
+    from gi.repository import Gtk
+
+    import keymasq.gui.wizards.hardware_setup as hardware_setup_module
+    from keymasq.common.models import DeviceType
+    from keymasq.gui.wizards.hardware_setup import HardwareSetupDialog
+
+    class _HardwareManager:
+        def __init__(self) -> None:
+            self.saved = []
+
+        def save_hardware(self, config) -> None:
+            self.saved.append(config)
+
+    requests: list[dict] = []
+
+    def fake_session_request_async(payload, callback):
+        requests.append(payload)
+        if payload["command"] == "begin_capture":
+            callback({"status": "ok", "warnings": ["limited permissions"]})
+        elif payload["command"] == "capture_read":
+            callback(
+                {
+                    "status": "ok",
+                    "captured": {
+                        "evdev": "btn_left",
+                        "code": 272,
+                        "value": 1,
+                        "direction": "press",
+                        "source": "mouse",
+                        "stable_path": "/dev/input/by-id/test-mouse",
+                    },
+                }
+            )
+        elif payload["command"] == "end_capture":
+            callback({"status": "ok"})
+
+    monkeypatch.setattr(HardwareSetupDialog, "_detect_devices", lambda self: None)
+    monkeypatch.setattr(hardware_setup_module, "session_request_async", fake_session_request_async)
+    monkeypatch.setattr(hardware_setup_module.GLib, "timeout_add", lambda *_args: 42)
+    monkeypatch.setattr(hardware_setup_module.GLib, "source_remove", lambda _source_id: True)
+
+    hardware_manager = _HardwareManager()
+    dialog = HardwareSetupDialog(Gtk.Window(), hardware_manager)
+    dialog._setup_page_capture()
+    dialog.selected_device = {
+        "vendor_id": "1234",
+        "product_id": "5678",
+        "name": "Capture Mouse",
+    }
+    dialog.discovered_interfaces = {
+        "mouse": {
+            "id": "mouse",
+            "stable_path": "/dev/input/by-id/test-mouse",
+            "device_types": ["mouse"],
+        }
+    }
+    dialog._capture_hardware_id = "1234:5678"
+    dialog.button_definitions = [
+        {"id": "btn_left", "label": "Left Click", "type": "button"},
+    ]
+    dialog.current_button_index = 0
+    dialog.emit = lambda _signal, _config: None
+    dialog.close = lambda: None
+
+    dialog._update_capture_ui()
+    dialog._on_start_capture(dialog.capture_btn)
+
+    assert dialog.capture_status.get_label() == "Capture warnings: limited permissions"
+    assert dialog._capture_poll_id == 42
+
+    assert dialog._poll_capture() is True
+
+    assert dialog.current_button_index == 1
+    assert dialog.capture_title.get_label() == "Setup Complete!"
+    assert dialog.capture_btn.get_label() == "Save"
+    assert dialog.button_definitions[0]["evdev"] == "btn_left"
+    assert dialog.button_definitions[0]["source"] == "mouse"
+
+    dialog._on_save(dialog.capture_btn)
+
+    saved = hardware_manager.saved[0]
+    assert saved.evdev_devices[0].device_type == DeviceType.MOUSE
+    assert saved.buttons[0].id == "btn_left"
+    assert saved.buttons[0].evdev == "btn_left"
+    assert requests == [
+        {"command": "begin_capture", "hardware_id": "1234:5678"},
+        {"command": "capture_read", "hardware_id": "1234:5678"},
+        {"command": "end_capture", "hardware_id": "1234:5678"},
+    ]

--- a/tests/gui/test_macro_editor_dialog_widget.py
+++ b/tests/gui/test_macro_editor_dialog_widget.py
@@ -668,3 +668,280 @@ def test_macro_editor_save_request_paths_and_undo(monkeypatch) -> None:
     assert dialog._macro_loop_finish_check.get_active() is False
     assert dialog._macro_move_to_start_check.get_active() is False
     assert dialog._macro_start_x_spin.get_value_as_int() == 0
+
+
+def test_macro_editor_time_mapping_updates_all_event_kinds(monkeypatch) -> None:
+    dialog = _build_macro_dialog(monkeypatch)
+    keyboard = EditableEvent(
+        device_type="keyboard",
+        ev_type=evdev.ecodes.EV_KEY,
+        code=evdev.ecodes.KEY_A,
+        press_t_us=1000,
+        release_t_us=3000,
+    )
+    mouse = EditableEvent(
+        device_type="mouse",
+        ev_type=evdev.ecodes.EV_KEY,
+        code=evdev.ecodes.BTN_LEFT,
+        press_t_us=5000,
+        release_t_us=9000,
+    )
+    move = EditableMove(mode="abs", t_us=7000, x=11, y=22)
+    control = EditableControl(mode="wait", t_us=8000, duration_us=2000)
+    passthrough = {
+        "device_type": "keyboard",
+        "type": evdev.ecodes.EV_KEY,
+        "code": evdev.ecodes.KEY_B,
+        "value": 2,
+        "t_us": 6000,
+    }
+    rel = {
+        "device_type": "mouse",
+        "type": evdev.ecodes.EV_REL,
+        "code": evdev.ecodes.REL_X,
+        "value": 4,
+        "t_us": 4000,
+    }
+    dialog._events = [mouse, keyboard]
+    dialog._rel_events = [rel]
+    dialog._passthrough_events = [passthrough]
+    dialog._synthetic_moves = [move]
+    dialog._control_events = [control]
+
+    mapping = dialog._build_time_mapping_with_gap_limits(
+        scale=2.0,
+        min_gap_us=500,
+        max_gap_us=1500,
+    )
+    dialog._apply_time_map(mapping)
+    dialog._recompute_duration()
+
+    assert dialog._events == [keyboard, mouse]
+    assert keyboard.press_t_us == 1000
+    assert keyboard.release_t_us == 2500
+    assert rel["t_us"] == 4000
+    assert mouse.press_t_us == 5500
+    assert passthrough["t_us"] == 7000
+    assert move.t_us == 8500
+    assert control.t_us == 10500
+    assert dialog._duration_us == 12000
+
+
+def test_macro_editor_trim_and_gap_helpers_keep_selection_consistent(monkeypatch) -> None:
+    dialog = _build_macro_dialog(monkeypatch)
+    removed = EditableEvent(
+        device_type="keyboard",
+        ev_type=evdev.ecodes.EV_KEY,
+        code=evdev.ecodes.KEY_A,
+        press_t_us=1000,
+        release_t_us=2000,
+    )
+    kept = EditableEvent(
+        device_type="keyboard",
+        ev_type=evdev.ecodes.EV_KEY,
+        code=evdev.ecodes.KEY_B,
+        press_t_us=5000,
+        release_t_us=9000,
+    )
+    move = EditableMove(mode="rel", t_us=6000, x=1, y=2)
+    control = EditableControl(mode="exec_sync", t_us=7000, command="echo hi")
+    dialog._events = [removed, kept]
+    dialog._rel_events = [
+        {
+            "device_type": "mouse",
+            "type": evdev.ecodes.EV_REL,
+            "code": evdev.ecodes.REL_X,
+            "value": 3,
+            "t_us": 6500,
+        }
+    ]
+    dialog._passthrough_events = [
+        {
+            "device_type": "mouse",
+            "type": evdev.ecodes.EV_KEY,
+            "code": evdev.ecodes.BTN_RIGHT,
+            "value": 2,
+            "t_us": 7500,
+        }
+    ]
+    dialog._synthetic_moves = [move]
+    dialog._control_events = [control]
+    dialog._timeline._selected = removed
+
+    dialog._set_startpoint(4000)
+
+    assert dialog._timeline._selected is None
+    assert dialog._revealer.get_reveal_child() is False
+    assert dialog._events == [kept]
+    assert kept.press_t_us == 1000
+    assert kept.release_t_us == 5000
+    assert move.t_us == 2000
+    assert control.t_us == 3000
+
+    dialog._timeline._selected = kept
+    dialog._set_endpoint(2500)
+
+    assert dialog._events == [kept]
+    assert kept.release_t_us == 2500
+    assert dialog._synthetic_moves == [move]
+    assert dialog._control_events == []
+    assert dialog._timeline._selected is kept
+
+
+def test_macro_editor_shift_timeline_for_gap_respects_scopes(monkeypatch) -> None:
+    dialog = _build_macro_dialog(monkeypatch)
+    keyboard = EditableEvent(
+        device_type="keyboard",
+        ev_type=evdev.ecodes.EV_KEY,
+        code=evdev.ecodes.KEY_A,
+        press_t_us=1000,
+        release_t_us=2000,
+    )
+    mouse = EditableEvent(
+        device_type="mouse",
+        ev_type=evdev.ecodes.EV_KEY,
+        code=evdev.ecodes.BTN_LEFT,
+        press_t_us=1000,
+        release_t_us=2000,
+    )
+    excluded = EditableControl(mode="wait", t_us=1000, duration_us=500)
+    shifted = EditableControl(mode="wait_random", t_us=2000, min_us=500, max_us=1500)
+    move = EditableMove(mode="rel", t_us=1000, x=1, y=1)
+    dialog._events = [keyboard, mouse]
+    dialog._synthetic_moves = [move]
+    dialog._control_events = [excluded, shifted]
+    dialog._rel_events = [
+        {
+            "device_type": "mouse",
+            "type": evdev.ecodes.EV_REL,
+            "code": evdev.ecodes.REL_Y,
+            "value": -1,
+            "t_us": 1000,
+        }
+    ]
+    dialog._passthrough_events = [
+        {
+            "device_type": "keyboard",
+            "type": evdev.ecodes.EV_KEY,
+            "code": evdev.ecodes.KEY_C,
+            "value": 2,
+            "t_us": 1000,
+        },
+        {
+            "device_type": "mouse",
+            "type": evdev.ecodes.EV_REL,
+            "code": evdev.ecodes.REL_X,
+            "value": 5,
+            "t_us": 1000,
+        },
+    ]
+
+    assert dialog._shift_timeline_for_gap(
+        at_us=1000,
+        delta_us=500,
+        scope="movement",
+        exclude_control=excluded,
+    ) is True
+    assert keyboard.press_t_us == 1000
+    assert mouse.press_t_us == 1000
+    assert move.t_us == 1500
+    assert dialog._rel_events[0]["t_us"] == 1500
+    assert excluded.t_us == 1000
+    assert shifted.t_us == 2500
+    assert dialog._passthrough_events[0]["t_us"] == 1000
+    assert dialog._passthrough_events[1]["t_us"] == 1500
+
+    assert dialog._shift_timeline_for_gap(
+        at_us=1000,
+        delta_us=-750,
+        scope="keyboard",
+        exclude_control=None,
+    ) is True
+    assert keyboard.press_t_us == 250
+    assert keyboard.release_t_us == 1250
+    assert mouse.press_t_us == 1000
+    assert dialog._passthrough_events[0]["t_us"] == 250
+
+
+def test_macro_editor_timeline_draws_and_hit_tests_all_tracks(monkeypatch) -> None:
+    import cairo
+
+    dialog = _build_macro_dialog(monkeypatch)
+    keyboard = EditableEvent(
+        device_type="keyboard",
+        ev_type=evdev.ecodes.EV_KEY,
+        code=evdev.ecodes.KEY_A,
+        press_t_us=10_000,
+        release_t_us=180_000,
+    )
+    mouse = EditableEvent(
+        device_type="mouse",
+        ev_type=evdev.ecodes.EV_KEY,
+        code=evdev.ecodes.BTN_LEFT,
+        press_t_us=60_000,
+        release_t_us=220_000,
+    )
+    move = EditableMove(mode="rel", t_us=40_000, x=8, y=-6)
+    absolute_move = EditableMove(mode="abs", t_us=280_000, x=640, y=360)
+    wait = EditableControl(mode="wait", t_us=150_000, duration_us=40_000)
+    command = EditableControl(mode="exec_sync", t_us=260_000, command="echo hi")
+    compositor = EditableControl(
+        mode="compositor_dispatch",
+        t_us=300_000,
+        compositor_dispatcher="workspace",
+        compositor_args="1",
+    )
+    keyboard_passthrough = {
+        "device_type": "keyboard",
+        "type": evdev.ecodes.EV_KEY,
+        "code": evdev.ecodes.KEY_B,
+        "value": 2,
+        "t_us": 120_000,
+    }
+    movement_passthrough = {
+        "device_type": "mouse",
+        "type": evdev.ecodes.EV_REL,
+        "code": evdev.ecodes.REL_Y,
+        "value": -3,
+        "t_us": 210_000,
+    }
+    dialog._events = [keyboard, mouse]
+    dialog._rel_events = [
+        {
+            "device_type": "mouse",
+            "type": evdev.ecodes.EV_REL,
+            "code": evdev.ecodes.REL_X,
+            "value": 4,
+            "t_us": 90_000,
+        }
+    ]
+    dialog._passthrough_events = [keyboard_passthrough, movement_passthrough]
+    dialog._synthetic_moves = [move, absolute_move]
+    dialog._control_events = [wait, command, compositor]
+    dialog._duration_us = 350_000
+    timeline = dialog._timeline
+    timeline._recompute_lanes()
+
+    surface = cairo.ImageSurface(cairo.FORMAT_ARGB32, 1200, 520)
+    context = cairo.Context(surface)
+    timeline._draw(None, context, 1200, 520, None)
+
+    assert timeline._get_track_at_y(timeline._kb_y + 5) == "keyboard"
+    assert timeline._get_track_at_y(timeline._m_y + 5) == "mouse"
+    assert timeline._get_track_at_y(timeline._wave_y + 5) == "movement"
+    assert timeline._hit_test(
+        timeline._time_to_x(keyboard.press_t_us) + 2,
+        timeline._kb_y + 12,
+    ) is keyboard
+    assert timeline._hit_test(
+        timeline._time_to_x(mouse.press_t_us) + 2,
+        timeline._m_y + 12,
+    ) is mouse
+    assert timeline._hit_test_move(
+        timeline._time_to_x(move.t_us),
+        timeline._wave_y + 14,
+    ) is move
+    assert timeline._hit_test_control(
+        timeline._time_to_x(compositor.t_us),
+        timeline._wave_y + timeline.TRACK_HEIGHT - 14,
+    ) is compositor

--- a/tests/session/test_session_manager_payloads_extra.py
+++ b/tests/session/test_session_manager_payloads_extra.py
@@ -1,0 +1,283 @@
+# ruff: noqa: F403, F405, I001
+from typing import cast
+
+from tests.session.command_support import *
+
+
+def _manager_with_superkeys(*configs):
+    from keymasq.session.manager.state import ExecRuntimeState, ProfileRuntimeState
+
+    by_name = {config.name: config for config in configs}
+    return SimpleNamespace(
+        exec_state=ExecRuntimeState(),
+        profile_state=ProfileRuntimeState(),
+        superkeys=SimpleNamespace(get_superkey=lambda name: by_name.get(name)),
+    )
+
+
+def test_profile_to_mapping_serializes_high_value_action_payloads() -> None:
+    from keymasq.common.models import ActionType, MappingAction, SuperkeyConfig, SuperkeyMode
+    from keymasq.session.manager import payloads
+    from keymasq.session.profiles import ResolvedDeviceProfile
+
+    superkey = SuperkeyConfig(
+        name="launcher",
+        mode=SuperkeyMode.OVERLOAD,
+        overload_actions=[
+            MappingAction(action_type=ActionType.KEYBOARD, target="key_space"),
+            MappingAction(action_type=ActionType.EXEC, cmd="notify-send launcher"),
+        ],
+    )
+    manager = _manager_with_superkeys(superkey)
+    resolved = ResolvedDeviceProfile(
+        hardware_id="kbd",
+        mappings={
+            "a": MappingAction(
+                action_type=ActionType.KEYBOARD,
+                target="key_a",
+                rapidfire_enabled=True,
+                rapidfire_hold_ms=7,
+                rapidfire_wait_ms=9,
+                tap_enabled=True,
+                tap_hold_ms=12,
+            ),
+            "move": MappingAction(
+                action_type=ActionType.MOUSE_MOVE_ABS,
+                target="cursor",
+                move_x=320,
+                move_y=240,
+            ),
+            "exec": MappingAction(action_type=ActionType.EXEC, cmd="echo hi"),
+            "dispatch": MappingAction(
+                action_type=ActionType.COMPOSITOR_DISPATCH,
+                compositor_id="hyprland",
+                compositor_dispatcher="workspace",
+                compositor_args="2",
+            ),
+            "macro": MappingAction(
+                action_type=ActionType.MACRO,
+                macro_name="paste",
+                macro_replay_mouse_movement=False,
+                macro_replay_mouse_clicks=True,
+                macro_speed=1.25,
+                macro_loop_mode="count",
+                macro_loop_count=3,
+                macro_loop_stop_behavior="cancel_run",
+                macro_move_to_start=True,
+                macro_start_x=10,
+                macro_start_y=20,
+                macro_block_mouse_movement=True,
+            ),
+            "profile": MappingAction(
+                action_type=ActionType.PROFILE_TOGGLE,
+                profile_name="Gaming",
+            ),
+            "super": MappingAction(
+                action_type=ActionType.SUPERKEY,
+                superkey_name="launcher",
+            ),
+        },
+    )
+
+    mapping = payloads.profile_to_mapping(manager, resolved, "kbd")
+
+    assert mapping["a"] == {
+        "action": "keyboard",
+        "target": "key_a",
+        "rapidfire_enabled": True,
+        "rapidfire_hold_ms": 7,
+        "rapidfire_wait_ms": 9,
+        "tap_enabled": True,
+        "tap_hold_ms": 12,
+    }
+    assert mapping["move"] == {
+        "action": "mouse_move_abs",
+        "target": "cursor",
+        "x": 320,
+        "y": 240,
+    }
+    assert mapping["exec"] == {"action": "exec", "exec_ref": 1}
+    assert manager.exec_state.exec_refs == {1: "echo hi"}
+    assert manager.exec_state.device_exec_refs == {"kbd": {1}}
+    assert mapping["dispatch"] == {
+        "action": "compositor_dispatch",
+        "compositor": "hyprland",
+        "dispatcher": "workspace",
+        "args": "2",
+    }
+    macro_mapping = cast(dict[str, object], mapping["macro"])
+    assert macro_mapping["macro_name"] == "paste"
+    assert macro_mapping["macro_loop_count"] == 3
+    assert macro_mapping["macro_block_mouse_movement"] is True
+    assert mapping["profile"] == {"action": "profile_toggle", "profile_name": "Gaming"}
+    super_mapping = cast(dict[str, object], mapping["super"])
+    superkey_payload = cast(dict[str, object], super_mapping["superkey"])
+    overload_actions = cast(list[dict[str, object]], superkey_payload["overload_actions"])
+    assert overload_actions[1] == {
+        "action": "exec",
+        "exec_ref": 10000,
+    }
+    assert manager.exec_state.superkey_exec_refs == {10000: ("kbd", "notify-send launcher")}
+
+
+def test_combo_payloads_filter_invalid_actions_and_track_exec_refs() -> None:
+    from keymasq.common.models import (
+        ActionType,
+        ComboEvent,
+        ComboStep,
+        MappingAction,
+        SuperkeyAction,
+        SuperkeyConfig,
+        SuperkeyMode,
+    )
+    from keymasq.session.manager import payloads
+    from keymasq.session.profiles import ResolvedCombo
+
+    superkey = SuperkeyConfig(
+        name="pattern",
+        mode=SuperkeyMode.PATTERN,
+        tap_actions=[SuperkeyAction(action_type=ActionType.EXEC, cmd="echo tap")],
+        double_tap_actions=[
+            SuperkeyAction(
+                action_type=ActionType.COMPOSITOR_DISPATCH,
+                compositor_dispatcher="togglefloating",
+            )
+        ],
+        hold_actions=[
+            SuperkeyAction(
+                action_type=ActionType.MACRO,
+                macro_name="hold_macro",
+                macro_loop_mode="hold",
+                macro_loop_stop_behavior="cancel_run",
+            )
+        ],
+        tap_hold_actions=[
+            SuperkeyAction(action_type=ActionType.PROFILE_ENABLE, profile_name="Work")
+        ],
+    )
+    manager = _manager_with_superkeys(superkey)
+    good_step = ComboStep(
+        events=[
+            ComboEvent(hardware_id="kbd", source="main", evdev="key_a"),
+            ComboEvent(hardware_id="", source="ignored", evdev="key_b"),
+        ],
+        timeout_ms=250,
+    )
+    empty_step = ComboStep(events=[ComboEvent(hardware_id="kbd", evdev="")])
+
+    combos = [
+        ResolvedCombo(
+            id="empty",
+            name="empty",
+            steps=[good_step],
+            action=MappingAction(action_type=ActionType.EXEC),
+        ),
+        ResolvedCombo(
+            id="dispatch",
+            name="dispatch",
+            steps=[good_step, empty_step],
+            action=MappingAction(
+                action_type=ActionType.COMPOSITOR_DISPATCH,
+                compositor_dispatcher="workspace",
+                compositor_args="3",
+            ),
+            profile_name="Default",
+            recall_trigger_keys=True,
+            restore_trigger_keys=["key_a"],
+        ),
+        ResolvedCombo(
+            id="super",
+            name="super",
+            steps=[good_step],
+            action=MappingAction(action_type=ActionType.SUPERKEY, superkey_name="pattern"),
+        ),
+    ]
+
+    combo_payload = payloads.resolved_combos_payload(manager, combos)
+
+    assert [combo["id"] for combo in combo_payload] == ["dispatch", "super"]
+    assert combo_payload[0] == {
+        "id": "dispatch",
+        "name": "dispatch",
+        "profile_name": "Default",
+        "steps": [
+            {
+                "events": [{"hardware_id": "kbd", "evdev": "key_a", "source": "main"}],
+                "timeout_ms": 250,
+            }
+        ],
+        "action": {
+            "action": "compositor_dispatch",
+            "dispatcher": "workspace",
+            "args": "3",
+        },
+        "recall_trigger_keys": True,
+        "restore_trigger_keys": ["key_a"],
+    }
+    combo_action = cast(dict[str, object], combo_payload[1]["action"])
+    super_action = cast(dict[str, object], combo_action["superkey"])
+    assert super_action["tap_actions"] == [{"action": "exec", "exec_ref": 10000}]
+    assert super_action["double_tap_actions"] == [
+        {
+            "action": "compositor_dispatch",
+            "dispatcher": "togglefloating",
+            "args": "",
+        }
+    ]
+    hold_actions = cast(list[dict[str, object]], super_action["hold_actions"])
+    assert hold_actions[0]["macro_name"] == "hold_macro"
+    assert super_action["tap_hold_actions"] == [
+        {"action": "profile_enable", "profile_name": "Work"}
+    ]
+    assert manager.exec_state.combo_superkey_exec_refs == {10000}
+
+
+def test_payload_signatures_and_log_view_are_stable() -> None:
+    from keymasq.common.models import ActionType, ComboEvent, ComboStep, MappingAction
+    from keymasq.session.manager import payloads
+    from keymasq.session.profiles import ResolvedCombo, ResolvedDeviceProfile
+
+    manager = _manager_with_superkeys()
+    resolved = ResolvedDeviceProfile(
+        hardware_id="kbd",
+        mappings={
+            "b": MappingAction(action_type=ActionType.EXEC, cmd="echo b"),
+            "a": MappingAction(
+                action_type=ActionType.MACRO,
+                macro_name="typed",
+                macro_events=[{"t_us": 1}, {"t_us": 2}],
+            ),
+        },
+    )
+    combo = ResolvedCombo(
+        id="combo",
+        name="Combo",
+        profile_name="Default",
+        steps=[
+            ComboStep(
+                events=[
+                    ComboEvent(hardware_id="kbd", source="z", evdev="key_z"),
+                    ComboEvent(hardware_id="kbd", source="a", evdev="key_a"),
+                ]
+            )
+        ],
+        action=MappingAction(action_type=ActionType.MACRO, macro_name="typed"),
+    )
+
+    mapping_signature = payloads.resolved_mapping_signature(manager, resolved, "kbd")
+    combo_signature = payloads.resolved_combos_signature(manager, [combo])
+    log_view = payloads.mapping_log_view(
+        {
+            "macro": {
+                "action": "macro",
+                "macro_events": [{"t_us": 1}, {"t_us": 2}],
+            },
+            "raw": "unchanged",
+        }
+    )
+
+    assert '"cmd":"echo b"' in mapping_signature
+    assert combo_signature.index('"source":"a"') < combo_signature.index('"source":"z"')
+    macro_log = cast(dict[str, object], log_view["macro"])
+    assert macro_log["macro_events"] == "<2 events>"
+    assert log_view["raw"] == "unchanged"

--- a/tests/test_wayland_protocol_trackers.py
+++ b/tests/test_wayland_protocol_trackers.py
@@ -1,12 +1,54 @@
 import asyncio
+import struct
+from pathlib import Path
 
+from keymasq.session.wayland_protocols import cosmic_toplevel_info_client as cosmic_client_module
+from keymasq.session.wayland_protocols import registry_probe
+from keymasq.session.wayland_protocols import wlr_foreign_toplevel_client as wlr_client_module
 from keymasq.session.wayland_protocols.ext_foreign_toplevel_list import (
     ExtForeignToplevelListTracker,
+)
+from keymasq.session.wayland_protocols.ext_foreign_toplevel_list_client import (
+    EXT_FOREIGN_TOPLEVEL_LIST_INTERFACE,
+    ExtForeignToplevelListWaylandClient,
 )
 from keymasq.session.wayland_protocols.wlr_foreign_toplevel_manager import (
     WLR_TOPLEVEL_STATE_ACTIVATED,
     WlrForeignToplevelManagerTracker,
 )
+
+
+class _FakeWaylandSocket:
+    def __init__(self) -> None:
+        self.sent: list[bytes] = []
+        self.closed = False
+
+    def sendall(self, data: bytes) -> None:
+        self.sent.append(data)
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def _wl_message(object_id: int, opcode: int, payload: bytes = b"") -> bytes:
+    size = 8 + len(payload)
+    return struct.pack("<II", object_id, ((size & 0xFFFF) << 16) | (opcode & 0xFFFF)) + payload
+
+
+def _registry_payload(global_name: int, interface: str, version: int) -> bytes:
+    return struct.pack("<I", global_name) + _encode_string(interface) + struct.pack("<I", version)
+
+
+def _encode_string(value: str) -> bytes:
+    encoded = value.encode("utf-8") + b"\x00"
+    padded = (len(encoded) + 3) & ~3
+    return struct.pack("<I", len(encoded)) + encoded + (b"\x00" * (padded - len(encoded)))
+
+
+def _encode_array(values: list[int]) -> bytes:
+    raw = b"".join(value.to_bytes(4, byteorder="little") for value in values)
+    padded = (len(raw) + 3) & ~3
+    return struct.pack("<I", len(raw)) + raw + (b"\x00" * (padded - len(raw)))
 
 
 def test_ext_tracker_emits_on_activation() -> None:
@@ -80,3 +122,367 @@ def test_wlr_tracker_switches_focus_between_handles() -> None:
     tracker.update_state("b", [WLR_TOPLEVEL_STATE_ACTIVATED])
     assert asyncio.run(tracker.next_active_window(timeout=0.01)) == ("", "")
     assert asyncio.run(tracker.next_active_window(timeout=0.01)) == ("b-app", "B")
+
+
+class _ProbeSocket:
+    def __init__(self, *responses: bytes) -> None:
+        self.responses = list(responses)
+        self.sent: list[bytes] = []
+        self.closed = False
+
+    def settimeout(self, timeout: float) -> None:
+        return
+
+    def connect(self, _path: str) -> None:
+        return
+
+    def sendall(self, data: bytes) -> None:
+        self.sent.append(data)
+
+    def recv(self, size: int) -> bytes:
+        if not self.responses:
+            return b""
+        return self.responses.pop(0)
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def test_registry_probe_reads_globals_sync(monkeypatch) -> None:
+    probe_socket = _ProbeSocket(
+                _wl_message(
+                    2,
+                    0,
+                    _registry_payload(7, EXT_FOREIGN_TOPLEVEL_LIST_INTERFACE, 1),
+                )
+                + _wl_message(2, 0, _registry_payload(8, "zwlr_foreign_toplevel_manager_v1", 3))
+                + _wl_message(3, 0)
+    )
+    monkeypatch.setattr(
+        registry_probe.socket,
+        "socket",
+        lambda _family, _type: probe_socket,
+    )
+
+    assert registry_probe.list_registry_globals_sync(Path("unused"), timeout_s=2.0) == {
+        EXT_FOREIGN_TOPLEVEL_LIST_INTERFACE,
+        "zwlr_foreign_toplevel_manager_v1",
+    }
+    assert len(probe_socket.sent) == 2
+    assert probe_socket.closed is True
+
+
+def test_registry_probe_reads_globals_async(tmp_path: Path) -> None:
+    async def run_probe() -> set[str]:
+        socket_path = tmp_path / "wayland-async"
+
+        async def handle_client(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+            await reader.read(4096)
+            writer.write(
+                _wl_message(2, 0, _registry_payload(1, "zcosmic_toplevel_info_v1", 3))
+                + _wl_message(3, 0)
+            )
+            await writer.drain()
+            await asyncio.wait_for(reader.read(4096), timeout=1.0)
+            writer.close()
+            await writer.wait_closed()
+
+        server = await asyncio.start_unix_server(handle_client, path=str(socket_path))
+        try:
+            return await registry_probe.list_registry_globals(socket_path)
+        finally:
+            server.close()
+            await server.wait_closed()
+
+    assert asyncio.run(run_probe()) == {"zcosmic_toplevel_info_v1"}
+
+
+def test_ext_wayland_client_dispatches_registry_and_toplevel_events() -> None:
+    tracker = ExtForeignToplevelListTracker()
+    client = ExtForeignToplevelListWaylandClient(tracker)
+    fake_socket = _FakeWaylandSocket()
+    client._socket = fake_socket
+    client._registry_id = 2
+    client._objects[2] = client._objects[1].__class__("wl_registry")
+
+    client._handle_registry_event(
+        2,
+        0,
+        _registry_payload(12, EXT_FOREIGN_TOPLEVEL_LIST_INTERFACE, 9),
+    )
+    assert client._list_id is not None
+    assert fake_socket.sent
+
+    client._handle_list_event(client._list_id, 0, struct.pack("<I", 40))
+    client._handle_toplevel_event(40, 2, _encode_string("Terminal"))
+    client._handle_toplevel_event(40, 3, _encode_string("org.example.Terminal"))
+    tracker.update_state("40", [2])
+    assert tracker.get_active_window() == ("org.example.Terminal", "Terminal")
+
+    client._handle_callback_event(99, 1)
+    client._sync_waiters.add(99)
+    client._handle_callback_event(99, 0)
+    assert 99 not in client._sync_waiters
+
+    client._handle_toplevel_event(40, 0, b"")
+    assert "40" not in tracker._windows
+    client._handle_display_event(1, struct.pack("<I", 40))
+    asyncio.run(client.stop())
+    assert fake_socket.closed is True
+
+
+def test_wlr_wayland_client_dispatches_manager_and_toplevel_events() -> None:
+    tracker = WlrForeignToplevelManagerTracker()
+    client = wlr_client_module.WlrForeignToplevelWaylandClient(tracker)
+    fake_socket = _FakeWaylandSocket()
+    client._socket = fake_socket
+    client._registry_id = 2
+    client._objects[2] = client._objects[1].__class__("wl_registry")
+
+    client._handle_registry_event(
+        2,
+        0,
+        _registry_payload(3, wlr_client_module.WLR_FOREIGN_TOPLEVEL_MANAGER_INTERFACE, 6),
+    )
+    assert client._manager_id is not None
+
+    client._handle_manager_event(client._manager_id, 0, struct.pack("<I", 50))
+    client._handle_toplevel_event(50, 0, _encode_string("Editor"))
+    client._handle_toplevel_event(50, 1, _encode_string("code"))
+    client._handle_toplevel_event(50, 4, _encode_array([WLR_TOPLEVEL_STATE_ACTIVATED]))
+    assert tracker.get_active_window() == ("code", "Editor")
+
+    client._handle_toplevel_event(50, 6, b"")
+    assert tracker.get_active_window() == ("", "")
+    asyncio.run(client.stop())
+    assert fake_socket.closed is True
+
+
+def test_cosmic_wayland_client_links_ext_handles_to_cosmic_state() -> None:
+    tracker = ExtForeignToplevelListTracker()
+    client = cosmic_client_module.CosmicToplevelInfoWaylandClient(tracker)
+    fake_socket = _FakeWaylandSocket()
+    client._socket = fake_socket
+    client._registry_id = 2
+    client._objects[2] = client._objects[1].__class__("wl_registry")
+
+    client._handle_registry_event(
+        2,
+        0,
+        _registry_payload(4, cosmic_client_module.EXT_FOREIGN_TOPLEVEL_LIST_INTERFACE, 1),
+    )
+    client._handle_registry_event(
+        2,
+        0,
+        _registry_payload(5, cosmic_client_module.COSMIC_TOPLEVEL_INFO_INTERFACE, 99),
+    )
+    assert client._list_id is not None
+    assert client._cosmic_info_id is not None
+
+    client._handle_list_event(client._list_id, 0, struct.pack("<I", 70))
+    cosmic_handle = client._ext_to_cosmic[70]
+    client._handle_toplevel_event(70, 2, _encode_string("Settings"))
+    client._handle_toplevel_event(70, 3, _encode_string("com.system76.Settings"))
+    client._handle_cosmic_toplevel_event(cosmic_handle, 8, _encode_array([2]))
+    assert tracker.get_active_window() == ("com.system76.Settings", "Settings")
+
+    client._handle_cosmic_info_event(2)
+    assert asyncio.run(tracker.next_active_window(timeout=0.01)) == (
+        "com.system76.Settings",
+        "Settings",
+    )
+
+    client._handle_display_event(1, struct.pack("<I", 70))
+    assert 70 not in client._toplevel_handles
+    assert cosmic_handle not in client._cosmic_handles
+    asyncio.run(client.stop())
+    assert fake_socket.closed is True
+
+
+def test_wayland_clients_require_display_environment(monkeypatch) -> None:
+    monkeypatch.delenv("XDG_RUNTIME_DIR", raising=False)
+    monkeypatch.delenv("WAYLAND_DISPLAY", raising=False)
+
+    async def start_clients() -> None:
+        ext = ExtForeignToplevelListWaylandClient(ExtForeignToplevelListTracker())
+        wlr = wlr_client_module.WlrForeignToplevelWaylandClient(
+            WlrForeignToplevelManagerTracker()
+        )
+        cosmic = cosmic_client_module.CosmicToplevelInfoWaylandClient(
+            ExtForeignToplevelListTracker()
+        )
+        for client in (ext, wlr, cosmic):
+            try:
+                await client.start()
+            except RuntimeError as exc:
+                assert "WAYLAND_DISPLAY" in str(exc)
+            else:
+                raise AssertionError("client.start() unexpectedly succeeded")
+
+    asyncio.run(start_clients())
+
+
+def test_ext_wayland_client_start_and_run_against_minimal_socket(tmp_path: Path) -> None:
+    async def run_client() -> tuple[str, str]:
+        socket_path = tmp_path / "ext-wayland"
+
+        async def handle_client(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+            await reader.read(4096)
+            writer.write(
+                _wl_message(
+                    2,
+                    0,
+                    _registry_payload(1, EXT_FOREIGN_TOPLEVEL_LIST_INTERFACE, 1),
+                )
+                + _wl_message(3, 0)
+            )
+            await writer.drain()
+
+            await reader.read(4096)
+            writer.write(_wl_message(5, 0))
+            await writer.drain()
+
+            await asyncio.sleep(0.01)
+            writer.write(
+                _wl_message(4, 0, struct.pack("<I", 80))
+                + _wl_message(80, 2, _encode_string("Live Window"))
+                + _wl_message(80, 3, _encode_string("live.app"))
+                + _wl_message(4, 1)
+            )
+            await writer.drain()
+            await asyncio.wait_for(reader.read(4096), timeout=1.0)
+            writer.close()
+            await writer.wait_closed()
+
+        server = await asyncio.start_unix_server(handle_client, path=str(socket_path))
+        tracker = ExtForeignToplevelListTracker()
+        client = ExtForeignToplevelListWaylandClient(tracker, socket_path=str(socket_path))
+        try:
+            await client.start()
+            await client.run()
+            tracker.update_state("80", [2])
+            return tracker.get_active_window()
+        finally:
+            await client.stop()
+            server.close()
+            await server.wait_closed()
+
+    assert asyncio.run(run_client()) == ("live.app", "Live Window")
+
+
+def test_wlr_wayland_client_start_and_run_against_minimal_socket(tmp_path: Path) -> None:
+    async def run_client() -> tuple[str, str]:
+        socket_path = tmp_path / "wlr-wayland"
+
+        async def handle_client(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+            await reader.read(4096)
+            writer.write(
+                _wl_message(
+                    2,
+                    0,
+                    _registry_payload(
+                        1,
+                        wlr_client_module.WLR_FOREIGN_TOPLEVEL_MANAGER_INTERFACE,
+                        3,
+                    ),
+                )
+                + _wl_message(3, 0)
+            )
+            await writer.drain()
+
+            await reader.read(4096)
+            writer.write(_wl_message(5, 0))
+            await writer.drain()
+
+            await asyncio.sleep(0.01)
+            writer.write(
+                _wl_message(4, 0, struct.pack("<I", 90))
+                + _wl_message(90, 0, _encode_string("WLR Window"))
+                + _wl_message(90, 1, _encode_string("wlr.app"))
+                + _wl_message(90, 4, _encode_array([WLR_TOPLEVEL_STATE_ACTIVATED]))
+            )
+            await writer.drain()
+            writer.close()
+            await writer.wait_closed()
+
+        server = await asyncio.start_unix_server(handle_client, path=str(socket_path))
+        tracker = WlrForeignToplevelManagerTracker()
+        client = wlr_client_module.WlrForeignToplevelWaylandClient(
+            tracker,
+            socket_path=str(socket_path),
+        )
+        try:
+            await client.start()
+            await client.run()
+            return tracker.get_active_window()
+        finally:
+            await client.stop()
+            server.close()
+            await server.wait_closed()
+
+    assert asyncio.run(run_client()) == ("wlr.app", "WLR Window")
+
+
+def test_cosmic_wayland_client_start_and_run_against_minimal_socket(tmp_path: Path) -> None:
+    async def run_client() -> tuple[str, str]:
+        socket_path = tmp_path / "cosmic-wayland"
+
+        async def handle_client(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+            await reader.read(4096)
+            writer.write(
+                _wl_message(
+                    2,
+                    0,
+                    _registry_payload(
+                        1,
+                        cosmic_client_module.EXT_FOREIGN_TOPLEVEL_LIST_INTERFACE,
+                        1,
+                    ),
+                )
+                + _wl_message(
+                    2,
+                    0,
+                    _registry_payload(
+                        2,
+                        cosmic_client_module.COSMIC_TOPLEVEL_INFO_INTERFACE,
+                        3,
+                    ),
+                )
+                + _wl_message(3, 0)
+            )
+            await writer.drain()
+
+            await reader.read(4096)
+            writer.write(_wl_message(6, 0))
+            await writer.drain()
+
+            await asyncio.sleep(0.01)
+            writer.write(
+                _wl_message(4, 0, struct.pack("<I", 100))
+                + _wl_message(5, 2)
+                + _wl_message(100, 2, _encode_string("COSMIC Window"))
+                + _wl_message(100, 3, _encode_string("cosmic.app"))
+                + _wl_message(7, 8, _encode_array([2]))
+                + _wl_message(4, 1)
+            )
+            await writer.drain()
+            await asyncio.wait_for(reader.read(4096), timeout=1.0)
+            writer.close()
+            await writer.wait_closed()
+
+        server = await asyncio.start_unix_server(handle_client, path=str(socket_path))
+        tracker = ExtForeignToplevelListTracker()
+        client = cosmic_client_module.CosmicToplevelInfoWaylandClient(
+            tracker,
+            socket_path=str(socket_path),
+        )
+        try:
+            await client.start()
+            await client.run()
+            return tracker.get_active_window()
+        finally:
+            await client.stop()
+            server.close()
+            await server.wait_closed()
+
+    assert asyncio.run(run_client()) == ("cosmic.app", "COSMIC Window")

--- a/tests/test_wayland_protocol_trackers.py
+++ b/tests/test_wayland_protocol_trackers.py
@@ -1,5 +1,8 @@
 import asyncio
 import struct
+import tempfile
+from collections.abc import Iterator
+from contextlib import contextmanager
 from pathlib import Path
 
 from keymasq.session.wayland_protocols import cosmic_toplevel_info_client as cosmic_client_module
@@ -49,6 +52,12 @@ def _encode_array(values: list[int]) -> bytes:
     raw = b"".join(value.to_bytes(4, byteorder="little") for value in values)
     padded = (len(raw) + 3) & ~3
     return struct.pack("<I", len(raw)) + raw + (b"\x00" * (padded - len(raw)))
+
+
+@contextmanager
+def _short_socket_path(name: str) -> Iterator[Path]:
+    with tempfile.TemporaryDirectory(prefix="kmq-", dir="/tmp") as temp_dir:
+        yield Path(temp_dir) / name
 
 
 def test_ext_tracker_emits_on_activation() -> None:
@@ -150,13 +159,13 @@ class _ProbeSocket:
 
 def test_registry_probe_reads_globals_sync(monkeypatch) -> None:
     probe_socket = _ProbeSocket(
-                _wl_message(
-                    2,
-                    0,
-                    _registry_payload(7, EXT_FOREIGN_TOPLEVEL_LIST_INTERFACE, 1),
-                )
-                + _wl_message(2, 0, _registry_payload(8, "zwlr_foreign_toplevel_manager_v1", 3))
-                + _wl_message(3, 0)
+        _wl_message(
+            2,
+            0,
+            _registry_payload(7, EXT_FOREIGN_TOPLEVEL_LIST_INTERFACE, 1),
+        )
+        + _wl_message(2, 0, _registry_payload(8, "zwlr_foreign_toplevel_manager_v1", 3))
+        + _wl_message(3, 0)
     )
     monkeypatch.setattr(
         registry_probe.socket,
@@ -172,27 +181,30 @@ def test_registry_probe_reads_globals_sync(monkeypatch) -> None:
     assert probe_socket.closed is True
 
 
-def test_registry_probe_reads_globals_async(tmp_path: Path) -> None:
+def test_registry_probe_reads_globals_async() -> None:
     async def run_probe() -> set[str]:
-        socket_path = tmp_path / "wayland-async"
+        with _short_socket_path("wayland-async") as socket_path:
 
-        async def handle_client(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
-            await reader.read(4096)
-            writer.write(
-                _wl_message(2, 0, _registry_payload(1, "zcosmic_toplevel_info_v1", 3))
-                + _wl_message(3, 0)
-            )
-            await writer.drain()
-            await asyncio.wait_for(reader.read(4096), timeout=1.0)
-            writer.close()
-            await writer.wait_closed()
+            async def handle_client(
+                reader: asyncio.StreamReader,
+                writer: asyncio.StreamWriter,
+            ) -> None:
+                await reader.read(4096)
+                writer.write(
+                    _wl_message(2, 0, _registry_payload(1, "zcosmic_toplevel_info_v1", 3))
+                    + _wl_message(3, 0)
+                )
+                await writer.drain()
+                await asyncio.wait_for(reader.read(4096), timeout=1.0)
+                writer.close()
+                await writer.wait_closed()
 
-        server = await asyncio.start_unix_server(handle_client, path=str(socket_path))
-        try:
-            return await registry_probe.list_registry_globals(socket_path)
-        finally:
-            server.close()
-            await server.wait_closed()
+            server = await asyncio.start_unix_server(handle_client, path=str(socket_path))
+            try:
+                return await registry_probe.list_registry_globals(socket_path)
+            finally:
+                server.close()
+                await server.wait_closed()
 
     assert asyncio.run(run_probe()) == {"zcosmic_toplevel_info_v1"}
 
@@ -322,167 +334,176 @@ def test_wayland_clients_require_display_environment(monkeypatch) -> None:
     asyncio.run(start_clients())
 
 
-def test_ext_wayland_client_start_and_run_against_minimal_socket(tmp_path: Path) -> None:
+def test_ext_wayland_client_start_and_run_against_minimal_socket() -> None:
     async def run_client() -> tuple[str, str]:
-        socket_path = tmp_path / "ext-wayland"
+        with _short_socket_path("ext-wayland") as socket_path:
 
-        async def handle_client(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
-            await reader.read(4096)
-            writer.write(
-                _wl_message(
-                    2,
-                    0,
-                    _registry_payload(1, EXT_FOREIGN_TOPLEVEL_LIST_INTERFACE, 1),
+            async def handle_client(
+                reader: asyncio.StreamReader,
+                writer: asyncio.StreamWriter,
+            ) -> None:
+                await reader.read(4096)
+                writer.write(
+                    _wl_message(
+                        2,
+                        0,
+                        _registry_payload(1, EXT_FOREIGN_TOPLEVEL_LIST_INTERFACE, 1),
+                    )
+                    + _wl_message(3, 0)
                 )
-                + _wl_message(3, 0)
-            )
-            await writer.drain()
+                await writer.drain()
 
-            await reader.read(4096)
-            writer.write(_wl_message(5, 0))
-            await writer.drain()
+                await reader.read(4096)
+                writer.write(_wl_message(5, 0))
+                await writer.drain()
 
-            await asyncio.sleep(0.01)
-            writer.write(
-                _wl_message(4, 0, struct.pack("<I", 80))
-                + _wl_message(80, 2, _encode_string("Live Window"))
-                + _wl_message(80, 3, _encode_string("live.app"))
-                + _wl_message(4, 1)
-            )
-            await writer.drain()
-            await asyncio.wait_for(reader.read(4096), timeout=1.0)
-            writer.close()
-            await writer.wait_closed()
+                await asyncio.sleep(0.01)
+                writer.write(
+                    _wl_message(4, 0, struct.pack("<I", 80))
+                    + _wl_message(80, 2, _encode_string("Live Window"))
+                    + _wl_message(80, 3, _encode_string("live.app"))
+                    + _wl_message(4, 1)
+                )
+                await writer.drain()
+                await asyncio.wait_for(reader.read(4096), timeout=1.0)
+                writer.close()
+                await writer.wait_closed()
 
-        server = await asyncio.start_unix_server(handle_client, path=str(socket_path))
-        tracker = ExtForeignToplevelListTracker()
-        client = ExtForeignToplevelListWaylandClient(tracker, socket_path=str(socket_path))
-        try:
-            await client.start()
-            await client.run()
-            tracker.update_state("80", [2])
-            return tracker.get_active_window()
-        finally:
-            await client.stop()
-            server.close()
-            await server.wait_closed()
+            server = await asyncio.start_unix_server(handle_client, path=str(socket_path))
+            tracker = ExtForeignToplevelListTracker()
+            client = ExtForeignToplevelListWaylandClient(tracker, socket_path=str(socket_path))
+            try:
+                await client.start()
+                await client.run()
+                tracker.update_state("80", [2])
+                return tracker.get_active_window()
+            finally:
+                await client.stop()
+                server.close()
+                await server.wait_closed()
 
     assert asyncio.run(run_client()) == ("live.app", "Live Window")
 
 
-def test_wlr_wayland_client_start_and_run_against_minimal_socket(tmp_path: Path) -> None:
+def test_wlr_wayland_client_start_and_run_against_minimal_socket() -> None:
     async def run_client() -> tuple[str, str]:
-        socket_path = tmp_path / "wlr-wayland"
+        with _short_socket_path("wlr-wayland") as socket_path:
 
-        async def handle_client(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
-            await reader.read(4096)
-            writer.write(
-                _wl_message(
-                    2,
-                    0,
-                    _registry_payload(
-                        1,
-                        wlr_client_module.WLR_FOREIGN_TOPLEVEL_MANAGER_INTERFACE,
-                        3,
-                    ),
+            async def handle_client(
+                reader: asyncio.StreamReader,
+                writer: asyncio.StreamWriter,
+            ) -> None:
+                await reader.read(4096)
+                writer.write(
+                    _wl_message(
+                        2,
+                        0,
+                        _registry_payload(
+                            1,
+                            wlr_client_module.WLR_FOREIGN_TOPLEVEL_MANAGER_INTERFACE,
+                            3,
+                        ),
+                    )
+                    + _wl_message(3, 0)
                 )
-                + _wl_message(3, 0)
+                await writer.drain()
+
+                await reader.read(4096)
+                writer.write(_wl_message(5, 0))
+                await writer.drain()
+
+                await asyncio.sleep(0.01)
+                writer.write(
+                    _wl_message(4, 0, struct.pack("<I", 90))
+                    + _wl_message(90, 0, _encode_string("WLR Window"))
+                    + _wl_message(90, 1, _encode_string("wlr.app"))
+                    + _wl_message(90, 4, _encode_array([WLR_TOPLEVEL_STATE_ACTIVATED]))
+                )
+                await writer.drain()
+                writer.close()
+                await writer.wait_closed()
+
+            server = await asyncio.start_unix_server(handle_client, path=str(socket_path))
+            tracker = WlrForeignToplevelManagerTracker()
+            client = wlr_client_module.WlrForeignToplevelWaylandClient(
+                tracker,
+                socket_path=str(socket_path),
             )
-            await writer.drain()
-
-            await reader.read(4096)
-            writer.write(_wl_message(5, 0))
-            await writer.drain()
-
-            await asyncio.sleep(0.01)
-            writer.write(
-                _wl_message(4, 0, struct.pack("<I", 90))
-                + _wl_message(90, 0, _encode_string("WLR Window"))
-                + _wl_message(90, 1, _encode_string("wlr.app"))
-                + _wl_message(90, 4, _encode_array([WLR_TOPLEVEL_STATE_ACTIVATED]))
-            )
-            await writer.drain()
-            writer.close()
-            await writer.wait_closed()
-
-        server = await asyncio.start_unix_server(handle_client, path=str(socket_path))
-        tracker = WlrForeignToplevelManagerTracker()
-        client = wlr_client_module.WlrForeignToplevelWaylandClient(
-            tracker,
-            socket_path=str(socket_path),
-        )
-        try:
-            await client.start()
-            await client.run()
-            return tracker.get_active_window()
-        finally:
-            await client.stop()
-            server.close()
-            await server.wait_closed()
+            try:
+                await client.start()
+                await client.run()
+                return tracker.get_active_window()
+            finally:
+                await client.stop()
+                server.close()
+                await server.wait_closed()
 
     assert asyncio.run(run_client()) == ("wlr.app", "WLR Window")
 
 
-def test_cosmic_wayland_client_start_and_run_against_minimal_socket(tmp_path: Path) -> None:
+def test_cosmic_wayland_client_start_and_run_against_minimal_socket() -> None:
     async def run_client() -> tuple[str, str]:
-        socket_path = tmp_path / "cosmic-wayland"
+        with _short_socket_path("cosmic-wayland") as socket_path:
 
-        async def handle_client(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
-            await reader.read(4096)
-            writer.write(
-                _wl_message(
-                    2,
-                    0,
-                    _registry_payload(
-                        1,
-                        cosmic_client_module.EXT_FOREIGN_TOPLEVEL_LIST_INTERFACE,
-                        1,
-                    ),
-                )
-                + _wl_message(
-                    2,
-                    0,
-                    _registry_payload(
+            async def handle_client(
+                reader: asyncio.StreamReader,
+                writer: asyncio.StreamWriter,
+            ) -> None:
+                await reader.read(4096)
+                writer.write(
+                    _wl_message(
                         2,
-                        cosmic_client_module.COSMIC_TOPLEVEL_INFO_INTERFACE,
-                        3,
-                    ),
+                        0,
+                        _registry_payload(
+                            1,
+                            cosmic_client_module.EXT_FOREIGN_TOPLEVEL_LIST_INTERFACE,
+                            1,
+                        ),
+                    )
+                    + _wl_message(
+                        2,
+                        0,
+                        _registry_payload(
+                            2,
+                            cosmic_client_module.COSMIC_TOPLEVEL_INFO_INTERFACE,
+                            3,
+                        ),
+                    )
+                    + _wl_message(3, 0)
                 )
-                + _wl_message(3, 0)
+                await writer.drain()
+
+                await reader.read(4096)
+                writer.write(_wl_message(6, 0))
+                await writer.drain()
+
+                await asyncio.sleep(0.01)
+                writer.write(
+                    _wl_message(4, 0, struct.pack("<I", 100))
+                    + _wl_message(5, 2)
+                    + _wl_message(100, 2, _encode_string("COSMIC Window"))
+                    + _wl_message(100, 3, _encode_string("cosmic.app"))
+                    + _wl_message(7, 8, _encode_array([2]))
+                    + _wl_message(4, 1)
+                )
+                await writer.drain()
+                await asyncio.wait_for(reader.read(4096), timeout=1.0)
+                writer.close()
+                await writer.wait_closed()
+
+            server = await asyncio.start_unix_server(handle_client, path=str(socket_path))
+            tracker = ExtForeignToplevelListTracker()
+            client = cosmic_client_module.CosmicToplevelInfoWaylandClient(
+                tracker,
+                socket_path=str(socket_path),
             )
-            await writer.drain()
-
-            await reader.read(4096)
-            writer.write(_wl_message(6, 0))
-            await writer.drain()
-
-            await asyncio.sleep(0.01)
-            writer.write(
-                _wl_message(4, 0, struct.pack("<I", 100))
-                + _wl_message(5, 2)
-                + _wl_message(100, 2, _encode_string("COSMIC Window"))
-                + _wl_message(100, 3, _encode_string("cosmic.app"))
-                + _wl_message(7, 8, _encode_array([2]))
-                + _wl_message(4, 1)
-            )
-            await writer.drain()
-            await asyncio.wait_for(reader.read(4096), timeout=1.0)
-            writer.close()
-            await writer.wait_closed()
-
-        server = await asyncio.start_unix_server(handle_client, path=str(socket_path))
-        tracker = ExtForeignToplevelListTracker()
-        client = cosmic_client_module.CosmicToplevelInfoWaylandClient(
-            tracker,
-            socket_path=str(socket_path),
-        )
-        try:
-            await client.start()
-            await client.run()
-            return tracker.get_active_window()
-        finally:
-            await client.stop()
-            server.close()
-            await server.wait_closed()
+            try:
+                await client.start()
+                await client.run()
+                return tracker.get_active_window()
+            finally:
+                await client.stop()
+                server.close()
+                await server.wait_closed()
 
     assert asyncio.run(run_client()) == ("cosmic.app", "COSMIC Window")


### PR DESCRIPTION
This branch adds focused coverage for session payload serialization, Wayland protocol client handshakes, GUI action labels, macro manager workflows, macro editor timing/rendering, and hardware setup capture flows.

Verified with:
- nix develop .#ci -c basedpyright
- nix develop -c ruff check ...
- pytest tests --ignore=tests/gui -m "not gui" --cov=keymasq/session ...
- pytest tests/gui -m gui --cov=keymasq/gui ...

Coverage targets reached:
- session excluding listeners: 71%
- gui: 72%
