### PR TITLE
Wait for timed-out session commands after kill

### DIFF
--- a/keymasq/session/action_handler.py
+++ b/keymasq/session/action_handler.py
@@ -44,6 +44,7 @@ class ActionHandler:
         except TimeoutError:
             log.error(f"Command timed out after 300s, killing: {cmd}")
             process.kill()
+            await process.wait()
             return -1
         except Exception as e:
             log.error(f"Failed to execute command: {e}")

--- a/tests/test_session_support.py
+++ b/tests/test_session_support.py
@@ -51,6 +51,7 @@ class _FakeProcess:
     ) -> None:
         self.returncode = returncode
         self.killed = False
+        self.waited = False
         self._communicate = communicate or self._default_communicate
 
     async def _default_communicate(self) -> tuple[bytes, bytes]:
@@ -61,6 +62,10 @@ class _FakeProcess:
 
     def kill(self) -> None:
         self.killed = True
+
+    async def wait(self) -> int:
+        self.waited = True
+        return self.returncode
 
 
 @pytest.mark.asyncio
@@ -248,6 +253,7 @@ async def test_action_handler_execute_command_kills_timed_out_process(
 
     assert result == -1
     assert process.killed is True
+    assert process.waited is True
     assert "Command timed out after 300s, killing: sleep 999" in caplog.text
 
 


### PR DESCRIPTION
## Summary
- Await `process.wait()` after killing a timed-out session command so the child process is fully reaped.
- Extend the session support test double to track `wait()` calls.
- Add coverage asserting timed-out commands are both killed and awaited.

## Testing
- Not run (not requested).
- Added/updated unit test coverage in `tests/test_session_support.py` for timeout handling.