### PR TITLE
Move profile settings to dialog with per-device grab toggles

### DIFF
--- a/docs/PROFILES.md
+++ b/docs/PROFILES.md
@@ -114,7 +114,13 @@ source = "mouse"
 
 ## Profile Types
 
-There are two profile types.
+There are two runtime profile types. In the GUI, the type is derived from
+Window Rules:
+
+- no window rules means the profile is permanent
+- one or more window rules means the profile is conditional
+
+To make a profile permanent again, remove its window rules.
 
 ### Permanent profiles
 

--- a/keymasq/gui/style.css
+++ b/keymasq/gui/style.css
@@ -46,6 +46,10 @@
 .status-inactive { background: alpha(@error_color, 0.15); color: @error_color; }
 .status-standby { background: alpha(@shade_color, 0.08); }
 
+.active-profiles-summary {
+  margin-top: -4px;
+}
+
 .recording-locked-notice {
   background: alpha(@warning_color, 0.12);
   border-left: 3px solid @warning_color;

--- a/keymasq/gui/widgets/device_tab.py
+++ b/keymasq/gui/widgets/device_tab.py
@@ -190,38 +190,49 @@ class DeviceTab(ProfileManagedTab):
             return self._selected_profile.config.ensure_layer(self.device.hardware_id)
         return self._selected_profile.config.get_layer(self.device.hardware_id)
 
-    def _append_profile_settings_rows(self, settings_grid: Gtk.Grid, row: int) -> int:
-        self.always_grab_checks: dict[str, Gtk.CheckButton] = {}
+    def _append_profile_settings_groups(self, container: Gtk.Box) -> None:
+        self.always_grab_checks: dict[str, Adw.SwitchRow] = {}
 
-        grab_label = Gtk.Label(label="Grab Mode")
-        grab_label.set_halign(Gtk.Align.START)
-        grab_label.set_valign(Gtk.Align.START)
-        grab_label.set_margin_top(4)
-        settings_grid.attach(grab_label, 0, row, 1, 1)
-
-        grab_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=6)
-        self.always_grab_box = grab_box
+        grab_group = Adw.PreferencesGroup()
+        self.always_grab_group = grab_group
         self._sync_always_grab_device_list()
 
         if not hasattr(self, "always_grab_check"):
-            self.always_grab_check = Gtk.CheckButton(label=self._device_grab_label_text())
+            self.always_grab_check = Adw.SwitchRow(title=self._device_grab_label_text())
 
-        settings_grid.attach(grab_box, 1, row, 1, 1)
-        return row + 1
+        container.append(grab_group)
 
     def _update_extra_profile_settings(self) -> None:
         self._sync_always_grab_device_list()
-        for hardware_id, check in self.always_grab_checks.items():
+        for hardware_id, switch_row in self.always_grab_checks.items():
             layer = self._profile_layer_for_hardware(hardware_id)
-            check.handler_block_by_func(self._on_always_grab_toggled)
-            check.set_active(layer.always_grab_all if layer else False)
-            check.handler_unblock_by_func(self._on_always_grab_toggled)
+            switch_row.handler_block_by_func(self._on_always_grab_toggled)
+            switch_row.set_active(layer.always_grab_all if layer else False)
+            switch_row.handler_unblock_by_func(self._on_always_grab_toggled)
 
     def _active_profile_names_from_response(self, data: dict) -> list[str]:
         devices = data.get("devices", {})
         if not isinstance(devices, dict):
             return []
         return list(devices.get(self.device.hardware_id, {}).get("profiles", []))
+
+    def _active_profiles_summary_title(self) -> str:
+        return "Applied profiles:"
+
+    def _active_profiles_summary_tooltip(self) -> str:
+        return (
+            "Profiles currently applied to this device. "
+            "Enabled profiles without mappings are not listed."
+        )
+
+    def _active_profiles_empty_tooltip(self) -> str:
+        return "No profiles are currently applied to this device."
+
+    def _active_profiles_layer_tooltip(self) -> str:
+        return (
+            "Applied profiles. Layer order: "
+            + " -> ".join(self._active_profile_names)
+        )
 
     def _after_profile_selection_applied(self) -> None:
         for button_id in self._button_widgets:
@@ -294,32 +305,33 @@ class DeviceTab(ProfileManagedTab):
 
         devices = self._profile_settings_devices()
         current_ids = {device.hardware_id for device in devices}
-        for hardware_id, check in list(self.always_grab_checks.items()):
+        for hardware_id, switch_row in list(self.always_grab_checks.items()):
             if hardware_id in current_ids:
                 continue
-            parent = check.get_parent()
-            if isinstance(parent, Gtk.Box):
-                parent.remove(check)
+            self.always_grab_group.remove(switch_row)
             del self.always_grab_checks[hardware_id]
 
         for device in self._profile_settings_devices():
-            check = self.always_grab_checks.get(device.hardware_id)
-            if check is None:
-                check = Gtk.CheckButton()
-                check.set_tooltip_text(
+            switch_row = self.always_grab_checks.get(device.hardware_id)
+            if switch_row is None:
+                switch_row = Adw.SwitchRow()
+                switch_row.set_tooltip_text(
                     "Grab all device interfaces even if not all are used. "
                     "Prevents lag when switching between profiles that need different interfaces."
                 )
-                check.connect("toggled", self._on_always_grab_toggled, device.hardware_id)
-                self.always_grab_box.append(check)
-                self.always_grab_checks[device.hardware_id] = check
-            check.set_label(self._device_grab_label_text(device))
+                switch_row.connect(
+                    "notify::active", self._on_always_grab_toggled, device.hardware_id
+                )
+                self.always_grab_group.add(switch_row)
+                self.always_grab_checks[device.hardware_id] = switch_row
+            switch_row.set_title(self._device_grab_label_text(device))
             if device.hardware_id == self.device.hardware_id:
-                self.always_grab_check = check
+                self.always_grab_check = switch_row
 
     def _on_always_grab_toggled(
         self,
-        check: Gtk.CheckButton,
+        switch_row: Adw.SwitchRow,
+        _param,
         hardware_id: str | None = None,
     ) -> None:
         layer = self._profile_layer_for_hardware(
@@ -327,7 +339,7 @@ class DeviceTab(ProfileManagedTab):
             create=True,
         )
         if layer:
-            layer.always_grab_all = check.get_active()
+            layer.always_grab_all = switch_row.get_active()
             self._save_profile()
 
     def _setup_header(self) -> None:
@@ -452,7 +464,7 @@ class DeviceTab(ProfileManagedTab):
     def _update_device_name_display(self) -> None:
         self.device_name_label.set_text(self.device.name)
         if hasattr(self, "always_grab_check"):
-            self.always_grab_check.set_label(self._device_grab_label_text())
+            self.always_grab_check.set_title(self._device_grab_label_text())
         self._sync_always_grab_device_list()
 
     def _notify_device_renamed(self) -> None:

--- a/keymasq/gui/widgets/device_tab.py
+++ b/keymasq/gui/widgets/device_tab.py
@@ -191,26 +191,31 @@ class DeviceTab(ProfileManagedTab):
         return self._selected_profile.config.get_layer(self.device.hardware_id)
 
     def _append_profile_settings_rows(self, settings_grid: Gtk.Grid, row: int) -> int:
+        self.always_grab_checks: dict[str, Gtk.CheckButton] = {}
+
         grab_label = Gtk.Label(label="Grab Mode")
         grab_label.set_halign(Gtk.Align.START)
-        grab_label.set_valign(Gtk.Align.CENTER)
+        grab_label.set_valign(Gtk.Align.START)
+        grab_label.set_margin_top(4)
         settings_grid.attach(grab_label, 0, row, 1, 1)
 
-        self.always_grab_check = Gtk.CheckButton(label=self._device_grab_label_text())
-        self.always_grab_check.set_active(False)
-        self.always_grab_check.set_tooltip_text(
-            "Grab all device interfaces even if not all are used. "
-            "Prevents lag when switching between profiles that need different interfaces."
-        )
-        self.always_grab_check.connect("toggled", self._on_always_grab_toggled)
-        settings_grid.attach(self.always_grab_check, 1, row, 1, 1)
+        grab_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=6)
+        self.always_grab_box = grab_box
+        self._sync_always_grab_device_list()
+
+        if not hasattr(self, "always_grab_check"):
+            self.always_grab_check = Gtk.CheckButton(label=self._device_grab_label_text())
+
+        settings_grid.attach(grab_box, 1, row, 1, 1)
         return row + 1
 
     def _update_extra_profile_settings(self) -> None:
