### PR TITLE
Add feedback dialog to GUI

### DIFF
--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -50,4 +50,6 @@ You've created your first remap. Explore further:
 - [Combos](COMBOS.md) — trigger actions from key combinations
 - [Super Keys](SUPERKEYS.md) — tap, hold, and double-tap behaviors
 
+Use **Feedback** in the app menu to send bug reports, ideas, or questions from the GUI.
+
 If remaps don't work, see [Troubleshooting](TROUBLESHOOTING.md).

--- a/keymasq/gui/application.py
+++ b/keymasq/gui/application.py
@@ -97,6 +97,10 @@ class Application(Adw.Application):
         record_macro_action.connect("activate", self._on_record_macro)
         self.add_action(record_macro_action)
 
+        feedback_action = Gio.SimpleAction.new("feedback", None)
+        feedback_action.connect("activate", self._on_feedback)
+        self.add_action(feedback_action)
+
         about_action = Gio.SimpleAction.new("about", None)
         about_action.connect("activate", self._on_about)
         self.add_action(about_action)
@@ -148,6 +152,14 @@ class Application(Adw.Application):
         if not self.window:
             return
         self.window.present_recording_settings_dialog()
+
+    def _on_feedback(self, action, param) -> None:
+        if not self.window:
+            return
+        from keymasq.gui.widgets.feedback_dialog import FeedbackDialog
+
+        dialog = FeedbackDialog(self.window)
+        dialog.present(self.window)
 
     def _on_about(self, action, param) -> None:
         if self.window:

--- a/keymasq/gui/widgets/feedback_dialog.py
+++ b/keymasq/gui/widgets/feedback_dialog.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import json
 import os
 import platform

