### PR TITLE
Unify exec ref bindings across session payloads

### DIFF
--- a/keymasq/session/manager/events.py
+++ b/keymasq/session/manager/events.py
@@ -33,24 +33,15 @@ async def handle_event(
         exec_ref_raw = data.get("exec_ref")
         exec_ref = _int_value(exec_ref_raw, -1) if exec_ref_raw is not None else None
         if exec_ref is not None:
-            if exec_ref >= 10000:
-                ref_data = manager.exec_state.superkey_exec_refs.get(exec_ref)
-                if ref_data:
-                    hardware_id, cmd = ref_data
-                    exec_data = dict(data)
-                    exec_data["cmd"] = cmd
-                    exec_data["hardware_id"] = hardware_id
-                    asyncio.create_task(handle_exec_trigger(manager, exec_data))
-                else:
-                    log.warning("Unknown superkey exec_ref: %s", exec_ref)
+            binding = manager.exec_state.exec_refs.get(exec_ref)
+            if binding:
+                exec_data = dict(data)
+                exec_data["cmd"] = binding.cmd
+                if binding.hardware_id:
+                    exec_data["hardware_id"] = binding.hardware_id
+                asyncio.create_task(handle_exec_trigger(manager, exec_data))
             else:
-                cmd = manager.exec_state.exec_refs.get(exec_ref)
-                if cmd:
-                    exec_data = dict(data)
-                    exec_data["cmd"] = cmd
-                    asyncio.create_task(handle_exec_trigger(manager, exec_data))
-                else:
-                    log.warning("Unknown exec_ref: %s", exec_ref)
+                log.warning("Unknown exec_ref: %s", exec_ref)
 
         action_type_str = str(data.get("action_type", "") or "")
         if action_type_str == "start_macro_recording":

--- a/keymasq/session/manager/payloads.py
+++ b/keymasq/session/manager/payloads.py
@@ -1,5 +1,5 @@
 import json
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Literal, cast
 
 from keymasq.common.models import (
     ActionType,
@@ -13,6 +13,7 @@ from keymasq.common.models import (
 from keymasq.session.profiles import ResolvedCombo, ResolvedDeviceProfile
 
 from .common import JsonObject, json_object
+from .state import ExecBinding
 
 if TYPE_CHECKING:
     from .core import SessionManager
@@ -23,27 +24,12 @@ def clear_exec_refs(manager: "SessionManager", hardware_id: str) -> None:
     for ref in refs:
         manager.exec_state.exec_refs.pop(ref, None)
 
-    superkey_refs_to_clear = [
-        ref
-        for ref, (resolved_hardware_id, _) in list(manager.exec_state.superkey_exec_refs.items())
-        if resolved_hardware_id == hardware_id
-    ]
-    for ref in superkey_refs_to_clear:
-        manager.exec_state.superkey_exec_refs.pop(ref, None)
-
 
 def clear_combo_exec_refs(manager: "SessionManager") -> None:
     refs = list(manager.exec_state.combo_exec_refs)
     manager.exec_state.combo_exec_refs.clear()
     for ref in refs:
         manager.exec_state.exec_refs.pop(ref, None)
-    # Combo-triggered superkey exec refs are tied to combo payload lifetime rather
-    # than a specific device binding, so they are only reclaimed by this bulk combo
-    # cleanup path instead of clear_exec_refs().
-    superkey_refs = list(manager.exec_state.combo_superkey_exec_refs)
-    manager.exec_state.combo_superkey_exec_refs.clear()
-    for ref in superkey_refs:
-        manager.exec_state.superkey_exec_refs.pop(ref, None)
 
 
 def clear_all_exec_refs(manager: "SessionManager") -> None:
@@ -278,10 +264,12 @@ def profile_to_mapping(
                 action_data["tap_hold_ms"] = action.tap_hold_ms
         elif action.action_type.value == "exec":
             if action.cmd:
-                exec_ref = manager.exec_state.next_exec_ref
-                manager.exec_state.next_exec_ref += 1
-                manager.exec_state.exec_refs[exec_ref] = action.cmd
-                manager.exec_state.device_exec_refs[hardware_id].add(exec_ref)
+                exec_ref = _allocate_exec_ref(
+                    manager,
+                    action.cmd,
+                    owner="device",
+                    hardware_id=hardware_id,
+                )
                 action_data["exec_ref"] = exec_ref
         elif action.action_type.value == "compositor_dispatch":
             if action.compositor_id:
@@ -414,10 +402,7 @@ def combo_action_to_payload(
     if action_type == "exec":
         if not action.cmd:
             return None
-        exec_ref = manager.exec_state.next_exec_ref
-        manager.exec_state.next_exec_ref += 1
-        manager.exec_state.exec_refs[exec_ref] = action.cmd
-        manager.exec_state.combo_exec_refs.add(exec_ref)
+        exec_ref = _allocate_exec_ref(manager, action.cmd, owner="combo")
         action_data["exec_ref"] = exec_ref
         return action_data
 
@@ -697,11 +682,11 @@ def serialize_overload_action(
 
     if action_type == "exec":
         if action.cmd:
-            exec_ref = _allocate_superkey_exec_ref(
+            exec_ref = _allocate_exec_ref(
                 manager,
-                hardware_id,
                 action.cmd,
-                track_combo_refs=track_combo_refs,
+                owner="combo" if track_combo_refs else "device",
+                hardware_id=None if track_combo_refs else hardware_id,
             )
             action_data["exec_ref"] = exec_ref
         return action_data
@@ -746,18 +731,29 @@ def serialize_overload_action(
     return action_data
 
 
-def _allocate_superkey_exec_ref(
+def _allocate_exec_ref(
     manager: "SessionManager",
-    hardware_id: str,
     cmd: str,
     *,
-    track_combo_refs: bool,
+    owner: Literal["device", "combo"],
+    hardware_id: str | None = None,
 ) -> int:
-    exec_ref = manager.exec_state.next_superkey_exec_ref
-    manager.exec_state.next_superkey_exec_ref += 1
-    manager.exec_state.superkey_exec_refs[exec_ref] = (hardware_id, cmd)
-    if track_combo_refs:
-        manager.exec_state.combo_superkey_exec_refs.add(exec_ref)
+    exec_ref = manager.exec_state.next_exec_ref
+    manager.exec_state.next_exec_ref += 1
+    if owner == "device":
+        if not hardware_id:
+            raise ValueError("device exec refs require a hardware_id")
+        manager.exec_state.device_exec_refs.setdefault(hardware_id, set()).add(exec_ref)
+        manager.exec_state.exec_refs[exec_ref] = ExecBinding(
+            cmd=cmd,
+            owner="device",
+            hardware_id=hardware_id,
+        )
+    elif owner == "combo":
+        manager.exec_state.combo_exec_refs.add(exec_ref)
+        manager.exec_state.exec_refs[exec_ref] = ExecBinding(cmd=cmd, owner="combo")
+    else:
+        raise ValueError(f"unknown exec ref owner: {owner}")
     return exec_ref
 
 

--- a/keymasq/session/manager/state.py
+++ b/keymasq/session/manager/state.py
@@ -1,5 +1,6 @@
 import asyncio
 from dataclasses import dataclass, field
+from typing import Literal
 
 from keymasq.session.listeners.base import WindowListener
 from keymasq.session.profiles import ResolvedDeviceProfile
@@ -74,14 +75,18 @@ class ProfileRuntimeState:
 
 
 @dataclass
+class ExecBinding:
+    cmd: str
+    owner: Literal["device", "combo"]
+    hardware_id: str | None = None
+
+
+@dataclass
 class ExecRuntimeState:
-    exec_refs: dict[int, str] = field(default_factory=dict)
+    exec_refs: dict[int, ExecBinding] = field(default_factory=dict)
     next_exec_ref: int = 1
     device_exec_refs: dict[str, set[int]] = field(default_factory=dict)
     combo_exec_refs: set[int] = field(default_factory=set)
-    combo_superkey_exec_refs: set[int] = field(default_factory=set)
-    superkey_exec_refs: dict[int, tuple[str, str]] = field(default_factory=dict)
-    next_superkey_exec_ref: int = 10000
 
 
 @dataclass

--- a/tests/session/test_session_manager_payloads_extra.py
+++ b/tests/session/test_session_manager_payloads_extra.py
@@ -97,8 +97,10 @@ def test_profile_to_mapping_serializes_high_value_action_payloads() -> None:
         "y": 240,
     }
     assert mapping["exec"] == {"action": "exec", "exec_ref": 1}
-    assert manager.exec_state.exec_refs == {1: "echo hi"}
-    assert manager.exec_state.device_exec_refs == {"kbd": {1}}
+    assert manager.exec_state.exec_refs[1].cmd == "echo hi"
+    assert manager.exec_state.exec_refs[1].owner == "device"
+    assert manager.exec_state.exec_refs[1].hardware_id == "kbd"
+    assert manager.exec_state.device_exec_refs == {"kbd": {1, 2}}
     assert mapping["dispatch"] == {
         "action": "compositor_dispatch",
         "compositor": "hyprland",
@@ -115,9 +117,11 @@ def test_profile_to_mapping_serializes_high_value_action_payloads() -> None:
     overload_actions = cast(list[dict[str, object]], superkey_payload["overload_actions"])
     assert overload_actions[1] == {
         "action": "exec",
-        "exec_ref": 10000,
+        "exec_ref": 2,
     }
-    assert manager.exec_state.superkey_exec_refs == {10000: ("kbd", "notify-send launcher")}
+    assert manager.exec_state.exec_refs[2].cmd == "notify-send launcher"
+    assert manager.exec_state.exec_refs[2].owner == "device"
+    assert manager.exec_state.exec_refs[2].hardware_id == "kbd"
 
 
 def test_combo_payloads_filter_invalid_actions_and_track_exec_refs() -> None:
@@ -216,7 +220,7 @@ def test_combo_payloads_filter_invalid_actions_and_track_exec_refs() -> None:
     }
     combo_action = cast(dict[str, object], combo_payload[1]["action"])
     super_action = cast(dict[str, object], combo_action["superkey"])
-    assert super_action["tap_actions"] == [{"action": "exec", "exec_ref": 10000}]
+    assert super_action["tap_actions"] == [{"action": "exec", "exec_ref": 1}]
     assert super_action["double_tap_actions"] == [
         {
             "action": "compositor_dispatch",
@@ -229,7 +233,9 @@ def test_combo_payloads_filter_invalid_actions_and_track_exec_refs() -> None:
     assert super_action["tap_hold_actions"] == [
         {"action": "profile_enable", "profile_name": "Work"}
     ]
-    assert manager.exec_state.combo_superkey_exec_refs == {10000}
+    assert manager.exec_state.combo_exec_refs == {1}
+    assert manager.exec_state.exec_refs[1].cmd == "echo tap"
+    assert manager.exec_state.exec_refs[1].owner == "combo"
 
 
 def test_payload_signatures_and_log_view_are_stable() -> None:

--- a/tests/test_session_manager_events.py
+++ b/tests/test_session_manager_events.py
@@ -10,6 +10,7 @@ import keymasq.session.manager.profiles as session_profiles_module
 from keymasq.common.ipc import CommandType
 from keymasq.session.listeners.hyprland import HyprlandListener
 from keymasq.session.manager import SessionManager
+from keymasq.session.manager.state import ExecBinding
 
 
 @pytest.mark.asyncio
@@ -170,7 +171,7 @@ async def test_handle_event_set_cursor_position_missing_request_id_is_one_way() 
 @pytest.mark.asyncio
 async def test_handle_event_exec_ref_schedules_command_without_blocking() -> None:
     manager = SessionManager()
-    manager.exec_state.exec_refs[7] = "echo once"
+    manager.exec_state.exec_refs[7] = ExecBinding(cmd="echo once", owner="combo")
     started = asyncio.Event()
     finish = asyncio.Event()
 
@@ -202,9 +203,9 @@ async def test_handle_event_exec_ref_schedules_command_without_blocking() -> Non
 
 
 @pytest.mark.asyncio
-async def test_handle_event_superkey_exec_ref_schedules_command_without_blocking() -> None:
+async def test_handle_event_high_exec_ref_schedules_command_without_numeric_split() -> None:
     manager = SessionManager()
-    manager.exec_state.superkey_exec_refs[10000] = ("1234:5678", "echo super")
+    manager.exec_state.exec_refs[10000] = ExecBinding(cmd="echo high", owner="combo")
     started = asyncio.Event()
     finish = asyncio.Event()
 
@@ -230,7 +231,7 @@ async def test_handle_event_superkey_exec_ref_schedules_command_without_blocking
     )
 
     await asyncio.wait_for(started.wait(), timeout=1.0)
-    manager.action_handler.execute_command.assert_awaited_once_with("echo super")
+    manager.action_handler.execute_command.assert_awaited_once_with("echo high")
     finish.set()
     await asyncio.sleep(0)
 
@@ -382,7 +383,10 @@ async def test_device_disconnect_event_invalidates_cached_grabs_and_reevaluates(
     manager.profile_state.last_sent_combo_signature = "combo"
     manager.exec_state.device_exec_refs = {"1234:5678": {7}}
     manager.exec_state.combo_exec_refs = {8}
-    manager.exec_state.exec_refs = {7: "echo device", 8: "echo combo"}
+    manager.exec_state.exec_refs = {
+        7: ExecBinding(cmd="echo device", owner="device", hardware_id="1234:5678"),
+        8: ExecBinding(cmd="echo combo", owner="combo"),
+    }
     monkeypatch.setattr(session_profiles_module, "reevaluate_profiles", AsyncMock())
 
     async def instant_sleep(_delay: float) -> None:

--- a/tests/test_superkeys.py
+++ b/tests/test_superkeys.py
@@ -23,6 +23,7 @@ from keymasq.session.manager.payloads import (
     combo_action_to_payload,
     serialize_superkey,
 )
+from keymasq.session.manager.state import ExecBinding, ExecRuntimeState
 from keymasq.session.profiles import ProfileManager
 from keymasq.session.superkeys import SuperkeyManager
 
@@ -299,11 +300,7 @@ rapidfire_wait_ms = 60
 
 def test_superkey_runtime_payload_round_trips_overload_actions() -> None:
     manager = SimpleNamespace(
-        exec_state=SimpleNamespace(
-            next_superkey_exec_ref=10000,
-            superkey_exec_refs={},
-            combo_superkey_exec_refs=set(),
-        ),
+        exec_state=ExecRuntimeState(),
         superkeys=SimpleNamespace(get_superkey=lambda _name: None),
     )
     config = SuperkeyConfig(
@@ -333,17 +330,17 @@ def test_superkey_runtime_payload_round_trips_overload_actions() -> None:
         ActionType.KEYBOARD,
         ActionType.EXEC,
     ]
-    assert parsed.overload_actions[1].exec_ref == 10000
-    assert manager.exec_state.superkey_exec_refs[10000] == ("1234:5678", "echo demo")
+    assert parsed.overload_actions[1].exec_ref == 1
+    assert manager.exec_state.exec_refs[1] == ExecBinding(
+        cmd="echo demo",
+        owner="device",
+        hardware_id="1234:5678",
+    )
 
 
 def test_superkey_runtime_payload_round_trips_split_overload_actions() -> None:
     manager = SimpleNamespace(
-        exec_state=SimpleNamespace(
-            next_superkey_exec_ref=10000,
-            superkey_exec_refs={},
-            combo_superkey_exec_refs=set(),
-        ),
+        exec_state=ExecRuntimeState(),
         superkeys=SimpleNamespace(get_superkey=lambda _name: None),
     )
     config = SuperkeyConfig(
@@ -377,8 +374,12 @@ def test_superkey_runtime_payload_round_trips_split_overload_actions() -> None:
     assert [action.target for action in parsed.overload_actions] == ["key_leftctrl"]
     assert [action.target for action in parsed.overload_down_actions] == ["key_a"]
     assert parsed.overload_up_actions[0].action_type == ActionType.EXEC
-    assert parsed.overload_up_actions[0].exec_ref == 10000
-    assert manager.exec_state.superkey_exec_refs[10000] == ("1234:5678", "echo up")
+    assert parsed.overload_up_actions[0].exec_ref == 1
+    assert manager.exec_state.exec_refs[1] == ExecBinding(
+        cmd="echo up",
+        owner="device",
+        hardware_id="1234:5678",
+    )
 
 
 def test_combo_superkey_payload_tracks_combo_scoped_exec_refs() -> None:
@@ -388,11 +389,7 @@ def test_combo_superkey_payload_tracks_combo_scoped_exec_refs() -> None:
         tap_actions=[SuperkeyAction(action_type=ActionType.EXEC, cmd="echo combo")],
     )
     manager = SimpleNamespace(
-        exec_state=SimpleNamespace(
-            next_superkey_exec_ref=10000,
-            superkey_exec_refs={},
-            combo_superkey_exec_refs=set(),
-        ),
+        exec_state=ExecRuntimeState(),
         superkeys=SimpleNamespace(
             get_superkey=lambda name: config if name == "combo_exec" else None
         ),
@@ -410,9 +407,9 @@ def test_combo_superkey_payload_tracks_combo_scoped_exec_refs() -> None:
     assert isinstance(superkey_payload, dict)
     tap_actions = superkey_payload["tap_actions"]
     assert isinstance(tap_actions, list)
-    assert tap_actions[0]["exec_ref"] == 10000
-    assert manager.exec_state.combo_superkey_exec_refs == {10000}
-    assert manager.exec_state.superkey_exec_refs[10000] == ("combo", "echo combo")
+    assert tap_actions[0]["exec_ref"] == 1
+    assert manager.exec_state.combo_exec_refs == {1}
+    assert manager.exec_state.exec_refs[1] == ExecBinding(cmd="echo combo", owner="combo")
 
 
 def test_combo_superkey_multistep_payload_and_signature_strip_double_tap_slots() -> None:
@@ -425,11 +422,7 @@ def test_combo_superkey_multistep_payload_and_signature_strip_double_tap_slots()
         tap_hold_actions=[SuperkeyAction(action_type=ActionType.KEYBOARD, target="key_d")],
     )
     manager = SimpleNamespace(
-        exec_state=SimpleNamespace(
-            next_superkey_exec_ref=10000,
-            superkey_exec_refs={},
-            combo_superkey_exec_refs=set(),
-        ),
+        exec_state=ExecRuntimeState(),
         superkeys=SimpleNamespace(
             get_superkey=lambda name: config if name == "pattern_combo" else None
         ),
@@ -453,22 +446,21 @@ def test_combo_superkey_multistep_payload_and_signature_strip_double_tap_slots()
     assert "hold_actions" in payload_superkey
 
 
-def test_clear_combo_exec_refs_clears_combo_superkey_exec_refs() -> None:
+def test_clear_combo_exec_refs_clears_combo_owned_exec_refs() -> None:
     manager = SimpleNamespace(
-        exec_state=SimpleNamespace(
-            combo_exec_refs={7},
-            combo_superkey_exec_refs={10000},
-            exec_refs={7: "echo combo"},
-            superkey_exec_refs={10000: ("combo", "echo super")},
+        exec_state=ExecRuntimeState(
+            combo_exec_refs={7, 8},
+            exec_refs={
+                7: ExecBinding(cmd="echo combo", owner="combo"),
+                8: ExecBinding(cmd="echo combo super", owner="combo"),
+            },
         )
     )
 
     clear_combo_exec_refs(manager)
 
     assert manager.exec_state.combo_exec_refs == set()
-    assert manager.exec_state.combo_superkey_exec_refs == set()
     assert manager.exec_state.exec_refs == {}
-    assert manager.exec_state.superkey_exec_refs == {}
 
 
 def test_superkey_runtime_payload_requires_explicit_mode() -> None:
@@ -563,11 +555,7 @@ def test_superkey_manager_rejects_nested_overload_superkeys(
 
 def test_superkey_payload_serializer_rejects_nested_overload_superkeys() -> None:
     manager = SimpleNamespace(
-        exec_state=SimpleNamespace(
-            next_superkey_exec_ref=10000,
-            superkey_exec_refs={},
-            combo_superkey_exec_refs=set(),
-        ),
+        exec_state=ExecRuntimeState(),
         superkeys=SimpleNamespace(get_superkey=lambda _name: None),
     )
     config = SuperkeyConfig(name="bad_payload_nested", mode=SuperkeyMode.OVERLOAD)


### PR DESCRIPTION
## Summary
- Consolidates exec reference storage into a single `ExecBinding` model in session runtime state.
- Removes the separate superkey exec-ref namespaces and routes all exec-ref lookups through unified bindings.
- Updates payload serialization and event handling so device and combo exec refs share the same allocation path.
- Adjusts session and superkey tests to reflect the new exec-ref structure and numbering.

## Testing
- run
- Existing coverage updated in `tests/test_session_manager_events.py`, `tests/session/test_session_manager_payloads_extra.py`, and `tests/test_superkeys.py` to validate the new binding model.