### PR TITLE
Use CLOCK_MONOTONIC for evdev input streams

### DIFF
--- a/keymasq/keymasqd/evdev_clock.py
+++ b/keymasq/keymasqd/evdev_clock.py
@@ -1,0 +1,49 @@
+import fcntl
+import logging
+import struct
+import time
+from collections.abc import Callable
+from typing import Final, cast
+
+log = logging.getLogger("keymasqd.evdev_clock")
+
+_IOC_NRBITS: Final = 8
+_IOC_TYPEBITS: Final = 8
+_IOC_SIZEBITS: Final = 14
+
+_IOC_NRSHIFT: Final = 0
+_IOC_TYPESHIFT: Final = _IOC_NRSHIFT + _IOC_NRBITS
+_IOC_SIZESHIFT: Final = _IOC_TYPESHIFT + _IOC_TYPEBITS
+_IOC_DIRSHIFT: Final = _IOC_SIZESHIFT + _IOC_SIZEBITS
+
+_IOC_WRITE: Final = 1
+
+CLOCK_MONOTONIC_ID: Final = int(getattr(time, "CLOCK_MONOTONIC", 1))
+EVIOCSCLOCKID: Final = (
+    (_IOC_WRITE << _IOC_DIRSHIFT)
+    | (ord("E") << _IOC_TYPESHIFT)
+    | (0xA0 << _IOC_NRSHIFT)
+    | (struct.calcsize("i") << _IOC_SIZESHIFT)
+)
+
+
+def set_evdev_clock_monotonic(
+    device: object,
+    *,
+    device_path: str | None = None,
+    logger: logging.Logger | None = None,
+) -> bool:
+    """Ask evdev to use CLOCK_MONOTONIC timestamps for this client fd."""
+    fileno = getattr(device, "fileno", None)
+    if not callable(fileno):
+        return False
+
+    try:
+        fd = int(cast(Callable[[], int], fileno)())
+        fcntl.ioctl(fd, EVIOCSCLOCKID, struct.pack("i", CLOCK_MONOTONIC_ID))
+    except OSError as exc:
+        active_log = logger or log
+        suffix = f" for {device_path}" if device_path else ""
+        active_log.debug("Failed to set monotonic evdev clock%s: %s", suffix, exc)
+        return False
+    return True

--- a/keymasq/keymasqd/recording.py
+++ b/keymasq/keymasqd/recording.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 from collections.abc import AsyncIterator, Awaitable, Callable
 from datetime import datetime, timedelta
 from pathlib import Path
@@ -14,12 +15,14 @@ from keymasq.common.devices import (
 )
 from keymasq.common.ipc import CommandType
 from keymasq.common.paths import STATE_DIR
+from keymasq.keymasqd.evdev_clock import set_evdev_clock_monotonic
 from keymasq.keymasqd.recording_spool import RecordingSnapshot, RecordingSpool
 
 type RecordingEvent = dict[str, object]
 type RecordingPayload = dict[str, object]
 type RecordingDevice = dict[str, object]
 PENDING_RECORDING_TTL_S = 30 * 60
+log = logging.getLogger("keymasqd.recording")
 
 
 class _RecordingInputDevice(Protocol):
@@ -90,10 +93,7 @@ class RecordingManager:
             if not isinstance(path_value, str) or not path_value:
                 continue
             try:
-                input_dev = cast(
-                    _RecordingInputDevice,
-                    await asyncio.to_thread(evdev.InputDevice, path_value),
-                )
+                input_dev = await asyncio.to_thread(_open_recording_input_device, path_value)
                 self._extra_devices.append(input_dev)
                 raw_classes = dev.get("device_types")
                 classes = (
@@ -347,6 +347,12 @@ class RecordingManager:
                     "duration_ms": duration_ms,
                 },
         )
+
+
+def _open_recording_input_device(path: str) -> _RecordingInputDevice:
+    device = cast(object, evdev.InputDevice(path))
+    set_evdev_clock_monotonic(device, device_path=path, logger=log)
+    return cast(_RecordingInputDevice, device)
 
 
 def _is_wheel_event(event: evdev.InputEvent) -> bool:

--- a/keymasq/keymasqd/runtime/grabbed_device.py
+++ b/keymasq/keymasqd/runtime/grabbed_device.py
@@ -14,6 +14,7 @@ from keymasq.common.devices import (
     resolve_stable_path,
 )
 from keymasq.common.models import ActionType, DeviceType, MappingAction
+from keymasq.keymasqd.evdev_clock import set_evdev_clock_monotonic
 from keymasq.keymasqd.output_helpers import resolve_output_code
 from keymasq.keymasqd.recording import RecordingManager
 from keymasq.keymasqd.runtime import adapters as runtime_adapters
