### PR TITLE
Extract async emit_move_action for cursor-position dispatch

### DIFF
--- a/keymasq/keymasqd/runtime/grabbed_device_actions.py
+++ b/keymasq/keymasqd/runtime/grabbed_device_actions.py
@@ -15,12 +15,12 @@ from keymasq.keymasqd.runtime.action_runner import (
 )
 from keymasq.keymasqd.runtime.grabbed_device_outputs import (
     bucket_for_uinput,
-    emit_configured_mouse_move,
     passthrough,
     track_superkey_output,
     write_key,
 )
 from keymasq.keymasqd.runtime.grabbed_device_repeat import (
+    emit_move_action,
     rapidfire_key,
     rapidfire_move,
     rapidfire_relative,
@@ -613,9 +613,4 @@ async def _execute_move_action(
                 f"tap move {event_name}",
             )
     elif event.value == 1:
-        if action.action_type == ActionType.MOUSE_MOVE_ABS:
-            cursor_position_setter = device_runtime.cursor_position_setter
-            if cursor_position_setter is not None:
-                await cursor_position_setter(int(action.move_x), int(action.move_y))
-                return
-        emit_configured_mouse_move(device_runtime, action)
+        await emit_move_action(device_runtime, action)

--- a/keymasq/keymasqd/runtime/grabbed_device_repeat.py
+++ b/keymasq/keymasqd/runtime/grabbed_device_repeat.py
@@ -5,6 +5,7 @@ from typing import cast
 import evdev
 
 from keymasq.common.models import (
+    ActionType,
     MappingAction,
     clamp_rapidfire_hold_ms,
     clamp_rapidfire_wait_ms,
@@ -29,6 +30,18 @@ from keymasq.keymasqd.runtime.mouse_actions import (
     tap_relative_pulse,
     write_relative_pulse,
 )
+
+
+async def emit_move_action(
+    device_runtime: GrabbedDeviceRuntime,
+    action: MappingAction,
+) -> None:
+    if action.action_type == ActionType.MOUSE_MOVE_ABS:
+        cursor_position_setter = device_runtime.cursor_position_setter
+        if cursor_position_setter is not None:
+            await cursor_position_setter(int(action.move_x), int(action.move_y))
+            return
+    emit_configured_mouse_move(device_runtime, action)
 
 
 def start_rapidfire_task(
@@ -383,7 +396,7 @@ async def rapidfire_move(
             device_runtime.state.rapidfire_active.get(event_name, False)
             and runtime_is_running(device_runtime)
         ):
-            emit_configured_mouse_move(device_runtime, action)
+            await emit_move_action(device_runtime, action)
             await asyncio_mod.sleep(hold)
 
             if not device_runtime.state.rapidfire_active.get(event_name, False):
@@ -408,7 +421,7 @@ async def tap_move(
     hold = hold_ms / 1000.0
 
     try:
-        emit_configured_mouse_move(device_runtime, action)
+        await emit_move_action(device_runtime, action)
         await asyncio_mod.sleep(hold)
     except Exception:
         pass

--- a/tests/keymasqd/test_grabbed_device_runtime_helpers.py
+++ b/tests/keymasqd/test_grabbed_device_runtime_helpers.py
@@ -727,7 +727,7 @@ class TestGrabbedDeviceHelpers:
         emitted_moves: list[tuple[ActionType, int, int]] = []
         fire_tasks: list[asyncio.Task] = []
         monkeypatch.setattr(
-            gda,
+            gdr,
             "emit_configured_mouse_move",
             lambda _device, action: emitted_moves.append(
                 (action.action_type, action.move_x, action.move_y)
@@ -920,6 +920,67 @@ class TestGrabbedDeviceHelpers:
             SimpleNamespace(value=1),
             "move_abs",
         )
+
+        cursor_position_setter.assert_awaited_once_with(10, 20)
+        assert mouse.writes == []
+
+    @pytest.mark.asyncio
+    async def test_rapidfire_mouse_move_abs_uses_cursor_position_setter(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        cursor_position_setter = AsyncMock(return_value={"status": "ok"})
+        mouse = _FakeUInput()
+        device = _make_grabbed_device(
+            monkeypatch,
+            cursor_position_setter=cursor_position_setter,
+            mouse_uinput=mouse,  # type: ignore[arg-type]
+        )
+        device._running = True
+        device.state.rapidfire_active["move_abs"] = True
+        action = dm.MappingAction(
+            action_type=ActionType.MOUSE_MOVE_ABS,
+            move_x=10,
+            move_y=20,
+        )
+
+        task = asyncio.create_task(
+            gdr.rapidfire_move(
+                device,
+                action,
+                "move_abs",
+                1,
+                100,
+                asyncio_mod=gdm.ASYNCIO_RUNTIME,
+            )
+        )
+        await asyncio.sleep(0.02)
+        device.state.rapidfire_active["move_abs"] = False
+        await task
+
+        cursor_position_setter.assert_awaited()
+        cursor_position_setter.assert_any_await(10, 20)
+        assert mouse.writes == []
+
+    @pytest.mark.asyncio
+    async def test_tap_mouse_move_abs_uses_cursor_position_setter(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        cursor_position_setter = AsyncMock(return_value={"status": "ok"})
+        mouse = _FakeUInput()
+        device = _make_grabbed_device(
+            monkeypatch,
+            cursor_position_setter=cursor_position_setter,
+            mouse_uinput=mouse,  # type: ignore[arg-type]
+        )
+        action = dm.MappingAction(
+            action_type=ActionType.MOUSE_MOVE_ABS,
+            move_x=10,
+            move_y=20,
+        )
+
+        await _runtime_tap_grabbed_move(device, action, "move_abs", 1)
 
         cursor_position_setter.assert_awaited_once_with(10, 20)
         assert mouse.writes == []


### PR DESCRIPTION
## Summary

- Extract `emit_move_action` into `grabbed_device_repeat.py` as an async function that handles both `MOUSE_MOVE_ABS` (via `cursor_position_setter`) and falls back to `emit_configured_mouse_move`.
- Replaces inline cursor-position-setter logic in `_execute_move_action` with a call to the new function.
- Updates `rapidfire_move` and `tap_move` to `await emit_move_action`, fixing a bug where absolute mouse moves during rapidfire/tap were dispatched synchronously and bypassed the cursor position setter.
- Adds two async tests verifying that rapidfire and tap absolute moves use the cursor position setter.

## Testing

- `test_rapidfire_mouse_move_abs_uses_cursor_position_setter` — passes, confirms rapidfire absolute moves go through the async setter and no uinput writes occur.
- `test_tap_mouse_move_abs_uses_cursor_position_setter` — passes, confirms tap absolute moves also use the async setter.
- Existing test suite (`test_grabbed_device_runtime_helpers.py`) passes with no regressions.
- `test_execute_action_covers_superkey_and_tap_move_branches` — unchanged, still passes.
- Ad-hoc runtime verification - run