-        layer = self._selected_layer()
-        self.always_grab_check.handler_block_by_func(self._on_always_grab_toggled)
-        self.always_grab_check.set_active(layer.always_grab_all if layer else False)
-        self.always_grab_check.handler_unblock_by_func(self._on_always_grab_toggled)
+        self._sync_always_grab_device_list()
+        for hardware_id, check in self.always_grab_checks.items():
+            layer = self._profile_layer_for_hardware(hardware_id)
+            check.handler_block_by_func(self._on_always_grab_toggled)
+            check.set_active(layer.always_grab_all if layer else False)
+            check.handler_unblock_by_func(self._on_always_grab_toggled)
 
     def _active_profile_names_from_response(self, data: dict) -> list[str]:
         devices = data.get("devices", {})
@@ -251,8 +256,76 @@ class DeviceTab(ProfileManagedTab):
             caption = base
         self._header_caption_label.set_text(caption)
 
-    def _on_always_grab_toggled(self, check: Gtk.CheckButton) -> None:
-        layer = self._selected_layer(create=True)
+    def _profile_layer_for_hardware(self, hardware_id: str, create: bool = False):
+        if not self._selected_profile:
+            return None
+        if create:
+            return self._selected_profile.config.ensure_layer(hardware_id)
+        return self._selected_profile.config.get_layer(hardware_id)
+
+    def _profile_settings_devices(self) -> list[HardwareConfig]:
+        devices: list[HardwareConfig] = []
+        seen: set[str] = set()
+
+        root = self.main_window or self.get_root()
+        stack = getattr(root, "stack", None)
+        if stack is not None:
+            child = stack.get_first_child()
+            while child is not None:
+                device = getattr(child, "device", None)
+                hardware_id = getattr(device, "hardware_id", None)
+                if (
+                    isinstance(device, HardwareConfig)
+                    and isinstance(hardware_id, str)
+                    and hardware_id not in seen
+                ):
+                    devices.append(device)
+                    seen.add(hardware_id)
+                child = child.get_next_sibling()
+
+        if self.device.hardware_id not in seen:
+            devices.append(self.device)
+
+        return devices
+
+    def _sync_always_grab_device_list(self) -> None:
+        if not hasattr(self, "always_grab_checks"):
+            return
+
+        devices = self._profile_settings_devices()
+        current_ids = {device.hardware_id for device in devices}
+        for hardware_id, check in list(self.always_grab_checks.items()):
+            if hardware_id in current_ids:
+                continue
+            parent = check.get_parent()
+            if isinstance(parent, Gtk.Box):
+                parent.remove(check)
+            del self.always_grab_checks[hardware_id]
+
+        for device in self._profile_settings_devices():
+            check = self.always_grab_checks.get(device.hardware_id)
+            if check is None:
+                check = Gtk.CheckButton()
+                check.set_tooltip_text(
+                    "Grab all device interfaces even if not all are used. "
+                    "Prevents lag when switching between profiles that need different interfaces."
+                )
+                check.connect("toggled", self._on_always_grab_toggled, device.hardware_id)
+                self.always_grab_box.append(check)
+                self.always_grab_checks[device.hardware_id] = check
+            check.set_label(self._device_grab_label_text(device))
+            if device.hardware_id == self.device.hardware_id:
+                self.always_grab_check = check
+
+    def _on_always_grab_toggled(
+        self,
+        check: Gtk.CheckButton,
+        hardware_id: str | None = None,
+    ) -> None:
+        layer = self._profile_layer_for_hardware(
+            hardware_id or self.device.hardware_id,
+            create=True,
+        )
         if layer:
             layer.always_grab_all = check.get_active()
             self._save_profile()
@@ -310,11 +383,12 @@ class DeviceTab(ProfileManagedTab):
 
         self.set_focusable(True)
 
-    def _device_grab_label_text(self) -> str:
-        iface_count = len(self.device.evdev_devices)
+    def _device_grab_label_text(self, device: HardwareConfig | None = None) -> str:
+        device = device or self.device
+        iface_count = len(device.evdev_devices)
         if iface_count > 1:
-            return f"Always grab all {iface_count} interfaces of {self.device.name}"
-        return f"Always grab {self.device.name}"
+            return f"Always grab all {iface_count} interfaces of {device.name}"
+        return f"Always grab {device.name}"
 
     def _on_device_name_right_clicked(self, click, n_press, x, y) -> None:
         if n_press != 1 or self.demo_mode:
@@ -379,6 +453,7 @@ class DeviceTab(ProfileManagedTab):
         self.device_name_label.set_text(self.device.name)
         if hasattr(self, "always_grab_check"):
             self.always_grab_check.set_label(self._device_grab_label_text())
+        self._sync_always_grab_device_list()
 
     def _notify_device_renamed(self) -> None:
         target = self.main_window or self.get_root()

--- a/keymasq/gui/widgets/profile_managed_tab.py
+++ b/keymasq/gui/widgets/profile_managed_tab.py
@@ -106,6 +106,10 @@ class ProfileManagedTab(Gtk.Box):
         self._setup_profile_dropdown()
         self.profile_dropdown.set_hexpand(True)
         self.profile_dropdown.connect("notify::selected", self._on_profile_selected)
