### PR TITLE
Track and cancel session background tasks

### DIFF
--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -212,7 +212,9 @@ Relevant controls:
 - `session_allowed_uids`
 - `daemon_allowed_uids`
 - `[macro]`
-  - `exec_timeout_max_ms`
+  - `exec_timeout_max_ms`: maximum `exec_sync` wait time; the daemon clamps macro
+    payloads to this limit and the session uses the same value as the subprocess
+    timeout, killing the command if it is exceeded.
 - `[gui]`
   - `emergency_cancel_combo_enabled`
 - `[recording_guard]`

--- a/keymasq/keymasqd/runtime/macros.py
+++ b/keymasq/keymasqd/runtime/macros.py
@@ -822,6 +822,7 @@ async def run_macro_control_action(
                         "action_type": "exec",
                         "cmd": command,
                         "macro_exec_wait_id": wait_id,
+                        "macro_exec_timeout_ms": timeout_ms,
                     },
                 )
                 with contextlib.suppress(asyncio_mod.TimeoutError):

--- a/keymasq/session/action_handler.py
+++ b/keymasq/session/action_handler.py
@@ -4,6 +4,7 @@ import logging
 from keymasq.gui.session_client import JsonDict
 
 log = logging.getLogger("keymasq-session.actions")
+DEFAULT_COMMAND_TIMEOUT_S = 300.0
 
 
 class ActionHandler:
@@ -21,7 +22,13 @@ class ActionHandler:
         if action_type == "exec" and isinstance(cmd, str) and cmd:
             await self.execute_command(cmd)
 
-    async def execute_command(self, cmd: str) -> int:
+    async def execute_command(
+        self,
+        cmd: str,
+        *,
+        timeout_s: float = DEFAULT_COMMAND_TIMEOUT_S,
+    ) -> int:
+        timeout_s = max(0.001, float(timeout_s))
         try:
             log.info(f"Executing: {cmd}")
 
@@ -35,14 +42,14 @@ class ActionHandler:
             return -1
 
         try:
-            _, stderr = await asyncio.wait_for(process.communicate(), timeout=300.0)
+            _, stderr = await asyncio.wait_for(process.communicate(), timeout=timeout_s)
 
             if process.returncode != 0:
                 log.warning(f"Command failed with code {process.returncode}: {stderr.decode()}")
             return int(process.returncode or 0)
 
         except TimeoutError:
-            log.error(f"Command timed out after 300s, killing: {cmd}")
+            log.error(f"Command timed out after {timeout_s:g}s, killing: {cmd}")
             process.kill()
             return -1
         except asyncio.CancelledError:

--- a/keymasq/session/action_handler.py
+++ b/keymasq/session/action_handler.py
@@ -8,7 +8,7 @@ log = logging.getLogger("keymasq-session.actions")
 
 class ActionHandler:
     def __init__(self) -> None:
-        pass
+        self._background_tasks: set[asyncio.Task[int]] = set()
 
     async def handle_action(self, data: JsonDict) -> None:
         action_type = data.get("action_type")
@@ -45,12 +45,41 @@ class ActionHandler:
             log.error(f"Command timed out after 300s, killing: {cmd}")
             process.kill()
             return -1
+        except asyncio.CancelledError:
+            log.debug("Command task cancelled, killing: %s", cmd)
+            process.kill()
+            raise
         except Exception as e:
             log.error(f"Failed to execute command: {e}")
             return -1
 
     def execute_command_sync(self, cmd: str) -> None:
-        async def _runner() -> None:
-            await self.execute_command(cmd)
+        task = asyncio.create_task(
+            self.execute_command(cmd),
+            name="keymasq-session:exec-command",
+        )
+        self._background_tasks.add(task)
+        task.add_done_callback(self._handle_background_task_done)
 
-        asyncio.create_task(_runner())
+    def _handle_background_task_done(self, task: asyncio.Task[int]) -> None:
+        self._background_tasks.discard(task)
+        try:
+            exc = task.exception()
+        except asyncio.CancelledError:
+            return
+        if exc is not None:
+            log.error(
+                "Unhandled exception in async command task",
+                exc_info=(type(exc), exc, exc.__traceback__),
+            )
+
+    async def cancel_background_tasks(self) -> None:
+        tasks = list(self._background_tasks)
+        if not tasks:
+            return
+
+        for task in tasks:
+            if not task.done():
+                task.cancel()
+        await asyncio.gather(*tasks, return_exceptions=True)
+        self._background_tasks.difference_update(tasks)

--- a/keymasq/session/manager/core.py
+++ b/keymasq/session/manager/core.py
@@ -163,6 +163,9 @@ class SessionManager:
 
         await runtime_events.cancel_event_tasks(self)
 
+        if self.action_handler is not None:
+            await self.action_handler.cancel_background_tasks()
+
         profile_apply_task = self.profile_state.apply_task
         if profile_apply_task:
             profile_apply_task.cancel()
@@ -226,6 +229,8 @@ class SessionManager:
 
         await self.client.disconnect()
         await runtime_events.cancel_event_tasks(self)
