### PR TITLE
Add daemon/session VM integration smoke test

### DIFF
--- a/docs/DAEMON_SESSION_INTEGRATION_TEST.md
+++ b/docs/DAEMON_SESSION_INTEGRATION_TEST.md
@@ -1,0 +1,100 @@
+# Daemon Session Integration Test
+
+Keymasq includes a NixOS VM integration test for the `keymasqd` daemon plus
+`keymasq-session` broker. It runs without the GTK GUI. A Python client script
+acts like the GUI by writing profile, hardware, superkey, and macro state,
+then driving virtual input devices and asserting the daemon's virtual outputs.
+
+## What It Covers
+
+The test is intentionally a smoke/integration suite, not exhaustive unit
+coverage. It verifies that the core runtime classes still work together:
+
+- simple keyboard remap
+- suppress
+- tap-enabled remap
+- rapidfire
+- macro playback and cancellation
+- macro create/update/rename/delete plus loop count
+- superkey tap
+- overloaded superkey with multiple press and release actions
+- chord, multi-step, prefix-shadowing, overlapping, negative, and multi-source combos
+- combo bound to a superkey
+- combo trigger-key recall and restore timing with a combo-bound superkey
+- profile toggle, priority override, passthrough fallback, and held-output profile change
+- mouse button, relative movement, wheel, and mouse combo output
+- gamepad button and analog trigger output
+- emergency reset
+- capture, combo capture, recording save, and playback
+- session restart, daemon restart, and secondary device hotplug/replug
+
+## Layout
+
+The NixOS VM check lives in:
+
+```text
+nix/daemon-session-integration-test.nix
+```
+
+The runner source lives in:
+
+```text
+nix/daemon-session-integration-test/
+```
+
+Important subdirectories:
+
+- `fixtures/` - TOML templates rendered into the VM user's `~/.config/keymasq`.
+- `scenarios/` - one scenario file per integration case.
+- `support.py` - VM test harness helpers for sockets, virtual devices, fixture rendering, and output assertions.
+- `runner.py` - loads and runs the scenario list.
+
+Fixtures are rendered through `support.py` by loading template files from
+`fixtures/` and substituting runtime values such as the virtual evdev paths.
+
+## Running It
+
+Run the VM check from the repository root:
+
+```bash
+nix build 'path:.#checks.x86_64-linux.daemon-session-integration-test'
+```
+
+Use the `path:` flake reference while the VM files are uncommitted. A plain
+`.#...` build evaluates the Git snapshot and can miss newly added fixture or
+scenario files.
+
+The test is VM-heavy. A Linux host with KVM acceleration is strongly
+recommended.
+
+## Debugging Failures
+
+On failure, Nix prints the failed derivation path and suggests a `nix log`
+command. Run that command to see:
+
+- `keymasqd` status and journal
+- `keymasq-session` status and user journal
+- `/dev/uinput` permissions
+- `/proc/bus/input/devices`
+- generated Keymasq config from inside the VM
+- scenario runner output
+
+The runner prints each scenario name as it starts. The last printed
+`integration: ...` line identifies the scenario that failed.
+
+## Adding Scenarios
+
+Add one file under:
+
+```text
+nix/daemon-session-integration-test/scenarios/
+```
+
+Then import it and append it to `SCENARIOS` in:
+
+```text
+nix/daemon-session-integration-test/scenarios/__init__.py
+```
+
+If the scenario needs new persistent profile, hardware, or superkey state, add
+or update a fixture under `fixtures/` rather than embedding TOML in Python.

--- a/docs/DAEMON_SESSION_INTEGRATION_TEST.md
+++ b/docs/DAEMON_SESSION_INTEGRATION_TEST.md
@@ -21,7 +21,7 @@ coverage. It verifies that the core runtime classes still work together:
 - chord, multi-step, prefix-shadowing, overlapping, negative, and multi-source combos
 - combo bound to a superkey
 - combo trigger-key recall and restore timing with a combo-bound superkey
-- profile toggle, priority override, passthrough fallback, and held-output profile change
+- profile toggle, priority override, passthrough override, and held-output profile change
 - mouse button, relative movement, wheel, and mouse combo output
 - gamepad button and analog trigger output
 - emergency reset

--- a/flake.nix
+++ b/flake.nix
@@ -149,6 +149,16 @@
           keymasqModule = self.nixosModules.default;
           source = mkCleanSrc pkgs;
         };
+      daemonSessionIntegrationChecks =
+        let
+          pkgs = mkPkgs "x86_64-linux";
+        in
+        import ./nix/daemon-session-integration-test.nix {
+          inherit pkgs;
+          system = "x86_64-linux";
+          keymasqPackage = packagesFor.x86_64-linux.default;
+          keymasqModule = self.nixosModules.default;
+        };
     in
     {
       packages = lib.recursiveUpdate packagesFor {
@@ -163,7 +173,8 @@
       });
 
       checks = {
-        x86_64-linux = listenerVmMatrix.checks // pytestVmChecks.checks;
+        x86_64-linux =
+          listenerVmMatrix.checks // pytestVmChecks.checks // daemonSessionIntegrationChecks.checks;
       };
 
       nixosModules.default = { config, lib, pkgs, ... }:

--- a/keymasq/session/profiles.py
+++ b/keymasq/session/profiles.py
@@ -673,9 +673,8 @@ class ProfileManager:
                     resolved.notify_profiles.append(profile.name)
                 for button_id, action in layer.mappings.items():
                     if action.action_type == ActionType.PASSTHROUGH:
-                        resolved.mappings.pop(button_id, None)
-                    else:
-                        resolved.mappings[button_id] = copy.deepcopy(action)
+                        continue
+                    resolved.mappings[button_id] = copy.deepcopy(action)
             devices[hardware_id] = resolved
 
         for profile in active_profiles:

--- a/keymasq/session/profiles.py
+++ b/keymasq/session/profiles.py
@@ -673,8 +673,9 @@ class ProfileManager:
                     resolved.notify_profiles.append(profile.name)
                 for button_id, action in layer.mappings.items():
                     if action.action_type == ActionType.PASSTHROUGH:
-                        continue
-                    resolved.mappings[button_id] = copy.deepcopy(action)
+                        resolved.mappings.pop(button_id, None)
+                    else:
+                        resolved.mappings[button_id] = copy.deepcopy(action)
             devices[hardware_id] = resolved
 
         for profile in active_profiles:

--- a/nix/daemon-session-integration-test.nix
+++ b/nix/daemon-session-integration-test.nix
@@ -1,0 +1,203 @@
+{ pkgs, system, keymasqPackage, keymasqModule }:
+
+let
+  vmUser = "keymasqvm";
+  vmUid = 1000;
+  runtimeDir = "/run/user/${toString vmUid}";
+  testSource = ./daemon-session-integration-test;
+  testPython = pkgs.python3.withPackages (ps: [ ps.evdev ]);
+
+  integrationRunner = pkgs.writeShellApplication {
+    name = "keymasq-daemon-session-integration-test";
+    runtimeInputs = [
+      pkgs.systemd
+      testPython
+    ];
+    text = ''
+      export PYTHONPATH="${testSource}"
+      export KEYMASQ_INTEGRATION_SYSTEMCTL="${pkgs.systemd}/bin/systemctl"
+      export KEYMASQ_INTEGRATION_SUDO="/run/wrappers/bin/sudo"
+      exec ${testPython}/bin/python ${testSource}/runner.py
+    '';
+  };
+
+  userCommand =
+    cmd:
+    "runuser -u ${vmUser} -- sh -lc 'export HOME=/home/${vmUser}; "
+    + "export XDG_RUNTIME_DIR=${runtimeDir}; "
+    + "export DBUS_SESSION_BUS_ADDRESS=unix:path=${runtimeDir}/bus; "
+    + "${cmd}'";
+in
+{
+  checks = {
+    daemon-session-integration-test = pkgs.testers.runNixOSTest {
+      name = "daemon-session-integration-test";
+
+      nodes.machine =
+        { ... }:
+        {
+          imports = [ keymasqModule ];
+
+          documentation.nixos.enable = false;
+
+          virtualisation = {
+            graphics = false;
+            memorySize = 2048;
+            cores = 2;
+          };
+
+          networking.hostName = "daemon-session-integration-test";
+          time.timeZone = "UTC";
+          i18n.defaultLocale = "en_US.UTF-8";
+
+          boot.kernelModules = [ "uinput" ];
+
+          services.keymasq = {
+            enable = true;
+            securityConfig = {
+              daemon_allowed_uids = [ vmUid ];
+              session_allowed_uids = [ vmUid ];
+              recording_guard = {
+                unlock_required = false;
+                macro_edit_requires_unlock = false;
+              };
+            };
+          };
+
+          systemd.services.keymasqd.serviceConfig.Environment = [ "KEYMASQ_TEST_UINPUT=1" ];
+
+          users.users.${vmUser} = {
+            isNormalUser = true;
+            uid = vmUid;
+            description = "Daemon/session integration test VM user";
+            createHome = true;
+            home = "/home/${vmUser}";
+            extraGroups = [ "input" ];
+          };
+
+          services.dbus.enable = true;
+          security = {
+            polkit.enable = true;
+            sudo = {
+              enable = true;
+              extraRules = [
+                {
+                  users = [ vmUser ];
+                  commands = [
+                    {
+                      command = "${pkgs.systemd}/bin/systemctl restart keymasqd.service";
+                      options = [ "NOPASSWD" ];
+                    }
+                  ];
+                }
+              ];
+            };
+          };
+
+          environment.systemPackages = [
+            keymasqPackage
+            integrationRunner
+            testPython
+          ];
+        };
+
+      testScript = ''
+        import time
+
+        output_path = "/tmp/daemon-session-integration-test-output.log"
+        status_path = "/tmp/daemon-session-integration-test-status.txt"
+
+        def as_user(cmd: str) -> str:
+            return "${userCommand "{cmd}"}".replace("{cmd}", cmd)
+
+        def log_command_output(label: str, cmd: str) -> None:
+            status, output = machine.execute(cmd)
+            machine.log(f"{label} (exit={status})\n{output}")
+
+        def dump_debug(label: str) -> None:
+            machine.log(f"==== {label} ====")
+            log_command_output("keymasqd status", "systemctl status keymasqd.service --no-pager || true")
+            log_command_output("keymasqd journal", "journalctl -b -u keymasqd.service --no-pager -n 240 || true")
+            log_command_output(
+                "uinput permissions",
+                "ls -l /dev/uinput || true; ${pkgs.acl}/bin/getfacl /dev/uinput || true",
+            )
+            log_command_output(
+                "keymasq-session status",
+                as_user("systemctl --user status keymasq-session.service --no-pager || true"),
+            )
+            log_command_output(
+                "keymasq-session journal",
+                as_user("journalctl --user -u keymasq-session.service --no-pager -n 240 || true"),
+            )
+            log_command_output("input devices", "cat /proc/bus/input/devices || true")
+            log_command_output(
+                "generated config",
+                as_user("find ~/.config/keymasq -maxdepth 3 -type f -print -exec sed -n 1,220p {} \\; || true"),
+            )
+            log_command_output("integration test output", f"cat {output_path} || true")
+
+        def wait_for_command(label: str, command: str, timeout: int = 60) -> None:
+            deadline = time.time() + timeout
+            while time.time() < deadline:
+                rc = machine.execute(command)[0]
+                if rc == 0:
+                    return
+                time.sleep(0.5)
+            dump_debug(f"timed out waiting for {label}")
+            raise Exception(f"Timed out waiting for {label}: {command}")
+
+        def wait_for_user_command(label: str, command: str, timeout: int = 60) -> None:
+            wait_for_command(label, as_user(command), timeout=timeout)
+
+        start_all()
+        machine.wait_for_unit("multi-user.target")
+        machine.wait_for_unit("keymasqd.service")
+
+        machine.succeed("modprobe uinput")
+        wait_for_command("uinput device", "test -c /dev/uinput")
+        machine.succeed("chgrp input /dev/uinput")
+        machine.succeed("chmod g+rw /dev/uinput")
+        machine.succeed("${pkgs.acl}/bin/setfacl -m u:${vmUser}:rw /dev/uinput")
+        wait_for_user_command("uinput writable", "test -w /dev/uinput")
+
+        machine.succeed("loginctl enable-linger ${vmUser}")
+        machine.wait_for_unit("user@${toString vmUid}.service")
+        wait_for_command("runtime dir", "test -d ${runtimeDir}")
+        wait_for_command("user bus", "test -S ${runtimeDir}/bus")
+
+        machine.succeed(as_user("systemctl --user start keymasq-session.service"))
+        wait_for_user_command(
+            "keymasq-session",
+            "systemctl --user is-active keymasq-session.service",
+        )
+        wait_for_command(
+            "session socket",
+            "test -S ${runtimeDir}/keymasq/session.sock",
+        )
+
+        status_code, runner_output = machine.execute(
+            as_user(
+                f"rm -f {output_path} {status_path}; "
+                "set +e; "
+                "keymasq-daemon-session-integration-test "
+                f"> {output_path} 2>&1; "
+                "status=$?; "
+                f"echo \"$status\" > {status_path}; "
+                "exit 0"
+            ),
+            timeout=300,
+        )
+        if status_code != 0:
+            raise Exception(f"failed to launch integration runner: {runner_output}")
+
+        output = machine.succeed(f"cat {output_path} || true")
+        print(output)
+        status = int(machine.succeed(f"cat {status_path}").strip())
+        if status != 0:
+            dump_debug("daemon/session integration test failed")
+            raise Exception("daemon-session-integration-test failed")
+      '';
+    };
+  };
+}