+        profile_dropdown_click = Gtk.GestureClick()
+        profile_dropdown_click.set_button(3)
+        profile_dropdown_click.connect("released", self._on_profile_dropdown_right_clicked)
+        self.profile_dropdown.add_controller(profile_dropdown_click)
         profile_box.append(self.profile_dropdown)
 
         self.enabled_check = Gtk.CheckButton(label="Enabled")
@@ -146,15 +150,13 @@ class ProfileManagedTab(Gtk.Box):
 
         active_profile_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=6)
         active_profile_box.add_css_class("active-profiles-summary")
-        active_profile_box.set_tooltip_text(
-            "Profiles are layered. All listed profiles are active; "
-            "later profiles override earlier ones."
-        )
+        active_profile_box.set_tooltip_text(self._active_profiles_summary_tooltip())
 
-        active_profile_title = Gtk.Label(label="Active profiles:")
+        active_profile_title = Gtk.Label(label=self._active_profiles_summary_title())
         active_profile_title.add_css_class("caption")
         active_profile_title.add_css_class("dim-label")
         active_profile_box.append(active_profile_title)
+        self.active_profiles_title_label = active_profile_title
 
         self.active_profiles_label = Gtk.Label(label="None")
         self.active_profiles_label.add_css_class("caption")
@@ -175,138 +177,84 @@ class ProfileManagedTab(Gtk.Box):
         settings_box.set_margin_start(12)
         settings_box.set_margin_end(12)
 
-        settings_grid = Gtk.Grid()
-        settings_grid.set_column_spacing(24)
-        settings_grid.set_row_spacing(12)
-        settings_grid.set_column_homogeneous(False)
+        settings_group = Adw.PreferencesGroup()
 
-        row = 0
-
-        name_label = Gtk.Label(label="Name")
-        name_label.set_halign(Gtk.Align.START)
-        name_label.set_valign(Gtk.Align.CENTER)
-        settings_grid.attach(name_label, 0, row, 1, 1)
-
-        self.name_entry = Gtk.Entry()
-        self.name_entry.set_hexpand(True)
-        self.name_entry.set_placeholder_text("Enter profile name")
-        self.name_entry.connect("activate", self._on_name_changed)
+        self.name_entry = Adw.EntryRow(title="Name")
+        self.name_entry.connect("entry-activated", self._on_name_changed)
         self._name_focus_controller = Gtk.EventControllerFocus()
         self._name_focus_controller.connect("leave", self._on_name_focus_leave)
         self.name_entry.add_controller(self._name_focus_controller)
-        settings_grid.attach(self.name_entry, 1, row, 1, 1)
+        settings_group.add(self.name_entry)
 
-        row += 1
-
-        type_label = Gtk.Label(label="Type")
-        type_label.set_halign(Gtk.Align.START)
-        type_label.set_valign(Gtk.Align.CENTER)
-        settings_grid.attach(type_label, 0, row, 1, 1)
-
-        type_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=12)
-        self.permanent_radio = Gtk.CheckButton(label="⭐ Permanent")
-        self.conditional_radio = Gtk.CheckButton(label="🪟 Conditional", group=self.permanent_radio)
-        self.permanent_radio.connect("toggled", self._on_profile_type_changed)
-        self.conditional_radio.connect("toggled", self._on_profile_type_changed)
-        type_box.append(self.permanent_radio)
-        type_box.append(self.conditional_radio)
-        settings_grid.attach(type_box, 1, row, 1, 1)
-
-        row += 1
-
-        priority_label = Gtk.Label(label="Priority")
-        priority_label.set_halign(Gtk.Align.START)
-        priority_label.set_valign(Gtk.Align.CENTER)
-        settings_grid.attach(priority_label, 0, row, 1, 1)
-
+        priority_row = Adw.ActionRow(title="Priority")
         self.priority_spin = Gtk.SpinButton()
         self.priority_spin.set_adjustment(
             Gtk.Adjustment(value=0, lower=0, upper=100, step_increment=1)
         )
+        self.priority_spin.set_valign(Gtk.Align.CENTER)
         self.priority_spin.set_tooltip_text(
             "Higher priority wins when multiple conditional profiles match"
         )
         self.priority_spin.connect("value-changed", self._on_priority_changed)
-        settings_grid.attach(self.priority_spin, 1, row, 1, 1)
+        priority_row.add_suffix(self.priority_spin)
+        settings_group.add(priority_row)
 
-        row += 1
-
-        rules_label = Gtk.Label(label="Rules")
-        rules_label.set_halign(Gtk.Align.START)
-        rules_label.set_valign(Gtk.Align.CENTER)
-        settings_grid.attach(rules_label, 0, row, 1, 1)
-
-        rules_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=6)
+        self.window_rules_row = Adw.ActionRow(title="Window Rules")
+        self.window_rules_row.set_tooltip_text(
+            "Profiles are always active unless window rules are configured."
+        )
         self.rules_list_label = Gtk.Label(label="No rules")
         self.rules_list_label.add_css_class("dim-label")
-        rules_box.append(self.rules_list_label)
+        self.rules_list_label.set_valign(Gtk.Align.CENTER)
+        self.window_rules_row.add_suffix(self.rules_list_label)
         edit_rules_btn = Gtk.Button(label="Edit")
+        edit_rules_btn.set_valign(Gtk.Align.CENTER)
         edit_rules_btn.connect("clicked", self._on_edit_window_rules)
-        rules_box.append(edit_rules_btn)
-        settings_grid.attach(rules_box, 1, row, 1, 1)
-        self.window_rules_box = rules_box
+        self.window_rules_row.add_suffix(edit_rules_btn)
+        self.window_rules_row.set_activatable_widget(edit_rules_btn)
+        settings_group.add(self.window_rules_row)
 
-        row += 1
+        self.notify_switch = Adw.SwitchRow(title="Notify on activation")
+        self.notify_switch.set_tooltip_text(
+            "Show a desktop notification when this profile becomes active."
+        )
+        self.notify_switch.set_active(True)
+        self.notify_switch.connect("notify::active", self._on_notify_toggled)
+        settings_group.add(self.notify_switch)
 
-        notify_label = Gtk.Label(label="Notify")
-        notify_label.set_halign(Gtk.Align.START)
-        notify_label.set_valign(Gtk.Align.CENTER)
-        settings_grid.attach(notify_label, 0, row, 1, 1)
-
-        self.notify_check = Gtk.CheckButton(label="On activation")
-        self.notify_check.set_active(True)
-        self.notify_check.connect("toggled", self._on_notify_toggled)
-        settings_grid.attach(self.notify_check, 1, row, 1, 1)
-
-        row += 1
-
-        activation_macro_label = Gtk.Label(label="Activation Macro")
-        activation_macro_label.set_halign(Gtk.Align.START)
-        activation_macro_label.set_valign(Gtk.Align.CENTER)
-        settings_grid.attach(activation_macro_label, 0, row, 1, 1)
-
-        self.activation_macro_dropdown = Gtk.DropDown()
-        self.activation_macro_dropdown.set_hexpand(True)
-        self.activation_macro_dropdown.set_tooltip_text("Macro to play when this profile activates")
+        self.activation_macro_dropdown = Adw.ComboRow(title="Activation Macro")
+        self.activation_macro_dropdown.set_tooltip_text(
+            "Macro to play once when this profile becomes active."
+        )
         self.activation_macro_dropdown.connect(
             "notify::selected",
             self._on_activation_macro_changed,
         )