--- a/keymasq/gui/widgets/feedback_dialog.py
+++ b/keymasq/gui/widgets/feedback_dialog.py
@@ -1,0 +1,327 @@
+from __future__ import annotations
+
+import json
+import os
+import platform
+import urllib.error
+import urllib.request
+from collections.abc import Iterable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import gi
+
+gi.require_version("Gtk", "4.0")
+gi.require_version("Adw", "1")
+
+from gi.repository import Adw, Gtk  # pyright: ignore[reportAttributeAccessIssue]
+
+from keymasq import __version__
+from keymasq.gui.session_client import GuiTaskResult, run_gui_task
+
+DEFAULT_FEEDBACK_ENDPOINT = "https://feedback.keymasq.tools/api/feedback"
+OS_RELEASE_PATH = Path("/etc/os-release")
+
+
+@dataclass(frozen=True)
+class FeedbackSubmissionResult:
+    ok: bool
+    message: str
+
+
+def feedback_endpoint() -> str:
+    return os.environ.get("KEYMASQ_FEEDBACK_URL", DEFAULT_FEEDBACK_ENDPOINT).strip()
+
+
+def linux_distribution_name(os_release_path: Path = OS_RELEASE_PATH) -> str:
+    try:
+        with os_release_path.open(encoding="utf-8") as file:
+            values = {}
+            for line in file:
+                key, value = _parse_os_release_line(line)
+                if key:
+                    values[key] = value
+    except OSError:
+        return "unknown"
+
+    return values.get("PRETTY_NAME") or values.get("NAME") or values.get("ID") or "unknown"
+
+
+def _parse_os_release_line(line: str) -> tuple[str, str]:
+    key, separator, raw_value = line.strip().partition("=")
+    if not separator or not key or key.startswith("#"):
+        return "", ""
+    value = raw_value.strip()
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
+        value = value[1:-1]
+    return key, value
+
+
+def submit_feedback(endpoint: str, payload: dict[str, Any]) -> FeedbackSubmissionResult:
+    if not endpoint:
+        return FeedbackSubmissionResult(False, "Feedback is not configured for this build.")
+
+    data = json.dumps(payload).encode("utf-8")
+    request = urllib.request.Request(
+        endpoint,
+        data=data,
+        headers={
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+            "User-Agent": f"keymasq-gui/{__version__}",
+        },
+        method="POST",
+    )
+
+    try:
+        with urllib.request.urlopen(request, timeout=8.0) as response:
+            response.read(4096)
+            if 200 <= response.status < 300:
+                return FeedbackSubmissionResult(True, "Thanks for the feedback.")
+    except urllib.error.HTTPError as exc:
+        exc.read(4096)
+        if exc.code == 429:
+            return FeedbackSubmissionResult(
+                False,
+                "Please wait before sending more feedback.",
+            )
+        if exc.code == 400:
+            return FeedbackSubmissionResult(
+                False,
+                "Add a little more detail before sending.",
+            )
+    except urllib.error.URLError:
+        pass
+    except TimeoutError:
+        pass
+
+    return FeedbackSubmissionResult(
+        False,
+        "Feedback could not be sent right now.",
+    )
+
+
+class FeedbackDialog(Adw.Dialog):
+    def __init__(self, parent: Gtk.Window, endpoint: str | None = None) -> None:
+        super().__init__(title="Feedback", content_width=480, content_height=520)
+        self._parent = parent
+        self._endpoint = endpoint if endpoint is not None else feedback_endpoint()
+        self._submit_inflight = False
+        self._sent = False
+
+        toolbar = Adw.ToolbarView()
+        header = Adw.HeaderBar()
+        toolbar.add_top_bar(header)
+
+        content = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=12)
+        content.set_margin_top(18)
+        content.set_margin_bottom(18)
+        content.set_margin_start(18)
+        content.set_margin_end(18)
+
+        category_label = Gtk.Label(label="Type", xalign=0)
+        category_label.add_css_class("caption")
+        content.append(category_label)
+
+        self.category_dropdown = Gtk.DropDown.new_from_strings(
+            ["Bug", "Idea", "Question", "Other"]
+        )
+        self.category_dropdown.set_selected(2)
+        content.append(self.category_dropdown)
+
+        message_label = Gtk.Label(label="Message", xalign=0)
+        message_label.add_css_class("caption")
+        content.append(message_label)
+
+        message_frame = Gtk.Frame()
+        message_frame.set_vexpand(True)
+        self.message_view = Gtk.TextView()
+        self.message_view.set_wrap_mode(Gtk.WrapMode.WORD_CHAR)
+        self.message_view.set_vexpand(True)
+        self.message_view.set_left_margin(8)
+        self.message_view.set_right_margin(8)
+        self.message_view.set_top_margin(8)
+        self.message_view.set_bottom_margin(8)
+        self.message_view.get_buffer().connect("changed", self._on_message_changed)
+        message_frame.set_child(self.message_view)
+        content.append(message_frame)
+
+        self.diagnostics_check = Gtk.CheckButton(label="Include Diagnostics")
+        self.diagnostics_check.set_active(True)
+        self.diagnostics_check.set_tooltip_text(
+            "Sends Keymasq version, Linux distribution, platform, desktop/session type, "
+            "and configured device names."
+        )
+        content.append(self.diagnostics_check)
+
+        contact_label = Gtk.Label(label="Contact", xalign=0)
+        contact_label.add_css_class("caption")
+        content.append(contact_label)
+
+        self.contact_entry = Gtk.Entry()
+        self.contact_entry.set_placeholder_text("optional")
+        content.append(self.contact_entry)
+
+        self.status_label = Gtk.Label(label="", xalign=0)
+        self.status_label.set_wrap(True)
+        self.status_label.add_css_class("caption")
+        self.status_label.set_visible(False)
+        content.append(self.status_label)
+
+        toolbar.set_content(content)
+        toolbar.add_bottom_bar(self._build_footer())
+        self.set_child(toolbar)
+        self._refresh_submit_state()
+
+    def _build_footer(self) -> Gtk.Widget:
+        footer = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=8)
+        footer.set_halign(Gtk.Align.END)
+        footer.set_margin_top(8)
+        footer.set_margin_bottom(8)
+        footer.set_margin_start(12)
+        footer.set_margin_end(12)
+
+        close_btn = Gtk.Button(label="Cancel")
+        close_btn.connect("clicked", self._on_close_clicked)
+        footer.append(close_btn)
+
+        self.submit_btn = Gtk.Button(label="Send")
+        self.submit_btn.add_css_class("suggested-action")
+        self.submit_btn.connect("clicked", self._on_submit_clicked)
+        footer.append(self.submit_btn)
+
+        return footer
+
+    def _on_close_clicked(self, _button: Gtk.Button) -> None:
+        self.close()
+
+    def _on_message_changed(self, _buffer) -> None:
+        self._refresh_submit_state()
+
+    def _refresh_submit_state(self) -> None:
+        self.submit_btn.set_sensitive(bool(self._message_text()) and not self._submit_inflight)
+
+    def _message_text(self) -> str:
+        buffer = self.message_view.get_buffer()
+        start, end = buffer.get_bounds()
+        return buffer.get_text(start, end, True).strip()
+
+    def _selected_category(self) -> str:
+        item = self.category_dropdown.get_selected_item()
+        if item is None:
+            return "Other"
+        value = getattr(item, "get_string", lambda: "Other")()
+        return str(value).strip() or "Other"
+
+    def _payload(self) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "source": "keymasq-gui",
+            "category": self._selected_category(),
+            "message": self._message_text(),
+            "contact": self.contact_entry.get_text().strip(),
+        }
+
+        if self.diagnostics_check.get_active():
+            payload.update(
+                {
+                    "app_version": __version__,
+                    "distribution": linux_distribution_name(),
+                    "platform": platform.platform(),
+                    "desktop": os.environ.get("XDG_CURRENT_DESKTOP", ""),
+                    "session_type": os.environ.get("XDG_SESSION_TYPE", ""),
+                    "devices": self._diagnostic_device_names(),
+                }
+            )
+        return payload
+
+    def _diagnostic_device_names(self) -> list[str]:
+        devices: dict[str, str] = {}
+        stack = getattr(self._parent, "stack", None)
+        child = stack.get_first_child() if stack is not None else None
+        while child is not None:
+            device = getattr(child, "device", None)
+            self._add_diagnostic_device(devices, device)
+            child = child.get_next_sibling()
+
+        hardware_manager = getattr(self._parent, "hardware_manager", None)
+        list_hardware = getattr(hardware_manager, "list_hardware", None)
+        if callable(list_hardware):
+            try:
+                loaded_devices = list_hardware()
+            except Exception:
+                pass
+            else:
+                if isinstance(loaded_devices, Iterable):
+                    for device in loaded_devices:
+                        self._add_diagnostic_device(devices, device)
+
+        return [f"{name} ({hardware_id})" for hardware_id, name in sorted(devices.items())]
+
+    def _add_diagnostic_device(self, devices: dict[str, str], device: object) -> None:
+        if device is None:
+            return
+        hardware_id = str(getattr(device, "hardware_id", "") or "").strip()
+        name = str(getattr(device, "name", "") or "").strip()
+        if not hardware_id and not name:
+            return
+        if not hardware_id:
+            hardware_id = name
+        devices.setdefault(hardware_id, name or hardware_id)
+
+    def _set_status(self, message: str, *, error: bool = False) -> None:
+        self.status_label.set_text(message)
+        self.status_label.set_visible(True)
+        if error:
+            self.status_label.add_css_class("error")
+        else:
+            self.status_label.remove_css_class("error")
+
+    def _on_submit_clicked(self, _button: Gtk.Button) -> None:
+        if self._submit_inflight or self._sent:
+            return
+
+        payload = self._payload()
+        if not payload["message"]:
+            self._refresh_submit_state()
+            return
+
+        self._submit_inflight = True
+        self.submit_btn.set_sensitive(False)
+        self.submit_btn.set_label("Sending...")
+        self._set_status("")
+
+        endpoint = self._endpoint
+
+        def worker() -> FeedbackSubmissionResult:
+            return submit_feedback(endpoint, payload)
+
+        run_gui_task(worker, self._on_submit_finished)
+
+    def _on_submit_finished(
+        self,
+        result: GuiTaskResult[FeedbackSubmissionResult],
+    ) -> bool:
+        self._submit_inflight = False
+        submission = result.value if result.ok else None
+
+        if submission is not None and submission.ok:
+            self._sent = True
+            self.submit_btn.set_label("Sent")
+            self.submit_btn.set_sensitive(False)
+            self.message_view.set_sensitive(False)
+            self.category_dropdown.set_sensitive(False)
+            self.contact_entry.set_sensitive(False)
+            self.diagnostics_check.set_sensitive(False)
+            self._set_status(submission.message)
+            return False
+
+        self.submit_btn.set_label("Send")
+        self._refresh_submit_state()
+        message = (
+            submission.message
+            if submission is not None
+            else "Feedback could not be sent right now."
+        )
+        self._set_status(message, error=True)
+        return False

