### PR TITLE
Log recording unlock chown failures

### DIFF
--- a/keymasq/common/recording_guard.py
+++ b/keymasq/common/recording_guard.py
@@ -1,8 +1,11 @@
+import logging
 import os
 import time
 from pathlib import Path
 
 from keymasq.common.paths import RECORDING_UNLOCK_PERSISTENT_DIR, RECORDING_UNLOCK_RUNTIME_DIR
+
+log = logging.getLogger(__name__)
 
 type UnlockStatus = dict[str, bool | int | str]
 
@@ -84,8 +87,14 @@ def write_unlock_expires_at(
     if owner_uid is not None and owner_gid is not None:
         try:
             os.chown(tmp_path, int(owner_uid), int(owner_gid))
-        except OSError:
-            pass
+        except OSError as exc:
+            log.warning(
+                "Failed to set recording unlock file owner on %s to %s:%s: %s",
+                tmp_path,
+                owner_uid,
+                owner_gid,
+                exc,
+            )
 
     os.chmod(tmp_path, int(mode))
     os.replace(tmp_path, path)

--- a/tests/test_recording_guard.py
+++ b/tests/test_recording_guard.py
@@ -1,3 +1,4 @@
+import logging
 from pathlib import Path
 
 import pytest
@@ -72,7 +73,7 @@ def test_resolve_unlock_status_none(monkeypatch: pytest.MonkeyPatch, tmp_path: P
 
 
 def test_write_unlock_expires_at_handles_chown_failure(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     lease = tmp_path / "nested" / "lease"
 
@@ -81,8 +82,10 @@ def test_write_unlock_expires_at_handles_chown_failure(
 
     monkeypatch.setattr(recording_guard.os, "chown", _raise_chown)
 
+    caplog.set_level(logging.WARNING, logger=recording_guard.__name__)
     recording_guard.write_unlock_expires_at(lease, 123, owner_uid=1, owner_gid=1)
 
     assert lease.read_text(encoding="utf-8") == "123\n"
+    assert "Failed to set recording unlock file owner" in caplog.text
     tmp_candidates = list(lease.parent.glob(f".{lease.name}.tmp-*"))
     assert tmp_candidates == []


### PR DESCRIPTION
## Summary
- Add a warning log when `recording_guard.write_unlock_expires_at()` cannot `chown` the temporary unlock file.
- Keep the unlock file write path resilient so the expiry timestamp is still persisted even if ownership fixup fails.
- Extend coverage to assert the warning is emitted when `os.chown` raises.

## Testing
- Not run (PR content only).
- Added/updated pytest coverage in `tests/test_recording_guard.py` for the warning path.