-        settings_grid.attach(self.activation_macro_dropdown, 1, row, 1, 1)
+        settings_group.add(self.activation_macro_dropdown)
 
-        row += 1
-
-        deactivation_macro_label = Gtk.Label(label="Deactivation Macro")
-        deactivation_macro_label.set_halign(Gtk.Align.START)
-        deactivation_macro_label.set_valign(Gtk.Align.CENTER)
-        settings_grid.attach(deactivation_macro_label, 0, row, 1, 1)
-
-        self.deactivation_macro_dropdown = Gtk.DropDown()
-        self.deactivation_macro_dropdown.set_hexpand(True)
+        self.deactivation_macro_dropdown = Adw.ComboRow(title="Deactivation Macro")
         self.deactivation_macro_dropdown.set_tooltip_text(
-            "Macro to play when this profile deactivates"
+            "Macro to play once when this profile stops being active."
         )
         self.deactivation_macro_dropdown.connect(
             "notify::selected",
             self._on_deactivation_macro_changed,
         )
-        settings_grid.attach(self.deactivation_macro_dropdown, 1, row, 1, 1)
+        settings_group.add(self.deactivation_macro_dropdown)
 
         self._refresh_lifecycle_macro_dropdowns()
         self._load_lifecycle_macros()
 
-        row = self._append_profile_settings_rows(settings_grid, row + 1)
-        _ = row
+        settings_box.append(settings_group)
 
-        settings_box.append(settings_grid)
+        self._append_profile_settings_groups(settings_box)
 
         self._profile_settings_content = settings_box
         self._profile_settings_dialog: Adw.Dialog | None = None
         self.settings_frame = self.settings_btn
 
-    def _append_profile_settings_rows(self, settings_grid: Gtk.Grid, row: int) -> int:
-        _ = settings_grid
-        return row
+    def _append_profile_settings_groups(self, container: Gtk.Box) -> None:
+        _ = container
 
     def _selected_layer(self, create: bool = False) -> object | None:
         _ = create
@@ -321,6 +269,21 @@ class ProfileManagedTab(Gtk.Box):
         if not isinstance(active_profiles, list):
             return []
         return [str(name) for name in active_profiles]
+
+    def _active_profiles_summary_title(self) -> str:
+        return "Active profiles:"
+
+    def _active_profiles_summary_tooltip(self) -> str:
+        return (
+            "Profiles are layered. All listed profiles are active; "
+            "later profiles override earlier ones."
+        )
+
+    def _active_profiles_empty_tooltip(self) -> str:
+        return "No profiles are active for this view."
+
+    def _active_profiles_layer_tooltip(self) -> str:
+        return "Layer order: " + " -> ".join(self._active_profile_names)
 
     def _after_profile_selection_applied(self) -> None:
         return
@@ -437,7 +400,7 @@ class ProfileManagedTab(Gtk.Box):
             self._profile_settings_dialog.present(self.get_root())
             return
 
-        dialog = Adw.Dialog(title="Profile Settings", content_width=640, content_height=560)
+        dialog = Adw.Dialog(title="Profile Settings", content_width=640, content_height=620)
         dialog.connect("closed", self._on_profile_settings_dialog_closed)
 
         content = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=0)
@@ -482,6 +445,15 @@ class ProfileManagedTab(Gtk.Box):
         self._profile_settings_dialog = dialog
         self._update_profile_settings()
         dialog.present(self.get_root())
+
+    def _on_profile_dropdown_right_clicked(
+        self,
+        _click: Gtk.GestureClick,
+        _n_press: int,
+        _x: float,
+        _y: float,
+    ) -> None:
+        self._on_profile_settings_clicked(self.settings_btn)
 
     def _on_profile_settings_dialog_closed(self, dialog: Adw.Dialog) -> None:
         if dialog is self._profile_settings_dialog:
@@ -560,35 +532,16 @@ class ProfileManagedTab(Gtk.Box):
             close_after_delete.close()
         notify_session_reload_async()
 
-    def _on_profile_type_changed(self, _check: Gtk.CheckButton) -> None:
-        if not self._selected_profile:
-            return
-
-        is_permanent = self.permanent_radio.get_active()
-        if is_permanent == self._selected_profile.config.is_permanent:
-            return
-
-        if is_permanent:
-            self._selected_profile.config.is_permanent = True
-            self._selected_profile.config.window_rules = []
-            self._update_rules_label()
-        else:
-            self._selected_profile.config.is_permanent = False
-
-        self.window_rules_box.set_sensitive(not is_permanent)
-        self._save_profile()
-        self._update_profile_state_display()
-
     def _on_priority_changed(self, spin: Gtk.SpinButton) -> None:
         if not self._selected_profile:
             return
         self._selected_profile.config.priority = int(spin.get_value())
         self._save_profile()
 
-    def _on_notify_toggled(self, check: Gtk.CheckButton) -> None:
+    def _on_notify_toggled(self, switch_row: Adw.SwitchRow, _param) -> None:
         if not self._selected_profile:
             return
-        self._selected_profile.config.notify_on_activation = check.get_active()
+        self._selected_profile.config.notify_on_activation = switch_row.get_active()
         self._save_profile()
 
     def _on_lifecycle_macros_loaded(self, result: dict | None) -> bool:
@@ -762,7 +715,16 @@ class ProfileManagedTab(Gtk.Box):
         content.append(actions_box)
 
         btn_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=6)
-        btn_box.set_halign(Gtk.Align.END)
+
+        remove_rules_btn = Gtk.Button(label="Remove Window Rules")
+        remove_rules_btn.add_css_class("destructive-action")
+        remove_rules_btn.connect("clicked", self._on_remove_window_rules_clicked)
+        btn_box.append(remove_rules_btn)
+        self._remove_window_rules_btn = remove_rules_btn
+
+        btn_spacer = Gtk.Box()
+        btn_spacer.set_hexpand(True)
+        btn_box.append(btn_spacer)
 
         cancel_btn = Gtk.Button(label="Cancel")
         cancel_btn.connect("clicked", self._on_close_current_rules_dialog_clicked)
@@ -775,12 +737,14 @@ class ProfileManagedTab(Gtk.Box):
 
         content.append(btn_box)
         self._current_rules_dialog.set_child(content)
+        self._update_window_rules_remove_button()
         self._current_rules_dialog.present(self.get_root())
 
     def _on_window_rules_dialog_closed(self, dialog: Adw.Dialog) -> None:
         _ = dialog
         self._window_rules_target_profile_name = None
         self._cancel_window_rule_capture("")
