### PR TITLE
Add configurable virtual gamepad outputs

### DIFF
--- a/docs/ACTIONS.md
+++ b/docs/ACTIONS.md
@@ -151,6 +151,13 @@ Map to a gamepad button or trigger. Available inputs include:
 
 ![Gamepad tab — face buttons, shoulders, triggers, D-pad, and sticks](assets/screenshots/key_selector_gamepad.png)
 
+Gamepad actions can route to a specific output with `output_id`. Use
+`virtual-gamepad-1` through `virtual-gamepad-4` for configured virtual Xbox
+360 outputs, or a configured hardware gamepad ID such as `045e:028e@2`.
+Omitting `output_id` uses the default output, `virtual-gamepad-1` when it
+exists. Explicit targets never fall back: if the daemon cannot route to the
+configured output, it logs a warning and drops the gamepad event.
+
 ## Compositor
 
 Send a command to your window compositor. Currently Keymasq supports

--- a/docs/GAMEPAD.md
+++ b/docs/GAMEPAD.md
@@ -6,6 +6,22 @@ Keymasq can remap mouse buttons, keyboard keys, or any input to virtual gamepad 
 
 When you map a button to a gamepad action, Keymasq creates a virtual gamepad device using Linux uinput. Games see this as a standard gamepad and can receive input from it.
 
+Keymasq creates one virtual Xbox 360 gamepad by default. You can configure
+0-4 virtual gamepads from the GUI hamburger menu under **Virtual Gamepads**.
+The setting is stored in `~/.config/keymasq/virtual_devices.toml`:
+
+```toml
+[gamepads]
+virtual_count = 1
+```
+
+Gamepad actions can optionally set `output_id` to route output. Valid values
+are `virtual-gamepad-1` through `virtual-gamepad-4`, or a configured hardware
+gamepad ID such as `045e:028e@2`. If `output_id` is omitted, output uses the
+default `virtual-gamepad-1`. Explicit `output_id` values are strict: if the
+target is not configured, connected, or grabbed, `keymasqd` logs a warning and
+drops the output with no fallback.
+
 ## Available Gamepad Buttons
 
 The virtual gamepad appears as an Xbox 360 controller. Button codes follow the Linux evdev naming convention.
@@ -89,6 +105,11 @@ target = "btn_y"  # Y button (top)
 rapidfire_enabled = true
 rapidfire_hold_ms = 30
 rapidfire_wait_ms = 20
+
+[devices."046d:c548".mapping.btn_forward]
+action = "gamepad"
+target = "btn_a"
+output_id = "virtual-gamepad-2"
 ```
 
 ## Rapidfire and Tap
@@ -156,6 +177,13 @@ Keymasq creates a uinput device with Xbox 360 hardware IDs for maximum compatibi
 - **Capabilities**:
   - 17 digital buttons (all standard gamepad buttons)
   - 8 analog axes (sticks, triggers, D-pad)
+
+Additional configured virtual gamepads use the same Xbox 360 template. Their
+names are `keymasq-gamepad-2`, `keymasq-gamepad-3`, and
+`keymasq-gamepad-4`.
+
+Macro playback does not store per-event gamepad routing. Recorded gamepad
+macro events still play through the default gamepad output.
 
 ### Linux Gamepad Specification
 

--- a/docs/GAMEPAD.md
+++ b/docs/GAMEPAD.md
@@ -182,8 +182,9 @@ Additional configured virtual gamepads use the same Xbox 360 template. Their
 names are `keymasq-gamepad-2`, `keymasq-gamepad-3`, and
 `keymasq-gamepad-4`.
 
-Macro playback does not store per-event gamepad routing. Recorded gamepad
-macro events still play through the default gamepad output.
+Macro gamepad events may include `output_id` and use the same strict routing
+rules as gamepad mappings. Macro events without `output_id` still play through
+the default gamepad output.
 
 ### Linux Gamepad Specification
 

--- a/docs/MACROS.md
+++ b/docs/MACROS.md
@@ -292,6 +292,7 @@ The editor lets you insert several kinds of events into the timeline:
 |---|---|
 | **Key press / release** | Any keyboard key — letters, modifiers, function keys, media keys, etc. |
 | **Mouse click** | Press or release of any mouse button. |
+| **Gamepad button** | Press or release of a gamepad button. Routed events can target a configured virtual or hardware gamepad output. |
 | **Relative mouse movement** | Move the pointer by a delta (pixels). Useful for macros that should work regardless of where the cursor starts. |
 | **Absolute mouse movement** | Move the pointer to an exact screen coordinate. Useful when a macro always targets a fixed UI element. |
 | **Wait** | Pause macro playback for a fixed duration. The editor stores it at its timestamp and does not move later events. |

--- a/docs/PROFILES.md
+++ b/docs/PROFILES.md
@@ -47,6 +47,19 @@ What "matching layers" means:
 - when input comes from your keyboard, Keymasq only looks at the keyboard
   parts of the active profiles
 
+Gamepad actions can route to a specific output with `output_id`:
+
+```toml
+[devices."046d:c548".mapping.btn_back]
+action = "gamepad"
+target = "btn_a"
+output_id = "virtual-gamepad-2"
+```
+
+Valid output IDs are `virtual-gamepad-1` through `virtual-gamepad-4`, or a
+configured hardware gamepad ID. Explicit output IDs are strict: unavailable
+outputs log a daemon warning and emit nothing.
+
 Simple example:
 
 - `Base` is your normal everyday profile

--- a/docs/agents/hardware.txt
+++ b/docs/agents/hardware.txt
@@ -102,3 +102,9 @@ btn_select, btn_start, btn_mode,
 btn_thumbl, btn_thumbr,
 btn_dpad_up, btn_dpad_down, btn_dpad_left, btn_dpad_right
 ```
+
+Gamepad action output routing uses `output_id`, not the button target name.
+Virtual output IDs are `virtual-gamepad-1` through `virtual-gamepad-4`.
+Hardware gamepad output IDs are the configured hardware IDs, for example
+`045e:028e` or `045e:028e@2`. Explicit output routes are strict and do not
+fall back if unavailable.

--- a/docs/agents/profiles.txt
+++ b/docs/agents/profiles.txt
@@ -86,6 +86,8 @@ target = "btn_left"
 # output virtual Xbox-style gamepad button
 action = "gamepad"
 target = "btn_x"
+# optional strict output route:
+# output_id = "virtual-gamepad-2" # or configured hardware gamepad ID
 
 # run shell command in the user's session
 action = "exec"

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -72,6 +72,7 @@ Primary docs:
   profiles/<profile_name>.toml
   superkeys/<superkey_name>.toml
   recording_settings.toml
