### PR TITLE
Scope command ACL checks to the caller's client class

### DIFF
--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -222,7 +222,7 @@ Empty UID allowlists mean no UID restriction. This is the default and is appropr
 
 `session_command_acl` applies to the single session-side client class: `client`. The session socket is a same-user endpoint, so Keymasq does not model GUI and CLI as separate enforceable trust classes there.
 
-ACL entries are deny rules only. Supported forms: `!command`, `-command`, or `deny:command`. Commands not explicitly denied are allowed. Positive entries (entries without a deny prefix) are ignored.
+Command ACLs are denylists, not allowlists. Supported deny forms are `!command`, `-command`, or `deny:command`. Commands not explicitly denied for the caller's client class are allowed. Positive entries (entries without a deny prefix) are ignored and should not be used to express allow-only policy. Unconfigured or unknown client classes default to allow unless separately blocked by UID policy, unlock state, or owner binding.
 
 `[recording_guard].unlock_required` controls whether sensitive original-input
 observation flows require an explicit unlock before they are allowed.

--- a/keymasq/common/security.py
+++ b/keymasq/common/security.py
@@ -135,11 +135,7 @@ def get_peer_credentials(transport_socket: Any) -> PeerCredentials | None:
 
 
 def command_allowed(command: str, acl: dict[str, list[str]], client_class: str) -> bool:
-    entries: list[str] | None = acl.get(client_class)
-    if entries is None:
-        entries = []
-        for value in acl.values():
-            entries.extend(value)
+    entries = acl.get(client_class, [])
 
     for raw in entries:
         token = raw.strip()

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -118,6 +118,13 @@ def test_acl_deny_prefixes_are_supported(tmp_path: Path) -> None:
     assert command_allowed("get_status", policy.session_command_acl, "client")
 
 
+def test_acl_unknown_client_class_does_not_inherit_other_denies() -> None:
+    acl = {"session": ["!emergency_reset"]}
+
+    assert not command_allowed("emergency_reset", acl, "session")
+    assert command_allowed("emergency_reset", acl, "unknown")
+
+
 def test_acl_explicit_wildcard_deny_blocks_all_commands(tmp_path: Path) -> None:
     policy_path = tmp_path / "security.toml"
     policy_path.write_text(


### PR DESCRIPTION
## Summary
- Change `command_allowed()` to evaluate only the ACL entries for the requesting client class instead of merging deny rules across all classes.
- Update the security docs to clarify that command ACLs are denylists scoped per client class, and that unknown classes default to allow unless blocked by other policy.
- Add a regression test covering unknown client classes so they do not inherit denies from other classes.

## Testing
- Not run (documentation and logic change only).
- Added coverage in `tests/test_security.py` for client-class scoping behavior.