+        self._remove_window_rules_btn = None
 
     def _window_rules_target_profile(self) -> ProfileInfo | None:
         if self.profile_manager is None:
@@ -880,6 +844,7 @@ class ProfileManagedTab(Gtk.Box):
             empty_label = self._create_empty_row()
             self._rules_list_box.append(empty_label)
             self._rule_rows.append(empty_label)
+            self._update_window_rules_remove_button()
             return
 
         for index, rule in enumerate(rules):
@@ -888,6 +853,7 @@ class ProfileManagedTab(Gtk.Box):
             self._rule_rows.append(row_widget)
 
         self._update_first_rule_delete_button()
+        self._update_window_rules_remove_button()
 
     def _remove_rule_row_widget(self, row: Gtk.Widget) -> None:
         if not hasattr(self, "_rules_list_box"):
@@ -1042,6 +1008,20 @@ class ProfileManagedTab(Gtk.Box):
         self._rules_list_box.append(new_row)
         self._rule_rows.append(new_row)
         self._update_first_rule_delete_button()
+        self._update_window_rules_remove_button()
+
+    def _on_remove_window_rules_clicked(self, _button: Gtk.Button) -> None:
+        if not hasattr(self, "_rules_list_box"):
+            return
+
+        for row in list(self._rule_rows):
+            self._remove_rule_row_widget(row)
+        self._rule_rows = []
+        empty_label = self._create_empty_row()
+        self._rules_list_box.append(empty_label)
+        self._rule_rows.append(empty_label)
+        self._update_window_rules_remove_button()
+        self._on_apply_window_rules(_button)
 
     def _on_delete_rule(self, _button: Gtk.Button, row: Gtk.Box) -> None:
         if not hasattr(self, "_rules_list_box"):
@@ -1057,6 +1037,7 @@ class ProfileManagedTab(Gtk.Box):
             self._rule_rows.append(empty_label)
         else:
             self._update_first_rule_delete_button()
+        self._update_window_rules_remove_button()
 
     def _update_first_rule_delete_button(self) -> None:
         rule_rows = [row for row in self._rule_rows if hasattr(row, "_is_rule_row")]
@@ -1064,6 +1045,12 @@ class ProfileManagedTab(Gtk.Box):
         for row in rule_rows:
             if hasattr(row, "_delete_btn"):
                 row._delete_btn.set_visible(show_delete)
+
+    def _update_window_rules_remove_button(self) -> None:
+        if not hasattr(self, "_remove_window_rules_btn") or self._remove_window_rules_btn is None:
+            return
+        has_rules = any(hasattr(row, "_is_rule_row") for row in getattr(self, "_rule_rows", []))
+        self._remove_window_rules_btn.set_sensitive(has_rules)
 
     def _on_apply_window_rules(self, _button: Gtk.Button) -> None:
         target_profile = self._window_rules_target_profile()
@@ -1098,6 +1085,7 @@ class ProfileManagedTab(Gtk.Box):
             return
 
         target_profile.config.window_rules = new_rules
