### PR TITLE
Drop oversized IPC frames without blocking valid traffic

### DIFF
--- a/keymasq/common/ipc.py
+++ b/keymasq/common/ipc.py
@@ -92,7 +92,8 @@ def decode_command(data: bytes) -> tuple[Command | None, bytes]:
 
     payload_len = struct.unpack(HEADER_FORMAT, data[:HEADER_SIZE])[0]
     if payload_len > MAX_PAYLOAD_SIZE:
-        return None, data[HEADER_SIZE:]
+        total_len = HEADER_SIZE + payload_len
+        return None, data[total_len:] if len(data) >= total_len else b""
 
     total_len = HEADER_SIZE + payload_len
 
@@ -132,7 +133,8 @@ def decode_response(data: bytes) -> tuple[Response | None, bytes]:
 
     payload_len = struct.unpack(HEADER_FORMAT, data[:HEADER_SIZE])[0]
     if payload_len > MAX_PAYLOAD_SIZE:
-        return None, data[HEADER_SIZE:]
+        total_len = HEADER_SIZE + payload_len
+        return None, data[total_len:] if len(data) >= total_len else b""
 
     total_len = HEADER_SIZE + payload_len
 

--- a/keymasq/keymasqd/socket_server.py
+++ b/keymasq/keymasqd/socket_server.py
@@ -200,11 +200,14 @@ class SocketServer:
                 self._buffer[writer] += data
 
                 while True:
-                    cmd, remaining = decode_command(self._buffer[writer])
+                    buffered = self._buffer[writer]
+                    cmd, remaining = decode_command(buffered)
+                    self._buffer[writer] = remaining
                     if cmd is None:
+                        if remaining != buffered:
+                            continue
                         break
 
-                    self._buffer[writer] = remaining
                     response = await self._process_command(cmd, context)
                     writer.write(encode_response(response))
                     await writer.drain()

--- a/keymasq/session/client.py
+++ b/keymasq/session/client.py
@@ -82,11 +82,14 @@ class KeymasqdClient:
                 self._buffer += data
 
                 while True:
-                    response, remaining = decode_response(self._buffer)
+                    buffered = self._buffer
+                    response, remaining = decode_response(buffered)
+                    self._buffer = remaining
                     if response is None:
+                        if remaining != buffered:
+                            continue
                         break
 
-                    self._buffer = remaining
                     await self._handle_response(response)
 
         except asyncio.CancelledError:

