### PR TITLE
Add diagnostics category filtering and live GTK diagnostics dialog

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -188,7 +188,7 @@ keymasq play key_a wait:20 key_b --print-json \
 Toggle keymasqd latency diagnostics.
 
 ```bash
-keymasq diagnostics on [--interval SECONDS]
+keymasq diagnostics on [--interval SECONDS] [--include CATEGORY] [--exclude CATEGORY]
 keymasq diagnostics off
 ```
 
@@ -202,3 +202,9 @@ journalctl -u keymasqd -f
 | Option | Description |
 |---|---|
 | `--interval SECONDS` | Logging interval in seconds |
+| `--include CATEGORY` | Add a diagnostics category: `mainline`, `combo`, `internal`, or `all` |
+| `--exclude CATEGORY` | Hide a diagnostics category after includes are applied: `mainline`, `combo`, or `internal` |
+
+The default category is `mainline`, which shows the normal passthrough and
+remap-action paths. Use `--include combo` for combo-specific timing and
+`--include internal` for low-level daemon details.

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -52,7 +52,18 @@ journalctl -u keymasqd -f
 ```
 
 This logs periodic latency percentiles (p50, p95, p99, max) for internal event
-processing. Disable when done:
+processing. By default, diagnostics logs the main input paths most useful for
+everyday latency checks. You can add narrower categories when debugging combo
+behavior or daemon internals:
+
+```bash
+keymasq diagnostics on --include combo
+keymasq diagnostics on --include internal
+keymasq diagnostics on --include all
+keymasq diagnostics on --include all --exclude internal
+```
+
+Disable when done:
 
 ```bash
 keymasq diagnostics off
@@ -116,3 +127,57 @@ For methodology and full results, see:
 
 Keymasq only grabs devices that have active remappings. Devices without
 remappings are not touched and operate at their native polling rate.
+
+## Diagnostics Labels
+
+Diagnostics measure Keymasq's daemon-side handling time for events that pass
+through grabbed devices. They are not the full time from your finger movement to
+the game or desktop reacting. They do not include USB polling, compositor/game
+processing, rendering, display latency, or the physical switch/button travel.
+
+### Mainline Diagnostics
+
+These are shown by default and are the most useful labels for checking normal
+input overhead.
+
+| Label | What it means | Example |
+|---|---|---|
+| `passthrough_fast` | An event passed through when the grabbed device has no active mapping work for it. | Moving an unmapped mouse, or clicking an unmapped button on a grabbed device. |
+| `passthrough_mapped` | An event passed through while a mapping profile is loaded, but this specific input has no remap action. | Moving the mouse while only one side button is remapped. |
+| `passthrough_other` | A non-key, non-relative event passed through. | An uncommon device event such as an absolute axis update. |
+| `wheel_passthrough` | A mouse wheel event passed through by an explicit passthrough mapping. | Scrolling normally when the wheel has a passthrough action. |
+| `action_*` | A configured remap action ran. The suffix names the action type. | Pressing a remapped button, a suppressed key, or a mapped wheel direction. |
+
+### Combo Diagnostics
+
+Enable with:
+
+```bash
+keymasq diagnostics on --include combo
+```
+
+These labels are useful when tuning combo behavior, but they are not a general
+latency baseline.
+
+| Label | What it means | Example |
+|---|---|---|
+| `combo_passthrough` | A combo-relevant event was checked by the combo engine and then passed through normally. | Pressing the first key of a two-key combo where the key should still type if the combo is not completed. |
+| `combo_passthrough_held` | A later event for a combo key that was already allowed through. | Releasing that first combo key after it had been passed through. |
+| `combo_release_action_*` | A combo-related release event triggered an action. | Releasing a held combo chord that fires a remapped button. |
+
+### Internal Diagnostics
+
+Enable with:
+
+```bash
+keymasq diagnostics on --include internal
+```
+
+These labels are mostly for development and bug reports.
+
+| Label | What it means | Example |
+|---|---|---|
+| `syn` | A Linux synchronization event was received and ignored by the remap logic. | The separator event that follows a group of mouse movement or key events. |
+| `wheel_high_res_suppressed` | A high-resolution wheel event was suppressed because the matching low-resolution wheel event is being handled. | A mouse wheel that reports both high-res and normal scroll events. |
+| `combo_recalled_repeat_suppressed` | A repeat event was suppressed for a combo trigger key that Keymasq temporarily recalled. | Holding a key involved in combo recall long enough for keyboard repeat to start. |
+| `combo_recalled_release_suppressed` | A release event was suppressed after combo recall cleanup. | Releasing a combo trigger key that Keymasq already restored synthetically. |

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -63,6 +63,9 @@ keymasq diagnostics on --include all
 keymasq diagnostics on --include all --exclude internal
 ```
 
+The GTK app includes the same live view under **Diagnostics** in the main menu.
+It shows the latest snapshot from keymasqd without reading journal logs.
+
 Disable when done:
 
 ```bash

--- a/keymasq/cli/__main__.py
+++ b/keymasq/cli/__main__.py
@@ -163,6 +163,20 @@ def main() -> None:
         default=5.0,
         help="Logging interval in seconds when enabled",
     )
+    diagnostics_parser.add_argument(
+        "--include",
+        action="append",
+        choices=("mainline", "combo", "internal", "all"),
+        default=[],
+        help="Diagnostics category to log; repeat to add categories",
+    )
+    diagnostics_parser.add_argument(
+        "--exclude",
+        action="append",
+        choices=("mainline", "combo", "internal"),
+        default=[],
+        help="Diagnostics category to hide after includes are applied",
+    )
     _add_json_output(diagnostics_parser)
 
     profiles_parser = subparsers.add_parser("profiles", help="Profile management")
@@ -228,7 +242,13 @@ def main() -> None:
         elif args.macros_command == "delete":
             delete_macro_cli(args.name, json_output=json_output)
     elif args.command == "diagnostics":
-        set_diagnostics_cli(args.state == "on", args.interval, json_output=json_output)
+        set_diagnostics_cli(
+            args.state == "on",
+            args.interval,
+            include=args.include,
+            exclude=args.exclude,
+            json_output=json_output,
+        )
     elif args.command == "profiles":
         if args.profiles_command == "list":
             list_profiles_cli(json_output=json_output)
@@ -330,11 +350,13 @@ def set_diagnostics_cli(
     enabled: bool,
     interval: float = 5.0,
     *,
+    include: list[str] | None = None,
+    exclude: list[str] | None = None,
     json_output: bool = False,
 ) -> None:
     from keymasq.cli.commands import set_diagnostics_cli as impl
 
-    impl(enabled, interval, json_output=json_output)
+    impl(enabled, interval, include=include, exclude=exclude, json_output=json_output)
 
 
 def list_profiles_cli(*, json_output: bool = False) -> None:

--- a/keymasq/cli/commands.py
+++ b/keymasq/cli/commands.py
@@ -7,6 +7,7 @@ from keymasq.common.paths import SESSION_SOCKET_PATH
 
 JsonObject = dict[str, Any]
 IntLike = int | float | str | bytes
+DIAGNOSTICS_CATEGORIES = ("mainline", "combo", "internal")
 
 
 def _session_unavailable() -> JsonObject:
@@ -390,10 +391,21 @@ def _macro_device_types(macro_data: JsonObject) -> list[str] | None:
 
 
 def set_diagnostics_cli(
-    enabled: bool, interval: float = 5.0, *, json_output: bool = False
+    enabled: bool,
+    interval: float = 5.0,
+    *,
+    include: list[str] | None = None,
+    exclude: list[str] | None = None,
+    json_output: bool = False,
 ) -> None:
+    categories = _diagnostics_categories(include, exclude)
     result = _request_or_error(
-        {"command": "set_diagnostics", "enabled": bool(enabled), "interval": float(interval)}
+        {
+            "command": "set_diagnostics",
+            "enabled": bool(enabled),
+            "interval": float(interval),
+            "categories": categories,
+        }
     )
     if _handled_json_or_error(result, json_output):
         return