--- a/nix/daemon-session-integration-test/fixtures/hardware/primary.toml
+++ b/nix/daemon-session-integration-test/fixtures/hardware/primary.toml
@@ -1,0 +1,14 @@
+[hardware]
+name = "Keymasq Integration Source Keyboard"
+vendor_id = "cafe"
+product_id = "0001"
+
+[[hardware.evdev.devices]]
+path = "$PRIMARY_SOURCE_PATH"
+type = "keyboard"
+id = "kbd"
+
+[hardware.layout]
+type = "keyboard"
+
+$PRIMARY_BUTTONS

--- a/nix/daemon-session-integration-test/fixtures/hardware/secondary.toml
+++ b/nix/daemon-session-integration-test/fixtures/hardware/secondary.toml
@@ -1,0 +1,14 @@
+[hardware]
+name = "Keymasq Integration Secondary Keyboard"
+vendor_id = "cafe"
+product_id = "0002"
+
+[[hardware.evdev.devices]]
+path = "$SECONDARY_SOURCE_PATH"
+type = "keyboard"
+id = "kbd"
+
+[hardware.layout]
+type = "keyboard"
+
+$SECONDARY_BUTTONS

--- a/nix/daemon-session-integration-test/fixtures/profiles/core-smoke.toml
+++ b/nix/daemon-session-integration-test/fixtures/profiles/core-smoke.toml
@@ -1,0 +1,203 @@
+[profile]
+name = "$PROFILE_NAME"
+enabled = true
+is_permanent = true
+priority = 100
+notify_on_activation = false
+created_at = "2026-05-12T00:00:00"
+
+[devices."$HARDWARE_ID"]
+always_grab_all = false
+
+[devices."$HARDWARE_ID".mapping.key_a]
+action = "keyboard"
+target = "key_q"
+
+[devices."$HARDWARE_ID".mapping.key_b]
+action = "superkey"
+superkey_name = "$SUPERKEY_NAME"
+
+[devices."$HARDWARE_ID".mapping.key_e]
+action = "superkey"
+superkey_name = "$OVERLOAD_SUPERKEY_NAME"
+
+[devices."$HARDWARE_ID".mapping.key_k]
+action = "macro"
+target = "$MACRO_NAME"
+
+[devices."$HARDWARE_ID".mapping.key_l]
+action = "suppress"
+
+[devices."$HARDWARE_ID".mapping.key_m]
+action = "keyboard"
+target = "key_o"
+tap_enabled = true
+tap_hold_ms = 5
+
+[devices."$HARDWARE_ID".mapping.key_n]
+action = "profile_toggle"
+profile_name = "$SECOND_PROFILE_NAME"
+
+[devices."$HARDWARE_ID".mapping.key_o]
+action = "mouse"
+target = "btn_left"
+
+[devices."$HARDWARE_ID".mapping.key_p]
+action = "mouse_move_rel"
+x = 12
+y = -7
+
+[devices."$HARDWARE_ID".mapping.key_r]
+action = "keyboard"
+target = "key_i"
+rapidfire_enabled = true
+rapidfire_hold_ms = 10
+rapidfire_wait_ms = 10
+
+[devices."$HARDWARE_ID".mapping.key_s]
+action = "gamepad"
+target = "btn_south"
+
+[devices."$HARDWARE_ID".mapping.key_t]
+action = "emergency_reset"
+
+[devices."$HARDWARE_ID".mapping.key_u]
+action = "gamepad"
+target = "btn_lt"
+
+[devices."$HARDWARE_ID".mapping.key_v]
+action = "mouse"
+target = "rel_wheel:1"
+
+[devices."$HARDWARE_ID".mapping.key_w]
+action = "cancel_macro_playback"
+
+[devices."$HARDWARE_ID".mapping.key_y]
+action = "macro"
+target = "$LONG_MACRO_NAME"
+
+[devices."$HARDWARE_ID".mapping.key_i]
+action = "gamepad"
+target = "btn_rt"
+
+[devices."$SECOND_HARDWARE_ID"]
+always_grab_all = false
+
+[devices."$SECOND_HARDWARE_ID".mapping.key_g]
+action = "keyboard"
+target = "key_5"
+
+[[combos]]
+id = "integration-chord"
+name = "Integration chord"
+steps = [
+  { events = [
+    { evdev = "key_c", hardware_id = "$HARDWARE_ID" },
+    { evdev = "key_d", hardware_id = "$HARDWARE_ID" },
+  ] },
+]
+action = { action = "keyboard", target = "key_e" }
+
+[[combos]]
+id = "integration-combo-superkey"
+name = "Integration combo superkey"
+steps = [
+  { events = [
+    { evdev = "key_f", hardware_id = "$HARDWARE_ID" },
+    { evdev = "key_g", hardware_id = "$HARDWARE_ID" },
+  ] },
+]
+action = { action = "superkey", superkey_name = "$COMBO_SUPERKEY_NAME" }
+
+[[combos]]
+id = "integration-recall-restore-superkey"
+name = "Integration recall restore superkey"
+steps = [
+  { events = [
+    { evdev = "key_i", hardware_id = "$SECOND_HARDWARE_ID" },
+    { evdev = "key_j", hardware_id = "$SECOND_HARDWARE_ID" },
+  ] },
+]
+action = { action = "superkey", superkey_name = "$COMBO_SUPERKEY_NAME" }
+recall_trigger_keys = true
+restore_trigger_keys = ["key_i"]
+
+[[combos]]
+id = "integration-sequence"
+name = "Integration sequence"
+steps = [
+  { timeout_ms = 500, events = [
+    { evdev = "key_h", hardware_id = "$HARDWARE_ID" },
+  ] },
+  { timeout_ms = 500, events = [
+    { evdev = "key_j", hardware_id = "$HARDWARE_ID" },
+  ] },
+]
+action = { action = "keyboard", target = "key_t" }
+
+[[combos]]
+id = "integration-mouse-combo"
+name = "Integration mouse combo"
+steps = [
+  { events = [
+    { evdev = "key_x", hardware_id = "$HARDWARE_ID" },
+    { evdev = "key_z", hardware_id = "$HARDWARE_ID" },
+  ] },
+]
+action = { action = "mouse", target = "btn_right" }
+
+[[combos]]
+id = "integration-secondary-ab"
+name = "Integration secondary A+B"
+steps = [
+  { events = [
+    { evdev = "key_a", hardware_id = "$SECOND_HARDWARE_ID" },
+    { evdev = "key_b", hardware_id = "$SECOND_HARDWARE_ID" },
+  ] },
+]
+action = { action = "keyboard", target = "key_f6" }
+
+[[combos]]
+id = "integration-secondary-abc"
+name = "Integration secondary A+B+C"
+steps = [
+  { events = [
+    { evdev = "key_a", hardware_id = "$SECOND_HARDWARE_ID" },
+    { evdev = "key_b", hardware_id = "$SECOND_HARDWARE_ID" },
+    { evdev = "key_c", hardware_id = "$SECOND_HARDWARE_ID" },
+  ] },
+]
+action = { action = "keyboard", target = "key_f7" }
+
+[[combos]]
+id = "integration-secondary-ad"
+name = "Integration secondary A+D"
+steps = [
+  { events = [
+    { evdev = "key_a", hardware_id = "$SECOND_HARDWARE_ID" },
+    { evdev = "key_d", hardware_id = "$SECOND_HARDWARE_ID" },
+  ] },
+]
+action = { action = "keyboard", target = "key_f8" }
+
+[[combos]]
+id = "integration-secondary-ae"
+name = "Integration secondary A+E"
+steps = [
+  { events = [
+    { evdev = "key_a", hardware_id = "$SECOND_HARDWARE_ID" },
+    { evdev = "key_e", hardware_id = "$SECOND_HARDWARE_ID" },
+  ] },
+]
+action = { action = "keyboard", target = "key_f9" }
+
+[[combos]]
+id = "integration-multi-source"
+name = "Integration multi-source"
+steps = [
+  { events = [
+    { evdev = "key_q", hardware_id = "$HARDWARE_ID" },
+    { evdev = "key_f", hardware_id = "$SECOND_HARDWARE_ID" },
+  ] },
+]
+action = { action = "keyboard", target = "key_f10" }