+        if self.action_handler is not None:
+            await self.action_handler.cancel_background_tasks()
 
         if self.connect_task:
             self.connect_task.cancel()
@@ -544,10 +549,14 @@ class SessionManager:
     def send_notification(self, title: str, message: str) -> None:
         log.info("Notification: %s: %s", title, message)
         try:
-            loop = asyncio.get_running_loop()
+            asyncio.get_running_loop()
         except RuntimeError:
             return
-        loop.create_task(self._send_notification_async(title, message))
+        runtime_events.create_event_task(
+            self,
+            self._send_notification_async(title, message),
+            name="notification",
+        )
 
     async def _send_notification_async(self, title: str, message: str) -> None:
         try:

--- a/keymasq/session/manager/events.py
+++ b/keymasq/session/manager/events.py
@@ -376,7 +376,16 @@ async def handle_exec_trigger(manager: "SessionManager", data: JsonObject) -> No
         return
 
     if wait_id:
-        returncode = await action_handler.execute_command(cmd)
+        policy_timeout_ms = max(1, int(manager.security_policy.macro_exec_timeout_max_ms))
+        timeout_ms = max(
+            1,
+            _int_value(data.get("macro_exec_timeout_ms"), policy_timeout_ms),
+        )
+        timeout_ms = min(timeout_ms, policy_timeout_ms)
+        returncode = await action_handler.execute_command(
+            cmd,
+            timeout_s=timeout_ms / 1000.0,
+        )
         try:
             await manager.client.send_command(
                 Command(

--- a/tests/keymasqd/test_device_manager_core.py
+++ b/tests/keymasqd/test_device_manager_core.py
@@ -924,6 +924,11 @@ class TestMacroControlActions:
         assert manager.macro_state.exec_waiters == {}
         callback.assert_awaited_once()
         assert callback.await_args.args[0] == CommandType.ACTION_TRIGGER
+        called_data = callback.await_args.args[1]
+        assert called_data["action_type"] == "exec"
+        assert called_data["cmd"] == "echo hi"
+        assert called_data["macro_exec_timeout_ms"] == 100
+        assert called_data["macro_exec_wait_id"]
         assert result == pytest.approx(0.025)
 
 

--- a/tests/keymasqd/test_device_manager_rapidfire.py
+++ b/tests/keymasqd/test_device_manager_rapidfire.py
@@ -83,7 +83,7 @@ class TestRapidfireRelease:
         await device.grab()
         await original_sleep(0)
 
-        assert wait_timeouts == [gdm.ACTIVE_KEY_IDLE_LOG_INTERVAL_S]
+        assert wait_timeouts == [pytest.approx(gdm.ACTIVE_KEY_IDLE_LOG_INTERVAL_S)]
         assert [call[0] for call in to_thread_calls] == [
             fake_input.active_keys,
             fake_input.active_keys,

--- a/tests/test_session_manager_events.py
+++ b/tests/test_session_manager_events.py
@@ -316,7 +316,8 @@ async def test_handle_event_macro_sync_exec_waits_and_reports_completion() -> No
     sent = asyncio.Event()
     sent_commands = []
 
-    async def _execute_command(cmd: str) -> int:
+    async def _execute_command(cmd: str, *, timeout_s: float = 300.0) -> int:
+        assert timeout_s == pytest.approx(1.25)
         started.set()
         await finish.wait()
         return 17
@@ -337,6 +338,7 @@ async def test_handle_event_macro_sync_exec_waits_and_reports_completion() -> No
                 "action_type": "exec",
                 "cmd": "echo macro",
                 "macro_exec_wait_id": "wait-1",
+                "macro_exec_timeout_ms": 1250,
             },
         ),
         timeout=1.0,
@@ -348,9 +350,42 @@ async def test_handle_event_macro_sync_exec_waits_and_reports_completion() -> No
     finish.set()
     await asyncio.wait_for(sent.wait(), timeout=1.0)
 
-    manager.action_handler.execute_command.assert_awaited_once_with("echo macro")
+    manager.action_handler.execute_command.assert_awaited_once_with(
+        "echo macro",
+        timeout_s=1.25,
+    )
     assert sent_commands[0].command == CommandType.MACRO_EXEC_COMPLETE
     assert sent_commands[0].data == {"wait_id": "wait-1", "returncode": 17}
+
+
+@pytest.mark.asyncio
+async def test_handle_event_macro_sync_exec_clamps_timeout_to_session_policy() -> None:
+    manager = SessionManager()
+    manager.security_policy.macro_exec_timeout_max_ms = 750
+    manager.client.send_command = AsyncMock(return_value=SimpleNamespace(status="ok", data={}))
+
+    async def _execute_command(_cmd: str, *, timeout_s: float = 300.0) -> int:
+        assert timeout_s == pytest.approx(0.75)
+        return 0
+
+    manager.action_handler.execute_command = AsyncMock(side_effect=_execute_command)
+
+    await session_events_module.handle_event(
+        manager,
+        CommandType.ACTION_TRIGGER,
+        {
+            "action_type": "exec",
+            "cmd": "echo macro",
+            "macro_exec_wait_id": "wait-1",
+            "macro_exec_timeout_ms": 30_000,
+        },
+    )
+    await asyncio.sleep(0)
+
+    manager.action_handler.execute_command.assert_awaited_once_with(
+        "echo macro",
+        timeout_s=0.75,
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/test_session_support.py
+++ b/tests/test_session_support.py
@@ -251,22 +251,84 @@ async def test_action_handler_execute_command_kills_timed_out_process(
     assert "Command timed out after 300s, killing: sleep 999" in caplog.text
 
 
-def test_action_handler_execute_command_sync_schedules_task(
+@pytest.mark.asyncio
+async def test_action_handler_execute_command_sync_tracks_task_until_done(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     handler = ActionHandler()
-    scheduled: list[Any] = []
+    started = asyncio.Event()
+    finish = asyncio.Event()
 
-    def _create_task(coro: Any) -> object:
-        scheduled.append(coro)
-        return object()
+    async def _execute_command(cmd: str) -> int:
+        assert cmd == "echo ok"
+        started.set()
+        await finish.wait()
+        return 0
 
-    monkeypatch.setattr(asyncio, "create_task", _create_task)
+    monkeypatch.setattr(handler, "execute_command", _execute_command)
 
     handler.execute_command_sync("echo ok")
+    await asyncio.wait_for(started.wait(), timeout=1.0)
 
-    assert len(scheduled) == 1
-    scheduled[0].close()
+    assert len(handler._background_tasks) == 1  # pyright: ignore[reportPrivateUsage]
+    task = next(iter(handler._background_tasks))  # pyright: ignore[reportPrivateUsage]
+
+    finish.set()
+    assert await task == 0
+    await asyncio.sleep(0)
+
+    assert handler._background_tasks == set()  # pyright: ignore[reportPrivateUsage]
+
+
+@pytest.mark.asyncio
+async def test_action_handler_execute_command_sync_logs_unhandled_task_error(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    handler = ActionHandler()
+
+    async def _execute_command(_cmd: str) -> int:
+        raise RuntimeError("exec exploded")
+
+    monkeypatch.setattr(handler, "execute_command", _execute_command)
+
+    with caplog.at_level(logging.ERROR, logger="keymasq-session.actions"):
+        handler.execute_command_sync("bad")
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+
+    assert handler._background_tasks == set()  # pyright: ignore[reportPrivateUsage]
+    assert "Unhandled exception in async command task" in caplog.text
+    assert "RuntimeError: exec exploded" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_action_handler_cancel_background_tasks_cancels_pending_command(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    handler = ActionHandler()
+    started = asyncio.Event()
+    cancelled = asyncio.Event()
+
+    async def _execute_command(_cmd: str) -> int:
+        started.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            cancelled.set()
+            raise
+        return 0
+
+    monkeypatch.setattr(handler, "execute_command", _execute_command)
+
+    handler.execute_command_sync("sleep 999")
+    await asyncio.wait_for(started.wait(), timeout=1.0)
+    assert len(handler._background_tasks) == 1  # pyright: ignore[reportPrivateUsage]
+
+    await handler.cancel_background_tasks()
+
+    assert cancelled.is_set()
+    assert handler._background_tasks == set()  # pyright: ignore[reportPrivateUsage]
 
 
 @pytest.mark.asyncio

--- a/tests/test_session_support.py
+++ b/tests/test_session_support.py
@@ -232,11 +232,13 @@ async def test_action_handler_execute_command_kills_timed_out_process(
 ) -> None:
     handler = ActionHandler()
     process = _FakeProcess(communicate=lambda: asyncio.sleep(360))
+    timeouts: list[float] = []
 
     async def _create_subprocess_shell(*_args: Any, **_kwargs: Any) -> _FakeProcess:
         return process
 
     async def _wait_for(_awaitable: Any, timeout: float) -> Any:
+        timeouts.append(timeout)
         _awaitable.close()
         raise TimeoutError
 
@@ -244,11 +246,12 @@ async def test_action_handler_execute_command_kills_timed_out_process(
     monkeypatch.setattr(asyncio, "wait_for", _wait_for)
 
     with caplog.at_level(logging.ERROR):
-        result = await handler.execute_command("sleep 999")
+        result = await handler.execute_command("sleep 999", timeout_s=0.25)
 
     assert result == -1
     assert process.killed is True
-    assert "Command timed out after 300s, killing: sleep 999" in caplog.text
+    assert timeouts == [0.25]
+    assert "Command timed out after 0.25s, killing: sleep 999" in caplog.text
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Track `ActionHandler` command tasks so session shutdown can cancel any in-flight background work.
- Add cleanup for background command tasks during session disconnect and teardown.
- Route session notifications through the same event-task helper used elsewhere.
- Expand session tests to cover task tracking, error logging, and cancellation behavior.

## Testing
- Added coverage in `tests/test_session_support.py` for:
  - task tracking until a command completes
  - logging unhandled task exceptions
  - cancelling pending background command tasks