### PR TITLE
Try-restart keymasqd on package upgrades only

### DIFF
--- a/debian/keymasq.postinst
+++ b/debian/keymasq.postinst
@@ -21,6 +21,14 @@ case "$1" in
             systemctl daemon-reload >/dev/null 2>&1 || true
         fi
 
+        if [ -n "${2:-}" ]; then
+            if command -v deb-systemd-invoke >/dev/null 2>&1; then
+                deb-systemd-invoke try-restart keymasqd.service >/dev/null 2>&1 || true
+            elif command -v systemctl >/dev/null 2>&1; then
+                systemctl try-restart keymasqd.service >/dev/null 2>&1 || true
+            fi
+        fi
+
         find /usr/share/icons/hicolor -path '*/apps/tools.keymasq.keymasq.*' -exec touch {} + >/dev/null 2>&1 || true
         touch /usr/share/icons/hicolor >/dev/null 2>&1 || true
         touch /usr/share/applications/tools.keymasq.keymasq.desktop >/dev/null 2>&1 || true

--- a/debian/rules
+++ b/debian/rules
@@ -7,10 +7,10 @@ export PYBUILD_SYSTEM = pyproject
 	dh $@ --buildsystem=pybuild
 
 override_dh_installsystemd:
-	dh_installsystemd --no-enable --no-start keymasqd.service
+	dh_installsystemd --no-enable --no-start --no-stop-on-upgrade keymasqd.service
 
 override_dh_installsystemduser:
-	dh_installsystemduser --no-enable --no-start keymasq-session.service
+	dh_installsystemduser --no-enable keymasq-session.service
 
 execute_after_dh_install:
 	set -eu; \

--- a/debian/rules
+++ b/debian/rules
@@ -6,6 +6,12 @@ export PYBUILD_SYSTEM = pyproject
 %:
 	dh $@ --buildsystem=pybuild
 
+override_dh_installsystemd:
+	dh_installsystemd --no-enable --no-start keymasqd.service
+
+override_dh_installsystemduser:
+	dh_installsystemduser --no-enable --no-start keymasq-session.service
+
 execute_after_dh_install:
 	set -eu; \
 	for icon in assets/icons/tools.keymasq.keymasq-*.png; do \

--- a/docs/PACKAGING.md
+++ b/docs/PACKAGING.md
@@ -124,6 +124,21 @@ In practice, the distro packages all install the same user-visible pieces:
 - the GNOME Shell bridge extension files
 - `/etc/keymasq/security.toml` as the default security configuration
 
+## Service restart policy
+
+Packages should not enable or start Keymasq services automatically on first
+install. Users should explicitly enable `keymasqd` and `keymasq-session`.
+
+On upgrades, Debian, Arch, Fedora, and openSUSE packages try to restart
+`keymasqd` only if it is already running. The NixOS module uses systemd
+`restartTriggers` for the same package-change behavior. The packaged
+`keymasq-session` user unit is configured to exit after an established
+`keymasqd` connection is lost, so systemd's `Restart=on-failure` restarts the
+session service without root package scripts needing to manage per-user systemd
+instances.
+
+The GUI is never restarted by packaging.
+
 The Nix outputs split that payload slightly differently:
 
 - the plain Nix package installs the application commands, desktop assets, and