--- a/keymasq/gui/window.py
+++ b/keymasq/gui/window.py
@@ -87,6 +87,7 @@ class MainWindow(Adw.ApplicationWindow):
         self._unlock_refresh_inflight = False
         self._placeholder_subtitle: Gtk.Label | None = None
         self._menu_unlock_btn: Gtk.Button | None = None
+        self._menu_unlock_separator: Gtk.Widget | None = None
         self._appearance_buttons: dict[AppearanceMode, Gtk.ToggleButton] = {}
         self._syncing_appearance = False
         self._unlock_status_label: Gtk.Label | None = None
@@ -677,14 +678,22 @@ class MainWindow(Adw.ApplicationWindow):
         self._appearance_buttons[current_appearance].set_active(True)
         self._syncing_appearance = False
         menu_box.append(appearance_box)
+        menu_box.append(self._create_menu_separator())
 
         superkeys_btn = Gtk.Button(label="Super Keys")
-        superkeys_btn.set_halign(Gtk.Align.FILL)
+        self._configure_menu_button(superkeys_btn)
         superkeys_btn.connect("clicked", self._on_menu_action_clicked, "superkeys", menu_popover)
         menu_box.append(superkeys_btn)
 
+        macros_btn = Gtk.Button(label="Macros")
+        self._configure_menu_button(macros_btn)
+        macros_btn.connect("clicked", self._on_menu_action_clicked, "macros", menu_popover)
+        menu_box.append(macros_btn)
+
+        menu_box.append(self._create_menu_separator())
+
         menu_unlock_btn = Gtk.Button(label="Unlock Recording")
