### PR TITLE
Clear stale hardware cache on hardware reload

### DIFF
--- a/keymasq/session/hardware.py
+++ b/keymasq/session/hardware.py
@@ -35,6 +35,7 @@ class HardwareManager:
                 log.error(f"Failed to load {config_file}: {e}")
 
     def reload(self) -> None:
+        self._cache.clear()
         self._load_all()
 
     def _load_config(self, path: Path) -> HardwareConfig:

--- a/tests/test_session_hardware.py
+++ b/tests/test_session_hardware.py
@@ -77,6 +77,34 @@ def test_hardware_manager_skips_invalid_files(
     assert "Failed to load" in caplog.text
 
 
+def test_hardware_manager_reload_removes_deleted_configs(temp_config_dir) -> None:
+    config_path = temp_config_dir / "hardware" / "1234_5678.toml"
+    config_path.write_text(
+        """
+[hardware]
+name = "Gaming Mouse"
+vendor_id = "1234"
+product_id = "5678"
+
+[hardware.evdev]
+devices = []
+
+[hardware.layout]
+buttons = []
+""".strip(),
+        encoding="utf-8",
+    )
+
+    manager = HardwareManager()
+    assert manager.get_hardware("1234:5678") is not None
+
+    config_path.unlink()
+    manager.reload()
+
+    assert manager.get_hardware("1234:5678") is None
+    assert manager.list_hardware_ids() == []
+
+
 def test_hardware_manager_save_load_and_delete_round_trip(temp_config_dir) -> None:
     manager = HardwareManager()
     config = HardwareConfig(


### PR DESCRIPTION
## Summary
- Clear `HardwareManager`'s in-memory cache before reloading hardware configs.
- Prevent deleted hardware config files from lingering in the session cache after `reload()`.
- Add a regression test covering removal of a hardware config followed by reload.

## Testing
- Not run (test-only change).
- Added coverage in `tests/test_session_hardware.py` for cache invalidation after config deletion.