@@ -401,7 +413,36 @@ def set_diagnostics_cli(
     raw_data = result.get("data")
     data = cast(JsonObject, raw_data) if isinstance(raw_data, dict) else {}
     state = "enabled" if bool(data.get("enabled", enabled)) else "disabled"
-    print(f"Diagnostics {state} (interval={float(data.get('interval', interval)):.2f}s)")
+    raw_categories = data.get("categories", categories)
+    shown_categories = (
+        ", ".join(str(category) for category in raw_categories)
+        if isinstance(raw_categories, list)
+        else ", ".join(categories)
+    )
+    print(
+        f"Diagnostics {state} "
+        f"(interval={float(data.get('interval', interval)):.2f}s, categories={shown_categories})"
+    )
+
+
+def _diagnostics_categories(
+    include: list[str] | None = None,
+    exclude: list[str] | None = None,
+) -> list[str]:
+    selected = {"mainline"}
+    include_set = {str(category or "").lower() for category in include or []}
+    if "all" in include_set:
+        selected = set(DIAGNOSTICS_CATEGORIES)
+    else:
+        selected.update(category for category in include_set if category in DIAGNOSTICS_CATEGORIES)
+    selected.difference_update(
+        str(category or "").lower()
+        for category in exclude or []
+        if str(category or "").lower() in DIAGNOSTICS_CATEGORIES
+    )
+    if not selected:
+        selected = {"mainline"}
+    return [category for category in DIAGNOSTICS_CATEGORIES if category in selected]
 
 
 def _profile_kind(profile: JsonObject) -> str:

--- a/keymasq/common/ipc.py
+++ b/keymasq/common/ipc.py
@@ -50,6 +50,7 @@ class CommandType(Enum):
     CAPTURE_END = "capture_end"
     CAPTURE_COMBO = "capture_combo"
     SET_DIAGNOSTICS = "set_diagnostics"
+    DIAGNOSTICS_SNAPSHOT = "diagnostics_snapshot"
     REFRESH_RECORDING_UNLOCK = "refresh_recording_unlock"
     LOCK_RECORDING_UNLOCK = "lock_recording_unlock"
 

--- a/keymasq/gui/application.py
+++ b/keymasq/gui/application.py
@@ -97,6 +97,10 @@ class Application(Adw.Application):
         record_macro_action.connect("activate", self._on_record_macro)
         self.add_action(record_macro_action)
 
+        diagnostics_action = Gio.SimpleAction.new("diagnostics", None)
+        diagnostics_action.connect("activate", self._on_diagnostics)
+        self.add_action(diagnostics_action)
+
         feedback_action = Gio.SimpleAction.new("feedback", None)
         feedback_action.connect("activate", self._on_feedback)
         self.add_action(feedback_action)
@@ -152,6 +156,14 @@ class Application(Adw.Application):
         if not self.window:
             return
         self.window.present_recording_settings_dialog()
+
+    def _on_diagnostics(self, action, param) -> None:
+        if not self.window:
+            return
+        from keymasq.gui.widgets.diagnostics_dialog import DiagnosticsDialog
+
+        dialog = DiagnosticsDialog(self.window)
+        dialog.present(self.window)
 
     def _on_feedback(self, action, param) -> None:
         if not self.window:

--- a/keymasq/gui/style.css
+++ b/keymasq/gui/style.css
@@ -208,6 +208,11 @@ button.square-key-button {
   min-height: 0;
 }
 
+/* Diagnostics stat cells: tabular figures for column alignment */
+.diagnostics-stat {
+  font-feature-settings: "tnum" 1;
+}
+
 button.media-key-button {
   padding: 6px 8px;
   min-width: 112px;

--- a/keymasq/gui/widgets/diagnostics_dialog.py
+++ b/keymasq/gui/widgets/diagnostics_dialog.py
@@ -1,3 +1,5 @@
+import logging
+import time
 from typing import Any, cast
 
 import gi
@@ -5,8 +7,9 @@ import gi
 gi.require_version("Gtk", "4.0")
 gi.require_version("Adw", "1")
 
-from gi.repository import Adw, Gtk  # pyright: ignore[reportAttributeAccessIssue]
+from gi.repository import Adw, GLib, Gtk  # pyright: ignore[reportAttributeAccessIssue]
 
+from keymasq import __version__
 from keymasq.gui.session_client import (
     JsonDict,
     register_session_event_callback,
@@ -28,9 +31,21 @@ DIAGNOSTICS_LABELS = {
     "combo_recalled_release_suppressed": "Combo recall release suppressed",
 }
 PEAK_TOOLTIP = (
-    "Peak is the single slowest sample in the current sample window. "
-    "p95 and p99 are better indicators of normal latency."
+    "One unusually slow event. If p95 and p99 are low, this usually reflects "
+    "OS scheduling noise, not normal input latency."
 )
+_LABEL_SORT_ORDER: dict[str, int] = {
+    "passthrough_mapped": 0,
+    "passthrough_fast": 1,
+    "passthrough_other": 2,
+    "wheel_passthrough": 3,
+    "combo_passthrough": 10,
+    "combo_passthrough_held": 11,
+    "syn": 30,
+    "wheel_high_res_suppressed": 31,
+    "combo_recalled_repeat_suppressed": 32,
+    "combo_recalled_release_suppressed": 33,
+}
 
 
 def _format_latency(value: object) -> str:
@@ -52,18 +67,71 @@ def _label_title(label: str) -> str:
     return DIAGNOSTICS_LABELS.get(label, label.replace("_", " ").title())
 
 
+def _label_sort_key(label: str) -> tuple[int, str]:
+    if label in _LABEL_SORT_ORDER:
+        return (_LABEL_SORT_ORDER[label], label)
+    if label.startswith("action_"):
+        return (20, label)
+    if label.startswith("combo_release_action_"):
+        return (21, label)
+    return (40, label)
+
+
+def _sort_by_priority(row1: Gtk.ListBoxRow, row2: Gtk.ListBoxRow) -> int:
+    key1: tuple[int, str] = getattr(row1, "_sort_key", (99, ""))
+    key2: tuple[int, str] = getattr(row2, "_sort_key", (99, ""))
+    if key1 < key2:
+        return -1
+    if key1 > key2:
+        return 1
+    return 0
+
+
+log = logging.getLogger("keymasq.gui.widgets.diagnostics_dialog")
+
+
+def _docs_version() -> str:
+    version = __version__.strip()
+    if not version:
+        return "master"
+    if "dev" in version:
+        return "master"
+    return f"v{version.removeprefix('v')}"
+
+
+def _diagnostics_docs_url() -> str:
+    return f"https://keymasq.tools/docs/{_docs_version()}/PERFORMANCE/#diagnostics-labels"
+
+
 class DiagnosticsDialog(Adw.Dialog):
     def __init__(self, parent: Gtk.Window):
         super().__init__(title="Diagnostics", content_width=760, content_height=560)
         self._parent = parent
         self._enabled = False
         self._request_inflight = False
+        self._closing = False
         self._syncing_controls = False
-        self._category_checks: dict[str, Gtk.CheckButton] = {}
+        self._category_checks: dict[str, Gtk.ToggleButton] = {}
         self._rows: dict[str, Gtk.ListBoxRow] = {}
+        self._last_snapshot_time: float | None = None
+        self._tick_source_id: int = 0
 
         toolbar = Adw.ToolbarView()
         header = Adw.HeaderBar()
+
+        self._docs_button = Gtk.Button(label="?")
+        self._docs_button.add_css_class("flat")
+        self._docs_button.add_css_class("actions-docs-button")
+        self._docs_button.set_tooltip_text("Open Diagnostics documentation")
+        self._docs_button.connect("clicked", self._on_docs_clicked)
+        header.pack_end(self._docs_button)
+
+        self._reset_button = Gtk.Button(icon_name="view-refresh-symbolic")
+        self._reset_button.set_tooltip_text("Reset collected samples")
+        self._reset_button.set_sensitive(False)
+        self._reset_button.connect("clicked", self._on_reset_clicked)
+        header.pack_end(self._reset_button)
+
         toolbar.add_top_bar(header)
 
         scrolled = Gtk.ScrolledWindow()
@@ -97,20 +165,36 @@ class DiagnosticsDialog(Adw.Dialog):
         self._interval_spin.connect("value-changed", self._on_interval_changed)
         controls.append(self._interval_spin)
 
+        suffix_label = Gtk.Label(label="s")
+        suffix_label.add_css_class("dim-label")
+        controls.append(suffix_label)
+
         content.append(controls)
 
-        category_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=8)
-        for category, label in (
+        filter_row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=12)
+        filter_row.set_valign(Gtk.Align.CENTER)
+
+        category_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL)
+        category_box.add_css_class("linked")
+        category_box.set_hexpand(True)
+        for category, label_text in (
             ("mainline", "Mainline"),
             ("combo", "Combo"),
             ("internal", "Internal"),
         ):
-            check = Gtk.CheckButton(label=label)
-            check.set_active(category == "mainline")
-            check.connect("toggled", self._on_category_toggled)
-            self._category_checks[category] = check
-            category_box.append(check)
-        content.append(category_box)
+            btn = Gtk.ToggleButton(label=label_text)
+            btn.set_active(category == "mainline")
+            btn.connect("toggled", self._on_category_toggled)
+            self._category_checks[category] = btn
+            category_box.append(btn)
+        filter_row.append(category_box)
+
+        self._show_peak_check = Gtk.CheckButton(label="Show peak")
+        self._show_peak_check.set_tooltip_text(PEAK_TOOLTIP)
+        self._show_peak_check.connect("toggled", self._on_show_peak_toggled)
+        filter_row.append(self._show_peak_check)
+
+        content.append(filter_row)
 
         self._status_label = Gtk.Label(label="Diagnostics are off.")
         self._status_label.set_halign(Gtk.Align.START)
@@ -121,6 +205,7 @@ class DiagnosticsDialog(Adw.Dialog):
         self._list = Gtk.ListBox()
         self._list.set_selection_mode(Gtk.SelectionMode.NONE)
         self._list.add_css_class("boxed-list")
+        self._list.set_sort_func(_sort_by_priority)
         content.append(self._list)
 
         self._empty_label = Gtk.Label(label="No samples yet.")
@@ -133,6 +218,7 @@ class DiagnosticsDialog(Adw.Dialog):
         self.set_child(toolbar)
 
         register_session_event_callback("diagnostics_snapshot", self._on_diagnostics_snapshot)
+        self._tick_source_id = GLib.timeout_add_seconds(1, self._update_status_tick)
         self.connect("closed", self._on_closed)
 
     def _selected_categories(self) -> list[str]:
@@ -155,30 +241,37 @@ class DiagnosticsDialog(Adw.Dialog):
         if self._enabled:
             self._apply_diagnostics_settings()
 
-    def _on_category_toggled(self, _button: Gtk.CheckButton) -> None:
+    def _on_category_toggled(self, button: Gtk.ToggleButton) -> None:
         if self._syncing_controls:
             return
-        if not self._selected_categories():
-            self._category_checks["mainline"].set_active(True)
+        active = [c for c in DIAGNOSTICS_CATEGORIES if self._category_checks[c].get_active()]
+        if not active:
+            self._syncing_controls = True
+            button.set_active(True)
+            self._syncing_controls = False
             return
         if self._enabled:
             self._apply_diagnostics_settings()
 
+    def _on_show_peak_toggled(self, _button: Gtk.CheckButton) -> None:
+        visible = self._show_peak_check.get_active()
+        for row in self._rows.values():
+            cells = getattr(row, "_diagnostics_cells", {})
+            if isinstance(cells, dict) and "max" in cells:
+                cells["max"].set_visible(visible)
+
     def _apply_diagnostics_settings(self) -> None:
         if self._request_inflight:
             return
-        payload: JsonDict = {
-            "command": "set_diagnostics",
-            "enabled": self._enabled,
-            "interval": self._interval_spin.get_value(),
-            "categories": self._selected_categories(),
-        }
+        payload = self._diagnostics_payload(self._enabled)
         self._request_inflight = True
         self._set_controls_sensitive(False)
         session_request_async(payload, self._on_diagnostics_response, timeout=2.0)
 
     def _on_diagnostics_response(self, result: JsonDict | None) -> bool:
         self._request_inflight = False
+        if self._closing:
+            return False
         self._set_controls_sensitive(True)
         if not result or result.get("status") != "ok":
             message = str((result or {}).get("message") or "Diagnostics request failed.")
@@ -193,6 +286,7 @@ class DiagnosticsDialog(Adw.Dialog):
         interval = response.get("interval")
         if isinstance(interval, (int, float)):
             self._interval_spin.set_value(float(interval))
+        self._reset_button.set_sensitive(self._enabled)
         if self._enabled:
             self._status_label.set_text("Waiting for samples...")
         else:
@@ -200,11 +294,20 @@ class DiagnosticsDialog(Adw.Dialog):
             self._clear_rows()
         return False
 
+    def _diagnostics_payload(self, enabled: bool) -> JsonDict:
+        return {
+            "command": "set_diagnostics",
+            "enabled": bool(enabled),
+            "interval": self._interval_spin.get_value(),
+            "categories": self._selected_categories(),
+        }
+
     def _set_controls_sensitive(self, sensitive: bool) -> None:
         self._enable_switch.set_sensitive(sensitive)
         self._interval_spin.set_sensitive(sensitive)
         for check in self._category_checks.values():
             check.set_sensitive(sensitive)
+        self._reset_button.set_sensitive(sensitive and self._enabled)
 
     def _sync_enabled_switch(self) -> None:
         self._syncing_controls = True
@@ -255,13 +358,16 @@ class DiagnosticsDialog(Adw.Dialog):
                 self._list.append(row)
             self._update_row(row, label, stats)
 
+        self._list.invalidate_sort()
         self._empty_label.set_visible(not self._rows)
         if self._rows:
-            self._status_label.set_text("Showing latest diagnostics snapshot.")
+            self._last_snapshot_time = time.monotonic()
+            self._status_label.set_text("Updated just now.")
 
     def _create_row(self, label: str) -> Gtk.ListBoxRow:
         row = Gtk.ListBoxRow()
         row.set_selectable(False)
+        row._sort_key = _label_sort_key(label)  # pyright: ignore[reportAttributeAccessIssue]
         grid = Gtk.Grid(column_spacing=12, row_spacing=2)
         grid.set_margin_top(8)
         grid.set_margin_bottom(8)
@@ -292,9 +398,11 @@ class DiagnosticsDialog(Adw.Dialog):
             cell.set_width_chars(10 if key != "n" else 7)
             cell.set_xalign(1.0)
             cell.add_css_class("caption")
+            cell.add_css_class("diagnostics-stat")
             if key == "max":
                 cell.add_css_class("dim-label")
                 cell.set_tooltip_text(PEAK_TOOLTIP)
+                cell.set_visible(self._show_peak_check.get_active())
             values.append(cell)
             cells[key] = cell
         row._diagnostics_cells = cells  # pyright: ignore[reportAttributeAccessIssue]
@@ -317,6 +425,49 @@ class DiagnosticsDialog(Adw.Dialog):
             self._list.remove(row)
         self._rows.clear()
         self._empty_label.set_visible(True)
+        self._last_snapshot_time = None
+
+    def _on_reset_clicked(self, _button: Gtk.Button) -> None:
+        if self._request_inflight:
+            return
+        self._clear_rows()
+        self._status_label.set_text(
+            "Waiting for samples..." if self._enabled else "Diagnostics are off."
+        )
+        if self._enabled:
+            self._apply_diagnostics_settings()
+
+    def _on_docs_clicked(self, _button: Gtk.Button) -> None:
+        url = _diagnostics_docs_url()
+        try:
+            launcher = Gtk.UriLauncher.new(url)
+            launcher.launch(None, None, None)
+        except Exception as exc:
+            log.warning("Could not open Diagnostics documentation %s: %s", url, exc)
+
+    def _update_status_tick(self) -> bool:
+        if self._last_snapshot_time is None:
+            return GLib.SOURCE_CONTINUE
+        elapsed = int(time.monotonic() - self._last_snapshot_time)
+        if elapsed < 2:
+            self._status_label.set_text("Updated just now.")
+        elif elapsed < 60:
+            self._status_label.set_text(f"Updated {elapsed}s ago.")
+        else:
+            minutes = elapsed // 60
+            self._status_label.set_text(f"Updated {minutes}m ago.")
+        return GLib.SOURCE_CONTINUE
 
     def _on_closed(self, _dialog: Adw.Dialog) -> None:
+        self._closing = True
+        if self._tick_source_id:
+            GLib.source_remove(self._tick_source_id)
+            self._tick_source_id = 0
         unregister_session_event_callback("diagnostics_snapshot", self._on_diagnostics_snapshot)
+        if self._enabled:
+            self._enabled = False
+            session_request_async(
+                self._diagnostics_payload(False),
+                lambda _result: False,
+                timeout=1.0,
+            )

--- a/keymasq/gui/widgets/diagnostics_dialog.py
+++ b/keymasq/gui/widgets/diagnostics_dialog.py
@@ -1,0 +1,322 @@
+from typing import Any, cast
+
+import gi
+
+gi.require_version("Gtk", "4.0")
+gi.require_version("Adw", "1")
+
+from gi.repository import Adw, Gtk  # pyright: ignore[reportAttributeAccessIssue]
+
+from keymasq.gui.session_client import (
+    JsonDict,
+    register_session_event_callback,
+    session_request_async,
+    unregister_session_event_callback,
+)
+
+DIAGNOSTICS_CATEGORIES = ("mainline", "combo", "internal")
+DIAGNOSTICS_LABELS = {
+    "passthrough_fast": "Unmapped passthrough",
+    "passthrough_mapped": "Passthrough with mappings",
+    "passthrough_other": "Other passthrough",
+    "wheel_passthrough": "Wheel passthrough",
+    "combo_passthrough": "Combo candidate passthrough",
+    "combo_passthrough_held": "Combo held passthrough",
+    "syn": "Synchronization event",
+    "wheel_high_res_suppressed": "High-res wheel suppressed",
+    "combo_recalled_repeat_suppressed": "Combo recall repeat suppressed",
+    "combo_recalled_release_suppressed": "Combo recall release suppressed",
+}
+PEAK_TOOLTIP = (
+    "Peak is the single slowest sample in the current sample window. "
+    "p95 and p99 are better indicators of normal latency."
+)
+
+
+def _format_latency(value: object) -> str:
+    try:
+        micros = float(cast(Any, value))
+    except (TypeError, ValueError):
+        micros = 0.0
+    if micros >= 1000.0:
+        return f"{micros / 1000.0:.2f} ms"
+    return f"{micros:.1f} us"
+
+
+def _label_title(label: str) -> str:
+    if label.startswith("action_"):
+        return f"Action: {label.removeprefix('action_').replace('_', ' ')}"
+    if label.startswith("combo_release_action_"):
+        action = label.removeprefix("combo_release_action_").replace("_", " ")
+        return f"Combo release action: {action}"
+    return DIAGNOSTICS_LABELS.get(label, label.replace("_", " ").title())
+
+
+class DiagnosticsDialog(Adw.Dialog):
+    def __init__(self, parent: Gtk.Window):
+        super().__init__(title="Diagnostics", content_width=760, content_height=560)
+        self._parent = parent
+        self._enabled = False
+        self._request_inflight = False
+        self._syncing_controls = False
+        self._category_checks: dict[str, Gtk.CheckButton] = {}
+        self._rows: dict[str, Gtk.ListBoxRow] = {}
+
+        toolbar = Adw.ToolbarView()
+        header = Adw.HeaderBar()
+        toolbar.add_top_bar(header)
+
+        scrolled = Gtk.ScrolledWindow()
+        scrolled.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
+
+        content = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=14)
+        content.set_margin_top(16)
+        content.set_margin_bottom(16)
+        content.set_margin_start(16)
+        content.set_margin_end(16)
+
+        controls = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=12)
+        controls.set_valign(Gtk.Align.CENTER)
+
+        self._enable_switch = Gtk.Switch()
+        self._enable_switch.set_valign(Gtk.Align.CENTER)
+        self._enable_switch.connect("notify::active", self._on_enabled_changed)
+        controls.append(self._enable_switch)
+
+        enable_label = Gtk.Label(label="Collect latency diagnostics")
+        enable_label.set_halign(Gtk.Align.START)
+        enable_label.set_hexpand(True)
+        controls.append(enable_label)
+
+        interval_label = Gtk.Label(label="Interval")
+        controls.append(interval_label)
+
+        adjustment = Gtk.Adjustment(value=5.0, lower=0.5, upper=60.0, step_increment=0.5)
+        self._interval_spin = Gtk.SpinButton(adjustment=adjustment, climb_rate=0.0, digits=1)
+        self._interval_spin.set_width_chars(5)
+        self._interval_spin.connect("value-changed", self._on_interval_changed)
+        controls.append(self._interval_spin)
+
+        content.append(controls)
+
+        category_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=8)
+        for category, label in (
+            ("mainline", "Mainline"),
+            ("combo", "Combo"),
+            ("internal", "Internal"),
+        ):
+            check = Gtk.CheckButton(label=label)
+            check.set_active(category == "mainline")
+            check.connect("toggled", self._on_category_toggled)
+            self._category_checks[category] = check
+            category_box.append(check)
+        content.append(category_box)
+
+        self._status_label = Gtk.Label(label="Diagnostics are off.")
+        self._status_label.set_halign(Gtk.Align.START)
+        self._status_label.add_css_class("caption")
+        self._status_label.add_css_class("dim-label")
+        content.append(self._status_label)
+
+        self._list = Gtk.ListBox()
+        self._list.set_selection_mode(Gtk.SelectionMode.NONE)
+        self._list.add_css_class("boxed-list")
+        content.append(self._list)
+
+        self._empty_label = Gtk.Label(label="No samples yet.")
+        self._empty_label.set_halign(Gtk.Align.START)
+        self._empty_label.add_css_class("dim-label")
+        content.append(self._empty_label)
+
+        scrolled.set_child(content)
+        toolbar.set_content(scrolled)
+        self.set_child(toolbar)
+
+        register_session_event_callback("diagnostics_snapshot", self._on_diagnostics_snapshot)
+        self.connect("closed", self._on_closed)
+
+    def _selected_categories(self) -> list[str]:
+        selected = [
+            category
+            for category in DIAGNOSTICS_CATEGORIES
+            if self._category_checks[category].get_active()
+        ]
+        return selected or ["mainline"]
+
+    def _on_enabled_changed(self, switch: Gtk.Switch, _param: object) -> None:
+        if self._syncing_controls:
+            return
+        self._enabled = switch.get_active()
+        self._apply_diagnostics_settings()
+
+    def _on_interval_changed(self, _spin: Gtk.SpinButton) -> None:
+        if self._syncing_controls:
+            return
+        if self._enabled:
+            self._apply_diagnostics_settings()
+
+    def _on_category_toggled(self, _button: Gtk.CheckButton) -> None:
+        if self._syncing_controls:
+            return
+        if not self._selected_categories():
+            self._category_checks["mainline"].set_active(True)
+            return
+        if self._enabled:
+            self._apply_diagnostics_settings()
+
+    def _apply_diagnostics_settings(self) -> None:
+        if self._request_inflight:
+            return
+        payload: JsonDict = {
+            "command": "set_diagnostics",
+            "enabled": self._enabled,
+            "interval": self._interval_spin.get_value(),
+            "categories": self._selected_categories(),
+        }
+        self._request_inflight = True
+        self._set_controls_sensitive(False)
+        session_request_async(payload, self._on_diagnostics_response, timeout=2.0)
+
+    def _on_diagnostics_response(self, result: JsonDict | None) -> bool:
+        self._request_inflight = False
+        self._set_controls_sensitive(True)
+        if not result or result.get("status") != "ok":
+            message = str((result or {}).get("message") or "Diagnostics request failed.")
+            self._status_label.set_text(message)
+            return False
+
+        data = result.get("data")
+        response = data if isinstance(data, dict) else {}
+        self._enabled = bool(response.get("enabled", self._enabled))
+        self._sync_enabled_switch()
+        self._sync_categories(response.get("categories"))
+        interval = response.get("interval")
+        if isinstance(interval, (int, float)):
+            self._interval_spin.set_value(float(interval))
+        if self._enabled:
+            self._status_label.set_text("Waiting for samples...")
+        else:
+            self._status_label.set_text("Diagnostics are off.")
+            self._clear_rows()
+        return False
+
+    def _set_controls_sensitive(self, sensitive: bool) -> None:
+        self._enable_switch.set_sensitive(sensitive)
+        self._interval_spin.set_sensitive(sensitive)
+        for check in self._category_checks.values():
+            check.set_sensitive(sensitive)
+
+    def _sync_enabled_switch(self) -> None:
+        self._syncing_controls = True
+        try:
+            if self._enable_switch.get_active() != self._enabled:
+                self._enable_switch.set_active(self._enabled)
+        finally:
+            self._syncing_controls = False
+
+    def _sync_categories(self, raw_categories: object) -> None:
+        if not isinstance(raw_categories, list):
+            return
+        selected = {str(category) for category in raw_categories}
+        self._syncing_controls = True
+        try:
+            for category, check in self._category_checks.items():
+                check.set_active(category in selected)
+        finally:
+            self._syncing_controls = False
+
+    def _on_diagnostics_snapshot(self, event: JsonDict) -> bool:
+        samples = event.get("samples")
+        if not isinstance(samples, dict):
+            return False
+        self._enabled = bool(event.get("enabled", True))
+        self._sync_enabled_switch()
+        self._sync_categories(event.get("categories"))
+        interval = event.get("interval")
+        if isinstance(interval, (int, float)):
+            self._interval_spin.set_value(float(interval))
+        self._render_samples(cast(dict[str, Any], samples))
+        return False
+
+    def _render_samples(self, samples: dict[str, Any]) -> None:
+        active_labels = set(samples)
+        for label in sorted(set(self._rows) - active_labels):
+            row = self._rows.pop(label)
+            self._list.remove(row)
+
+        for label in sorted(samples):
+            stats = samples[label]
+            if not isinstance(stats, dict):
+                continue
+            row = self._rows.get(label)
+            if row is None:
+                row = self._create_row(label)
+                self._rows[label] = row
+                self._list.append(row)
+            self._update_row(row, label, stats)
+
+        self._empty_label.set_visible(not self._rows)
+        if self._rows:
+            self._status_label.set_text("Showing latest diagnostics snapshot.")
+
+    def _create_row(self, label: str) -> Gtk.ListBoxRow:
+        row = Gtk.ListBoxRow()
+        row.set_selectable(False)
+        grid = Gtk.Grid(column_spacing=12, row_spacing=2)
+        grid.set_margin_top(8)
+        grid.set_margin_bottom(8)
+        grid.set_margin_start(10)
+        grid.set_margin_end(10)
+
+        title = Gtk.Label(label=_label_title(label))
+        title.set_halign(Gtk.Align.START)
+        title.set_hexpand(True)
+        title.set_tooltip_text(label)
+        title.add_css_class("heading")
+        grid.attach(title, 0, 0, 1, 1)
+
+        raw = Gtk.Label(label=label)
+        raw.set_halign(Gtk.Align.START)
+        raw.add_css_class("caption")
+        raw.add_css_class("dim-label")
+        grid.attach(raw, 0, 1, 1, 1)
+
+        values = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=12)
+        values.set_halign(Gtk.Align.END)
+        values.set_hexpand(True)
+        grid.attach(values, 1, 0, 1, 2)
+
+        cells: dict[str, Gtk.Label] = {}
+        for key in ("n", "p50", "p95", "p99", "max"):
+            cell = Gtk.Label(label="")
+            cell.set_width_chars(10 if key != "n" else 7)
+            cell.set_xalign(1.0)
+            cell.add_css_class("caption")
+            if key == "max":
+                cell.add_css_class("dim-label")
+                cell.set_tooltip_text(PEAK_TOOLTIP)
+            values.append(cell)
+            cells[key] = cell
+        row._diagnostics_cells = cells  # pyright: ignore[reportAttributeAccessIssue]
+        row.set_child(grid)
+        return row
+
+    def _update_row(self, row: Gtk.ListBoxRow, _label: str, stats: dict[str, Any]) -> None:
+        cells = getattr(row, "_diagnostics_cells", {})
+        if not isinstance(cells, dict):
+            return
+        labels = cast(dict[str, Gtk.Label], cells)
+        labels["n"].set_text(f"n {int(stats.get('n', 0) or 0)}")
+        labels["p50"].set_text(f"p50 {_format_latency(stats.get('p50'))}")
+        labels["p95"].set_text(f"p95 {_format_latency(stats.get('p95'))}")
+        labels["p99"].set_text(f"p99 {_format_latency(stats.get('p99'))}")
+        labels["max"].set_text(f"peak {_format_latency(stats.get('max'))}")
+
+    def _clear_rows(self) -> None:
+        for row in list(self._rows.values()):
+            self._list.remove(row)
+        self._rows.clear()
+        self._empty_label.set_visible(True)
+
+    def _on_closed(self, _dialog: Adw.Dialog) -> None:
+        unregister_session_event_callback("diagnostics_snapshot", self._on_diagnostics_snapshot)

