### PR TITLE
Confirm unsaved super key edits on close

### DIFF
--- a/docs/SUPERKEYS.md
+++ b/docs/SUPERKEYS.md
@@ -79,6 +79,9 @@ Open **Super Keys** from the GUI. The dialog has two panels:
 - **Right panel**: edit the selected super key's name, description, mode,
   actions, and timing.
 
+Use **Save** to apply changes. If you close the dialog or press Escape with
+unsaved edits, Keymasq asks whether to save, discard, or keep editing.
+
 ### Editing Pattern Slots
 
 In pattern mode, each slot has its own ordered action list:
@@ -123,8 +126,8 @@ kinds of actions that regular mappings support, except:
 | List | When it runs | Behavior |
 |---|---|---|
 | **Main Actions** | Entire key lifecycle | Actions start first, stay pressed while the source key is held, and release last. |
-| **On Press** | Once on key down | Actions run as a quick press-and-release pulse when the source key is pressed. |
-| **On Release** | Once on key up | Actions run as a quick press-and-release pulse when the source key is released. |
+| **On Press** | Once on key down | Actions go through their press/release cycle when the source key goes down. |
+| **On Release** | Once on key up | Actions go through their press/release cycle when the source key comes up. |
 
 On Press and On Release are optional. Leave them empty if you only need
 held output.
@@ -132,13 +135,13 @@ held output.
 Execution order is deterministic:
 
 1. On key down, Keymasq starts **Main Actions** first.
-2. It then pulses **On Press** actions.
-3. On key up, it pulses **On Release** actions.
+2. **On Press** actions go through their press/release cycle.
+3. On key up, **On Release** actions go through their press/release cycle.
 4. It then releases **Main Actions**.
 
-This makes Main Actions a held context for both pulse lists. For example,
-if Main Actions holds `key_leftctrl`, an On Press `key_c` pulse becomes
-`Ctrl+C`, and an On Release `key_v` pulse becomes `Ctrl+V`.
+This makes Main Actions a held context for both press/release lists. For example,
+if Main Actions holds `key_leftctrl`, an On Press `key_c` cycle becomes
+`Ctrl+C`, and an On Release `key_v` cycle becomes `Ctrl+V`.
 
 Another common pattern is a temporary profile layer: On Press enables a
 profile, and On Release disables it again. See
@@ -198,9 +201,9 @@ That applies to:
 - Pattern-mode held outputs
 - Overload-mode held key and button outputs
 
-On Press and On Release actions are one-shot pulses, so they do not create
+On Press and On Release actions are one-shot press/release cycles, so they do not create
 held child output state. The Main Actions list still uses normal held child
-output state and wraps both pulse lists: it starts before On Press and
+output state and wraps both press/release lists: it starts before On Press and
 releases after On Release.
 
 ## Using Super Keys

--- a/keymasq/gui/widgets/superkey_dialog.py
+++ b/keymasq/gui/widgets/superkey_dialog.py
@@ -155,7 +155,11 @@ class ActionListDialog(Adw.Dialog):
                 else (
                     "Actions receive the source key's normal down/repeat/up cycle in order."
                     if self._action_key == "overload"
-                    else "Actions run once immediately as a press and release."
+                    else (
+                        "Actions go through their press/release cycle when the key goes down."
+                        if self._action_key == "overload_down"
+                        else "Actions go through their press/release cycle when the key comes up."
+                    )
                 )
             )
         )
@@ -413,6 +417,7 @@ class SuperkeyDialog(Adw.Dialog):
         self.profile_manager = profile_manager
         self._current_config: SuperkeyConfig | None = None
         self._modified = False
+        self._close_warning_dialog: Adw.AlertDialog | None = None
         self._mode_items = [SuperkeyMode.PATTERN, SuperkeyMode.OVERLOAD]
         self.new_superkey_row: Gtk.ListBoxRow | None = None
 
@@ -428,9 +433,12 @@ class SuperkeyDialog(Adw.Dialog):
 
     def _on_key_pressed(self, _controller, keyval, _keycode, _state) -> bool:
         if keyval == Gdk.KEY_Escape:
-            self.close()
+            self._request_close()
             return True
         return False
+
+    def do_close_attempt(self) -> None:
+        self._request_close()
 
     def _build_ui(self) -> None:
         main_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=0)
@@ -542,24 +550,19 @@ class SuperkeyDialog(Adw.Dialog):
         self.overload_row._static_description = "Held while pressed, released when you let go"
         self.overload_row.set_tooltip_text(
             "Main Actions start before On Press and stay held until after On Release, "
-            "so they can provide a held modifier or context for both pulse lists."
+            "so they can provide a held modifier or context for both press/release lists."
         )
         self._refresh_child_rows(self.overload_row)
         self.actions_group.add(self.overload_row)
 
         self.overload_down_row = self._build_action_row("On Press", "overload_down", "overload")
-        self.overload_down_row._static_description = "Runs once when the key is pressed"
         self._refresh_child_rows(self.overload_down_row)
 
         self.overload_up_row = self._build_action_row("On Release", "overload_up", "overload")
