### PR TITLE
Polish device tab styling and add grave key to keyboard layouts

### DIFF
--- a/keymasq/gui/style.css
+++ b/keymasq/gui/style.css
@@ -1,15 +1,15 @@
 /* Active mapping: green left indicator + subtle tint */
 .button-card-mapped-active {
-  border-left: 3px solid @success_color;
+  border-left: 4px solid @success_color;
   padding-left: 6px;
-  background: alpha(@success_color, 0.08);
+  background: alpha(@success_color, 0.12);
 }
 
-/* Overridden mapping: grey indicator, still editable */
+/* Overridden mapping: orange indicator, still editable */
 .button-card-mapped-inactive {
-  border-left: 3px solid @warning_color;
+  border-left: 4px solid @warning_color;
   padding-left: 6px;
-  background: alpha(@warning_color, 0.08);
+  background: alpha(@warning_color, 0.12);
 }
 
 /* Passthrough button: subdued */
@@ -17,6 +17,21 @@
   border-left: 3px solid alpha(@shade_color, 0.2);
   padding-left: 6px;
   opacity: 0.6;
+}
+
+/* Hover/press feedback for all key cards */
+.button-card-passthrough:hover,
+.button-card-mapped-active:hover,
+.button-card-mapped-inactive:hover {
+  background: alpha(@accent_color, 0.08);
+  border-left-color: @accent_color;
+  cursor: pointer;
+}
+
+.button-card-passthrough:active,
+.button-card-mapped-active:active,
+.button-card-mapped-inactive:active {
+  background: alpha(@accent_color, 0.14);
 }
 
 /* Status pill badges */
@@ -79,8 +94,35 @@
   opacity: 0.7;
 }
 
+/* Keyboard/device section expanders */
+.device-section-expander {
+  margin-top: 4px;
+  padding-top: 6px;
+  border-top: 1px solid alpha(@borders, 0.3);
+}
+
+.device-section-expander:first-child {
+  border-top: none;
+  margin-top: 0;
+  padding-top: 0;
+}
+
+.device-section-expander > title {
+  font-weight: 600;
+}
+
 .combo-row {
   padding: 6px 12px;
+  border-radius: 6px;
+}
+
+.combo-row:hover {
+  background: alpha(@accent_color, 0.08);
+  cursor: pointer;
+}
+
+.combo-row:active {
+  background: alpha(@accent_color, 0.14);
 }
 
 .combo-column-header {
@@ -151,23 +193,29 @@ button.actions-docs-button {
 
 /* Learn-keys placeholder tile: dashed border, dim, accent on hover */
 .button-card-learn {
-  border: 1.5px dashed alpha(@borders, 0.7);
+  border: 1.5px dashed alpha(@borders, 0.5);
   border-radius: 8px;
-  padding: 10px 16px;
-  opacity: 0.65;
+  padding: 10px 20px;
+  opacity: 0.55;
   background: transparent;
   min-height: 0;
+  margin-top: 4px;
 }
 
 .button-card-learn:hover {
   opacity: 1;
   border-color: @accent_color;
+  border-style: solid;
   background: alpha(@accent_color, 0.08);
 }
 
 .button-card-learn:focus {
   opacity: 1;
   border-color: @accent_color;
+}
+
+.button-card-learn:active {
+  background: alpha(@accent_color, 0.14);
 }
 
 .superkey-add-row {

--- a/keymasq/gui/widgets/device_tab.py
+++ b/keymasq/gui/widgets/device_tab.py
@@ -221,10 +221,35 @@ class DeviceTab(ProfileManagedTab):
     def _after_profile_selection_applied(self) -> None:
         for button_id in self._button_widgets:
             self._update_button_display(button_id)
+        self._update_header_caption()
 
     def _after_active_profiles_changed(self) -> None:
         for button_id in self._button_widgets:
             self._update_button_display(button_id)
+        self._update_header_caption()
+
+    def _count_mapped_buttons(self) -> int:
+        layer = self._selected_layer()
+        if not layer:
+            return 0
+        return sum(
+            1
+            for mapping in layer.mappings.values()
+            if mapping.action_type != ActionType.PASSTHROUGH
+        )
+
+    def _update_header_caption(self) -> None:
+        mapped = self._count_mapped_buttons()
+        total = len(self.device.buttons)
+        base = (
+            f"{self.device.hardware_id} | {len(self.device.evdev_devices)} evdev, "
+            f"{total} buttons"
+        )
+        if mapped > 0:
+            caption = f"{base} · {mapped} mapped"
+        else:
+            caption = base
+        self._header_caption_label.set_text(caption)
 
     def _on_always_grab_toggled(self, check: Gtk.CheckButton) -> None:
         layer = self._selected_layer(create=True)
@@ -272,11 +297,11 @@ class DeviceTab(ProfileManagedTab):
             f"{self.device.hardware_id} | {len(self.device.evdev_devices)} evdev, "
             f"{len(self.device.buttons)} buttons"
         )
-        caption_label = Gtk.Label(label=caption)
-        caption_label.add_css_class("dim-label")
-        caption_label.add_css_class("caption")
-        caption_label.set_halign(Gtk.Align.START)
-        info_box.append(caption_label)
+        self._header_caption_label = Gtk.Label(label=caption)
+        self._header_caption_label.add_css_class("dim-label")
+        self._header_caption_label.add_css_class("caption")
+        self._header_caption_label.set_halign(Gtk.Align.START)
+        info_box.append(self._header_caption_label)
 
         header_box.append(info_box)
         header_box.set_hexpand(True)
@@ -466,7 +491,7 @@ class DeviceTab(ProfileManagedTab):
                 content,
                 "Keyboard (Left)",
                 [
-                    ["key_esc"],
+                    ["key_esc", "key_grave"],
                     ["key_tab", "key_q", "key_w", "key_e", "key_r", "key_t"],
                     ["key_capslock", "key_a", "key_s", "key_d", "key_f", "key_g"],
                     ["key_leftshift", "key_z", "key_x", "key_c", "key_v", "key_b"],
@@ -753,6 +778,7 @@ class DeviceTab(ProfileManagedTab):
         grid = self._build_keyboard_grid(layout_rows, buttons_by_id, used_ids, max_cols)
 
         expander = Gtk.Expander(label=title)
+        expander.add_css_class("device-section-expander")
         expander.set_expanded(expanded)
         expander.set_child(grid)
         parent.append(expander)
@@ -765,8 +791,8 @@ class DeviceTab(ProfileManagedTab):
         max_cols: int,
     ) -> Gtk.Grid:
         grid = Gtk.Grid()
-        grid.set_column_spacing(8)
-        grid.set_row_spacing(8)
+        grid.set_column_spacing(4)
+        grid.set_row_spacing(4)
 
         for row_i, row_items in enumerate(layout_rows):
             col_i = 0
@@ -801,8 +827,8 @@ class DeviceTab(ProfileManagedTab):
         prepend: bool = False,
     ) -> None:
         grid = Gtk.Grid()
-        grid.set_column_spacing(8)
-        grid.set_row_spacing(8)
+        grid.set_column_spacing(4)
+        grid.set_row_spacing(4)
 
         col = 0
         row = 0
@@ -817,6 +843,7 @@ class DeviceTab(ProfileManagedTab):
                 row += 1
 
         expander = Gtk.Expander(label=f"{title} ({len(extras)})")
+        expander.add_css_class("device-section-expander")
         expander.set_expanded(expanded)
         expander.set_child(grid)
         if prepend:
@@ -830,10 +857,10 @@ class DeviceTab(ProfileManagedTab):
         box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=4)
         box.add_css_class("card")
         box.add_css_class("button-card-passthrough")