--- a/tests/test_ipc.py
+++ b/tests/test_ipc.py
@@ -1,4 +1,7 @@
+import struct
+
 from keymasq.common.ipc import (
+    HEADER_FORMAT,
     Command,
     CommandType,
     Response,
@@ -72,6 +75,36 @@ class TestProtocolEncoding:
         assert decoded2.request_id == "2"
         assert remaining2 == b""
 
+    def test_decode_oversized_command_discards_full_frame(self, monkeypatch):
+        import keymasq.common.ipc as ipc
+
+        valid = encode_command(Command(command=CommandType.PING, data={}, request_id="ok"))
+        max_payload_size = struct.unpack(HEADER_FORMAT, valid[: ipc.HEADER_SIZE])[0]
+        monkeypatch.setattr(ipc, "MAX_PAYLOAD_SIZE", max_payload_size)
+        payload_len = max_payload_size + 1
+        oversized = struct.pack(HEADER_FORMAT, payload_len) + (b"x" * payload_len)
+
+        decoded, remaining = decode_command(oversized + valid)
+
+        assert decoded is None
+        assert remaining == valid
+
+        decoded, remaining = decode_command(remaining)
+        assert decoded is not None
+        assert decoded.request_id == "ok"
+        assert remaining == b""
+
+    def test_decode_partial_oversized_command_discards_buffer(self, monkeypatch):
+        import keymasq.common.ipc as ipc
+
+        monkeypatch.setattr(ipc, "MAX_PAYLOAD_SIZE", 8)
+        partial = struct.pack(HEADER_FORMAT, 9) + b"xxx"
+
+        decoded, remaining = decode_command(partial)
+
+        assert decoded is None
+        assert remaining == b""
+
     def test_error_response(self):
         resp = Response(
             status="error",
@@ -84,6 +117,36 @@ class TestProtocolEncoding:
 
         assert decoded.status == "error"
         assert decoded.error == "Device not found"
+
+    def test_decode_oversized_response_discards_full_frame(self, monkeypatch):
+        import keymasq.common.ipc as ipc
+
+        valid = encode_response(Response(status="ok", request_id="ok"))
+        max_payload_size = struct.unpack(HEADER_FORMAT, valid[: ipc.HEADER_SIZE])[0]
+        monkeypatch.setattr(ipc, "MAX_PAYLOAD_SIZE", max_payload_size)
+        payload_len = max_payload_size + 1
+        oversized = struct.pack(HEADER_FORMAT, payload_len) + (b"x" * payload_len)
+
+        decoded, remaining = decode_response(oversized + valid)
+
+        assert decoded is None
+        assert remaining == valid
+
+        decoded, remaining = decode_response(remaining)
+        assert decoded is not None
+        assert decoded.request_id == "ok"
+        assert remaining == b""
+
+    def test_decode_partial_oversized_response_discards_buffer(self, monkeypatch):
+        import keymasq.common.ipc as ipc
+
+        monkeypatch.setattr(ipc, "MAX_PAYLOAD_SIZE", 8)
+        partial = struct.pack(HEADER_FORMAT, 9) + b"xxx"
+
+        decoded, remaining = decode_response(partial)
+
+        assert decoded is None
+        assert remaining == b""
 
 
 class TestCommandTypes:

--- a/tests/test_keymasqd_client.py
+++ b/tests/test_keymasqd_client.py
@@ -1,8 +1,9 @@
 import asyncio
+import struct
 
 import pytest
 
-from keymasq.common.ipc import Command, CommandType, Response
+from keymasq.common.ipc import HEADER_FORMAT, Command, CommandType, Response, encode_response
 from keymasq.session.client import KeymasqdClient
 
 
@@ -16,6 +17,16 @@ class _BlockingAsyncReader:
 
     def release(self) -> None:
         self._release.set()
+
+
+class _ChunkedAsyncReader:
+    def __init__(self, chunks: list[bytes]) -> None:
+        self._chunks = chunks
+
+    async def read(self, _size: int) -> bytes:
+        if not self._chunks:
+            return b""
+        return self._chunks.pop(0)
 
 
 class _FakeAsyncWriter:
@@ -86,5 +97,30 @@ def test_keymasqd_client_send_command_uses_custom_timeout(monkeypatch: pytest.Mo
         assert response.status == "ok"
         assert response.data == {"pong": True}
         assert timeouts == [42.0]
+
+    asyncio.run(_run())
+
+
+def test_keymasqd_client_discards_oversized_response_before_valid(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def _run() -> None:
+        import keymasq.common.ipc as ipc
+
+        monkeypatch.setattr(ipc, "MAX_PAYLOAD_SIZE", 128)
+        payload_len = 129
+        oversized = struct.pack(HEADER_FORMAT, payload_len) + (b"x" * payload_len)
+        valid = encode_response(Response(status="ok", request_id="ok", data={"done": True}))
+
+        client = KeymasqdClient(event_handler=lambda _event, _data: None)
+        client.reader = _ChunkedAsyncReader([oversized + valid, b""])
+        client.writer = _FakeAsyncWriter()
+        future: asyncio.Future[Response] = asyncio.get_running_loop().create_future()
+        client._pending_requests["ok"] = future
+
+        await client._listen_loop()
+
+        assert future.done() is True
+        assert future.result().data == {"done": True}
 
     asyncio.run(_run())

--- a/tests/test_socket_server.py
+++ b/tests/test_socket_server.py
@@ -1,11 +1,12 @@
 import asyncio
 import os
+import struct
 
 import pytest
 import pytest_asyncio
 
 from keymasq.common import paths
-from keymasq.common.ipc import Command, CommandType, decode_response, encode_command
+from keymasq.common.ipc import HEADER_FORMAT, Command, CommandType, decode_response, encode_command
 from keymasq.keymasqd.socket_server import ClientContext, SocketServer
 
 
@@ -176,6 +177,36 @@ class TestSocketServer:
         assert response is not None
         assert response.status == "ok"
         assert response.data["pong"] is True
+
+        writer.close()
+        await writer.wait_closed()
+
+    async def test_oversized_command_frame_does_not_block_next_command(
+        self,
+        server_and_handlers,
+        monkeypatch,
+    ):
+        import keymasq.common.ipc as ipc
+
+        _server, _cmd_handler, _ = server_and_handlers
+        monkeypatch.setattr(ipc, "MAX_PAYLOAD_SIZE", 128)
+
+        reader, writer = await asyncio.open_unix_connection(str(paths.SOCKET_PATH))
+
+        payload_len = 129
+        oversized = struct.pack(HEADER_FORMAT, payload_len) + (b"x" * payload_len)
+        valid = encode_command(Command(command=CommandType.PING, data={}, request_id="ok"))
+        writer.write(oversized + valid)
+        await writer.drain()
+
+        response_data = await asyncio.wait_for(reader.read(1024), timeout=1.0)
+        response, remaining = decode_response(response_data)
+
+        assert response is not None
+        assert response.status == "ok"
+        assert response.request_id == "ok"
+        assert response.data["pong"] is True
+        assert remaining == b""
 
         writer.close()
         await writer.wait_closed()


### PR DESCRIPTION
## Summary
- Updated IPC decoding to discard an entire oversized frame instead of only its header, so the stream stays aligned.
- Adjusted the socket server and session client read loops to keep draining buffered data after an oversized frame is skipped.
- Added regression tests covering oversized and partial oversized command/response frames, plus end-to-end cases where a valid frame follows an invalid one.

## Testing
- `Not run` in this context.
- Added unit coverage for `decode_command` and `decode_response` oversized-frame handling.
- Added client/server regression tests proving a valid frame is still processed after an oversized frame is dropped.