### PR TITLE
Discard oversized IPC frames without stalling subsequent messages

### DIFF
--- a/keymasq/common/ipc.py
+++ b/keymasq/common/ipc.py
@@ -92,7 +92,8 @@ def decode_command(data: bytes) -> tuple[Command | None, bytes]:
 
     payload_len = struct.unpack(HEADER_FORMAT, data[:HEADER_SIZE])[0]
     if payload_len > MAX_PAYLOAD_SIZE:
-        return None, data[HEADER_SIZE:]
+        total_len = HEADER_SIZE + payload_len
+        return None, data[total_len:] if len(data) >= total_len else b""
 
     total_len = HEADER_SIZE + payload_len
 
@@ -132,7 +133,8 @@ def decode_response(data: bytes) -> tuple[Response | None, bytes]:
 
     payload_len = struct.unpack(HEADER_FORMAT, data[:HEADER_SIZE])[0]
     if payload_len > MAX_PAYLOAD_SIZE:
-        return None, data[HEADER_SIZE:]
+        total_len = HEADER_SIZE + payload_len
+        return None, data[total_len:] if len(data) >= total_len else b""
 
     total_len = HEADER_SIZE + payload_len
 

--- a/keymasq/session/client.py
+++ b/keymasq/session/client.py
@@ -82,8 +82,12 @@ class KeymasqdClient:
                 self._buffer += data
 
                 while True:
-                    response, remaining = decode_response(self._buffer)
+                    buffered = self._buffer
+                    response, remaining = decode_response(buffered)
                     if response is None:
+                        if remaining != buffered:
+                            self._buffer = remaining
+                            continue
                         break
 
                     self._buffer = remaining

--- a/keymasq/session/manager/events.py
+++ b/keymasq/session/manager/events.py
@@ -22,19 +22,19 @@ TOPOLOGY_REFRESH_DEBOUNCE_S = 0.5
 TOPOLOGY_REFRESH_RETRY_S = 1.0
 
 
-def create_event_task(
+def create_event_task[TaskResult](
     manager: "SessionManager",
-    coro: Coroutine[Any, Any, None],
+    coro: Coroutine[Any, Any, TaskResult],
     *,
     name: str,
-    extra_task_set: set[asyncio.Task[None]] | None = None,
-) -> asyncio.Task[None]:
+    extra_task_set: set[asyncio.Task[TaskResult]] | None = None,
+) -> asyncio.Task[TaskResult]:
     task = asyncio.create_task(coro, name=f"keymasq-session:{name}")
     manager.event_state.tasks.add(task)
     if extra_task_set is not None:
         extra_task_set.add(task)
 
-    def _discard(done: asyncio.Task[None]) -> None:
+    def _discard(done: asyncio.Task[TaskResult]) -> None:
         manager.event_state.tasks.discard(done)
         if extra_task_set is not None:
             extra_task_set.discard(done)

--- a/keymasq/session/manager/state.py
+++ b/keymasq/session/manager/state.py
@@ -1,6 +1,6 @@
 import asyncio
 from dataclasses import dataclass, field
-from typing import Literal
+from typing import Any, Literal
 
 from keymasq.session.listeners.base import WindowListener
 from keymasq.session.profiles import ResolvedDeviceProfile
@@ -116,4 +116,4 @@ class CompositorRuntimeState:
 
 @dataclass
 class EventRuntimeState:
-    tasks: set[asyncio.Task[None]] = field(default_factory=set)
+    tasks: set[asyncio.Task[Any]] = field(default_factory=set)

