### PR TITLE
Clamp combo capture timeout to 15 seconds

### DIFF
--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -171,6 +171,7 @@ Combo recording uses the same guarded original-input path as recording and captu
 - It observes raw original-input events from the hardware interfaces associated with the selected profile
 - It requires the caller to already hold the active recording owner chain
 - `CaptureManager.begin_combo()` additionally requires a one-shot daemon-issued authorization capability
+- The daemon clamps each combo capture request to a 15-second maximum duration
 - It is therefore gated by both unlock state and owner identity
 
 This is important because combo capture is effectively a short-lived privileged input observation flow, even though its output is only a compact trigger description.

--- a/keymasq/keymasqd/daemon_capture_commands.py
+++ b/keymasq/keymasqd/daemon_capture_commands.py
@@ -13,6 +13,9 @@ from keymasq.keymasqd.daemon_helpers import (
     str_list,
 )
 
+MIN_CAPTURE_TIMEOUT_S = 1.0
+MAX_CAPTURE_TIMEOUT_S = 15.0
+
 
 class _GrabbedDeviceRef(Protocol):
     path: str
@@ -160,7 +163,11 @@ async def capture_combo(
         )
         daemon.capture_manager.register_combo_notifier(token, loop, notify_event)
         warnings = str_list(capture_result.get("warnings", []))
-        deadline = loop.time() + max(1.0, float(timeout_s))
+        capture_timeout_s = min(
+            max(MIN_CAPTURE_TIMEOUT_S, float(timeout_s)),
+            MAX_CAPTURE_TIMEOUT_S,
+        )
+        deadline = loop.time() + capture_timeout_s
         pressed: set[str] = set()
         events: list[dict[str, str]] = []
 

--- a/tests/keymasqd/test_daemon_capture_commands.py
+++ b/tests/keymasqd/test_daemon_capture_commands.py
@@ -276,6 +276,44 @@ async def test_capture_combo_waits_on_event_not_sleep(daemon_testbed, monkeypatc
 
 
 @pytest.mark.asyncio
+async def test_capture_combo_clamps_client_timeout_to_daemon_max(daemon_testbed, monkeypatch):
+    daemon, _device_manager, _recording_manager, _macro_store, _capture_manager = daemon_testbed
+    deadline_offsets: list[float] = []
+    queued_events = [
+        {"evdev": "key_a", "hardware_id": "1234:5678", "source": "kbd", "value": 1},
+        {"evdev": "key_a", "hardware_id": "1234:5678", "source": "kbd", "value": 0},
+    ]
+
+    async def read_event(
+        _daemon,
+        _token: str,
+        _notify_event: asyncio.Event,
+        deadline: float,
+    ) -> dict:
+        deadline_offsets.append(deadline - asyncio.get_running_loop().time())
+        return queued_events.pop(0)
+
+    monkeypatch.setattr(daemon_capture_commands, "read_capture_combo_event", read_event)
+
+    result = await daemon_capture_commands.capture_combo(
+        daemon,
+        {"1234:5678"},
+        daemon_capture_commands.MAX_CAPTURE_TIMEOUT_S + 3600.0,
+    )
+
+    assert result == {
+        "events": [{"evdev": "key_a", "hardware_id": "1234:5678", "source": "kbd"}],
+        "warnings": [],
+    }
+    assert deadline_offsets
+    assert (
+        0.0
+        < deadline_offsets[0]
+        <= daemon_capture_commands.MAX_CAPTURE_TIMEOUT_S
+    )
+
+
+@pytest.mark.asyncio
 async def test_capture_combo_returns_immediately_on_wheel_pulse(daemon_testbed):
     daemon, device_manager, _recording_manager, _macro_store, capture_manager = daemon_testbed
     notify: dict[str, asyncio.Event] = {}


### PR DESCRIPTION
## Summary
- Clamp combo capture requests to a daemon-side maximum of 15 seconds, regardless of client-provided timeout.
- Keep the existing 1-second minimum floor for very short requests.
- Document the new combo-capture timeout limit in `docs/SECURITY.md`.
- Add regression coverage to verify oversized client timeouts are capped by the daemon.

## Testing
- `pytest tests/keymasqd/test_daemon_capture_commands.py`
- run: full repository check suite (`./scripts/check.sh full`)