--- a/keymasq/gui/widgets/diagnostics_dialog.py
+++ b/keymasq/gui/widgets/diagnostics_dialog.py
@@ -285,7 +285,11 @@ class DiagnosticsDialog(Adw.Dialog):
         self._sync_categories(response.get("categories"))
         interval = response.get("interval")
         if isinstance(interval, (int, float)):
-            self._interval_spin.set_value(float(interval))
+            self._syncing_controls = True
+            try:
+                self._interval_spin.set_value(float(interval))
+            finally:
+                self._syncing_controls = False
         self._reset_button.set_sensitive(self._enabled)
         if self._enabled:
             self._status_label.set_text("Waiting for samples...")
@@ -337,7 +341,12 @@ class DiagnosticsDialog(Adw.Dialog):
         self._sync_categories(event.get("categories"))
         interval = event.get("interval")
         if isinstance(interval, (int, float)):
-            self._interval_spin.set_value(float(interval))
+            self._syncing_controls = True
+            try:
+                self._interval_spin.set_value(float(interval))
+            finally:
+                self._syncing_controls = False
+        self._reset_button.set_sensitive(self._enabled)
         self._render_samples(cast(dict[str, Any], samples))
         return False
 

--- a/keymasq/gui/window.py
+++ b/keymasq/gui/window.py
@@ -690,6 +690,16 @@ class MainWindow(Adw.ApplicationWindow):
         macros_btn.connect("clicked", self._on_menu_action_clicked, "macros", menu_popover)
         menu_box.append(macros_btn)
 