+        target_profile.config.is_permanent = not new_rules
         if not self._save_specific_profile(target_profile):
             return
         if (
@@ -1128,13 +1116,13 @@ class ProfileManagedTab(Gtk.Box):
 
         rules = self._selected_profile.config.window_rules
         if not rules:
-            self.rules_list_label.set_text("No rules")
+            self.rules_list_label.set_text("No rules - always active")
             return
 
         parts = [f"{rule.field}={rule.pattern}" for rule in rules[:2]]
         if len(rules) > 2:
             parts.append(f"... (+{len(rules) - 2})")
-        self.rules_list_label.set_text(", ".join(parts))
+        self.rules_list_label.set_text(f"{', '.join(parts)} - conditional")
 
     def _setup_profile_dropdown(self) -> None:
         current_selected = (
@@ -1231,7 +1219,7 @@ class ProfileManagedTab(Gtk.Box):
 
         if not self._active_profile_names:
             self.active_profiles_label.set_text("None")
-            self.active_profiles_label.set_tooltip_text("No profiles are active for this view.")
+            self.active_profiles_label.set_tooltip_text(self._active_profiles_empty_tooltip())
             return
 
         visible_names = self._active_profile_names[:3]
@@ -1239,9 +1227,7 @@ class ProfileManagedTab(Gtk.Box):
         if len(self._active_profile_names) > len(visible_names):
             summary += f", +{len(self._active_profile_names) - len(visible_names)}"
         self.active_profiles_label.set_text(summary)
-        self.active_profiles_label.set_tooltip_text(
-            "Layer order: " + " -> ".join(self._active_profile_names)
-        )
+        self.active_profiles_label.set_tooltip_text(self._active_profiles_layer_tooltip())
 
     def refresh_profiles(
         self,
@@ -1321,26 +1307,16 @@ class ProfileManagedTab(Gtk.Box):
         self.name_entry.set_text(config.name)
         self.name_entry.handler_unblock_by_func(self._on_name_changed)
 
-        self.permanent_radio.handler_block_by_func(self._on_profile_type_changed)
-        self.conditional_radio.handler_block_by_func(self._on_profile_type_changed)
-        if config.is_permanent:
-            self.permanent_radio.set_active(True)
-        else:
-            self.conditional_radio.set_active(True)
-        self.permanent_radio.handler_unblock_by_func(self._on_profile_type_changed)
-        self.conditional_radio.handler_unblock_by_func(self._on_profile_type_changed)
-
         self.priority_spin.handler_block_by_func(self._on_priority_changed)
         self.priority_spin.set_value(config.priority)
         self.priority_spin.handler_unblock_by_func(self._on_priority_changed)
 
-        self.notify_check.handler_block_by_func(self._on_notify_toggled)
-        self.notify_check.set_active(config.notify_on_activation)
-        self.notify_check.handler_unblock_by_func(self._on_notify_toggled)
+        self.notify_switch.handler_block_by_func(self._on_notify_toggled)
+        self.notify_switch.set_active(config.notify_on_activation)
+        self.notify_switch.handler_unblock_by_func(self._on_notify_toggled)
 
         self._refresh_lifecycle_macro_dropdowns()
         self._update_rules_label()
-        self.window_rules_box.set_sensitive(not config.is_permanent)
         self._update_extra_profile_settings()
 
     def _on_new_profile(self, _button: Gtk.Button) -> None:

--- a/keymasq/gui/widgets/profile_managed_tab.py
+++ b/keymasq/gui/widgets/profile_managed_tab.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import copy
+import logging
 import re
 from datetime import datetime
 
@@ -9,8 +10,9 @@ import gi
 gi.require_version("Gtk", "4.0")
 gi.require_version("Adw", "1")
 
-from gi.repository import Adw, GLib, Gtk  # pyright: ignore[reportAttributeAccessIssue]
+from gi.repository import Adw, GLib, Gtk, Pango  # pyright: ignore[reportAttributeAccessIssue]
 
+from keymasq import __version__
 from keymasq.common.models import ProfileConfig, ProfileState, WindowRule
 from keymasq.gui.session_client import (
     get_active_window_async,
@@ -24,6 +26,21 @@ PROFILE_TYPE_ICONS = {
     "permanent": "⭐",
     "conditional": "🪟",
 }
+
+log = logging.getLogger("keymasq.gui.widgets.profile_managed_tab")
+
+
+def _docs_version() -> str:
+    version = __version__.strip()
+    if not version:
+        return "master"
+    if "dev" in version:
+        return "master"
+    return f"v{version.removeprefix('v')}"
+
+
+def _profiles_docs_url() -> str:
+    return f"https://keymasq.tools/docs/{_docs_version()}/PROFILES/"
 
 
 class ProfileManagedTab(Gtk.Box):
@@ -109,27 +126,49 @@ class ProfileManagedTab(Gtk.Box):
         copy_btn.connect("clicked", self._on_copy_profile)
         btn_group.append(copy_btn)
 
-        delete_btn = Gtk.Button(icon_name="user-trash-symbolic")
-        delete_btn.set_tooltip_text("Delete profile")
-        delete_btn.connect("clicked", self._on_delete_profile)
-        btn_group.append(delete_btn)
-        self.delete_profile_btn = delete_btn
+        settings_btn = Gtk.Button(icon_name="emblem-system-symbolic")
+        settings_btn.set_tooltip_text("Profile settings")
+        settings_btn.connect("clicked", self._on_profile_settings_clicked)
+        btn_group.append(settings_btn)
+        self.settings_btn = settings_btn
 
         profile_box.append(btn_group)
 
         self.status_label = Gtk.Label()
         self.status_label.add_css_class("status-pill")
+        self.status_label.set_tooltip_text(
+            "State of the currently selected profile. "
+            "Other profiles can be active at the same time."
+        )
         profile_box.append(self.status_label)
 
         self.append(profile_box)
 
+        active_profile_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=6)
+        active_profile_box.add_css_class("active-profiles-summary")
+        active_profile_box.set_tooltip_text(
+            "Profiles are layered. All listed profiles are active; "
+            "later profiles override earlier ones."
+        )
+
+        active_profile_title = Gtk.Label(label="Active profiles:")
+        active_profile_title.add_css_class("caption")
+        active_profile_title.add_css_class("dim-label")
+        active_profile_box.append(active_profile_title)
+
+        self.active_profiles_label = Gtk.Label(label="None")
+        self.active_profiles_label.add_css_class("caption")
+        self.active_profiles_label.set_ellipsize(Pango.EllipsizeMode.END)
+        self.active_profiles_label.set_hexpand(True)
+        self.active_profiles_label.set_halign(Gtk.Align.START)
+        active_profile_box.append(self.active_profiles_label)
+
+        self.append(active_profile_box)
+        self._update_active_profiles_summary()
+
         self._setup_profile_settings()
 
     def _setup_profile_settings(self) -> None:
-        settings_expander = Gtk.Expander(label="Profile Settings")
-        settings_expander.set_expanded(False)
-        settings_expander.set_sensitive(False)
-
         settings_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=12)
         settings_box.set_margin_top(12)
         settings_box.set_margin_bottom(12)
@@ -260,10 +299,10 @@ class ProfileManagedTab(Gtk.Box):
         _ = row
 
         settings_box.append(settings_grid)
-        settings_expander.set_child(settings_box)
 
-        self.settings_frame = settings_expander
-        self.append(settings_expander)
+        self._profile_settings_content = settings_box
+        self._profile_settings_dialog: Adw.Dialog | None = None
+        self.settings_frame = self.settings_btn
 
     def _append_profile_settings_rows(self, settings_grid: Gtk.Grid, row: int) -> int:
         _ = settings_grid
@@ -391,7 +430,80 @@ class ProfileManagedTab(Gtk.Box):
         self.refresh_profiles(preferred_profile_name=new_config.name, publish_selection=False)
         notify_session_reload_async()
 
-    def _on_delete_profile(self, _button: Gtk.Button) -> None:
+    def _on_profile_settings_clicked(self, _button: Gtk.Button) -> None:
+        if not self._selected_profile:
+            return
+        if self._profile_settings_dialog is not None:
+            self._profile_settings_dialog.present(self.get_root())
+            return
+
+        dialog = Adw.Dialog(title="Profile Settings", content_width=640, content_height=560)
+        dialog.connect("closed", self._on_profile_settings_dialog_closed)
+
+        content = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=0)
+
+        scrolled = Gtk.ScrolledWindow()
+        scrolled.set_vexpand(True)
+        scrolled.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
+        scrolled.set_propagate_natural_height(True)
+        scrolled.set_child(self._profile_settings_content)
+        content.append(scrolled)
+        content.append(Gtk.Separator())
+
+        footer = Gtk.CenterBox(orientation=Gtk.Orientation.HORIZONTAL)
+        footer.set_margin_top(6)
+        footer.set_margin_bottom(6)
+        footer.set_margin_start(12)
+        footer.set_margin_end(12)
+
+        docs_btn = Gtk.Button(label="?")
+        docs_btn.add_css_class("flat")
+        docs_btn.add_css_class("actions-docs-button")
+        docs_btn.set_tooltip_text("Open Profiles documentation")
+        docs_btn.connect("clicked", self._on_profiles_docs_clicked)
+        footer.set_start_widget(docs_btn)
+
+        end_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=8)
+
+        delete_btn = Gtk.Button(label="Delete Profile")
+        delete_btn.add_css_class("destructive-action")
+        delete_btn.set_sensitive(not self.demo_mode)
+        delete_btn.connect("clicked", self._on_delete_profile, dialog)
+        end_box.append(delete_btn)
+
+        close_btn = Gtk.Button(label="Close")
+        close_btn.connect("clicked", self._on_close_dialog_clicked, dialog)
+        end_box.append(close_btn)
+
+        footer.set_end_widget(end_box)
+        content.append(footer)
+
+        dialog.set_child(content)
+        self._profile_settings_dialog = dialog
+        self._update_profile_settings()
+        dialog.present(self.get_root())
+
+    def _on_profile_settings_dialog_closed(self, dialog: Adw.Dialog) -> None:
+        if dialog is self._profile_settings_dialog:
+            parent = self._profile_settings_content.get_parent()
+            if isinstance(parent, Gtk.ScrolledWindow):
+                parent.set_child(None)
+            dialog.set_child(None)
+            self._profile_settings_dialog = None
+
+    def _on_profiles_docs_clicked(self, _button: Gtk.Button) -> None:
+        url = _profiles_docs_url()
+        try:
+            launcher = Gtk.UriLauncher.new(url)
+            launcher.launch(None, None, None)
+        except Exception as exc:
+            log.warning("Could not open Profiles documentation %s: %s", url, exc)
+
+    def _on_delete_profile(
+        self,
+        _button: Gtk.Button,
+        close_after_delete: Adw.Dialog | None = None,
+    ) -> None:
         if not self._selected_profile or self.demo_mode:
             return
 