--- a/nix/daemon-session-integration-test/fixtures/profiles/lower-fallback.toml
+++ b/nix/daemon-session-integration-test/fixtures/profiles/lower-fallback.toml
@@ -1,0 +1,14 @@
+[profile]
+name = "$LOWER_PROFILE_NAME"
+enabled = false
+is_permanent = true
+priority = 10
+notify_on_activation = false
+created_at = "2026-05-12T00:00:02"
+
+[devices."$SECOND_HARDWARE_ID"]
+always_grab_all = false
+
+[devices."$SECOND_HARDWARE_ID".mapping.key_h]
+action = "keyboard"
+target = "key_6"

--- a/nix/daemon-session-integration-test/fixtures/profiles/passthrough-override.toml
+++ b/nix/daemon-session-integration-test/fixtures/profiles/passthrough-override.toml
@@ -1,0 +1,13 @@
+[profile]
+name = "$PASSTHROUGH_PROFILE_NAME"
+enabled = false
+is_permanent = true
+priority = 300
+notify_on_activation = false
+created_at = "2026-05-12T00:00:03"
+
+[devices."$SECOND_HARDWARE_ID"]
+always_grab_all = false
+
+[devices."$SECOND_HARDWARE_ID".mapping.key_h]
+action = "passthrough"

--- a/nix/daemon-session-integration-test/fixtures/profiles/priority-override.toml
+++ b/nix/daemon-session-integration-test/fixtures/profiles/priority-override.toml
@@ -1,0 +1,14 @@
+[profile]
+name = "$SECOND_PROFILE_NAME"
+enabled = false
+is_permanent = true
+priority = 200
+notify_on_activation = false
+created_at = "2026-05-12T00:00:01"
+
+[devices."$HARDWARE_ID"]
+always_grab_all = false
+
+[devices."$HARDWARE_ID".mapping.key_a]
+action = "keyboard"
+target = "key_p"

--- a/nix/daemon-session-integration-test/fixtures/superkeys/combo-superkey.toml
+++ b/nix/daemon-session-integration-test/fixtures/superkeys/combo-superkey.toml
@@ -1,0 +1,10 @@
+name = "$COMBO_SUPERKEY_NAME"
+mode = "pattern"
+
+[timing]
+tap_timeout_ms = 80
+double_tap_window_ms = 120
+hold_threshold_ms = 120
+
+[actions]
+tap = [{ action = "keyboard", target = "key_r" }]

--- a/nix/daemon-session-integration-test/fixtures/superkeys/overload-superkey.toml
+++ b/nix/daemon-session-integration-test/fixtures/superkeys/overload-superkey.toml
@@ -1,0 +1,16 @@
+name = "$OVERLOAD_SUPERKEY_NAME"
+mode = "overload"
+
+[actions]
+overload = [
+  { action = "keyboard", target = "key_leftctrl" },
+  { action = "keyboard", target = "key_leftshift" },
+]
+overload_down = [
+  { action = "keyboard", target = "key_1" },
+  { action = "keyboard", target = "key_2" },
+]
+overload_up = [
+  { action = "keyboard", target = "key_3" },
+  { action = "keyboard", target = "key_4" },
+]

--- a/nix/daemon-session-integration-test/fixtures/superkeys/tap-superkey.toml
+++ b/nix/daemon-session-integration-test/fixtures/superkeys/tap-superkey.toml
@@ -1,0 +1,10 @@
+name = "$SUPERKEY_NAME"
+mode = "pattern"
+
+[timing]
+tap_timeout_ms = 80
+double_tap_window_ms = 120
+hold_threshold_ms = 120
+
+[actions]
+tap = [{ action = "keyboard", target = "key_w" }]