-        menu_unlock_btn.set_halign(Gtk.Align.FILL)
+        self._configure_menu_button(menu_unlock_btn)
         menu_unlock_btn.set_tooltip_text(
             "Authorize raw original-input capture for adding inputs, combo capture, "
             "and live macro recording. Uses Polkit and stays tied to this GUI session."
@@ -693,20 +702,22 @@ class MainWindow(Adw.ApplicationWindow):
         menu_box.append(menu_unlock_btn)
         self._menu_unlock_btn = menu_unlock_btn
 
-        macros_btn = Gtk.Button(label="Macros")
-        macros_btn.set_halign(Gtk.Align.FILL)
-        macros_btn.connect("clicked", self._on_menu_action_clicked, "macros", menu_popover)
-        menu_box.append(macros_btn)
+        menu_unlock_separator = self._create_menu_separator()
+        menu_box.append(menu_unlock_separator)
+        self._menu_unlock_separator = menu_unlock_separator
 
-        menu_box.append(Gtk.Separator())
+        feedback_btn = Gtk.Button(label="Feedback")
+        self._configure_menu_button(feedback_btn)
+        feedback_btn.connect("clicked", self._on_menu_action_clicked, "feedback", menu_popover)
+        menu_box.append(feedback_btn)
 
         about_btn = Gtk.Button(label="About")
-        about_btn.set_halign(Gtk.Align.FILL)
+        self._configure_menu_button(about_btn)
         about_btn.connect("clicked", self._on_menu_action_clicked, "about", menu_popover)
         menu_box.append(about_btn)
 
         quit_btn = Gtk.Button(label="Quit")
-        quit_btn.set_halign(Gtk.Align.FILL)
+        self._configure_menu_button(quit_btn)
         quit_btn.connect("clicked", self._on_menu_action_clicked, "quit", menu_popover)
         menu_box.append(quit_btn)
 
@@ -797,6 +808,20 @@ class MainWindow(Adw.ApplicationWindow):
         self._setup_placeholder()
         self._setup_combo_tab()
         self._update_unlock_state(None)
+
+    def _create_menu_separator(self) -> Gtk.Widget:
+        separator = Gtk.Separator(orientation=Gtk.Orientation.HORIZONTAL)
+        separator.set_margin_top(9)
+        separator.set_margin_bottom(9)
+        separator.set_margin_start(4)
+        separator.set_margin_end(4)
+        separator.set_size_request(-1, 2)
+        return separator
+
+    def _configure_menu_button(self, button: Gtk.Button) -> None:
+        button.set_halign(Gtk.Align.FILL)
+        button.set_margin_top(2)
+        button.set_margin_bottom(2)
 
     def _on_appearance_mode_toggled(
         self,
@@ -1188,6 +1213,8 @@ class MainWindow(Adw.ApplicationWindow):
     def _refresh_macro_menu_state(self) -> None:
         if self._menu_unlock_btn is not None:
             self._menu_unlock_btn.set_visible(not self._recording_unlocked)
+        if self._menu_unlock_separator is not None:
+            self._menu_unlock_separator.set_visible(not self._recording_unlocked)
 
         app = self.get_application()
         if app is not None:

--- a/tests/gui/test_application_and_reload.py
+++ b/tests/gui/test_application_and_reload.py
@@ -4,6 +4,7 @@ from tests.gui.support import *
 
 def test_application_dialog_actions_route_to_window_helpers(monkeypatch) -> None:
     import keymasq.gui.application as application_module
+    import keymasq.gui.widgets.feedback_dialog as feedback_module
     import keymasq.gui.widgets.macro_manager_dialog as macro_manager_module
     import keymasq.gui.widgets.superkey_dialog as superkey_module
     from keymasq.gui.application import Application
@@ -48,6 +49,7 @@ def test_application_dialog_actions_route_to_window_helpers(monkeypatch) -> None
     )
     monkeypatch.setattr(superkey_module, "SuperkeyDialog", _Dialog)
     monkeypatch.setattr(macro_manager_module, "MacroManagerDialog", _Dialog)
+    monkeypatch.setattr(feedback_module, "FeedbackDialog", _Dialog)
     monkeypatch.setattr(application_module.Adw, "AboutDialog", _AboutDialog)
 
     app = Application()
@@ -60,6 +62,7 @@ def test_application_dialog_actions_route_to_window_helpers(monkeypatch) -> None
     app._on_superkey_changed(None, "Nav")
     app._on_macros(None, None)
     app._on_record_macro(None, None)
+    app._on_feedback(None, None)
     app._on_about(None, None)
     app._on_macro_manager_closed(None, window)
 
@@ -159,3 +162,141 @@ def test_session_reload_reports_sync_and_async_status(monkeypatch) -> None:
 
     assert callbacks == [False, False]
     assert seen == [True, False]
+
+
+def test_feedback_submit_reports_thanks_without_backend_detail(monkeypatch) -> None:
+    import keymasq.gui.widgets.feedback_dialog as feedback_module
+
+    class _Response:
+        status = 202
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return None
+
+        def read(self, _limit: int) -> bytes:
+            return b'{"message":"Discord notification sent"}'
+
+    captured: dict[str, object] = {}
+
+    def fake_urlopen(request, timeout: float):
+        captured["timeout"] = timeout
+        captured["body"] = request.data.decode("utf-8")
+        return _Response()
+
+    monkeypatch.setattr(feedback_module.urllib.request, "urlopen", fake_urlopen)
+
+    result = feedback_module.submit_feedback(
+        "https://feedback.example/api/feedback",
+        {"message": "This is a useful amount of feedback."},
+    )
+
+    assert result.ok is True
+    assert result.message == "Thanks for the feedback."
+    body = captured["body"]
+    assert isinstance(body, str)
+    assert "useful amount" in body
+
+
+def test_feedback_submit_reports_rate_limit(monkeypatch) -> None:
+    from io import BytesIO
+    import urllib.error
+
+    import keymasq.gui.widgets.feedback_dialog as feedback_module
+
+    def fake_urlopen(_request, timeout: float):
+        raise urllib.error.HTTPError(
+            "https://feedback.example/api/feedback",
+            429,
+            "Too Many Requests",
+            {},
+            BytesIO(b"rate limited"),
+        )
+
+    monkeypatch.setattr(feedback_module.urllib.request, "urlopen", fake_urlopen)
+
+    result = feedback_module.submit_feedback(
+        "https://feedback.example/api/feedback",
+        {"message": "This is a useful amount of feedback."},
+    )
+
+    assert result.ok is False
+    assert result.message == "Please wait before sending more feedback."
+
+
+def test_feedback_dialog_includes_diagnostics_by_default(monkeypatch) -> None:
+    gi.require_version("Gtk", "4.0")
+    from gi.repository import Gtk
+
+    import keymasq.gui.widgets.feedback_dialog as feedback_module
+
+    monkeypatch.setattr(feedback_module.platform, "platform", lambda: "Linux-Test")
+    monkeypatch.setattr(
+        feedback_module,
+        "linux_distribution_name",
+        lambda: "NixOS Test",
+    )
+    monkeypatch.setenv("XDG_CURRENT_DESKTOP", "GNOME")
+    monkeypatch.setenv("XDG_SESSION_TYPE", "wayland")
+
+    parent = Gtk.Window()
+    parent.hardware_manager = SimpleNamespace(  # type: ignore[attr-defined]
+        list_hardware=lambda: [
+            SimpleNamespace(
+                hardware_id="1111:2222",
+                name="Test Keyboard",
+            )
+        ]
+    )
+    dialog = feedback_module.FeedbackDialog(parent, endpoint="https://feedback.example")
+    buffer = dialog.message_view.get_buffer()
+    buffer.set_text("The app did something unexpected.", -1)
+
+    payload = dialog._payload()
+    message = payload["message"]
+    assert isinstance(message, str)
+    assert payload["category"] == "Question"
+    assert "The app did something unexpected." in message
+    assert "Diagnostics:" not in message
+    assert dialog.diagnostics_check.get_active() is True
+    assert "Keymasq version" in (dialog.diagnostics_check.get_tooltip_text() or "")
+    assert payload["distribution"] == "NixOS Test"
+    assert payload["platform"] == "Linux-Test"
+    assert payload["desktop"] == "GNOME"
+    assert payload["session_type"] == "wayland"
+    assert payload["devices"] == ["Test Keyboard (1111:2222)"]
+
+
+def test_feedback_dialog_can_opt_out_of_diagnostics(monkeypatch) -> None:
+    gi.require_version("Gtk", "4.0")
+    from gi.repository import Gtk
+
+    import keymasq.gui.widgets.feedback_dialog as feedback_module
+
+    monkeypatch.setattr(feedback_module.platform, "platform", lambda: "Linux-Test")
+    dialog = feedback_module.FeedbackDialog(Gtk.Window(), endpoint="https://feedback.example")
+    dialog.message_view.get_buffer().set_text("The app did something unexpected.", -1)
+    dialog.diagnostics_check.set_active(False)
+
+    payload = dialog._payload()
+
+    assert "app_version" not in payload
+    assert "distribution" not in payload
+    assert "platform" not in payload
+    assert "desktop" not in payload
+    assert "session_type" not in payload
+    assert "devices" not in payload
+
+
+def test_feedback_distribution_name_uses_os_release_pretty_name(tmp_path) -> None:
+    import keymasq.gui.widgets.feedback_dialog as feedback_module
+
+    os_release = tmp_path / "os-release"
+    os_release.write_text(
+        'NAME="NixOS"\nPRETTY_NAME="NixOS 25.05 (Warbler)"\nID=nixos\n',
+        encoding="utf-8",
+    )
+
+    assert feedback_module.linux_distribution_name(os_release) == "NixOS 25.05 (Warbler)"


### PR DESCRIPTION
## Summary

- New `FeedbackDialog` (GTK4/Adw) for submitting bug reports, ideas, and questions from the app menu
- Sends JSON payload to a configurable endpoint (`KEYMASQ_FEEDBACK_URL` env var or default)
- Optional diagnostics toggle includes app version, distro, platform, desktop/session type, and device names
- Rate-limit (429) and validation (400) errors surface user-friendly messages
- Added "Feedback", "Macros", and "Super Keys" entries to the hamburger menu with improved separators and button styling
- Updated `GETTING_STARTED.md` to mention the new feedback action

## Testing

- `test_application_dialog_actions_route_to_window_helpers` verifies the `feedback` action routes correctly
- `test_feedback_submit_reports_thanks_without_backend_detail` confirms successful submission
- `test_feedback_submit_reports_rate_limit` confirms 429 handling
- `test_feedback_dialog_includes_diagnostics_by_default` checks payload structure with diagnostics enabled
- `test_feedback_dialog_can_opt_out_of_diagnostics` checks payload excludes diagnostic fields when unchecked
- `test_feedback_distribution_name_uses_os_release_pretty_name` validates `/etc/os-release` parsing
- Not run: `./scripts/check.sh gui` (full lint/typecheck suite)