+        diagnostics_btn = Gtk.Button(label="Diagnostics")
+        self._configure_menu_button(diagnostics_btn)
+        diagnostics_btn.connect(
+            "clicked",
+            self._on_menu_action_clicked,
+            "diagnostics",
+            menu_popover,
+        )
+        menu_box.append(diagnostics_btn)
+
         menu_box.append(self._create_menu_separator())
 
         menu_unlock_btn = Gtk.Button(label="Unlock Recording")

--- a/keymasq/keymasqd/daemon.py
+++ b/keymasq/keymasqd/daemon.py
@@ -132,7 +132,12 @@ class _DaemonDeviceManager(Protocol):
 
     def read_combo_capture(self, token: str) -> JsonObject: ...
 
-    async def set_diagnostics(self, enabled: bool, interval: float) -> JsonObject: ...
+    async def set_diagnostics(
+        self,
+        enabled: bool,
+        interval: float,
+        categories: Sequence[object] | None = None,
+    ) -> JsonObject: ...
 
     def complete_macro_exec_wait(self, wait_id: str, returncode: int) -> JsonObject: ...
 

--- a/keymasq/keymasqd/daemon_device_commands.py
+++ b/keymasq/keymasqd/daemon_device_commands.py
@@ -1,5 +1,5 @@
 from collections.abc import Sequence
