### PR TITLE
Add appearance preference with system/light/dark toggle

### DIFF
--- a/keymasq/gui/application.py
+++ b/keymasq/gui/application.py
@@ -22,12 +22,23 @@ from gi.repository import (  # pyright: ignore[reportMissingImports, reportAttri
 
 from keymasq.common.paths import ensure_config_dirs  # noqa: E402
 from keymasq.gui.icons import register_icon_search_path, theme_supports_core_icons  # noqa: E402
+from keymasq.gui.preferences import (  # noqa: E402
+    AppearanceMode,
+    load_appearance_mode,
+    save_appearance_mode,
+)
 from keymasq.gui.session_reload import notify_session_reload_async  # noqa: E402
 from keymasq.gui.window import MainWindow  # noqa: E402
 
 APP_VERSION = __version__
 APP_ID = "tools.keymasq.keymasq"
 APP_ICON_NAME = APP_ID
+
+COLOR_SCHEME_BY_APPEARANCE: dict[AppearanceMode, Adw.ColorScheme] = {
+    "system": Adw.ColorScheme.DEFAULT,
+    "light": Adw.ColorScheme.FORCE_LIGHT,
+    "dark": Adw.ColorScheme.FORCE_DARK,
+}
 
 
 def _docs_version() -> str:
@@ -70,6 +81,8 @@ class Application(Adw.Application):
             settings = Gtk.Settings.get_default()
             if settings:
                 settings.set_property("gtk-icon-theme-name", "Adwaita")
+
+        self.apply_appearance_mode(load_appearance_mode(), persist=False)
 
         superkeys_action = Gio.SimpleAction.new("superkeys", None)
         superkeys_action.connect("activate", self._on_superkeys)
@@ -150,6 +163,11 @@ class Application(Adw.Application):
 
     def _on_quit(self, action, param) -> None:
         self.quit()
+
+    def apply_appearance_mode(self, mode: AppearanceMode, *, persist: bool = True) -> None:
+        Adw.StyleManager.get_default().set_color_scheme(COLOR_SCHEME_BY_APPEARANCE[mode])
+        if persist:
+            save_appearance_mode(mode)
 
 
 def main() -> None:

--- a/keymasq/gui/preferences.py
+++ b/keymasq/gui/preferences.py
@@ -1,0 +1,43 @@
+import logging
+import tomllib
+from pathlib import Path
+from typing import Literal, cast
+
+import tomli_w
+
+from keymasq.common import paths
+
+log = logging.getLogger(__name__)
+
+AppearanceMode = Literal["system", "light", "dark"]
+
+DEFAULT_APPEARANCE_MODE: AppearanceMode = "system"
+VALID_APPEARANCE_MODES: set[str] = {"system", "light", "dark"}
+
+
+def _settings_path() -> Path:
+    return paths.CONFIG_DIR / "gui_settings.toml"
+
+
+def load_appearance_mode() -> AppearanceMode:
+    settings_path = _settings_path()
+    if not settings_path.exists():
+        return DEFAULT_APPEARANCE_MODE
+
+    try:
+        with settings_path.open("rb") as f:
+            data = tomllib.load(f)
+    except Exception:
+        log.warning("Failed to load GUI settings: %s", settings_path, exc_info=True)
+        return DEFAULT_APPEARANCE_MODE
+
+    appearance = data.get("appearance")
+    if isinstance(appearance, str) and appearance in VALID_APPEARANCE_MODES:
+        return cast(AppearanceMode, appearance)
+    return DEFAULT_APPEARANCE_MODE
+
+
+def save_appearance_mode(mode: AppearanceMode) -> None:
+    paths.ensure_config_dirs()
+    with _settings_path().open("wb") as f:
+        tomli_w.dump({"appearance": mode}, f)

--- a/keymasq/gui/window.py
+++ b/keymasq/gui/window.py
@@ -18,6 +18,7 @@ from keymasq.gui.icons import (
     image_from_icon_names,
     resolve_icon_name,
 )
+from keymasq.gui.preferences import AppearanceMode, load_appearance_mode
 from keymasq.gui.session_client import (
     GuiTaskResult,
     register_session_event_callback,
@@ -86,6 +87,8 @@ class MainWindow(Adw.ApplicationWindow):
         self._unlock_refresh_inflight = False
         self._placeholder_subtitle: Gtk.Label | None = None
         self._menu_unlock_btn: Gtk.Button | None = None
+        self._appearance_buttons: dict[AppearanceMode, Gtk.ToggleButton] = {}
+        self._syncing_appearance = False
         self._unlock_status_label: Gtk.Label | None = None
         self._selected_profile_name: str | None = None
         self._syncing_profile_selection = False
@@ -649,6 +652,32 @@ class MainWindow(Adw.ApplicationWindow):
         menu_box.set_margin_start(6)
         menu_box.set_margin_end(6)
 
+        appearance_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=0)
+        appearance_box.add_css_class("linked")
+        appearance_box.set_margin_bottom(6)
+        appearance_group: Gtk.ToggleButton | None = None
+        appearance_options: tuple[tuple[AppearanceMode, str], ...] = (
+            ("system", "System"),
+            ("light", "Light"),
+            ("dark", "Dark"),
+        )
+        for mode, label in appearance_options:
+            button = Gtk.ToggleButton(label=label)
+            button.set_hexpand(True)
+            if appearance_group is not None:
+                button.set_group(appearance_group)
+            else:
+                appearance_group = button
+            button.connect("toggled", self._on_appearance_mode_toggled, mode)
+            self._appearance_buttons[mode] = button
+            appearance_box.append(button)
+
+        current_appearance = load_appearance_mode()
+        self._syncing_appearance = True
+        self._appearance_buttons[current_appearance].set_active(True)
+        self._syncing_appearance = False
+        menu_box.append(appearance_box)
+
         superkeys_btn = Gtk.Button(label="Super Keys")
         superkeys_btn.set_halign(Gtk.Align.FILL)
         superkeys_btn.connect("clicked", self._on_menu_action_clicked, "superkeys", menu_popover)
@@ -768,6 +797,19 @@ class MainWindow(Adw.ApplicationWindow):
         self._setup_placeholder()
         self._setup_combo_tab()
         self._update_unlock_state(None)
+
+    def _on_appearance_mode_toggled(
+        self,
+        button: Gtk.ToggleButton,
+        mode: AppearanceMode,
+    ) -> None:
+        if self._syncing_appearance or not button.get_active():
+            return
+
+        app = self.get_application()
+        apply_appearance_mode = getattr(app, "apply_appearance_mode", None)
+        if callable(apply_appearance_mode):
+            apply_appearance_mode(mode)
 
     def _on_menu_action_clicked(
         self,

--- a/tests/gui/test_application_and_reload.py
+++ b/tests/gui/test_application_and_reload.py
@@ -113,6 +113,19 @@ def test_application_activate_and_main_use_configured_entrypoints(monkeypatch) -
     assert calls[-2:] == ["main:True", "run"]
 
 
+def test_gui_appearance_preference_round_trips(temp_config_dir) -> None:
+    from keymasq.gui.preferences import load_appearance_mode, save_appearance_mode
+
+    assert load_appearance_mode() == "system"
+
+    save_appearance_mode("dark")
+
+    assert load_appearance_mode() == "dark"
+    assert (temp_config_dir / "gui_settings.toml").read_text(encoding="utf-8").strip() == (
+        'appearance = "dark"'
+    )
+
+
 def test_session_reload_reports_sync_and_async_status(monkeypatch) -> None:
     import keymasq.gui.session_reload as session_reload_module
 

--- a/tests/gui/test_main_window.py
+++ b/tests/gui/test_main_window.py
@@ -108,6 +108,17 @@ class TestMainWindow:
         assert add_calls == [True]
         assert unlock_calls == []
 
+    def test_main_window_menu_reflects_saved_appearance(self, temp_config_dir):
+        from keymasq.gui.preferences import save_appearance_mode
+        from keymasq.gui.window import MainWindow
+
+        save_appearance_mode("dark")
+
+        window = MainWindow(demo_mode=True)
+
+        assert set(window._appearance_buttons) == {"system", "light", "dark"}
+        assert window._appearance_buttons["dark"].get_active() is True
+
     def test_main_window_unlock_uses_runtime_polkit_without_prompt(
         self, temp_config_dir, monkeypatch
     ):


### PR DESCRIPTION
## Summary

- Add per-user `gui_settings.toml` for persisting GUI preferences, starting with appearance mode
- Support `system`, `light`, and `dark` appearance modes driven by `Adw.StyleManager`
- Load the saved appearance on startup and apply it immediately
- Expose a linked toggle-button group in the main window menu to switch appearance
- Persist changes as soon as a toggle is selected

## Testing

- `tests/gui/test_application_and_reload.py` — round-trip test for `load_appearance_mode` / `save_appearance_mode`
- `tests/gui/test_main_window.py` — verifies the menu reflects the saved appearance on window creation
- Manual smoke test: toggling between modes updates the GTK theme in real time