--- a/tests/test_ipc.py
+++ b/tests/test_ipc.py
@@ -1,4 +1,7 @@
+import struct
+
 from keymasq.common.ipc import (
+    HEADER_FORMAT,
     Command,
     CommandType,
     Response,
@@ -72,6 +75,36 @@ class TestProtocolEncoding:
         assert decoded2.request_id == "2"
         assert remaining2 == b""
 
+    def test_decode_oversized_command_discards_full_frame(self, monkeypatch):
+        import keymasq.common.ipc as ipc
+
+        valid = encode_command(Command(command=CommandType.PING, data={}, request_id="ok"))
+        max_payload_size = struct.unpack(HEADER_FORMAT, valid[: ipc.HEADER_SIZE])[0]
+        monkeypatch.setattr(ipc, "MAX_PAYLOAD_SIZE", max_payload_size)
+        payload_len = max_payload_size + 1
+        oversized = struct.pack(HEADER_FORMAT, payload_len) + (b"x" * payload_len)
+
+        decoded, remaining = decode_command(oversized + valid)
+
+        assert decoded is None
+        assert remaining == valid
+
+        decoded, remaining = decode_command(remaining)
+        assert decoded is not None
+        assert decoded.request_id == "ok"
+        assert remaining == b""
+
+    def test_decode_partial_oversized_command_discards_buffer(self, monkeypatch):
+        import keymasq.common.ipc as ipc
+
+        monkeypatch.setattr(ipc, "MAX_PAYLOAD_SIZE", 8)
+        partial = struct.pack(HEADER_FORMAT, 9) + b"xxx"
+
+        decoded, remaining = decode_command(partial)
+
+        assert decoded is None
+        assert remaining == b""
+
     def test_error_response(self):
         resp = Response(
             status="error",
@@ -84,6 +117,36 @@ class TestProtocolEncoding:
 
         assert decoded.status == "error"
         assert decoded.error == "Device not found"
+
+    def test_decode_oversized_response_discards_full_frame(self, monkeypatch):
+        import keymasq.common.ipc as ipc
+
+        valid = encode_response(Response(status="ok", request_id="ok"))
+        max_payload_size = struct.unpack(HEADER_FORMAT, valid[: ipc.HEADER_SIZE])[0]
+        monkeypatch.setattr(ipc, "MAX_PAYLOAD_SIZE", max_payload_size)
+        payload_len = max_payload_size + 1
+        oversized = struct.pack(HEADER_FORMAT, payload_len) + (b"x" * payload_len)
+
+        decoded, remaining = decode_response(oversized + valid)
+
+        assert decoded is None
+        assert remaining == valid
+
+        decoded, remaining = decode_response(remaining)
+        assert decoded is not None
+        assert decoded.request_id == "ok"
+        assert remaining == b""
+
+    def test_decode_partial_oversized_response_discards_buffer(self, monkeypatch):
+        import keymasq.common.ipc as ipc
+
+        monkeypatch.setattr(ipc, "MAX_PAYLOAD_SIZE", 8)
+        partial = struct.pack(HEADER_FORMAT, 9) + b"xxx"
+
+        decoded, remaining = decode_response(partial)
+
+        assert decoded is None
+        assert remaining == b""
 
 
 class TestCommandTypes:

--- a/tests/test_keymasqd_client.py
+++ b/tests/test_keymasqd_client.py
@@ -1,8 +1,9 @@
 import asyncio
+import struct
 
 import pytest
 
-from keymasq.common.ipc import Command, CommandType, Response
+from keymasq.common.ipc import HEADER_FORMAT, Command, CommandType, Response, encode_response
 from keymasq.session.client import KeymasqdClient
 
 
@@ -16,6 +17,16 @@ class _BlockingAsyncReader:
 
     def release(self) -> None:
         self._release.set()
+
+
+class _ChunkedAsyncReader:
+    def __init__(self, chunks: list[bytes]) -> None:
+        self._chunks = chunks
+
+    async def read(self, _size: int) -> bytes:
+        if not self._chunks:
+            return b""
+        return self._chunks.pop(0)
 
 
 class _FakeAsyncWriter:
@@ -86,5 +97,30 @@ def test_keymasqd_client_send_command_uses_custom_timeout(monkeypatch: pytest.Mo
         assert response.status == "ok"
         assert response.data == {"pong": True}
         assert timeouts == [42.0]
+
+    asyncio.run(_run())
+
+
+def test_keymasqd_client_discards_oversized_response_before_valid(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def _run() -> None:
+        import keymasq.common.ipc as ipc
+
+        monkeypatch.setattr(ipc, "MAX_PAYLOAD_SIZE", 128)
+        payload_len = 129
+        oversized = struct.pack(HEADER_FORMAT, payload_len) + (b"x" * payload_len)
+        valid = encode_response(Response(status="ok", request_id="ok", data={"done": True}))
+
+        client = KeymasqdClient(event_handler=lambda _event, _data: None)
+        client.reader = _ChunkedAsyncReader([oversized + valid, b""])
+        client.writer = _FakeAsyncWriter()
+        future: asyncio.Future[Response] = asyncio.get_running_loop().create_future()
+        client._pending_requests["ok"] = future
+
+        await client._listen_loop()
+
+        assert future.done() is True
+        assert future.result().data == {"done": True}
 
     asyncio.run(_run())

--- a/tests/test_session_clients.py
+++ b/tests/test_session_clients.py
@@ -1,5 +1,6 @@
 import asyncio
 import queue
+import struct
 import sys
 import threading
 import types
@@ -8,7 +9,7 @@ from typing import Any
 
 import pytest
 
-from keymasq.common.ipc import Command, CommandType, Response
+from keymasq.common.ipc import Command, CommandType, Response, encode_response
 from keymasq.gui import session_client as gui_session_client
 from keymasq.session.client import KeymasqdClient
 
@@ -53,6 +54,39 @@ def test_keymasqd_client_handle_response_dispatches_event() -> None:
             },
         )
         await client._handle_response(response)
+
+        assert calls == [(CommandType.PING, {"ok": True})]
+
+    asyncio.run(_run())
+
+
+def test_keymasqd_client_listen_loop_skips_discarded_response_frame() -> None:
+    async def _run() -> None:
+        calls: list[tuple[CommandType, dict[str, Any]]] = []
+
+        async def _event_handler(event_type: CommandType, data: dict[str, Any]) -> None:
+            calls.append((event_type, data))
+
+        client = KeymasqdClient(event_handler=_event_handler)
+        reader = asyncio.StreamReader()
+        malformed_payload = b"{not-json"
+        reader.feed_data(
+            struct.pack("!I", len(malformed_payload))
+            + malformed_payload
+            + encode_response(
+                Response(
+                    status="event",
+                    data={
+                        "command": CommandType.PING.value,
+                        "data": {"ok": True},
+                    },
+                )
+            )
+        )
+        reader.feed_eof()
+        client.reader = reader
+
+        await client._listen_loop()
 
         assert calls == [(CommandType.PING, {"ok": True})]
 

--- a/tests/test_socket_server.py
+++ b/tests/test_socket_server.py
@@ -8,7 +8,6 @@ import pytest_asyncio
 from keymasq.common import paths
 from keymasq.common.ipc import (
     HEADER_FORMAT,
-    MAX_PAYLOAD_SIZE,
     Command,
     CommandType,
     decode_response,
@@ -213,14 +212,22 @@ class TestSocketServer:
             writer.close()
             await writer.wait_closed()
 
-    async def test_oversized_frame_does_not_block_following_command(self, server_and_handlers):
+    async def test_oversized_frame_does_not_block_following_command(
+        self,
+        server_and_handlers,
+        monkeypatch,
+    ):
+        import keymasq.common.ipc as ipc
+
         _server, cmd_handler, _ = server_and_handlers
+        monkeypatch.setattr(ipc, "MAX_PAYLOAD_SIZE", 128)
 
         reader, writer = await asyncio.open_unix_connection(str(paths.SOCKET_PATH))
 
-        oversized_header = struct.pack(HEADER_FORMAT, MAX_PAYLOAD_SIZE + 1)
+        payload_len = 129
         writer.write(
-            oversized_header
+            struct.pack(HEADER_FORMAT, payload_len)
+            + (b"x" * payload_len)
             + encode_command(
                 Command(command=CommandType.PING, data={}, request_id="after-oversized")
             )


### PR DESCRIPTION
## Summary
- Updated IPC decoding to drop the entire oversized frame when the payload length exceeds the limit, instead of leaving the buffer misaligned.
- Taught the session client listen loop to consume discarded oversized frames and continue processing later valid responses.
- Tightened event-task typing in the session manager and adjusted state storage to match the new task generics.
- Added regression coverage for oversized and partial frames in IPC decoding, the keymasqd client, session clients, and the socket server.

## Testing
- Added pytest coverage for oversized/partial IPC frame handling in `tests/test_ipc.py`.
- Added regression tests for client-side frame discarding in `tests/test_keymasqd_client.py` and `tests/test_session_clients.py`.
- Added socket server coverage to verify oversized frames do not block the next command in `tests/test_socket_server.py`.