### PR TITLE
Close input devices after device metadata scan

### DIFF
--- a/keymasq/keymasqd/device_manager.py
+++ b/keymasq/keymasqd/device_manager.py
@@ -925,6 +925,7 @@ class DeviceManager:
         grabbed_metadata = self._recording_grabbed_source_metadata()
 
         for path in _device_paths():
+            device: _ManagedInputDevice | None = None
             try:
                 device = _device_input(path)
                 info = device.info
@@ -980,6 +981,10 @@ class DeviceManager:
                 )
             except Exception as e:
                 log.debug(f"Could not read device {path}: {e}")
+            finally:
+                if device is not None:
+                    with contextlib.suppress(Exception):
+                        device.close()
 
         return {"devices": devices}
 

--- a/tests/keymasqd/test_device_manager_core.py
+++ b/tests/keymasqd/test_device_manager_core.py
@@ -321,6 +321,71 @@ class TestDeviceDetection:
 
 
 class TestListDevices:
+    def test_list_devices_closes_devices_after_metadata_scan(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        manager = DeviceManager()
+        closed_paths: list[str] = []
+
+        class FakeDevice:
+            name = "Raw Keyboard"
+            phys = "usb-test"
+            uniq = ""
+            info = SimpleNamespace(vendor=0x1234, product=0x5678)
+
+            def __init__(self, path: str) -> None:
+                self.path = path
+
+            def capabilities(self):
+                return {evdev.ecodes.EV_KEY: [evdev.ecodes.KEY_A]}
+
+            def input_props(self):
+                return []
+
+            def close(self) -> None:
+                closed_paths.append(self.path)
+
+        monkeypatch.setattr(dm, "_device_paths", lambda: ["/dev/input/event0"])
+        monkeypatch.setattr(dm.evdev, "InputDevice", FakeDevice)
+        monkeypatch.setattr(dm, "resolve_stable_path", lambda _path: "/dev/input/by-id/raw-kbd")
+        monkeypatch.setattr(dm, "get_interface_id", lambda _path: "kbd")
+
+        result = manager._list_devices_sync()
+
+        assert len(cast(list[dict[str, object]], result["devices"])) == 1
+        assert closed_paths == ["/dev/input/event0"]
+
+    def test_list_devices_closes_devices_when_metadata_scan_fails(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        manager = DeviceManager()
+        closed_paths: list[str] = []
+
+        class FakeDevice:
+            name = "Broken Keyboard"
+            phys = "usb-test"
+            uniq = ""
+            info = SimpleNamespace(vendor=0x1234, product=0x5678)
+
+            def __init__(self, path: str) -> None:
+                self.path = path
+
+            def capabilities(self):
+                raise RuntimeError("unreadable capabilities")
+
+            def close(self) -> None:
+                closed_paths.append(self.path)
+
+        monkeypatch.setattr(dm, "_device_paths", lambda: ["/dev/input/event0"])
+        monkeypatch.setattr(dm.evdev, "InputDevice", FakeDevice)
+
+        result = manager._list_devices_sync()
+
+        assert result == {"devices": []}
+        assert closed_paths == ["/dev/input/event0"]
+
     def test_list_devices_marks_physical_recording_identity(
         self,
         monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary
- Close each `InputDevice` after listing metadata to prevent file descriptor leaks in the device scan path.
- Keep cleanup safe even when metadata collection raises, by closing in a `finally` block and suppressing close-time errors.
- Add regression tests covering both successful scans and failures during metadata collection.

## Testing
- Added unit test verifying listed devices are closed after a successful metadata scan.
- Added unit test verifying devices are still closed when capability lookup fails.