### PR TITLE
Replace mouse-remap config gate with always-on warning dialogs

### DIFF
--- a/docs/ACTIONS.md
+++ b/docs/ACTIONS.md
@@ -374,8 +374,8 @@ key is held.
 
 ## Safety Note
 
-Left and right mouse buttons are protected in the GUI — you cannot remap them
-away. This prevents accidentally locking yourself out of clicking.
+The GUI warns before editing left or right mouse click mappings. Remapping a
+primary or secondary click can remove that click **everywhere**.
 
 ## See Also
 

--- a/docs/COMBOS.md
+++ b/docs/COMBOS.md
@@ -204,6 +204,10 @@ The combo editor won't let you save two combos with the same trigger sequence
 in the same profile. Across profiles, if two combos share the same trigger,
 the one from the last-applied profile wins.
 
+If you save a single-button, single-step combo that uses left or right mouse
+click as the trigger, the GUI shows a warning first. Remapping a primary or
+secondary click can remove that click **everywhere**.
+
 `Ctrl+Alt+Esc` is reserved by default as Keymasq's emergency combo on grabbed
 keyboards. The daemon injects it into the active combo set, and the GUI rejects
 that exact trigger while the safety combo is enabled. One tap cancels macro

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -181,7 +181,6 @@ settings below:
               macro.exec_timeout_max_ms = 30000;
 
               gui = {
-                allow_left_right_click_remap = false;
                 emergency_cancel_combo_enabled = true;
               };
 
@@ -205,11 +204,9 @@ settings below:
 sudo nixos-rebuild switch --flake .#desktop
 ```
 
-To change the policy, edit `services.keymasq.securityConfig` and rebuild. For
-example, set `gui.allow_left_right_click_remap = true;` if you intentionally
-want the GUI to allow left/right mouse click remaps. The default
-`gui.emergency_cancel_combo_enabled = true;` reserves `Ctrl+Alt+Esc` on grabbed
-keyboards as an emergency combo.
+To change the policy, edit `services.keymasq.securityConfig` and rebuild. The
+default `gui.emergency_cancel_combo_enabled = true;` reserves `Ctrl+Alt+Esc` on
+grabbed keyboards as an emergency combo.
 
 ### GNOME Wayland: enable the Shell bridge
 
@@ -280,14 +277,6 @@ requirement in `/etc/keymasq/security.toml`:
 ```toml
 [recording_guard]
 unlock_required = false