-from typing import Protocol
+from typing import Protocol, cast
 
 from keymasq.common.ipc import CommandType
 from keymasq.keymasqd import daemon_macro_commands
@@ -45,7 +45,12 @@ class _DeviceCommandManager(Protocol):
 
     async def list_devices(self) -> JsonObject: ...
 
-    async def set_diagnostics(self, enabled: bool, interval: float) -> JsonObject: ...
+    async def set_diagnostics(
+        self,
+        enabled: bool,
+        interval: float,
+        categories: Sequence[object] | None = None,
+    ) -> JsonObject: ...
 
 
 class _DeviceCommandMacroStore(Protocol):
@@ -126,6 +131,12 @@ async def handle_device_command(
     if command_type == CommandType.SET_DIAGNOSTICS:
         enabled = bool(data.get("enabled", False))
         interval = float_like(data.get("interval", 5.0), 5.0)
-        return await daemon.device_manager.set_diagnostics(enabled, interval)
+        raw_categories = data.get("categories")
+        categories = (
+            [str_value(category) for category in cast(list[object], raw_categories)]
+            if isinstance(raw_categories, list)
+            else None
+        )
+        return await daemon.device_manager.set_diagnostics(enabled, interval, categories)
 
     return None

--- a/keymasq/keymasqd/device_manager.py
+++ b/keymasq/keymasqd/device_manager.py
@@ -302,6 +302,18 @@ def _diagnostics_label_is_internal(label: str) -> bool:
     }
 
 
+def _diagnostics_int(value: object) -> int:
+    if isinstance(value, (int, float, str, bytes)):
+        return int(value)
+    return 0
+
+
+def _diagnostics_float(value: object) -> float:
+    if isinstance(value, (int, float, str, bytes)):
+        return float(value)
+    return 0.0
+
+
 @dataclass
 class GrabRuntimeState:
     release_grace_s: float
@@ -756,13 +768,21 @@ class DeviceManager:
                     if samples
                 }
                 if snapshot:
-                    await asyncio.to_thread(self._log_diagnostics_snapshot, snapshot)
+                    summary = await asyncio.to_thread(
+                        self._summarize_diagnostics_snapshot,
+                        snapshot,
+                    )
+                    self._broadcast_diagnostics_snapshot(summary)
+                    await asyncio.to_thread(self._log_diagnostics_summary, summary)
         except asyncio.CancelledError:
             raise
 
-    def _log_diagnostics_snapshot(self, snapshot: dict[str, list[float]]) -> None:
+    def _summarize_diagnostics_snapshot(
+        self,
+        snapshot: dict[str, list[float]],
+    ) -> dict[str, JsonObject]:
         if not snapshot:
-            return
+            return {}
 
         def pct(values: list[float], p: float) -> float:
             if not values:
@@ -770,22 +790,49 @@ class DeviceManager:
             idx = int((len(values) - 1) * p)
             return values[max(0, min(idx, len(values) - 1))]
 
+        summary: dict[str, JsonObject] = {}
         for label, samples in snapshot.items():
             if not samples:
                 continue
             values = sorted(samples)
-            p50 = pct(values, 0.50)
-            p95 = pct(values, 0.95)
-            p99 = pct(values, 0.99)
-            max_v = values[-1]
+            summary[label] = {
+                "n": len(values),
+                "p50": pct(values, 0.50),
+                "p95": pct(values, 0.95),
+                "p99": pct(values, 0.99),
+                "max": values[-1],
+            }
+        return summary
+
+    def _broadcast_diagnostics_snapshot(self, summary: dict[str, JsonObject]) -> None:
+        if not summary or self.broadcast_callback is None:
+            return
+        self._broadcast_runtime_event(
+            CommandType.DIAGNOSTICS_SNAPSHOT,
+            {
+                "enabled": True,
+                "interval": self.diagnostics_state.interval,
+                "categories": sorted(self.diagnostics_state.categories),
+                "samples": summary,
+            },
+        )
+
+    def _log_diagnostics_snapshot(self, snapshot: dict[str, list[float]]) -> None:
+        self._log_diagnostics_summary(self._summarize_diagnostics_snapshot(snapshot))
+
+    def _log_diagnostics_summary(self, summary: dict[str, JsonObject]) -> None:
+        if not summary:
+            return
+
+        for label, stats in summary.items():
             log.info(
                 "diagnostics[%s]: n=%d p50=%.2fus p95=%.2fus p99=%.2fus max=%.2fus",
                 label,
-                len(values),
-                p50,
-                p95,
-                p99,
-                max_v,
+                _diagnostics_int(stats.get("n", 0)),
+                _diagnostics_float(stats.get("p50", 0.0)),
+                _diagnostics_float(stats.get("p95", 0.0)),
+                _diagnostics_float(stats.get("p99", 0.0)),
+                _diagnostics_float(stats.get("max", 0.0)),
             )
 
     async def list_devices(self) -> JsonObject:

--- a/keymasq/keymasqd/device_manager.py
+++ b/keymasq/keymasqd/device_manager.py
@@ -249,8 +249,57 @@ class MacroRuntimeState:
 class DiagnosticsState:
     enabled: bool = False
     interval: float = 5.0
+    categories: set[str] = field(default_factory=lambda: {"mainline"})
     task: asyncio.Task[None] | None = None
     samples: dict[str, deque[float]] = field(default_factory=dict)
+
+
+DIAGNOSTICS_CATEGORIES = frozenset({"mainline", "combo", "internal"})
+DEFAULT_DIAGNOSTICS_CATEGORIES = frozenset({"mainline"})
+
+
+def _normalize_diagnostics_categories(categories: Sequence[object] | None) -> set[str]:
+    if not categories:
+        return set(DEFAULT_DIAGNOSTICS_CATEGORIES)
+
+    normalized = {
+        str(category or "").strip().lower()
+        for category in categories
+        if str(category or "").strip()
+    }
+    if "all" in normalized:
+        return set(DIAGNOSTICS_CATEGORIES)
+    selected = normalized & DIAGNOSTICS_CATEGORIES
+    return selected or set(DEFAULT_DIAGNOSTICS_CATEGORIES)
+
+
+def _diagnostics_label_enabled(label: str, categories: set[str]) -> bool:
+    label = str(label or "").lower()
+    if "internal" in categories and _diagnostics_label_is_internal(label):
+        return True
+    if "combo" in categories and _diagnostics_label_is_combo(label):
+        return True
+    return "mainline" in categories and _diagnostics_label_is_mainline(label)
+
+
+def _diagnostics_label_is_mainline(label: str) -> bool:
+    return (
+        label.startswith("action_")
+        or label in {"passthrough_fast", "passthrough_mapped", "passthrough_other"}
+        or label == "wheel_passthrough"
+    )
+
+
+def _diagnostics_label_is_combo(label: str) -> bool:
+    return label.startswith("combo_") and not label.startswith("combo_recalled_")
+
+
+def _diagnostics_label_is_internal(label: str) -> bool:
+    return label == "syn" or label in {
+        "combo_recalled_repeat_suppressed",
+        "combo_recalled_release_suppressed",
+        "wheel_high_res_suppressed",
+    }
 
 
 @dataclass
@@ -650,9 +699,16 @@ class DeviceManager:
             return False
         return all(binding.hardware_id in keyboard_hardware_ids for binding in step.bindings)
 
-    async def set_diagnostics(self, enabled: bool, interval: float = 5.0) -> JsonObject:
+    async def set_diagnostics(
+        self,
+        enabled: bool,
+        interval: float = 5.0,
+        categories: Sequence[object] | None = None,
+    ) -> JsonObject:
         self.diagnostics_state.enabled = bool(enabled)
         self.diagnostics_state.interval = max(0.5, float(interval or 5.0))
+        self.diagnostics_state.categories = _normalize_diagnostics_categories(categories)
+        self.diagnostics_state.samples.clear()
 
         if not self.diagnostics_state.enabled:
             if self.diagnostics_state.task:
@@ -662,17 +718,30 @@ class DeviceManager:
                 except asyncio.CancelledError:
                     pass
                 self.diagnostics_state.task = None
-            self.diagnostics_state.samples.clear()
             log.info("Diagnostics disabled")
-            return {"enabled": False, "interval": self.diagnostics_state.interval}
+            return {
+                "enabled": False,
+                "interval": self.diagnostics_state.interval,
+                "categories": sorted(self.diagnostics_state.categories),
+            }
 
         if self.diagnostics_state.task is None or self.diagnostics_state.task.done():
             self.diagnostics_state.task = asyncio.create_task(self._diagnostics_loop())
-        log.info("Diagnostics enabled (interval %.2fs)", self.diagnostics_state.interval)
-        return {"enabled": True, "interval": self.diagnostics_state.interval}
+        log.info(
+            "Diagnostics enabled (interval %.2fs, categories=%s)",
+            self.diagnostics_state.interval,
+            ",".join(sorted(self.diagnostics_state.categories)),
+        )
+        return {
+            "enabled": True,
+            "interval": self.diagnostics_state.interval,
+            "categories": sorted(self.diagnostics_state.categories),
+        }
 
     def _record_diagnostic(self, label: str, duration_us: float) -> None:
         if not self.diagnostics_state.enabled:
+            return
+        if not _diagnostics_label_enabled(label, self.diagnostics_state.categories):
             return
         bucket = self.diagnostics_state.samples.setdefault(label, deque(maxlen=20000))
         bucket.append(float(duration_us))

--- a/keymasq/session/manager/commands.py
+++ b/keymasq/session/manager/commands.py
@@ -662,11 +662,16 @@ async def _handle_set_diagnostics(
 ) -> JsonObject:
     enabled = bool(request.get("enabled", False))
     interval = float_value(request.get("interval"), 5.0)
+    categories = [
+        str_value(category, "")
+        for category in json_list(request.get("categories"))
+        if str_value(category, "")
+    ]
     try:
         result = await manager.client.send_command(
             Command(
                 command=CommandType.SET_DIAGNOSTICS,
-                data={"enabled": enabled, "interval": interval},
+                data={"enabled": enabled, "interval": interval, "categories": categories},
             )
         )
     except Exception:

--- a/keymasq/session/manager/events.py
+++ b/keymasq/session/manager/events.py
@@ -99,6 +99,10 @@ async def handle_event(
         asyncio.create_task(handle_runtime_reset_event(manager, data))
         return
 
+    if event_type == CommandType.DIAGNOSTICS_SNAPSHOT:
+        manager.broadcast_to_session_clients({"event": "diagnostics_snapshot", **data})
+        return
+
     if event_type == CommandType.RECORDING_STARTED:
         manager.recording_state.active = True
         manager.broadcast_to_session_clients({"event": "recording_started", **data})

--- a/tests/gui/test_application_and_reload.py
+++ b/tests/gui/test_application_and_reload.py
@@ -4,6 +4,7 @@ from tests.gui.support import *
 
 def test_application_dialog_actions_route_to_window_helpers(monkeypatch) -> None:
     import keymasq.gui.application as application_module
+    import keymasq.gui.widgets.diagnostics_dialog as diagnostics_module
     import keymasq.gui.widgets.feedback_dialog as feedback_module
     import keymasq.gui.widgets.macro_manager_dialog as macro_manager_module
     import keymasq.gui.widgets.superkey_dialog as superkey_module
@@ -49,6 +50,7 @@ def test_application_dialog_actions_route_to_window_helpers(monkeypatch) -> None
     )
     monkeypatch.setattr(superkey_module, "SuperkeyDialog", _Dialog)
     monkeypatch.setattr(macro_manager_module, "MacroManagerDialog", _Dialog)
+    monkeypatch.setattr(diagnostics_module, "DiagnosticsDialog", _Dialog)
     monkeypatch.setattr(feedback_module, "FeedbackDialog", _Dialog)
     monkeypatch.setattr(application_module.Adw, "AboutDialog", _AboutDialog)
 
@@ -62,6 +64,7 @@ def test_application_dialog_actions_route_to_window_helpers(monkeypatch) -> None
     app._on_superkey_changed(None, "Nav")
     app._on_macros(None, None)
     app._on_record_macro(None, None)
+    app._on_diagnostics(None, None)
     app._on_feedback(None, None)
     app._on_about(None, None)
     app._on_macro_manager_closed(None, window)