@@ -62,7 +63,9 @@ ASYNCIO_RUNTIME: Final[_AsyncioModule] = cast(_AsyncioModule, runtime_adapters.A
 
 
 def _device_input(path: str) -> _ManagedInputDevice:
-    return cast(_ManagedInputDevice, evdev.InputDevice(path))
+    device = cast(object, evdev.InputDevice(path))
+    set_evdev_clock_monotonic(device, device_path=path, logger=log)
+    return cast(_ManagedInputDevice, device)
 
 
 def _uinput_writer(device: object | None) -> _WritableUInput | None:

--- a/tests/keymasqd/test_evdev_clock.py
+++ b/tests/keymasqd/test_evdev_clock.py
@@ -1,0 +1,30 @@
+import struct
+
+from keymasq.keymasqd import evdev_clock
+
+
+class _FdDevice:
+    def fileno(self) -> int:
+        return 42
+
+
+def test_set_evdev_clock_monotonic_uses_eviocsclockid(monkeypatch) -> None:
+    calls: list[tuple[int, int, bytes]] = []
+
+    def fake_ioctl(fd: int, request: int, arg: bytes) -> None:
+        calls.append((fd, request, arg))
+
+    monkeypatch.setattr(evdev_clock.fcntl, "ioctl", fake_ioctl)
+
+    assert evdev_clock.set_evdev_clock_monotonic(_FdDevice())
+    assert calls == [
+        (
+            42,
+            evdev_clock.EVIOCSCLOCKID,
+            struct.pack("i", evdev_clock.CLOCK_MONOTONIC_ID),
+        )
+    ]
+
+
+def test_set_evdev_clock_monotonic_skips_objects_without_fd() -> None:
+    assert not evdev_clock.set_evdev_clock_monotonic(object())

--- a/tests/keymasqd/test_macro_backend_loops.py
+++ b/tests/keymasqd/test_macro_backend_loops.py
@@ -24,7 +24,7 @@ async def test_recording_manager_start_opens_extra_devices_via_to_thread(monkeyp
     await asyncio.sleep(0)
     await recorder.stop()
 
-    assert calls == [(evdev.InputDevice, ("/dev/input/event0",))]
+    assert calls == [(recording_module._open_recording_input_device, ("/dev/input/event0",))]
 
 
 @pytest.mark.asyncio

--- a/tests/keymasqd/test_macro_backend_recording.py
+++ b/tests/keymasqd/test_macro_backend_recording.py
@@ -107,6 +107,50 @@ class _QuietInputDevice:
             yield evdev.InputEvent(1, 1, evdev.ecodes.EV_SYN, 0, 0)
 
 
+@pytest.mark.asyncio
+async def test_recording_manager_sets_monotonic_clock_on_extra_devices(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    recorder = RecordingManager()
+    fake_device = _QuietInputDevice()
+    clock_calls: list[tuple[object, str | None]] = []
+
+    monkeypatch.setattr(recording_module.evdev, "InputDevice", lambda _path: fake_device)
+    monkeypatch.setattr(
+        recording_module,
+        "set_evdev_clock_monotonic",
+        lambda device, **kwargs: clock_calls.append(
+            (device, kwargs.get("device_path"))
+        )
+        or True,
+    )
+
+    await recorder.start([{"path": "/dev/input/event10", "device_type": "keyboard"}])
+    await recorder.stop()
+
+    assert clock_calls == [(fake_device, "/dev/input/event10")]
+
+
+def test_grabbed_device_input_sets_monotonic_clock_for_recordable_raw_stream(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_device = object()
+    clock_calls: list[tuple[object, str | None]] = []
+
+    monkeypatch.setattr(gdm.evdev, "InputDevice", lambda _path: fake_device)
+    monkeypatch.setattr(
+        gdm,
+        "set_evdev_clock_monotonic",
+        lambda device, **kwargs: clock_calls.append(
+            (device, kwargs.get("device_path"))
+        )
+        or True,
+    )
+
+    assert gdm._device_input("/dev/input/event0") is fake_device
+    assert clock_calls == [(fake_device, "/dev/input/event0")]
+
+
 def _grabbed_recording_device(
     recorder: RecordingManager,
     *,


### PR DESCRIPTION
## Summary
- Add a small evdev helper that requests `EVIOCSCLOCKID` with `CLOCK_MONOTONIC` for device fds.
- Apply the monotonic clock setup when opening recordable extra devices and grabbed runtime devices.
- Cover the new helper and both call sites with unit tests, including the `asyncio.to_thread` path used by recording startup.

## Testing
- Added unit coverage for successful `EVIOCSCLOCKID` usage and the no-fd fallback.
- Added checks that recording and grabbed-device paths invoke the monotonic clock helper with the expected device path.