### PR TITLE
Respect XDG_CONFIG_HOME for config directory

### DIFF
--- a/keymasq/common/paths.py
+++ b/keymasq/common/paths.py
@@ -41,7 +41,8 @@ XDG_RUNTIME_DIR = Path(os.environ.get("XDG_RUNTIME_DIR", f"/run/user/{os.getuid(
 SESSION_SOCKET_PATH = XDG_RUNTIME_DIR / "keymasq" / "session.sock"
 GNOME_BRIDGE_SOCKET_PATH = XDG_RUNTIME_DIR / "keymasq" / "gnome-bridge.sock"
 
-CONFIG_DIR = Path.home() / ".config" / "keymasq"
+XDG_CONFIG_HOME = Path(os.environ.get("XDG_CONFIG_HOME") or Path.home() / ".config")
+CONFIG_DIR = XDG_CONFIG_HOME / "keymasq"
 HARDWARE_DIR = CONFIG_DIR / "hardware"
 PROFILES_DIR = CONFIG_DIR / "profiles"
 SUPERKEYS_DIR = CONFIG_DIR / "superkeys"

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -7,6 +7,39 @@ from types import SimpleNamespace
 import pytest
 
 
+def test_config_dir_defaults_to_home_config(monkeypatch: pytest.MonkeyPatch) -> None:
+    import keymasq.common.paths as paths
+
+    monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
+
+    reloaded = importlib.reload(paths)
+    try:
+        assert reloaded.CONFIG_DIR == Path.home() / ".config" / "keymasq"
+        assert reloaded.HARDWARE_DIR == reloaded.CONFIG_DIR / "hardware"
+        assert reloaded.PROFILES_DIR == reloaded.CONFIG_DIR / "profiles"
+        assert reloaded.SUPERKEYS_DIR == reloaded.CONFIG_DIR / "superkeys"
+    finally:
+        importlib.reload(paths)
+
+
+def test_config_dir_honors_xdg_config_home(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import keymasq.common.paths as paths
+
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg-config"))
+
+    reloaded = importlib.reload(paths)
+    try:
+        assert reloaded.XDG_CONFIG_HOME == tmp_path / "xdg-config"
+        assert reloaded.CONFIG_DIR == tmp_path / "xdg-config" / "keymasq"
+        assert reloaded.HARDWARE_DIR == reloaded.CONFIG_DIR / "hardware"
+        assert reloaded.PROFILES_DIR == reloaded.CONFIG_DIR / "profiles"
+        assert reloaded.SUPERKEYS_DIR == reloaded.CONFIG_DIR / "superkeys"
+    finally:
+        importlib.reload(paths)
+
+
 def test_resolve_keymasq_record_helper_path_uses_build_override(
     tmp_path: Path,
     monkeypatch,


### PR DESCRIPTION
## Summary
- derive Keymasq user config storage from XDG_CONFIG_HOME when set
- keep ~/.config/keymasq as the fallback when XDG_CONFIG_HOME is unset or empty
- add path tests for default and override behavior

## Tests
- nix develop -c ./scripts/check.sh full