### PR TITLE
Track and cancel session event tasks

### DIFF
--- a/keymasq/session/manager/core.py
+++ b/keymasq/session/manager/core.py
@@ -45,6 +45,7 @@ from .common import JsonObject
 from .state import (
     CaptureRuntimeState,
     CompositorRuntimeState,
+    EventRuntimeState,
     ExecRuntimeState,
     ProfileRuntimeState,
     RecordingRuntimeState,
@@ -99,6 +100,7 @@ class SessionManager:
         self.capture_state = CaptureRuntimeState()
 
         self.exec_state = ExecRuntimeState()
+        self.event_state = EventRuntimeState()
         self.recording_state = RecordingRuntimeState()
         self.unlock_state = UnlockRuntimeState()
         runtime_recording.load_recording_settings_from_disk(self)
@@ -158,6 +160,8 @@ class SessionManager:
             with contextlib.suppress(asyncio.CancelledError, Exception):
                 await self.compositor_state.supervisor_task
             self.compositor_state.supervisor_task = None
+
+        await runtime_events.cancel_event_tasks(self)
 
         profile_apply_task = self.profile_state.apply_task
         if profile_apply_task:
@@ -221,6 +225,7 @@ class SessionManager:
         self.capture_state.tokens.clear()
 
         await self.client.disconnect()
+        await runtime_events.cancel_event_tasks(self)
 
         if self.connect_task:
             self.connect_task.cancel()

--- a/keymasq/session/manager/events.py
+++ b/keymasq/session/manager/events.py
@@ -1,6 +1,7 @@
 import asyncio
 import logging
-from typing import TYPE_CHECKING
+from collections.abc import Coroutine
+from typing import TYPE_CHECKING, Any
 
 from keymasq.common.ipc import Command, CommandType
 
@@ -21,6 +22,50 @@ TOPOLOGY_REFRESH_DEBOUNCE_S = 0.5
 TOPOLOGY_REFRESH_RETRY_S = 1.0
 
 
+def create_event_task(
+    manager: "SessionManager",
+    coro: Coroutine[Any, Any, None],
+    *,
+    name: str,
+    extra_task_set: set[asyncio.Task[None]] | None = None,
+) -> asyncio.Task[None]:
+    task = asyncio.create_task(coro, name=f"keymasq-session:{name}")
+    manager.event_state.tasks.add(task)
+    if extra_task_set is not None:
+        extra_task_set.add(task)
+
+    def _discard(done: asyncio.Task[None]) -> None:
+        manager.event_state.tasks.discard(done)
+        if extra_task_set is not None:
+            extra_task_set.discard(done)
+        try:
+            exc = done.exception()
+        except asyncio.CancelledError:
+            return
+        if exc is not None:
+            log.error(
+                "Unhandled exception in %s event task",
+                name,
+                exc_info=(type(exc), exc, exc.__traceback__),
+            )
+
+    task.add_done_callback(_discard)
+    return task
+
+
+async def cancel_event_tasks(manager: "SessionManager") -> None:
+    tasks = list(manager.event_state.tasks)
+    if not tasks:
+        return
+
+    for task in tasks:
+        if not task.done():
+            task.cancel()
+    await asyncio.gather(*tasks, return_exceptions=True)
+    manager.event_state.tasks.difference_update(tasks)
+    manager.compositor_state.cursor_position_tasks.difference_update(tasks)
+
+
 async def handle_event(
     manager: "SessionManager",
     event_type: CommandType,
@@ -39,29 +84,55 @@ async def handle_event(
                 exec_data["cmd"] = binding.cmd
                 if binding.hardware_id:
                     exec_data["hardware_id"] = binding.hardware_id
-                asyncio.create_task(handle_exec_trigger(manager, exec_data))
+                create_event_task(manager, handle_exec_trigger(manager, exec_data), name="exec")
             else:
                 log.warning("Unknown exec_ref: %s", exec_ref)
 
         action_type_str = str(data.get("action_type", "") or "")
         if action_type_str == "start_macro_recording":
-            asyncio.create_task(handle_start_macro_trigger(manager))
+            create_event_task(
+                manager,
+                handle_start_macro_trigger(manager),
+                name="start_macro_recording",
+            )
         elif action_type_str == "stop_macro_recording":
-            asyncio.create_task(handle_stop_macro_trigger(manager))
+            create_event_task(
+                manager,
+                handle_stop_macro_trigger(manager),
+                name="stop_macro_recording",
+            )
         elif action_type_str == "cancel_macro_playback":
-            asyncio.create_task(handle_cancel_macro_trigger(manager))
+            create_event_task(
+                manager,
+                handle_cancel_macro_trigger(manager),
+                name="cancel_macro_playback",
+            )
         elif action_type_str == "emergency_reset":
-            asyncio.create_task(handle_emergency_reset_trigger(manager))
+            create_event_task(
+                manager,
+                handle_emergency_reset_trigger(manager),
+                name="emergency_reset",
+            )
         elif action_type_str in {"profile_enable", "profile_disable", "profile_toggle"}:
-            asyncio.create_task(handle_profile_trigger(manager, data))
+            create_event_task(
+                manager,
+                handle_profile_trigger(manager, data),
+                name="profile_trigger",
+            )
         elif action_type_str == "exec" and exec_ref is None:
-            asyncio.create_task(handle_exec_trigger(manager, data))
+            create_event_task(manager, handle_exec_trigger(manager, data), name="exec")
         elif action_type_str == "compositor_dispatch":
-            asyncio.create_task(
-                runtime_compositor.handle_compositor_dispatch_trigger(manager, data)
+            create_event_task(
+                manager,
+                runtime_compositor.handle_compositor_dispatch_trigger(manager, data),
+                name="compositor_dispatch",
             )
         elif action_type_str == "macro":
-            asyncio.create_task(runtime_recording.play_macro_trigger(manager, data))
+            create_event_task(
+                manager,
+                runtime_recording.play_macro_trigger(manager, data),
+                name="macro_playback",
+            )
         return
 
     if event_type == CommandType.SET_CURSOR_POSITION:
@@ -87,7 +158,11 @@ async def handle_event(
         return
 
     if event_type == CommandType.RUNTIME_RESET:
-        asyncio.create_task(handle_runtime_reset_event(manager, data))
+        create_event_task(
+            manager,
+            handle_runtime_reset_event(manager, data),
+            name="runtime_reset",
+        )
         return
 
     if event_type == CommandType.DIAGNOSTICS_SNAPSHOT:
@@ -134,19 +209,12 @@ async def handle_event(
 
 
 def schedule_cursor_position_request(manager: "SessionManager", data: JsonObject) -> None:
-    task = asyncio.create_task(handle_set_cursor_position_request(manager, data))
-    manager.compositor_state.cursor_position_tasks.add(task)
-
-    def _discard(done: asyncio.Task[None]) -> None:
-        manager.compositor_state.cursor_position_tasks.discard(done)
-        try:
-            exc = done.exception()
-        except asyncio.CancelledError:
-            return
-        if exc is not None:
-            log.debug("Cursor position request failed: %s", exc)
-
-    task.add_done_callback(_discard)
+    create_event_task(
+        manager,
+        handle_set_cursor_position_request(manager, data),
+        name="cursor_position",
+        extra_task_set=manager.compositor_state.cursor_position_tasks,
+    )
 
 
 async def handle_set_cursor_position_request(
@@ -407,7 +475,11 @@ async def on_device_connected(manager: "SessionManager", device_info: JsonObject
         TOPOLOGY_REFRESH_DEBOUNCE_S,
         TOPOLOGY_REFRESH_RETRY_S,
     )
-    asyncio.create_task(_refresh_recording_devices_cache_after_topology(manager))
+    create_event_task(
+        manager,
+        _refresh_recording_devices_cache_after_topology(manager),
+        name="recording_devices_refresh",
+    )
 
 
 async def on_device_disconnected(manager: "SessionManager", device_info: JsonObject) -> None:
@@ -429,7 +501,11 @@ async def on_device_disconnected(manager: "SessionManager", device_info: JsonObj
         TOPOLOGY_REFRESH_DEBOUNCE_S,
         TOPOLOGY_REFRESH_RETRY_S,
     )
-    asyncio.create_task(_refresh_recording_devices_cache_after_topology(manager))
+    create_event_task(
+        manager,
+        _refresh_recording_devices_cache_after_topology(manager),
+        name="recording_devices_refresh",
+    )
 
 
 async def _refresh_recording_devices_cache_after_topology(manager: "SessionManager") -> None:

--- a/keymasq/session/manager/state.py
+++ b/keymasq/session/manager/state.py
@@ -112,3 +112,8 @@ class CompositorRuntimeState:
     support_details_cache_ttl_s: float = 5.0
     support_details_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
     cursor_position_tasks: set[asyncio.Task[None]] = field(default_factory=set)
+
+
+@dataclass
+class EventRuntimeState:
+    tasks: set[asyncio.Task[None]] = field(default_factory=set)

--- a/tests/test_session_manager_core.py
+++ b/tests/test_session_manager_core.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock
 import pytest
 
 import keymasq.session.manager.core as session_manager_core_module
+import keymasq.session.manager.events as session_events_module
 import keymasq.session.manager.profiles as session_profiles_module
 from keymasq.common.security import PeerCredentials
 from keymasq.session.manager import SessionManager
@@ -103,6 +104,39 @@ def test_signal_handler_only_sets_shutdown_state() -> None:
     assert manager.running is True
     assert manager._shutdown_event.is_set()
     assert manager._retry_event.is_set()
+
+
+@pytest.mark.asyncio
+async def test_stop_cancels_tracked_event_tasks() -> None:
+    manager = SessionManager()
+    manager.running = True
+    manager.client.disconnect = AsyncMock()  # type: ignore[method-assign]
+    manager.dbus.disconnect = AsyncMock()  # type: ignore[method-assign]
+    started = asyncio.Event()
+    cancelled = asyncio.Event()
+
+    async def _wait_forever() -> None:
+        started.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            cancelled.set()
+            raise
+
+    task = session_events_module.create_event_task(
+        manager,
+        _wait_forever(),
+        name="stop-test",
+    )
+    await asyncio.wait_for(started.wait(), timeout=1.0)
+
+    await manager.stop()
+
+    assert cancelled.is_set()
+    assert task.cancelled()
+    assert manager.event_state.tasks == set()
+    manager.client.disconnect.assert_awaited_once()  # type: ignore[attr-defined]
+    manager.dbus.disconnect.assert_awaited_once()  # type: ignore[attr-defined]
 
 
 @pytest.mark.asyncio

--- a/tests/test_session_manager_events.py
+++ b/tests/test_session_manager_events.py
@@ -203,6 +203,57 @@ async def test_handle_event_exec_ref_schedules_command_without_blocking() -> Non
 
 
 @pytest.mark.asyncio
+async def test_event_background_task_logs_exception_and_clears_reference(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    manager = SessionManager()
+    manager.action_handler.execute_command = AsyncMock(  # type: ignore[method-assign]
+        side_effect=RuntimeError("exec failed")
+    )
+
+    with caplog.at_level(logging.ERROR, logger="keymasq-session"):
+        await session_events_module.handle_event(
+            manager,
+            CommandType.ACTION_TRIGGER,
+            {"action_type": "exec", "cmd": "echo fail"},
+        )
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+
+    assert manager.event_state.tasks == set()
+    assert "Unhandled exception in exec event task" in caplog.text
+    assert "RuntimeError: exec failed" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_cancel_event_tasks_cancels_tracked_background_task() -> None:
+    manager = SessionManager()
+    started = asyncio.Event()
+    cancelled = asyncio.Event()
+
+    async def _wait_forever() -> None:
+        started.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            cancelled.set()
+            raise
+
+    task = session_events_module.create_event_task(
+        manager,
+        _wait_forever(),
+        name="test",
+    )
+    await asyncio.wait_for(started.wait(), timeout=1.0)
+
+    await session_events_module.cancel_event_tasks(manager)
+
+    assert cancelled.is_set()
+    assert task.cancelled()
+    assert manager.event_state.tasks == set()
+
+
+@pytest.mark.asyncio
 async def test_handle_event_high_exec_ref_schedules_command_without_numeric_split() -> None:
     manager = SessionManager()
     manager.exec_state.exec_refs[10000] = ExecBinding(cmd="echo high", owner="combo")


### PR DESCRIPTION
## Summary
- Add `EventRuntimeState` to track all background session event tasks in one place.
- Route event-triggered work through a shared task creator so tasks are named, tracked, and cleaned up consistently.
- Cancel tracked event tasks during session shutdown and disconnect to avoid orphaned work.
- Update event tests to cover exception logging, task cleanup, and shutdown cancellation behavior.

## Testing
- `pytest tests/test_session_manager_core.py`
- `pytest tests/test_session_manager_events.py`
- Not run: full project checks via `./scripts/check.sh full`