### PR TITLE
Log uinput release failures in keymasqd

### DIFF
--- a/keymasq/keymasqd/runtime/grabbed_device_outputs.py
+++ b/keymasq/keymasqd/runtime/grabbed_device_outputs.py
@@ -1,3 +1,4 @@
+import logging
 from typing import cast
 
 import evdev
@@ -12,6 +13,8 @@ from keymasq.keymasqd.runtime.grabbed_device_types import (
     WritableUInput,
     identity_uinput_writer,
 )
+
+log = logging.getLogger("keymasqd.devices")
 
 
 def bucket_for_uinput(
@@ -133,8 +136,14 @@ def ensure_trigger_released(
         if gamepad_uinput is not None:
             gamepad_uinput.write(evdev_mod.ecodes.EV_ABS, axis_code, 0)
             gamepad_uinput.syn()
-    except Exception:
-        pass
+    except Exception as exc:
+        log.debug(
+            "Failed to release gamepad trigger axis %s on %s: %s",
+            axis_code,
+            device_runtime.path,
+            exc,
+            exc_info=True,
+        )
 
 
 def ensure_key_released(
@@ -150,8 +159,15 @@ def ensure_key_released(
                 evdev_mod=evdev,
                 uinput_writer=identity_uinput_writer,
             )
-    except Exception:
-        pass
+    except Exception as exc:
+        log.debug(
+            "Failed to release output key %s on %s bucket=%s: %s",
+            code,
+            device_runtime.path,
+            bucket_for_uinput(device_runtime, uinput_dev) or "unknown",
+            exc,
+            exc_info=True,
+        )
 
 
 def emit_configured_mouse_move(
@@ -188,9 +204,16 @@ def release_all_keys(
             for code in held:
                 writer.write(evdev_mod.ecodes.EV_KEY, int(code), 0)
             writer.syn()
-        except Exception:
-            pass
-        finally:
+        except Exception as exc:
+            log.debug(
+                "Failed to release held output keys on %s bucket=%s keys=%s: %s",
+                device_runtime.path,
+                bucket,
+                held,
+                exc,
+                exc_info=True,
+            )
+        else:
             device_runtime.state.held_output_keys[bucket].clear()
             if bucket in device_runtime.state.superkey_output_refcounts:
                 device_runtime.state.superkey_output_refcounts[bucket].clear()
@@ -201,8 +224,13 @@ def release_all_keys(
             gamepad_uinput.write(evdev_mod.ecodes.EV_ABS, evdev_mod.ecodes.ABS_Z, 0)
             gamepad_uinput.write(evdev_mod.ecodes.EV_ABS, evdev_mod.ecodes.ABS_RZ, 0)
             gamepad_uinput.syn()
-        except Exception:
-            pass
+        except Exception as exc:
+            log.debug(
+                "Failed to release gamepad trigger axes on %s: %s",
+                device_runtime.path,
+                exc,
+                exc_info=True,
+            )
 
     for task in list(device_runtime.state.rapidfire_tasks.values()):
         if not task.done():

--- a/tests/keymasqd/test_grabbed_device_runtime_helpers.py
+++ b/tests/keymasqd/test_grabbed_device_runtime_helpers.py
@@ -21,6 +21,11 @@ class _FakeGrabbedRecorder:
         self.calls.append((device_type, event))
 
 
+class _FailingWriteUInput(_FakeUInput):
+    def write(self, event_type: int, code: int, value: int) -> None:
+        raise OSError("uinput disconnected")
+
+
 class TestGrabbedDeviceHelpers:
     def test_find_action_for_event_prefers_evdev_code_over_alias_name(
         self,
@@ -505,6 +510,51 @@ class TestGrabbedDeviceHelpers:
         assert device.state.tap_active == {}
         assert device.state.combo_recalled_bindings == set()
         assert device.state.held_source_actions == {}
+    def test_release_helpers_log_failed_uinput_releases(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        device = _make_grabbed_device(monkeypatch)
+        keyboard = _FailingWriteUInput()
+        gamepad = _FailingWriteUInput()
+        device.keyboard_uinput = keyboard  # type: ignore[assignment]
+        device.gamepad_uinput = gamepad  # type: ignore[assignment]
+
+        with caplog.at_level(logging.DEBUG, logger="keymasqd.devices"):
+            gdo.ensure_key_released(device, evdev.ecodes.KEY_A, device.keyboard_uinput)
+            gdo.ensure_trigger_released(
+                device,
+                evdev.ecodes.ABS_Z,
+                evdev_mod=evdev,
+                uinput_writer=lambda device: cast(gdt.WritableUInput | None, device),
+            )
+
+        assert "Failed to release output key" in caplog.text
+        assert "Failed to release gamepad trigger axis" in caplog.text
+    def test_release_all_keys_keeps_tracking_after_failed_release(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        device = _make_grabbed_device(monkeypatch)
+        keyboard = _FailingWriteUInput()
+        device.keyboard_uinput = keyboard  # type: ignore[assignment]
+        device.state.held_output_keys["keyboard"].add(evdev.ecodes.KEY_A)
+        device.state.superkey_output_refcounts["keyboard"][evdev.ecodes.KEY_A] = 1
+
+        with caplog.at_level(logging.DEBUG, logger="keymasqd.devices"):
+            gdo.release_all_keys(
+                device,
+                evdev_mod=evdev,
+                uinput_writer=lambda device: cast(gdt.WritableUInput | None, device),
+            )
+
+        assert device.state.held_output_keys["keyboard"] == {evdev.ecodes.KEY_A}
+        assert device.state.superkey_output_refcounts["keyboard"] == {
+            evdev.ecodes.KEY_A: 1
+        }
+        assert "Failed to release held output keys" in caplog.text
     @pytest.mark.asyncio
     async def test_wait_for_active_key_activity_handles_timeouts_and_drain_errors(
         self,


### PR DESCRIPTION
## Summary
- Replace silent exceptions during key and trigger release cleanup with debug logging in `grabbed_device_outputs.py`.
- Include device path, bucket, and exception details so release failures are easier to diagnose.
- Add tests covering logged failures and preserving held-key tracking when release cleanup fails.

## Testing
- Not run (not requested).
- Added unit coverage for failed `ensure_key_released` and `ensure_trigger_released` logging.
- Added unit coverage for `release_all_keys` leaving internal state intact when uinput release fails.