@@ -418,14 +530,24 @@ class ProfileManagedTab(Gtk.Box):
 
         delete_btn = Gtk.Button(label="Delete")
         delete_btn.add_css_class("destructive-action")
-        delete_btn.connect("clicked", self._on_confirm_delete_profile, dialog)
+        delete_btn.connect(
+            "clicked",
+            self._on_confirm_delete_profile,
+            dialog,
+            close_after_delete,
+        )
         btn_box.append(delete_btn)
 
         content.append(btn_box)
         dialog.set_child(content)
         dialog.present(self.get_root())
 
-    def _on_confirm_delete_profile(self, _button: Gtk.Button, dialog: Adw.Dialog) -> None:
+    def _on_confirm_delete_profile(
+        self,
+        _button: Gtk.Button,
+        dialog: Adw.Dialog,
+        close_after_delete: Adw.Dialog | None = None,
+    ) -> None:
         if not self._selected_profile or self.profile_manager is None:
             dialog.close()
             return
@@ -434,6 +556,8 @@ class ProfileManagedTab(Gtk.Box):
         self._refresh_other_profile_tabs()
         self.refresh_profiles(publish_selection=False)
         dialog.close()
+        if close_after_delete is not None:
+            close_after_delete.close()
         notify_session_reload_async()
 
     def _on_profile_type_changed(self, _check: Gtk.CheckButton) -> None:
@@ -1088,7 +1212,6 @@ class ProfileManagedTab(Gtk.Box):
             self.enabled_check.set_sensitive(False)
             self.enabled_check.set_active(False)
             self.settings_frame.set_sensitive(False)
-            self.delete_profile_btn.set_sensitive(False)
         else:
             self._update_profile_state_display()
             self.enabled_check.set_sensitive(True)
@@ -1096,12 +1219,29 @@ class ProfileManagedTab(Gtk.Box):
             self.enabled_check.set_active(self._selected_profile.config.enabled)
             self.enabled_check.handler_unblock_by_func(self._on_enabled_toggled)
             self.settings_frame.set_sensitive(True)
-            self.delete_profile_btn.set_sensitive(not self.demo_mode)
             self._update_profile_settings()
 
         self._after_profile_selection_applied()
         if publish_selection:
             self._publish_profile_selection()