--- a/tests/gui/test_diagnostics_dialog.py
+++ b/tests/gui/test_diagnostics_dialog.py
@@ -1,0 +1,89 @@
+# ruff: noqa: F403, F405, I001, E402
+from tests.gui.support import *
+
+gi.require_version("Gtk", "4.0")
+from gi.repository import Gtk  # pyright: ignore[reportAttributeAccessIssue]
+
+
+def test_diagnostics_format_helpers() -> None:
+    from keymasq.gui.widgets.diagnostics_dialog import _format_latency, _label_title
+
+    assert _format_latency(22.25) == "22.2 us"
+    assert _format_latency(1500.0) == "1.50 ms"
+    assert _label_title("action_key") == "Action: key"
+    assert _label_title("combo_passthrough") == "Combo candidate passthrough"
+
+
+def test_diagnostics_dialog_sends_settings_and_renders_snapshot(monkeypatch) -> None:
+    import keymasq.gui.widgets.diagnostics_dialog as dialog_module
+    from keymasq.gui.widgets.diagnostics_dialog import DiagnosticsDialog
+
+    sent: list[dict[str, object]] = []
+    registered: list[tuple[str, object]] = []
+    unregistered: list[tuple[str, object]] = []
+
+    def fake_request_async(payload, callback, timeout=5.0):
+        sent.append(payload)
+        return callback(
+            {
+                "status": "ok",
+                "data": {
+                    "enabled": bool(payload["enabled"]),
+                    "interval": payload["interval"],
+                    "categories": payload["categories"],
+                },
+            }
+        )
+
+    monkeypatch.setattr(dialog_module, "session_request_async", fake_request_async)
+    monkeypatch.setattr(
+        dialog_module,
+        "register_session_event_callback",
+        lambda event, callback: registered.append((event, callback)),
+    )
+    monkeypatch.setattr(
+        dialog_module,
+        "unregister_session_event_callback",
+        lambda event, callback: unregistered.append((event, callback)),
+    )
+
+    dialog = DiagnosticsDialog(Gtk.Window())
+    assert registered and registered[0][0] == "diagnostics_snapshot"
+
+    dialog._category_checks["combo"].set_active(True)
+    dialog._enable_switch.set_active(True)
+
+    assert sent[-1] == {
+        "command": "set_diagnostics",
+        "enabled": True,
+        "interval": 5.0,
+        "categories": ["mainline", "combo"],
+    }
+
+    dialog._on_diagnostics_snapshot(
+        {
+            "event": "diagnostics_snapshot",
+            "enabled": True,
+            "interval": 5.0,
+            "categories": ["mainline", "combo"],
+            "samples": {
+                "passthrough_mapped": {
+                    "n": 2,
+                    "p50": 1.0,
+                    "p95": 2.0,
+                    "p99": 2.0,
+                    "max": 3.0,
+                }
+            },
+        }
+    )
+
+    assert "passthrough_mapped" in dialog._rows
+    row = dialog._rows["passthrough_mapped"]
+    cells = row._diagnostics_cells  # pyright: ignore[reportAttributeAccessIssue]
+    assert cells["n"].get_text() == "n 2"
+    assert cells["max"].get_text() == "peak 3.0 us"
+    assert "single slowest sample" in (cells["max"].get_tooltip_text() or "")
+
+    dialog._on_closed(dialog)
+    assert unregistered == [("diagnostics_snapshot", dialog._on_diagnostics_snapshot)]

--- a/tests/gui/test_diagnostics_dialog.py
+++ b/tests/gui/test_diagnostics_dialog.py
@@ -6,12 +6,17 @@ from gi.repository import Gtk  # pyright: ignore[reportAttributeAccessIssue]
 
 
 def test_diagnostics_format_helpers() -> None:
-    from keymasq.gui.widgets.diagnostics_dialog import _format_latency, _label_title
+    from keymasq.gui.widgets.diagnostics_dialog import (
+        _diagnostics_docs_url,
+        _format_latency,
+        _label_title,
+    )
 
     assert _format_latency(22.25) == "22.2 us"
     assert _format_latency(1500.0) == "1.50 ms"
     assert _label_title("action_key") == "Action: key"
     assert _label_title("combo_passthrough") == "Combo candidate passthrough"
+    assert _diagnostics_docs_url().endswith("/PERFORMANCE/#diagnostics-labels")
 
 
 def test_diagnostics_dialog_sends_settings_and_renders_snapshot(monkeypatch) -> None:
@@ -49,6 +54,7 @@ def test_diagnostics_dialog_sends_settings_and_renders_snapshot(monkeypatch) -> 
 
     dialog = DiagnosticsDialog(Gtk.Window())
     assert registered and registered[0][0] == "diagnostics_snapshot"
+    assert dialog._docs_button.get_tooltip_text() == "Open Diagnostics documentation"
 
     dialog._category_checks["combo"].set_active(True)
     dialog._enable_switch.set_active(True)
@@ -83,7 +89,129 @@ def test_diagnostics_dialog_sends_settings_and_renders_snapshot(monkeypatch) -> 
     cells = row._diagnostics_cells  # pyright: ignore[reportAttributeAccessIssue]
     assert cells["n"].get_text() == "n 2"
     assert cells["max"].get_text() == "peak 3.0 us"
-    assert "single slowest sample" in (cells["max"].get_tooltip_text() or "")
+    assert "OS scheduling noise" in (cells["max"].get_tooltip_text() or "")
+    assert cells["max"].has_css_class("dim-label")
 
+    sent.clear()
     dialog._on_closed(dialog)
     assert unregistered == [("diagnostics_snapshot", dialog._on_diagnostics_snapshot)]
+    assert sent == [
+        {
+            "command": "set_diagnostics",
+            "enabled": False,
+            "interval": 5.0,
+            "categories": ["mainline", "combo"],
+        }
+    ]
+
+
+def test_diagnostics_sort_by_priority(monkeypatch) -> None:
+    import keymasq.gui.widgets.diagnostics_dialog as dialog_module
+    from keymasq.gui.widgets.diagnostics_dialog import DiagnosticsDialog, _label_sort_key
+
+    def fake_request_async(payload, callback, timeout=5.0):
+        return callback(
+            {
+                "status": "ok",
+                "data": {
+                    "enabled": bool(payload["enabled"]),
+                    "interval": payload["interval"],
+                    "categories": payload["categories"],
+                },
+            }
+        )
+
+    monkeypatch.setattr(dialog_module, "session_request_async", fake_request_async)
+    monkeypatch.setattr(
+        dialog_module, "register_session_event_callback", lambda *a: None
+    )
+    monkeypatch.setattr(
+        dialog_module, "unregister_session_event_callback", lambda *a: None
+    )
+
+    assert _label_sort_key("passthrough_mapped") < _label_sort_key("passthrough_fast")
+    assert _label_sort_key("passthrough_fast") < _label_sort_key("combo_passthrough")
+    assert _label_sort_key("combo_passthrough") < _label_sort_key("action_key")
+    assert _label_sort_key("action_key") < _label_sort_key("syn")
+
+    dialog = DiagnosticsDialog(Gtk.Window())
+    dialog._enable_switch.set_active(True)
+
+    dialog._on_diagnostics_snapshot(
+        {
+            "event": "diagnostics_snapshot",
+            "enabled": True,
+            "interval": 5.0,
+            "categories": ["mainline"],
+            "samples": {
+                "passthrough_fast": {"n": 100, "p50": 5, "p95": 10, "p99": 15, "max": 20},
+                "passthrough_mapped": {"n": 50, "p50": 50, "p95": 100, "p99": 200, "max": 300},
+                "action_key": {"n": 75, "p50": 25, "p95": 50, "p99": 80, "max": 100},
+            },
+        }
+    )
+
+    assert dialog._rows["passthrough_mapped"]._sort_key < dialog._rows["passthrough_fast"]._sort_key  # pyright: ignore[reportAttributeAccessIssue]
+    assert dialog._rows["passthrough_fast"]._sort_key < dialog._rows["action_key"]._sort_key  # pyright: ignore[reportAttributeAccessIssue]
+
+    dialog._on_closed(dialog)
+
+
+def test_diagnostics_reset_clears_rows(monkeypatch) -> None:
+    import keymasq.gui.widgets.diagnostics_dialog as dialog_module
+    from keymasq.gui.widgets.diagnostics_dialog import DiagnosticsDialog
+
+    sent: list[dict[str, object]] = []
+
+    def fake_request_async(payload, callback, timeout=5.0):
+        sent.append(payload)
+        return callback(
+            {
+                "status": "ok",
+                "data": {
+                    "enabled": bool(payload["enabled"]),
+                    "interval": payload["interval"],
+                    "categories": payload["categories"],
+                },
+            }
+        )
+
+    monkeypatch.setattr(dialog_module, "session_request_async", fake_request_async)
+    monkeypatch.setattr(
+        dialog_module, "register_session_event_callback", lambda *a: None
+    )
+    monkeypatch.setattr(
+        dialog_module, "unregister_session_event_callback", lambda *a: None
+    )
+
+    dialog = DiagnosticsDialog(Gtk.Window())
+    dialog._enable_switch.set_active(True)
+
+    dialog._on_diagnostics_snapshot(
+        {
+            "event": "diagnostics_snapshot",
+            "enabled": True,
+            "interval": 5.0,
+            "categories": ["mainline"],
+            "samples": {
+                "passthrough_mapped": {
+                    "n": 100,
+                    "p50": 10,
+                    "p95": 20,
+                    "p99": 30,
+                    "max": 40,
+                }
+            },
+        }
+    )
+    assert len(dialog._rows) == 1
+
+    sent.clear()
+    dialog._on_reset_clicked(dialog._reset_button)
+
+    assert len(dialog._rows) == 0
+    assert dialog._last_snapshot_time is None
+    assert any(s["command"] == "set_diagnostics" for s in sent)
+
+    dialog._enabled = False
+    dialog._on_closed(dialog)

--- a/tests/keymasqd/test_daemon_runtime_unlock.py
+++ b/tests/keymasqd/test_daemon_runtime_unlock.py
@@ -11,7 +11,24 @@ async def test_set_diagnostics_forwards_with_type_conversion(daemon_testbed):
     )
 
     assert result == {"status": "ok"}
