### PR TITLE
Preserve gamepad identity for passthrough uinput clones

### DIFF
--- a/docs/GAMEPAD.md
+++ b/docs/GAMEPAD.md
@@ -124,6 +124,11 @@ Analog axes still passthrough normally, but they are not editable remap sources 
 If your controller has unusual extra digital buttons, you can add them later from the
 device tab using the same listen/capture flow used for keyboards and mice.
 
+When Keymasq grabs a physical gamepad, it creates a passthrough uinput clone for
+unmapped controller events. That clone reuses the source controller name and input
+IDs, so tools such as Steam see it as the same controller model rather than a
+generic Keymasq device.
+
 ## Game Compatibility
 
 The virtual gamepad appears as a standard Linux gamepad. Most games detect it automatically through:

--- a/keymasq/keymasqd/runtime/grabbed_device.py
+++ b/keymasq/keymasqd/runtime/grabbed_device.py
@@ -46,6 +46,8 @@ log = logging.getLogger("keymasqd.devices")
 ACTIVE_KEY_IDLE_LOG_INTERVAL_S = 1.0
 ACTIVE_KEY_IDLE_MAX_WAIT_S = 300.0
 COMBO_HELD_REARM_MODIFIERS = frozenset({"shift", "ctrl", "alt", "meta"})