-        self.overload_up_row._static_description = "Runs once when the key is released"
         self._refresh_child_rows(self.overload_up_row)
 
         self.overload_pulse_group = Adw.PreferencesGroup()
         self.overload_pulse_group.set_title("On Press / Release")
-        self.overload_pulse_group.set_description(
-            "Actions that run once as a quick press-and-release pulse."
-        )
         self.overload_pulse_group.add(self.overload_down_row)
         self.overload_pulse_group.add(self.overload_up_row)
 
@@ -859,6 +862,7 @@ class SuperkeyDialog(Adw.Dialog):
             return
         self.revert_btn.set_sensitive(self._modified)
         self.save_btn.set_sensitive(self._modified)
+        self.set_can_close(not self._modified)
 
     def _begin_new_superkey(self) -> None:
         self._current_config = SuperkeyConfig(name="New Super Key")
@@ -922,10 +926,10 @@ class SuperkeyDialog(Adw.Dialog):
         self._modified = False
         self._update_buttons()
 
-    def _on_save_clicked(self, _button) -> None:
+    def _save_current_superkey(self) -> bool:
         name = self.name_entry.get_text().strip()
         if not name:
-            return
+            return False
 
         old_name = self._current_config.name if self._current_config else None
         mode = self._current_mode()
@@ -979,6 +983,10 @@ class SuperkeyDialog(Adw.Dialog):
             idx += 1
 
         self.emit("superkey-saved", name)
