### PR TITLE
Reject colliding superkey storage names

### DIFF
--- a/keymasq/gui/widgets/superkey_dialog.py
+++ b/keymasq/gui/widgets/superkey_dialog.py
@@ -963,10 +963,19 @@ class SuperkeyDialog(Adw.Dialog):
             hold_threshold_ms=self.hold_threshold_spin.get_value_as_int(),
         )
 
-        if old_name and old_name != name:
-            self.manager.rename_superkey(old_name, name)
-
-        self.manager.save_superkey(config)
+        try:
+            if (
+                old_name
+                and old_name != name
+                and self.manager.get_superkey(old_name) is not None
+                and not self.manager.rename_superkey(old_name, name)
+            ):
+                self._show_save_error(f"Super Key '{name}' already exists")
+                return False
+            self.manager.save_superkey(config)
+        except ValueError as exc:
+            self._show_save_error(str(exc))
+            return False
         self._current_config = config
         self._modified = False
         self._update_buttons()
@@ -984,6 +993,15 @@ class SuperkeyDialog(Adw.Dialog):
 
         self.emit("superkey-saved", name)
         return True
+
+    def _show_save_error(self, message: str) -> None:
+        dialog = Adw.AlertDialog()
+        dialog.set_heading("Unable To Save Super Key")
+        dialog.set_body(message)
+        dialog.add_response("ok", "OK")
+        dialog.set_default_response("ok")
+        dialog.set_close_response("ok")
+        dialog.present(self)
 
     def _on_save_clicked(self, _button) -> None:
         self._save_current_superkey()

--- a/keymasq/session/superkeys.py
+++ b/keymasq/session/superkeys.py
@@ -284,12 +284,12 @@ class SuperkeyManager:
     def get_all_superkeys(self) -> dict[str, SuperkeyConfig]:
         return self._superkeys.copy()
 
-    def save_superkey(self, config: SuperkeyConfig) -> None:
+    def save_superkey(self, config: SuperkeyConfig, *, replacing_name: str | None = None) -> None:
         paths.ensure_config_dirs()
         self._validate_before_save(config)
 
-        safe_name = self._sanitize_name(config.name)
-        path = paths.SUPERKEYS_DIR / f"{safe_name}.toml"
+        path = self._path_for_name(config.name)
+        self._ensure_storage_path_available(config.name, path, replacing_name=replacing_name)
 
         data: dict[str, object] = {
             "name": config.name,
@@ -463,12 +463,18 @@ class SuperkeyManager:
             return False
 
         config = self._superkeys[old_name]
-        old_path = paths.SUPERKEYS_DIR / f"{self._sanitize_name(old_name)}.toml"
+        old_path = self._path_for_name(old_name)
+        new_path = self._path_for_name(new_name)
+        self._ensure_storage_path_available(new_name, new_path, replacing_name=old_name)
 
         config.name = new_name
-        self.save_superkey(config)
+        try:
+            self.save_superkey(config, replacing_name=old_name)
+        except Exception:
+            config.name = old_name
+            raise
 
-        if old_path.exists():
+        if old_path != new_path and old_path.exists():
             old_path.unlink()
 
         del self._superkeys[old_name]
@@ -479,6 +485,35 @@ class SuperkeyManager:
     def _sanitize_name(self, name: str) -> str:
         safe = "".join(c if c.isalnum() or c in "-_" else "_" for c in name)
         return safe.lower()
+
+    def _path_for_name(self, name: str) -> Path:
+        return paths.SUPERKEYS_DIR / f"{self._sanitize_name(name)}.toml"
+
+    def _storage_file_name(self, path: Path) -> str | None:
+        if not path.exists():
+            return None
+        try:
+            with open(path, "rb") as f:
+                data = cast(TomlDict, tomllib.load(f))
+            return _toml_str(data, "name", path.stem) or path.stem
+        except Exception as exc:
+            raise ValueError(
+                f"Superkey storage path '{path.name}' already exists but could not be read"
+            ) from exc
+
+    def _ensure_storage_path_available(
+        self,
+        name: str,
+        path: Path,
+        *,
+        replacing_name: str | None = None,
+    ) -> None:
+        stored_name = self._storage_file_name(path)
+        if stored_name is None or stored_name == name or stored_name == replacing_name:
+            return
+        raise ValueError(
+            f"Superkey name '{name}' conflicts with existing superkey '{stored_name}'"
+        )
 
     def reload(self) -> None:
         self._load_all()

--- a/tests/gui/test_gui_demo_and_dialogs.py
+++ b/tests/gui/test_gui_demo_and_dialogs.py
@@ -701,6 +701,42 @@ class TestDialogConstruction:
         assert [action.target for action in saved.overload_down_actions] == ["key_a"]
         assert [action.target for action in saved.overload_up_actions] == ["key_b"]
 
+    def test_superkey_dialog_shows_storage_collision_error(self, temp_config_dir, monkeypatch):
+        gi.require_version("Gtk", "4.0")
+        from gi.repository import Gtk
+
+        from keymasq.common import paths
+        from keymasq.common.models import ActionType, SuperkeyAction, SuperkeyConfig, SuperkeyMode
+        import keymasq.gui.widgets.superkey_dialog as superkey_dialog_module
+        from keymasq.gui.widgets.superkey_dialog import SuperkeyDialog
+
+        monkeypatch.setattr(paths, "SUPERKEYS_DIR", temp_config_dir / "superkeys")
+
+        dialog = SuperkeyDialog(Gtk.Window())
+        alerts: list[tuple[object, object]] = []
+        monkeypatch.setattr(
+            superkey_dialog_module.Adw.AlertDialog,
+            "present",
+            lambda alert, parent: alerts.append((alert, parent)),
+        )
+        dialog.manager.save_superkey(
+            SuperkeyConfig(
+                name="A B",
+                mode=SuperkeyMode.PATTERN,
+                tap_actions=[SuperkeyAction(action_type=ActionType.KEYBOARD, target="key_a")],
+            )
+        )
+
+        dialog.start_new_superkey()
+        dialog.name_entry.set_text("A_B")
+
+        assert dialog._save_current_superkey() is False
+        assert len(alerts) == 1
+        alert = alerts[0][0]
+        assert alert.get_heading() == "Unable To Save Super Key"
+        assert "conflicts with existing superkey 'A B'" in alert.get_body()
+        assert dialog.manager.get_superkey("A_B") is None
+
     def test_superkey_dialog_empty_state_starts_new_draft_and_keeps_close_available(
         self, temp_config_dir, monkeypatch
     ):

--- a/tests/test_superkeys.py
+++ b/tests/test_superkeys.py
@@ -37,6 +37,14 @@ def _parse_manager() -> object:
     )
 
 
