### PR TITLE
Preserve falsy values in `str_value`

### DIFF
--- a/keymasq/keymasqd/daemon_helpers.py
+++ b/keymasq/keymasqd/daemon_helpers.py
@@ -13,7 +13,7 @@ def float_like(value: object, default: float) -> float:
 
 
 def str_value(value: object, default: str = "") -> str:
-    return str(value or default)
+    return default if value is None else str(value)
 
 
 def json_object(value: object) -> JsonObject:

--- a/tests/keymasqd/test_daemon_helpers.py
+++ b/tests/keymasqd/test_daemon_helpers.py
@@ -1,0 +1,12 @@
+from keymasq.keymasqd.daemon_helpers import str_value
+
+
+def test_str_value_preserves_falsy_non_none_values() -> None:
+    assert str_value(0) == "0"
+    assert str_value(False) == "False"
+    assert str_value([]) == "[]"
+    assert str_value("") == ""
+
+
+def test_str_value_uses_default_for_none_only() -> None:
+    assert str_value(None, "fallback") == "fallback"


### PR DESCRIPTION
## Summary
- Updated `str_value` to return the default only when the input is `None`.
- Preserved falsy but valid values like `0`, `False`, `[]`, and `""` instead of falling back to the default.
- Added tests covering falsy non-`None` values and the `None` fallback case.

## Testing
- Not run (changes summarized from existing diff)
- Added unit coverage in `tests/keymasqd/test_daemon_helpers.py` for `str_value` behavior