### PR TITLE
Re-resolve expired runtime unlock cache entries

### DIFF
--- a/keymasq/keymasqd/daemon.py
+++ b/keymasq/keymasqd/daemon.py
@@ -463,13 +463,14 @@ class Daemon:
 
     def _recording_unlocked_for_uid(self, uid: int) -> tuple[bool, int, str]:
         now_mono = time.monotonic()
+        now_wall = int(time.time())
         cached = self._unlock_cache.get(uid)
 
         if cached is not None:
             checked_mono, unlocked, expires_at, source = cached
-            if unlocked and (expires_at == 0 or expires_at >= int(time.time())):
+            if unlocked and (expires_at == 0 or expires_at >= now_wall):
                 return unlocked, expires_at, source
-            if (now_mono - checked_mono) < self._unlock_cache_interval_s:
+            if not unlocked and (now_mono - checked_mono) < self._unlock_cache_interval_s:
                 return unlocked, expires_at, source
 
         status = resolve_unlock_status(uid)

--- a/tests/keymasqd/test_daemon_runtime_unlock.py
+++ b/tests/keymasqd/test_daemon_runtime_unlock.py
@@ -99,6 +99,26 @@ async def test_refresh_then_lock_runtime_unlock_updates_owner_cache_and_file(
     assert not unlock_file.exists()
 
 
+def test_expired_unlocked_cache_entry_is_re_resolved(daemon_testbed, monkeypatch):
+    daemon, _device_manager, _recording_manager, _macro_store, _capture_manager = daemon_testbed
+    uid = 5555
+    resolved_uids: list[int] = []
+
+    def fake_resolve_unlock_status(requested_uid: int) -> dict[str, object]:
+        resolved_uids.append(requested_uid)
+        return {"unlocked": False, "source": "none", "expires_at": 0}
+
+    monkeypatch.setattr(daemon_module, "resolve_unlock_status", fake_resolve_unlock_status)
+    monkeypatch.setattr(daemon_module.time, "monotonic", lambda: 500.25)
+    monkeypatch.setattr(daemon_module.time, "time", lambda: 1002)
+
+    daemon._unlock_cache[uid] = (500.0, True, 1001, "runtime")
+
+    assert daemon._recording_unlocked_for_uid(uid) == (False, 0, "none")
+    assert resolved_uids == [uid]
+    assert daemon._unlock_cache[uid] == (500.25, False, 0, "none")
+
+
 @pytest.mark.asyncio
 async def test_client_disconnect_clears_owned_and_unowned_runtime_unlocks(
     daemon_testbed,


### PR DESCRIPTION
## Summary
- Re-check cached runtime unlock state when an unlocked entry has passed its wall-clock expiry.
- Keep negative cache entries on the existing monotonic cooldown path, avoiding unnecessary re-resolution.
- Add a regression test covering an expired unlocked cache entry being refreshed through `resolve_unlock_status`.

## Testing
- Not run (change reviewed via tests added and existing daemon unlock cache logic).
- Added regression coverage in `tests/keymasqd/test_daemon_runtime_unlock.py` for expired unlock cache re-resolution.