-        box.set_margin_top(6)
-        box.set_margin_bottom(6)
-        box.set_margin_start(6)
-        box.set_margin_end(6)
+        box.set_margin_top(2)
+        box.set_margin_bottom(2)
+        box.set_margin_start(2)
+        box.set_margin_end(2)
 
         header = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=4)
 
@@ -1148,6 +1175,7 @@ class DeviceTab(ProfileManagedTab):
                 layer.mappings[button.id] = action
             self._save_profile()
             self._update_button_display(button.id)
+            self._update_header_caption()
 
         dialog = KeySelectorDialog(self, button.label, current_action)
         dialog.connect("key-selected", on_key_selected)

--- a/keymasq/gui/wizards/hardware_setup.py
+++ b/keymasq/gui/wizards/hardware_setup.py
@@ -1466,6 +1466,7 @@ class HardwareSetupDialog(Adw.Window):
         buttons: list[ButtonDefinition] = []
         standard_keys = [
             "KEY_ESC",
+            "KEY_GRAVE",
             "KEY_1",
             "KEY_2",
             "KEY_3",

--- a/tests/gui/test_hardware_setup_dialog.py
+++ b/tests/gui/test_hardware_setup_dialog.py
@@ -548,8 +548,10 @@ def test_hardware_setup_saves_standard_keyboard_template(monkeypatch):
     assert saved.evdev_devices[0].device_type == DeviceType.KEYBOARD
     assert saved.evdev_devices[0].id == "kbd"
     assert saved.buttons[0].id == "key_esc"
+    assert saved.buttons[1].id == "key_grave"
     assert saved.buttons[0].source == "kbd"
     assert {button.id for button in saved.buttons} >= {
+        "key_grave",
         "key_space",
         "key_leftctrl",
         "key_rightmeta",


### PR DESCRIPTION
## Summary

- Refine key card visual feedback with hover/active states and accent-color transitions
- Update border-left indicators on mapped/overridden cards for clearer visual distinction
- Add `.device-section-expander` styling and tighten grid spacing in keyboard layout sections
- Add hover/active feedback to combo rows and improve learn-keys placeholder tile style
- Show mapped button count in the device tab header caption, updated on profile changes
- Add `KEY_GRAVE` to both the keyboard layout in `DeviceTab` and the hardware setup wizard

## Testing

- Verified `test_hardware_setup_saves_standard_keyboard_template` passes with the new grave key assertion
- Visual review of device tab hover/press states on passthrough, active, and overridden key cards
- Visual review of section expander borders, grid spacing, and combo row feedback
- Confirmed header caption reflects mapped button count correctly after applying/removing mappings