### PR TITLE
Guard session socket startup and clean up stale sockets

### DIFF
--- a/keymasq/session/manager/core.py
+++ b/keymasq/session/manager/core.py
@@ -5,6 +5,7 @@ import json
 import logging
 import os
 import signal
+import socket
 import sys
 import traceback
 from typing import cast
@@ -92,6 +93,7 @@ class SessionManager:
         self.compositor_state = CompositorRuntimeState()
         self.connect_task: asyncio.Task[None] | None = None
         self.session_server: asyncio.Server | None = None
+        self._session_socket_owned = False
         self.session_clients: set[asyncio.StreamWriter] = set()
         self.session_client_peers: dict[asyncio.StreamWriter, PeerCredentials] = {}
         self.session_client_drain_tasks: dict[
@@ -247,16 +249,20 @@ class SessionManager:
                 await self.connect_task
             self.connect_task = None
 
-        if SESSION_SOCKET_PATH.exists():
+        if self._session_socket_owned and SESSION_SOCKET_PATH.exists():
             try:
                 SESSION_SOCKET_PATH.unlink()
             except Exception:
                 pass
+            self._session_socket_owned = False
 
     async def _start_session_server(self) -> None:
         ensure_session_socket_dir()
 
         if SESSION_SOCKET_PATH.exists():
+            if await _session_socket_accepts_connections():
+                msg = f"keymasq-session is already listening on {SESSION_SOCKET_PATH}"
+                raise RuntimeError(msg)
             try:
                 SESSION_SOCKET_PATH.unlink()
             except Exception:
@@ -266,6 +272,7 @@ class SessionManager:
             self._handle_session_client,
             path=str(SESSION_SOCKET_PATH),
         )
+        self._session_socket_owned = True
         try:
             os.chmod(SESSION_SOCKET_PATH, 0o600)
         except OSError:
@@ -638,6 +645,23 @@ def main() -> None:
 
 def _env_flag(name: str) -> bool:
     return os.environ.get(name, "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+async def _session_socket_accepts_connections(timeout_s: float = 0.2) -> bool:
+    sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    sock.setblocking(False)
+    try:
+        await asyncio.wait_for(
+            asyncio.get_running_loop().sock_connect(sock, str(SESSION_SOCKET_PATH)),
+            timeout=timeout_s,
+        )
+    except TimeoutError:
+        return True
+    except OSError:
+        return False
+    finally:
+        sock.close()
+    return True
 
 
 if __name__ == "__main__":

--- a/tests/session/test_session_manager_socket_lifecycle.py
+++ b/tests/session/test_session_manager_socket_lifecycle.py
@@ -1,0 +1,73 @@
+import asyncio
+import socket
+import tempfile
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+import keymasq.common.paths as paths_module
+import keymasq.session.manager.core as core_module
+from keymasq.session.manager import SessionManager
+
+
+@pytest.fixture
+def session_socket_path(monkeypatch: pytest.MonkeyPatch) -> Iterator[Path]:
+    with tempfile.TemporaryDirectory(dir="/tmp", prefix="km-") as runtime_dir:
+        socket_path = Path(runtime_dir) / "session.sock"
+        monkeypatch.setattr(paths_module, "SESSION_SOCKET_PATH", socket_path)
+        monkeypatch.setattr(core_module, "SESSION_SOCKET_PATH", socket_path)
+        yield socket_path
+
+
+@pytest.mark.asyncio
+async def test_start_session_server_refuses_live_existing_socket(session_socket_path) -> None:
+    session_socket_path.parent.mkdir(parents=True, exist_ok=True)
+
+    async def handle_client(
+        reader: asyncio.StreamReader,
+        writer: asyncio.StreamWriter,
+    ) -> None:
+        _ = reader
+        writer.close()
+        await writer.wait_closed()
+
+    existing_server = await asyncio.start_unix_server(
+        handle_client,
+        path=str(session_socket_path),
+    )
+    manager = SessionManager()
+
+    try:
+        with pytest.raises(RuntimeError, match="already listening"):
+            await manager._start_session_server()
+
+        assert session_socket_path.exists()
+    finally:
+        existing_server.close()
+        await existing_server.wait_closed()
+        session_socket_path.unlink(missing_ok=True)
+
+
+@pytest.mark.asyncio
+async def test_start_session_server_replaces_stale_socket(session_socket_path) -> None:
+    session_socket_path.parent.mkdir(parents=True, exist_ok=True)
+    stale_sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    try:
+        stale_sock.bind(str(session_socket_path))
+    finally:
+        stale_sock.close()
+
+    manager = SessionManager()
+
+    try:
+        await manager._start_session_server()
+
+        assert manager._session_socket_owned is True
+        assert session_socket_path.exists()
+        assert await core_module._session_socket_accepts_connections()
+    finally:
+        if manager.session_server is not None:
+            manager.session_server.close()
+            await manager.session_server.wait_closed()
+        session_socket_path.unlink(missing_ok=True)


### PR DESCRIPTION
## Summary
- Detect when `keymasq-session` is already listening on the session socket and fail startup instead of blindly unlinking it.
- Track whether the session manager owns the socket, so shutdown only removes sockets it created.
- Keep stale socket cleanup behavior for leftover filesystem entries that are not backed by a live server.
- Add regression tests covering live-socket refusal and stale-socket replacement.

## Testing
- Added async tests for refusing an active existing UNIX socket.
- Added async tests for replacing a stale socket file and verifying the new server accepts connections.