--- a/nix/daemon-session-integration-test/runner.py
+++ b/nix/daemon-session-integration-test/runner.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+
+from scenarios import SCENARIOS
+from support import ScenarioContext
+
+
+def main() -> int:
+    context = ScenarioContext()
+    try:
+        context.setup()
+        for scenario in SCENARIOS:
+            context.subtest(scenario.name, lambda run=scenario.run: run(context))
+    finally:
+        context.cleanup()
+
+    print("integration: daemon/session smoke passed", flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/nix/daemon-session-integration-test/scenarios/__init__.py
+++ b/nix/daemon-session-integration-test/scenarios/__init__.py
@@ -15,7 +15,7 @@ from .macro_playback import run as macro_playback
 from .mouse_output import run as mouse_output
 from .multi_source_combo import run as multi_source_combo
 from .multi_step_combo import run as multi_step_combo
-from .passthrough_fallback import run as passthrough_fallback
+from .passthrough_fallback import run as passthrough_override
 from .profile_toggle import run as profile_toggle
 from .rapidfire_keyboard import run as rapidfire_keyboard
 from .recording_capture import run as recording_capture
@@ -44,7 +44,7 @@ SCENARIOS = [
     ScenarioCase("prefix and overlapping combos", combo_prefix_overlap),
     ScenarioCase("multi-source combo", multi_source_combo),
     ScenarioCase("profile toggle", profile_toggle),
-    ScenarioCase("passthrough lower-profile fallback", passthrough_fallback),
+    ScenarioCase("passthrough overrides lower-profile mapping", passthrough_override),
     ScenarioCase("held output profile change", held_output_profile_change),
     ScenarioCase("mouse output", mouse_output),
     ScenarioCase("gamepad output", gamepad_output),

--- a/nix/daemon-session-integration-test/scenarios/__init__.py
+++ b/nix/daemon-session-integration-test/scenarios/__init__.py
@@ -1,0 +1,55 @@
+from support import ScenarioCase
+
+from .cancel_macro_playback import run as cancel_macro_playback
+from .combo_chord import run as combo_chord
+from .combo_negative_timeout import run as combo_negative_timeout
+from .combo_prefix_overlap import run as combo_prefix_overlap
+from .combo_superkey import run as combo_superkey
+from .combo_superkey_recall_restore import run as combo_superkey_recall_restore
+from .emergency_reset import run as emergency_reset
+from .gamepad_output import run as gamepad_output
+from .held_output_profile_change import run as held_output_profile_change
+from .hotplug_replug import run as hotplug_replug
+from .macro_lifecycle import run as macro_lifecycle
+from .macro_playback import run as macro_playback
+from .mouse_output import run as mouse_output
+from .multi_source_combo import run as multi_source_combo
+from .multi_step_combo import run as multi_step_combo
+from .passthrough_fallback import run as passthrough_fallback
+from .profile_toggle import run as profile_toggle
+from .rapidfire_keyboard import run as rapidfire_keyboard
+from .recording_capture import run as recording_capture
+from .restart_recovery import run as restart_recovery
+from .simple_remap import run as simple_remap
+from .superkey_overload_multi_action import run as superkey_overload_multi_action
+from .superkey_tap import run as superkey_tap
+from .suppress import run as suppress
+from .tap_enabled import run as tap_enabled
+
+SCENARIOS = [
+    ScenarioCase("simple 1->1 remap", simple_remap),
+    ScenarioCase("suppress", suppress),
+    ScenarioCase("tap-enabled keyboard action", tap_enabled),
+    ScenarioCase("rapidfire keyboard action", rapidfire_keyboard),
+    ScenarioCase("macro playback", macro_playback),
+    ScenarioCase("cancel macro playback", cancel_macro_playback),
+    ScenarioCase("macro lifecycle", macro_lifecycle),
+    ScenarioCase("superkey tap", superkey_tap),
+    ScenarioCase("superkey overload multi-action press/release", superkey_overload_multi_action),
+    ScenarioCase("combo chord", combo_chord),
+    ScenarioCase("combo bound to superkey", combo_superkey),
+    ScenarioCase("combo superkey recall and restore", combo_superkey_recall_restore),
+    ScenarioCase("multi-step combo", multi_step_combo),
+    ScenarioCase("combo negative and timeout", combo_negative_timeout),
+    ScenarioCase("prefix and overlapping combos", combo_prefix_overlap),
+    ScenarioCase("multi-source combo", multi_source_combo),
+    ScenarioCase("profile toggle", profile_toggle),
+    ScenarioCase("passthrough lower-profile fallback", passthrough_fallback),
+    ScenarioCase("held output profile change", held_output_profile_change),
+    ScenarioCase("mouse output", mouse_output),
+    ScenarioCase("gamepad output", gamepad_output),
+    ScenarioCase("emergency reset", emergency_reset),
+    ScenarioCase("recording and capture", recording_capture),
+    ScenarioCase("restart recovery", restart_recovery),
+    ScenarioCase("hotplug replug", hotplug_replug),
+]

--- a/nix/daemon-session-integration-test/scenarios/cancel_macro_playback.py
+++ b/nix/daemon-session-integration-test/scenarios/cancel_macro_playback.py
@@ -1,0 +1,12 @@
+import evdev
+from support import ScenarioContext
+
+
+def run(ctx: ScenarioContext) -> None:
+    ctx.source_key(evdev.ecodes.KEY_Y, 1)
+    try:
+        ctx.expect_keys([(evdev.ecodes.KEY_Y, 1)])
+        ctx.tap_source(evdev.ecodes.KEY_W)
+        ctx.expect_keys([(evdev.ecodes.KEY_Y, 0)])
+    finally:
+        ctx.source_key(evdev.ecodes.KEY_Y, 0)

--- a/nix/daemon-session-integration-test/scenarios/combo_chord.py
+++ b/nix/daemon-session-integration-test/scenarios/combo_chord.py
@@ -1,0 +1,13 @@
+import time
+
+import evdev
+from support import ScenarioContext
+
+
+def run(ctx: ScenarioContext) -> None:
+    ctx.source_key(evdev.ecodes.KEY_C, 1)
+    ctx.source_key(evdev.ecodes.KEY_D, 1)
+    time.sleep(0.08)
+    ctx.source_key(evdev.ecodes.KEY_D, 0)
+    ctx.source_key(evdev.ecodes.KEY_C, 0)
+    ctx.expect_keys([(evdev.ecodes.KEY_E, 1), (evdev.ecodes.KEY_E, 0)])

--- a/nix/daemon-session-integration-test/scenarios/combo_negative_timeout.py
+++ b/nix/daemon-session-integration-test/scenarios/combo_negative_timeout.py
@@ -1,0 +1,16 @@
+import time
+
+import evdev
+from support import ScenarioContext
+
+
+def run(ctx: ScenarioContext) -> None:
+    ctx.tap_source(evdev.ecodes.KEY_H)
+    ctx.expect_no_keyboard_events()
+
+    ctx.source_key(evdev.ecodes.KEY_H, 1)
+    time.sleep(0.05)
+    ctx.source_key(evdev.ecodes.KEY_H, 0)
+    time.sleep(0.65)
+    ctx.tap_source(evdev.ecodes.KEY_J)
+    ctx.expect_no_keyboard_events()

--- a/nix/daemon-session-integration-test/scenarios/combo_prefix_overlap.py
+++ b/nix/daemon-session-integration-test/scenarios/combo_prefix_overlap.py
@@ -1,0 +1,31 @@
+import time
+
+import evdev
+from support import ScenarioContext
+
+
+def run(ctx: ScenarioContext) -> None:
+    ctx.secondary_key(evdev.ecodes.KEY_A, 1)
+    ctx.secondary_key(evdev.ecodes.KEY_B, 1)
+    ctx.expect_keys([(evdev.ecodes.KEY_F6, 1)])
+    ctx.secondary_key(evdev.ecodes.KEY_C, 1)
+    ctx.expect_keys([(evdev.ecodes.KEY_F7, 1)])
+    ctx.secondary_key(evdev.ecodes.KEY_C, 0)
+    ctx.secondary_key(evdev.ecodes.KEY_B, 0)
+    ctx.secondary_key(evdev.ecodes.KEY_A, 0)
+    ctx.expect_keys([(evdev.ecodes.KEY_F7, 0), (evdev.ecodes.KEY_F6, 0)])
+
+    time.sleep(0.05)
+    ctx.secondary_key(evdev.ecodes.KEY_A, 1)
+    ctx.secondary_key(evdev.ecodes.KEY_D, 1)
+    ctx.expect_keys([(evdev.ecodes.KEY_F8, 1)])
+    ctx.secondary_key(evdev.ecodes.KEY_D, 0)
+    ctx.secondary_key(evdev.ecodes.KEY_A, 0)
+    ctx.expect_keys([(evdev.ecodes.KEY_F8, 0)])
+
+    ctx.secondary_key(evdev.ecodes.KEY_A, 1)
+    ctx.secondary_key(evdev.ecodes.KEY_E, 1)
+    ctx.expect_keys([(evdev.ecodes.KEY_F9, 1)])
+    ctx.secondary_key(evdev.ecodes.KEY_E, 0)
+    ctx.secondary_key(evdev.ecodes.KEY_A, 0)
+    ctx.expect_keys([(evdev.ecodes.KEY_F9, 0)])

--- a/nix/daemon-session-integration-test/scenarios/combo_superkey.py
+++ b/nix/daemon-session-integration-test/scenarios/combo_superkey.py
@@ -1,0 +1,13 @@
+import time
+
+import evdev
+from support import ScenarioContext
+
+
+def run(ctx: ScenarioContext) -> None:
+    ctx.source_key(evdev.ecodes.KEY_F, 1)
+    ctx.source_key(evdev.ecodes.KEY_G, 1)
+    time.sleep(0.08)
+    ctx.source_key(evdev.ecodes.KEY_G, 0)
+    ctx.source_key(evdev.ecodes.KEY_F, 0)
+    ctx.expect_keys([(evdev.ecodes.KEY_R, 1), (evdev.ecodes.KEY_R, 0)])

--- a/nix/daemon-session-integration-test/scenarios/combo_superkey_recall_restore.py
+++ b/nix/daemon-session-integration-test/scenarios/combo_superkey_recall_restore.py
@@ -1,0 +1,88 @@
+import time
+
+import evdev
+from support import SECOND_HARDWARE_ID, ScenarioContext
+
+
+def run(ctx: ScenarioContext) -> None:
+    passthrough = ctx.open_passthrough_output(SECOND_HARDWARE_ID)
+    try:
+        ctx.secondary_key(evdev.ecodes.KEY_I, 1)
+        ctx.expect_events(
+            passthrough,
+            [(evdev.ecodes.EV_KEY, evdev.ecodes.KEY_I, 1)],
+            label="secondary passthrough",
+        )
+
+        ctx.secondary_key(evdev.ecodes.KEY_J, 1)
+        ctx.expect_events(
+            passthrough,
+            [(evdev.ecodes.EV_KEY, evdev.ecodes.KEY_I, 0)],
+            label="secondary passthrough",
+        )
+        ctx.expect_no_keyboard_events(timeout_s=0.12)
+
+        ctx.secondary_key(evdev.ecodes.KEY_J, 0)
+        expect_ordered_outputs(
+            ctx,
+            [
+                ("keyboard", evdev.ecodes.EV_KEY, evdev.ecodes.KEY_R, 1),
+                ("keyboard", evdev.ecodes.EV_KEY, evdev.ecodes.KEY_R, 0),
+                ("passthrough", evdev.ecodes.EV_KEY, evdev.ecodes.KEY_I, 1),
+            ],
+            passthrough=passthrough,
+        )
+
+        ctx.secondary_key(evdev.ecodes.KEY_I, 0)
+        ctx.expect_events(
+            passthrough,
+            [(evdev.ecodes.EV_KEY, evdev.ecodes.KEY_I, 0)],
+            label="secondary passthrough",
+        )
+    finally:
+        passthrough.close()
+
+
+def expect_ordered_outputs(
+    ctx: ScenarioContext,
+    expected: list[tuple[str, int, int, int]],
+    *,
+    passthrough: evdev.InputDevice,
+    timeout_s: float = 3.0,
+) -> None:
+    devices = {
+        "keyboard": ctx.keyboard_output,
+        "passthrough": passthrough,
+    }
+    observed: list[tuple[str, int, int, int]] = []
+    index = 0
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        for label, device in devices.items():
+            if device is None:
+                continue
+            for event in ctx.read_output_events(device):
+                if event.type == evdev.ecodes.EV_SYN:
+                    continue
+                event_tuple = (label, int(event.type), int(event.code), int(event.value))
+                observed.append(event_tuple)
+                if event_tuple == expected[index]:
+                    index += 1
+                    if index == len(expected):
+                        return
+        time.sleep(0.01)
+
+    raise AssertionError(
+        "missing ordered combo recall/restore output "
+        f"{format_events(ctx, expected)}; observed {format_events(ctx, observed)}"
+    )
+
+
+def format_events(
+    ctx: ScenarioContext,
+    events: list[tuple[str, int, int, int]],
+) -> list[str]:
+    return [
+        f"{label}:{ctx.event_label((event_type, code, value))}"
+        for label, event_type, code, value in events
+    ]

--- a/nix/daemon-session-integration-test/scenarios/emergency_reset.py
+++ b/nix/daemon-session-integration-test/scenarios/emergency_reset.py
@@ -1,0 +1,31 @@
+import time
+
+import evdev
+from support import PROFILE_NAME, ScenarioContext
+
+
+def run(ctx: ScenarioContext) -> None:
+    try:
+        ctx.source_key(evdev.ecodes.KEY_A, 1)
+        ctx.expect_keys([(evdev.ecodes.KEY_Q, 1)])
+
+        ctx.source_key(evdev.ecodes.KEY_O, 1)
+        ctx.expect_mouse_events([(evdev.ecodes.EV_KEY, evdev.ecodes.BTN_LEFT, 1)])
+
+        ctx.source_key(evdev.ecodes.KEY_S, 1)
+        ctx.expect_gamepad_events([(evdev.ecodes.EV_KEY, evdev.ecodes.BTN_SOUTH, 1)])
+
+        ctx.tap_source(evdev.ecodes.KEY_T)
+        ctx.expect_keys([(evdev.ecodes.KEY_Q, 0)])
+        ctx.expect_mouse_events([(evdev.ecodes.EV_KEY, evdev.ecodes.BTN_LEFT, 0)])
+        ctx.expect_gamepad_events([(evdev.ecodes.EV_KEY, evdev.ecodes.BTN_SOUTH, 0)])
+    finally:
+        for code in (evdev.ecodes.KEY_A, evdev.ecodes.KEY_O, evdev.ecodes.KEY_S):
+            ctx.source_key(code, 0)
+
+    time.sleep(0.5)
+    ctx.wait_for_active_profile(PROFILE_NAME, enabled=True)
+    ctx.request({"command": "reevaluate_hardware"})
+    ctx.reopen_outputs()
+    ctx.tap_source(evdev.ecodes.KEY_A)
+    ctx.expect_keys([(evdev.ecodes.KEY_Q, 1), (evdev.ecodes.KEY_Q, 0)])

--- a/nix/daemon-session-integration-test/scenarios/gamepad_output.py
+++ b/nix/daemon-session-integration-test/scenarios/gamepad_output.py
@@ -1,0 +1,28 @@
+import evdev
+from support import ScenarioContext
+
+
+def run(ctx: ScenarioContext) -> None:
+    ctx.tap_source(evdev.ecodes.KEY_S)
+    ctx.expect_gamepad_events(
+        [
+            (evdev.ecodes.EV_KEY, evdev.ecodes.BTN_SOUTH, 1),
+            (evdev.ecodes.EV_KEY, evdev.ecodes.BTN_SOUTH, 0),
+        ]
+    )
+
+    ctx.tap_source(evdev.ecodes.KEY_U)
+    ctx.expect_gamepad_events(
+        [
+            (evdev.ecodes.EV_ABS, evdev.ecodes.ABS_Z, 255),
+            (evdev.ecodes.EV_ABS, evdev.ecodes.ABS_Z, 0),
+        ]
+    )
+
+    ctx.tap_source(evdev.ecodes.KEY_I)
+    ctx.expect_gamepad_events(
+        [
+            (evdev.ecodes.EV_ABS, evdev.ecodes.ABS_RZ, 255),
+            (evdev.ecodes.EV_ABS, evdev.ecodes.ABS_RZ, 0),
+        ]
+    )

--- a/nix/daemon-session-integration-test/scenarios/held_output_profile_change.py
+++ b/nix/daemon-session-integration-test/scenarios/held_output_profile_change.py
@@ -1,0 +1,20 @@
+import evdev
+from support import SECOND_PROFILE_NAME, ScenarioContext
+
+
+def run(ctx: ScenarioContext) -> None:
+    try:
+        ctx.source_key(evdev.ecodes.KEY_A, 1)
+        ctx.expect_keys([(evdev.ecodes.KEY_Q, 1)])
+
+        ctx.tap_source(evdev.ecodes.KEY_N)
+        ctx.wait_for_active_profile(SECOND_PROFILE_NAME, enabled=True)
+
+        ctx.source_key(evdev.ecodes.KEY_A, 0)
+        ctx.expect_keys([(evdev.ecodes.KEY_Q, 0)])
+
+        ctx.tap_source(evdev.ecodes.KEY_A)
+        ctx.expect_keys([(evdev.ecodes.KEY_P, 1), (evdev.ecodes.KEY_P, 0)])
+    finally:
+        ctx.source_key(evdev.ecodes.KEY_A, 0)
+        ctx.set_profile_enabled(SECOND_PROFILE_NAME, enabled=False)

--- a/nix/daemon-session-integration-test/scenarios/hotplug_replug.py
+++ b/nix/daemon-session-integration-test/scenarios/hotplug_replug.py
@@ -1,0 +1,11 @@
+import evdev
+from support import ScenarioContext
+
+
+def run(ctx: ScenarioContext) -> None:
+    ctx.tap_secondary_source(evdev.ecodes.KEY_G)
+    ctx.expect_keys([(evdev.ecodes.KEY_5, 1), (evdev.ecodes.KEY_5, 0)])
+
+    ctx.recreate_secondary_source()
+    ctx.tap_secondary_source(evdev.ecodes.KEY_G)
+    ctx.expect_keys([(evdev.ecodes.KEY_5, 1), (evdev.ecodes.KEY_5, 0)])

--- a/nix/daemon-session-integration-test/scenarios/macro_lifecycle.py
+++ b/nix/daemon-session-integration-test/scenarios/macro_lifecycle.py
@@ -1,0 +1,74 @@
+import evdev
+from support import ScenarioContext
+
+MACRO_NAME = "integration-lifecycle-macro"
+RENAMED_MACRO_NAME = "integration-lifecycle-renamed"
+
+
+def key_events(code: int) -> list[dict[str, object]]:
+    return [
+        {
+            "device_type": "keyboard",
+            "type": evdev.ecodes.EV_KEY,
+            "code": code,
+            "value": 1,
+            "t_us": 0,
+        },
+        {
+            "device_type": "keyboard",
+            "type": evdev.ecodes.EV_KEY,
+            "code": code,
+            "value": 0,
+            "t_us": 10000,
+        },
+    ]
+
+
+def run(ctx: ScenarioContext) -> None:
+    ctx.request({"command": "delete_macro", "name": MACRO_NAME}, ok=False)
+    ctx.request({"command": "delete_macro", "name": RENAMED_MACRO_NAME}, ok=False)
+
+    ctx.request(
+        {
+            "command": "create_macro",
+            "macro": {"name": MACRO_NAME, "events": key_events(evdev.ecodes.KEY_1)},
+        }
+    )
+    ctx.request({"command": "play_macro", "name": MACRO_NAME})
+    ctx.expect_keys([(evdev.ecodes.KEY_1, 1), (evdev.ecodes.KEY_1, 0)])
+
+    ctx.request(
+        {
+            "command": "update_macro",
+            "name": MACRO_NAME,
+            "macro": {"name": MACRO_NAME, "events": key_events(evdev.ecodes.KEY_2)},
+        }
+    )
+    ctx.request({"command": "play_macro", "name": MACRO_NAME})
+    ctx.expect_keys([(evdev.ecodes.KEY_2, 1), (evdev.ecodes.KEY_2, 0)])
+
+    ctx.request({"command": "rename_macro", "old": MACRO_NAME, "new": RENAMED_MACRO_NAME})
+    ctx.request({"command": "play_macro", "name": RENAMED_MACRO_NAME})
+    ctx.expect_keys([(evdev.ecodes.KEY_2, 1), (evdev.ecodes.KEY_2, 0)])
+
+    ctx.request(
+        {
+            "command": "play_macro_payload",
+            "macro_events": key_events(evdev.ecodes.KEY_3),
+            "loop_mode": "count",
+            "loop_count": 2,
+        }
+    )
+    ctx.expect_keys(
+        [
+            (evdev.ecodes.KEY_3, 1),
+            (evdev.ecodes.KEY_3, 0),
+            (evdev.ecodes.KEY_3, 1),
+            (evdev.ecodes.KEY_3, 0),
+        ]
+    )
+
+    ctx.request({"command": "delete_macro", "name": RENAMED_MACRO_NAME})
+    result = ctx.request({"command": "play_macro", "name": RENAMED_MACRO_NAME}, ok=False)
+    if result.get("status") == "ok":
+        raise AssertionError("deleted macro still played successfully")

--- a/nix/daemon-session-integration-test/scenarios/macro_playback.py
+++ b/nix/daemon-session-integration-test/scenarios/macro_playback.py
@@ -1,0 +1,7 @@
+import evdev
+from support import ScenarioContext
+
+
+def run(ctx: ScenarioContext) -> None:
+    ctx.tap_source(evdev.ecodes.KEY_K)
+    ctx.expect_keys([(evdev.ecodes.KEY_Y, 1), (evdev.ecodes.KEY_Y, 0)])

--- a/nix/daemon-session-integration-test/scenarios/mouse_output.py
+++ b/nix/daemon-session-integration-test/scenarios/mouse_output.py
@@ -1,0 +1,37 @@
+import time
+
+import evdev
+from support import ScenarioContext
+
+
+def run(ctx: ScenarioContext) -> None:
+    ctx.tap_source(evdev.ecodes.KEY_O)
+    ctx.expect_mouse_events(
+        [
+            (evdev.ecodes.EV_KEY, evdev.ecodes.BTN_LEFT, 1),
+            (evdev.ecodes.EV_KEY, evdev.ecodes.BTN_LEFT, 0),
+        ]
+    )
+
+    ctx.tap_source(evdev.ecodes.KEY_P)
+    ctx.expect_mouse_events(
+        [
+            (evdev.ecodes.EV_REL, evdev.ecodes.REL_X, 12),
+            (evdev.ecodes.EV_REL, evdev.ecodes.REL_Y, -7),
+        ]
+    )
+
+    ctx.tap_source(evdev.ecodes.KEY_V)
+    ctx.expect_mouse_events([(evdev.ecodes.EV_REL, evdev.ecodes.REL_WHEEL, 1)])
+
+    ctx.source_key(evdev.ecodes.KEY_X, 1)
+    ctx.source_key(evdev.ecodes.KEY_Z, 1)
+    time.sleep(0.08)
+    ctx.source_key(evdev.ecodes.KEY_Z, 0)
+    ctx.source_key(evdev.ecodes.KEY_X, 0)
+    ctx.expect_mouse_events(
+        [
+            (evdev.ecodes.EV_KEY, evdev.ecodes.BTN_RIGHT, 1),
+            (evdev.ecodes.EV_KEY, evdev.ecodes.BTN_RIGHT, 0),
+        ]
+    )

--- a/nix/daemon-session-integration-test/scenarios/multi_source_combo.py
+++ b/nix/daemon-session-integration-test/scenarios/multi_source_combo.py
@@ -1,0 +1,14 @@
+import time
+
+import evdev
+from support import ScenarioContext
+
+
+def run(ctx: ScenarioContext) -> None:
+    ctx.source_key(evdev.ecodes.KEY_Q, 1)
+    ctx.secondary_key(evdev.ecodes.KEY_F, 1)
+    ctx.expect_keys([(evdev.ecodes.KEY_F10, 1)])
+    time.sleep(0.05)
+    ctx.secondary_key(evdev.ecodes.KEY_F, 0)
+    ctx.source_key(evdev.ecodes.KEY_Q, 0)
+    ctx.expect_keys([(evdev.ecodes.KEY_F10, 0)])

--- a/nix/daemon-session-integration-test/scenarios/multi_step_combo.py
+++ b/nix/daemon-session-integration-test/scenarios/multi_step_combo.py
@@ -1,0 +1,8 @@
+import evdev
+from support import ScenarioContext
+
+
+def run(ctx: ScenarioContext) -> None:
+    ctx.tap_source(evdev.ecodes.KEY_H, pause_s=0.05)
+    ctx.tap_source(evdev.ecodes.KEY_J, pause_s=0.05)
+    ctx.expect_keys([(evdev.ecodes.KEY_T, 1), (evdev.ecodes.KEY_T, 0)])

--- a/nix/daemon-session-integration-test/scenarios/passthrough_fallback.py
+++ b/nix/daemon-session-integration-test/scenarios/passthrough_fallback.py
@@ -1,8 +1,14 @@
 import evdev
-from support import LOWER_PROFILE_NAME, PASSTHROUGH_PROFILE_NAME, ScenarioContext
+from support import (
+    LOWER_PROFILE_NAME,
+    PASSTHROUGH_PROFILE_NAME,
+    SECOND_HARDWARE_ID,
+    ScenarioContext,
+)
 
 
 def run(ctx: ScenarioContext) -> None:
+    passthrough = ctx.open_passthrough_output(SECOND_HARDWARE_ID)
     try:
         ctx.set_profile_enabled(LOWER_PROFILE_NAME, enabled=True)
         ctx.tap_secondary_source(evdev.ecodes.KEY_H)
@@ -10,7 +16,16 @@ def run(ctx: ScenarioContext) -> None:
 
         ctx.set_profile_enabled(PASSTHROUGH_PROFILE_NAME, enabled=True)
         ctx.tap_secondary_source(evdev.ecodes.KEY_H)
-        ctx.expect_keys([(evdev.ecodes.KEY_6, 1), (evdev.ecodes.KEY_6, 0)])
+        ctx.expect_no_keyboard_events()
+        ctx.expect_events(
+            passthrough,
+            [
+                (evdev.ecodes.EV_KEY, evdev.ecodes.KEY_H, 1),
+                (evdev.ecodes.EV_KEY, evdev.ecodes.KEY_H, 0),
+            ],
+            label="secondary passthrough",
+        )
     finally:
+        passthrough.close()
         ctx.set_profile_enabled(PASSTHROUGH_PROFILE_NAME, enabled=False)
         ctx.set_profile_enabled(LOWER_PROFILE_NAME, enabled=False)

--- a/nix/daemon-session-integration-test/scenarios/passthrough_fallback.py
+++ b/nix/daemon-session-integration-test/scenarios/passthrough_fallback.py
@@ -1,0 +1,16 @@
+import evdev
+from support import LOWER_PROFILE_NAME, PASSTHROUGH_PROFILE_NAME, ScenarioContext
+
+
+def run(ctx: ScenarioContext) -> None:
+    try:
+        ctx.set_profile_enabled(LOWER_PROFILE_NAME, enabled=True)
+        ctx.tap_secondary_source(evdev.ecodes.KEY_H)
+        ctx.expect_keys([(evdev.ecodes.KEY_6, 1), (evdev.ecodes.KEY_6, 0)])
+
+        ctx.set_profile_enabled(PASSTHROUGH_PROFILE_NAME, enabled=True)
+        ctx.tap_secondary_source(evdev.ecodes.KEY_H)
+        ctx.expect_keys([(evdev.ecodes.KEY_6, 1), (evdev.ecodes.KEY_6, 0)])
+    finally:
+        ctx.set_profile_enabled(PASSTHROUGH_PROFILE_NAME, enabled=False)
+        ctx.set_profile_enabled(LOWER_PROFILE_NAME, enabled=False)

--- a/nix/daemon-session-integration-test/scenarios/profile_toggle.py
+++ b/nix/daemon-session-integration-test/scenarios/profile_toggle.py
@@ -1,0 +1,14 @@
+import evdev
+from support import SECOND_PROFILE_NAME, ScenarioContext
+
+
+def run(ctx: ScenarioContext) -> None:
+    ctx.tap_source(evdev.ecodes.KEY_N)
+    ctx.wait_for_active_profile(SECOND_PROFILE_NAME, enabled=True)
+    ctx.tap_source(evdev.ecodes.KEY_A)
+    ctx.expect_keys([(evdev.ecodes.KEY_P, 1), (evdev.ecodes.KEY_P, 0)])
+
+    ctx.tap_source(evdev.ecodes.KEY_N)
+    ctx.wait_for_active_profile(SECOND_PROFILE_NAME, enabled=False)
+    ctx.tap_source(evdev.ecodes.KEY_A)
+    ctx.expect_keys([(evdev.ecodes.KEY_Q, 1), (evdev.ecodes.KEY_Q, 0)])

--- a/nix/daemon-session-integration-test/scenarios/rapidfire_keyboard.py
+++ b/nix/daemon-session-integration-test/scenarios/rapidfire_keyboard.py
@@ -1,0 +1,18 @@
+import time
+
+import evdev
+from support import ScenarioContext
+
+
+def run(ctx: ScenarioContext) -> None:
+    ctx.source_key(evdev.ecodes.KEY_R, 1)
+    time.sleep(0.12)
+    ctx.source_key(evdev.ecodes.KEY_R, 0)
+    ctx.expect_keys(
+        [
+            (evdev.ecodes.KEY_I, 1),
+            (evdev.ecodes.KEY_I, 0),
+            (evdev.ecodes.KEY_I, 1),
+            (evdev.ecodes.KEY_I, 0),
+        ]
+    )

--- a/nix/daemon-session-integration-test/scenarios/recording_capture.py
+++ b/nix/daemon-session-integration-test/scenarios/recording_capture.py
@@ -1,0 +1,83 @@
+import concurrent.futures
+import time
+
+import evdev
+from support import HARDWARE_ID, PROFILE_NAME, SECOND_HARDWARE_ID, ScenarioContext
+
+
+def run(ctx: ScenarioContext) -> None:
+    capture = ctx.request({"command": "begin_capture", "hardware_id": HARDWARE_ID})
+    if capture.get("status") != "ok":
+        raise AssertionError(f"begin_capture failed: {capture}")
+    try:
+        ctx.source_key(evdev.ecodes.KEY_Q, 1)
+        captured = wait_for_capture(ctx, HARDWARE_ID)
+        ctx.source_key(evdev.ecodes.KEY_Q, 0)
+        if (
+            captured.get("evdev") != "key_q"
+            or captured.get("code") != evdev.ecodes.KEY_Q
+            or captured.get("device_path") != ctx.source.device.path
+        ):
+            raise AssertionError(f"unexpected captured event: {captured}")
+    finally:
+        ctx.request({"command": "end_capture", "hardware_id": HARDWARE_ID}, ok=False)
+
+    ctx.request({"command": "reevaluate_hardware"})
+    ctx.reopen_outputs()
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
+        future = executor.submit(
+            lambda: ctx.request(
+                {"command": "capture_combo", "profile_name": PROFILE_NAME, "timeout_s": 3.0},
+                timeout=5.0,
+            )
+        )
+        time.sleep(0.2)
+        ctx.source_key(evdev.ecodes.KEY_Q, 1)
+        ctx.secondary_key(evdev.ecodes.KEY_F, 1)
+        time.sleep(0.05)
+        ctx.secondary_key(evdev.ecodes.KEY_F, 0)
+        ctx.source_key(evdev.ecodes.KEY_Q, 0)
+        combo = future.result(timeout=6)
+
+    events = {
+        (str(event.get("hardware_id")), str(event.get("evdev")))
+        for event in combo.get("events", [])
+        if isinstance(event, dict)
+    }
+    expected = {(HARDWARE_ID, "key_q"), (SECOND_HARDWARE_ID, "key_f")}
+    if events != expected:
+        raise AssertionError(f"unexpected captured combo events: {combo}")
+
+    ctx.request({"command": "list_devices_for_recording"})
+    start = ctx.request({"command": "start_recording"})
+    if start.get("status") != "ok":
+        raise AssertionError(f"start_recording failed: {start}")
+    ctx.tap_source(evdev.ecodes.KEY_Q)
+    stopped = ctx.request({"command": "stop_recording"})
+    if stopped.get("status") != "ok":
+        raise AssertionError(f"stop_recording failed: {stopped}")
+    token = str(stopped.get("pending_save_token", ""))
+    saved_name = "integration-recorded-macro"
+    ctx.request(
+        {
+            "command": "save_recording",
+            "name": saved_name,
+            "pending_save_token": token,
+        }
+    )
+    ctx.request({"command": "play_macro", "name": saved_name})
+    ctx.expect_keys([(evdev.ecodes.KEY_Q, 1), (evdev.ecodes.KEY_Q, 0)])
+
+
+def wait_for_capture(ctx: ScenarioContext, hardware_id: str) -> dict[str, object]:
+    deadline = time.monotonic() + 3
+    last: dict[str, object] | None = None
+    while time.monotonic() < deadline:
+        result = ctx.request({"command": "capture_read", "hardware_id": hardware_id}, ok=False)
+        captured = result.get("captured")
+        if isinstance(captured, dict):
+            return captured
+        last = result
+        time.sleep(0.1)
+    raise AssertionError(f"capture_read did not return an event: {last}")

--- a/nix/daemon-session-integration-test/scenarios/restart_recovery.py
+++ b/nix/daemon-session-integration-test/scenarios/restart_recovery.py
@@ -1,0 +1,12 @@
+import evdev
+from support import ScenarioContext
+
+
+def run(ctx: ScenarioContext) -> None:
+    ctx.restart_session()
+    ctx.tap_source(evdev.ecodes.KEY_A)
+    ctx.expect_keys([(evdev.ecodes.KEY_Q, 1), (evdev.ecodes.KEY_Q, 0)])
+
+    ctx.restart_keymasqd()
+    ctx.tap_source(evdev.ecodes.KEY_A)
+    ctx.expect_keys([(evdev.ecodes.KEY_Q, 1), (evdev.ecodes.KEY_Q, 0)])

--- a/nix/daemon-session-integration-test/scenarios/simple_remap.py
+++ b/nix/daemon-session-integration-test/scenarios/simple_remap.py
@@ -1,0 +1,7 @@
+import evdev
+from support import ScenarioContext
+
+
+def run(ctx: ScenarioContext) -> None:
+    ctx.tap_source(evdev.ecodes.KEY_A)
+    ctx.expect_keys([(evdev.ecodes.KEY_Q, 1), (evdev.ecodes.KEY_Q, 0)])

--- a/nix/daemon-session-integration-test/scenarios/superkey_overload_multi_action.py
+++ b/nix/daemon-session-integration-test/scenarios/superkey_overload_multi_action.py
@@ -1,0 +1,28 @@
+import evdev
+from support import ScenarioContext
+
+
+def run(ctx: ScenarioContext) -> None:
+    ctx.source_key(evdev.ecodes.KEY_E, 1)
+    ctx.expect_keys(
+        [
+            (evdev.ecodes.KEY_LEFTCTRL, 1),
+            (evdev.ecodes.KEY_LEFTSHIFT, 1),
+            (evdev.ecodes.KEY_1, 1),
+            (evdev.ecodes.KEY_1, 0),
+            (evdev.ecodes.KEY_2, 1),
+            (evdev.ecodes.KEY_2, 0),
+        ]
+    )
+
+    ctx.source_key(evdev.ecodes.KEY_E, 0)
+    ctx.expect_keys(
+        [
+            (evdev.ecodes.KEY_3, 1),
+            (evdev.ecodes.KEY_3, 0),
+            (evdev.ecodes.KEY_4, 1),
+            (evdev.ecodes.KEY_4, 0),
+            (evdev.ecodes.KEY_LEFTCTRL, 0),
+            (evdev.ecodes.KEY_LEFTSHIFT, 0),
+        ]
+    )

--- a/nix/daemon-session-integration-test/scenarios/superkey_tap.py
+++ b/nix/daemon-session-integration-test/scenarios/superkey_tap.py
@@ -1,0 +1,7 @@
+import evdev
+from support import ScenarioContext
+
+
+def run(ctx: ScenarioContext) -> None:
+    ctx.tap_source(evdev.ecodes.KEY_B)
+    ctx.expect_keys([(evdev.ecodes.KEY_W, 1), (evdev.ecodes.KEY_W, 0)])

--- a/nix/daemon-session-integration-test/scenarios/suppress.py
+++ b/nix/daemon-session-integration-test/scenarios/suppress.py
@@ -1,0 +1,7 @@
+import evdev
+from support import ScenarioContext
+
+
+def run(ctx: ScenarioContext) -> None:
+    ctx.tap_source(evdev.ecodes.KEY_L)
+    ctx.expect_no_keyboard_events()

--- a/nix/daemon-session-integration-test/scenarios/tap_enabled.py
+++ b/nix/daemon-session-integration-test/scenarios/tap_enabled.py
@@ -1,0 +1,8 @@
+import evdev
+from support import ScenarioContext
+
+
+def run(ctx: ScenarioContext) -> None:
+    ctx.source_key(evdev.ecodes.KEY_M, 1)
+    ctx.expect_keys([(evdev.ecodes.KEY_O, 1), (evdev.ecodes.KEY_O, 0)])
+    ctx.source_key(evdev.ecodes.KEY_M, 0)

--- a/nix/daemon-session-integration-test/support.py
+++ b/nix/daemon-session-integration-test/support.py
@@ -1,0 +1,631 @@
+#!/usr/bin/env python3
+
+import concurrent.futures
+import contextlib
+import json
+import os
+import socket
+import subprocess
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+from string import Template
+from typing import Any
+
+import evdev
+
+HARDWARE_ID = "cafe:0001"
+SECOND_HARDWARE_ID = "cafe:0002"
+SOURCE_NAME = "keymasq-integration-source-keyboard"
+SECOND_SOURCE_NAME = "keymasq-integration-secondary-keyboard"
+PROFILE_NAME = "Integration Core Smoke"
+SECOND_PROFILE_NAME = "Integration Priority Override"
+LOWER_PROFILE_NAME = "Integration Lower Fallback"
+PASSTHROUGH_PROFILE_NAME = "Integration Passthrough Override"
+MACRO_NAME = "integration-macro"
+LONG_MACRO_NAME = "integration-hold-macro"
+SUPERKEY_NAME = "integration-tap-superkey"
+COMBO_SUPERKEY_NAME = "integration-combo-superkey"
+OVERLOAD_SUPERKEY_NAME = "integration-overload-superkey"
+FIXTURES_DIR = Path(__file__).resolve().parent / "fixtures"
+
+
+@dataclass(frozen=True)
+class ScenarioCase:
+    name: str
+    run: Callable[["ScenarioContext"], None]
+
+
+class ScenarioContext:
+    def __init__(self) -> None:
+        runtime_dir = Path(os.environ.get("XDG_RUNTIME_DIR", f"/run/user/{os.getuid()}"))
+        self.session_socket = runtime_dir / "keymasq" / "session.sock"
+        self.config_dir = Path.home() / ".config" / "keymasq"
+        self.source: evdev.UInput | None = None
+        self.secondary_source: evdev.UInput | None = None
+        self.keyboard_output: evdev.InputDevice | None = None
+        self.mouse_output: evdev.InputDevice | None = None
+        self.gamepad_output: evdev.InputDevice | None = None
+
+    def setup(self) -> None:
+        self.wait_for_session()
+        self.wait_for_keymasqd_connection()
+        self.source = self.create_source_keyboard(SOURCE_NAME, vendor=0xCAFE, product=0x0001)
+        self.secondary_source = self.create_source_keyboard(
+            SECOND_SOURCE_NAME,
+            vendor=0xCAFE,
+            product=0x0002,
+        )
+        self.write_configs(self.source.device.path, self.secondary_source.device.path)
+        self.create_macro()
+        self.request({"command": "reload"})
+        self.request({"command": "reevaluate_hardware"})
+        self.reopen_outputs()
+
+    def cleanup(self) -> None:
+        with contextlib.suppress(Exception):
+            self.request(
+                {"command": "disable_profile", "profile_name": PASSTHROUGH_PROFILE_NAME},
+                ok=False,
+            )
+            self.request(
+                {"command": "disable_profile", "profile_name": LOWER_PROFILE_NAME},
+                ok=False,
+            )
+            self.request(
+                {"command": "disable_profile", "profile_name": SECOND_PROFILE_NAME},
+                ok=False,
+            )
+            self.request({"command": "disable_profile", "profile_name": PROFILE_NAME}, ok=False)
+        for device in self.output_devices():
+            device.close()
+        if self.source is not None:
+            self.source.close()
+        if self.secondary_source is not None:
+            self.secondary_source.close()
+
+    def wait_for_session(self) -> None:
+        deadline = time.monotonic() + 60
+        while time.monotonic() < deadline:
+            if self.session_socket.exists():
+                try:
+                    result = self.request({"command": "ping"}, timeout=1.0, ok=False)
+                    if result.get("status") == "ok":
+                        return
+                except OSError:
+                    pass
+            time.sleep(0.25)
+        raise AssertionError(f"session socket did not become ready: {self.session_socket}")
+
+    def wait_for_keymasqd_connection(self) -> None:
+        deadline = time.monotonic() + 60
+        last: dict[str, Any] | None = None
+        while time.monotonic() < deadline:
+            try:
+                last = self.request({"command": "get_status"}, timeout=2.0)
+                if last.get("keymasqd_connected") is True:
+                    return
+            except OSError:
+                pass
+            time.sleep(0.5)
+        raise AssertionError(f"keymasqd did not connect to session: {last}")
+
+    def request(
+        self,
+        payload: dict[str, Any],
+        *,
+        timeout: float = 10.0,
+        ok: bool = True,
+    ) -> dict[str, Any]:
+        with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as client:
+            client.settimeout(timeout)
+            client.connect(str(self.session_socket))
+            client.sendall(json.dumps(payload).encode("utf-8") + b"\n")
+
+            data = b""
+            deadline = time.monotonic() + timeout
+            while time.monotonic() < deadline:
+                chunk = client.recv(4096)
+                if not chunk:
+                    break
+                data += chunk
+                while b"\n" in data:
+                    line_bytes, data = data.split(b"\n", 1)
+                    line = line_bytes.decode("utf-8", "ignore")
+                    if not line.strip():
+                        continue
+                    message = json.loads(line)
+                    if not isinstance(message, dict):
+                        continue
+                    if "event" in message and "status" not in message:
+                        continue
+                    if ok and message.get("status") not in {"ok", None}:
+                        raise AssertionError(f"session request failed: {payload} -> {message}")
+                    return message
+        raise AssertionError(f"no response for session request: {payload}")
+
+    def create_source_keyboard(self, name: str, *, vendor: int, product: int) -> evdev.UInput:
+        source_keys = [
+            getattr(evdev.ecodes, f"KEY_{letter}") for letter in "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+        ]
+        device = evdev.UInput(
+            events={evdev.ecodes.EV_KEY: source_keys},
+            name=name,
+            vendor=vendor,
+            product=product,
+        )
+        if not getattr(device.device, "path", None):
+            device.close()
+            raise AssertionError("source uinput did not expose an evdev path")
+        self.settle_udev()
+        time.sleep(0.5)
+        return device
+
+    def write_configs(self, primary_source_path: str, secondary_source_path: str) -> None:
+        hardware_dir = self.config_dir / "hardware"
+        profiles_dir = self.config_dir / "profiles"
+        superkeys_dir = self.config_dir / "superkeys"
+        for directory in (hardware_dir, profiles_dir, superkeys_dir):
+            directory.mkdir(parents=True, exist_ok=True)
+
+        values = self.fixture_values(primary_source_path, secondary_source_path)
+        self.write_hardware_configs(primary_source_path, secondary_source_path)
+        self.write_fixture(
+            superkeys_dir / "integration-tap-superkey.toml",
+            "superkeys/tap-superkey.toml",
+            values,
+        )
+        self.write_fixture(
+            superkeys_dir / "integration-combo-superkey.toml",
+            "superkeys/combo-superkey.toml",
+            values,
+        )
+        self.write_fixture(
+            superkeys_dir / "integration-overload-superkey.toml",
+            "superkeys/overload-superkey.toml",
+            values,
+        )
+        self.write_fixture(
+            profiles_dir / "integration-core-smoke.toml",
+            "profiles/core-smoke.toml",
+            values,
+        )
+        self.write_fixture(
+            profiles_dir / "integration-priority-override.toml",
+            "profiles/priority-override.toml",
+            values,
+        )
+        self.write_fixture(
+            profiles_dir / "integration-lower-fallback.toml",
+            "profiles/lower-fallback.toml",
+            values,
+        )
+        self.write_fixture(
+            profiles_dir / "integration-passthrough-override.toml",
+            "profiles/passthrough-override.toml",
+            values,
+        )
+
+    def write_hardware_configs(
+        self,
+        primary_source_path: str,
+        secondary_source_path: str,
+    ) -> None:
+        hardware_dir = self.config_dir / "hardware"
+        hardware_dir.mkdir(parents=True, exist_ok=True)
+        values = self.fixture_values(primary_source_path, secondary_source_path)
+        self.write_fixture(hardware_dir / "cafe_0001.toml", "hardware/primary.toml", values)
+        self.write_fixture(hardware_dir / "cafe_0002.toml", "hardware/secondary.toml", values)
+
+    def write_fixture(self, destination: Path, fixture_name: str, values: dict[str, str]) -> None:
+        template = Template((FIXTURES_DIR / fixture_name).read_text(encoding="utf-8"))
+        destination.write_text(template.safe_substitute(values), encoding="utf-8")
+
+    def fixture_values(
+        self,
+        primary_source_path: str,
+        secondary_source_path: str,
+    ) -> dict[str, str]:
+        return {
+            "HARDWARE_ID": HARDWARE_ID,
+            "SECOND_HARDWARE_ID": SECOND_HARDWARE_ID,
+            "PRIMARY_SOURCE_PATH": primary_source_path,
+            "SECONDARY_SOURCE_PATH": secondary_source_path,
+            "PRIMARY_BUTTONS": self.button_blocks("abcdefghijklmnopqrstuvwxyz"),
+            "SECONDARY_BUTTONS": self.button_blocks("abcdefghijklmnopqrstuvwxyz"),
+            "PROFILE_NAME": PROFILE_NAME,
+            "SECOND_PROFILE_NAME": SECOND_PROFILE_NAME,
+            "LOWER_PROFILE_NAME": LOWER_PROFILE_NAME,
+            "PASSTHROUGH_PROFILE_NAME": PASSTHROUGH_PROFILE_NAME,
+            "MACRO_NAME": MACRO_NAME,
+            "LONG_MACRO_NAME": LONG_MACRO_NAME,
+            "SUPERKEY_NAME": SUPERKEY_NAME,
+            "COMBO_SUPERKEY_NAME": COMBO_SUPERKEY_NAME,
+            "OVERLOAD_SUPERKEY_NAME": OVERLOAD_SUPERKEY_NAME,
+        }
+
+    def button_blocks(self, keys: str) -> str:
+        return "\n\n".join(
+            f"""
+[[hardware.layout.buttons]]
+id = "key_{key}"
+label = "{key.upper()}"
+evdev = "key_{key}"
+source = "kbd"
+type = "key"
+""".strip()
+            for key in keys
+        )
+
+    def create_macro(self) -> None:
+        self.create_macro_named(
+            MACRO_NAME,
+            [
+                {
+                    "device_type": "keyboard",
+                    "type": evdev.ecodes.EV_KEY,
+                    "code": evdev.ecodes.KEY_Y,
+                    "value": 1,
+                    "t_us": 0,
+                },
+                {
+                    "device_type": "keyboard",
+                    "type": evdev.ecodes.EV_KEY,
+                    "code": evdev.ecodes.KEY_Y,
+                    "value": 0,
+                    "t_us": 10000,
+                },
+            ],
+        )
+        self.create_macro_named(
+            LONG_MACRO_NAME,
+            [
+                {
+                    "device_type": "keyboard",
+                    "type": evdev.ecodes.EV_KEY,
+                    "code": evdev.ecodes.KEY_Y,
+                    "value": 1,
+                    "t_us": 0,
+                },
+                {
+                    "device_type": "keyboard",
+                    "type": evdev.ecodes.EV_KEY,
+                    "code": evdev.ecodes.KEY_Y,
+                    "value": 0,
+                    "t_us": 5_000_000,
+                },
+            ],
+        )
+
+    def create_macro_named(self, name: str, events: list[dict[str, object]]) -> None:
+        result = self.request(
+            {
+                "command": "create_macro",
+                "macro": {
+                    "name": name,
+                    "events": events,
+                },
+            },
+            ok=False,
+        )
+        if result.get("status") == "ok":
+            return
+        if "already exists" in str(result.get("message", "")).lower():
+            return
+        raise AssertionError(f"macro creation failed: {result}")
+
+    def request_background(
+        self,
+        payload: dict[str, Any],
+        *,
+        timeout: float = 20.0,
+    ) -> tuple[concurrent.futures.Executor, concurrent.futures.Future[dict[str, Any]]]:
+        executor = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+        future = executor.submit(lambda: self.request(payload, timeout=timeout))
+        return executor, future
+
+    def restart_session(self) -> None:
+        subprocess.run(
+            [
+                os.environ.get("KEYMASQ_INTEGRATION_SYSTEMCTL", "systemctl"),
+                "--user",
+                "restart",
+                "keymasq-session.service",
+            ],
+            check=True,
+            timeout=30,
+        )
+        self.wait_for_session()
+        self.wait_for_keymasqd_connection()
+        self.request({"command": "reevaluate_hardware"})
+        self.reopen_outputs()
+
+    def restart_keymasqd(self) -> None:
+        subprocess.run(
+            [
+                os.environ.get("KEYMASQ_INTEGRATION_SUDO", "sudo"),
+                os.environ.get("KEYMASQ_INTEGRATION_SYSTEMCTL", "systemctl"),
+                "restart",
+                "keymasqd.service",
+            ],
+            check=True,
+            timeout=30,
+        )
+        self.wait_for_session()
+        self.wait_for_keymasqd_connection()
+        self.request({"command": "reevaluate_hardware"})
+        self.reopen_outputs()
+
+    def recreate_secondary_source(self) -> None:
+        if self.source is None:
+            raise AssertionError("primary source keyboard is not available")
+        if self.secondary_source is not None:
+            self.secondary_source.close()
+            self.secondary_source = None
+        self.settle_udev()
+        time.sleep(0.5)
+        self.secondary_source = self.create_source_keyboard(
+            SECOND_SOURCE_NAME,
+            vendor=0xCAFE,
+            product=0x0002,
+        )
+        self.write_hardware_configs(self.source.device.path, self.secondary_source.device.path)
+        self.request({"command": "reload"})
+        self.request({"command": "reevaluate_hardware"})
+        self.reopen_outputs()
+
+    def reopen_outputs(self) -> None:
+        self.close_outputs()
+        self.keyboard_output = self.wait_for_output_device(
+            {"keymasq-test-keyboard", "keymasq-keyboard"},
+            "keyboard",
+        )
+        self.mouse_output = self.wait_for_output_device(
+            {"keymasq-test-mouse", "keymasq-mouse"},
+            "mouse",
+        )
+        self.gamepad_output = self.wait_for_output_device(
+            {"keymasq-test-gamepad", "keymasq-gamepad"},
+            "gamepad",
+        )
+        self.drain_outputs()
+
+    def close_outputs(self) -> None:
+        for device in self.output_devices():
+            device.close()
+        self.keyboard_output = None
+        self.mouse_output = None
+        self.gamepad_output = None
+
+    def wait_for_output_device(self, wanted: set[str], label: str) -> evdev.InputDevice:
+        deadline = time.monotonic() + 30
+        last_status: dict[str, Any] | None = None
+        while time.monotonic() < deadline:
+            self.settle_udev()
+            for path in evdev.list_devices():
+                try:
+                    device = evdev.InputDevice(path)
+                except OSError:
+                    continue
+                if device.name in wanted:
+                    return device
+                device.close()
+            last_status = self.request({"command": "get_active_profiles"}, ok=False)
+            time.sleep(0.5)
+        raise AssertionError(f"output {label} was not created; active profiles: {last_status}")
+
+    def open_passthrough_output(self, hardware_id: str) -> evdev.InputDevice:
+        return self.wait_for_output_device(
+            {f"keymasq-test-passthrough-{hardware_id}", f"keymasq-{hardware_id}"},
+            f"passthrough {hardware_id}",
+        )
+
+    def subtest(self, label: str, fn: Callable[[], object]) -> None:
+        print(f"integration: {label}", flush=True)
+        self.drain_outputs()
+        fn()
+
+    def tap_source(self, code: int, *, pause_s: float = 0.03) -> None:
+        self.source_key(code, 1)
+        time.sleep(pause_s)
+        self.source_key(code, 0)
+
+    def tap_secondary_source(self, code: int, *, pause_s: float = 0.03) -> None:
+        self.secondary_key(code, 1)
+        time.sleep(pause_s)
+        self.secondary_key(code, 0)
+
+    def source_key(self, code: int, value: int) -> None:
+        if self.source is None:
+            raise AssertionError("source keyboard is not available")
+        self.source.write(evdev.ecodes.EV_KEY, code, value)
+        self.source.syn()
+
+    def secondary_key(self, code: int, value: int) -> None:
+        if self.secondary_source is None:
+            raise AssertionError("secondary source keyboard is not available")
+        self.secondary_source.write(evdev.ecodes.EV_KEY, code, value)
+        self.secondary_source.syn()
+
+    def expect_keys(self, expected: list[tuple[int, int]], *, timeout_s: float = 3.0) -> None:
+        self.expect_events(
+            self.keyboard_output,
+            [(evdev.ecodes.EV_KEY, code, value) for code, value in expected],
+            label="keyboard",
+            timeout_s=timeout_s,
+        )
+
+    def expect_mouse_events(
+        self,
+        expected: list[tuple[int, int, int]],
+        *,
+        timeout_s: float = 3.0,
+    ) -> None:
+        self.expect_events(self.mouse_output, expected, label="mouse", timeout_s=timeout_s)
+
+    def expect_gamepad_events(
+        self,
+        expected: list[tuple[int, int, int]],
+        *,
+        timeout_s: float = 3.0,
+    ) -> None:
+        self.expect_events(self.gamepad_output, expected, label="gamepad", timeout_s=timeout_s)
+
+    def expect_events(
+        self,
+        device: evdev.InputDevice | None,
+        expected: list[tuple[int, int, int]],
+        *,
+        label: str,
+        timeout_s: float = 3.0,
+    ) -> None:
+        if device is None:
+            raise AssertionError(f"output {label} is not available")
+
+        observed: list[tuple[int, int, int]] = []
+        index = 0
+        deadline = time.monotonic() + timeout_s
+        while time.monotonic() < deadline:
+            for event in self.read_output_events(device):
+                if event.type == evdev.ecodes.EV_SYN:
+                    continue
+                event_tuple = (int(event.type), int(event.code), int(event.value))
+                observed.append(event_tuple)
+                if event_tuple == expected[index]:
+                    index += 1
+                    if index == len(expected):
+                        return
+            time.sleep(0.01)
+
+        expected_names = [self.event_label(event) for event in expected]
+        observed_names = [self.event_label(event) for event in observed]
+        raise AssertionError(
+            f"missing {label} output sequence {expected_names}; observed {observed_names}"
+        )
+
+    def expect_no_keyboard_events(self, *, timeout_s: float = 0.25) -> None:
+        self.expect_no_events(
+            self.keyboard_output,
+            label="keyboard",
+            event_types={evdev.ecodes.EV_KEY},
+            timeout_s=timeout_s,
+        )
+
+    def expect_no_mouse_events(self, *, timeout_s: float = 0.25) -> None:
+        self.expect_no_events(
+            self.mouse_output,
+            label="mouse",
+            event_types={evdev.ecodes.EV_KEY, evdev.ecodes.EV_REL},
+            timeout_s=timeout_s,
+        )
+
+    def expect_no_gamepad_events(self, *, timeout_s: float = 0.25) -> None:
+        self.expect_no_events(
+            self.gamepad_output,
+            label="gamepad",
+            event_types={evdev.ecodes.EV_KEY, evdev.ecodes.EV_ABS},
+            timeout_s=timeout_s,
+        )
+
+    def expect_no_events(
+        self,
+        device: evdev.InputDevice | None,
+        *,
+        label: str,
+        event_types: set[int],
+        timeout_s: float = 0.25,
+    ) -> None:
+        if device is None:
+            raise AssertionError(f"output {label} is not available")
+        observed: list[tuple[int, int, int]] = []
+        deadline = time.monotonic() + timeout_s
+        while time.monotonic() < deadline:
+            for event in self.read_output_events(device):
+                event_tuple = (int(event.type), int(event.code), int(event.value))
+                if event.type in event_types:
+                    observed.append(event_tuple)
+            time.sleep(0.01)
+        if observed:
+            observed_names = [self.event_label(event) for event in observed]
+            raise AssertionError(f"unexpected {label} output events: {observed_names}")
+
+    def wait_for_active_profile(self, profile_name: str, *, enabled: bool) -> None:
+        deadline = time.monotonic() + 5
+        last: dict[str, Any] | None = None
+        while time.monotonic() < deadline:
+            last = self.request({"command": "get_active_profiles"}, ok=False)
+            active = set(str(name) for name in last.get("active_profiles", []))
+            if (profile_name in active) is enabled:
+                return
+            time.sleep(0.1)
+        raise AssertionError(f"profile {profile_name} enabled={enabled} not observed: {last}")
+
+    def set_profile_enabled(self, profile_name: str, *, enabled: bool) -> None:
+        command = "enable_profile" if enabled else "disable_profile"
+        self.request({"command": command, "profile_name": profile_name})
+        self.wait_for_active_profile(profile_name, enabled=enabled)
+
+    def wait_until(
+        self,
+        label: str,
+        predicate: Callable[[], bool],
+        *,
+        timeout_s: float = 5,
+    ) -> None:
+        deadline = time.monotonic() + timeout_s
+        while time.monotonic() < deadline:
+            if predicate():
+                return
+            time.sleep(0.1)
+        raise AssertionError(f"timed out waiting for {label}")
+
+    def output_devices(self) -> list[evdev.InputDevice]:
+        return [
+            device
+            for device in (self.keyboard_output, self.mouse_output, self.gamepad_output)
+            if device is not None
+        ]
+
+    def drain_outputs(self) -> None:
+        end = time.monotonic() + 0.05
+        while time.monotonic() < end:
+            events = [
+                event
+                for device in self.output_devices()
+                for event in self.read_output_events(device)
+            ]
+            if not events:
+                time.sleep(0.005)
+
+    def read_output_events(self, device: evdev.InputDevice) -> list[evdev.InputEvent]:
+        try:
+            return list(device.read())
+        except BlockingIOError:
+            return []
+        except OSError:
+            return []
+
+    def event_label(self, event: tuple[int, int, int]) -> str:
+        event_type, code, value = event
+        if event_type == evdev.ecodes.EV_KEY:
+            name = evdev.ecodes.KEY.get(code, str(code))
+        elif event_type == evdev.ecodes.EV_REL:
+            name = evdev.ecodes.REL.get(code, str(code))
+        elif event_type == evdev.ecodes.EV_ABS:
+            name = evdev.ecodes.ABS.get(code, str(code))
+        else:
+            name = str(code)
+        return f"{event_type}:{name}:{value}"
+
+    def settle_udev(self) -> None:
+        try:
+            subprocess.run(
+                ["udevadm", "settle", "--timeout=5"],
+                check=False,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                timeout=6,
+            )
+        except Exception:
+            pass


### PR DESCRIPTION
## Summary
- Add a NixOS VM smoke test for the `keymasqd` + `keymasq-session` stack, with a Python runner that exercises remaps, macros, superkeys, combos, profile switching, capture, restart recovery, and hotplug behavior.
- Add reusable VM fixtures and scenario modules under `nix/daemon-session-integration-test/` to keep the test data-driven and easy to extend.
- Document the new check in `docs/DAEMON_SESSION_INTEGRATION_TEST.md`, including layout, execution, and debugging guidance.
- Wire the new check into `flake.nix` so it runs with the existing `x86_64-linux` checks.

## Testing
- The new check is intended to run via `nix build 'path:.#checks.x86_64-linux.daemon-session-integration-test'`.