### PR TITLE
Add timeout when closing session client sockets

### DIFF
--- a/keymasq/session/manager/core.py
+++ b/keymasq/session/manager/core.py
@@ -62,6 +62,7 @@ TOPOLOGY_REFRESH_RETRY_S = 1.0
 class SessionManager:
     RECORDING_SETTINGS_PATH = CONFIG_DIR / "recording_settings.toml"
     MAX_SESSION_CLIENT_BUFFER_BYTES = 16 * 1024 * 1024
+    SESSION_CLIENT_CLOSE_TIMEOUT_S = 0.5
 
     def __init__(self, verbosity: int = 0) -> None:
         async def _client_event_handler(event_type: CommandType, data: JsonObject) -> None:
@@ -199,12 +200,20 @@ class SessionManager:
             self.session_server.close()
             await self.session_server.wait_closed()
 
-        for writer in list(self.session_clients):
-            try:
-                writer.close()
-                await writer.wait_closed()
-            except Exception:
-                pass
+        session_writers = list(self.session_clients)
+        if session_writers:
+            await asyncio.gather(
+                *(
+                    self._close_session_writer(
+                        writer,
+                        self.session_client_peers.get(writer),
+                    )
+                    for writer in session_writers
+                ),
+                return_exceptions=True,
+            )
+            for writer in session_writers:
+                self._drop_session_client_writer(writer)
         for task in list(self.session_client_drain_tasks.values()):
             task.cancel()
         if self.session_client_drain_tasks:
@@ -271,8 +280,7 @@ class SessionManager:
     ) -> None:
         peer = get_peer_credentials(writer.get_extra_info("socket"))
         if peer is None:
-            writer.close()
-            await writer.wait_closed()
+            await self._close_session_writer(writer)
             return
 
         if not uid_allowed(peer.uid, self.security_policy.session_allowed_uids):
@@ -282,8 +290,7 @@ class SessionManager:
                 peer.uid,
                 f"uid {peer.uid} is not allowed by session policy",
             )
-            writer.close()
-            await writer.wait_closed()
+            await self._close_session_writer(writer, peer)
             return
 
         client_class = "client"
@@ -350,11 +357,7 @@ class SessionManager:
             await runtime_recording.discard_pending_macro_save_if_writer(self, writer)
             await runtime_recording.clear_recording_refresh_owner_if_writer(self, peer, writer)
             self._drop_session_client_writer(writer)
-            try:
-                writer.close()
-                await writer.wait_closed()
-            except Exception:
-                pass
+            await self._close_session_writer(writer, peer)
 
     async def _handle_session_request(
         self,
@@ -396,13 +399,39 @@ class SessionManager:
         except asyncio.CancelledError:
             raise
         except Exception:
+            peer = self.session_client_peers.get(writer)
             self._drop_session_client_writer(writer)
-            with contextlib.suppress(Exception):
-                writer.close()
-                await writer.wait_closed()
+            await self._close_session_writer(writer, peer)
         finally:
             if self.session_client_drain_tasks.get(writer) is asyncio.current_task():
                 self.session_client_drain_tasks.pop(writer, None)
+
+    async def _close_session_writer(
+        self,
+        writer: asyncio.StreamWriter,
+        peer: PeerCredentials | None = None,
+    ) -> None:
+        try:
+            writer.close()
+            await asyncio.wait_for(
+                writer.wait_closed(),
+                timeout=self.SESSION_CLIENT_CLOSE_TIMEOUT_S,
+            )
+        except TimeoutError:
+            if peer is None:
+                log.debug("Timed out waiting for session client socket to close")
+            else:
+                log.debug(
+                    "Timed out waiting for session client socket to close pid=%s uid=%s",
+                    peer.pid,
+                    peer.uid,
+                )
+            transport = getattr(writer, "transport", None)
+            if transport is not None:
+                with contextlib.suppress(Exception):
+                    transport.abort()
+        except Exception:
+            pass
 
     def _drop_session_client_writer(self, writer: asyncio.StreamWriter) -> None:
         self.session_clients.discard(writer)

--- a/tests/test_session_manager_core.py
+++ b/tests/test_session_manager_core.py
@@ -59,6 +59,20 @@ class _FakeSessionWriter:
         self.wait_closed_calls += 1
 
 
+class _HangingSessionWriter(_FakeSessionWriter):
+    def __init__(self) -> None:
+        super().__init__()
+        self.abort_calls = 0
+        self.transport = self
+
+    async def wait_closed(self) -> None:
+        self.wait_closed_calls += 1
+        await asyncio.Event().wait()
+
+    def abort(self) -> None:
+        self.abort_calls += 1
+
+
 @pytest.mark.asyncio
 async def test_connect_loop_reconnect_reapplies_profiles_after_restart() -> None:
     manager = SessionManager()
@@ -140,6 +154,24 @@ async def test_stop_cancels_tracked_event_tasks() -> None:
 
 
 @pytest.mark.asyncio
+async def test_stop_times_out_hanging_session_client_wait_closed() -> None:
+    manager = SessionManager()
+    manager.running = True
+    manager.SESSION_CLIENT_CLOSE_TIMEOUT_S = 0.01
+    manager.client.disconnect = AsyncMock()  # type: ignore[method-assign]
+    manager.dbus.disconnect = AsyncMock()  # type: ignore[method-assign]
+    writer = _HangingSessionWriter()
+    manager.session_clients.add(writer)  # type: ignore[arg-type]
+
+    await asyncio.wait_for(manager.stop(), timeout=1.0)
+
+    assert writer.closed is True
+    assert writer.wait_closed_calls == 1
+    assert writer.abort_calls == 1
+    assert writer not in manager.session_clients
+
+
+@pytest.mark.asyncio
 async def test_reload_handler_debounces_burst_updates() -> None:
     manager = SessionManager()
     calls = 0
@@ -212,6 +244,33 @@ async def test_session_client_drops_connection_when_buffer_exceeds_limit(
     manager._handle_session_request.assert_not_awaited()
     assert writer.closed is True
     assert writer.writes == []
+
+
+@pytest.mark.asyncio
+async def test_session_client_cleanup_times_out_hanging_wait_closed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = SessionManager()
+    manager.running = True
+    manager.SESSION_CLIENT_CLOSE_TIMEOUT_S = 0.01
+    reader = _FakeSessionReader([])
+    writer = _HangingSessionWriter()
+
+    monkeypatch.setattr(
+        session_manager_core_module,
+        "get_peer_credentials",
+        lambda _sock: PeerCredentials(pid=321, uid=1000, gid=1000),
+    )
+
+    await asyncio.wait_for(
+        manager._handle_session_client(reader, writer),  # type: ignore[arg-type]
+        timeout=1.0,
+    )
+
+    assert writer.closed is True
+    assert writer.wait_closed_calls == 1
+    assert writer.abort_calls == 1
+    assert writer not in manager.session_clients
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Added a bounded timeout for closing session client sockets during shutdown and cleanup.
- Falls back to aborting the transport if `wait_closed()` hangs, and logs the peer when available.
- Covered the timeout path with tests for both manager shutdown and client cleanup.

## Testing
- `pytest tests/test_session_manager_core.py`
- Not run: full project checks (`./scripts/check.sh full`)