+DEFAULT_UINPUT_VERSION = 0x0001
+DEFAULT_UINPUT_BUSTYPE = 0x0003
 
 __all__ = [
     "ASYNCIO_RUNTIME",
@@ -70,6 +72,94 @@ def _device_input(path: str) -> _ManagedInputDevice:
 
 def _uinput_writer(device: object | None) -> _WritableUInput | None:
     return identity_uinput_writer(device)
+
+
+def _is_gamepad_passthrough(device_type: DeviceType, device_types: Sequence[str]) -> bool:
+    if device_type == DeviceType.GAMEPAD:
+        return True
+    return "gamepad" in {str(value or "").strip().lower() for value in device_types}
+
+
+def _passthrough_name(
+    device: _ManagedInputDevice,
+    hardware_id: str,
+    interface_id: str,
+    *,
+    is_gamepad: bool,
+) -> str:
+    if not is_gamepad:
+        return f"keymasq-{hardware_id}"
+
+    source_name = str(getattr(device, "name", "") or "").strip()
+    if source_name:
+        return source_name
+
+    suffix = str(interface_id or "").strip() or str(hardware_id or "").strip()
+    if suffix:
+        return f"Keymasq Gamepad Passthrough ({suffix})"
+    return "Keymasq Gamepad Passthrough"
+
+
+def _int_u16(value: object) -> int | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        parsed = value
+    elif isinstance(value, str):
+        try:
+            parsed = int(value, 0)
+        except ValueError:
+            return None
+    else:
+        return None
+    if 0 <= parsed <= 0xFFFF:
+        return parsed
+    return None
+
+
+def _hardware_id_vendor_product(hardware_id: str) -> tuple[int | None, int | None]:
+    parts = str(hardware_id or "").split(":", 1)
+    if len(parts) != 2:
+        return None, None
+    try:
+        vendor = int(parts[0], 16)
+        product = int(parts[1], 16)
+    except ValueError:
+        return None, None
+    return _int_u16(vendor), _int_u16(product)
+
+
+def _passthrough_input_id(
+    device: _ManagedInputDevice,
+    hardware_id: str,
+) -> tuple[int | None, int | None, int, int]:
+    info = getattr(device, "info", None)
+    vendor = _int_u16(getattr(info, "vendor", None))
+    product = _int_u16(getattr(info, "product", None))
+    if vendor is None or product is None:
+        vendor, product = _hardware_id_vendor_product(hardware_id)
+
+    version = _int_u16(getattr(info, "version", None))
+    bustype = _int_u16(getattr(info, "bustype", None))
+    return (
+        vendor,
+        product,
+        DEFAULT_UINPUT_VERSION if version is None else version,
+        DEFAULT_UINPUT_BUSTYPE if bustype is None else bustype,
+    )
+
+
+def _passthrough_input_props(device: _ManagedInputDevice) -> Sequence[int] | None:
+    try:
+        converted: list[int] = []
+        for value in device.input_props():
+            parsed = _int_u16(value)
+            if parsed is None:
+                return None
+            converted.append(parsed)
+        return converted
+    except Exception:
+        return None
 
 
 class GrabbedDevice:
@@ -173,17 +263,59 @@ class GrabbedDevice:
         self.device = _device_input(self.path)
         caps = self.device.capabilities()
         caps.pop(evdev.ecodes.EV_SYN, None)
+        is_gamepad_passthrough = _is_gamepad_passthrough(self.device_type, self.device_types)
 
         passthrough_name, passthrough_vendor, passthrough_product = uinput_identity(
-            f"keymasq-{self.hardware_id}",
+            _passthrough_name(
+                self.device,
+                self.hardware_id,
+                self.interface_id,
+                is_gamepad=is_gamepad_passthrough,
+            ),
             "passthrough",
             test_name=f"passthrough-{self.hardware_id}",
         )
+        passthrough_version: int | None = None
+        passthrough_bustype: int | None = None
+        passthrough_input_props = None
+        if (
+            is_gamepad_passthrough
+            and passthrough_vendor is None
+            and passthrough_product is None
+        ):
+            (
+                passthrough_vendor,
+                passthrough_product,
+                passthrough_version,
+                passthrough_bustype,
+            ) = _passthrough_input_id(self.device, self.hardware_id)
+            passthrough_input_props = _passthrough_input_props(self.device)
+
         if passthrough_vendor is None or passthrough_product is None:
             self.uinput = evdev.UInput(
                 events=cast(dict[int, Sequence[int]], caps),
                 name=passthrough_name,
             )
+        elif passthrough_version is not None and passthrough_bustype is not None:
+            if passthrough_input_props is None:
+                self.uinput = evdev.UInput(
+                    events=cast(dict[int, Sequence[int]], caps),
+                    name=passthrough_name,
+                    vendor=passthrough_vendor,
+                    product=passthrough_product,
+                    version=passthrough_version,
+                    bustype=passthrough_bustype,
+                )
+            else:
+                self.uinput = evdev.UInput(
+                    events=cast(dict[int, Sequence[int]], caps),
+                    name=passthrough_name,
+                    vendor=passthrough_vendor,
+                    product=passthrough_product,
+                    version=passthrough_version,
+                    bustype=passthrough_bustype,
+                    input_props=passthrough_input_props,
+                )
         else:
             self.uinput = evdev.UInput(
                 events=cast(dict[int, Sequence[int]], caps),

--- a/keymasq/keymasqd/runtime/grabbed_device_types.py
+++ b/keymasq/keymasqd/runtime/grabbed_device_types.py
@@ -1,6 +1,14 @@
 import asyncio
 import logging
-from collections.abc import AsyncIterator, Awaitable, Callable, Coroutine, Mapping, Sequence
+from collections.abc import (
+    AsyncIterator,
+    Awaitable,
+    Callable,
+    Coroutine,
+    Iterable,
+    Mapping,
+    Sequence,
+)
 from dataclasses import dataclass, field
 from typing import Final, Protocol, TypeVar, cast
 
@@ -52,6 +60,8 @@ class ManagedInputDevice(Protocol):
     def read_one(self) -> evdev.InputEvent | None: ...
 
     def active_keys(self) -> Sequence[int]: ...
+
+    def input_props(self) -> Iterable[int]: ...
 
     def close(self) -> None: ...
 

--- a/tests/keymasqd/test_device_manager_rapidfire.py
+++ b/tests/keymasqd/test_device_manager_rapidfire.py
@@ -387,6 +387,117 @@ class TestRapidfireRelease:
             task.cancel()
             with contextlib.suppress(asyncio.CancelledError):
                 await task
+
+    @pytest.mark.asyncio
+    async def test_gamepad_passthrough_copies_source_identity(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.delenv("KEYMASQ_TEST_UINPUT", raising=False)
+        monkeypatch.setattr(gdm, "resolve_stable_path", lambda path: path)
+        monkeypatch.setattr(gdm, "get_interface_id", lambda _path: "js")
+
+        class _FakeInputDevice:
+            name = "Xbox 360 Wireless Controller"
+            info = SimpleNamespace(
+                vendor=0x045E,
+                product=0x02A1,
+                version=0x0114,
+                bustype=0x0003,
+            )
+
+            def capabilities(self) -> dict[int, list[object]]:
+                return {
+                    evdev.ecodes.EV_KEY: [evdev.ecodes.BTN_SOUTH],
+                    evdev.ecodes.EV_ABS: [
+                        (
+                            evdev.ecodes.ABS_X,
+                            evdev.AbsInfo(0, -32768, 32767, 16, 128, 0),
+                        )
+                    ],
+                    evdev.ecodes.EV_SYN: [],
+                }
+
+            def input_props(self) -> list[int]:
+                return []
+
+            def active_keys(self) -> list[int]:
+                return []
+
+            def grab(self) -> None:
+                return
+
+        created_tasks: list[asyncio.Task[None]] = []
+        original_create_task = asyncio.create_task
+
+        async def fake_to_thread(func, /, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        def fake_create_task(coro):
+            coro.close()
+            task = original_create_task(asyncio.sleep(0))
+            created_tasks.append(task)
+            return task
+
+        monkeypatch.setattr(gdm.evdev, "InputDevice", lambda _path: _FakeInputDevice())
+        monkeypatch.setattr(gdm.evdev, "UInput", _FakeUInput)
+        monkeypatch.setattr(gdm.asyncio, "to_thread", fake_to_thread)
+        monkeypatch.setattr(gdm.asyncio, "create_task", fake_create_task)
+
+        device = GrabbedDevice(
+            path="/dev/input/event-test",
+            hardware_id="045e:02a1",
+            button_map={},
+            mapping_getter=lambda: {},
+            event_callback=AsyncMock(return_value=None),
+            device_type=DeviceType.GAMEPAD,
+            device_types=["gamepad"],
+            gamepad_uinput=_FakeUInput(),  # type: ignore[arg-type]
+        )
+
+        await device.grab()
+        await asyncio.sleep(0)
+
+        assert isinstance(device.uinput, _FakeUInput)
+        assert device.uinput.kwargs["name"] == "Xbox 360 Wireless Controller"
+        assert device.uinput.kwargs["vendor"] == 0x045E
+        assert device.uinput.kwargs["product"] == 0x02A1
+        assert device.uinput.kwargs["version"] == 0x0114
+        assert device.uinput.kwargs["bustype"] == 0x0003
+
+        for task in created_tasks:
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
+
+    def test_gamepad_passthrough_fallback_name_includes_interface(self) -> None:
+        device = SimpleNamespace(name="")
+
+        assert (
+            gdm._passthrough_name(  # pyright: ignore[reportPrivateUsage]
+                device,  # type: ignore[arg-type]
+                "045e:02a1",
+                "js0",
+                is_gamepad=True,
+            )
+            == "Keymasq Gamepad Passthrough (js0)"
+        )
+
+    def test_gamepad_passthrough_fallback_name_uses_hardware_id_without_interface(
+        self,
+    ) -> None:
+        device = SimpleNamespace(name=None)
+
+        assert (
+            gdm._passthrough_name(  # pyright: ignore[reportPrivateUsage]
+                device,  # type: ignore[arg-type]
+                "045e:02a1",
+                "",
+                is_gamepad=True,
+            )
+            == "Keymasq Gamepad Passthrough (045e:02a1)"
+        )
+
     @pytest.mark.asyncio
     async def test_rapidfire_key_releases_before_exiting_when_stopped_during_hold(
         self,


### PR DESCRIPTION
## Summary
- Make passthrough uinput clones for grabbed gamepads reuse the source controller name when available.
- Copy vendor, product, version, bustype, and input properties onto the passthrough device so downstream tools can recognize the controller model instead of a generic Keymasq device.
- Add fallback naming for gamepad passthrough clones when the source name is unavailable, and expand runtime typing to expose `input_props()`.
- Document the behavior in `docs/GAMEPAD.md` and add regression coverage for gamepad passthrough identity handling.

## Testing
- Added pytest coverage in `tests/keymasqd/test_device_manager_rapidfire.py` for copying gamepad identity onto passthrough uinput clones.
- Added unit checks for passthrough fallback naming when the source controller name is missing.
- Not run: `./scripts/check.sh keymasqd`