### PR TITLE
Compact key selector and input picker layout

### DIFF
--- a/keymasq/gui/style.css
+++ b/keymasq/gui/style.css
@@ -160,6 +160,12 @@
   color: @error_color;
 }
 
+button.key-button {
+  padding: 2px 0;
+  min-width: 0;
+  min-height: 0;
+}
+
 button.square-key-button {
   padding: 0;
   min-width: 0;

--- a/keymasq/gui/widgets/input_picker_shared.py
+++ b/keymasq/gui/widgets/input_picker_shared.py
@@ -24,14 +24,14 @@ def build_keyboard_tab(
     scrolled = Gtk.ScrolledWindow()
     scrolled.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
 
-    box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=8)
-    box.set_margin_top(12)
-    box.set_margin_bottom(12)
-    box.set_margin_start(12)
-    box.set_margin_end(12)
+    box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=4)
+    box.set_margin_top(8)
+    box.set_margin_bottom(8)
+    box.set_margin_start(8)
+    box.set_margin_end(8)
 
     for row in keyboard_layout:
-        row_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=4)
+        row_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=3)
         row_box.set_halign(Gtk.Align.CENTER)
 
         for key in row:
@@ -55,7 +55,7 @@ def build_navigation_tab(
     *,
     f_extra: list[str],
 ) -> Gtk.Box:
-    square_size = 44
+    square_size = 50
 
     outer = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=24)
     outer.set_margin_top(16)
@@ -405,7 +405,7 @@ def _build_gamepad_center_col(owner) -> Gtk.Box:
         ("Guide", "btn_mode"),
         ("Start", "btn_start"),
     ]:
-        btn = owner._create_key_button(label, evdev_id)
+        btn = owner._create_key_button(label, evdev_id, width=1.5)
         btn.connect("clicked", owner._on_gamepad_clicked, evdev_id)
         center_btns.append(btn)
 

--- a/keymasq/gui/widgets/key_selector_dialog.py
+++ b/keymasq/gui/widgets/key_selector_dialog.py
@@ -347,7 +347,7 @@ class KeySelectorDialog(Adw.Dialog):
         allow_tap: bool = True,
         allow_macro_options: bool = True,
     ):
-        super().__init__(title=f"Map: {button_label}", content_width=650, content_height=620)
+        super().__init__(title=f"Map: {button_label}", content_width=570, content_height=580)
         self._parent = parent
         self._button_label = button_label
         self._current_action = current_action
@@ -650,10 +650,15 @@ class KeySelectorDialog(Adw.Dialog):
         scrolled.set_vexpand(True)
         outer.append(scrolled)
 
+        toolbar_sep = Gtk.Separator(orientation=Gtk.Orientation.HORIZONTAL)
+        toolbar_sep.set_margin_start(12)
+        toolbar_sep.set_margin_end(12)
+        outer.append(toolbar_sep)
+
         toolbar = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=8)
         toolbar.set_halign(Gtk.Align.CENTER)
-        toolbar.set_margin_top(8)
-        toolbar.set_margin_bottom(8)
+        toolbar.set_margin_top(12)
+        toolbar.set_margin_bottom(12)
         toolbar.set_margin_start(12)
         toolbar.set_margin_end(12)
 
@@ -991,8 +996,8 @@ class KeySelectorDialog(Adw.Dialog):
         if large:
             btn.set_size_request(200, 50)
         else:
-            base_width = 44
-            btn.set_size_request(int(base_width * width), 40)
+            base_width = 36
+            btn.set_size_request(int(base_width * width), 34)
 
         if protected:
             btn.add_css_class("protected-key")
@@ -1866,7 +1871,7 @@ class SuperkeyActionDialog(Adw.Dialog):
         self._parent = parent
 
         title = f"Configure {action_type.replace('_', ' ').title()} Action"
-        super().__init__(title=title, content_width=600, content_height=550)
+        super().__init__(title=title, content_width=540, content_height=520)
 
         self._rapidfire_enabled = False
         self._rapidfire_hold = 20
@@ -2291,8 +2296,8 @@ class SuperkeyActionDialog(Adw.Dialog):
         if large:
             btn.set_size_request(200, 50)
         else:
-            base_width = 44
-            btn.set_size_request(int(base_width * width), 40)
+            base_width = 36
+            btn.set_size_request(int(base_width * width), 34)
 
         btn._evdev_name = evdev
         return btn


### PR DESCRIPTION
## Summary

- Reduce key selector dialog dimensions (`content_width` 650→570, `content_height` 620→580) and superkey action dialog (`content_width` 600→540, `content_height` 550→520)
- Shrink keyboard tab margins/spacing (12→8 for box margins, 8→4 for row spacing, 4→3 for key spacing inside rows)
- Decrease key button base size (44→36 width, 40→34 height) for both key selector and superkey action dialogs
- Increase navigation tab square button size from 44 to 50
- Add a CSS class `.key-button` with zero min-width/min-height and tighter padding (2px 0)
- Insert a horizontal separator above the toolbar in the key selector dialog
- Apply `width=1.5` to gamepad center column buttons (Guide, Start) for better proportions

## Testing

- Verify key selector dialogs render without clipping or overflow at the new dimensions
- Check keyboard tab layout is visually balanced with reduced spacing on GTK4
- Confirm navigation buttons still have adequate tap targets at 50px square
- Test gamepad center buttons display proportionally with the 1.5× width multiplier
- Validate the toolbar separator appears correctly between the content area and toolbar