### PR TITLE
Drop the `hyprland_dispatch` action alias

### DIFF
--- a/keymasq/keymasqd/runtime/actions.py
+++ b/keymasq/keymasqd/runtime/actions.py
@@ -41,10 +41,6 @@ def parse_action(
         return MappingAction(action_type=ActionType.KEYBOARD, target=action_data)
 
     action_type_str = str_value(action_data.get("action"), "passthrough")
-    if action_type_str == "hyprland_dispatch":
-        action_data = dict(action_data)
-        action_data.setdefault("compositor", "hyprland")
-        action_type_str = "compositor_dispatch"
     action_type = ActionType(action_type_str)
 
     superkey_config = None

--- a/keymasq/session/manager/events.py
+++ b/keymasq/session/manager/events.py
@@ -65,7 +65,7 @@ async def handle_event(
             asyncio.create_task(handle_profile_trigger(manager, data))
         elif action_type_str == "exec" and exec_ref is None:
             asyncio.create_task(handle_exec_trigger(manager, data))
-        elif action_type_str in {"compositor_dispatch", "hyprland_dispatch"}:
+        elif action_type_str == "compositor_dispatch":
             asyncio.create_task(
                 runtime_compositor.handle_compositor_dispatch_trigger(manager, data)
             )

--- a/keymasq/session/profiles.py
+++ b/keymasq/session/profiles.py
@@ -274,10 +274,6 @@ class ProfileManager:
             return MappingAction(action_type=ActionType.KEYBOARD, target=action_data)
 
         action_type_str = str(action_data.get("action", "passthrough"))
-        if action_type_str == "hyprland_dispatch":
-            action_data = dict(action_data)
-            action_data.setdefault("compositor", "hyprland")
-            action_type_str = "compositor_dispatch"
         if action_type_str == "rapidfire":
             action_type_str = "keyboard"
             action_data = dict(action_data)

--- a/keymasq/session/superkeys.py
+++ b/keymasq/session/superkeys.py
@@ -163,10 +163,6 @@ class SuperkeyManager:
 
     def _parse_mapping_action(self, action_data: TomlDict) -> MappingAction:
         action_type_str = str(action_data.get("action", "passthrough"))
-        if action_type_str == "hyprland_dispatch":
-            action_data = dict(action_data)
-            action_data.setdefault("compositor", "hyprland")
-            action_type_str = "compositor_dispatch"
         if action_type_str == "rapidfire":
             action_type_str = "keyboard"
             action_data = dict(action_data)

--- a/tests/gui/test_gui_device_tab_misc.py
+++ b/tests/gui/test_gui_device_tab_misc.py
@@ -735,7 +735,7 @@ def test_key_selector_dialog_profile_tab_populates_and_maps_selected_action(monk
     assert results[0].profile_name == "Gaming"
 
 
-def test_key_selector_dialog_only_shows_hyprland_dispatch_for_active_hyprland_listener():
+def test_key_selector_dialog_only_shows_hyprland_actions_for_active_hyprland_listener():
     from gi.repository import Gtk
 
     from keymasq.common.models import ActionType, MappingAction

--- a/tests/keymasqd/test_device_manager_runtime_recovery.py
+++ b/tests/keymasqd/test_device_manager_runtime_recovery.py
@@ -259,13 +259,18 @@ class TestDeviceManagerHelpers:
         assert manager.active_mappings == {}
         assert manager.grab_state.desired_paths == {}
         destroy_global_uinputs.assert_called_once()
-    def test_parse_action_supports_string_and_hyprland_dispatch_alias(self) -> None:
+    def test_parse_action_supports_string_and_compositor_dispatch(self) -> None:
         manager = DeviceManager()
 
         string_action = _runtime_parse_action(manager, "key_a")
         dispatch_action = _runtime_parse_action(
             manager,
-            {"action": "hyprland_dispatch", "dispatcher": "workspace", "args": "2"},
+            {
+                "action": "compositor_dispatch",
+                "compositor": "hyprland",
+                "dispatcher": "workspace",
+                "args": "2",
+            },
         )
 
         assert string_action.action_type == ActionType.KEYBOARD


### PR DESCRIPTION
## Summary
- Remove the legacy `hyprland_dispatch` action alias from runtime parsing and session-side action handling.
- Standardize compositor dispatch behavior on `compositor_dispatch` with an explicit `compositor` field.
- Update GUI and runtime recovery tests to reflect the new action name and expectations.

## Testing
- Not run (change is covered by updated unit tests in `tests/keymasqd/test_device_manager_runtime_recovery.py` and `tests/gui/test_gui_device_tab_misc.py`).
- Confirmed the code paths now only dispatch compositor actions through `compositor_dispatch`.