-```
-
-If you want to remap left or right mouse click (disabled by default to prevent
-locking yourself out of the desktop):
-
-```toml
-[gui]
-allow_left_right_click_remap = true
 ```
 
 `Ctrl+Alt+Esc` is reserved by default as an emergency combo while Keymasq has a

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -213,7 +213,6 @@ Relevant controls:
 - `[macro]`
   - `exec_timeout_max_ms`
 - `[gui]`
-  - `allow_left_right_click_remap`
   - `emergency_cancel_combo_enabled`
 - `[recording_guard]`
   - `unlock_required`
@@ -249,21 +248,10 @@ development setups that do not provide the packaged Polkit-based unlock path.
 macro create/update/get APIs also require an unlock, in addition to live
 recording and capture.
 
-`[gui].allow_left_right_click_remap` controls whether the GUI is allowed to edit
-left and right click mappings. The default is `false`.
-
-When `allow_left_right_click_remap = false`:
-
-- left click and right click remain blocked in the GUI
-- the GUI explains that you must explicitly opt in through `security.toml`
-
-When `allow_left_right_click_remap = true`:
-
-- the GUI allows editing those buttons
-- the GUI still shows a warning before opening the remap editor
-
-This setting exists because remapping the primary or secondary click can leave
-you without a usable pointer button in the desktop UI.
+The GUI warns before editing left and right click mappings, and before saving a
+single-button, single-step combo that uses left or right click as the trigger.
+These warnings exist because remapping the primary or secondary click can remove
+that click **everywhere**.
 
 `[gui].emergency_cancel_combo_enabled` controls whether `keymasqd` reserves
 `Ctrl+Alt+Esc` on grabbed keyboards as an emergency combo. The default is

--- a/examples/security.toml
+++ b/examples/security.toml
@@ -5,9 +5,6 @@ session_allowed_uids = []
 exec_timeout_max_ms = 30000
 
 [gui]
-# Allow remapping left/right click in the GUI.
-# Warning: this can leave the desktop without a usable primary/secondary click.
-allow_left_right_click_remap = false
 # Inject Ctrl+Alt+Esc on grabbed keyboards as the emergency cancel/reset combo.
 emergency_cancel_combo_enabled = true
 

--- a/flake.nix
+++ b/flake.nix
@@ -194,7 +194,6 @@
                 session_allowed_uids = [ ];
                 macro.exec_timeout_max_ms = 30000;
                 gui = {
-                  allow_left_right_click_remap = false;
                   emergency_cancel_combo_enabled = true;
                 };
                 recording_guard = {

--- a/keymasq/common/security.py
+++ b/keymasq/common/security.py
@@ -22,7 +22,6 @@ class SecurityPolicy:
     macro_exec_timeout_max_ms: int = 30000
     recording_unlock_required: bool = True
     macro_edit_requires_unlock: bool = False
-    gui_allow_left_right_click_remap: bool = False
     emergency_cancel_combo_enabled: bool = True
 
 
@@ -108,12 +107,6 @@ def load_security_policy(config_path: Path) -> SecurityPolicy:
     gui_cfg = raw.get("gui")
     if isinstance(gui_cfg, dict):
         gui_settings = cast(dict[str, Any], gui_cfg)
-        policy.gui_allow_left_right_click_remap = bool(
-            gui_settings.get(
-                "allow_left_right_click_remap",
-                policy.gui_allow_left_right_click_remap,
-            )
-        )
         policy.emergency_cancel_combo_enabled = bool(
             gui_settings.get(
                 "emergency_cancel_combo_enabled",

--- a/keymasq/gui/widgets/combo_editor_dialog.py
+++ b/keymasq/gui/widgets/combo_editor_dialog.py
@@ -16,6 +16,7 @@ from keymasq.common.combos import (
     normalize_combo_evdev,
 )
 from keymasq.common.models import (
+    PROTECTED_BUTTONS,
     ActionType,
     ComboConfig,
     ComboEvent,
@@ -126,6 +127,14 @@ def combo_is_emergency_cancel_trigger(steps: list[ComboStep]) -> bool:
         len(steps) == 1
         and bool(steps[0].events)
         and is_emergency_cancel_combo_evdevs(event.evdev for event in steps[0].events)
+    )
+
+
+def combo_is_single_critical_mouse_trigger(steps: list[ComboStep]) -> bool:
+    return (
+        len(steps) == 1
+        and len(steps[0].events) == 1
+        and normalize_combo_evdev(steps[0].events[0].evdev) in PROTECTED_BUTTONS
     )
 
 
@@ -448,10 +457,43 @@ class ComboEditorDialog(Adw.Dialog):
     def _on_save_clicked(self, _button: Gtk.Button) -> None:
         if not self.save_button.get_sensitive():
             return
+        if combo_is_single_critical_mouse_trigger(self._draft.steps):
+            self._show_critical_mouse_combo_warning()
+            return
+        self._save_draft()
+
+    def _save_draft(self) -> None:
         name = self.name_entry.get_text().strip()
         self._draft.name = name or combo_default_name(self._draft)
         self.emit("combo-saved", deepcopy(self._draft))
         self.close()
+
+    def _show_critical_mouse_combo_warning(self) -> None:
+        trigger = combo_trigger_label(self._draft.steps) or "this button"
+        dialog = Adw.AlertDialog(
+            heading="Remap Critical Mouse Button?",
+            body=(
+                f"{trigger} is a critical pointer button. Using it as a single-button "
+                "combo can remove your normal left or right click <b>everywhere</b>.\n\n"
+                "Continue only if you have a reliable recovery path, such as another "
+                "mouse, keyboard navigation, or direct access to the profile files."
+            ),
+        )
+        dialog.set_body_use_markup(True)
+        dialog.add_response("cancel", "Cancel")
+        dialog.add_response("continue", "Continue")
+        dialog.set_response_appearance("continue", Adw.ResponseAppearance.DESTRUCTIVE)
+        dialog.set_default_response("cancel")
+        dialog.connect("response", self._on_critical_mouse_combo_warning_response)
+        dialog.present(self)
+
+    def _on_critical_mouse_combo_warning_response(
+        self,
+        _dialog: Adw.AlertDialog,
+        response: str,
+    ) -> None:
+        if response == "continue":
+            self._save_draft()
 
     def _refresh_trigger_display(self) -> None:
         while child := self.steps_box.get_first_child():

--- a/keymasq/gui/widgets/device_tab.py
+++ b/keymasq/gui/widgets/device_tab.py
@@ -946,10 +946,6 @@ class DeviceTab(ProfileManagedTab):
         if click.get_current_button() != Gdk.BUTTON_PRIMARY:
             return
 
-        if protected and not self._left_right_click_remap_allowed():
-            self._show_protected_dialog(button)
-            return
-
         if self._selected_profile is None:
             self._show_no_profile_dialog()
             return
@@ -959,19 +955,6 @@ class DeviceTab(ProfileManagedTab):
             return
 
         self._show_function_editor(button)
-
-    def _left_right_click_remap_allowed(self) -> bool:
-        if self.main_window is not None:
-            getter = getattr(self.main_window, "left_right_click_remap_allowed", None)
-            if callable(getter):
-                return bool(getter())
-
-        root = self.get_root()
-        getter = getattr(root, "left_right_click_remap_allowed", None)
-        if callable(getter):
-            return bool(getter())
-
-        return False
 
     def _on_action_label_right_clicked(
         self, click, n_press, x, y, button: ButtonDefinition
@@ -1102,30 +1085,17 @@ class DeviceTab(ProfileManagedTab):
         if self.profile_manager is not None:
             self._reload_ui()
 
-    def _show_protected_dialog(self, button) -> None:
-        dialog = Adw.AlertDialog(
-            heading="Protected Button",
-            body=(
-                f"{button.label} cannot be remapped in the GUI unless you explicitly "
-                "opt in via /etc/keymasq/security.toml.\n\n"
-                "Set [gui] allow_left_right_click_remap = true only if you understand "
-                "that remapping left or right click can leave you without a usable "
-                "pointer button."
-            ),
-        )
-        dialog.add_response("ok", "OK")
-        dialog.present(self.get_root())
-
     def _show_protected_remap_warning_dialog(self, button: ButtonDefinition) -> None:
         dialog = Adw.AlertDialog(
             heading="Remap Critical Mouse Button?",
             body=(
-                f"{button.label} is a critical pointer button. Remapping it can leave "
-                "you without a working primary or secondary click in the GUI.\n\n"
-                "Continue only if you have another way to recover, such as a second "
+                f"{button.label} is a critical pointer button. Remapping it can remove "
+                "your normal left or right click <b>everywhere</b>.\n\n"
+                "Continue only if you have a reliable recovery path, such as another "
                 "mouse, keyboard navigation, or direct access to the profile files."
             ),
         )
+        dialog.set_body_use_markup(True)
         dialog.add_response("cancel", "Cancel")
         dialog.add_response("continue", "Continue")
         dialog.set_response_appearance("continue", Adw.ResponseAppearance.DESTRUCTIVE)

--- a/keymasq/gui/window.py
+++ b/keymasq/gui/window.py
@@ -79,7 +79,6 @@ class MainWindow(Adw.ApplicationWindow):
         self._recording_unlock_source = "none"
         self._recording_unlock_expires_at = 0
         self._recording_refresh_owner = False
-        self._gui_allow_left_right_click_remap = False
         self._emergency_cancel_combo_enabled = True
         self._recording_refresh_lease_id: str = ""
         self._recording_claim_attempt_key: tuple[str, int] | None = None
@@ -436,9 +435,6 @@ class MainWindow(Adw.ApplicationWindow):
             source = status_data.get("recording_unlock_source")
             expires_at = status_data.get("recording_unlock_expires_at")
             refresh_owner = status_data.get("recording_refresh_owner")
-            self._gui_allow_left_right_click_remap = bool(
-                status_data.get("gui_allow_left_right_click_remap", False)
-            )
             self._emergency_cancel_combo_enabled = bool(
                 status_data.get("emergency_cancel_combo_enabled", True)
             )
@@ -487,9 +483,6 @@ class MainWindow(Adw.ApplicationWindow):
 
         self._refresh_macro_menu_state()
         self._refresh_unlock_status_label()
-
-    def left_right_click_remap_allowed(self) -> bool:
-        return bool(self._gui_allow_left_right_click_remap)
 
     def emergency_cancel_combo_enabled(self) -> bool:
         return bool(self._emergency_cancel_combo_enabled)

--- a/keymasq/session/manager/commands.py
+++ b/keymasq/session/manager/commands.py
@@ -184,7 +184,6 @@ async def _handle_compositor_commands(
             "compositor_dispatch_available": compositor_status["compositor_dispatch_available"],
             "recording_active": manager.recording_state.active,
             "macro_exec_timeout_max_ms": int(policy.macro_exec_timeout_max_ms),
-            "gui_allow_left_right_click_remap": bool(policy.gui_allow_left_right_click_remap),
             "emergency_cancel_combo_enabled": bool(policy.emergency_cancel_combo_enabled),
             **runtime_recording.serialize_recording_unlock_state(
                 manager,

--- a/tests/gui/test_combo_editor_dialog.py
+++ b/tests/gui/test_combo_editor_dialog.py
@@ -395,6 +395,32 @@ class TestComboEditorDialog:
         assert "emergency macro playback cancellation" in dialog.validation_label.get_text()
         assert dialog.save_button.get_sensitive() is False
 
+    def test_combo_editor_detects_single_button_critical_mouse_triggers(self):
+        from keymasq.common.models import ComboEvent, ComboStep
+        from keymasq.gui.widgets.combo_editor_dialog import (
+            combo_is_single_critical_mouse_trigger,
+        )
+
+        assert combo_is_single_critical_mouse_trigger(
+            [ComboStep(events=[ComboEvent(evdev="btn_left", hardware_id="1234:5678")])]
+        )
+        assert combo_is_single_critical_mouse_trigger(
+            [ComboStep(events=[ComboEvent(evdev="BTN_RIGHT", hardware_id="1234:5678")])]
+        )
+        assert not combo_is_single_critical_mouse_trigger(
+            [ComboStep(events=[ComboEvent(evdev="btn_side", hardware_id="1234:5678")])]
+        )
+        assert not combo_is_single_critical_mouse_trigger(
+            [
+                ComboStep(
+                    events=[
+                        ComboEvent(evdev="key_leftctrl", hardware_id="1234:5678"),
+                        ComboEvent(evdev="btn_left", hardware_id="1234:5678"),
+                    ]
+                )
+            ]
+        )
+
     def test_combo_editor_allows_emergency_cancel_chord_when_disabled(self):
         from gi.repository import Gtk
 

--- a/tests/gui/test_device_tab_widget.py
+++ b/tests/gui/test_device_tab_widget.py
@@ -495,34 +495,24 @@ class TestDeviceTabWidget:
             ],
         )
 
-        protected_tab = DeviceTab(device=device, profile_manager=None, demo_mode=True)
-        protected_calls: list[str] = []
-        protected_tab._show_protected_dialog = lambda button: protected_calls.append(button.id)
-        protected_tab._show_no_profile_dialog = lambda: protected_calls.append("no-profile")
-        protected_tab._show_function_editor = lambda button: protected_calls.append(
-            f"edit:{button.id}"
+        no_profile_protected_tab = DeviceTab(device=device, profile_manager=None, demo_mode=True)
+        protected_no_profile_calls: list[str] = []
+        no_profile_protected_tab._show_no_profile_dialog = (
+            lambda: protected_no_profile_calls.append("no-profile")
         )
 
-        protected_tab._on_button_clicked(
+        no_profile_protected_tab._on_button_clicked(
             _Click(Gdk.BUTTON_PRIMARY), 1, 0, 0, device.buttons[0], True
         )
-        protected_tab._on_button_clicked(
+        no_profile_protected_tab._on_button_clicked(
             _Click(Gdk.BUTTON_SECONDARY), 1, 0, 0, device.buttons[1], False
         )
 
-        assert protected_calls == ["btn_left"]
+        assert protected_no_profile_calls == ["no-profile"]
 
-        allowed_tab = DeviceTab(
-            device=device,
-            profile_manager=None,
-            demo_mode=True,
-            main_window=SimpleNamespace(left_right_click_remap_allowed=lambda: True),
-        )
+        allowed_tab = DeviceTab(device=device, profile_manager=None, demo_mode=True)
         allowed_tab._selected_profile = SimpleNamespace()
         allowed_calls: list[str] = []
-        allowed_tab._show_protected_dialog = lambda button: allowed_calls.append(
-            f"blocked:{button.id}"
-        )
         allowed_tab._show_protected_remap_warning_dialog = lambda button: allowed_calls.append(
             f"warn:{button.id}"
         )

--- a/tests/session/test_session_manager_command_runtime.py
+++ b/tests/session/test_session_manager_command_runtime.py
@@ -80,7 +80,6 @@ async def test_handle_session_request_run_compositor_setup_action(
 async def test_get_status_uses_async_unlock_helper(monkeypatch: pytest.MonkeyPatch) -> None:
     manager = SessionManager()
     manager.security_policy.recording_unlock_required = True
-    manager.security_policy.gui_allow_left_right_click_remap = True
     manager.security_policy.emergency_cancel_combo_enabled = False
     peer = PeerCredentials(pid=1, uid=1000, gid=1000)
     writer = object()
@@ -112,7 +111,6 @@ async def test_get_status_uses_async_unlock_helper(monkeypatch: pytest.MonkeyPat
     assert result["status"] == "ok"
     assert result["recording_unlocked"] is True
     assert result["recording_unlock_required"] is True
-    assert result["gui_allow_left_right_click_remap"] is True
     assert result["emergency_cancel_combo_enabled"] is False
     assert result["recording_unlock_source"] == "runtime"
     assert result["recording_unlock_expires_at"] == 1234

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -11,7 +11,6 @@ def test_load_security_policy_defaults_when_missing(tmp_path: Path) -> None:
     assert command_allowed("unknown_command", policy.daemon_command_acl, "session")
     assert policy.recording_unlock_required is True
     assert policy.macro_edit_requires_unlock is False
-    assert policy.gui_allow_left_right_click_remap is False
     assert policy.emergency_cancel_combo_enabled is True
 
 
@@ -72,7 +71,6 @@ def test_load_security_policy_gui_section(tmp_path: Path) -> None:
         "\n".join(
             [
                 "[gui]",
-                "allow_left_right_click_remap = true",
                 "emergency_cancel_combo_enabled = false",
             ]
         )
@@ -80,7 +78,6 @@ def test_load_security_policy_gui_section(tmp_path: Path) -> None:
 
     policy = load_security_policy(policy_path)
 
-    assert policy.gui_allow_left_right_click_remap is True
     assert policy.emergency_cancel_combo_enabled is False
 
 


### PR DESCRIPTION
## Summary

- Removes the `allow_left_right_click_remap` configuration gate (`security.toml`, `SecurityPolicy`, session IPC, docs, Nix module example)
- Replaces hard blocking of left/right click remapping with a warning dialog that lets the user proceed after acknowledging the risk
- Adds a matching critical-mouse-button warning dialog to the combo editor for single-button, single-step combos that use left or right click as the trigger
- Updates `docs/SECURITY.md`, `docs/ACTIONS.md`, `docs/COMBOS.md`, and `docs/INSTALL.md` to reflect the new always-on warning approach
- Adjusts GUI unit tests to cover the new behaviour

## Testing

- [x] `nix develop -c pytest tests/gui/test_device_tab_widget.py` passes — protected button clicks show warning instead of blocked dialog
- [x] `nix develop -c pytest tests/gui/test_combo_editor_dialog.py` passes — includes new test for single‑button critical mouse trigger detection
- [x] `nix develop -c pytest tests/test_security.py` passes — `gui_allow_left_right_click_remap` removed from policy
- [x] `nix develop -c pytest tests/session/test_session_manager_command_runtime.py` passes — status response no longer includes `gui_allow_left_right_click_remap`
- [x] Manual smoke: open device tab with a grabbed mouse, left‑click a left‑click button mapping → warning dialog appears, "Continue" opens remap editor
- [x] Manual smoke: open combo editor, set trigger to single left‑click step → save triggers warning dialog, "Continue" saves the combo
- [x] `./scripts/check.sh full` passes with no lint or type errors