--- a/flake.nix
+++ b/flake.nix
@@ -268,6 +268,7 @@
               restartTriggers = [ cfg.package ];
               serviceConfig = {
                 Type = "simple";
+                Environment = [ "KEYMASQ_SESSION_RESTART_ON_DAEMON_DISCONNECT=1" ];
                 ExecStart = "${cfg.package}/bin/keymasq-session";
                 Restart = "on-failure";
                 RestartSec = 3;

--- a/keymasq.install
+++ b/keymasq.install
@@ -90,13 +90,16 @@ post_upgrade() {
 
     _ensure_security_policy
 
+    systemctl daemon-reload 2>/dev/null || true
+    systemctl try-restart keymasqd.service 2>/dev/null || true
+
     echo ""
     echo "Keymasq has been upgraded!"
     echo ""
     echo "Security policy uses UID/ACL controls; verify /etc/keymasq/security.toml"
     echo "If session cannot connect to daemon, verify runtime socket policy in /etc/keymasq/security.toml"
-    echo "Restart services to apply changes:"
-    echo "  sudo systemctl restart keymasqd"
+    echo "The package tried to restart keymasqd if it was already running."
+    echo "If needed, restart services manually:"
     echo "  systemctl --user restart keymasq-session"
 }
 

--- a/keymasq/session/manager/core.py
+++ b/keymasq/session/manager/core.py
@@ -5,6 +5,7 @@ import json
 import logging
 import os
 import signal
+import sys
 import traceback
 from typing import cast
 
@@ -77,6 +78,10 @@ class SessionManager:
         self._shutdown_event = asyncio.Event()
         self._retry_event = asyncio.Event()
         self.connected = False
+        self.restart_on_daemon_disconnect = _env_flag(
+            "KEYMASQ_SESSION_RESTART_ON_DAEMON_DISCONNECT"
+        )
+        self.restart_requested = False
         self.reload_task: asyncio.Task[None] | None = None
         self.reload_pending = False
         self.verbosity = verbosity
@@ -485,37 +490,46 @@ class SessionManager:
                 await runtime_recording.refresh_recording_devices_cache(self)
 
                 await self.client.wait_disconnected()
+                log.warning("Disconnected from keymasqd")
+                self._handle_keymasqd_disconnect()
+                if self.restart_on_daemon_disconnect:
+                    log.info("Requesting keymasq-session restart after keymasqd disconnect")
+                    self.restart_requested = True
+                    self._shutdown_event.set()
+                    return
 
             except Exception as e:
                 log.warning(f"Connection failed: {e}")
-                was_connected = self.connected
-                self.connected = False
-                self.profile_state.grabbed_devices.clear()
-                self.profile_state.grabbed_interfaces.clear()
-                self.profile_state.grab_waiting_devices.clear()
-                for task in list(self.profile_state.grab_retry_tasks.values()):
-                    if not task.done():
-                        task.cancel()
-                self.profile_state.grab_retry_tasks.clear()
-                self.profile_state.last_sent_grab_signatures.clear()
-                self.profile_state.last_sent_mapping_signatures.clear()
-                self.profile_state.last_sent_combo_signature = ""
-                self.profile_state.active_profile_names.clear()
-                self.profile_state.resolved_devices.clear()
-                self.recording_state.devices_cache.clear()
-                self.recording_state.selected_devices_cache.clear()
-                self.recording_state.devices_cache_ready = False
+                self._handle_keymasqd_disconnect()
 
-                if was_connected:
-                    self._broadcast_keymasqd_status(False)
+            if self.running:
+                try:
+                    await asyncio.wait_for(self._retry_event.wait(), timeout=retry_delay)
+                except TimeoutError:
+                    pass
+                retry_delay = min(retry_delay * 2, max_delay)
 
-                if self.running:
-                    try:
-                        await asyncio.wait_for(self._retry_event.wait(), timeout=retry_delay)
-                    except TimeoutError:
-                        pass
-                    retry_delay = min(retry_delay * 2, max_delay)
+    def _handle_keymasqd_disconnect(self) -> None:
+        was_connected = self.connected
+        self.connected = False
+        self.profile_state.grabbed_devices.clear()
+        self.profile_state.grabbed_interfaces.clear()
+        self.profile_state.grab_waiting_devices.clear()
+        for task in list(self.profile_state.grab_retry_tasks.values()):
+            if not task.done():
+                task.cancel()
+        self.profile_state.grab_retry_tasks.clear()
+        self.profile_state.last_sent_grab_signatures.clear()
+        self.profile_state.last_sent_mapping_signatures.clear()
+        self.profile_state.last_sent_combo_signature = ""
+        self.profile_state.active_profile_names.clear()
+        self.profile_state.resolved_devices.clear()
+        self.recording_state.devices_cache.clear()
+        self.recording_state.selected_devices_cache.clear()
+        self.recording_state.devices_cache_ready = False
 
+        if was_connected:
+            self._broadcast_keymasqd_status(False)
 
     async def on_window_change(
         self, window_class: str, window_title: str, window_tags: list[str]
@@ -570,11 +584,17 @@ def main() -> None:
     try:
         manager = SessionManager(verbosity=args.verbose)
         asyncio.run(manager.start())
+        if manager.restart_requested:
+            sys.exit(75)
     except KeyboardInterrupt:
         pass
     except Exception as e:
         log.error(f"Fatal error: {e}")
         raise
+
+
+def _env_flag(name: str) -> bool:
+    return os.environ.get(name, "").strip().lower() in {"1", "true", "yes", "on"}
 
 
 if __name__ == "__main__":

--- a/packaging/aur/keymasq.install
+++ b/packaging/aur/keymasq.install
@@ -90,13 +90,16 @@ post_upgrade() {
 
     _ensure_security_policy
 
+    systemctl daemon-reload 2>/dev/null || true
+    systemctl try-restart keymasqd.service 2>/dev/null || true
+
     echo ""
     echo "Keymasq has been upgraded!"
     echo ""
     echo "Security policy uses UID/ACL controls; verify /etc/keymasq/security.toml"
     echo "If session cannot connect to daemon, verify runtime socket policy in /etc/keymasq/security.toml"
-    echo "Restart services to apply changes:"
-    echo "  sudo systemctl restart keymasqd"
+    echo "The package tried to restart keymasqd if it was already running."
+    echo "If needed, restart services manually:"
     echo "  systemctl --user restart keymasq-session"
 }
 

--- a/packaging/pacman/hooks/keymasq-restart.hook
+++ b/packaging/pacman/hooks/keymasq-restart.hook
@@ -1,7 +1,11 @@
-# Optional pacman hook for Keymasq upgrades.
+# Optional pacman hook for local, non-packaged Keymasq upgrades.
 #
 # Purpose:
-#   Restart keymasqd and keymasq-session automatically after keymasq upgrades.
+#   Restart keymasqd after keymasq upgrades if it is already running.
+#
+# Packaged Arch/AUR installs already run this from keymasq.install; this hook
+# is only useful for custom local package flows that do not use that install
+# script.
 #
 # Install:
 #   sudo install -Dm644 packaging/pacman/hooks/keymasq-restart.hook \
@@ -14,6 +18,6 @@ Type = Package
 Target = keymasq
 
 [Action]
-Description = Restarting keymasq services after keymasq upgrade
+Description = Restarting keymasqd after keymasq upgrade
 When = PostTransaction
-Exec = /usr/lib/keymasq/restart-services.sh
+Exec = /usr/bin/systemctl try-restart keymasqd.service

--- a/packaging/pacman/templates/keymasq.install.in
+++ b/packaging/pacman/templates/keymasq.install.in
@@ -89,13 +89,16 @@ post_upgrade() {
 
     _ensure_security_policy
 
+    systemctl daemon-reload 2>/dev/null || true
+    systemctl try-restart keymasqd.service 2>/dev/null || true
+
     echo ""
     echo "Keymasq has been upgraded!"
     echo ""
     echo "Security policy uses UID/ACL controls; verify /etc/keymasq/security.toml"
     echo "If session cannot connect to daemon, verify runtime socket policy in /etc/keymasq/security.toml"
-    echo "Restart services to apply changes:"
-    echo "  sudo systemctl restart keymasqd"
+    echo "The package tried to restart keymasqd if it was already running."
+    echo "If needed, restart services manually:"
     echo "  systemctl --user restart keymasq-session"
 }
 

--- a/scripts/restart-services.sh
+++ b/scripts/restart-services.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-set -euo pipefail
-
-sudo systemctl try-restart keymasqd.service || true
-systemctl --user try-restart keymasq-session.service || true

--- a/scripts/rpm-postinstall.sh
+++ b/scripts/rpm-postinstall.sh
@@ -13,6 +13,12 @@ udevadm trigger --subsystem-match=misc --action=add 2>/dev/null || true
 # Reload systemd
 systemctl daemon-reload 2>/dev/null || true
 
+# On RPM upgrades, $1 is greater than 1. Restart only an already-running daemon;
+# do not start keymasqd on first install.
+if [ "${1:-1}" -gt 1 ]; then
+    systemctl try-restart keymasqd.service 2>/dev/null || true
+fi
+
 # Bump mtimes so desktop environments that watch icon/theme changes
 # can notice the new launcher assets without a full session restart.
 find /usr/share/icons/hicolor -path '*/apps/tools.keymasq.keymasq.*' -exec touch {} + >/dev/null 2>&1 || true

--- a/systemd/keymasq-session.service
+++ b/systemd/keymasq-session.service
@@ -7,6 +7,7 @@ PartOf=default.target
 
 [Service]
 Type=simple
+Environment=KEYMASQ_SESSION_RESTART_ON_DAEMON_DISCONNECT=1
 ExecStart=/usr/bin/keymasq-session
 Restart=on-failure
 RestartSec=3

--- a/tests/session/test_session_manager_connect_loop.py
+++ b/tests/session/test_session_manager_connect_loop.py
@@ -1,0 +1,94 @@
+# ruff: noqa: F403, F405, I001
+from tests.session.command_support import *
+from unittest.mock import call
+import keymasq.session.manager.core as session_core_module
+
+
+@pytest.mark.asyncio
+async def test_keymasqd_disconnect_clears_runtime_state() -> None:
+    manager = SessionManager()
+    retry_task = asyncio.create_task(asyncio.sleep(60))
+    manager.connected = True
+    manager.profile_state.grabbed_devices.add("1234:5678")
+    manager.profile_state.grabbed_interfaces["1234:5678"] = {"event0": "/dev/input/event0"}
+    manager.profile_state.grab_waiting_devices.add("1234:5678")
+    manager.profile_state.grab_retry_tasks["1234:5678"] = retry_task
+    manager.profile_state.last_sent_grab_signatures["1234:5678"] = "grab"
+    manager.profile_state.last_sent_mapping_signatures["1234:5678"] = "mapping"
+    manager.profile_state.last_sent_combo_signature = "combos"
+    manager.profile_state.active_profile_names = ["Default"]
+    manager.profile_state.resolved_devices["1234:5678"] = object()  # type: ignore[assignment]
+    manager.recording_state.devices_cache = [{"name": "Keyboard"}]
+    manager.recording_state.selected_devices_cache = [{"name": "Keyboard"}]
+    manager.recording_state.devices_cache_ready = True
+    manager._broadcast_keymasqd_status = Mock()  # type: ignore[method-assign]
+
+    manager._handle_keymasqd_disconnect()
+    await asyncio.sleep(0)
+
+    assert manager.connected is False
+    assert manager.profile_state.grabbed_devices == set()
+    assert manager.profile_state.grabbed_interfaces == {}
+    assert manager.profile_state.grab_waiting_devices == set()
+    assert retry_task.cancelled()
+    assert manager.profile_state.grab_retry_tasks == {}
+    assert manager.profile_state.last_sent_grab_signatures == {}
+    assert manager.profile_state.last_sent_mapping_signatures == {}
+    assert manager.profile_state.last_sent_combo_signature == ""
+    assert manager.profile_state.active_profile_names == []
+    assert manager.profile_state.resolved_devices == {}
+    assert manager.recording_state.devices_cache == []
+    assert manager.recording_state.selected_devices_cache == []
+    assert manager.recording_state.devices_cache_ready is False
+    manager._broadcast_keymasqd_status.assert_called_once_with(False)  # type: ignore[attr-defined]
+
+    with pytest.raises(asyncio.CancelledError):
+        await retry_task
+
+
+@pytest.mark.asyncio
+async def test_connect_loop_requests_session_restart_after_established_disconnect(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class FakeClient:
+        async def connect(self) -> None:
+            return None
+
+        async def wait_disconnected(self) -> None:
+            return None
+
+    manager = SessionManager()
+    manager.running = True
+    manager.restart_on_daemon_disconnect = True
+    manager.client = FakeClient()  # type: ignore[assignment]
+    manager._broadcast_keymasqd_status = Mock()  # type: ignore[method-assign]
+    sync_cursor = AsyncMock()
+    activate_initial_profiles = AsyncMock()
+    refresh_devices = AsyncMock()
+    monkeypatch.setattr(
+        session_core_module.runtime_compositor,
+        "sync_cursor_position_backend",
+        sync_cursor,
+    )
+    monkeypatch.setattr(
+        session_core_module.runtime_profiles,
+        "activate_initial_profiles",
+        activate_initial_profiles,
+    )
+    monkeypatch.setattr(
+        session_core_module.runtime_recording,
+        "refresh_recording_devices_cache",
+        refresh_devices,
+    )
+
+    await manager.connect_loop()
+
+    assert manager.restart_requested is True
+    assert manager._shutdown_event.is_set()
+    assert manager.connected is False
+    manager._broadcast_keymasqd_status.assert_has_calls(  # type: ignore[attr-defined]
+        [call(True), call(False)]
+    )
+    sync_cursor.assert_awaited_once_with(manager)
+    activate_initial_profiles.assert_awaited_once_with(manager)
+    refresh_devices.assert_awaited_once_with(manager)


### PR DESCRIPTION
## Summary

- Add `try-restart` for `keymasqd.service` on package upgrades across Debian, Arch, and RPM packaging
- Never auto-start or enable services on first install
- Add `KEYMASQ_SESSION_RESTART_ON_DAEMON_DISCONNECT` env var to allow session service to exit (exit code 75) when daemon disconnects, triggering systemd `Restart=on-failure`
- Extract `_handle_keymasqd_disconnect` helper in session manager for cleaner state cleanup
- Update `PACKAGING.md` with service restart policy documentation
- Remove obsolete `restart-services.sh` script
- Add tests for disconnect state cleanup and restart-on-disconnect behavior

## Testing

- `nix develop -c pytest tests/session/test_session_manager_connect_loop.py` — new tests pass
- `nix develop -c ruff check keymasq/session/manager/core.py` — no lint errors
- `nix develop -c basedpyright keymasq/session/manager/core.py` — no type errors
- Verify Debian `postinst` only calls `try-restart` when `$2` is set (upgrade path)
- Verify RPM `postinstall` only calls `try-restart` when `$1 > 1`
- Verify `keymasq-session` exits with code 75 on daemon disconnect when env var is set