### PR TITLE
Preserve valid buffered frames after malformed input

### DIFF
--- a/keymasq/keymasqd/socket_server.py
+++ b/keymasq/keymasqd/socket_server.py
@@ -202,6 +202,9 @@ class SocketServer:
                 while True:
                     cmd, remaining = decode_command(self._buffer[writer])
                     if cmd is None:
+                        if len(remaining) < len(self._buffer[writer]):
+                            self._buffer[writer] = remaining
+                            continue
                         break
 
                     self._buffer[writer] = remaining

--- a/keymasq/session/client.py
+++ b/keymasq/session/client.py
@@ -84,6 +84,9 @@ class KeymasqdClient:
                 while True:
                     response, remaining = decode_response(self._buffer)
                     if response is None:
+                        if len(remaining) < len(self._buffer):
+                            self._buffer = remaining
+                            continue
                         break
 
                     self._buffer = remaining

--- a/tests/test_session_clients.py
+++ b/tests/test_session_clients.py
@@ -1,5 +1,6 @@
 import asyncio
 import queue
+import struct
 import sys
 import threading
 import types
@@ -8,7 +9,7 @@ from typing import Any
 
 import pytest
 
-from keymasq.common.ipc import Command, CommandType, Response
+from keymasq.common.ipc import Command, CommandType, Response, encode_response
 from keymasq.gui import session_client as gui_session_client
 from keymasq.session.client import KeymasqdClient
 
@@ -53,6 +54,39 @@ def test_keymasqd_client_handle_response_dispatches_event() -> None:
             },
         )
         await client._handle_response(response)
+
+        assert calls == [(CommandType.PING, {"ok": True})]
+
+    asyncio.run(_run())
+
+
+def test_keymasqd_client_listen_loop_skips_discarded_response_frame() -> None:
+    async def _run() -> None:
+        calls: list[tuple[CommandType, dict[str, Any]]] = []
+
+        async def _event_handler(event_type: CommandType, data: dict[str, Any]) -> None:
+            calls.append((event_type, data))
+
+        client = KeymasqdClient(event_handler=_event_handler)
+        reader = asyncio.StreamReader()
+        malformed_payload = b"{not-json"
+        reader.feed_data(
+            struct.pack("!I", len(malformed_payload))
+            + malformed_payload
+            + encode_response(
+                Response(
+                    status="event",
+                    data={
+                        "command": CommandType.PING.value,
+                        "data": {"ok": True},
+                    },
+                )
+            )
+        )
+        reader.feed_eof()
+        client.reader = reader
+
+        await client._listen_loop()
 
         assert calls == [(CommandType.PING, {"ok": True})]
 

--- a/tests/test_socket_server.py
+++ b/tests/test_socket_server.py
@@ -1,5 +1,6 @@
 import asyncio
 import os
+import struct
 
 import pytest
 import pytest_asyncio
@@ -171,6 +172,28 @@ class TestSocketServer:
         await writer.drain()
 
         response_data = await reader.read(1024)
+        response, _ = decode_response(response_data)
+
+        assert response is not None
+        assert response.status == "ok"
+        assert response.data["pong"] is True
+
+        writer.close()
+        await writer.wait_closed()
+
+    async def test_discarded_command_frame_does_not_wedge_client(self, server_and_handlers):
+        _server, _cmd_handler, _ = server_and_handlers
+
+        reader, writer = await asyncio.open_unix_connection(str(paths.SOCKET_PATH))
+        malformed_payload = b"{not-json"
+        writer.write(
+            struct.pack("!I", len(malformed_payload))
+            + malformed_payload
+            + encode_command(Command(command=CommandType.PING, data={}))
+        )
+        await writer.drain()
+
+        response_data = await asyncio.wait_for(reader.read(1024), timeout=1.0)
         response, _ = decode_response(response_data)
 
         assert response is not None


### PR DESCRIPTION
## Summary
- Fix socket and session listeners so a malformed frame does not discard any valid frames that were already buffered behind it.
- Keep parsing after dropping only the malformed prefix instead of breaking out of the read loop.
- Add regression tests for both the daemon socket server and the session client to verify a valid command/event still gets processed after bad input.

## Testing
- Added `tests/test_socket_server.py::TestSocketServer::test_discarded_command_frame_does_not_wedge_client` to confirm a malformed command frame followed by a valid command still returns `pong`.
- Added `tests/test_session_clients.py::test_keymasqd_client_listen_loop_skips_discarded_response_frame` to confirm a malformed response frame followed by a valid event is still dispatched.
- Not run locally.