+
+    def _update_active_profiles_summary(self) -> None:
+        if not hasattr(self, "active_profiles_label"):
+            return
+
+        if not self._active_profile_names:
+            self.active_profiles_label.set_text("None")
+            self.active_profiles_label.set_tooltip_text("No profiles are active for this view.")
+            return
+
+        visible_names = self._active_profile_names[:3]
+        summary = ", ".join(visible_names)
+        if len(self._active_profile_names) > len(visible_names):
+            summary += f", +{len(self._active_profile_names) - len(visible_names)}"
+        self.active_profiles_label.set_text(summary)
+        self.active_profiles_label.set_tooltip_text(
+            "Layer order: " + " -> ".join(self._active_profile_names)
+        )
 
     def refresh_profiles(
         self,
@@ -1217,7 +1357,7 @@ class ProfileManagedTab(Gtk.Box):
         if self.profile_manager is not None:
             self.profile_manager.reload()
         self.refresh_profiles(preferred_profile_name=profile_name)
-        self.settings_frame.set_expanded(True)
+        self._on_profile_settings_clicked(self.settings_btn)
         notify_session_reload_async()
 
     def _save_specific_profile(self, profile: ProfileInfo | None) -> bool:
@@ -1254,6 +1394,7 @@ class ProfileManagedTab(Gtk.Box):
         if active_profiles != self._active_profile_names:
             self._active_profile_names = active_profiles
             self._refresh_profile_dropdown_states()
+            self._update_active_profiles_summary()
         self._update_profile_state_display()
         self._after_active_profiles_changed()
 

--- a/tests/gui/test_combo_tab_widget.py
+++ b/tests/gui/test_combo_tab_widget.py
@@ -203,7 +203,30 @@ class TestComboTabWidget:
         tab._on_active_profile_response({"active_profiles": ["Desktop"]})
 
         assert tab._active_profile_names == ["Desktop"]
+        assert tab.active_profiles_label.get_text() == "Desktop"
+        assert tab.active_profiles_label.get_tooltip_text() == "Layer order: Desktop"
         assert tab.status_label.get_text() == "active"
+
+    def test_combo_tab_summarizes_layered_active_profiles(self, temp_config_dir):
+        from keymasq.common.models import ProfileConfig
+        from keymasq.gui.widgets.combo_tab import ComboTab
+        from keymasq.session.profiles import ProfileManager
+
+        profile_manager = ProfileManager()
+        for name in ("Base", "App", "Game", "Overlay"):
+            profile_manager.save_profile(ProfileConfig(name=name, enabled=True, is_permanent=True))
+
+        tab = ComboTab(profile_manager=profile_manager, demo_mode=True)
+        tab.refresh_profiles(preferred_profile_name="Base", publish_selection=False)
+        tab._on_active_profile_response(
+            {"active_profiles": ["Base", "App", "Game", "Overlay"]}
+        )
+
+        assert tab.active_profiles_label.get_text() == "Base, App, Game, +1"
+        assert (
+            tab.active_profiles_label.get_tooltip_text()
+            == "Layer order: Base -> App -> Game -> Overlay"
+        )
 
     def test_combo_tab_respects_compositor_tag_rule_capability(self, temp_config_dir):
         from keymasq.common.models import ProfileConfig, WindowRule

--- a/tests/gui/test_device_tab_widget.py
+++ b/tests/gui/test_device_tab_widget.py
@@ -402,6 +402,49 @@ class TestDeviceTabWidget:
         assert layer.always_grab_all is True
         assert save_calls == [True]
 
+    def test_device_tab_profile_settings_lists_all_devices_for_grab_mode(self, temp_config_dir):
+        from keymasq.common.models import ButtonDefinition, HardwareConfig, ProfileConfig
+        from keymasq.gui.window import MainWindow
+
+        window = MainWindow(demo_mode=True)
+        assert window.profile_manager is not None
+        window.profile_manager.save_profile(
+            ProfileConfig(name="Gaming", enabled=True, is_permanent=True)
+        )
+
+        device1 = HardwareConfig(
+            vendor_id="1234",
+            product_id="5678",
+            name="Mouse One",
+            evdev_devices=[],
+            buttons=[ButtonDefinition(id="btn_back", label="Back", evdev="btn_side")],
+        )
+        device2 = HardwareConfig(
+            vendor_id="2234",
+            product_id="6678",
+            name="Mouse Two",
+            evdev_devices=[],
+            buttons=[ButtonDefinition(id="btn_back", label="Back", evdev="btn_side")],
+        )
+
+        window._add_device_tab(device1)
+        window._add_device_tab(device2)
+        tab = window.stack.get_page(window.stack.get_child_by_name(device1.hardware_id)).get_child()
+        tab.refresh_profiles(preferred_profile_name="Gaming", publish_selection=False)
+
+        tab._on_profile_settings_clicked(tab.settings_btn)
+
+        assert set(tab.always_grab_checks) == {device1.hardware_id, device2.hardware_id}
+        assert tab.always_grab_checks[device1.hardware_id].get_label() == "Always grab Mouse One"
+        assert tab.always_grab_checks[device2.hardware_id].get_label() == "Always grab Mouse Two"
+
+        tab.always_grab_checks[device2.hardware_id].set_active(True)
+
+        assert tab._selected_profile is not None
+        layer = tab._selected_profile.config.get_layer(device2.hardware_id)
+        assert layer is not None
+        assert layer.always_grab_all is True
+
     def test_device_tab_confirm_delete_device_updates_runtime_and_stack(
         self, temp_config_dir, monkeypatch
     ):

--- a/tests/gui/test_device_tab_widget.py
+++ b/tests/gui/test_device_tab_widget.py
@@ -435,8 +435,8 @@ class TestDeviceTabWidget:
         tab._on_profile_settings_clicked(tab.settings_btn)
 
         assert set(tab.always_grab_checks) == {device1.hardware_id, device2.hardware_id}
-        assert tab.always_grab_checks[device1.hardware_id].get_label() == "Always grab Mouse One"
-        assert tab.always_grab_checks[device2.hardware_id].get_label() == "Always grab Mouse Two"
+        assert tab.always_grab_checks[device1.hardware_id].get_title() == "Always grab Mouse One"
+        assert tab.always_grab_checks[device2.hardware_id].get_title() == "Always grab Mouse Two"
 
         tab.always_grab_checks[device2.hardware_id].set_active(True)
 
@@ -576,7 +576,7 @@ class TestDeviceTabWidget:
         assert reloaded.name == "Work Mouse"
         assert reload_requests == [{"command": "reload"}]
         assert tab.device_name_label.get_text() == "Work Mouse"
-        assert tab.always_grab_check.get_label() == "Always grab Work Mouse"
+        assert tab.always_grab_check.get_title() == "Always grab Work Mouse"
         assert main_window.renamed == [("1234:5678", "Work Mouse")]
 
         assert tab._rename_device("   ") is False

--- a/tests/gui/test_gui_device_tab_misc.py
+++ b/tests/gui/test_gui_device_tab_misc.py
@@ -379,7 +379,43 @@ def test_window_rules_dialog_applies_to_profile_it_was_opened_for(temp_config_di
     assert [(rule.field, rule.pattern) for rule in desktop.config.window_rules] == [
         ("class", "steam")
     ]
+    assert desktop.config.is_permanent is False
     assert gaming.config.window_rules == []
+
+    tab.refresh_profiles(preferred_profile_name="Desktop", publish_selection=False)
+    tab._show_window_rules_dialog()
+    tab._set_window_rule_rows([])
+    tab._on_apply_window_rules(None)
+
+    desktop = profile_manager.get_profile("Desktop")
+    assert desktop is not None
+    assert desktop.config.window_rules == []
+    assert desktop.config.is_permanent is True
+
+
+def test_window_rules_remove_button_tracks_captured_rules(temp_config_dir):
+    from keymasq.common.models import ButtonDefinition, HardwareConfig, ProfileConfig
+    from keymasq.gui.widgets.device_tab import DeviceTab
+    from keymasq.session.profiles import ProfileManager
+
+    profile_manager = ProfileManager()
+    profile_manager.save_profile(ProfileConfig(name="Desktop", enabled=True, is_permanent=True))
+    device = HardwareConfig(
+        vendor_id="1234",
+        product_id="5678",
+        name="Test Mouse",
+        evdev_devices=[],
+        buttons=[ButtonDefinition(id="btn_back", label="Back", evdev="btn_side")],
+    )
+    tab = DeviceTab(device=device, profile_manager=profile_manager, demo_mode=True)
+    tab.refresh_profiles(preferred_profile_name="Desktop", publish_selection=False)
+    tab._show_window_rules_dialog()
+
+    assert tab._remove_window_rules_btn.get_sensitive() is False
+
+    tab._set_window_rule_rows(tab._build_captured_window_rules({"class": "Steam"}))
+
+    assert tab._remove_window_rules_btn.get_sensitive() is True
 
 
 def test_describe_mapping_action_compact_includes_runtime_markers():

--- a/tests/gui/test_main_window.py
+++ b/tests/gui/test_main_window.py
@@ -290,7 +290,7 @@ class TestMainWindow:
         assert window._selected_profile_name == "Gaming"
         assert tab._selected_profile is not None
         assert tab._selected_profile.config.name == "Gaming"
-        assert tab.settings_frame.get_expanded() is True
+        assert tab._profile_settings_dialog is not None
         assert window.combo_tab is not None
         assert window.combo_tab._selected_profile is not None
         assert window.combo_tab._selected_profile.config.name == "Gaming"

--- a/tests/gui/test_main_window.py
+++ b/tests/gui/test_main_window.py
@@ -429,8 +429,14 @@ class TestMainWindow:
         )
 
         assert tab._active_profile_names == ["Gaming"]
+        assert tab.active_profiles_title_label.get_text() == "Applied profiles:"
+        assert (
+            tab.active_profiles_label.get_tooltip_text()
+            == "Applied profiles. Layer order: Gaming"
+        )
         assert tab.status_label.get_text() == "active"
         assert window.combo_tab is not None
+        assert window.combo_tab.active_profiles_title_label.get_text() == "Active profiles:"
         assert window.combo_tab._active_profile_names == ["Gaming"]
         assert window.combo_tab.status_label.get_text() == "active"
 


### PR DESCRIPTION
## Summary

- Replace the inline profile settings expander with a dedicated `Adw.Dialog` opened from the profile settings button
- Add right-click on the profile selector to open profile settings
- Move profile deletion into the settings dialog footer alongside Close and the docs (`?`) button
- Convert profile settings content to Adwaita preferences rows/groups
- Show all configured devices in the Grab Mode section, with per-device always-grab toggles
- Derive permanent vs conditional profile behavior from Window Rules instead of a separate Type selector
- Keep Window Rules always editable; adding rules makes a profile conditional, removing all rules makes it permanent again
- Add a Remove Window Rules action that clears rules, saves, and closes the rules dialog
- Improve profile state wording with Active profiles for combos and Applied profiles for device tabs
- Clarify applied-profile tooltips so enabled profiles without mappings are not listed
- Add tooltips for notification and activation/deactivation macro settings
- Update profile documentation for the derived Window Rules behavior

## Testing

- `nix develop -c ./scripts/check.sh gui`
- New/updated GUI coverage for profile settings dialog behavior, multi-device grab toggles, layered profile summaries, Window Rules permanent/conditional transitions, captured-rule remove-button state, and applied-profile wording