+  virtual_devices.toml
 ```
 
 Macros are daemon-owned:
@@ -79,6 +80,17 @@ Macros are daemon-owned:
 ```text
 /var/lib/keymasq/macros/*.kmacro.xz
 ```
+
+Virtual gamepad count lives in `~/.config/keymasq/virtual_devices.toml`:
+
+```toml
+[gamepads]
+virtual_count = 1
+```
+
+Clamp `virtual_count` to 0..4. Gamepad profile actions may include
+`output_id`; valid values are `virtual-gamepad-1`..`virtual-gamepad-4` or a
+configured hardware gamepad ID. Explicit gamepad outputs do not fall back.
 
 Do not edit macro storage directly. Use `keymasq macros ...` or the GUI.
 

--- a/keymasq/common/ipc.py
+++ b/keymasq/common/ipc.py
@@ -50,6 +50,7 @@ class CommandType(Enum):
     CAPTURE_END = "capture_end"
     CAPTURE_COMBO = "capture_combo"
     SET_DIAGNOSTICS = "set_diagnostics"
+    SET_VIRTUAL_GAMEPADS = "set_virtual_gamepads"
     DIAGNOSTICS_SNAPSHOT = "diagnostics_snapshot"
     REFRESH_RECORDING_UNLOCK = "refresh_recording_unlock"
     LOCK_RECORDING_UNLOCK = "lock_recording_unlock"

--- a/keymasq/common/models.py
+++ b/keymasq/common/models.py
@@ -174,6 +174,15 @@ def normalize_macro_loop_stop_behavior(value: object) -> str:
     return DEFAULT_MACRO_LOOP_STOP_BEHAVIOR
 
 
+def normalize_gamepad_output_id(action_type: ActionType, output_id: object) -> str | None:
+    if action_type != ActionType.GAMEPAD:
+        return None
+    if output_id is None:
+        return None
+    normalized = str(output_id).strip()
+    return normalized or None
+
+
 @dataclass
 class EvdevDevice:
     path: str
@@ -220,6 +229,7 @@ class HardwareConfig:
 class MappingAction:
     action_type: ActionType
     target: str | None = None
+    output_id: str | None = None
     keys: list[str] | None = None
     cmd: str | None = None
     exec_ref: int | None = None
@@ -254,6 +264,7 @@ class MappingAction:
     tap_hold_ms: int = 10
 
     def __post_init__(self) -> None:
+        self.output_id = normalize_gamepad_output_id(self.action_type, self.output_id)
         rapidfire_enabled, rapidfire_hold_ms, rapidfire_wait_ms = normalize_rapidfire_fields(
             self.action_type,
             rapidfire_enabled=bool(self.rapidfire_enabled),
@@ -269,6 +280,7 @@ class MappingAction:
 class SuperkeyAction:
     action_type: ActionType
     target: str | None = None
+    output_id: str | None = None
     cmd: str | None = None
     exec_ref: int | None = None
     macro_name: str | None = None
@@ -297,6 +309,7 @@ class SuperkeyAction:
         return self.action_type in SUPERKEY_ACTION_TYPES
 
     def __post_init__(self) -> None:
+        self.output_id = normalize_gamepad_output_id(self.action_type, self.output_id)
         rapidfire_enabled, rapidfire_hold_ms, rapidfire_wait_ms = normalize_rapidfire_fields(
             self.action_type,
             rapidfire_enabled=bool(self.rapidfire_enabled),
@@ -310,6 +323,7 @@ class SuperkeyAction:
 
 SUPERKEY_ACTION_SHARED_FIELDS = (
     "target",
+    "output_id",
     "cmd",
     "exec_ref",
     "macro_name",

--- a/keymasq/common/paths.py
+++ b/keymasq/common/paths.py
@@ -8,6 +8,7 @@ __all__ = [
     "HARDWARE_DIR",
     "PROFILES_DIR",
     "SUPERKEYS_DIR",
+    "VIRTUAL_DEVICES_PATH",
     "STATE_DIR",
     "SECURITY_POLICY_PATH",
     "RECORDING_UNLOCK_RUNTIME_DIR",
@@ -46,6 +47,7 @@ CONFIG_DIR = XDG_CONFIG_HOME / "keymasq"
 HARDWARE_DIR = CONFIG_DIR / "hardware"
 PROFILES_DIR = CONFIG_DIR / "profiles"
 SUPERKEYS_DIR = CONFIG_DIR / "superkeys"
+VIRTUAL_DEVICES_PATH = CONFIG_DIR / "virtual_devices.toml"
 
 _build_helper_path = "/usr/bin/keymasq-record"
 _build_slurp_path = "/usr/bin/slurp"

--- a/keymasq/common/virtual_devices.py
+++ b/keymasq/common/virtual_devices.py
@@ -1,0 +1,25 @@
+MIN_VIRTUAL_GAMEPADS = 0
+MAX_VIRTUAL_GAMEPADS = 4
+DEFAULT_VIRTUAL_GAMEPADS = 1
+
+
+def clamp_virtual_gamepad_count(value: object) -> int:
+    try:
+        count = int(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        count = DEFAULT_VIRTUAL_GAMEPADS
+    return max(MIN_VIRTUAL_GAMEPADS, min(MAX_VIRTUAL_GAMEPADS, count))
+
+
+def virtual_gamepad_output_id(index: int) -> str:
+    return f"virtual-gamepad-{index}"
+
+
+def is_virtual_gamepad_output_id(output_id: str) -> bool:
+    if not output_id.startswith("virtual-gamepad-"):
+        return False
+    try:
+        index = int(output_id.removeprefix("virtual-gamepad-"))
+    except ValueError:
+        return False
+    return 1 <= index <= MAX_VIRTUAL_GAMEPADS

--- a/keymasq/gui/application.py
+++ b/keymasq/gui/application.py
@@ -101,6 +101,10 @@ class Application(Adw.Application):
         diagnostics_action.connect("activate", self._on_diagnostics)
         self.add_action(diagnostics_action)
 
+        virtual_gamepads_action = Gio.SimpleAction.new("virtual-gamepads", None)
+        virtual_gamepads_action.connect("activate", self._on_virtual_gamepads)
+        self.add_action(virtual_gamepads_action)
+
         feedback_action = Gio.SimpleAction.new("feedback", None)
         feedback_action.connect("activate", self._on_feedback)
         self.add_action(feedback_action)
@@ -163,6 +167,14 @@ class Application(Adw.Application):
         from keymasq.gui.widgets.diagnostics_dialog import DiagnosticsDialog
 
         dialog = DiagnosticsDialog(self.window)
+        dialog.present(self.window)
+
+    def _on_virtual_gamepads(self, action, param) -> None:
+        if not self.window:
+            return
+        from keymasq.gui.widgets.virtual_gamepads_dialog import VirtualGamepadsDialog
+
+        dialog = VirtualGamepadsDialog(self.window)
         dialog.present(self.window)
 
     def _on_feedback(self, action, param) -> None:

--- a/keymasq/gui/widgets/action_labels.py
+++ b/keymasq/gui/widgets/action_labels.py
@@ -35,7 +35,8 @@ def describe_mapping_action_compact(
     elif action.action_type == ActionType.MOUSE_MOVE_ABS:
         parts.append(f"⌖ {action.move_x},{action.move_y}")
     elif action.action_type == ActionType.GAMEPAD:
-        parts.append(f"🎮 {action.target or '?'}")
+        suffix = f" @{action.output_id}" if action.output_id else ""
+        parts.append(f"🎮 {action.target or '?'}{suffix}")
     elif action.action_type == ActionType.EXEC:
         cmd = action.cmd or "exec"
         parts.append(f"▶ {cmd}")
@@ -106,7 +107,8 @@ def describe_mapping_action_verbose(
     if action.action_type == ActionType.MOUSE_MOVE_ABS:
         return f"Mouse Move (abs) → {action.move_x}, {action.move_y}"
     if action.action_type == ActionType.GAMEPAD:
-        return f"Gamepad → {_resolved_label(action.target, gamepad_label)}"
+        suffix = f" @ {_gamepad_output_label(action.output_id)}" if action.output_id else ""
+        return f"Gamepad → {_resolved_label(action.target, gamepad_label)}{suffix}"
     if action.action_type == ActionType.MACRO:
         return f"Macro → {action.macro_name or '?'}"
     if action.action_type == ActionType.EXEC:
@@ -136,3 +138,15 @@ def describe_mapping_action_verbose(
     if action.action_type == ActionType.PROFILE_TOGGLE:
         return f"Toggle Profile → {action.profile_name or '?'}"
     return action.action_type.value
+
+
+def _gamepad_output_label(output_id: str | None) -> str:
+    if not output_id:
+        return ""
+    if output_id.startswith("virtual-gamepad-"):
+        try:
+            index = int(output_id.removeprefix("virtual-gamepad-"))
+        except ValueError:
+            return output_id
+        return f"Virtual Gamepad {index}"
+    return output_id

--- a/keymasq/gui/widgets/key_selector_dialog.py
+++ b/keymasq/gui/widgets/key_selector_dialog.py
@@ -916,8 +916,7 @@ class KeySelectorDialog(Adw.Dialog):
 
     def _build_gamepad_output_header(self) -> Gtk.Widget | None:
         choices = self._gamepad_output_choices()
-        concrete_count = sum(1 for output_id, _label in choices if output_id is not None)
-        if concrete_count <= 1 and not self._selected_gamepad_output_id:
+        if len(choices) <= 1 and not self._selected_gamepad_output_id:
             return None
 
         box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=8)
@@ -941,21 +940,25 @@ class KeySelectorDialog(Adw.Dialog):
         return box
 
     def _gamepad_output_choices(self) -> list[tuple[str | None, str]]:
-        choices: list[tuple[str | None, str]] = [(None, "Default")]
         try:
             count = load_virtual_gamepad_count()
         except Exception:
             count = 1
-        for index in range(1, count + 1):
+        choices: list[tuple[str | None, str]] = [(None, "Virtual Gamepad 1")]
+        for index in range(2, count + 1):
             output_id = virtual_gamepad_output_id(index)
-            label = "Virtual Gamepad 1" if index == 1 else f"Virtual Gamepad {index}"
-            choices.append((output_id, label))
+            choices.append((output_id, f"Virtual Gamepad {index}"))
 
         try:
             hardware = HardwareManager()
             for config in hardware.list_hardware():
                 if self._is_hardware_gamepad(config):
-                    choices.append((config.hardware_id, config.hardware_id))
+                    choices.append(
+                        (
+                            config.hardware_id,
+                            self._hardware_gamepad_output_label(config),
+                        )
+                    )
         except Exception:
             pass
 
@@ -980,6 +983,13 @@ class KeySelectorDialog(Adw.Dialog):
             is_gamepad_button_name(getattr(button, "evdev", None))
             for button in getattr(config, "buttons", []) or []
         )
+
+    def _hardware_gamepad_output_label(self, config: object) -> str:
+        hardware_id = str(getattr(config, "hardware_id", "") or "")
+        name = str(getattr(config, "name", "") or "").strip()
+        if name and hardware_id:
+            return f"{name} ({hardware_id})"
+        return name or hardware_id
 
     def _on_gamepad_output_selected(self, dropdown: Gtk.DropDown, _param) -> None:
         selected = int(dropdown.get_selected())
@@ -2434,8 +2444,7 @@ class SuperkeyActionDialog(Adw.Dialog):
 
     def _build_gamepad_tab(self) -> Gtk.Widget:
         choices = self._gamepad_output_choices()
-        concrete_count = sum(1 for output_id, _label in choices if output_id is not None)
-        if concrete_count <= 1 and not self._selected_gamepad_output_id:
+        if len(choices) <= 1 and not self._selected_gamepad_output_id:
             return build_shared_gamepad_tab(self)
         outer = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=8)
         outer.set_margin_top(8)
@@ -2461,19 +2470,23 @@ class SuperkeyActionDialog(Adw.Dialog):
         return outer
 
     def _gamepad_output_choices(self) -> list[tuple[str | None, str]]:
-        choices: list[tuple[str | None, str]] = [(None, "Default")]
         try:
             count = load_virtual_gamepad_count()
         except Exception:
             count = 1
-        for index in range(1, count + 1):
+        choices: list[tuple[str | None, str]] = [(None, "Virtual Gamepad 1")]
+        for index in range(2, count + 1):
             output_id = virtual_gamepad_output_id(index)
-            label = "Virtual Gamepad 1" if index == 1 else f"Virtual Gamepad {index}"
-            choices.append((output_id, label))
+            choices.append((output_id, f"Virtual Gamepad {index}"))
         try:
             for config in HardwareManager().list_hardware():
                 if KeySelectorDialog._is_hardware_gamepad(self, config):
-                    choices.append((config.hardware_id, config.hardware_id))
+                    choices.append(
+                        (
+                            config.hardware_id,
+                            KeySelectorDialog._hardware_gamepad_output_label(self, config),
+                        )
+                    )
         except Exception:
             pass
         if self._selected_gamepad_output_id and all(

--- a/keymasq/gui/widgets/key_selector_dialog.py
+++ b/keymasq/gui/widgets/key_selector_dialog.py
@@ -15,6 +15,7 @@ from gi.repository import (  # pyright: ignore[reportAttributeAccessIssue]
 )
 
 from keymasq import __version__
+from keymasq.common.devices import is_gamepad_button_name
 from keymasq.common.models import (
     MIN_RAPIDFIRE_HOLD_MS,
     MIN_RAPIDFIRE_WAIT_MS,
@@ -25,6 +26,7 @@ from keymasq.common.models import (
     action_type_supports_rapidfire,
 )
 from keymasq.common.slurp import get_slurp_capture
+from keymasq.common.virtual_devices import virtual_gamepad_output_id
 from keymasq.gui.session_client import session_request_async
 from keymasq.gui.widgets.action_labels import describe_mapping_action_verbose
 from keymasq.gui.widgets.compositor_actions import (
@@ -47,7 +49,9 @@ from keymasq.gui.widgets.input_picker_shared import (
     build_navigation_tab as build_shared_navigation_tab,
 )
 from keymasq.session.compositor import detect_compositor_sync
+from keymasq.session.hardware import HardwareManager
 from keymasq.session.superkeys import SuperkeyManager
+from keymasq.session.virtual_devices import load_virtual_gamepad_count
 
 log = logging.getLogger("keymasq.gui.widgets.key_selector_dialog")
 
@@ -377,6 +381,13 @@ class KeySelectorDialog(Adw.Dialog):
         self._profile_entries: list[dict] = []
         self._selected_profile_action: str = "toggle"
         self._selected_profile_name: str = ""
+        self._selected_gamepad_output_id: str | None = (
+            current_action.output_id
+            if current_action and current_action.action_type == ActionType.GAMEPAD
+            else None
+        )
+        self._gamepad_output_ids: list[str | None] = []
+        self._gamepad_output_dropdown: Gtk.DropDown | None = None
         self._profile_name_items: list[str] = []
         self._exec_cmd: str = ""
         self._mouse_move_x: int = 0
@@ -891,7 +902,80 @@ class KeySelectorDialog(Adw.Dialog):
         return box
 
     def _build_gamepad_tab(self) -> Gtk.Widget:
-        return build_shared_gamepad_tab(self)
+        choices = self._gamepad_output_choices()
+        concrete_count = sum(1 for output_id, _label in choices if output_id is not None)
+        if concrete_count <= 1 and not self._selected_gamepad_output_id:
+            return build_shared_gamepad_tab(self)
+
+        outer = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=8)
+        outer.set_margin_top(8)
+        row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=8)
+        row.set_margin_start(12)
+        row.set_margin_end(12)
+        label = Gtk.Label(label="Output")
+        label.set_xalign(0)
+        label.set_hexpand(True)
+        self._gamepad_output_ids = [output_id for output_id, _label in choices]
+        dropdown = Gtk.DropDown.new_from_strings([label for _output_id, label in choices])
+        selected = 0
+        for index, output_id in enumerate(self._gamepad_output_ids):
+            if output_id == self._selected_gamepad_output_id:
+                selected = index
+                break
+        dropdown.set_selected(selected)
+        dropdown.connect("notify::selected", self._on_gamepad_output_selected)
+        self._gamepad_output_dropdown = dropdown
+        row.append(label)
+        row.append(dropdown)
+        outer.append(row)
+        outer.append(build_shared_gamepad_tab(self))
+        return outer
+
+    def _gamepad_output_choices(self) -> list[tuple[str | None, str]]:
+        choices: list[tuple[str | None, str]] = [(None, "Default")]
+        try:
+            count = load_virtual_gamepad_count()
+        except Exception:
+            count = 1
+        for index in range(1, count + 1):
+            output_id = virtual_gamepad_output_id(index)
+            label = "Virtual Gamepad 1" if index == 1 else f"Virtual Gamepad {index}"
+            choices.append((output_id, label))
+
+        try:
+            hardware = HardwareManager()
+            for config in hardware.list_hardware():
+                if self._is_hardware_gamepad(config):
+                    choices.append((config.hardware_id, config.hardware_id))
+        except Exception:
+            pass
+
+        if self._selected_gamepad_output_id and all(
+            output_id != self._selected_gamepad_output_id for output_id, _label in choices
+        ):
+            choices.append(
+                (
+                    self._selected_gamepad_output_id,
+                    f"{self._selected_gamepad_output_id} (unknown)",
+                )
+            )
+        return choices
+
+    def _is_hardware_gamepad(self, config: object) -> bool:
+        evdev_devices = getattr(config, "evdev_devices", []) or []
+        for device in evdev_devices:
+            device_type = getattr(device, "device_type", None)
+            if getattr(device_type, "value", device_type) == "gamepad":
+                return True
+        return any(
+            is_gamepad_button_name(getattr(button, "evdev", None))
+            for button in getattr(config, "buttons", []) or []
+        )
+
+    def _on_gamepad_output_selected(self, dropdown: Gtk.DropDown, _param) -> None:
+        selected = int(dropdown.get_selected())
+        if 0 <= selected < len(self._gamepad_output_ids):
+            self._selected_gamepad_output_id = self._gamepad_output_ids[selected]
 
     def _build_options_box(self) -> Gtk.Widget:
         box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=8)
@@ -1300,6 +1384,7 @@ class KeySelectorDialog(Adw.Dialog):
         action = MappingAction(
             action_type=ActionType.GAMEPAD,
             target=evdev_name,
+            output_id=self._selected_gamepad_output_id,
             rapidfire_enabled=self._rapidfire_enabled,
             rapidfire_hold_ms=int(self.hold_spin.get_value()),
             rapidfire_wait_ms=int(self.wait_spin.get_value()),
@@ -1887,6 +1972,12 @@ class SuperkeyActionDialog(Adw.Dialog):
         self._rapidfire_wait = 20
         self._superkey_macro_list: list[dict] = []
         self._superkey_selected_macro: str | None = None
+        self._selected_gamepad_output_id: str | None = (
+            current_action.output_id
+            if current_action and current_action.action_type == ActionType.GAMEPAD
+            else None
+        )
+        self._gamepad_output_ids: list[str | None] = []
 
         if current_action:
             self._rapidfire_enabled = current_action.rapidfire_enabled
@@ -2273,6 +2364,7 @@ class SuperkeyActionDialog(Adw.Dialog):
         action = SuperkeyAction(
             action_type=ActionType.GAMEPAD,
             target=evdev_name,
+            output_id=self._selected_gamepad_output_id,
             rapidfire_enabled=self._rapidfire_enabled if self.rapidfire_check else False,
             rapidfire_hold_ms=int(self.hold_spin.get_value()) if self.rapidfire_check else 20,
             rapidfire_wait_ms=int(self.wait_spin.get_value()) if self.rapidfire_check else 20,
@@ -2329,7 +2421,64 @@ class SuperkeyActionDialog(Adw.Dialog):
         return build_shared_mouse_tab(self)
 
     def _build_gamepad_tab(self) -> Gtk.Widget:
-        return build_shared_gamepad_tab(self)
+        choices = self._gamepad_output_choices()
+        concrete_count = sum(1 for output_id, _label in choices if output_id is not None)
+        if concrete_count <= 1 and not self._selected_gamepad_output_id:
+            return build_shared_gamepad_tab(self)
+        outer = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=8)
+        outer.set_margin_top(8)
+        row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=8)
+        row.set_margin_start(12)
+        row.set_margin_end(12)
+        label = Gtk.Label(label="Output")
+        label.set_xalign(0)
+        label.set_hexpand(True)
+        self._gamepad_output_ids = [output_id for output_id, _label in choices]
+        dropdown = Gtk.DropDown.new_from_strings([label for _output_id, label in choices])
+        selected = 0
+        for index, output_id in enumerate(self._gamepad_output_ids):
+            if output_id == self._selected_gamepad_output_id:
+                selected = index
+                break
+        dropdown.set_selected(selected)
+        dropdown.connect("notify::selected", self._on_gamepad_output_selected)
+        row.append(label)
+        row.append(dropdown)
+        outer.append(row)
+        outer.append(build_shared_gamepad_tab(self))
+        return outer
+
+    def _gamepad_output_choices(self) -> list[tuple[str | None, str]]:
+        choices: list[tuple[str | None, str]] = [(None, "Default")]
+        try:
+            count = load_virtual_gamepad_count()
+        except Exception:
+            count = 1
+        for index in range(1, count + 1):
+            output_id = virtual_gamepad_output_id(index)
+            label = "Virtual Gamepad 1" if index == 1 else f"Virtual Gamepad {index}"
+            choices.append((output_id, label))
+        try:
+            for config in HardwareManager().list_hardware():
+                if KeySelectorDialog._is_hardware_gamepad(self, config):
+                    choices.append((config.hardware_id, config.hardware_id))
+        except Exception:
+            pass
+        if self._selected_gamepad_output_id and all(
+            output_id != self._selected_gamepad_output_id for output_id, _label in choices
+        ):
+            choices.append(
+                (
+                    self._selected_gamepad_output_id,
+                    f"{self._selected_gamepad_output_id} (unknown)",
+                )
+            )
+        return choices
+
+    def _on_gamepad_output_selected(self, dropdown: Gtk.DropDown, _param) -> None:
+        selected = int(dropdown.get_selected())
+        if 0 <= selected < len(self._gamepad_output_ids):
+            self._selected_gamepad_output_id = self._gamepad_output_ids[selected]
 
     def _on_f_key_selected(self, btn):
         idx = self.f_dropdown.get_selected()

--- a/keymasq/gui/widgets/key_selector_dialog.py
+++ b/keymasq/gui/widgets/key_selector_dialog.py
@@ -1,4 +1,5 @@
 import logging
+from collections.abc import Sequence
 
 import evdev
 import gi
@@ -92,6 +93,60 @@ def _format_current_virtual_output_choice(output_id: str) -> str:
     if is_virtual_gamepad_output_id(output_id):
         return f"{output_id} (unavailable)"
     return f"{output_id} (unknown)"
+
+
+def _is_hardware_gamepad(config: object) -> bool:
+    evdev_devices = getattr(config, "evdev_devices", []) or []
+    for device in evdev_devices:
+        device_type = getattr(device, "device_type", None)
+        if getattr(device_type, "value", device_type) == "gamepad":
+            return True
+    return any(
+        is_gamepad_button_name(getattr(button, "evdev", None))
+        for button in getattr(config, "buttons", []) or []
+    )
+
+
+def _hardware_gamepad_output_label(config: object) -> str:
+    hardware_id = str(getattr(config, "hardware_id", "") or "")
+    name = str(getattr(config, "name", "") or "").strip()
+    if name and hardware_id:
+        return f"{name} ({hardware_id})"
+    return name or hardware_id
+
+
+def _gamepad_output_choice_matches(choice_id: str | None, selected_id: str | None) -> bool:
+    if choice_id == selected_id:
+        return True
+    return choice_id is None and selected_id == "virtual-gamepad-1"
+
+
+def _gamepad_output_choices_for(
+    selected_id: str | None,
+    count: int,
+    hardware_configs: Sequence[object],
+) -> list[tuple[str | None, str]]:
+    default_label = "Virtual Gamepad 1" if count > 0 else "Default output unavailable"
+    choices: list[tuple[str | None, str]] = [(None, default_label)]
+    for index in range(2, count + 1):
+        output_id = virtual_gamepad_output_id(index)
+        choices.append((output_id, f"Virtual Gamepad {index}"))
+
+    for config in hardware_configs:
+        if _is_hardware_gamepad(config):
+            choices.append(
+                (
+                    str(getattr(config, "hardware_id", "") or ""),
+                    _hardware_gamepad_output_label(config),
+                )
+            )
+
+    if selected_id and all(
+        not _gamepad_output_choice_matches(output_id, selected_id)
+        for output_id, _label in choices
+    ):
+        choices.append((selected_id, _format_current_virtual_output_choice(selected_id)))
+    return choices
 
 
 KEYBOARD_LAYOUT = [
@@ -981,7 +1036,7 @@ class KeySelectorDialog(Adw.Dialog):
         dropdown.set_valign(Gtk.Align.CENTER)
         selected = 0
         for index, output_id in enumerate(self._gamepad_output_ids):
-            if output_id == self._selected_gamepad_output_id:
+            if _gamepad_output_choice_matches(output_id, self._selected_gamepad_output_id):
                 selected = index
                 break
         dropdown.set_selected(selected)
@@ -994,53 +1049,15 @@ class KeySelectorDialog(Adw.Dialog):
 
     def _gamepad_output_choices(self) -> list[tuple[str | None, str]]:
         count = _virtual_gamepad_count()
-        default_label = "Virtual Gamepad 1" if count > 0 else "Default output unavailable"
-        choices: list[tuple[str | None, str]] = [(None, default_label)]
-        for index in range(2, count + 1):
-            output_id = virtual_gamepad_output_id(index)
-            choices.append((output_id, f"Virtual Gamepad {index}"))
-
         try:
-            hardware = HardwareManager()
-            for config in hardware.list_hardware():
-                if self._is_hardware_gamepad(config):
-                    choices.append(
-                        (
-                            config.hardware_id,
-                            self._hardware_gamepad_output_label(config),
-                        )
-                    )
+            hardware_configs = list(HardwareManager().list_hardware())
         except Exception:
-            pass
-
-        if self._selected_gamepad_output_id and all(
-            output_id != self._selected_gamepad_output_id for output_id, _label in choices
-        ):
-            choices.append(
-                (
-                    self._selected_gamepad_output_id,
-                    _format_current_virtual_output_choice(self._selected_gamepad_output_id),
-                )
-            )
-        return choices
-
-    def _is_hardware_gamepad(self, config: object) -> bool:
-        evdev_devices = getattr(config, "evdev_devices", []) or []
-        for device in evdev_devices:
-            device_type = getattr(device, "device_type", None)
-            if getattr(device_type, "value", device_type) == "gamepad":
-                return True
-        return any(
-            is_gamepad_button_name(getattr(button, "evdev", None))
-            for button in getattr(config, "buttons", []) or []
+            hardware_configs = []
+        return _gamepad_output_choices_for(
+            self._selected_gamepad_output_id,
+            count,
+            hardware_configs,
         )
-
-    def _hardware_gamepad_output_label(self, config: object) -> str:
-        hardware_id = str(getattr(config, "hardware_id", "") or "")
-        name = str(getattr(config, "name", "") or "").strip()
-        if name and hardware_id:
-            return f"{name} ({hardware_id})"
-        return name or hardware_id
 
     def _on_gamepad_output_selected(self, dropdown: Gtk.DropDown, _param) -> None:
         selected = int(dropdown.get_selected())
@@ -2521,7 +2538,7 @@ class SuperkeyActionDialog(Adw.Dialog):
             dropdown = Gtk.DropDown.new_from_strings([label for _output_id, label in choices])
             selected = 0
             for index, output_id in enumerate(self._gamepad_output_ids):
-                if output_id == self._selected_gamepad_output_id:
+                if _gamepad_output_choice_matches(output_id, self._selected_gamepad_output_id):
                     selected = index
                     break
             dropdown.set_selected(selected)
@@ -2544,32 +2561,15 @@ class SuperkeyActionDialog(Adw.Dialog):
 
     def _gamepad_output_choices(self) -> list[tuple[str | None, str]]:
         count = _virtual_gamepad_count()
-        default_label = "Virtual Gamepad 1" if count > 0 else "Default output unavailable"
-        choices: list[tuple[str | None, str]] = [(None, default_label)]
-        for index in range(2, count + 1):
-            output_id = virtual_gamepad_output_id(index)
-            choices.append((output_id, f"Virtual Gamepad {index}"))
         try:
-            for config in HardwareManager().list_hardware():
-                if KeySelectorDialog._is_hardware_gamepad(self, config):
-                    choices.append(
-                        (
-                            config.hardware_id,
-                            KeySelectorDialog._hardware_gamepad_output_label(self, config),
-                        )
-                    )
+            hardware_configs = list(HardwareManager().list_hardware())
         except Exception:
-            pass
-        if self._selected_gamepad_output_id and all(
-            output_id != self._selected_gamepad_output_id for output_id, _label in choices
-        ):
-            choices.append(
-                (
-                    self._selected_gamepad_output_id,
-                    _format_current_virtual_output_choice(self._selected_gamepad_output_id),
-                )
-            )
-        return choices
+            hardware_configs = []
+        return _gamepad_output_choices_for(
+            self._selected_gamepad_output_id,
+            count,
+            hardware_configs,
+        )
 
     def _on_gamepad_output_selected(self, dropdown: Gtk.DropDown, _param) -> None:
         selected = int(dropdown.get_selected())

--- a/keymasq/gui/widgets/key_selector_dialog.py
+++ b/keymasq/gui/widgets/key_selector_dialog.py
@@ -388,6 +388,7 @@ class KeySelectorDialog(Adw.Dialog):
         )
         self._gamepad_output_ids: list[str | None] = []
         self._gamepad_output_dropdown: Gtk.DropDown | None = None
+        self._gamepad_output_header: Gtk.Widget | None = None
         self._profile_name_items: list[str] = []
         self._exec_cmd: str = ""
         self._mouse_move_x: int = 0
@@ -482,12 +483,21 @@ class KeySelectorDialog(Adw.Dialog):
 
         inner = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=0)
 
+        title_row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=8)
+        title_row.set_halign(Gtk.Align.CENTER)
+        title_row.set_margin_top(12)
+        title_row.set_margin_bottom(6)
+
         title_label = Gtk.Label(label=f"Map: {self._button_label}")
         title_label.add_css_class("title-3")
         title_label.set_halign(Gtk.Align.CENTER)
-        title_label.set_margin_top(12)
-        title_label.set_margin_bottom(6)
-        inner.append(title_label)
+        title_row.append(title_label)
+
+        self._gamepad_output_header = self._build_gamepad_output_header()
+        if self._gamepad_output_header is not None:
+            title_row.append(self._gamepad_output_header)
+
+        inner.append(title_row)
 
         if self._current_action:
             current_label = Gtk.Label(label=self._describe_current_action())
@@ -496,7 +506,7 @@ class KeySelectorDialog(Adw.Dialog):
             current_label.set_margin_bottom(10)
             inner.append(current_label)
         else:
-            title_label.set_margin_bottom(12)
+            title_row.set_margin_bottom(12)
 
         inner.append(Gtk.Separator())
 
@@ -902,21 +912,21 @@ class KeySelectorDialog(Adw.Dialog):
         return box
 
     def _build_gamepad_tab(self) -> Gtk.Widget:
+        return build_shared_gamepad_tab(self)
+
+    def _build_gamepad_output_header(self) -> Gtk.Widget | None:
         choices = self._gamepad_output_choices()
         concrete_count = sum(1 for output_id, _label in choices if output_id is not None)
         if concrete_count <= 1 and not self._selected_gamepad_output_id:
-            return build_shared_gamepad_tab(self)
+            return None
 
-        outer = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=8)
-        outer.set_margin_top(8)
-        row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=8)
-        row.set_margin_start(12)
-        row.set_margin_end(12)
-        label = Gtk.Label(label="Output")
-        label.set_xalign(0)
-        label.set_hexpand(True)
+        box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=8)
+        box.set_valign(Gtk.Align.CENTER)
+        arrow = Gtk.Label(label="→")
+        arrow.add_css_class("dim-label")
         self._gamepad_output_ids = [output_id for output_id, _label in choices]
         dropdown = Gtk.DropDown.new_from_strings([label for _output_id, label in choices])
+        dropdown.set_valign(Gtk.Align.CENTER)
         selected = 0
         for index, output_id in enumerate(self._gamepad_output_ids):
             if output_id == self._selected_gamepad_output_id:
@@ -925,11 +935,10 @@ class KeySelectorDialog(Adw.Dialog):
         dropdown.set_selected(selected)
         dropdown.connect("notify::selected", self._on_gamepad_output_selected)
         self._gamepad_output_dropdown = dropdown
-        row.append(label)
-        row.append(dropdown)
-        outer.append(row)
-        outer.append(build_shared_gamepad_tab(self))
-        return outer
+        box.append(arrow)
+        box.append(dropdown)
+        box.set_visible(False)
+        return box
 
     def _gamepad_output_choices(self) -> list[tuple[str | None, str]]:
         choices: list[tuple[str | None, str]] = [(None, "Default")]
@@ -1098,6 +1107,7 @@ class KeySelectorDialog(Adw.Dialog):
         is_macro = child_name == "macro"
         is_profile = child_name == "profile"
         is_exec = child_name == "exec"
+        is_gamepad = child_name == "gamepad"
         is_compositor_action = child_name in self._compositor_action_page_ids
         has_options = self._allow_rapidfire or self._allow_tap
         options_enabled = (
@@ -1126,6 +1136,8 @@ class KeySelectorDialog(Adw.Dialog):
             self.map_btn.set_sensitive(bool(self._selected_profile_name))
         else:
             self.map_btn.set_sensitive(False)
+        if self._gamepad_output_header is not None:
+            self._gamepad_output_header.set_visible(is_gamepad)
         self._update_actions_docs_button()
 
     def _active_actions_docs_link(self) -> tuple[str, str] | None:

--- a/keymasq/gui/widgets/key_selector_dialog.py
+++ b/keymasq/gui/widgets/key_selector_dialog.py
@@ -26,7 +26,7 @@ from keymasq.common.models import (
     action_type_supports_rapidfire,
 )
 from keymasq.common.slurp import get_slurp_capture
-from keymasq.common.virtual_devices import virtual_gamepad_output_id
+from keymasq.common.virtual_devices import is_virtual_gamepad_output_id, virtual_gamepad_output_id
 from keymasq.gui.session_client import session_request_async
 from keymasq.gui.widgets.action_labels import describe_mapping_action_verbose
 from keymasq.gui.widgets.compositor_actions import (
@@ -54,6 +54,45 @@ from keymasq.session.superkeys import SuperkeyManager
 from keymasq.session.virtual_devices import load_virtual_gamepad_count
 
 log = logging.getLogger("keymasq.gui.widgets.key_selector_dialog")
+
+
+def _virtual_gamepad_count() -> int:
+    try:
+        return max(0, int(load_virtual_gamepad_count()))
+    except Exception:
+        return 1
+
+
+def _virtual_gamepad_index(output_id: str | None) -> int | None:
+    if output_id is None:
+        return 1
+    if not is_virtual_gamepad_output_id(output_id):
+        return None
+    try:
+        return int(output_id.removeprefix("virtual-gamepad-"))
+    except ValueError:
+        return None
+
+
+def _gamepad_output_unavailable_message(output_id: str | None, count: int) -> str | None:
+    index = _virtual_gamepad_index(output_id)
+    if index is None:
+        return None
+    if index <= count:
+        return None
+    if output_id is None:
+        return "No virtual gamepads are configured."
+    return (
+        f"{output_id} is not configured. This mapping will be saved, but output will be "
+        "dropped until that virtual gamepad is enabled."
+    )
+
+
+def _format_current_virtual_output_choice(output_id: str) -> str:
+    if is_virtual_gamepad_output_id(output_id):
+        return f"{output_id} (unavailable)"
+    return f"{output_id} (unknown)"
+
 
 KEYBOARD_LAYOUT = [
     ["Esc", "F1", "F2", "F3", "F4", "F5", "F6", "F7", "F8", "F9", "F10", "F11", "F12"],
@@ -389,6 +428,7 @@ class KeySelectorDialog(Adw.Dialog):
         self._gamepad_output_ids: list[str | None] = []
         self._gamepad_output_dropdown: Gtk.DropDown | None = None
         self._gamepad_output_header: Gtk.Widget | None = None
+        self._gamepad_output_warning_label: Gtk.Label | None = None
         self._profile_name_items: list[str] = []
         self._exec_cmd: str = ""
         self._mouse_move_x: int = 0
@@ -912,7 +952,20 @@ class KeySelectorDialog(Adw.Dialog):
         return box
 
     def _build_gamepad_tab(self) -> Gtk.Widget:
-        return build_shared_gamepad_tab(self)
+        box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=8)
+        warning = Gtk.Label(label="")
+        warning.set_margin_top(8)
+        warning.set_margin_start(12)
+        warning.set_margin_end(12)
+        warning.set_wrap(True)
+        warning.set_xalign(0)
+        warning.add_css_class("dim-label")
+        warning.add_css_class("warning")
+        self._gamepad_output_warning_label = warning
+        box.append(warning)
+        box.append(build_shared_gamepad_tab(self))
+        self._update_gamepad_output_warning()
+        return box
 
     def _build_gamepad_output_header(self) -> Gtk.Widget | None:
         choices = self._gamepad_output_choices()
@@ -940,11 +993,9 @@ class KeySelectorDialog(Adw.Dialog):
         return box
 
     def _gamepad_output_choices(self) -> list[tuple[str | None, str]]:
-        try:
-            count = load_virtual_gamepad_count()
-        except Exception:
-            count = 1
-        choices: list[tuple[str | None, str]] = [(None, "Virtual Gamepad 1")]
+        count = _virtual_gamepad_count()
+        default_label = "Virtual Gamepad 1" if count > 0 else "Default output unavailable"
+        choices: list[tuple[str | None, str]] = [(None, default_label)]
         for index in range(2, count + 1):
             output_id = virtual_gamepad_output_id(index)
             choices.append((output_id, f"Virtual Gamepad {index}"))
@@ -968,7 +1019,7 @@ class KeySelectorDialog(Adw.Dialog):
             choices.append(
                 (
                     self._selected_gamepad_output_id,
-                    f"{self._selected_gamepad_output_id} (unknown)",
+                    _format_current_virtual_output_choice(self._selected_gamepad_output_id),
                 )
             )
         return choices
@@ -995,6 +1046,18 @@ class KeySelectorDialog(Adw.Dialog):
         selected = int(dropdown.get_selected())
         if 0 <= selected < len(self._gamepad_output_ids):
             self._selected_gamepad_output_id = self._gamepad_output_ids[selected]
+        self._update_gamepad_output_warning()
+
+    def _update_gamepad_output_warning(self) -> None:
+        label = self._gamepad_output_warning_label
+        if label is None:
+            return
+        message = _gamepad_output_unavailable_message(
+            self._selected_gamepad_output_id,
+            _virtual_gamepad_count(),
+        )
+        label.set_label(message or "")
+        label.set_visible(bool(message))
 
     def _build_options_box(self) -> Gtk.Widget:
         box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=8)
@@ -2000,6 +2063,7 @@ class SuperkeyActionDialog(Adw.Dialog):
             else None
         )
         self._gamepad_output_ids: list[str | None] = []
+        self._gamepad_output_warning_label: Gtk.Label | None = None
 
         if current_action:
             self._rapidfire_enabled = current_action.rapidfire_enabled
@@ -2444,37 +2508,44 @@ class SuperkeyActionDialog(Adw.Dialog):
 
     def _build_gamepad_tab(self) -> Gtk.Widget:
         choices = self._gamepad_output_choices()
-        if len(choices) <= 1 and not self._selected_gamepad_output_id:
-            return build_shared_gamepad_tab(self)
         outer = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=8)
         outer.set_margin_top(8)
-        row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=8)
-        row.set_margin_start(12)
-        row.set_margin_end(12)
-        label = Gtk.Label(label="Output")
-        label.set_xalign(0)
-        label.set_hexpand(True)
-        self._gamepad_output_ids = [output_id for output_id, _label in choices]
-        dropdown = Gtk.DropDown.new_from_strings([label for _output_id, label in choices])
-        selected = 0
-        for index, output_id in enumerate(self._gamepad_output_ids):
-            if output_id == self._selected_gamepad_output_id:
-                selected = index
-                break
-        dropdown.set_selected(selected)
-        dropdown.connect("notify::selected", self._on_gamepad_output_selected)
-        row.append(label)
-        row.append(dropdown)
-        outer.append(row)
+        if len(choices) > 1 or self._selected_gamepad_output_id:
+            row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=8)
+            row.set_margin_start(12)
+            row.set_margin_end(12)
+            label = Gtk.Label(label="Output")
+            label.set_xalign(0)
+            label.set_hexpand(True)
+            self._gamepad_output_ids = [output_id for output_id, _label in choices]
+            dropdown = Gtk.DropDown.new_from_strings([label for _output_id, label in choices])
+            selected = 0
+            for index, output_id in enumerate(self._gamepad_output_ids):
+                if output_id == self._selected_gamepad_output_id:
+                    selected = index
+                    break
+            dropdown.set_selected(selected)
+            dropdown.connect("notify::selected", self._on_gamepad_output_selected)
+            row.append(label)
+            row.append(dropdown)
+            outer.append(row)
+        warning = Gtk.Label(label="")
+        warning.set_margin_start(12)
+        warning.set_margin_end(12)
+        warning.set_wrap(True)
+        warning.set_xalign(0)
+        warning.add_css_class("dim-label")
+        warning.add_css_class("warning")
+        self._gamepad_output_warning_label = warning
+        outer.append(warning)
         outer.append(build_shared_gamepad_tab(self))
+        self._update_gamepad_output_warning()
         return outer
 
     def _gamepad_output_choices(self) -> list[tuple[str | None, str]]:
-        try:
-            count = load_virtual_gamepad_count()
-        except Exception:
-            count = 1
-        choices: list[tuple[str | None, str]] = [(None, "Virtual Gamepad 1")]
+        count = _virtual_gamepad_count()
+        default_label = "Virtual Gamepad 1" if count > 0 else "Default output unavailable"
+        choices: list[tuple[str | None, str]] = [(None, default_label)]
         for index in range(2, count + 1):
             output_id = virtual_gamepad_output_id(index)
             choices.append((output_id, f"Virtual Gamepad {index}"))
@@ -2495,7 +2566,7 @@ class SuperkeyActionDialog(Adw.Dialog):
             choices.append(
                 (
                     self._selected_gamepad_output_id,
-                    f"{self._selected_gamepad_output_id} (unknown)",
+                    _format_current_virtual_output_choice(self._selected_gamepad_output_id),
                 )
             )
         return choices
@@ -2504,6 +2575,18 @@ class SuperkeyActionDialog(Adw.Dialog):
         selected = int(dropdown.get_selected())
         if 0 <= selected < len(self._gamepad_output_ids):
             self._selected_gamepad_output_id = self._gamepad_output_ids[selected]
+        self._update_gamepad_output_warning()
+
+    def _update_gamepad_output_warning(self) -> None:
+        label = self._gamepad_output_warning_label
+        if label is None:
+            return
+        message = _gamepad_output_unavailable_message(
+            self._selected_gamepad_output_id,
+            _virtual_gamepad_count(),
+        )
+        label.set_label(message or "")
+        label.set_visible(bool(message))
 
     def _on_f_key_selected(self, btn):
         idx = self.f_dropdown.get_selected()

--- a/keymasq/gui/widgets/macro_editor_dialog.py
+++ b/keymasq/gui/widgets/macro_editor_dialog.py
@@ -68,6 +68,8 @@ def _passthrough_track(ev: MacroEvent) -> str:
             return "keyboard"
         if device_type == "mouse":
             return "mouse"
+        if device_type == "gamepad":
+            return "gamepad"
     return "movement"
 
 
@@ -152,11 +154,12 @@ def _set_entry_text_if_needed(entry: Gtk.Entry, text: str) -> None:
 
 @dataclass
 class EditableEvent:
-    device_type: str  # "keyboard" or "mouse"
+    device_type: str  # "keyboard", "mouse", or "gamepad"
     ev_type: int  # evdev EV_KEY (1)
     code: int  # e.g. 30=KEY_A, 272=BTN_LEFT
     press_t_us: int  # microseconds from macro start (press)
     release_t_us: int  # microseconds from macro start (release)
+    output_id: str | None = None
 
 
 @dataclass
@@ -228,7 +231,7 @@ def parse_events(
     passthrough_events: list[MacroEvent] = []
     editable_moves: list[EditableMove] = []
     control_events: list[EditableControl] = []
-    open_presses: dict[tuple, list[int]] = {}  # (device_type, code) -> press_t_us stack
+    open_presses: dict[tuple, list[int]] = {}
 
     for ev in raw_events:
         macro_action = str(ev.get("macro_action", "") or "")
@@ -261,7 +264,8 @@ def parse_events(
             continue
 
         if ev["type"] == ev_key:
-            key = (ev["device_type"], ev["code"])
+            output_id = str(ev.get("output_id", "") or "").strip() or None
+            key = (ev["device_type"], ev["code"], output_id)
             if ev["value"] == 1:
                 open_presses.setdefault(key, []).append(ev["t_us"])
             elif ev["value"] == 0:
@@ -275,6 +279,7 @@ def parse_events(
                             code=ev["code"],
                             press_t_us=press_t,
                             release_t_us=ev["t_us"],
+                            output_id=output_id if ev["device_type"] == "gamepad" else None,
                         )
                     )
                 else:
@@ -286,17 +291,18 @@ def parse_events(
         else:
             passthrough_events.append(ev)
 
-    for (device_type, code), presses in open_presses.items():
+    for (device_type, code, output_id), presses in open_presses.items():
         for press_t in presses:
-            passthrough_events.append(
-                {
-                    "device_type": device_type,
-                    "type": ev_key,
-                    "code": code,
-                    "value": 1,
-                    "t_us": press_t,
-                }
-            )
+            event = {
+                "device_type": device_type,
+                "type": ev_key,
+                "code": code,
+                "value": 1,
+                "t_us": press_t,
+            }
+            if device_type == "gamepad" and output_id:
+                event["output_id"] = output_id
+            passthrough_events.append(event)
 
     editable.sort(key=lambda e: e.press_t_us)
     editable_moves.sort(key=lambda m: m.t_us)
@@ -317,24 +323,25 @@ def reconstruct_events(
     raw: list[MacroEvent] = []
 
     for ev in editable:
-        raw.append(
-            {
-                "device_type": ev.device_type,
-                "type": ev_key,
-                "code": ev.code,
-                "value": 1,
-                "t_us": ev.press_t_us,
-            }
-        )
-        raw.append(
-            {
-                "device_type": ev.device_type,
-                "type": ev_key,
-                "code": ev.code,
-                "value": 0,
-                "t_us": ev.release_t_us,
-            }
-        )
+        press_event = {
+            "device_type": ev.device_type,
+            "type": ev_key,
+            "code": ev.code,
+            "value": 1,
+            "t_us": ev.press_t_us,
+        }
+        release_event = {
+            "device_type": ev.device_type,
+            "type": ev_key,
+            "code": ev.code,
+            "value": 0,
+            "t_us": ev.release_t_us,
+        }
+        if ev.device_type == "gamepad" and ev.output_id:
+            press_event["output_id"] = ev.output_id
+            release_event["output_id"] = ev.output_id
+        raw.append(press_event)
+        raw.append(release_event)
 
     raw.extend(rel_events)
 
@@ -441,9 +448,10 @@ def _compute_macro_editor_dialog_size(parent: Gtk.Window) -> tuple[int, int]:
 
 class TimelineWidget(Gtk.DrawingArea):
     """
-    Custom Gtk.DrawingArea that renders the macro timeline with three tracks:
+    Custom Gtk.DrawingArea that renders the macro timeline with four tracks:
       K  — keyboard key press/release rectangles
       M  — mouse click press/release rectangles
+      G  — gamepad button press/release rectangles
       ≈  — mouse movement waveform (read-only, from EV_REL events)
 
     The left 28px column is used for track labels and scrolls with the content.
@@ -470,8 +478,10 @@ class TimelineWidget(Gtk.DrawingArea):
         # Lane assignment — recomputed before each draw
         self._kb_lanes: dict[int, int] = {}  # id(ev) -> lane index
         self._m_lanes: dict[int, int] = {}
+        self._g_lanes: dict[int, int] = {}
         self._kb_num_lanes: int = 1
         self._m_num_lanes: int = 1
+        self._g_num_lanes: int = 1
 
         # Drag state
         self._drag_event: EditableEvent | None = None
@@ -538,6 +548,10 @@ class TimelineWidget(Gtk.DrawingArea):
         return self._get_track_h(self._m_num_lanes)
 
     @property
+    def _g_track_h(self) -> int:
+        return self._get_track_h(self._g_num_lanes)
+
+    @property
     def _kb_y(self) -> int:
         return self.RULER_HEIGHT
 
@@ -546,18 +560,29 @@ class TimelineWidget(Gtk.DrawingArea):
         return self.RULER_HEIGHT + self._kb_track_h
 
     @property
-    def _wave_y(self) -> int:
+    def _g_y(self) -> int:
         return self.RULER_HEIGHT + self._kb_track_h + self._m_track_h
 
     @property
+    def _wave_y(self) -> int:
+        return self.RULER_HEIGHT + self._kb_track_h + self._m_track_h + self._g_track_h
+
+    @property
     def _total_height(self) -> int:
-        return self.RULER_HEIGHT + self._kb_track_h + self._m_track_h + self.TRACK_HEIGHT
+        return (
+            self.RULER_HEIGHT
+            + self._kb_track_h
+            + self._m_track_h
+            + self._g_track_h
+            + self.TRACK_HEIGHT
+        )
 
     def _recompute_lanes(self) -> None:
         """Recompute lane assignments from current events and update size request."""
         events = self._editor._events
         self._kb_lanes, self._kb_num_lanes = _assign_lanes(events, "keyboard")
         self._m_lanes, self._m_num_lanes = _assign_lanes(events, "mouse")
+        self._g_lanes, self._g_num_lanes = _assign_lanes(events, "gamepad")
         self.set_size_request(-1, self._total_height)
 
     # ------------------------------------------------------------------
@@ -589,6 +614,7 @@ class TimelineWidget(Gtk.DrawingArea):
         self._draw_ruler(cr, width, duration_us)
         self._draw_keyboard_track(cr, width, events)
         self._draw_mouse_track(cr, width, events)
+        self._draw_gamepad_track(cr, width, events)
         self._draw_movement_track(cr, width, rel_events)
         self._draw_passthrough_markers(cr, width)
         self._draw_synthetic_move_markers(cr, width)
@@ -599,7 +625,7 @@ class TimelineWidget(Gtk.DrawingArea):
         # Horizontal separator lines between tracks
         cr.set_source_rgba(0.30, 0.30, 0.30, 0.8)
         cr.set_line_width(1)
-        for y in [self._kb_y, self._m_y, self._wave_y]:
+        for y in [self._kb_y, self._m_y, self._g_y, self._wave_y]:
             cr.move_to(0, y + 0.5)
             cr.line_to(width, y + 0.5)
             cr.stroke()
@@ -799,6 +825,23 @@ class TimelineWidget(Gtk.DrawingArea):
             sel_border_rgba=(1.00, 0.85, 0.40, 1.0),
         )
 
+    def _draw_gamepad_track(self, cr, width: int, events: list) -> None:
+        self._draw_track_with_lanes(
+            cr,
+            width,
+            events,
+            device_type="gamepad",
+            y_top=self._g_y,
+            track_h=self._g_track_h,
+            num_lanes=self._g_num_lanes,
+            lanes_dict=self._g_lanes,
+            bg_rgb=(0.10, 0.14, 0.15),
+            fill_rgba=(0.10, 0.66, 0.72, 0.75),
+            border_rgba=(0.28, 0.82, 0.86, 0.9),
+            sel_fill_rgba=(0.18, 0.85, 0.92, 0.92),
+            sel_border_rgba=(0.60, 1.00, 1.00, 1.0),
+        )
+
     def _draw_movement_track(self, cr, width: int, rel_events: list[MacroEvent]) -> None:
         y_top = self._wave_y
         track_h = self.TRACK_HEIGHT
@@ -848,6 +891,13 @@ class TimelineWidget(Gtk.DrawingArea):
             track="mouse",
             y_top=self._m_y,
             track_h=self._m_track_h,
+        )
+        self._draw_passthrough_markers_for_track(
+            cr,
+            width,
+            track="gamepad",
+            y_top=self._g_y,
+            track_h=self._g_track_h,
         )
         self._draw_passthrough_markers_for_track(
             cr,
@@ -944,6 +994,7 @@ class TimelineWidget(Gtk.DrawingArea):
         labels = [
             (self._kb_y + self._kb_track_h * 0.5, "K"),
             (self._m_y + self._m_track_h * 0.5, "M"),
+            (self._g_y + self._g_track_h * 0.5, "G"),
             (self._wave_y + self.TRACK_HEIGHT * 0.5, "≈"),
         ]
         for y_center, label in labels:
@@ -1096,13 +1147,15 @@ class TimelineWidget(Gtk.DrawingArea):
     # ------------------------------------------------------------------
 
     def _get_track_at_y(self, y: float) -> str | None:
-        """Return 'keyboard', 'mouse', 'movement', or None (ruler)."""
+        """Return 'keyboard', 'mouse', 'gamepad', 'movement', or None (ruler)."""
         if y < self.RULER_HEIGHT:
             return None
         if y < self._m_y:
             return "keyboard"
-        if y < self._wave_y:
+        if y < self._g_y:
             return "mouse"
+        if y < self._wave_y:
+            return "gamepad"
         if y < self._wave_y + self.TRACK_HEIGHT:
             return "movement"
         return None
@@ -1134,6 +1187,9 @@ class TimelineWidget(Gtk.DrawingArea):
         elif track == "mouse":
             y_top = self._m_y
             track_h = self._m_track_h
+        elif track == "gamepad":
+            y_top = self._g_y
+            track_h = self._g_track_h
         else:
             y_top = self._wave_y
             track_h = self.TRACK_HEIGHT
@@ -1168,6 +1224,12 @@ class TimelineWidget(Gtk.DrawingArea):
             track_h = self._m_track_h
             num_lanes = self._m_num_lanes
             lanes_dict = self._m_lanes
+        elif track == "gamepad":
+            device_type = "gamepad"
+            track_y = self._g_y
+            track_h = self._g_track_h
+            num_lanes = self._g_num_lanes
+            lanes_dict = self._g_lanes
         elif track == "movement":
             control = self._hit_test_control(x, y)
             if control is not None:
@@ -1347,6 +1409,17 @@ class TimelineWidget(Gtk.DrawingArea):
             add_btn.connect("clicked", _add_click)
             box.append(add_btn)
 
+        elif track == "gamepad":
+            add_btn = Gtk.Button(label=f"Add Gamepad Button at {t_label}")
+            add_btn.add_css_class("flat")
+
+            def _add_gamepad(_b, _t=t_us, _p=popover):
+                _p.popdown()
+                self._editor._present_add_key_dialog(default_t_us=_t)
+
+            add_btn.connect("clicked", _add_gamepad)
+            box.append(add_btn)
+
         elif track == "movement":
             add_rel_btn = Gtk.Button(label=f"Add Move REL at {t_label}")
             add_rel_btn.add_css_class("flat")
@@ -1376,7 +1449,7 @@ class TimelineWidget(Gtk.DrawingArea):
             add_abs_btn.connect("clicked", _add_abs)
             box.append(add_abs_btn)
 
-        if track in ("keyboard", "mouse", "movement"):
+        if track in ("keyboard", "mouse", "gamepad", "movement"):
             if box.get_first_child():
                 box.append(Gtk.Separator())
 
@@ -3150,7 +3223,7 @@ class MacroEditorDialog(Adw.Dialog):
 
         changed = False
 
-        if scope in ("all", "keyboard", "mouse"):
+        if scope in ("all", "keyboard", "mouse", "gamepad"):
             for ev in self._events:
                 if scope != "all" and ev.device_type != scope:
                     continue
@@ -3196,6 +3269,8 @@ class MacroEditorDialog(Adw.Dialog):
                 matches_scope = ev_type == evdev.ecodes.EV_KEY and device_type == "keyboard"
             elif scope == "mouse":
                 matches_scope = ev_type == evdev.ecodes.EV_KEY and device_type == "mouse"
+            elif scope == "gamepad":
+                matches_scope = ev_type == evdev.ecodes.EV_KEY and device_type == "gamepad"
             elif scope == "movement":
                 matches_scope = ev_type == evdev.ecodes.EV_REL and device_type == "mouse"
 
@@ -3348,7 +3423,8 @@ class MacroEditorDialog(Adw.Dialog):
         ev = selected_obj
         name = _get_key_name(ev.code)
         self._prop_title.set_label(name)
-        self._key_info_label.set_label(f"{name} (code {ev.code})")
+        output_suffix = f" @ {ev.output_id}" if ev.device_type == "gamepad" and ev.output_id else ""
+        self._key_info_label.set_label(f"{name} (code {ev.code}){output_suffix}")
         self._press_label.set_label("Press:")
         self._duration_text_label.set_visible(True)
         self._duration_spin.set_visible(True)
@@ -3489,10 +3565,16 @@ class MacroEditorDialog(Adw.Dialog):
                 action_type=ActionType.KEYBOARD,
                 target=key_name_lower,
             )
-        else:
+        elif ev.device_type == "mouse":
             current_action = MappingAction(
                 action_type=ActionType.MOUSE,
                 target=key_name_lower,
+            )
+        else:
+            current_action = MappingAction(
+                action_type=ActionType.GAMEPAD,
+                target=key_name_lower,
+                output_id=ev.output_id,
             )
 
         dialog = KeySelectorDialog(self._parent, _get_key_name(ev.code), current_action)
@@ -3513,11 +3595,19 @@ class MacroEditorDialog(Adw.Dialog):
             if code is not None:
                 ev.code = code
                 ev.device_type = "keyboard"
+                ev.output_id = None
         elif action.action_type == ActionType.MOUSE and target:
             code = getattr(evdev.ecodes, target.upper(), None)
             if code is not None:
                 ev.code = code
                 ev.device_type = "mouse"
+                ev.output_id = None
+        elif action.action_type == ActionType.GAMEPAD and target:
+            code = getattr(evdev.ecodes, target.upper(), None)
+            if code is not None:
+                ev.code = code
+                ev.device_type = "gamepad"
+                ev.output_id = getattr(action, "output_id", None)
         else:
             return
 
@@ -4059,7 +4149,7 @@ class MacroEditorDialog(Adw.Dialog):
     def _on_key_selected_for_insert(self, dialog: Gtk.Widget, action, default_t_us: int) -> None:
         from keymasq.common.models import ActionType
 
-        if action is None or action.action_type != ActionType.KEYBOARD:
+        if action is None or action.action_type not in {ActionType.KEYBOARD, ActionType.GAMEPAD}:
             return
 
         target = getattr(action, "target", None)
@@ -4071,11 +4161,14 @@ class MacroEditorDialog(Adw.Dialog):
             return
 
         ev = EditableEvent(
-            device_type="keyboard",
+            device_type="gamepad" if action.action_type == ActionType.GAMEPAD else "keyboard",
             ev_type=evdev.ecodes.EV_KEY,
             code=code,
             press_t_us=max(0, int(default_t_us)),
             release_t_us=max(1000, int(default_t_us) + 50000),
+            output_id=getattr(action, "output_id", None)
+            if action.action_type == ActionType.GAMEPAD
+            else None,
         )
         self._events.append(ev)
         self._events.sort(key=lambda item: item.press_t_us)

--- a/keymasq/gui/widgets/virtual_gamepads_dialog.py
+++ b/keymasq/gui/widgets/virtual_gamepads_dialog.py
@@ -1,0 +1,109 @@
+import gi
+
+gi.require_version("Gtk", "4.0")
+gi.require_version("Adw", "1")
+
+from gi.repository import (  # pyright: ignore[reportAttributeAccessIssue]
+    Adw,  # pyright: ignore[reportAttributeAccessIssue]
+    Gtk,  # pyright: ignore[reportAttributeAccessIssue]
+)
+
+from keymasq.common.virtual_devices import MAX_VIRTUAL_GAMEPADS, MIN_VIRTUAL_GAMEPADS
+from keymasq.gui.session_client import session_request_async
+from keymasq.session.virtual_devices import (
+    load_virtual_gamepad_count,
+    save_virtual_gamepad_count,
+)
+
+
+class VirtualGamepadsDialog(Adw.Dialog):
+    def __init__(self, parent: Gtk.Window | None = None) -> None:
+        super().__init__(title="Virtual Gamepads")
+        self.set_default_size(420, 220)
+        self._parent = parent
+
+        toolbar = Adw.ToolbarView()
+        header = Adw.HeaderBar()
+        toolbar.add_top_bar(header)
+
+        page = Adw.PreferencesPage()
+        group = Adw.PreferencesGroup()
+        page.add(group)
+
+        row = Adw.ActionRow(title="Virtual gamepads")
+        row.set_subtitle("Xbox 360 virtual controller outputs")
+        adjustment = Gtk.Adjustment(
+            value=load_virtual_gamepad_count(),
+            lower=MIN_VIRTUAL_GAMEPADS,
+            upper=MAX_VIRTUAL_GAMEPADS,
+            step_increment=1,
+            page_increment=1,
+            page_size=0,
+        )
+        self._spin = Gtk.SpinButton(adjustment=adjustment, climb_rate=1, digits=0)
+        self._spin.set_numeric(True)
+        self._spin.set_valign(Gtk.Align.CENTER)
+        row.add_suffix(self._spin)
+        group.add(row)
+
+        self._status = Gtk.Label(label="")
+        self._status.set_xalign(0)
+        self._status.add_css_class("dim-label")
+        group.add(self._status)
+
+        actions = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=6)
+        actions.set_halign(Gtk.Align.END)
+        actions.set_margin_top(12)
+        close_btn = Gtk.Button(label="Close")
+        close_btn.connect("clicked", self._on_close_clicked)
+        apply_btn = Gtk.Button(label="Apply")
+        apply_btn.add_css_class("suggested-action")
+        apply_btn.connect("clicked", self._on_apply_clicked)
+        actions.append(close_btn)
+        actions.append(apply_btn)
+        group.add(actions)
+
+        toolbar.set_content(page)
+        self.set_child(toolbar)
+        session_request_async(
+            {"command": "get_virtual_gamepads"},
+            self._on_loaded,
+            timeout=1.0,
+        )
+
+    def _count(self) -> int:
+        value = int(round(self._spin.get_value()))
+        return max(MIN_VIRTUAL_GAMEPADS, min(MAX_VIRTUAL_GAMEPADS, value))
+
+    def _on_close_clicked(self, _button: Gtk.Button) -> None:
+        self.close()
+
+    def _on_loaded(self, response: dict[str, object] | None) -> bool:
+        if isinstance(response, dict) and response.get("status") == "ok":
+            try:
+                raw_count = response.get("count", load_virtual_gamepad_count())
+                count = raw_count if isinstance(raw_count, (int, float, str)) else 1
+                self._spin.set_value(float(count))
+            except (TypeError, ValueError):
+                self._spin.set_value(float(load_virtual_gamepad_count()))
+        return False
+
+    def _on_apply_clicked(self, _button: Gtk.Button) -> None:
+        count = self._count()
+        self._spin.set_value(float(count))
+
+        def on_response(response: dict[str, object] | None) -> bool:
+            if isinstance(response, dict) and response.get("status") == "ok":
+                raw_saved = response.get("count", count)
+                saved = int(raw_saved if isinstance(raw_saved, (int, float, str)) else count)
+                self._status.set_text(f"Saved {saved} virtual gamepad(s)")
+                return False
+            saved = save_virtual_gamepad_count(count)
+            self._status.set_text(f"Saved {saved} virtual gamepad(s)")
+            return False
+
+        session_request_async(
+            {"command": "set_virtual_gamepads", "count": count},
+            on_response,
+            timeout=1.0,
+        )

--- a/keymasq/gui/widgets/virtual_gamepads_dialog.py
+++ b/keymasq/gui/widgets/virtual_gamepads_dialog.py
@@ -18,8 +18,7 @@ from keymasq.session.virtual_devices import (
 
 class VirtualGamepadsDialog(Adw.Dialog):
     def __init__(self, parent: Gtk.Window | None = None) -> None:
-        super().__init__(title="Virtual Gamepads")
-        self.set_default_size(420, 220)
+        super().__init__(title="Virtual Gamepads", content_width=420, content_height=220)
         self._parent = parent
 
         toolbar = Adw.ToolbarView()

--- a/keymasq/gui/widgets/virtual_gamepads_dialog.py
+++ b/keymasq/gui/widgets/virtual_gamepads_dialog.py
@@ -97,6 +97,10 @@ class VirtualGamepadsDialog(Adw.Dialog):
                 saved = int(raw_saved if isinstance(raw_saved, (int, float, str)) else count)
                 self._status.set_text(f"Saved {saved} virtual gamepad(s)")
                 return False
+            if isinstance(response, dict):
+                message = str(response.get("message") or "Failed to apply virtual gamepad count")
+                self._status.set_text(message)
+                return False
             saved = save_virtual_gamepad_count(count)
             self._status.set_text(f"Saved {saved} virtual gamepad(s)")
             return False

--- a/keymasq/gui/window.py
+++ b/keymasq/gui/window.py
@@ -700,6 +700,16 @@ class MainWindow(Adw.ApplicationWindow):
         )
         menu_box.append(diagnostics_btn)
 
+        virtual_gamepads_btn = Gtk.Button(label="Virtual Gamepads")
+        self._configure_menu_button(virtual_gamepads_btn)
+        virtual_gamepads_btn.connect(
+            "clicked",
+            self._on_menu_action_clicked,
+            "virtual-gamepads",
+            menu_popover,
+        )
+        menu_box.append(virtual_gamepads_btn)
+
         menu_box.append(self._create_menu_separator())
 
         menu_unlock_btn = Gtk.Button(label="Unlock Recording")

--- a/keymasq/keymasqd/daemon_device_commands.py
+++ b/keymasq/keymasqd/daemon_device_commands.py
@@ -52,6 +52,8 @@ class _DeviceCommandManager(Protocol):
         categories: Sequence[object] | None = None,
     ) -> JsonObject: ...
 
+    async def set_virtual_gamepads(self, count: object) -> JsonObject: ...
+
 
 class _DeviceCommandMacroStore(Protocol):
     def get(self, name: str) -> JsonObject: ...
@@ -138,5 +140,8 @@ async def handle_device_command(
             else None
         )
         return await daemon.device_manager.set_diagnostics(enabled, interval, categories)
+
+    if command_type == CommandType.SET_VIRTUAL_GAMEPADS:
+        return await daemon.device_manager.set_virtual_gamepads(data.get("count"))
 
     return None

--- a/keymasq/keymasqd/device_manager.py
+++ b/keymasq/keymasqd/device_manager.py
@@ -471,19 +471,25 @@ class DeviceManager:
             if clamped_count == self.output_state.virtual_gamepad_count:
                 return {"status": "ok", "count": clamped_count}
 
+            cancelled_rapidfire_tasks: list[asyncio.Task[None]] = []
             await runtime_combos.clear_combo_runtime(
                 self,
                 deps=runtime_grab_lifecycle._combo_runtime_deps(),  # pyright: ignore[reportPrivateUsage]
             )
             for devices in self.grabbed_devices.values():
                 for device in devices:
-                    release_outputs = getattr(device, "release_tracked_outputs", None)
-                    if callable(release_outputs):
-                        release_outputs()
                     state = getattr(device, "state", None)
                     if state is not None:
                         for task in list(getattr(state, "rapidfire_tasks", {}).values()):
                             if isinstance(task, asyncio.Task) and not task.done():
+                                cancelled_rapidfire_tasks.append(cast(asyncio.Task[None], task))
+                    release_outputs = getattr(device, "release_tracked_outputs", None)
+                    if callable(release_outputs):
+                        release_outputs()
+                    if state is not None:
+                        for task in list(getattr(state, "rapidfire_tasks", {}).values()):
+                            if isinstance(task, asyncio.Task) and not task.done():
+                                cancelled_rapidfire_tasks.append(cast(asyncio.Task[None], task))
                                 task.cancel()
                         getattr(state, "rapidfire_tasks", {}).clear()
                         getattr(state, "rapidfire_outputs", {}).clear()
@@ -494,6 +500,13 @@ class DeviceManager:
                         reset_result = reset()
                         if inspect.isawaitable(reset_result):
                             await reset_result
+
+            if cancelled_rapidfire_tasks:
+                unique_tasks = list(dict.fromkeys(cancelled_rapidfire_tasks))
+                for task in unique_tasks:
+                    if not task.done():
+                        task.cancel()
+                await asyncio.gather(*unique_tasks, return_exceptions=True)
 
             if self.output_state.device_count > 0:
                 runtime_outputs.configure_virtual_gamepads(

--- a/keymasq/keymasqd/device_manager.py
+++ b/keymasq/keymasqd/device_manager.py
@@ -1,7 +1,6 @@
 import asyncio
 import contextlib
 import errno
-import inspect
 import logging
 import time
 from collections import deque
@@ -478,28 +477,13 @@ class DeviceManager:
             )
             for devices in self.grabbed_devices.values():
                 for device in devices:
-                    state = getattr(device, "state", None)
-                    if state is not None:
-                        for task in list(getattr(state, "rapidfire_tasks", {}).values()):
-                            if isinstance(task, asyncio.Task) and not task.done():
-                                cancelled_rapidfire_tasks.append(cast(asyncio.Task[None], task))
-                    release_outputs = getattr(device, "release_tracked_outputs", None)
-                    if callable(release_outputs):
-                        release_outputs()
-                    if state is not None:
-                        for task in list(getattr(state, "rapidfire_tasks", {}).values()):
-                            if isinstance(task, asyncio.Task) and not task.done():
-                                cancelled_rapidfire_tasks.append(cast(asyncio.Task[None], task))
-                                task.cancel()
-                        getattr(state, "rapidfire_tasks", {}).clear()
-                        getattr(state, "rapidfire_outputs", {}).clear()
-                        getattr(state, "rapidfire_active", {}).clear()
-                        getattr(state, "tap_active", {}).clear()
-                    reset = getattr(device, "reset_superkeys", None)
-                    if callable(reset):
-                        reset_result = reset()
-                        if inspect.isawaitable(reset_result):
-                            await reset_result
+                    cancelled_rapidfire_tasks.extend(
+                        task
+                        for task in list(device.state.rapidfire_tasks.values())
+                        if not task.done()
+                    )
+                    device.release_tracked_outputs()
+                    await device.reset_mapping_runtime_state()
 
             if cancelled_rapidfire_tasks:
                 unique_tasks = list(dict.fromkeys(cancelled_rapidfire_tasks))

--- a/keymasq/keymasqd/device_manager.py
+++ b/keymasq/keymasqd/device_manager.py
@@ -1,7 +1,9 @@
 import asyncio
 import contextlib
 import errno
+import inspect
 import logging
+import time
 from collections import deque
 from collections.abc import AsyncIterator, Awaitable, Callable, Iterator, Sequence
 from dataclasses import dataclass, field
@@ -28,6 +30,11 @@ from keymasq.common.models import (
     DeviceType,
     MappingAction,
     SuperkeyMode,
+)
+from keymasq.common.virtual_devices import (
+    DEFAULT_VIRTUAL_GAMEPADS,
+    clamp_virtual_gamepad_count,
+    is_virtual_gamepad_output_id,
 )
 from keymasq.keymasqd.combo_engine import (
     ComboDecision,
@@ -268,7 +275,29 @@ class OutputRuntimeState:
     device_count: int = 0
     keyboard_uinput: runtime_adapters.WritableUInput | None = None
     mouse_uinput: runtime_adapters.WritableUInput | None = None
-    gamepad_uinput: runtime_adapters.WritableUInput | None = None
+    virtual_gamepad_uinputs: dict[str, runtime_adapters.WritableUInput] = field(
+        default_factory=dict
+    )
+    virtual_gamepad_count: int = DEFAULT_VIRTUAL_GAMEPADS
+
+    @property
+    def gamepad_uinput(self) -> runtime_adapters.WritableUInput | None:
+        return self.virtual_gamepad_uinputs.get("virtual-gamepad-1")
+
+    @gamepad_uinput.setter
+    def gamepad_uinput(self, value: runtime_adapters.WritableUInput | None) -> None:
+        if value is None:
+            self.virtual_gamepad_uinputs.pop("virtual-gamepad-1", None)
+        else:
+            self.virtual_gamepad_uinputs["virtual-gamepad-1"] = value
+
+
+@dataclass(frozen=True)
+class GamepadOutputTarget:
+    output_id: str
+    uinput: object
+    bucket: str
+    is_virtual: bool
 
 
 @dataclass
@@ -423,6 +452,7 @@ class DeviceManager:
         self._command_type = CommandType
         self._desired_grab_config_cls = DesiredGrabConfig
         self._device_input = _device_input
+        self._gamepad_output_warning_at: dict[tuple[str, str], float] = {}
 
     def initialize_output_devices(self) -> None:
         runtime_outputs.create_global_uinputs(
@@ -434,6 +464,116 @@ class DeviceManager:
 
     def shutdown_output_devices(self) -> None:
         runtime_outputs.destroy_global_uinputs(cast(Any, self), log=log)
+
+    async def set_virtual_gamepads(self, count: object) -> JsonObject:
+        clamped_count = clamp_virtual_gamepad_count(count)
+        async with self._op_lock:
+            if clamped_count == self.output_state.virtual_gamepad_count:
+                return {"status": "ok", "count": clamped_count}
+
+            await runtime_combos.clear_combo_runtime(
+                self,
+                deps=runtime_grab_lifecycle._combo_runtime_deps(),  # pyright: ignore[reportPrivateUsage]
+            )
+            for devices in self.grabbed_devices.values():
+                for device in devices:
+                    release_outputs = getattr(device, "release_tracked_outputs", None)
+                    if callable(release_outputs):
+                        release_outputs()
+                    state = getattr(device, "state", None)
+                    if state is not None:
+                        for task in list(getattr(state, "rapidfire_tasks", {}).values()):
+                            if isinstance(task, asyncio.Task) and not task.done():
+                                task.cancel()
+                        getattr(state, "rapidfire_tasks", {}).clear()
+                        getattr(state, "rapidfire_outputs", {}).clear()
+                        getattr(state, "rapidfire_active", {}).clear()
+                        getattr(state, "tap_active", {}).clear()
+                    reset = getattr(device, "reset_superkeys", None)
+                    if callable(reset):
+                        reset_result = reset()
+                        if inspect.isawaitable(reset_result):
+                            await reset_result
+
+            if self.output_state.device_count > 0:
+                runtime_outputs.configure_virtual_gamepads(
+                    cast(Any, self),
+                    clamped_count,
+                    evdev_mod=evdev,  # pyright: ignore[reportArgumentType]
+                    log=log,
+                    uinput_writer=runtime_adapters.identity_uinput_writer,
+                )
+            else:
+                self.output_state.virtual_gamepad_count = clamped_count
+            log.info("Configured %d virtual gamepad output(s)", clamped_count)
+            return {"status": "ok", "count": clamped_count}
+
+    def resolve_gamepad_output(
+        self,
+        output_id: str | None,
+        *,
+        context: str = "",
+    ) -> GamepadOutputTarget | None:
+        explicit = output_id is not None
+        resolved_id = str(output_id or "virtual-gamepad-1").strip()
+        if not resolved_id:
+            resolved_id = "virtual-gamepad-1"
+
+        if is_virtual_gamepad_output_id(resolved_id):
+            uinput = self.output_state.virtual_gamepad_uinputs.get(resolved_id)
+            if uinput is None:
+                reason = "virtual output is not configured"
+                self._warn_gamepad_output_unavailable(resolved_id, reason, context, explicit)
+                return None
+            return GamepadOutputTarget(
+                output_id=resolved_id,
+                uinput=uinput,
+                bucket=f"gamepad:{resolved_id}",
+                is_virtual=True,
+            )
+
+        devices = self.grabbed_devices.get(resolved_id)
+        if not devices:
+            reason = "target hardware is not grabbed"
+            self._warn_gamepad_output_unavailable(resolved_id, reason, context, explicit)
+            return None
+
+        for device in devices:
+            device_type = getattr(device, "device_type", None)
+            raw_device_types = getattr(device, "device_types", None)
+            device_types: set[object] = set()
+            if isinstance(raw_device_types, Sequence):
+                device_types = set(cast(Sequence[object], raw_device_types))
+            if device_type == DeviceType.GAMEPAD or DeviceType.GAMEPAD in device_types:
+                uinput = getattr(device, "uinput", None)
+                if uinput is not None:
+                    return GamepadOutputTarget(
+                        output_id=resolved_id,
+                        uinput=uinput,
+                        bucket=f"gamepad:{resolved_id}",
+                        is_virtual=False,
+                    )
+        reason = "target hardware has no grabbed gamepad passthrough output"
+        self._warn_gamepad_output_unavailable(resolved_id, reason, context, explicit)
+        return None
+
+    def _warn_gamepad_output_unavailable(
+        self,
+        output_id: str,
+        reason: str,
+        context: str,
+        explicit: bool,
+    ) -> None:
+        key = (output_id, reason)
+        now = time.monotonic()
+        last = self._gamepad_output_warning_at.get(key)
+        if last is not None and now - last < 5.0:
+            return
+        self._gamepad_output_warning_at[key] = now
+        prefix = f"Gamepad output target {output_id} unavailable"
+        context_text = f" for {context}" if context else ""
+        mode_text = "" if explicit else " default"
+        log.warning("%s%s%s: %s; dropping output", prefix, mode_text, context_text, reason)
 
     @property
     def active_combos(self) -> list[RuntimeCombo]:
@@ -993,7 +1133,6 @@ class DeviceManager:
         output_devices = {
             "keyboard": self.output_state.keyboard_uinput,
             "mouse": self.output_state.mouse_uinput,
-            "gamepad": self.output_state.gamepad_uinput,
         }
         for output_class, uinput_dev in output_devices.items():
             path = _uinput_device_path(uinput_dev)
@@ -1003,6 +1142,21 @@ class DeviceManager:
                 "recording_id": f"keymasq:output:{output_class}",
                 "recording_kind": "keymasq_output",
                 "keymasq_output": output_class,
+            }
+        for output_id, uinput_dev in sorted(self.output_state.virtual_gamepad_uinputs.items()):
+            path = _uinput_device_path(uinput_dev)
+            if not path:
+                continue
+            recording_id = (
+                "keymasq:output:gamepad"
+                if output_id == "virtual-gamepad-1"
+                else f"keymasq:output:gamepad:{output_id}"
+            )
+            metadata[path] = {
+                "recording_id": recording_id,
+                "recording_kind": "keymasq_output",
+                "keymasq_output": "gamepad",
+                "keymasq_output_id": output_id,
             }
 
         for devices in self.grabbed_devices.values():

--- a/keymasq/keymasqd/device_manager.py
+++ b/keymasq/keymasqd/device_manager.py
@@ -474,7 +474,7 @@ class DeviceManager:
             cancelled_rapidfire_tasks: list[asyncio.Task[None]] = []
             await runtime_combos.clear_combo_runtime(
                 self,
-                deps=runtime_grab_lifecycle._combo_runtime_deps(),  # pyright: ignore[reportPrivateUsage]
+                deps=runtime_grab_lifecycle.combo_runtime_deps(),
             )
             for devices in self.grabbed_devices.values():
                 for device in devices:

--- a/keymasq/keymasqd/runtime/actions.py
+++ b/keymasq/keymasqd/runtime/actions.py
@@ -85,6 +85,7 @@ def parse_action(
     return MappingAction(
         action_type=action_type,
         target=optional_str(target),
+        output_id=optional_str(action_data.get("output_id")),
         keys=cast(list[str] | None, action_data.get("keys")),
         cmd=optional_str(cmd),
         exec_ref=int_or_none(action_data.get("exec_ref")),
@@ -384,6 +385,7 @@ def parse_superkey_action(
     return SuperkeyActionData(
         action_type=action_type.value,
         target=optional_str(action.get("target")),
+        output_id=optional_str(action.get("output_id")),
         cmd=optional_str(action.get("cmd")),
         exec_ref=int_or_none(action.get("exec_ref")),
         macro_name=optional_str(action.get("macro_name")),

--- a/keymasq/keymasqd/runtime/combos.py
+++ b/keymasq/keymasqd/runtime/combos.py
@@ -83,6 +83,8 @@ class ComboActionState:
     code: int | None = None
     axis_code: int | None = None
     uinput: object | None = None
+    bucket: str | None = None
+    output_id: str | None = None
     active: bool = False
     task: asyncio.Task[None] | None = None
     started: runtime_adapters.AsyncioEvent | None = None
@@ -549,9 +551,9 @@ def track_combo_superkey_output(
     code: int,
     value: int,
 ) -> bool:
-    bucket = action_type if action_type in manager.combo_state.superkey_output_refcounts else None
-    if bucket is None:
-        return True
+    bucket = action_type
+    manager.combo_state.superkey_output_refcounts.setdefault(bucket, {})
+    manager.combo_state.held_output_keys.setdefault(bucket, set())
 
     refcounts = manager.combo_state.superkey_output_refcounts[bucket]
     current = refcounts.get(int(code), 0)
@@ -691,6 +693,10 @@ async def _combo_superkey_machine(
         broadcast_callback=combo_superkey_broadcast,
         cursor_position_setter=manager.set_cursor_position,
         key_event_tracker=combo_superkey_output_tracker,
+        gamepad_output_resolver=lambda output_id, context: manager.resolve_gamepad_output(
+            output_id,
+            context=context,
+        ),
     )
     manager.combo_state.superkey_machines[combo_id] = machine
     return machine
@@ -812,6 +818,7 @@ async def combo_tap_trigger(
     axis_code: int,
     hold_ms: int,
     started: runtime_adapters.AsyncioEvent | None = None,
+    uinput_dev: object | None = None,
     *,
     deps: ComboRuntimeDeps,
 ) -> None:
@@ -821,7 +828,7 @@ async def combo_tap_trigger(
 
     try:
         write_combo_trigger(
-            manager,
+            uinput_dev,
             axis_code,
             255,
             deps=deps,
@@ -835,7 +842,7 @@ async def combo_tap_trigger(
     finally:
         if pressed:
             write_combo_trigger(
-                manager,
+                uinput_dev,
                 axis_code,
                 0,
                 deps=deps,
@@ -1023,6 +1030,15 @@ async def _start_combo_action_instance(
         return
 
     if action.action_type == ActionType.GAMEPAD and action.target:
+        target = manager.resolve_gamepad_output(
+            action.output_id,
+            context=f"combo:{combo_id} -> {action.target}",
+        )
+        if target is None:
+            return
+        target_uinput = getattr(target, "uinput", None)
+        target_bucket = str(getattr(target, "bucket", "gamepad"))
+        target_output_id = str(getattr(target, "output_id", action.output_id or ""))
         is_trigger, axis_code = deps.get_trigger_axis_fn(action.target)
         if is_trigger and axis_code is not None:
             if action.tap_enabled:
@@ -1034,12 +1050,16 @@ async def _start_combo_action_instance(
                         axis_code,
                         action.tap_hold_ms,
                         started,
+                        target_uinput,
                         deps=deps,
                     )
                 )
                 manager.combo_state.active_actions[combo_id] = ComboActionState(
                     kind="tap_trigger",
                     axis_code=axis_code,
+                    uinput=target_uinput,
+                    bucket=target_bucket,
+                    output_id=target_output_id,
                     task=task,
                     started=started,
                 )
@@ -1054,19 +1074,23 @@ async def _start_combo_action_instance(
                         action.rapidfire_hold_ms,
                         action.rapidfire_wait_ms,
                         started,
+                        target_uinput,
                         deps=deps,
                     )
                 )
                 manager.combo_state.active_actions[combo_id] = ComboActionState(
                     kind="rapidfire_trigger",
                     axis_code=axis_code,
+                    uinput=target_uinput,
+                    bucket=target_bucket,
+                    output_id=target_output_id,
                     active=True,
                     task=task,
                     started=started,
                 )
                 return
             write_combo_trigger(
-                manager,
+                target_uinput,
                 axis_code,
                 255,
                 deps=deps,
@@ -1074,14 +1098,18 @@ async def _start_combo_action_instance(
             manager.combo_state.active_actions[combo_id] = ComboActionState(
                 kind="trigger",
                 axis_code=axis_code,
+                uinput=target_uinput,
+                bucket=target_bucket,
+                output_id=target_output_id,
             )
             return
         await start_combo_key_action(
             manager,
             combo_id,
             action,
-            manager.output_state.gamepad_uinput,
+            target_uinput,
             deps=deps,
+            bucket=target_bucket,
         )
         return
 
@@ -1164,6 +1192,7 @@ async def start_combo_key_action(
     uinput_dev: object | None,
     *,
     deps: ComboRuntimeDeps,
+    bucket: str | None = None,
 ) -> None:
     target = str(action.target or "")
     if not target:
@@ -1190,6 +1219,7 @@ async def start_combo_key_action(
             code=code,
             task=task,
             started=started,
+            bucket=bucket,
         )
         return
     if action.rapidfire_enabled:
@@ -1213,6 +1243,7 @@ async def start_combo_key_action(
             active=True,
             task=task,
             started=started,
+            bucket=bucket,
         )
         return
     write_combo_key(uinput_dev, code, 1, deps=deps)
@@ -1220,6 +1251,7 @@ async def start_combo_key_action(
         kind="key",
         uinput=uinput_dev,
         code=code,
+        bucket=bucket,
     )
 
 
@@ -1370,7 +1402,7 @@ async def stop_combo_action(
         axis_code = state.axis_code
         if axis_code is not None:
             write_combo_trigger(
-                manager,
+                state.uinput,
                 axis_code,
                 0,
                 deps=deps,
@@ -1677,6 +1709,7 @@ async def combo_rapidfire_trigger(
     hold_ms: int,
     wait_ms: int,
     started: runtime_adapters.AsyncioEvent | None = None,
+    uinput_dev: object | None = None,
     *,
     deps: ComboRuntimeDeps,
 ) -> None:
@@ -1685,7 +1718,7 @@ async def combo_rapidfire_trigger(
     try:
         while _combo_action_active(manager, combo_id):
             write_combo_trigger(
-                manager,
+                uinput_dev,
                 axis_code,
                 255,
                 deps=deps,
@@ -1697,7 +1730,7 @@ async def combo_rapidfire_trigger(
             if not _combo_action_active(manager, combo_id):
                 break
             write_combo_trigger(
-                manager,
+                uinput_dev,
                 axis_code,
                 0,
                 deps=deps,
@@ -1706,7 +1739,7 @@ async def combo_rapidfire_trigger(
     except deps.asyncio_mod.CancelledError:
         raise
     finally:
-        write_combo_trigger(manager, axis_code, 0, deps=deps)
+        write_combo_trigger(uinput_dev, axis_code, 0, deps=deps)
         if not started_set:
             mark_combo_action_started(started)
 
@@ -1742,13 +1775,13 @@ def write_combo_relative(
 
 
 def write_combo_trigger(
-    manager: _ComboManager,
+    uinput_dev: object | None,
     axis_code: int,
     value: int,
     *,
     deps: ComboRuntimeDeps,
 ) -> None:
-    writer = deps.uinput_writer(manager.output_state.gamepad_uinput)
+    writer = deps.uinput_writer(uinput_dev)
     if writer is None:
         return
     writer.write(deps.evdev_mod.ecodes.EV_ABS, int(axis_code), int(value))

--- a/keymasq/keymasqd/runtime/grab_lifecycle.py
+++ b/keymasq/keymasqd/runtime/grab_lifecycle.py
@@ -48,7 +48,7 @@ def _fire_and_forget(coro: Awaitable[object], _label: str) -> asyncio.Task[objec
     return asyncio.ensure_future(coro)
 
 
-def _combo_runtime_deps(
+def combo_runtime_deps(
     *,
     resolve_code_fn: runtime_combos.ResolveCodeFn = resolve_output_code,
     fire_and_observe_fn: runtime_combos.FireAndObserve = _fire_and_forget,
@@ -170,7 +170,7 @@ async def grab_device_unlocked(
             get_interface_id_fn=get_interface_id_fn,
             int_value_fn=int_value_fn,
             str_value_fn=str_value_fn,
-            deps=_combo_runtime_deps(fire_and_observe_fn=fire_and_observe_fn),
+            deps=combo_runtime_deps(fire_and_observe_fn=fire_and_observe_fn),
         )
 
     async def runtime_cleanup_callback(
@@ -181,7 +181,7 @@ async def grab_device_unlocked(
             manager,
             cleanup_hardware_id,
             cleanup_source,
-            deps=_combo_runtime_deps(fire_and_observe_fn=fire_and_observe_fn),
+            deps=combo_runtime_deps(fire_and_observe_fn=fire_and_observe_fn),
         )
 
     for path in sorted(requested_paths):
@@ -405,7 +405,7 @@ async def release_device_unlocked(
         manager,
         hardware_id,
         None,
-        deps=_combo_runtime_deps(),
+        deps=combo_runtime_deps(),
     )
     manager.grab_state.desired_grabs.pop(hardware_id, None)
     devices = manager.grabbed_devices.pop(hardware_id, [])
@@ -582,7 +582,7 @@ async def release_interface_unlocked(
         manager,
         hardware_id,
         str(getattr(removed, "interface_id", "") or "").lower(),
-        deps=_combo_runtime_deps(),
+        deps=combo_runtime_deps(),
     )
     removed.release_tracked_outputs()
     await removed.release()
@@ -605,7 +605,7 @@ async def release_all_devices(
         await manager.cancel_macro_playback()
         await runtime_combos.clear_combo_runtime(
             manager,
-            deps=_combo_runtime_deps(fire_and_observe_fn=fire_and_observe_fn),
+            deps=combo_runtime_deps(fire_and_observe_fn=fire_and_observe_fn),
         )
         hardware_ids = set(manager.grabbed_devices) | set(manager.grab_state.desired_grabs)
         for hardware_id in list(hardware_ids):

--- a/keymasq/keymasqd/runtime/grab_lifecycle.py
+++ b/keymasq/keymasqd/runtime/grab_lifecycle.py
@@ -216,6 +216,12 @@ async def grab_device_unlocked(
                 def diagnostics_recorder(label: str, duration_us: float) -> None:
                     manager._record_diagnostic(label, duration_us)
 
+                def gamepad_output_resolver(
+                    output_id: str | None,
+                    context: str,
+                ) -> object | None:
+                    return manager.resolve_gamepad_output(output_id, context=context)
+
                 device = grabbed_device_cls(
                     path=path,
                     hardware_id=hardware_id,
@@ -230,6 +236,7 @@ async def grab_device_unlocked(
                     keyboard_uinput=manager.output_state.keyboard_uinput,
                     mouse_uinput=manager.output_state.mouse_uinput,
                     gamepad_uinput=manager.output_state.gamepad_uinput,
+                    gamepad_output_resolver=gamepad_output_resolver,
                     broadcast_callback=manager.broadcast_callback,
                     cursor_position_setter=manager.set_cursor_position,
                     recording_manager=manager.recording_manager,

--- a/keymasq/keymasqd/runtime/grabbed_device.py
+++ b/keymasq/keymasqd/runtime/grabbed_device.py
@@ -412,8 +412,6 @@ class GrabbedDevice:
             return self.keyboard_uinput
         if action_type == ActionType.MOUSE:
             return self.mouse_uinput
-        if action_type == ActionType.GAMEPAD:
-            return self.gamepad_uinput
         return None
 
     def _combo_binding_output(self, evdev_name: str) -> tuple[object, int, str] | None:
@@ -439,16 +437,30 @@ class GrabbedDevice:
             return (self.uinput, int(code), "passthrough")
         if held_action.rapidfire_enabled or held_action.tap_enabled:
             return None
-        target_uinput = self._combo_binding_target_uinput(held_action.action_type)
         code = resolve_output_code(held_action.target or "")
-        if target_uinput is None or code is None:
+        if code is None:
             return None
         if held_action.action_type == ActionType.KEYBOARD:
+            target_uinput = self._combo_binding_target_uinput(held_action.action_type)
+            if target_uinput is None:
+                return None
             bucket = "keyboard"
         elif held_action.action_type == ActionType.MOUSE:
+            target_uinput = self._combo_binding_target_uinput(held_action.action_type)
+            if target_uinput is None:
+                return None
             bucket = "mouse"
         elif held_action.action_type == ActionType.GAMEPAD:
-            bucket = "gamepad"
+            target = self.resolve_gamepad_output(
+                held_action.output_id,
+                f"combo binding {evdev_name} -> {held_action.target}",
+            )
+            if target is None:
+                return None
+            target_uinput = getattr(target, "uinput", None)
+            if target_uinput is None:
+                return None
+            bucket = str(getattr(target, "bucket", "gamepad"))
         else:
             return None
         return (target_uinput, int(code), bucket)
@@ -457,7 +469,7 @@ class GrabbedDevice:
         output = self._combo_binding_output(evdev_name)
         if output is None:
             return
-        target_uinput, code, _bucket = output
+        target_uinput, code, bucket = output
         runtime_outputs.write_key(
             self,
             target_uinput,
@@ -465,6 +477,7 @@ class GrabbedDevice:
             0,
             evdev_mod=evdev,
             uinput_writer=_uinput_writer,
+            bucket=bucket,
         )
 
     def emit_combo_press(self, evdev_name: str) -> None:
@@ -479,6 +492,7 @@ class GrabbedDevice:
             1,
             evdev_mod=evdev,
             uinput_writer=_uinput_writer,
+            bucket=bucket,
         )
         if bucket == "passthrough":
             self.state.combo_passthrough_held.add(str(evdev_name or "").lower())
@@ -488,7 +502,7 @@ class GrabbedDevice:
         if output is None:
             return False
         _target_uinput, code, bucket = output
-        return int(code) in self.state.held_output_keys[bucket]
+        return int(code) in self.state.held_output_keys.get(bucket, set())
 
     def combo_source_binding_held(self, evdev_name: str) -> bool:
         normalized = str(evdev_name or "").lower()

--- a/keymasq/keymasqd/runtime/grabbed_device.py
+++ b/keymasq/keymasqd/runtime/grabbed_device.py
@@ -2,6 +2,7 @@ import asyncio
 import logging
 import time
 from collections.abc import Awaitable, Callable, Sequence
+from types import SimpleNamespace
 from typing import Final, cast
 
 import evdev
@@ -176,6 +177,7 @@ class GrabbedDevice:
         keyboard_uinput: evdev.UInput | None = None,
         mouse_uinput: evdev.UInput | None = None,
         gamepad_uinput: evdev.UInput | None = None,
+        gamepad_output_resolver: Callable[[str | None, str], object | None] | None = None,
         broadcast_callback: BroadcastCallback | None = None,
         cursor_position_setter: CursorPositionSetter | None = None,
         recording_manager: RecordingManager | None = None,
@@ -207,6 +209,7 @@ class GrabbedDevice:
         self.keyboard_uinput = keyboard_uinput
         self.mouse_uinput = mouse_uinput
         self.gamepad_uinput = gamepad_uinput
+        self._gamepad_output_resolver = gamepad_output_resolver
         self.broadcast_callback = broadcast_callback
         self.cursor_position_setter = cursor_position_setter
         self.recording_manager: RecordingManager | None = recording_manager
@@ -390,6 +393,16 @@ class GrabbedDevice:
 
     def release_tracked_outputs(self) -> None:
         runtime_outputs.release_all_keys(self, evdev_mod=evdev, uinput_writer=_uinput_writer)
+
+    def resolve_gamepad_output(self, output_id: str | None, context: str) -> object | None:
+        if self._gamepad_output_resolver is None:
+            return SimpleNamespace(
+                output_id=output_id or "virtual-gamepad-1",
+                uinput=self.gamepad_uinput,
+                bucket="gamepad",
+                is_virtual=True,
+            )
+        return self._gamepad_output_resolver(output_id, context)
 
     def _combo_binding_action(self, evdev_name: str) -> object | None:
         return self.state.held_source_actions.get(str(evdev_name or "").lower())

--- a/keymasq/keymasqd/runtime/grabbed_device_actions.py
+++ b/keymasq/keymasqd/runtime/grabbed_device_actions.py
@@ -16,6 +16,7 @@ from keymasq.keymasqd.runtime.action_runner import (
 from keymasq.keymasqd.runtime.grabbed_device_outputs import (
     bucket_for_uinput,
     passthrough,
+    track_abs_state,
     track_superkey_output,
     write_key,
 )
@@ -121,6 +122,7 @@ async def execute_action(
                                     asyncio_mod=deps.asyncio_mod,
                                     evdev_mod=deps.evdev_mod,
                                     uinput_writer=deps.uinput_writer,
+                                    bucket=target_bucket,
                                 )
                             ),
                             axis_code=axis_code,
@@ -149,6 +151,7 @@ async def execute_action(
                                 asyncio_mod=deps.asyncio_mod,
                                 evdev_mod=deps.evdev_mod,
                                 uinput_writer=deps.uinput_writer,
+                                bucket=target_bucket,
                             ),
                             f"tap action {event_name}",
                         )
@@ -171,6 +174,12 @@ async def execute_action(
                         255 if event.value else 0,
                     )
                     gamepad_uinput.syn()
+                    track_abs_state(
+                        device_runtime,
+                        axis_code,
+                        255 if event.value else 0,
+                        bucket=target_bucket,
+                    )
             else:
                 await _execute_key_action(
                     device_runtime,

--- a/keymasq/keymasqd/runtime/grabbed_device_actions.py
+++ b/keymasq/keymasqd/runtime/grabbed_device_actions.py
@@ -92,6 +92,14 @@ async def execute_action(
 
     elif action.action_type == ActionType.GAMEPAD:
         if action.target:
+            target = device_runtime.resolve_gamepad_output(
+                action.output_id,
+                f"{event_name} -> {action.target}",
+            )
+            if target is None:
+                return
+            target_uinput = getattr(target, "uinput", None)
+            target_bucket = str(getattr(target, "bucket", "gamepad"))
             is_trigger, axis_code = get_trigger_axis(action.target)
             if is_trigger:
                 if axis_code is None:
@@ -109,6 +117,7 @@ async def execute_action(
                                     action.rapidfire_hold_ms,
                                     action.rapidfire_wait_ms,
                                     event_name,
+                                    target_uinput,
                                     asyncio_mod=deps.asyncio_mod,
                                     evdev_mod=deps.evdev_mod,
                                     uinput_writer=deps.uinput_writer,
@@ -116,7 +125,8 @@ async def execute_action(
                             ),
                             axis_code=axis_code,
                             code=None,
-                            uinput=None,
+                            uinput=target_uinput,
+                            bucket=target_bucket,
                         )
                     elif event.value == 0:
                         await stop_rapidfire_async(
@@ -135,6 +145,7 @@ async def execute_action(
                                 axis_code,
                                 action.tap_hold_ms,
                                 event_name,
+                                target_uinput,
                                 asyncio_mod=deps.asyncio_mod,
                                 evdev_mod=deps.evdev_mod,
                                 uinput_writer=deps.uinput_writer,
@@ -142,13 +153,13 @@ async def execute_action(
                             f"tap action {event_name}",
                         )
                 else:
-                    gamepad_uinput = uinput_writer(device_runtime.gamepad_uinput)
+                    gamepad_uinput = uinput_writer(target_uinput)
                     if gamepad_uinput is None:
                         return
                     should_emit = True
                     if shared_output_tracker is not None:
                         should_emit = shared_output_tracker(
-                            ActionType.GAMEPAD.value,
+                            target_bucket,
                             axis_code,
                             int(event.value),
                         )
@@ -167,7 +178,8 @@ async def execute_action(
                     event,
                     event_name,
                     deps=deps,
-                    uinput_dev=device_runtime.gamepad_uinput,
+                    uinput_dev=target_uinput,
+                    explicit_bucket=target_bucket,
                     target_kind="key",
                     trigger_kind="key",
                     shared_output_tracker=shared_output_tracker,
@@ -331,6 +343,7 @@ async def execute_action(
                     broadcast_callback=superkey_broadcast,
                     cursor_position_setter=device_runtime.cursor_position_setter,
                     key_event_tracker=superkey_key_event_tracker,
+                    gamepad_output_resolver=device_runtime.resolve_gamepad_output,
                 )
                 device_runtime.state.superkey_machines[event_name] = machine
 
@@ -348,6 +361,7 @@ async def execute_action_pulse(
     *,
     deps: ActionExecutionDeps,
     shared_output_tracker: Callable[[str, int, int], bool] | None = None,
+    explicit_bucket: str | None = None,
 ) -> None:
     await execute_action(
         device_runtime,
@@ -461,6 +475,7 @@ async def _execute_key_action(
     target_kind: str,
     trigger_kind: str,
     shared_output_tracker: Callable[[str, int, int], bool] | None = None,
+    explicit_bucket: str | None = None,
 ) -> None:
     del target_kind
     if not action.target:
@@ -483,11 +498,13 @@ async def _execute_key_action(
                         event_name,
                         uinput_dev,
                         asyncio_mod=deps.asyncio_mod,
+                        bucket=explicit_bucket,
                     )
                 ),
                 code=code,
                 uinput=uinput_dev,
                 axis_code=None,
+                bucket=explicit_bucket,
             )
         elif event.value == 0:
             await stop_rapidfire_async(
@@ -506,13 +523,14 @@ async def _execute_key_action(
                     event_name,
                     uinput_dev,
                     asyncio_mod=deps.asyncio_mod,
+                    bucket=explicit_bucket,
                 ),
                 f"tap action {event_name}",
             )
     else:
         should_emit = True
         if shared_output_tracker is not None:
-            bucket = bucket_for_uinput(device_runtime, uinput_dev)
+            bucket = explicit_bucket or bucket_for_uinput(device_runtime, uinput_dev)
             if bucket is not None:
                 should_emit = shared_output_tracker(bucket, int(code), int(event.value))
         if not should_emit:
@@ -524,6 +542,7 @@ async def _execute_key_action(
             int(event.value),
             evdev_mod=deps.evdev_mod,
             uinput_writer=deps.uinput_writer,
+            bucket=explicit_bucket,
         )
 
 

--- a/keymasq/keymasqd/runtime/grabbed_device_outputs.py
+++ b/keymasq/keymasqd/runtime/grabbed_device_outputs.py
@@ -237,7 +237,8 @@ def release_all_keys(
     for bucket, uinput_dev in devices.items():
         writer = uinput_writer(uinput_dev)
         if writer is None:
-            device_runtime.state.held_output_keys[bucket].clear()
+            device_runtime.state.held_output_keys.get(bucket, set()).clear()
+            device_runtime.state.held_output_abs.get(bucket, set()).clear()
             if bucket in device_runtime.state.superkey_output_refcounts:
                 device_runtime.state.superkey_output_refcounts[bucket].clear()
             continue

--- a/keymasq/keymasqd/runtime/grabbed_device_outputs.py
+++ b/keymasq/keymasqd/runtime/grabbed_device_outputs.py
@@ -34,9 +34,14 @@ def bucket_for_uinput(
 
 
 def track_key_state(
-    device_runtime: GrabbedDeviceRuntime, uinput_dev: object | None, code: int, value: int
+    device_runtime: GrabbedDeviceRuntime,
+    uinput_dev: object | None,
+    code: int,
+    value: int,
+    *,
+    bucket: str | None = None,
 ) -> None:
-    bucket = bucket_for_uinput(device_runtime, uinput_dev)
+    bucket = bucket or bucket_for_uinput(device_runtime, uinput_dev)
     if not bucket:
         return
     held = device_runtime.state.held_output_keys[bucket]
@@ -54,23 +59,22 @@ def write_key(
     *,
     evdev_mod: EvdevModule,
     uinput_writer: UInputWriter,
+    bucket: str | None = None,
 ) -> None:
     writer = uinput_writer(uinput_dev)
     if writer is None:
         return
     writer.write(evdev_mod.ecodes.EV_KEY, int(code), int(value))
     writer.syn()
-    track_key_state(device_runtime, uinput_dev, int(code), int(value))
+    track_key_state(device_runtime, uinput_dev, int(code), int(value), bucket=bucket)
 
 
 def track_superkey_output(
     device_runtime: GrabbedDeviceRuntime, action_type: str, code: int, value: int
 ) -> bool:
-    bucket = (
-        action_type if action_type in device_runtime.state.superkey_output_refcounts else None
-    )
-    if bucket is None:
-        return True
+    bucket = action_type
+    if bucket not in device_runtime.state.superkey_output_refcounts:
+        device_runtime.state.superkey_output_refcounts[bucket] = {}
 
     refcounts = device_runtime.state.superkey_output_refcounts[bucket]
     current = refcounts.get(int(code), 0)
@@ -130,9 +134,10 @@ def ensure_trigger_released(
     *,
     evdev_mod: EvdevModule,
     uinput_writer: UInputWriter,
+    uinput_dev: object | None = None,
 ) -> None:
     try:
-        gamepad_uinput = uinput_writer(device_runtime.gamepad_uinput)
+        gamepad_uinput = uinput_writer(uinput_dev or device_runtime.gamepad_uinput)
         if gamepad_uinput is not None:
             gamepad_uinput.write(evdev_mod.ecodes.EV_ABS, axis_code, 0)
             gamepad_uinput.syn()
@@ -147,7 +152,11 @@ def ensure_trigger_released(
 
 
 def ensure_key_released(
-    device_runtime: GrabbedDeviceRuntime, code: int, uinput_dev: object | None
+    device_runtime: GrabbedDeviceRuntime,
+    code: int,
+    uinput_dev: object | None,
+    *,
+    bucket: str | None = None,
 ) -> None:
     try:
         if uinput_dev:
@@ -158,6 +167,7 @@ def ensure_key_released(
                 0,
                 evdev_mod=evdev,
                 uinput_writer=identity_uinput_writer,
+                bucket=bucket,
             )
     except Exception as exc:
         log.debug(
@@ -187,15 +197,25 @@ def release_all_keys(
     evdev_mod: EvdevModule,
     uinput_writer: UInputWriter,
 ) -> None:
-    devices = {
+    devices: dict[str, object | None] = {
         "passthrough": device_runtime.uinput,
         "keyboard": device_runtime.keyboard_uinput,
         "mouse": device_runtime.mouse_uinput,
         "gamepad": device_runtime.gamepad_uinput,
     }
+    for bucket in device_runtime.state.held_output_keys:
+        if bucket.startswith("gamepad:") and bucket not in devices:
+            target = device_runtime.resolve_gamepad_output(
+                bucket.removeprefix("gamepad:"),
+                f"release tracked {bucket}",
+            )
+            devices[bucket] = getattr(target, "uinput", None) if target is not None else None
     for bucket, uinput_dev in devices.items():
         writer = uinput_writer(uinput_dev)
         if writer is None:
+            device_runtime.state.held_output_keys[bucket].clear()
+            if bucket in device_runtime.state.superkey_output_refcounts:
+                device_runtime.state.superkey_output_refcounts[bucket].clear()
             continue
         held = sorted(device_runtime.state.held_output_keys.get(bucket, set()))
         if not held:

--- a/keymasq/keymasqd/runtime/grabbed_device_outputs.py
+++ b/keymasq/keymasqd/runtime/grabbed_device_outputs.py
@@ -51,6 +51,22 @@ def track_key_state(
         held.discard(int(code))
 
 
+def track_abs_state(
+    device_runtime: GrabbedDeviceRuntime,
+    axis_code: int,
+    value: int,
+    *,
+    bucket: str | None,
+) -> None:
+    if not bucket:
+        return
+    held = device_runtime.state.held_output_abs.setdefault(bucket, set())
+    if int(value) != 0:
+        held.add(int(axis_code))
+    else:
+        held.discard(int(axis_code))
+
+
 def write_key(
     device_runtime: GrabbedDeviceRuntime,
     uinput_dev: object | None,
@@ -136,12 +152,14 @@ def ensure_trigger_released(
     evdev_mod: EvdevModule,
     uinput_writer: UInputWriter,
     uinput_dev: object | None = None,
+    bucket: str | None = None,
 ) -> None:
     try:
         gamepad_uinput = uinput_writer(uinput_dev or device_runtime.gamepad_uinput)
         if gamepad_uinput is not None:
             gamepad_uinput.write(evdev_mod.ecodes.EV_ABS, axis_code, 0)
             gamepad_uinput.syn()
+            track_abs_state(device_runtime, axis_code, 0, bucket=bucket)
     except Exception as exc:
         log.debug(
             "Failed to release gamepad trigger axis %s on %s: %s",
@@ -204,7 +222,12 @@ def release_all_keys(
         "mouse": device_runtime.mouse_uinput,
         "gamepad": device_runtime.gamepad_uinput,
     }
-    for bucket in device_runtime.state.held_output_keys:
+    for state in device_runtime.state.rapidfire_outputs.values():
+        if state.kind == "trigger" and state.bucket:
+            devices.setdefault(state.bucket, state.uinput)
+    for bucket in set(device_runtime.state.held_output_keys) | set(
+        device_runtime.state.held_output_abs
+    ):
         if bucket.startswith("gamepad:") and bucket not in devices:
             target = device_runtime.resolve_gamepad_output(
                 bucket.removeprefix("gamepad:"),
@@ -239,19 +262,29 @@ def release_all_keys(
             if bucket in device_runtime.state.superkey_output_refcounts:
                 device_runtime.state.superkey_output_refcounts[bucket].clear()
 
-    gamepad_uinput = uinput_writer(device_runtime.gamepad_uinput)
-    if gamepad_uinput is not None:
+    for bucket, held_abs in list(device_runtime.state.held_output_abs.items()):
+        if not bucket.startswith("gamepad") and not held_abs:
+            continue
+        uinput_dev = devices.get(bucket)
+        writer = uinput_writer(uinput_dev)
+        if writer is None:
+            held_abs.clear()
+            continue
         try:
-            gamepad_uinput.write(evdev_mod.ecodes.EV_ABS, evdev_mod.ecodes.ABS_Z, 0)
-            gamepad_uinput.write(evdev_mod.ecodes.EV_ABS, evdev_mod.ecodes.ABS_RZ, 0)
-            gamepad_uinput.syn()
+            axes = held_abs or {evdev_mod.ecodes.ABS_Z, evdev_mod.ecodes.ABS_RZ}
+            for axis_code in sorted(axes):
+                writer.write(evdev_mod.ecodes.EV_ABS, int(axis_code), 0)
+            writer.syn()
         except Exception as exc:
             log.debug(
-                "Failed to release gamepad trigger axes on %s: %s",
+                "Failed to release gamepad trigger axes on %s bucket=%s: %s",
                 device_runtime.path,
+                bucket,
                 exc,
                 exc_info=True,
             )
+        else:
+            held_abs.clear()
 
     for task in list(device_runtime.state.rapidfire_tasks.values()):
         if not task.done():

--- a/keymasq/keymasqd/runtime/grabbed_device_outputs.py
+++ b/keymasq/keymasqd/runtime/grabbed_device_outputs.py
@@ -44,7 +44,7 @@ def track_key_state(
     bucket = bucket or bucket_for_uinput(device_runtime, uinput_dev)
     if not bucket:
         return
-    held = device_runtime.state.held_output_keys[bucket]
+    held = device_runtime.state.held_output_keys.setdefault(bucket, set())
     if int(value) == 1:
         held.add(int(code))
     elif int(value) == 0:
@@ -75,19 +75,20 @@ def track_superkey_output(
     bucket = action_type
     if bucket not in device_runtime.state.superkey_output_refcounts:
         device_runtime.state.superkey_output_refcounts[bucket] = {}
+    held = device_runtime.state.held_output_keys.setdefault(bucket, set())
 
     refcounts = device_runtime.state.superkey_output_refcounts[bucket]
     current = refcounts.get(int(code), 0)
 
     if int(value) == 1:
         refcounts[int(code)] = current + 1
-        device_runtime.state.held_output_keys[bucket].add(int(code))
+        held.add(int(code))
         return current == 0
 
     if int(value) == 0:
         if current <= 1:
             refcounts.pop(int(code), None)
-            device_runtime.state.held_output_keys[bucket].discard(int(code))
+            held.discard(int(code))
             return current == 1
 
         refcounts[int(code)] = current - 1

--- a/keymasq/keymasqd/runtime/grabbed_device_repeat.py
+++ b/keymasq/keymasqd/runtime/grabbed_device_repeat.py
@@ -14,6 +14,7 @@ from keymasq.keymasqd.runtime.grabbed_device_outputs import (
     emit_configured_mouse_move,
     ensure_key_released,
     ensure_trigger_released,
+    track_abs_state,
     write_key,
 )
 from keymasq.keymasqd.runtime.grabbed_device_types import (
@@ -90,6 +91,7 @@ def stop_rapidfire(device_runtime: GrabbedDeviceRuntime, event_name: str) -> Non
                 evdev_mod=evdev,
                 uinput_writer=_uinput_writer,
                 uinput_dev=state.uinput,
+                bucket=state.bucket,
             )
         return
     if kind == "relative":
@@ -136,6 +138,7 @@ def finish_rapidfire_task(
                 evdev_mod=evdev,
                 uinput_writer=_uinput_writer,
                 uinput_dev=state.uinput,
+                bucket=state.bucket,
             )
         return
     if kind == "relative":
@@ -158,6 +161,7 @@ async def rapidfire_trigger(
     asyncio_mod: AsyncioModule,
     evdev_mod: EvdevModule,
     uinput_writer: UInputWriter,
+    bucket: str | None = None,
 ) -> None:
     hold = clamp_rapidfire_hold_ms(hold_ms) / 1000.0
     wait = clamp_rapidfire_wait_ms(wait_ms) / 1000.0
@@ -174,12 +178,14 @@ async def rapidfire_trigger(
                 return
             gamepad_uinput.write(evdev_mod.ecodes.EV_ABS, axis_code, 255)
             gamepad_uinput.syn()
+            track_abs_state(device_runtime, axis_code, 255, bucket=bucket)
             pressed = True
             await asyncio_mod.sleep(hold)
 
             if pressed:
                 gamepad_uinput.write(evdev_mod.ecodes.EV_ABS, axis_code, 0)
                 gamepad_uinput.syn()
+                track_abs_state(device_runtime, axis_code, 0, bucket=bucket)
                 pressed = False
             if not device_runtime.state.rapidfire_active.get(event_name, False):
                 break
@@ -195,6 +201,7 @@ async def rapidfire_trigger(
                 evdev_mod=evdev_mod,
                 uinput_writer=uinput_writer,
                 uinput_dev=uinput_dev,
+                bucket=bucket,
             )
         if task is not None:
             finish_rapidfire_task(device_runtime, event_name, task)
@@ -210,6 +217,7 @@ async def tap_trigger(
     asyncio_mod: AsyncioModule,
     evdev_mod: EvdevModule,
     uinput_writer: UInputWriter,
+    bucket: str | None = None,
 ) -> None:
     hold = hold_ms / 1000.0
 
@@ -219,9 +227,11 @@ async def tap_trigger(
             return
         gamepad_uinput.write(evdev_mod.ecodes.EV_ABS, axis_code, 255)
         gamepad_uinput.syn()
+        track_abs_state(device_runtime, axis_code, 255, bucket=bucket)
         await asyncio_mod.sleep(hold)
         gamepad_uinput.write(evdev_mod.ecodes.EV_ABS, axis_code, 0)
         gamepad_uinput.syn()
+        track_abs_state(device_runtime, axis_code, 0, bucket=bucket)
     except Exception:
         pass
     finally:

--- a/keymasq/keymasqd/runtime/grabbed_device_repeat.py
+++ b/keymasq/keymasqd/runtime/grabbed_device_repeat.py
@@ -53,6 +53,7 @@ def start_rapidfire_task(
     code: int | None,
     uinput: object | None,
     axis_code: int | None,
+    bucket: str | None = None,
 ) -> None:
     stop_rapidfire(device_runtime, event_name)
     task = task_factory()
@@ -67,6 +68,7 @@ def start_rapidfire_task(
         state.uinput = uinput
     if axis_code is not None:
         state.axis_code = int(axis_code)
+    state.bucket = bucket
     device_runtime.state.rapidfire_outputs[event_name] = state
 
 
@@ -87,6 +89,7 @@ def stop_rapidfire(device_runtime: GrabbedDeviceRuntime, event_name: str) -> Non
                 axis_code,
                 evdev_mod=evdev,
                 uinput_writer=_uinput_writer,
+                uinput_dev=state.uinput,
             )
         return
     if kind == "relative":
@@ -95,7 +98,8 @@ def stop_rapidfire(device_runtime: GrabbedDeviceRuntime, event_name: str) -> Non
         code = state.code
         uinput = state.uinput
         if code is not None:
-            ensure_key_released(device_runtime, code, uinput)
+            ensure_key_released(device_runtime, code, uinput, bucket=state.bucket)
+            return
 
 
 async def stop_rapidfire_async(
@@ -131,6 +135,7 @@ def finish_rapidfire_task(
                 axis_code,
                 evdev_mod=evdev,
                 uinput_writer=_uinput_writer,
+                uinput_dev=state.uinput,
             )
         return
     if kind == "relative":
@@ -139,7 +144,7 @@ def finish_rapidfire_task(
         code = state.code
         uinput = state.uinput
         if code is not None:
-            ensure_key_released(device_runtime, code, uinput)
+            ensure_key_released(device_runtime, code, uinput, bucket=state.bucket)
 
 
 async def rapidfire_trigger(
@@ -148,6 +153,7 @@ async def rapidfire_trigger(
     hold_ms: int,
     wait_ms: int,
     event_name: str,
+    uinput_dev: object | None,
     *,
     asyncio_mod: AsyncioModule,
     evdev_mod: EvdevModule,
@@ -163,7 +169,7 @@ async def rapidfire_trigger(
             device_runtime.state.rapidfire_active.get(event_name, False)
             and runtime_is_running(device_runtime)
         ):
-            gamepad_uinput = uinput_writer(device_runtime.gamepad_uinput)
+            gamepad_uinput = uinput_writer(uinput_dev)
             if gamepad_uinput is None:
                 return
             gamepad_uinput.write(evdev_mod.ecodes.EV_ABS, axis_code, 255)
@@ -188,6 +194,7 @@ async def rapidfire_trigger(
                 axis_code,
                 evdev_mod=evdev_mod,
                 uinput_writer=uinput_writer,
+                uinput_dev=uinput_dev,
             )
         if task is not None:
             finish_rapidfire_task(device_runtime, event_name, task)
@@ -198,6 +205,7 @@ async def tap_trigger(
     axis_code: int,
     hold_ms: int,
     event_name: str,
+    uinput_dev: object | None,
     *,
     asyncio_mod: AsyncioModule,
     evdev_mod: EvdevModule,
@@ -206,7 +214,7 @@ async def tap_trigger(
     hold = hold_ms / 1000.0
 
     try:
-        gamepad_uinput = uinput_writer(device_runtime.gamepad_uinput)
+        gamepad_uinput = uinput_writer(uinput_dev)
         if gamepad_uinput is None:
             return
         gamepad_uinput.write(evdev_mod.ecodes.EV_ABS, axis_code, 255)
@@ -229,6 +237,7 @@ async def rapidfire_key(
     uinput_dev: object | None,
     *,
     asyncio_mod: AsyncioModule,
+    bucket: str | None = None,
 ) -> None:
     hold = clamp_rapidfire_hold_ms(hold_ms) / 1000.0
     wait = clamp_rapidfire_wait_ms(wait_ms) / 1000.0
@@ -247,6 +256,7 @@ async def rapidfire_key(
                 1,
                 evdev_mod=evdev,
                 uinput_writer=_uinput_writer,
+                bucket=bucket,
             )
             pressed = True
             await asyncio_mod.sleep(hold)
@@ -259,6 +269,7 @@ async def rapidfire_key(
                     0,
                     evdev_mod=evdev,
                     uinput_writer=_uinput_writer,
+                    bucket=bucket,
                 )
                 pressed = False
             if not device_runtime.state.rapidfire_active.get(event_name, False):
@@ -269,7 +280,7 @@ async def rapidfire_key(
         pass
     finally:
         if pressed:
-            ensure_key_released(device_runtime, code, uinput_dev)
+            ensure_key_released(device_runtime, code, uinput_dev, bucket=bucket)
         if task is not None:
             finish_rapidfire_task(device_runtime, event_name, task)
 
@@ -282,6 +293,7 @@ async def tap_key(
     uinput_dev: object | None,
     *,
     asyncio_mod: AsyncioModule,
+    bucket: str | None = None,
 ) -> None:
     hold = hold_ms / 1000.0
 
@@ -293,6 +305,7 @@ async def tap_key(
             1,
             evdev_mod=evdev,
             uinput_writer=_uinput_writer,
+            bucket=bucket,
         )
         await asyncio_mod.sleep(hold)
         write_key(
@@ -302,6 +315,7 @@ async def tap_key(
             0,
             evdev_mod=evdev,
             uinput_writer=_uinput_writer,
+            bucket=bucket,
         )
     except Exception:
         pass

--- a/keymasq/keymasqd/runtime/grabbed_device_types.py
+++ b/keymasq/keymasqd/runtime/grabbed_device_types.py
@@ -194,6 +194,11 @@ class GrabbedDeviceState:
             "gamepad": set(),
         }
     )
+    held_output_abs: dict[str, set[int]] = field(
+        default_factory=lambda: {
+            "gamepad": set(),
+        }
+    )
     superkey_output_refcounts: dict[str, dict[int, int]] = field(
         default_factory=lambda: {
             "keyboard": {},

--- a/keymasq/keymasqd/runtime/grabbed_device_types.py
+++ b/keymasq/keymasqd/runtime/grabbed_device_types.py
@@ -173,6 +173,7 @@ class RapidfireOutputState:
     code: int | None = None
     uinput: object | None = None
     axis_code: int | None = None
+    bucket: str | None = None
 
 
 @dataclass
@@ -283,6 +284,8 @@ class GrabbedDeviceRuntime(Protocol):
     def _running(self) -> bool: ...
 
     async def reset_superkeys(self) -> None: ...
+
+    def resolve_gamepad_output(self, output_id: str | None, context: str) -> object | None: ...
 
 
 def runtime_is_running(device_runtime: GrabbedDeviceRuntime) -> bool:

--- a/keymasq/keymasqd/runtime/macros.py
+++ b/keymasq/keymasqd/runtime/macros.py
@@ -90,6 +90,7 @@ async def play_macro(
         manager.output_state.keyboard_uinput
         or manager.output_state.mouse_uinput
         or manager.output_state.gamepad_uinput
+        or manager.output_state.virtual_gamepad_uinputs
     ):
         return {"status": "error", "message": "No output uinput devices available"}
 
@@ -461,8 +462,15 @@ async def play_macro_task(
                     uinput = manager.output_state.mouse_uinput
                     output_class = "mouse"
                 elif device_type == "gamepad":
-                    uinput = manager.output_state.gamepad_uinput
-                    output_class = "gamepad"
+                    output_id = str_value_fn(ev.get("output_id"), "").strip() or None
+                    target = manager.resolve_gamepad_output(
+                        output_id,
+                        context=f"macro {macro_name or '<unnamed>'}",
+                    )
+                    if target is None:
+                        continue
+                    uinput = target.uinput
+                    output_class = target.bucket
                 else:
                     if event_type == evdev_mod.ecodes.EV_KEY:
                         uinput = manager.output_state.keyboard_uinput
@@ -586,6 +594,15 @@ def _is_wheel_event(event_type: int, event_code: int, *, evdev_mod: Any) -> bool
     }
 
 
+def gamepad_output_class(device_class: str) -> str | None:
+    if device_class == "gamepad":
+        return "virtual-gamepad-1"
+    if device_class.startswith("gamepad:"):
+        output_id = device_class.removeprefix("gamepad:").strip()
+        return output_id or None
+    return None
+
+
 def track_macro_key_press(
     manager: _MacroManager, instance_id: int, device_class: str, code: int
 ) -> None:
@@ -623,7 +640,7 @@ def track_macro_abs_value(
     *,
     deps: MacroRuntimeDeps,
 ) -> None:
-    if device_class != "gamepad":
+    if not gamepad_output_class(device_class):
         return
     if int(code) not in gamepad_abs_cleanup_codes(deps.evdev_mod):
         return
@@ -664,6 +681,20 @@ def release_macro_held_for_instance(
         "mouse": deps.uinput_writer(manager.output_state.mouse_uinput),
         "gamepad": deps.uinput_writer(manager.output_state.gamepad_uinput),
     }
+    for output_id, uinput_dev in getattr(
+        manager.output_state, "virtual_gamepad_uinputs", {}
+    ).items():
+        uinputs[f"gamepad:{output_id}"] = deps.uinput_writer(uinput_dev)
+    for key in [*held, *held_abs]:
+        device_class = str(key[0])
+        output_id = gamepad_output_class(device_class)
+        if output_id is None or device_class in uinputs:
+            continue
+        target = manager.resolve_gamepad_output(
+            output_id,
+            context="macro cleanup",
+        )
+        uinputs[device_class] = deps.uinput_writer(target.uinput) if target is not None else None
     synced: set[str] = set()
     held_refcount = manager.macro_state.held_refcount
     held_abs_refcount = manager.macro_state.held_abs_refcount

--- a/keymasq/keymasqd/runtime/outputs.py
+++ b/keymasq/keymasqd/runtime/outputs.py
@@ -3,7 +3,9 @@ import os
 import re
 from collections.abc import Callable, Mapping, Sequence
 from hashlib import blake2b
-from typing import Final, Protocol, cast
+from typing import Any, Final, Protocol, cast
+
+from keymasq.common.virtual_devices import clamp_virtual_gamepad_count, virtual_gamepad_output_id
 
 TEST_UINPUT_ENV = "KEYMASQ_TEST_UINPUT"
 TEST_UINPUT_PREFIX = "keymasq-test"
@@ -35,6 +37,8 @@ class _OutputState(Protocol):
     keyboard_uinput: _ClosableUInput | None
     mouse_uinput: _ClosableUInput | None
     gamepad_uinput: _ClosableUInput | None
+    virtual_gamepad_uinputs: dict[str, _ClosableUInput]
+    virtual_gamepad_count: int
 
 
 class _OutputManager(Protocol):
@@ -286,6 +290,125 @@ def uinput_identity(
     )
 
 
+def gamepad_caps(evdev_mod: _EvdevModule) -> dict[int, Sequence[object]]:
+    return {
+        evdev_mod.ecodes.EV_KEY: [
+            evdev_mod.ecodes.BTN_SOUTH,
+            evdev_mod.ecodes.BTN_EAST,
+            evdev_mod.ecodes.BTN_NORTH,
+            evdev_mod.ecodes.BTN_WEST,
+            evdev_mod.ecodes.BTN_TL,
+            evdev_mod.ecodes.BTN_TR,
+            evdev_mod.ecodes.BTN_TL2,
+            evdev_mod.ecodes.BTN_TR2,
+            evdev_mod.ecodes.BTN_SELECT,
+            evdev_mod.ecodes.BTN_START,
+            evdev_mod.ecodes.BTN_MODE,
+            evdev_mod.ecodes.BTN_THUMBL,
+            evdev_mod.ecodes.BTN_THUMBR,
+            evdev_mod.ecodes.BTN_DPAD_UP,
+            evdev_mod.ecodes.BTN_DPAD_DOWN,
+            evdev_mod.ecodes.BTN_DPAD_LEFT,
+            evdev_mod.ecodes.BTN_DPAD_RIGHT,
+        ],
+        evdev_mod.ecodes.EV_ABS: [
+            (evdev_mod.ecodes.ABS_X, evdev_mod.AbsInfo(0, -32768, 32767, 16, 128, 0)),
+            (evdev_mod.ecodes.ABS_Y, evdev_mod.AbsInfo(0, -32768, 32767, 16, 128, 0)),
+            (evdev_mod.ecodes.ABS_RX, evdev_mod.AbsInfo(0, -32768, 32767, 16, 128, 0)),
+            (evdev_mod.ecodes.ABS_RY, evdev_mod.AbsInfo(0, -32768, 32767, 16, 128, 0)),
+            (evdev_mod.ecodes.ABS_Z, evdev_mod.AbsInfo(0, 0, 255, 0, 0, 0)),
+            (evdev_mod.ecodes.ABS_RZ, evdev_mod.AbsInfo(0, 0, 255, 0, 0, 0)),
+            (evdev_mod.ecodes.ABS_HAT0X, evdev_mod.AbsInfo(0, -1, 1, 0, 0, 0)),
+            (evdev_mod.ecodes.ABS_HAT0Y, evdev_mod.AbsInfo(0, -1, 1, 0, 0, 0)),
+        ],
+        evdev_mod.ecodes.EV_SYN: [],
+    }
+
+
+def _initialize_gamepad_axes(
+    uinput_dev: _WritableUInput | None,
+    evdev_mod: _EvdevModule,
+) -> None:
+    if uinput_dev is None:
+        return
+    for axis in (
+        evdev_mod.ecodes.ABS_X,
+        evdev_mod.ecodes.ABS_Y,
+        evdev_mod.ecodes.ABS_RX,
+        evdev_mod.ecodes.ABS_RY,
+        evdev_mod.ecodes.ABS_Z,
+        evdev_mod.ecodes.ABS_RZ,
+        evdev_mod.ecodes.ABS_HAT0X,
+        evdev_mod.ecodes.ABS_HAT0Y,
+    ):
+        uinput_dev.write(evdev_mod.ecodes.EV_ABS, axis, 0)
+    uinput_dev.syn()
+
+
+def create_virtual_gamepad(
+    _manager: _OutputManager,
+    output_id: str,
+    index: int,
+    evdev_mod: _EvdevModule,
+    uinput_writer: UInputWriter,
+) -> _ClosableUInput:
+    normal_name = "keymasq-gamepad" if index == 1 else f"keymasq-gamepad-{index}"
+    gamepad_name, gamepad_vendor, gamepad_product = uinput_identity(
+        normal_name,
+        "gamepad",
+        test_name="gamepad" if index == 1 else f"gamepad-{index}",
+    )
+    uinput_dev = evdev_mod.UInput(
+        events=cast(dict[int, Sequence[int]], gamepad_caps(evdev_mod)),
+        name=gamepad_name,
+        vendor=0x045E if gamepad_vendor is None else gamepad_vendor,
+        product=0x028E if gamepad_product is None else gamepad_product,
+        version=0x0110,
+        bustype=0x0003,
+    )
+    _initialize_gamepad_axes(uinput_writer(uinput_dev), evdev_mod)
+    return uinput_dev
+
+
+def configure_virtual_gamepads(
+    manager: _OutputManager,
+    count: int,
+    *,
+    evdev_mod: _EvdevModule,
+    log: logging.Logger,
+    uinput_writer: UInputWriter,
+) -> int:
+    count = clamp_virtual_gamepad_count(count)
+    output_state = cast(Any, manager.output_state)
+    if not hasattr(output_state, "virtual_gamepad_uinputs"):
+        output_state.virtual_gamepad_uinputs = {}
+    current = cast(dict[str, _ClosableUInput], output_state.virtual_gamepad_uinputs)
+    desired_ids = {virtual_gamepad_output_id(index) for index in range(1, count + 1)}
+
+    for output_id in sorted(set(current) - desired_ids):
+        uinput_dev = current.pop(output_id)
+        try:
+            uinput_dev.close()
+        except Exception as exc:
+            log.warning("Failed to close virtual gamepad %s: %s", output_id, exc)
+
+    for index in range(1, count + 1):
+        output_id = virtual_gamepad_output_id(index)
+        if output_id in current:
+            continue
+        current[output_id] = create_virtual_gamepad(
+            manager,
+            output_id,
+            index,
+            evdev_mod,
+            uinput_writer,
+        )
+        log.info("Created virtual gamepad %s", output_id)
+
+    output_state.virtual_gamepad_count = count
+    return count
+
+
 def create_global_uinputs(
     manager: _OutputManager,
     *,
@@ -469,62 +592,13 @@ def create_global_uinputs(
                 product=mouse_product,
             )
 
-        gamepad_caps = {
-            evdev_mod.ecodes.EV_KEY: [
-                evdev_mod.ecodes.BTN_SOUTH,
-                evdev_mod.ecodes.BTN_EAST,
-                evdev_mod.ecodes.BTN_NORTH,
-                evdev_mod.ecodes.BTN_WEST,
-                evdev_mod.ecodes.BTN_TL,
-                evdev_mod.ecodes.BTN_TR,
-                evdev_mod.ecodes.BTN_TL2,
-                evdev_mod.ecodes.BTN_TR2,
-                evdev_mod.ecodes.BTN_SELECT,
-                evdev_mod.ecodes.BTN_START,
-                evdev_mod.ecodes.BTN_MODE,
-                evdev_mod.ecodes.BTN_THUMBL,
-                evdev_mod.ecodes.BTN_THUMBR,
-                evdev_mod.ecodes.BTN_DPAD_UP,
-                evdev_mod.ecodes.BTN_DPAD_DOWN,
-                evdev_mod.ecodes.BTN_DPAD_LEFT,
-                evdev_mod.ecodes.BTN_DPAD_RIGHT,
-            ],
-            evdev_mod.ecodes.EV_ABS: [
-                (evdev_mod.ecodes.ABS_X, evdev_mod.AbsInfo(0, -32768, 32767, 16, 128, 0)),
-                (evdev_mod.ecodes.ABS_Y, evdev_mod.AbsInfo(0, -32768, 32767, 16, 128, 0)),
-                (evdev_mod.ecodes.ABS_RX, evdev_mod.AbsInfo(0, -32768, 32767, 16, 128, 0)),
-                (evdev_mod.ecodes.ABS_RY, evdev_mod.AbsInfo(0, -32768, 32767, 16, 128, 0)),
-                (evdev_mod.ecodes.ABS_Z, evdev_mod.AbsInfo(0, 0, 255, 0, 0, 0)),
-                (evdev_mod.ecodes.ABS_RZ, evdev_mod.AbsInfo(0, 0, 255, 0, 0, 0)),
-                (evdev_mod.ecodes.ABS_HAT0X, evdev_mod.AbsInfo(0, -1, 1, 0, 0, 0)),
-                (evdev_mod.ecodes.ABS_HAT0Y, evdev_mod.AbsInfo(0, -1, 1, 0, 0, 0)),
-            ],
-            evdev_mod.ecodes.EV_SYN: [],
-        }
-        gamepad_name, gamepad_vendor, gamepad_product = uinput_identity(
-            "keymasq-gamepad",
-            "gamepad",
+        configure_virtual_gamepads(
+            manager,
+            getattr(manager.output_state, "virtual_gamepad_count", 1),
+            evdev_mod=evdev_mod,
+            log=log,
+            uinput_writer=uinput_writer,
         )
-        manager.output_state.gamepad_uinput = evdev_mod.UInput(
-            events=cast(dict[int, Sequence[int]], gamepad_caps),
-            name=gamepad_name,
-            vendor=0x045E if gamepad_vendor is None else gamepad_vendor,
-            product=0x028E if gamepad_product is None else gamepad_product,
-            version=0x0110,
-            bustype=0x0003,
-        )
-
-        gamepad_uinput = uinput_writer(manager.output_state.gamepad_uinput)
-        if gamepad_uinput is not None:
-            gamepad_uinput.write(evdev_mod.ecodes.EV_ABS, evdev_mod.ecodes.ABS_X, 0)
-            gamepad_uinput.write(evdev_mod.ecodes.EV_ABS, evdev_mod.ecodes.ABS_Y, 0)
-            gamepad_uinput.write(evdev_mod.ecodes.EV_ABS, evdev_mod.ecodes.ABS_RX, 0)
-            gamepad_uinput.write(evdev_mod.ecodes.EV_ABS, evdev_mod.ecodes.ABS_RY, 0)
-            gamepad_uinput.write(evdev_mod.ecodes.EV_ABS, evdev_mod.ecodes.ABS_Z, 0)
-            gamepad_uinput.write(evdev_mod.ecodes.EV_ABS, evdev_mod.ecodes.ABS_RZ, 0)
-            gamepad_uinput.write(evdev_mod.ecodes.EV_ABS, evdev_mod.ecodes.ABS_HAT0X, 0)
-            gamepad_uinput.write(evdev_mod.ecodes.EV_ABS, evdev_mod.ecodes.ABS_HAT0Y, 0)
-            gamepad_uinput.syn()
 
     manager.output_state.device_count += 1
 
@@ -538,7 +612,7 @@ def destroy_global_uinputs(manager: _OutputManager, *, log: logging.Logger) -> N
         for uinput_dev in [
             manager.output_state.keyboard_uinput,
             manager.output_state.mouse_uinput,
-            manager.output_state.gamepad_uinput,
+            *manager.output_state.virtual_gamepad_uinputs.values(),
         ]:
             if uinput_dev:
                 try:
@@ -548,4 +622,4 @@ def destroy_global_uinputs(manager: _OutputManager, *, log: logging.Logger) -> N
 
         manager.output_state.keyboard_uinput = None
         manager.output_state.mouse_uinput = None
-        manager.output_state.gamepad_uinput = None
+        manager.output_state.virtual_gamepad_uinputs.clear()

--- a/keymasq/keymasqd/superkey_state.py
+++ b/keymasq/keymasqd/superkey_state.py
@@ -43,6 +43,7 @@ class SuperkeyState(Enum):
 class SuperkeyActionData:
     action_type: str
     target: str | None = None
+    output_id: str | None = None
     cmd: str | None = None
     exec_ref: int | None = None
     macro_name: str | None = None
@@ -67,6 +68,11 @@ class SuperkeyActionData:
     rapidfire_wait_ms: int = 20
 
     def __post_init__(self) -> None:
+        self.output_id = (
+            str(self.output_id).strip()
+            if self.action_type == ActionType.GAMEPAD.value and self.output_id is not None
+            else None
+        ) or None
         self.rapidfire_hold_ms = clamp_rapidfire_hold_ms(self.rapidfire_hold_ms)
         self.rapidfire_wait_ms = clamp_rapidfire_wait_ms(self.rapidfire_wait_ms)
 
@@ -126,6 +132,7 @@ class SuperkeyMachine:
         broadcast_callback: Callable[[dict[str, object]], Awaitable[None]] | None = None,
         cursor_position_setter: CursorPositionSetter | None = None,
         key_event_tracker: Callable[[str, int, int], bool] | None = None,
+        gamepad_output_resolver: Callable[[str | None, str], object | None] | None = None,
     ) -> None:
         self.config = config
         self.event_name = event_name
@@ -136,6 +143,7 @@ class SuperkeyMachine:
         self.broadcast_callback = broadcast_callback
         self.cursor_position_setter = cursor_position_setter
         self.key_event_tracker = key_event_tracker
+        self.gamepad_output_resolver = gamepad_output_resolver
 
         self.state = SuperkeyState.IDLE
         self._hold_task: asyncio.Task[None] | None = None
@@ -422,7 +430,7 @@ class SuperkeyMachine:
             if code is None:
                 return
 
-            uinput = self._get_uinput(action.action_type)
+            uinput, bucket = self._get_action_output(action)
             if uinput is None:
                 return
 
@@ -447,7 +455,7 @@ class SuperkeyMachine:
             else:
                 should_emit = True
                 if self.key_event_tracker:
-                    should_emit = self.key_event_tracker(action.action_type, int(code), 1)
+                    should_emit = self.key_event_tracker(bucket, int(code), 1)
                 if should_emit:
                     uinput.write(evdev.ecodes.EV_KEY, code, 1)
                     uinput.syn()
@@ -479,7 +487,7 @@ class SuperkeyMachine:
             if code is None:
                 return
 
-            uinput = self._get_uinput(action.action_type)
+            uinput, bucket = self._get_action_output(action)
             if uinput is None:
                 return
 
@@ -498,7 +506,7 @@ class SuperkeyMachine:
             else:
                 should_emit = True
                 if self.key_event_tracker:
-                    should_emit = self.key_event_tracker(action.action_type, int(code), 0)
+                    should_emit = self.key_event_tracker(bucket, int(code), 0)
                 if should_emit:
                     uinput.write(evdev.ecodes.EV_KEY, code, 0)
                     uinput.syn()
@@ -511,6 +519,21 @@ class SuperkeyMachine:
         elif action_type == "gamepad":
             return self.gamepad_uinput
         return None
+
+    def _get_action_output(self, action: SuperkeyActionData) -> tuple[_WritableUInput | None, str]:
+        if action.action_type != "gamepad":
+            return self._get_uinput(action.action_type), action.action_type
+        if self.gamepad_output_resolver is not None:
+            target = self.gamepad_output_resolver(
+                action.output_id,
+                f"{self.event_name} -> {action.target or ''}",
+            )
+            if target is None:
+                return None, "gamepad"
+            return cast(_WritableUInput | None, getattr(target, "uinput", None)), str(
+                getattr(target, "bucket", "gamepad")
+            )
+        return self.gamepad_uinput, "gamepad"
 
     def _resolve_code(self, target: str | None) -> int | None:
         return resolve_output_code(target)

--- a/keymasq/session/manager/commands.py
+++ b/keymasq/session/manager/commands.py
@@ -5,6 +5,8 @@ from typing import TYPE_CHECKING, cast
 from keymasq.common.ipc import Command, CommandType
 from keymasq.common.models import normalize_macro_loop_stop_behavior
 from keymasq.common.security import PeerCredentials, command_allowed
+from keymasq.common.virtual_devices import MAX_VIRTUAL_GAMEPADS, MIN_VIRTUAL_GAMEPADS
+from keymasq.session.virtual_devices import save_virtual_gamepad_count
 
 from . import compositor as runtime_compositor
 from . import profiles as runtime_profiles
@@ -77,6 +79,10 @@ async def handle_session_request(
     if result is not None:
         return result
 
+    result = await _handle_virtual_gamepad_commands(manager, command, request)
+    if result is not None:
+        return result
+
     if command == "set_diagnostics":
         return await _handle_set_diagnostics(manager, request)
 
@@ -121,6 +127,45 @@ async def _handle_profile_commands(
         return {"status": "ok"}
 
     return None
+
+
+async def _handle_virtual_gamepad_commands(
+    manager: "SessionManager",
+    command: str,
+    request: JsonObject,
+) -> JsonObject | None:
+    if command == "get_virtual_gamepads":
+        return {
+            "status": "ok",
+            "count": int(manager.virtual_gamepad_count),
+            "min_count": MIN_VIRTUAL_GAMEPADS,
+            "max_count": MAX_VIRTUAL_GAMEPADS,
+        }
+    if command != "set_virtual_gamepads":
+        return None
+
+    requested_count = int_value(request.get("count"), manager.virtual_gamepad_count)
+    count = save_virtual_gamepad_count(requested_count)
+    manager.virtual_gamepad_count = count
+    if manager.connected:
+        response = await manager.client.send_command(
+            Command(command=CommandType.SET_VIRTUAL_GAMEPADS, data={"count": count})
+        )
+        if response.status != "ok":
+            return {"status": "error", "message": response.error or "daemon rejected count"}
+        if isinstance(response.data, dict):
+            data = cast(JsonObject, response.data)
+            count = int_value(data.get("count"), count)
+            manager.virtual_gamepad_count = count
+    manager.broadcast_to_session_clients(
+        {"event": "virtual_gamepads_changed", "count": int(manager.virtual_gamepad_count)}
+    )
+    return {
+        "status": "ok",
+        "count": int(manager.virtual_gamepad_count),
+        "min_count": MIN_VIRTUAL_GAMEPADS,
+        "max_count": MAX_VIRTUAL_GAMEPADS,
+    }
 
 
 async def _handle_compositor_commands(

--- a/keymasq/session/manager/core.py
+++ b/keymasq/session/manager/core.py
@@ -35,6 +35,7 @@ from keymasq.session.dbus import SessionDBus
 from keymasq.session.hardware import HardwareManager
 from keymasq.session.profiles import ProfileManager
 from keymasq.session.superkeys import SuperkeyManager
+from keymasq.session.virtual_devices import load_virtual_gamepad_count
 
 from . import commands as session_commands
 from . import compositor as runtime_compositor
@@ -75,6 +76,7 @@ class SessionManager:
             auto_create_default_if_empty=True,
         )
         self.hardware = HardwareManager()
+        self.virtual_gamepad_count = load_virtual_gamepad_count()
         self.action_handler: ActionHandler | None = None
         self.running = False
         self._shutdown_event = asyncio.Event()
@@ -486,6 +488,7 @@ class SessionManager:
 
         await asyncio.to_thread(self.reload_config_from_disk)
         log.info("Reloaded all superkeys, profiles and hardware configs")
+        await self._sync_virtual_gamepads_to_daemon()
         runtime_profiles.invalidate_runtime_payload_signatures(self)
 
         configured_ids = set(self.hardware.list_hardware_ids())
@@ -506,6 +509,25 @@ class SessionManager:
         self.superkeys.reload()
         self.profiles.reload()
         self.hardware.reload()
+        self.virtual_gamepad_count = load_virtual_gamepad_count()
+
+    async def _sync_virtual_gamepads_to_daemon(self) -> None:
+        if not self.connected:
+            return
+        try:
+            response = await self.client.send_command(
+                Command(
+                    command=CommandType.SET_VIRTUAL_GAMEPADS,
+                    data={"count": int(self.virtual_gamepad_count)},
+                )
+            )
+            if response.status == "ok" and isinstance(response.data, dict):
+                data = cast(JsonObject, response.data)
+                raw_count = data.get("count", self.virtual_gamepad_count)
+                if isinstance(raw_count, (int, float, str)):
+                    self.virtual_gamepad_count = int(raw_count)
+        except Exception as exc:
+            log.warning("Failed to configure virtual gamepads in keymasqd: %s", exc)
 
     async def connect_loop(self) -> None:
         retry_delay = 1.0
@@ -520,6 +542,7 @@ class SessionManager:
                 log.info("Connected to keymasqd")
                 self._broadcast_keymasqd_status(True)
                 await runtime_compositor.sync_cursor_position_backend(self)
+                await self._sync_virtual_gamepads_to_daemon()
 
                 try:
                     await runtime_profiles.activate_initial_profiles(self)

--- a/keymasq/session/manager/payloads.py
+++ b/keymasq/session/manager/payloads.py
@@ -138,6 +138,8 @@ def action_signature_payload(
         "mouse_move_abs",
     ):
         data["target"] = action.target or ""
+        if action_type == "gamepad" and action.output_id:
+            data["output_id"] = action.output_id
         if action_type in ("mouse_move_rel", "mouse_move_abs"):
             data["x"] = int(action.move_x)
             data["y"] = int(action.move_y)
@@ -252,6 +254,8 @@ def profile_to_mapping(
             "mouse_move_abs",
         ):
             action_data["target"] = action.target
+            if action.action_type.value == "gamepad" and action.output_id:
+                action_data["output_id"] = action.output_id
             if action.action_type.value in ("mouse_move_rel", "mouse_move_abs"):
                 action_data["x"] = int(action.move_x)
                 action_data["y"] = int(action.move_y)
@@ -387,6 +391,8 @@ def combo_action_to_payload(
         "mouse_move_abs",
     ):
         action_data["target"] = action.target
+        if action_type == "gamepad" and action.output_id:
+            action_data["output_id"] = action.output_id
         if action_type in ("mouse_move_rel", "mouse_move_abs"):
             action_data["x"] = int(action.move_x)
             action_data["y"] = int(action.move_y)
@@ -668,6 +674,8 @@ def serialize_overload_action(
         "mouse_move_abs",
     ):
         action_data["target"] = action.target
+        if action_type == "gamepad" and action.output_id:
+            action_data["output_id"] = action.output_id
         if action_type in ("mouse_move_rel", "mouse_move_abs"):
             action_data["x"] = int(action.move_x)
             action_data["y"] = int(action.move_y)

--- a/keymasq/session/profiles.py
+++ b/keymasq/session/profiles.py
@@ -384,6 +384,7 @@ class ProfileManager:
         return MappingAction(
             action_type=action_type,
             target=str(target) if target is not None else None,
+            output_id=str(action_data.get("output_id", "") or "") or None,
             keys=cast(list[str] | None, action_data.get("keys")),
             cmd=str(cmd) if cmd is not None else None,
             rapidfire_enabled=rapidfire_enabled,
@@ -397,6 +398,8 @@ class ProfileManager:
         action_data: dict[str, object] = {"action": action.action_type.value}
         if action.target:
             action_data["target"] = action.target
+        if action.action_type == ActionType.GAMEPAD and action.output_id:
+            action_data["output_id"] = action.output_id
         if action.keys:
             action_data["keys"] = action.keys
         if action.cmd:

--- a/keymasq/session/superkeys.py
+++ b/keymasq/session/superkeys.py
@@ -260,6 +260,7 @@ class SuperkeyManager:
         return MappingAction(
             action_type=action_type,
             target=str(target) if target is not None else None,
+            output_id=str(action_data.get("output_id", "") or "") or None,
             keys=cast(list[str] | None, action_data.get("keys")),
             cmd=str(cmd) if cmd is not None else None,
             rapidfire_enabled=rapidfire_enabled,
@@ -382,6 +383,8 @@ class SuperkeyManager:
         action_data: dict[str, object] = {"action": action.action_type.value}
         if action.target:
             action_data["target"] = action.target
+        if action.action_type == ActionType.GAMEPAD and action.output_id:
+            action_data["output_id"] = action.output_id
         if action.keys:
             action_data["keys"] = action.keys
         if action.cmd:

--- a/keymasq/session/virtual_devices.py
+++ b/keymasq/session/virtual_devices.py
@@ -1,0 +1,53 @@
+import logging
+import tomllib
+from typing import cast
+
+import tomli_w
+
+from keymasq.common.paths import VIRTUAL_DEVICES_PATH, ensure_config_dirs
+from keymasq.common.virtual_devices import (
+    DEFAULT_VIRTUAL_GAMEPADS,
+    MAX_VIRTUAL_GAMEPADS,
+    MIN_VIRTUAL_GAMEPADS,
+    clamp_virtual_gamepad_count,
+)
+
+__all__ = [
+    "DEFAULT_VIRTUAL_GAMEPADS",
+    "MAX_VIRTUAL_GAMEPADS",
+    "MIN_VIRTUAL_GAMEPADS",
+    "clamp_virtual_gamepad_count",
+    "load_virtual_gamepad_count",
+    "save_virtual_gamepad_count",
+]
+
+log = logging.getLogger("keymasq-session.virtual-devices")
+
+
+def load_virtual_gamepad_count() -> int:
+    if not VIRTUAL_DEVICES_PATH.exists():
+        return DEFAULT_VIRTUAL_GAMEPADS
+    try:
+        with open(VIRTUAL_DEVICES_PATH, "rb") as config_file:
+            data = cast(dict[str, object], tomllib.load(config_file))
+        gamepads = data.get("gamepads")
+        if not isinstance(gamepads, dict):
+            return DEFAULT_VIRTUAL_GAMEPADS
+        gamepad_data = cast(dict[str, object], gamepads)
+        return clamp_virtual_gamepad_count(gamepad_data.get("virtual_count"))
+    except Exception as exc:
+        log.warning(
+            "Failed to load virtual device config from %s: %s; using default count %s",
+            VIRTUAL_DEVICES_PATH,
+            exc,
+            DEFAULT_VIRTUAL_GAMEPADS,
+        )
+        return DEFAULT_VIRTUAL_GAMEPADS
+
+
+def save_virtual_gamepad_count(count: int) -> int:
+    ensure_config_dirs()
+    clamped_count = clamp_virtual_gamepad_count(count)
+    with open(VIRTUAL_DEVICES_PATH, "wb") as config_file:
+        tomli_w.dump({"gamepads": {"virtual_count": clamped_count}}, config_file)
+    return clamped_count

--- a/tests/gui/test_gui_device_tab_misc.py
+++ b/tests/gui/test_gui_device_tab_misc.py
@@ -626,6 +626,34 @@ def test_key_selector_dialog_gamepad_output_selector_lives_in_title(monkeypatch)
     assert dialog._gamepad_output_header.get_visible() is True
 
 
+def test_key_selector_dialog_gamepad_output_labels_hardware_by_name(monkeypatch):
+    gi.require_version("Gtk", "4.0")
+    from gi.repository import Gtk
+
+    from keymasq.common.models import ButtonDefinition, HardwareConfig
+    from keymasq.gui.widgets import key_selector_dialog as dialog_module
+    from keymasq.gui.widgets.key_selector_dialog import KeySelectorDialog
+
+    hardware = HardwareConfig(
+        vendor_id="045e",
+        product_id="028e",
+        name="Living Room Pad",
+        evdev_devices=[],
+        buttons=[ButtonDefinition(id="btn_a", label="A", evdev="btn_a")],
+        id="045e:028e@2",
+    )
+    monkeypatch.setattr(dialog_module, "load_virtual_gamepad_count", lambda: 1)
+    monkeypatch.setattr(
+        dialog_module,
+        "HardwareManager",
+        lambda: SimpleNamespace(list_hardware=lambda: [hardware]),
+    )
+
+    dialog = KeySelectorDialog(Gtk.Box(), "Extra Button 14")
+
+    assert ("045e:028e@2", "Living Room Pad (045e:028e@2)") in dialog._gamepad_output_choices()
+
+
 def test_key_selector_dialog_mouse_back_forward_use_browser_button_codes():
     gi.require_version("Gtk", "4.0")
     from gi.repository import Gtk

--- a/tests/gui/test_gui_device_tab_misc.py
+++ b/tests/gui/test_gui_device_tab_misc.py
@@ -711,6 +711,76 @@ def test_key_selector_dialog_explicit_missing_virtual_output_warns(monkeypatch):
     )
 
 
+def test_key_selector_dialog_explicit_first_virtual_output_uses_default_choice(monkeypatch):
+    gi.require_version("Gtk", "4.0")
+    from gi.repository import Gtk
+
+    from keymasq.common.models import ActionType, MappingAction
+    from keymasq.gui.widgets import key_selector_dialog as dialog_module
+    from keymasq.gui.widgets.key_selector_dialog import KeySelectorDialog
+
+    monkeypatch.setattr(dialog_module, "load_virtual_gamepad_count", lambda: 1)
+    monkeypatch.setattr(
+        dialog_module,
+        "HardwareManager",
+        lambda: SimpleNamespace(list_hardware=lambda: []),
+    )
+
+    dialog = KeySelectorDialog(
+        Gtk.Box(),
+        "Extra Button 14",
+        MappingAction(
+            action_type=ActionType.GAMEPAD,
+            target="btn_south",
+            output_id="virtual-gamepad-1",
+        ),
+    )
+
+    assert dialog._gamepad_output_choices() == [(None, "Virtual Gamepad 1")]
+    assert dialog._gamepad_output_dropdown is not None
+    assert dialog._gamepad_output_dropdown.get_selected() == 0
+    assert dialog._gamepad_output_warning_label is not None
+    assert dialog._gamepad_output_warning_label.get_visible() is False
+
+
+def test_superkey_action_dialog_explicit_first_virtual_output_uses_default_choice(
+    monkeypatch,
+):
+    gi.require_version("Gtk", "4.0")
+    from gi.repository import Gtk
+
+    from keymasq.common.models import ActionType, SuperkeyAction
+    from keymasq.gui.widgets import key_selector_dialog as dialog_module
+    from keymasq.gui.widgets.key_selector_dialog import SuperkeyActionDialog
+
+    monkeypatch.setattr(dialog_module, "load_virtual_gamepad_count", lambda: 1)
+    monkeypatch.setattr(
+        dialog_module,
+        "HardwareManager",
+        lambda: SimpleNamespace(list_hardware=lambda: []),
+    )
+    monkeypatch.setattr(
+        dialog_module,
+        "session_request_async",
+        lambda payload, callback, timeout=5.0: None,
+    )
+
+    dialog = SuperkeyActionDialog(
+        Gtk.Box(),
+        "hold",
+        SuperkeyAction(
+            action_type=ActionType.GAMEPAD,
+            target="btn_south",
+            output_id="virtual-gamepad-1",
+        ),
+    )
+
+    assert dialog._gamepad_output_choices() == [(None, "Virtual Gamepad 1")]
+    assert dialog._gamepad_output_ids == [None]
+    assert dialog._gamepad_output_warning_label is not None
+    assert dialog._gamepad_output_warning_label.get_visible() is False
+
+
 def test_key_selector_dialog_mouse_back_forward_use_browser_button_codes():
     gi.require_version("Gtk", "4.0")
     from gi.repository import Gtk

--- a/tests/gui/test_gui_device_tab_misc.py
+++ b/tests/gui/test_gui_device_tab_misc.py
@@ -598,6 +598,34 @@ def test_key_selector_dialog_keyboard_mapping_uses_rapidfire_or_tap_state():
     assert tap_results[0].tap_hold_ms == 70
 
 
+def test_key_selector_dialog_gamepad_output_selector_lives_in_title(monkeypatch):
+    gi.require_version("Gtk", "4.0")
+    from gi.repository import Gtk
+
+    from keymasq.gui.widgets import key_selector_dialog as dialog_module
+    from keymasq.gui.widgets.key_selector_dialog import KeySelectorDialog
+
+    monkeypatch.setattr(dialog_module, "load_virtual_gamepad_count", lambda: 2)
+    monkeypatch.setattr(
+        dialog_module,
+        "HardwareManager",
+        lambda: SimpleNamespace(list_hardware=lambda: []),
+    )
+
+    dialog = KeySelectorDialog(Gtk.Box(), "Extra Button 14")
+    gamepad_tab = dialog.stack.get_child_by_name("gamepad")
+
+    assert dialog._gamepad_output_header is not None
+    assert dialog._gamepad_output_dropdown is not None
+    assert dialog._gamepad_output_header.get_parent() is not gamepad_tab
+    assert dialog._gamepad_output_dropdown.get_parent() is dialog._gamepad_output_header
+    assert dialog._gamepad_output_header.get_visible() is False
+
+    dialog.stack.set_visible_child_name("gamepad")
+
+    assert dialog._gamepad_output_header.get_visible() is True
+
+
 def test_key_selector_dialog_mouse_back_forward_use_browser_button_codes():
     gi.require_version("Gtk", "4.0")
     from gi.repository import Gtk

--- a/tests/gui/test_gui_device_tab_misc.py
+++ b/tests/gui/test_gui_device_tab_misc.py
@@ -654,6 +654,63 @@ def test_key_selector_dialog_gamepad_output_labels_hardware_by_name(monkeypatch)
     assert ("045e:028e@2", "Living Room Pad (045e:028e@2)") in dialog._gamepad_output_choices()
 
 
+def test_key_selector_dialog_gamepad_default_warns_when_virtual_count_zero(monkeypatch):
+    gi.require_version("Gtk", "4.0")
+    from gi.repository import Gtk
+
+    from keymasq.gui.widgets import key_selector_dialog as dialog_module
+    from keymasq.gui.widgets.key_selector_dialog import KeySelectorDialog
+
+    monkeypatch.setattr(dialog_module, "load_virtual_gamepad_count", lambda: 0)
+    monkeypatch.setattr(
+        dialog_module,
+        "HardwareManager",
+        lambda: SimpleNamespace(list_hardware=lambda: []),
+    )
+
+    dialog = KeySelectorDialog(Gtk.Box(), "Extra Button 14")
+
+    assert dialog._gamepad_output_choices()[0] == (None, "Default output unavailable")
+    assert dialog._gamepad_output_warning_label is not None
+    assert dialog._gamepad_output_warning_label.get_visible() is True
+    assert dialog._gamepad_output_warning_label.get_label() == "No virtual gamepads are configured."
+
+
+def test_key_selector_dialog_explicit_missing_virtual_output_warns(monkeypatch):
+    gi.require_version("Gtk", "4.0")
+    from gi.repository import Gtk
+
+    from keymasq.common.models import ActionType, MappingAction
+    from keymasq.gui.widgets import key_selector_dialog as dialog_module
+    from keymasq.gui.widgets.key_selector_dialog import KeySelectorDialog
+
+    monkeypatch.setattr(dialog_module, "load_virtual_gamepad_count", lambda: 1)
+    monkeypatch.setattr(
+        dialog_module,
+        "HardwareManager",
+        lambda: SimpleNamespace(list_hardware=lambda: []),
+    )
+
+    dialog = KeySelectorDialog(
+        Gtk.Box(),
+        "Extra Button 14",
+        MappingAction(
+            action_type=ActionType.GAMEPAD,
+            target="btn_south",
+            output_id="virtual-gamepad-3",
+        ),
+    )
+
+    assert ("virtual-gamepad-3", "virtual-gamepad-3 (unavailable)") in (
+        dialog._gamepad_output_choices()
+    )
+    assert dialog._gamepad_output_warning_label is not None
+    assert dialog._gamepad_output_warning_label.get_visible() is True
+    assert "virtual-gamepad-3 is not configured" in (
+        dialog._gamepad_output_warning_label.get_label()
+    )
+
+
 def test_key_selector_dialog_mouse_back_forward_use_browser_button_codes():
     gi.require_version("Gtk", "4.0")
     from gi.repository import Gtk

--- a/tests/gui/test_macro_editor_dialog_widget.py
+++ b/tests/gui/test_macro_editor_dialog_widget.py
@@ -1,9 +1,12 @@
 # ruff: noqa: F403, F405, I001
 from collections.abc import Callable
 
+from keymasq.common.models import MappingAction
 from keymasq.gui.widgets.macro_editor_dialog import EditableControl
 
 from tests.gui.macro_editor_dialog_support import *
+
+from gi.repository import Gtk
 
 def test_macro_editor_initial_state_load_applies_macro_fields(monkeypatch) -> None:
     from keymasq.gui.session_client import GuiTaskResult
@@ -86,6 +89,58 @@ def test_macro_editor_initial_state_load_applies_macro_fields(monkeypatch) -> No
     assert dialog._macro_start_x_spin.get_sensitive() is True
     assert dialog._macro_start_y_spin.get_sensitive() is True
     assert dialog._macro_block_mouse_check.get_active() is True
+
+
+def test_macro_editor_gamepad_events_round_trip_output_id(monkeypatch) -> None:
+    raw_events = [
+        {
+            "device_type": "gamepad",
+            "type": evdev.ecodes.EV_KEY,
+            "code": evdev.ecodes.BTN_SOUTH,
+            "value": 1,
+            "t_us": 1000,
+            "output_id": "virtual-gamepad-2",
+        },
+        {
+            "device_type": "gamepad",
+            "type": evdev.ecodes.EV_KEY,
+            "code": evdev.ecodes.BTN_SOUTH,
+            "value": 0,
+            "t_us": 5000,
+            "output_id": "virtual-gamepad-2",
+        },
+    ]
+
+    events, rel_events, passthrough_events, moves, controls = parse_events(raw_events)
+
+    assert len(events) == 1
+    assert events[0].device_type == "gamepad"
+    assert events[0].output_id == "virtual-gamepad-2"
+    assert _passthrough_track(raw_events[0]) == "gamepad"
+    assert reconstruct_events(events, rel_events, passthrough_events, moves, controls) == raw_events
+
+
+def test_macro_editor_insert_gamepad_action_adds_timeline_event(monkeypatch) -> None:
+    dialog = _build_macro_dialog(monkeypatch)
+    action = MappingAction(
+        action_type=ActionType.GAMEPAD,
+        target="btn_south",
+        output_id="virtual-gamepad-2",
+    )
+
+    dialog._on_key_selected_for_insert(Gtk.Window(), action, 12000)
+
+    assert len(dialog._events) == 1
+    event = dialog._events[0]
+    assert event.device_type == "gamepad"
+    assert event.code == evdev.ecodes.BTN_SOUTH
+    assert event.output_id == "virtual-gamepad-2"
+    payload = dialog._build_macro_payload("demo_macro")
+    gamepad_events = [ev for ev in payload["events"] if ev.get("device_type") == "gamepad"]
+    assert [ev.get("output_id") for ev in gamepad_events] == [
+        "virtual-gamepad-2",
+        "virtual-gamepad-2",
+    ]
 
 
 def test_macro_editor_event_selection_and_timing_edits_refresh_event(monkeypatch) -> None:
@@ -804,10 +859,18 @@ def test_macro_editor_shift_timeline_for_gap_respects_scopes(monkeypatch) -> Non
         press_t_us=1000,
         release_t_us=2000,
     )
+    gamepad = EditableEvent(
+        device_type="gamepad",
+        ev_type=evdev.ecodes.EV_KEY,
+        code=evdev.ecodes.BTN_SOUTH,
+        press_t_us=1000,
+        release_t_us=2000,
+        output_id="virtual-gamepad-2",
+    )
     excluded = EditableControl(mode="wait", t_us=1000, duration_us=500)
     shifted = EditableControl(mode="wait_random", t_us=2000, min_us=500, max_us=1500)
     move = EditableMove(mode="rel", t_us=1000, x=1, y=1)
-    dialog._events = [keyboard, mouse]
+    dialog._events = [keyboard, mouse, gamepad]
     dialog._synthetic_moves = [move]
     dialog._control_events = [excluded, shifted]
     dialog._rel_events = [
@@ -844,6 +907,7 @@ def test_macro_editor_shift_timeline_for_gap_respects_scopes(monkeypatch) -> Non
     ) is True
     assert keyboard.press_t_us == 1000
     assert mouse.press_t_us == 1000
+    assert gamepad.press_t_us == 1000
     assert move.t_us == 1500
     assert dialog._rel_events[0]["t_us"] == 1500
     assert excluded.t_us == 1000
@@ -861,6 +925,16 @@ def test_macro_editor_shift_timeline_for_gap_respects_scopes(monkeypatch) -> Non
     assert keyboard.release_t_us == 1250
     assert mouse.press_t_us == 1000
     assert dialog._passthrough_events[0]["t_us"] == 250
+
+    assert dialog._shift_timeline_for_gap(
+        at_us=1000,
+        delta_us=500,
+        scope="gamepad",
+        exclude_control=None,
+    ) is True
+    assert keyboard.press_t_us == 250
+    assert mouse.press_t_us == 1000
+    assert gamepad.press_t_us == 1500
 
 
 def test_macro_editor_timeline_draws_and_hit_tests_all_tracks(monkeypatch) -> None:
@@ -880,6 +954,14 @@ def test_macro_editor_timeline_draws_and_hit_tests_all_tracks(monkeypatch) -> No
         code=evdev.ecodes.BTN_LEFT,
         press_t_us=60_000,
         release_t_us=220_000,
+    )
+    gamepad = EditableEvent(
+        device_type="gamepad",
+        ev_type=evdev.ecodes.EV_KEY,
+        code=evdev.ecodes.BTN_SOUTH,
+        press_t_us=80_000,
+        release_t_us=200_000,
+        output_id="virtual-gamepad-2",
     )
     move = EditableMove(mode="rel", t_us=40_000, x=8, y=-6)
     absolute_move = EditableMove(mode="abs", t_us=280_000, x=640, y=360)
@@ -905,7 +987,7 @@ def test_macro_editor_timeline_draws_and_hit_tests_all_tracks(monkeypatch) -> No
         "value": -3,
         "t_us": 210_000,
     }
-    dialog._events = [keyboard, mouse]
+    dialog._events = [keyboard, mouse, gamepad]
     dialog._rel_events = [
         {
             "device_type": "mouse",
@@ -928,6 +1010,7 @@ def test_macro_editor_timeline_draws_and_hit_tests_all_tracks(monkeypatch) -> No
 
     assert timeline._get_track_at_y(timeline._kb_y + 5) == "keyboard"
     assert timeline._get_track_at_y(timeline._m_y + 5) == "mouse"
+    assert timeline._get_track_at_y(timeline._g_y + 5) == "gamepad"
     assert timeline._get_track_at_y(timeline._wave_y + 5) == "movement"
     assert timeline._hit_test(
         timeline._time_to_x(keyboard.press_t_us) + 2,
@@ -937,6 +1020,10 @@ def test_macro_editor_timeline_draws_and_hit_tests_all_tracks(monkeypatch) -> No
         timeline._time_to_x(mouse.press_t_us) + 2,
         timeline._m_y + 12,
     ) is mouse
+    assert timeline._hit_test(
+        timeline._time_to_x(gamepad.press_t_us) + 2,
+        timeline._g_y + 12,
+    ) is gamepad
     assert timeline._hit_test_move(
         timeline._time_to_x(move.t_us),
         timeline._wave_y + 14,

--- a/tests/gui/test_virtual_gamepads_dialog.py
+++ b/tests/gui/test_virtual_gamepads_dialog.py
@@ -21,3 +21,63 @@ def test_virtual_gamepads_dialog_constructs(monkeypatch, temp_config_dir) -> Non
     assert dialog.get_child() is not None
     assert dialog.get_content_width() == 420
     assert dialog.get_content_height() == 220
+
+
+def test_virtual_gamepads_dialog_shows_session_apply_error(
+    monkeypatch,
+    temp_config_dir,
+) -> None:
+    from keymasq.gui.widgets import virtual_gamepads_dialog as dialog_module
+    from keymasq.gui.widgets.virtual_gamepads_dialog import VirtualGamepadsDialog
+
+    callbacks = []
+    saves = []
+
+    def fake_session_request_async(payload, callback, timeout=5.0):
+        callbacks.append((payload, callback))
+
+    monkeypatch.setattr(dialog_module, "session_request_async", fake_session_request_async)
+    monkeypatch.setattr(
+        dialog_module,
+        "save_virtual_gamepad_count",
+        lambda count: saves.append(count) or count,
+    )
+
+    dialog = VirtualGamepadsDialog()
+    dialog._spin.set_value(2)
+    dialog._on_apply_clicked(dialog._spin)
+
+    callbacks[-1][1]({"status": "error", "message": "daemon rejected request"})
+
+    assert dialog._status.get_text() == "daemon rejected request"
+    assert saves == []
+
+
+def test_virtual_gamepads_dialog_local_saves_only_without_session_response(
+    monkeypatch,
+    temp_config_dir,
+) -> None:
+    from keymasq.gui.widgets import virtual_gamepads_dialog as dialog_module
+    from keymasq.gui.widgets.virtual_gamepads_dialog import VirtualGamepadsDialog
+
+    callbacks = []
+    saves = []
+
+    def fake_session_request_async(payload, callback, timeout=5.0):
+        callbacks.append((payload, callback))
+
+    monkeypatch.setattr(dialog_module, "session_request_async", fake_session_request_async)
+    monkeypatch.setattr(
+        dialog_module,
+        "save_virtual_gamepad_count",
+        lambda count: saves.append(count) or count,
+    )
+
+    dialog = VirtualGamepadsDialog()
+    dialog._spin.set_value(3)
+    dialog._on_apply_clicked(dialog._spin)
+
+    callbacks[-1][1](None)
+
+    assert dialog._status.get_text() == "Saved 3 virtual gamepad(s)"
+    assert saves == [3]

--- a/tests/gui/test_virtual_gamepads_dialog.py
+++ b/tests/gui/test_virtual_gamepads_dialog.py
@@ -1,0 +1,23 @@
+# ruff: noqa: F403, F405, I001
+from tests.gui.support import *
+
+
+def test_virtual_gamepads_dialog_constructs(monkeypatch, temp_config_dir) -> None:
+    gi.require_version("Adw", "1")
+    from gi.repository import Adw
+
+    from keymasq.gui.widgets import virtual_gamepads_dialog as dialog_module
+    from keymasq.gui.widgets.virtual_gamepads_dialog import VirtualGamepadsDialog
+
+    monkeypatch.setattr(
+        dialog_module,
+        "session_request_async",
+        lambda payload, callback, timeout=5.0: None,
+    )
+
+    dialog = VirtualGamepadsDialog()
+
+    assert isinstance(dialog, Adw.Dialog)
+    assert dialog.get_child() is not None
+    assert dialog.get_content_width() == 420
+    assert dialog.get_content_height() == 220

--- a/tests/keymasqd/device_manager_support.py
+++ b/tests/keymasqd/device_manager_support.py
@@ -271,6 +271,7 @@ async def _runtime_tap_grabbed_trigger(
         axis_code,
         hold_ms,
         event_name,
+        device.gamepad_uinput,
         asyncio_mod=gdm.ASYNCIO_RUNTIME,
         evdev_mod=evdev,
         uinput_writer=gdt.identity_uinput_writer,

--- a/tests/keymasqd/test_device_manager_rapidfire.py
+++ b/tests/keymasqd/test_device_manager_rapidfire.py
@@ -3,6 +3,57 @@ from tests.keymasqd.device_manager_support import *
 
 class TestRapidfireRelease:
     @pytest.mark.asyncio
+    async def test_set_virtual_gamepads_waits_for_cancelled_rapidfire_finalizers(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        manager = DeviceManager()
+        manager.output_state.device_count = 1
+        manager.output_state.virtual_gamepad_count = 1
+        finalized: list[str] = []
+
+        async def rapidfire_task() -> None:
+            try:
+                await asyncio.Future()
+            finally:
+                finalized.append("rapidfire")
+
+        task = asyncio.create_task(rapidfire_task())
+        await asyncio.sleep(0)
+        state = SimpleNamespace(
+            rapidfire_tasks={"btn": task},
+            rapidfire_outputs={},
+            rapidfire_active={"btn": True},
+            tap_active={},
+        )
+        device = SimpleNamespace(
+            state=state,
+            release_tracked_outputs=lambda: None,
+            reset_superkeys=AsyncMock(),
+        )
+        manager.grabbed_devices = {"device": [device]}
+
+        async def fake_clear_combo_runtime(*_args, **_kwargs) -> None:
+            return None
+
+        def fake_configure_virtual_gamepads(*_args, **_kwargs) -> int:
+            assert finalized == ["rapidfire"]
+            manager.output_state.virtual_gamepad_count = 2
+            return 2
+
+        monkeypatch.setattr(dm.runtime_combos, "clear_combo_runtime", fake_clear_combo_runtime)
+        monkeypatch.setattr(
+            dm.runtime_outputs,
+            "configure_virtual_gamepads",
+            fake_configure_virtual_gamepads,
+        )
+
+        result = await manager.set_virtual_gamepads(2)
+
+        assert result == {"status": "ok", "count": 2}
+        assert task.done()
+
+    @pytest.mark.asyncio
     async def test_grab_waits_until_active_keys_clear_before_grabbing(
         self,
         monkeypatch: pytest.MonkeyPatch,

--- a/tests/keymasqd/test_device_manager_rapidfire.py
+++ b/tests/keymasqd/test_device_manager_rapidfire.py
@@ -29,6 +29,7 @@ class TestRapidfireRelease:
         device = SimpleNamespace(
             state=state,
             release_tracked_outputs=lambda: None,
+            reset_mapping_runtime_state=AsyncMock(),
             reset_superkeys=AsyncMock(),
         )
         manager.grabbed_devices = {"device": [device]}
@@ -52,6 +53,43 @@ class TestRapidfireRelease:
 
         assert result == {"status": "ok", "count": 2}
         assert task.done()
+
+    @pytest.mark.asyncio
+    async def test_set_virtual_gamepads_reuses_device_runtime_reset(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        manager = DeviceManager()
+        manager.output_state.device_count = 1
+        manager.output_state.virtual_gamepad_count = 1
+        device = SimpleNamespace(
+            state=SimpleNamespace(rapidfire_tasks={}),
+            release_tracked_outputs=Mock(),
+            reset_mapping_runtime_state=AsyncMock(),
+            reset_superkeys=AsyncMock(),
+        )
+        manager.grabbed_devices = {"device": [device]}
+
+        async def fake_clear_combo_runtime(*_args, **_kwargs) -> None:
+            return None
+
+        def fake_configure_virtual_gamepads(*_args, **_kwargs) -> int:
+            manager.output_state.virtual_gamepad_count = 2
+            return 2
+
+        monkeypatch.setattr(dm.runtime_combos, "clear_combo_runtime", fake_clear_combo_runtime)
+        monkeypatch.setattr(
+            dm.runtime_outputs,
+            "configure_virtual_gamepads",
+            fake_configure_virtual_gamepads,
+        )
+
+        result = await manager.set_virtual_gamepads(2)
+
+        assert result == {"status": "ok", "count": 2}
+        device.release_tracked_outputs.assert_called_once()
+        device.reset_mapping_runtime_state.assert_awaited_once()
+        device.reset_superkeys.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_grab_waits_until_active_keys_clear_before_grabbing(

--- a/tests/keymasqd/test_grabbed_device_runtime_helpers.py
+++ b/tests/keymasqd/test_grabbed_device_runtime_helpers.py
@@ -471,6 +471,7 @@ class TestGrabbedDeviceHelpers:
         keyboard = _FakeUInput()
         mouse = _FakeUInput()
         gamepad = _FakeUInput()
+        second_gamepad = _FakeUInput()
         canceled = Mock()
         task = SimpleNamespace(done=lambda: False, cancel=canceled)
 
@@ -478,12 +479,16 @@ class TestGrabbedDeviceHelpers:
         device.keyboard_uinput = keyboard  # type: ignore[assignment]
         device.mouse_uinput = mouse  # type: ignore[assignment]
         device.gamepad_uinput = gamepad  # type: ignore[assignment]
-        device._gamepad_output_resolver = lambda output_id, context: SimpleNamespace(  # type: ignore[method-assign, reportPrivateUsage]
-            output_id=output_id,
-            uinput=gamepad,
-            bucket=f"gamepad:{output_id}",
-            is_virtual=True,
-        )
+        def resolve_gamepad_output(output_id, context):
+            output = second_gamepad if output_id == "virtual-gamepad-2" else gamepad
+            return SimpleNamespace(
+                output_id=output_id,
+                uinput=output,
+                bucket=f"gamepad:{output_id}",
+                is_virtual=True,
+            )
+
+        device._gamepad_output_resolver = resolve_gamepad_output  # type: ignore[method-assign, reportPrivateUsage]
         gdo.track_key_state(device, device.uinput, evdev.ecodes.KEY_A, 1)
         gdo.track_key_state(device, device.keyboard_uinput, evdev.ecodes.KEY_B, 1)
         gdo.track_key_state(device, device.mouse_uinput, evdev.ecodes.BTN_LEFT, 1)
@@ -493,6 +498,12 @@ class TestGrabbedDeviceHelpers:
             evdev.ecodes.BTN_EAST,
             1,
             bucket="gamepad:virtual-gamepad-1",
+        )
+        gdo.track_abs_state(
+            device,
+            evdev.ecodes.ABS_Z,
+            255,
+            bucket="gamepad:virtual-gamepad-2",
         )
         gdo.track_superkey_output(device, "gamepad", evdev.ecodes.BTN_SOUTH, 1)
         device.state.rapidfire_tasks["btn_side"] = task  # type: ignore[assignment]
@@ -519,6 +530,8 @@ class TestGrabbedDeviceHelpers:
             (evdev.ecodes.EV_ABS, evdev.ecodes.ABS_Z, 0),
             (evdev.ecodes.EV_ABS, evdev.ecodes.ABS_RZ, 0),
         ]
+        assert second_gamepad.writes == [(evdev.ecodes.EV_ABS, evdev.ecodes.ABS_Z, 0)]
+        assert device.state.held_output_abs["gamepad:virtual-gamepad-2"] == set()
         canceled.assert_called_once()
         assert device.state.rapidfire_tasks == {}
         assert device.state.tap_active == {}
@@ -964,6 +977,48 @@ class TestGrabbedDeviceHelpers:
         emergency_resetter.assert_awaited_once_with()
         assert macro_player.await_args_list[0].kwargs["trigger_value"] == 1
         assert macro_player.await_args_list[1].kwargs["trigger_value"] == 0
+
+    @pytest.mark.asyncio
+    async def test_routed_gamepad_trigger_release_all_keys_zeros_target_output(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        device = _make_grabbed_device(monkeypatch)
+        default_gamepad = _FakeUInput()
+        second_gamepad = _FakeUInput()
+        device.gamepad_uinput = default_gamepad  # type: ignore[assignment]
+        device._gamepad_output_resolver = lambda output_id, context: SimpleNamespace(  # type: ignore[method-assign, reportPrivateUsage]
+            output_id=output_id,
+            uinput=second_gamepad if output_id == "virtual-gamepad-2" else default_gamepad,
+            bucket=f"gamepad:{output_id or 'virtual-gamepad-1'}",
+            is_virtual=True,
+        )
+        press = evdev.InputEvent(0, 0, evdev.ecodes.EV_KEY, evdev.ecodes.BTN_SOUTH, 1)
+
+        await _runtime_execute_grabbed_action(
+            device,
+            dm.MappingAction(
+                action_type=ActionType.GAMEPAD,
+                target="btn_lt",
+                output_id="virtual-gamepad-2",
+            ),
+            press,
+            "trigger_btn",
+        )
+
+        assert second_gamepad.writes == [(evdev.ecodes.EV_ABS, evdev.ecodes.ABS_Z, 255)]
+        assert device.state.held_output_abs["gamepad:virtual-gamepad-2"] == {
+            evdev.ecodes.ABS_Z
+        }
+
+        gdo.release_all_keys(
+            device,
+            evdev_mod=evdev,
+            uinput_writer=lambda device: cast(gdt.WritableUInput | None, device),
+        )
+
+        assert (evdev.ecodes.EV_ABS, evdev.ecodes.ABS_Z, 0) in second_gamepad.writes
+        assert device.state.held_output_abs["gamepad:virtual-gamepad-2"] == set()
 
     @pytest.mark.asyncio
     async def test_execute_action_mouse_move_abs_uses_cursor_position_setter(

--- a/tests/keymasqd/test_grabbed_device_runtime_helpers.py
+++ b/tests/keymasqd/test_grabbed_device_runtime_helpers.py
@@ -1020,6 +1020,70 @@ class TestGrabbedDeviceHelpers:
         assert (evdev.ecodes.EV_ABS, evdev.ecodes.ABS_Z, 0) in second_gamepad.writes
         assert device.state.held_output_abs["gamepad:virtual-gamepad-2"] == set()
 
+    def test_combo_restore_routes_gamepad_output_id_and_tracks_bucket(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        device = _make_grabbed_device(monkeypatch)
+        default_gamepad = _FakeUInput()
+        second_gamepad = _FakeUInput()
+        device.gamepad_uinput = default_gamepad  # type: ignore[assignment]
+        device._gamepad_output_resolver = lambda output_id, context: SimpleNamespace(  # type: ignore[method-assign, reportPrivateUsage]
+            output_id=output_id,
+            uinput=second_gamepad if output_id == "virtual-gamepad-2" else default_gamepad,
+            bucket=f"gamepad:{output_id or 'virtual-gamepad-1'}",
+            is_virtual=True,
+        )
+        device.state.held_source_actions["key_x"] = dm.MappingAction(
+            action_type=ActionType.GAMEPAD,
+            target="btn_south",
+            output_id="virtual-gamepad-2",
+        )
+        device.state.held_output_keys["gamepad:virtual-gamepad-2"] = {
+            evdev.ecodes.BTN_SOUTH
+        }
+
+        assert device.combo_passthrough_binding_active("key_x") is True
+
+        device.emit_combo_release("key_x")
+
+        assert default_gamepad.writes == []
+        assert second_gamepad.writes == [
+            (evdev.ecodes.EV_KEY, evdev.ecodes.BTN_SOUTH, 0)
+        ]
+        assert device.state.held_output_keys["gamepad:virtual-gamepad-2"] == set()
+
+        device.emit_combo_press("key_x")
+
+        assert default_gamepad.writes == []
+        assert second_gamepad.writes == [
+            (evdev.ecodes.EV_KEY, evdev.ecodes.BTN_SOUTH, 0),
+            (evdev.ecodes.EV_KEY, evdev.ecodes.BTN_SOUTH, 1),
+        ]
+        assert device.state.held_output_keys["gamepad:virtual-gamepad-2"] == {
+            evdev.ecodes.BTN_SOUTH
+        }
+
+    def test_release_all_keys_clears_missing_routed_abs_bucket_without_key_bucket(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        device = _make_grabbed_device(monkeypatch)
+        device._gamepad_output_resolver = lambda output_id, context: None  # type: ignore[method-assign, reportPrivateUsage]
+        device.state.held_output_abs["gamepad:virtual-gamepad-2"] = {
+            evdev.ecodes.ABS_Z
+        }
+        device.state.held_output_keys.pop("gamepad:virtual-gamepad-2", None)
+
+        gdo.release_all_keys(
+            device,
+            evdev_mod=evdev,
+            uinput_writer=lambda device: cast(gdt.WritableUInput | None, device),
+        )
+
+        assert "gamepad:virtual-gamepad-2" not in device.state.held_output_keys
+        assert device.state.held_output_abs["gamepad:virtual-gamepad-2"] == set()
+
     @pytest.mark.asyncio
     async def test_execute_action_mouse_move_abs_uses_cursor_position_setter(
         self,

--- a/tests/keymasqd/test_grabbed_device_runtime_helpers.py
+++ b/tests/keymasqd/test_grabbed_device_runtime_helpers.py
@@ -478,9 +478,22 @@ class TestGrabbedDeviceHelpers:
         device.keyboard_uinput = keyboard  # type: ignore[assignment]
         device.mouse_uinput = mouse  # type: ignore[assignment]
         device.gamepad_uinput = gamepad  # type: ignore[assignment]
+        device._gamepad_output_resolver = lambda output_id, context: SimpleNamespace(  # type: ignore[method-assign, reportPrivateUsage]
+            output_id=output_id,
+            uinput=gamepad,
+            bucket=f"gamepad:{output_id}",
+            is_virtual=True,
+        )
         gdo.track_key_state(device, device.uinput, evdev.ecodes.KEY_A, 1)
         gdo.track_key_state(device, device.keyboard_uinput, evdev.ecodes.KEY_B, 1)
         gdo.track_key_state(device, device.mouse_uinput, evdev.ecodes.BTN_LEFT, 1)
+        gdo.track_key_state(
+            device,
+            gamepad,
+            evdev.ecodes.BTN_EAST,
+            1,
+            bucket="gamepad:virtual-gamepad-1",
+        )
         gdo.track_superkey_output(device, "gamepad", evdev.ecodes.BTN_SOUTH, 1)
         device.state.rapidfire_tasks["btn_side"] = task  # type: ignore[assignment]
         device.state.rapidfire_outputs["btn_side"] = gdt.RapidfireOutputState(kind="key")
@@ -501,6 +514,7 @@ class TestGrabbedDeviceHelpers:
         assert passthrough.writes == [(evdev.ecodes.EV_KEY, evdev.ecodes.KEY_A, 0)]
         assert keyboard.writes == [(evdev.ecodes.EV_KEY, evdev.ecodes.KEY_B, 0)]
         assert mouse.writes == [(evdev.ecodes.EV_KEY, evdev.ecodes.BTN_LEFT, 0)]
+        assert (evdev.ecodes.EV_KEY, evdev.ecodes.BTN_EAST, 0) in gamepad.writes
         assert gamepad.writes[-2:] == [
             (evdev.ecodes.EV_ABS, evdev.ecodes.ABS_Z, 0),
             (evdev.ecodes.EV_ABS, evdev.ecodes.ABS_RZ, 0),

--- a/tests/keymasqd/test_macro_backend_recording.py
+++ b/tests/keymasqd/test_macro_backend_recording.py
@@ -754,6 +754,56 @@ async def test_macro_abs_cleanup_ignores_explicit_neutral_value() -> None:
 
 
 @pytest.mark.asyncio
+async def test_play_macro_routes_gamepad_event_output_id() -> None:
+    manager = DeviceManager()
+    default_gamepad = MagicMock()
+    second_gamepad = MagicMock()
+    manager.output_state.virtual_gamepad_uinputs = {
+        "virtual-gamepad-1": default_gamepad,
+        "virtual-gamepad-2": second_gamepad,
+    }
+
+    await _play_macro_task(
+        manager,
+        instance_id=1,
+        macro_events=[
+            {
+                "t_us": 0,
+                "type": evdev.ecodes.EV_KEY,
+                "code": evdev.ecodes.BTN_SOUTH,
+                "value": 1,
+                "device_type": "gamepad",
+                "output_id": "virtual-gamepad-2",
+            },
+            {
+                "t_us": 0,
+                "type": evdev.ecodes.EV_KEY,
+                "code": evdev.ecodes.BTN_SOUTH,
+                "value": 0,
+                "device_type": "gamepad",
+                "output_id": "virtual-gamepad-2",
+            },
+        ],
+        macro_name="routed_gamepad",
+        replay_mouse_movement=True,
+        replay_mouse_clicks=True,
+        speed=1.0,
+        loop_mode="none",
+        loop_count=1,
+        move_to_start=False,
+        start_x=0,
+        start_y=0,
+        block_mouse_movement=False,
+    )
+
+    default_gamepad.write.assert_not_called()
+    assert [call.args for call in second_gamepad.write.call_args_list] == [
+        (evdev.ecodes.EV_KEY, evdev.ecodes.BTN_SOUTH, 1),
+        (evdev.ecodes.EV_KEY, evdev.ecodes.BTN_SOUTH, 0),
+    ]
+
+
+@pytest.mark.asyncio
 async def test_macro_switch_interrupt_releases_held_state_for_previous_instance() -> None:
     manager = DeviceManager()
     manager.output_state.keyboard_uinput = MagicMock()

--- a/tests/session/test_session_manager_payloads_extra.py
+++ b/tests/session/test_session_manager_payloads_extra.py
@@ -124,6 +124,49 @@ def test_profile_to_mapping_serializes_high_value_action_payloads() -> None:
     assert manager.exec_state.exec_refs[2].hardware_id == "kbd"
 
 
+def test_gamepad_payloads_include_output_id_and_signature_changes() -> None:
+    from keymasq.common.models import ActionType, ComboEvent, ComboStep, MappingAction
+    from keymasq.session.manager import payloads
+    from keymasq.session.profiles import ResolvedCombo, ResolvedDeviceProfile
+
+    manager = _manager_with_superkeys()
+    action = MappingAction(
+        action_type=ActionType.GAMEPAD,
+        target="btn_a",
+        output_id="virtual-gamepad-2",
+    )
+    resolved = ResolvedDeviceProfile(hardware_id="pad", mappings={"x": action})
+
+    mapping = payloads.profile_to_mapping(manager, resolved, "pad")
+    mapped_action = cast(dict[str, object], mapping["x"])
+    assert mapped_action["output_id"] == "virtual-gamepad-2"
+
+    combo_payload = payloads.resolved_combos_payload(
+        manager,
+        [
+            ResolvedCombo(
+                id="combo",
+                name="combo",
+                steps=[ComboStep(events=[ComboEvent(hardware_id="pad", evdev="btn_x")])],
+                action=action,
+            )
+        ],
+    )
+    combo_action = cast(dict[str, object], combo_payload[0]["action"])
+    assert combo_action["output_id"] == "virtual-gamepad-2"
+
+    default_sig = payloads.resolved_mapping_signature(
+        manager,
+        ResolvedDeviceProfile(
+            hardware_id="pad",
+            mappings={"x": MappingAction(action_type=ActionType.GAMEPAD, target="btn_a")},
+        ),
+        "pad",
+    )
+    routed_sig = payloads.resolved_mapping_signature(manager, resolved, "pad")
+    assert default_sig != routed_sig
+
+
 def test_combo_payloads_filter_invalid_actions_and_track_exec_refs() -> None:
     from keymasq.common.models import (
         ActionType,

--- a/tests/session/test_virtual_devices.py
+++ b/tests/session/test_virtual_devices.py
@@ -1,0 +1,36 @@
+import logging
+
+
+def test_virtual_gamepad_config_defaults_and_clamps(tmp_path, monkeypatch) -> None:
+    from keymasq.common import paths
+    from keymasq.session import virtual_devices
+
+    config_dir = tmp_path / "keymasq"
+    monkeypatch.setattr(paths, "CONFIG_DIR", config_dir)
+    monkeypatch.setattr(
+        virtual_devices,
+        "VIRTUAL_DEVICES_PATH",
+        config_dir / "virtual_devices.toml",
+    )
+
+    assert virtual_devices.load_virtual_gamepad_count() == 1
+    assert virtual_devices.save_virtual_gamepad_count(-2) == 0
+    assert virtual_devices.load_virtual_gamepad_count() == 0
+    assert virtual_devices.save_virtual_gamepad_count(9) == 4
+    assert virtual_devices.load_virtual_gamepad_count() == 4
+
+
+def test_virtual_gamepad_config_malformed_defaults(tmp_path, monkeypatch, caplog) -> None:
+    from keymasq.common import paths
+    from keymasq.session import virtual_devices
+
+    config_dir = tmp_path / "keymasq"
+    config_dir.mkdir()
+    config_path = config_dir / "virtual_devices.toml"
+    config_path.write_text("[gamepads\n", encoding="utf-8")
+    monkeypatch.setattr(paths, "CONFIG_DIR", config_dir)
+    monkeypatch.setattr(virtual_devices, "VIRTUAL_DEVICES_PATH", config_path)
+
+    with caplog.at_level(logging.WARNING, logger="keymasq-session.virtual-devices"):
+        assert virtual_devices.load_virtual_gamepad_count() == 1
+    assert "Failed to load virtual device config" in caplog.text

--- a/tests/test_superkeys.py
+++ b/tests/test_superkeys.py
@@ -210,6 +210,22 @@ def test_superkey_action_roundtrip_preserves_shared_fields() -> None:
     assert round_tripped.rapidfire_wait_ms == 60
 
 
+def test_superkey_action_roundtrip_preserves_gamepad_output_id() -> None:
+    action = MappingAction(
+        action_type=ActionType.GAMEPAD,
+        target="btn_a",
+        output_id="virtual-gamepad-2",
+    )
+
+    superkey_action = mapping_action_to_superkey_action(action)
+    round_tripped = superkey_action_to_mapping_action(superkey_action)
+
+    assert superkey_action.output_id == "virtual-gamepad-2"
+    assert round_tripped.output_id == "virtual-gamepad-2"
+    non_gamepad = MappingAction(action_type=ActionType.KEYBOARD, output_id="virtual-gamepad-2")
+    assert non_gamepad.output_id is None
+
+
 def test_superkey_action_roundtrip_strips_unsupported_rapidfire() -> None:
     action = MappingAction(
         action_type=ActionType.MACRO,

--- a/tests/test_toml.py
+++ b/tests/test_toml.py
@@ -108,6 +108,39 @@ class TestProfileTOML:
         assert layer.mappings["btn_forward"].rapidfire_enabled is True
         assert layer.mappings["btn_forward"].rapidfire_hold_ms == 50
 
+    def test_profile_gamepad_output_id_roundtrip(self, temp_config_dir):
+        original = ProfileConfig(
+            name="Routed Gamepad",
+            device_layers={
+                "1234:5678": DeviceProfileLayer(
+                    hardware_id="1234:5678",
+                    mappings={
+                        "btn_back": MappingAction(
+                            action_type=ActionType.GAMEPAD,
+                            target="btn_a",
+                            output_id="virtual-gamepad-2",
+                        ),
+                        "btn_forward": MappingAction(
+                            action_type=ActionType.KEYBOARD,
+                            target="key_a",
+                            output_id="virtual-gamepad-3",
+                        ),
+                    },
+                )
+            },
+        )
+
+        manager = ProfileManager()
+        manager.save_profile(original)
+        content = manager.get_profile(original.name).path.read_text(encoding="utf-8")
+
+        loaded = manager.get_profile(original.name).config
+        layer = loaded.device_layers["1234:5678"]
+        assert layer.mappings["btn_back"].output_id == "virtual-gamepad-2"
+        assert layer.mappings["btn_forward"].output_id is None
+        assert 'output_id = "virtual-gamepad-2"' in content
+        assert 'output_id = "virtual-gamepad-3"' not in content
+
     def test_profile_file_is_human_readable(self, temp_config_dir, sample_profile_config):
         manager = ProfileManager()
         manager.save_profile(sample_profile_config)


### PR DESCRIPTION
## Summary
- Add a `virtual_devices.toml` setting and GUI dialog to configure 0-4 virtual Xbox 360 outputs.
- Extend gamepad actions and superkeys with strict `output_id` routing for virtual or hardware gamepad targets.
- Update daemon/runtime routing, device labeling, and docs to reflect the new output model.

## Testing
- Added/updated tests cover GUI selection, session payloads, virtual device config, superkeys, and TOML parsing.