+        return True
+
+    def _on_save_clicked(self, _button) -> None:
+        self._save_current_superkey()
 
     def _on_edit_action_clicked(self, _button, row: Adw.ExpanderRow) -> None:
         title = (
@@ -1007,7 +1015,41 @@ class SuperkeyDialog(Adw.Dialog):
         self._on_modified()
 
     def _on_close_clicked(self, _button: Gtk.Button) -> None:
-        self.close()
+        self._request_close()
+
+    def _request_close(self) -> None:
+        if not self._modified:
+            self.force_close()
+            return
+        self._show_unsaved_close_warning()
+
+    def _show_unsaved_close_warning(self) -> None:
+        if self._close_warning_dialog is not None:
+            return
+
+        dialog = Adw.AlertDialog()
+        dialog.set_heading("Unsaved Super Key Changes")
+        dialog.set_body("Save your changes before closing, or discard them?")
+        dialog.add_response("cancel", "Cancel")
+        dialog.add_response("discard", "Discard")
+        dialog.add_response("save", "Save")
+        dialog.set_default_response("cancel")
+        dialog.set_close_response("cancel")
+        dialog.set_response_appearance("discard", Adw.ResponseAppearance.DESTRUCTIVE)
+        dialog.set_response_appearance("save", Adw.ResponseAppearance.SUGGESTED)
+        dialog.connect("response", self._on_unsaved_close_response)
+        self._close_warning_dialog = dialog
+        dialog.present(self)
+
+    def _on_unsaved_close_response(self, _dialog: Adw.AlertDialog, response: str) -> None:
+        self._close_warning_dialog = None
+        if response == "discard":
+            self._modified = False
+            self._update_buttons()
+            self.force_close()
+            return
+        if response == "save" and self._save_current_superkey():
+            self.force_close()
 
     def _on_superkeys_docs_clicked(self, _button: Gtk.Button) -> None:
         url = _superkeys_docs_url()

--- a/tests/gui/test_gui_demo_and_dialogs.py
+++ b/tests/gui/test_gui_demo_and_dialogs.py
@@ -650,7 +650,7 @@ class TestDialogConstruction:
 
         assert dialog.overload_row.get_tooltip_text() == (
             "Main Actions start before On Press and stay held until after On Release, "
-            "so they can provide a held modifier or context for both pulse lists."
+            "so they can provide a held modifier or context for both press/release lists."
         )
         assert "Held while pressed, released when you let go" in dialog.overload_row.get_subtitle()
         assert "(none)" in dialog.overload_row.get_subtitle()
@@ -662,6 +662,8 @@ class TestDialogConstruction:
 
         assert "Held while pressed, released when you let go" in dialog.overload_row.get_subtitle()
         assert "1 action" in dialog.overload_row.get_subtitle()
+        assert dialog.overload_down_row.get_subtitle() == "(none)"
+        assert dialog.overload_up_row.get_subtitle() == "(none)"
 
     def test_superkey_dialog_overload_saves_press_and_release_actions(
         self, temp_config_dir, monkeypatch
@@ -706,13 +708,20 @@ class TestDialogConstruction:
         from gi.repository import Gdk, Gtk
 
         from keymasq.common import paths
+        import keymasq.gui.widgets.superkey_dialog as superkey_dialog_module
         from keymasq.gui.widgets.superkey_dialog import SuperkeyDialog
 
         monkeypatch.setattr(paths, "SUPERKEYS_DIR", temp_config_dir / "superkeys")
 
         dialog = SuperkeyDialog(Gtk.Window())
         closed: list[bool] = []
-        monkeypatch.setattr(dialog, "close", lambda: closed.append(True))
+        alerts: list[tuple[object, object]] = []
+        monkeypatch.setattr(dialog, "force_close", lambda: closed.append(True))
+        monkeypatch.setattr(
+            superkey_dialog_module.Adw.AlertDialog,
+            "present",
+            lambda alert, parent: alerts.append((alert, parent)),
+        )
 
         new_row = dialog.new_superkey_row
         assert new_row is not None
@@ -726,13 +735,60 @@ class TestDialogConstruction:
         assert dialog.delete_btn.get_sensitive() is False
         assert dialog.right_box.get_sensitive() is True
         assert dialog.close_btn.get_sensitive() is True
+        assert dialog.get_can_close() is False
 
         dialog.close_btn.emit("clicked")
-        assert closed == [True]
+        assert closed == []
+        assert len(alerts) == 1
+        assert alerts[0][1] is dialog
 
-        closed.clear()
+        dialog._on_unsaved_close_response(alerts[0][0], "cancel")
+        assert closed == []
+
         assert dialog._on_key_pressed(None, Gdk.KEY_Escape, 0, 0) is True
+        assert closed == []
+        assert len(alerts) == 2
+
+        dialog._on_unsaved_close_response(alerts[1][0], "discard")
         assert closed == [True]
+        assert dialog.get_can_close() is True
+
+    def test_superkey_dialog_unsaved_close_save_response_saves_and_closes(
+        self, temp_config_dir, monkeypatch
+    ):
+        gi.require_version("Gtk", "4.0")
+        from gi.repository import Gtk
+
+        from keymasq.common import paths
+        import keymasq.gui.widgets.superkey_dialog as superkey_dialog_module
+        from keymasq.gui.widgets.superkey_dialog import SuperkeyDialog
+
+        monkeypatch.setattr(paths, "SUPERKEYS_DIR", temp_config_dir / "superkeys")
+
+        dialog = SuperkeyDialog(Gtk.Window())
+        closed: list[bool] = []
+        alerts: list[tuple[object, object]] = []
+        saved: list[str] = []
+        monkeypatch.setattr(dialog, "force_close", lambda: closed.append(True))
+        monkeypatch.setattr(
+            superkey_dialog_module.Adw.AlertDialog,
+            "present",
+            lambda alert, parent: alerts.append((alert, parent)),
+        )
+        dialog.connect("superkey-saved", lambda _dialog, name: saved.append(name))
+
+        dialog.name_entry.set_text("close_saved")
+        dialog._request_close()
+
+        assert closed == []
+        assert len(alerts) == 1
+
+        dialog._on_unsaved_close_response(alerts[0][0], "save")
+
+        assert closed == [True]
+        assert saved == ["close_saved"]
+        assert dialog.manager.get_superkey("close_saved") is not None
+        assert dialog.get_can_close() is True
 
     def test_superkey_dialog_docs_button_links_to_superkeys_docs(
         self, temp_config_dir, monkeypatch
@@ -872,6 +928,36 @@ class TestDialogConstruction:
             "allow_tap": False,
             "allow_macro_options": True,
         }
+
+    def test_overload_pulse_action_editors_describe_down_and_up_timing(self, temp_config_dir):
+        gi.require_version("Gtk", "4.0")
+        from gi.repository import Gtk
+
+        from keymasq.gui.widgets.superkey_dialog import ActionListDialog
+
+        parent = Gtk.Window()
+        down_dialog = ActionListDialog(
+            parent,
+            "Edit On Press",
+            "overload",
+            action_key="overload_down",
+        )
+        up_dialog = ActionListDialog(
+            parent,
+            "Edit On Release",
+            "overload",
+            action_key="overload_up",
+        )
+
+        down_label = down_dialog.get_child().get_first_child()
+        up_label = up_dialog.get_child().get_first_child()
+
+        assert down_label.get_label() == (
+            "Actions go through their press/release cycle when the key goes down."
+        )
+        assert up_label.get_label() == (
+            "Actions go through their press/release cycle when the key comes up."
+        )
 
     def test_pattern_superkey_action_summary_formats_without_label_rewrite(self):
         from keymasq.common.models import ActionType, SuperkeyAction


### PR DESCRIPTION
## Summary
- Added an unsaved-changes confirmation flow to the Super Key dialog when closing via the window controls or Escape.
- The dialog now offers `Save`, `Discard`, and `Cancel`, and keeps editing if the user cancels.
- Saving from the close prompt reuses the existing save path so edits are persisted before the dialog closes.
- Updated Super Keys docs and dialog copy to reflect the new press/release terminology and close behavior.
- Expanded GUI tests to cover close confirmation, discard/save paths, and updated action descriptions.

## Testing
- Added/updated GUI test coverage in `tests/gui/test_gui_demo_and_dialogs.py` for:
  - close confirmation on unsaved edits
  - discard response closes the dialog
  - save response persists the super key and closes the dialog
  - updated overload press/release descriptions