-    device_manager.set_diagnostics.assert_awaited_once_with(True, 3.25)
+    device_manager.set_diagnostics.assert_awaited_once_with(True, 3.25, None)
+
+
+@pytest.mark.asyncio
+async def test_set_diagnostics_forwards_categories(daemon_testbed):
+    daemon, device_manager, _recording_manager, _macro_store, _capture_manager = daemon_testbed
+
+    result = await daemon._handle_command(
+        CommandType.SET_DIAGNOSTICS,
+        {"enabled": 1, "interval": "3.25", "categories": ["mainline", "combo"]},
+    )
+
+    assert result == {"status": "ok"}
+    device_manager.set_diagnostics.assert_awaited_once_with(
+        True,
+        3.25,
+        ["mainline", "combo"],
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/keymasqd/test_device_manager_core.py
+++ b/tests/keymasqd/test_device_manager_core.py
@@ -486,6 +486,40 @@ class TestListDevices:
         assert calls == [(snapshots.append, ({"event": [1.0, 3.0]},))]
 
     @pytest.mark.asyncio
+    async def test_diagnostics_filters_to_mainline_by_default(self) -> None:
+        manager = DeviceManager()
+        manager.diagnostics_state.enabled = True
+
+        manager._record_diagnostic("passthrough_mapped", 10.0)
+        manager._record_diagnostic("action_key", 20.0)
+        manager._record_diagnostic("combo_passthrough", 30.0)
+        manager._record_diagnostic("syn", 40.0)
+
+        assert set(manager.diagnostics_state.samples) == {
+            "passthrough_mapped",
+            "action_key",
+        }
+
+    @pytest.mark.asyncio
+    async def test_diagnostics_can_include_combo_and_internal_categories(self) -> None:
+        manager = DeviceManager()
+        manager.diagnostics_state.enabled = True
+        manager.diagnostics_state.categories = {"combo", "internal"}
+
+        manager._record_diagnostic("passthrough_mapped", 10.0)
+        manager._record_diagnostic("combo_passthrough", 20.0)
+        manager._record_diagnostic("combo_passthrough_held", 30.0)
+        manager._record_diagnostic("syn", 40.0)
+        manager._record_diagnostic("combo_recalled_release_suppressed", 50.0)
+
+        assert set(manager.diagnostics_state.samples) == {
+            "combo_passthrough",
+            "combo_passthrough_held",
+            "syn",
+            "combo_recalled_release_suppressed",
+        }
+
+    @pytest.mark.asyncio
     async def test_topology_watch_loop_retries_when_live_and_reconciled_snapshots_differ(
         self,
         monkeypatch: pytest.MonkeyPatch,

--- a/tests/keymasqd/test_device_manager_core.py
+++ b/tests/keymasqd/test_device_manager_core.py
@@ -461,11 +461,13 @@ class TestListDevices:
     async def test_diagnostics_loop_offloads_snapshot_to_thread(
         self,
         monkeypatch: pytest.MonkeyPatch,
-    ) -> None:
+        ) -> None:
         manager = DeviceManager()
         manager.diagnostics_state.enabled = True
-        manager.diagnostics_state.samples = {"event": deque([1.0, 3.0])}
-        snapshots: list[dict[str, list[float]]] = []
+        manager.broadcast_callback = AsyncMock()
+        manager.diagnostics_state.samples = {"passthrough_mapped": deque([1.0, 3.0])}
+        summaries: list[dict[str, dict[str, object]]] = []
+        broadcasts: list[tuple[CommandType, dict[str, object]]] = []
         calls: list[tuple[object, tuple[object, ...]]] = []
 
         async def fake_sleep(_delay: float) -> None:
@@ -478,12 +480,37 @@ class TestListDevices:
 
         monkeypatch.setattr(dm.asyncio, "sleep", fake_sleep)
         monkeypatch.setattr(dm.asyncio, "to_thread", fake_to_thread)
-        monkeypatch.setattr(manager, "_log_diagnostics_snapshot", snapshots.append)
+        monkeypatch.setattr(manager, "_log_diagnostics_summary", summaries.append)
+        monkeypatch.setattr(
+            manager,
+            "_broadcast_runtime_event",
+            lambda *args: broadcasts.append(args),
+        )
 
         await manager._diagnostics_loop()
 
-        assert snapshots == [{"event": [1.0, 3.0]}]
-        assert calls == [(snapshots.append, ({"event": [1.0, 3.0]},))]
+        expected_summary = {
+            "passthrough_mapped": {"n": 2, "p50": 1.0, "p95": 1.0, "p99": 1.0, "max": 3.0}
+        }
+        assert summaries == [expected_summary]
+        assert calls == [
+            (
+                manager._summarize_diagnostics_snapshot,
+                ({"passthrough_mapped": [1.0, 3.0]},),
+            ),
+            (summaries.append, (expected_summary,)),
+        ]
+        assert broadcasts == [
+            (
+                CommandType.DIAGNOSTICS_SNAPSHOT,
+                {
+                    "enabled": True,
+                    "interval": 5.0,
+                    "categories": ["mainline"],
+                    "samples": expected_summary,
+                },
+            )
+        ]
 
     @pytest.mark.asyncio
     async def test_diagnostics_filters_to_mainline_by_default(self) -> None:

--- a/tests/session/test_session_manager_command_runtime.py
+++ b/tests/session/test_session_manager_command_runtime.py
@@ -495,6 +495,33 @@ async def test_runtime_reset_event_invalidates_and_reevaluates(
 
 
 @pytest.mark.asyncio
+async def test_diagnostics_snapshot_event_forwards_to_gui_clients() -> None:
+    manager = SessionManager()
+    manager.broadcast_to_session_clients = Mock()  # type: ignore[method-assign]
+
+    await session_events_module.handle_event(
+        manager,
+        CommandType.DIAGNOSTICS_SNAPSHOT,
+        {
+            "enabled": True,
+            "interval": 5.0,
+            "categories": ["mainline"],
+            "samples": {"passthrough_mapped": {"n": 2, "p50": 1.0}},
+        },
+    )
+
+    manager.broadcast_to_session_clients.assert_called_once_with(  # type: ignore[attr-defined]
+        {
+            "event": "diagnostics_snapshot",
+            "enabled": True,
+            "interval": 5.0,
+            "categories": ["mainline"],
+            "samples": {"passthrough_mapped": {"n": 2, "p50": 1.0}},
+        }
+    )
+
+
+@pytest.mark.asyncio
 async def test_get_status_reports_effective_unlock_when_unlock_not_required(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_cli_commands_helpers.py
+++ b/tests/test_cli_commands_helpers.py
@@ -164,6 +164,34 @@ def test_set_diagnostics_cli_exits_on_error(monkeypatch: pytest.MonkeyPatch) -> 
     assert excinfo.value.code == 1
 
 
+def test_set_diagnostics_cli_sends_categories(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    sent: list[dict[str, object]] = []
+
+    def _session_request(payload: dict[str, object]) -> dict[str, object]:
+        sent.append(payload)
+        return {
+            "status": "ok",
+            "data": {"enabled": True, "interval": 3.0, "categories": ["mainline", "combo"]},
+        }
+
+    monkeypatch.setattr(commands, "_session_request", _session_request)
+
+    commands.set_diagnostics_cli(True, interval=3.0, include=["combo"])
+
+    assert sent == [
+        {
+            "command": "set_diagnostics",
+            "enabled": True,
+            "interval": 3.0,
+            "categories": ["mainline", "combo"],
+        }
+    ]
+    assert "categories=mainline, combo" in capsys.readouterr().out
+
+
 def test_type_cli_compiles_and_sends_payload(monkeypatch: pytest.MonkeyPatch) -> None:
     sent: list[dict[str, object]] = []
 


### PR DESCRIPTION
## Summary

- Add `--include`/`--exclude` CLI flags for `keymasq diagnostics on` to filter by category (`mainline`, `combo`, `internal`, `all`)
- Add `DiagnosticsDialog` GTK widget showing live latency snapshots from keymasqd, accessible from the main menu
- Introduce `DIAGNOSTICS_SNAPSHOT` IPC event to push summarized diagnostics to session clients
- Categorize diagnostics labels into mainline, combo, and internal groups with label filtering in `DeviceManager`
- Expand `docs/PERFORMANCE.md` with diagnostics label reference tables and usage examples
- Update `docs/CLI.md` with new category options

## Testing

- `nix develop -c pytest tests/gui/test_diagnostics_dialog.py` — new dialog unit tests
- `nix develop -c pytest tests/gui/test_application_and_reload.py` — updated action routing test
- `nix develop -c pytest tests/keymasqd/test_device_manager_core.py` — diagnostics category filtering tests
- `nix develop -c pytest tests/keymasqd/test_daemon_runtime_unlock.py` — updated diagnostics IPC tests
- `nix develop -c pytest tests/test_cli_commands_helpers.py` — CLI category resolution tests
- `nix develop -c pytest tests/session/test_session_manager_command_runtime.py` — session forwarding test
- `./scripts/check.sh full`