+def _pattern_superkey(name: str, target: str = "key_a") -> SuperkeyConfig:
+    return SuperkeyConfig(
+        name=name,
+        mode=SuperkeyMode.PATTERN,
+        tap_actions=[SuperkeyAction(action_type=ActionType.KEYBOARD, target=target)],
+    )
+
+
 def test_superkey_manager_requires_explicit_mode(
     temp_config_dir,
     monkeypatch: pytest.MonkeyPatch,
@@ -117,6 +125,70 @@ def test_superkey_manager_round_trips_pattern_bundles(temp_config_dir, monkeypat
     text = (superkeys_dir / "bundle.toml").read_text(encoding="utf-8")
     assert 'mode = "pattern"' in text
     assert "tap = [" in text
+
+
+def test_superkey_manager_rejects_sanitized_storage_collision(
+    temp_config_dir,
+    monkeypatch,
+) -> None:
+    superkeys_dir = temp_config_dir / "superkeys"
+    superkeys_dir.mkdir()
+    monkeypatch.setattr(paths, "SUPERKEYS_DIR", superkeys_dir)
+
+    manager = SuperkeyManager()
+    manager.save_superkey(_pattern_superkey("A B", "key_a"))
+
+    with pytest.raises(ValueError, match="conflicts with existing superkey 'A B'"):
+        manager.save_superkey(_pattern_superkey("A_B", "key_b"))
+
+    assert sorted(path.name for path in superkeys_dir.glob("*.toml")) == ["a_b.toml"]
+    reloaded = SuperkeyManager().get_superkey("A B")
+
+    assert reloaded is not None
+    assert reloaded.tap_actions[0].target == "key_a"
+
+
+def test_superkey_manager_rejects_rename_to_sanitized_storage_collision(
+    temp_config_dir,
+    monkeypatch,
+) -> None:
+    superkeys_dir = temp_config_dir / "superkeys"
+    superkeys_dir.mkdir()
+    monkeypatch.setattr(paths, "SUPERKEYS_DIR", superkeys_dir)
+
+    manager = SuperkeyManager()
+    manager.save_superkey(_pattern_superkey("A B", "key_a"))
+    manager.save_superkey(_pattern_superkey("Other", "key_b"))
+
+    with pytest.raises(ValueError, match="conflicts with existing superkey 'A B'"):
+        manager.rename_superkey("Other", "A_B")
+
+    assert sorted(path.name for path in superkeys_dir.glob("*.toml")) == [
+        "a_b.toml",
+        "other.toml",
+    ]
+    assert manager.get_superkey("Other") is not None
+    assert manager.get_superkey("A_B") is None
+
+
+def test_superkey_manager_same_storage_path_rename_does_not_delete_file(
+    temp_config_dir,
+    monkeypatch,
+) -> None:
+    superkeys_dir = temp_config_dir / "superkeys"
+    superkeys_dir.mkdir()
+    monkeypatch.setattr(paths, "SUPERKEYS_DIR", superkeys_dir)
+
+    manager = SuperkeyManager()
+    manager.save_superkey(_pattern_superkey("Work/Mode", "key_a"))
+
+    assert manager.rename_superkey("Work/Mode", "Work?Mode") is True
+
+    path = superkeys_dir / "work_mode.toml"
+    assert sorted(item.name for item in superkeys_dir.glob("*.toml")) == ["work_mode.toml"]
+    assert path.exists()
+    assert 'name = "Work?Mode"' in path.read_text(encoding="utf-8")
+    assert SuperkeyManager().get_superkey("Work?Mode") is not None
 
 
 def test_superkey_action_roundtrip_preserves_shared_fields() -> None:


### PR DESCRIPTION
## Summary
- Reject superkey saves when a distinct name sanitizes to an already-used storage filename.
- Reject renames that would collide with another superkey storage file.
- Preserve same-path renames such as `Work/Mode` -> `Work?Mode` without deleting the rewritten file.
- Surface storage collision errors in the Super Key dialog instead of silently overwriting or failing.

## Testing
- `nix develop -c pytest tests/test_superkeys.py -k 'storage_collision or same_storage_path_rename'`
- `nix develop -c pytest tests/gui/test_gui_demo_and_dialogs.py -k 'superkey_dialog_shows_storage_collision_error or superkey_dialog_overload_saves_press_and_release_actions or superkey_dialog_unsaved_close_save_response_saves_and_closes'`
- `nix develop -c ruff check keymasq/session/superkeys.py keymasq/gui/widgets/superkey_dialog.py tests/test_superkeys.py tests/gui/test_gui_demo_and_dialogs.py`
- `nix develop -c ./scripts/check.sh full`