### PR TITLE
Support raw evdev devices in hardware setup

### DIFF
--- a/docs/GAMEPAD.md
+++ b/docs/GAMEPAD.md
@@ -140,6 +140,10 @@ When you add a gamepad in the hardware setup flow, Keymasq now detects its repor
 digital gamepad buttons from evdev capabilities and creates the hardware profile
 automatically. Standard buttons such as face buttons, shoulders, start/select/guide,
 stick clicks, and digital D-pad buttons are added when the controller reports them.
+Third-party uinput controllers and wheels can be added when they report gamepad
+capabilities; Keymasq's own virtual output devices stay hidden from the picker.
+Devices with controller-style axes but non-standard joystick buttons are treated
+as gamepads, and their buttons can be added later with the learn flow.
 
 Analog axes still passthrough normally, but they are not editable remap sources yet.
 If your controller has unusual extra digital buttons, you can add them later from the

--- a/keymasq/common/devices.py
+++ b/keymasq/common/devices.py
@@ -34,6 +34,10 @@ _GAMEPAD_ABS_CODES = frozenset(
         evdev.ecodes.ABS_BRAKE,
     }
 )
+_GAMEPAD_CONTROLLER_ONLY_ABS_CODES = _GAMEPAD_ABS_CODES - {
+    evdev.ecodes.ABS_X,
+    evdev.ecodes.ABS_Y,
+}
 _GAMEPAD_BUTTON_CODES = frozenset(
     {
         evdev.ecodes.BTN_SOUTH,
@@ -364,8 +368,11 @@ def detect_input_classes_from_capabilities(
     )
 
     has_gamepad_axes = bool(abs_codes & _GAMEPAD_ABS_CODES)
-    has_gamepad_buttons = bool(key_codes & _GAMEPAD_BUTTON_CODES)
-    if has_gamepad_axes and has_gamepad_buttons:
+    has_controller_buttons = bool(key_codes & _GAMEPAD_BUTTON_CODES) or any(
+        evdev.ecodes.BTN_JOYSTICK <= code < evdev.ecodes.BTN_DIGI for code in key_codes
+    )
+    is_plain_absolute_touch = evdev.ecodes.BTN_TOUCH in key_codes and not has_controller_buttons
+    if has_gamepad_axes and not is_touchpad and not is_plain_absolute_touch:
         classes.append("gamepad")
 
     if is_touchpad:

--- a/keymasq/gui/window.py
+++ b/keymasq/gui/window.py
@@ -1098,7 +1098,7 @@ class MainWindow(Adw.ApplicationWindow):
 
         dialog = HardwareSetupDialog(self, self.hardware_manager)
         dialog.connect("device-created", self._on_device_created)
-        dialog.present()
+        dialog.present(self)
 
     def _on_add_device_clicked(self, _button: Gtk.Button) -> None:
         self._on_add_device(_button)

--- a/keymasq/gui/wizards/hardware_setup.py
+++ b/keymasq/gui/wizards/hardware_setup.py
@@ -9,7 +9,13 @@ import gi
 gi.require_version("Gtk", "4.0")
 gi.require_version("Adw", "1")
 
-from gi.repository import Adw, GLib, GObject, Gtk  # pyright: ignore[reportAttributeAccessIssue]
+from gi.repository import (
+    Adw,  # pyright: ignore[reportAttributeAccessIssue]
+    Gdk,  # pyright: ignore[reportAttributeAccessIssue]
+    GLib,  # pyright: ignore[reportAttributeAccessIssue]
+    GObject,  # pyright: ignore[reportAttributeAccessIssue]
+    Gtk,  # pyright: ignore[reportAttributeAccessIssue]
+)
 
 from keymasq.common.devices import (
     INPUT_CLASS_ORDER,
@@ -77,24 +83,26 @@ def _logical_hardware_identity_key(
     if _looks_like_by_id_path(stable_path):
         return f"by-id:{_by_id_device_stem(stable_path)}"
     phys_base = _strip_input_suffix(phys)
+    if phys_base == "py-evdev-uinput":
+        return f"uinput-model:{model_id}"
     if phys_base and not _is_usb_phys(phys_base):
         return f"phys:{phys_base}"
     return f"model:{model_id}"
 
 
-class HardwareSetupDialog(Adw.Window):
+class HardwareSetupDialog(Adw.Dialog):
     __gsignals__ = {
         "device-created": (GObject.SignalFlags.RUN_FIRST, None, (object,)),
     }
 
-    def __init__(self, parent, hardware_manager: HardwareManager) -> None:
+    def __init__(self, parent: Gtk.Window, hardware_manager: HardwareManager) -> None:
         super().__init__(
             title="Add New Device",
-            transient_for=parent,
-            modal=True,
-            default_width=500,
-            default_height=450,
+            content_width=500,
+            content_height=450,
         )
+        if hasattr(self, "set_modal"):
+            self.set_modal(True)
 
         self.hardware_manager = hardware_manager
         self.detected_devices: dict[str, DetectedDevice] = {}
@@ -110,9 +118,33 @@ class HardwareSetupDialog(Adw.Window):
         self._capture_remaining_ids: list[str] = []
         self._capture_hardware_id: str | None = None
         self._detect_devices_inflight = False
+        self._show_raw_evdev_devices = False
 
+        self._setup_escape_close()
         self._setup_ui()
         self._detect_devices()
+        self.connect("closed", self._on_closed)
+
+    def _setup_escape_close(self) -> None:
+        controller = Gtk.EventControllerKey.new()
+        controller.connect("key-pressed", self._on_key_pressed)
+        self.add_controller(controller)
+
+    def _on_key_pressed(
+        self,
+        _controller: Gtk.EventControllerKey,
+        keyval: int,
+        _keycode: int,
+        _state: Gdk.ModifierType,
+    ) -> bool:
+        if keyval != Gdk.KEY_Escape:
+            return False
+        self.close()
+        return True
+
+    def _on_closed(self, *_args: object) -> None:
+        if self._capturing:
+            self._stop_capture()
 
     def _setup_ui(self) -> None:
         self.stack = Adw.ViewStack()
@@ -140,7 +172,7 @@ class HardwareSetupDialog(Adw.Window):
         toolbar = Adw.ToolbarView()
         toolbar.add_top_bar(header)
         toolbar.set_content(self.stack)
-        self.set_content(toolbar)
+        self.set_child(toolbar)
 
     def _setup_page_select(self) -> None:
         box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=12)
@@ -156,6 +188,13 @@ class HardwareSetupDialog(Adw.Window):
         subtitle = Gtk.Label(label="Choose the device you want to configure")
         subtitle.add_css_class("dim-label")
         box.append(subtitle)
+
+        self.raw_evdev_check = Gtk.CheckButton(label="Show raw evdev devices")
+        self.raw_evdev_check.set_tooltip_text(
+            "Show each event node separately, including unknown device types."
+        )
+        self.raw_evdev_check.connect("toggled", self._on_raw_evdev_toggled)
+        box.append(self.raw_evdev_check)
 
         self.device_list = Gtk.ListBox()
         self.device_list.set_selection_mode(Gtk.SelectionMode.SINGLE)
@@ -240,6 +279,17 @@ class HardwareSetupDialog(Adw.Window):
         self.gamepad_mode_info.set_halign(Gtk.Align.START)
         box.append(self.gamepad_mode_info)
 
+        self.custom_mode_info = Gtk.Label(
+            label=(
+                "Custom profile saves the selected raw evdev interface without preset "
+                "buttons. Add controls later with Learn Buttons."
+            )
+        )
+        self.custom_mode_info.add_css_class("dim-label")
+        self.custom_mode_info.set_wrap(True)
+        self.custom_mode_info.set_halign(Gtk.Align.START)
+        box.append(self.custom_mode_info)
+
         self.stack.add_titled(box, "describe", "Describe Device")
 
     def _setup_page_capture(self) -> None:
@@ -297,6 +347,7 @@ class HardwareSetupDialog(Adw.Window):
             self.device_list.remove(row)
 
         self.next_btn.set_sensitive(False)
+        self.raw_evdev_check.set_sensitive(False)
         loading_row = Gtk.ListBoxRow()
         loading_row.set_selectable(False)
         loading_label = Gtk.Label(label="Loading devices...")
@@ -322,6 +373,7 @@ class HardwareSetupDialog(Adw.Window):
 
     def _on_detected_devices_done(self) -> None:
         self._detect_devices_inflight = False
+        self.raw_evdev_check.set_sensitive(True)
 
     def _on_detected_devices_ready(
         self,
@@ -367,25 +419,29 @@ class HardwareSetupDialog(Adw.Window):
             vidpid.set_halign(Gtk.Align.START)
             row_box.append(vidpid)
 
-            expander = Gtk.Expander(label="Evdev devices")
-            expander.set_expanded(False)
+            expander: Gtk.Expander | None = None
+            if self._should_show_interface_expander(interfaces):
+                interface_expander = Gtk.Expander(label="Evdev devices")
+                interface_expander.set_expanded(False)
 
-            iface_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=2)
-            iface_box.set_margin_top(4)
-            iface_box.set_margin_start(12)
+                iface_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=2)
+                iface_box.set_margin_top(4)
+                iface_box.set_margin_start(12)
 
-            for iface in interfaces:
-                iface_name = Gtk.Label(label=f"- {iface['name']}")
-                iface_name.add_css_class("caption")
-                iface_name.set_halign(Gtk.Align.START)
-                iface_box.append(iface_name)
+                for iface in interfaces:
+                    iface_name = Gtk.Label(label=f"- {iface['name']}")
+                    iface_name.add_css_class("caption")
+                    iface_name.set_halign(Gtk.Align.START)
+                    iface_box.append(iface_name)
 
-            expander.set_child(iface_box)
-            row_box.append(expander)
+                interface_expander.set_child(iface_box)
+                row_box.append(interface_expander)
+                expander = interface_expander
 
             row.set_child(row_box)
             row.hardware_id = hardware_id
-            row._expander = expander
+            if expander is not None:
+                row._expander = expander
             self.device_list.append(row)
 
         if not detected_devices:
@@ -422,6 +478,33 @@ class HardwareSetupDialog(Adw.Window):
     def _on_refresh_clicked(self, _button: Gtk.Button) -> None:
         self._detect_devices()
 
+    def _on_raw_evdev_toggled(self, check: Gtk.CheckButton) -> None:
+        self._show_raw_evdev_devices = check.get_active()
+        self.selected_device = None
+        self.next_btn.set_sensitive(False)
+        self._detect_devices()
+
+    def _should_show_interface_expander(self, interfaces: list[dict]) -> bool:
+        return not self._show_raw_evdev_devices and len(interfaces) > 1
+
+    def _detected_identity_key(
+        self,
+        *,
+        model_id: str,
+        device_types: list[str],
+        stable_path: str,
+        phys: str = "",
+        path: str = "",
+    ) -> str:
+        if self._show_raw_evdev_devices:
+            return f"raw:{stable_path or path}"
+        return _logical_hardware_identity_key(
+            model_id=model_id,
+            device_types=device_types,
+            stable_path=stable_path,
+            phys=phys,
+        )
+
     def _detect_devices_locally(
         self,
         lsusb_map: dict[str, dict[str, str]],
@@ -452,14 +535,16 @@ class HardwareSetupDialog(Adw.Window):
                     continue
                 stable_path = resolve_stable_path(path)
                 phys = str(getattr(device, "phys", "") or "")
-                identity_key = _logical_hardware_identity_key(
+                identity_key = self._detected_identity_key(
                     model_id=vid_pid,
                     device_types=device_types,
                     stable_path=stable_path,
                     phys=phys,
+                    path=path,
                 )
-                if identity_key in configured_identity_keys or (
-                    not has_config_inventory and self._hardware_config_exists(vid_pid)
+                if not self._show_raw_evdev_devices and (
+                    identity_key in configured_identity_keys
+                    or (not has_config_inventory and self._hardware_config_exists(vid_pid))
                 ):
                     continue
                 hardware_id = pending_identity_hardware_ids.get(identity_key)
@@ -513,7 +598,13 @@ class HardwareSetupDialog(Adw.Window):
                 pass
 
     def _detect_devices_via_session(self, detected_devices: dict[str, dict]) -> bool:
-        result = session_request({"command": "list_devices_for_recording"}, timeout=3.0) or {}
+        result = session_request(
+            {
+                "command": "list_devices_for_recording",
+                "include_other": self._show_raw_evdev_devices,
+            },
+            timeout=3.0,
+        ) or {}
         if result.get("status") != "ok":
             return False
 
@@ -555,14 +646,16 @@ class HardwareSetupDialog(Adw.Window):
                 continue
             stable_path = str(dev.get("stable_path", "") or path)
             phys = str(dev.get("phys", "") or "")
-            identity_key = _logical_hardware_identity_key(
+            identity_key = self._detected_identity_key(
                 model_id=vid_pid,
                 device_types=device_types,
                 stable_path=stable_path,
                 phys=phys,
+                path=path,
             )
-            if identity_key in configured_identity_keys or (
-                not has_config_inventory and self._hardware_config_exists(vid_pid)
+            if not self._show_raw_evdev_devices and (
+                identity_key in configured_identity_keys
+                or (not has_config_inventory and self._hardware_config_exists(vid_pid))
             ):
                 continue
             hardware_id = pending_identity_hardware_ids.get(identity_key)
@@ -610,26 +703,30 @@ class HardwareSetupDialog(Adw.Window):
         return bool(detected_devices)
 
     def _should_skip_detected_device(self, device: evdev.InputDevice) -> bool:
-        return self._should_skip_detected_device_info(
-            {
-                "name": device.name,
-                "phys": getattr(device, "phys", None),
-            }
-        )
+        device_info = {
+            "name": device.name,
+            "phys": getattr(device, "phys", None),
+        }
+        if self._should_skip_detected_device_info(device_info):
+            return True
+
+        phys = str(getattr(device, "phys", "") or "").strip().lower()
+        return phys == "py-evdev-uinput" and not self._show_raw_evdev_devices
 
     def _should_skip_detected_device_info(self, device_info: dict[str, Any]) -> bool:
         name = str(device_info.get("name", "") or "").strip().lower()
-        phys = str(device_info.get("phys", "") or "").strip().lower()
+        recording_kind = str(device_info.get("recording_kind", "") or "").strip().lower()
 
         if "keymasq" in name:
             return True
-
-        if phys == "py-evdev-uinput":
+        if recording_kind in {"keymasq_output", "keymasq_passthrough"}:
             return True
 
         return False
 
     def _should_include_detected_interface(self, device_types: list[str]) -> bool:
+        if self._show_raw_evdev_devices:
+            return True
         return "touchpad" not in normalize_input_classes(device_types)
 
     def _hardware_config_exists(self, hardware_id: str) -> bool:
@@ -688,6 +785,7 @@ class HardwareSetupDialog(Adw.Window):
                     continue
                 device_type = getattr(getattr(device, "device_type", None), "value", None)
                 device_types = [str(device_type or "other")]
+                keys.update(self._configured_raw_identity_keys(path))
                 keys.add(
                     _logical_hardware_identity_key(
                         model_id=model_id,
@@ -697,6 +795,22 @@ class HardwareSetupDialog(Adw.Window):
                     )
                 )
         return keys
+
+    def _configured_raw_identity_keys(self, path: str) -> set[str]:
+        candidates = {str(path or "")}
+        try:
+            stable_path = self._configured_device_stable_path(path)
+        except Exception:
+            stable_path = ""
+        if stable_path:
+            candidates.add(stable_path)
+        try:
+            real_path = os.path.realpath(path)
+        except Exception:
+            real_path = ""
+        if real_path:
+            candidates.add(real_path)
+        return {f"raw:{candidate}" for candidate in candidates if candidate}
 
     def _configured_device_stable_path(self, path: str) -> str:
         path = str(path or "")
@@ -759,7 +873,8 @@ class HardwareSetupDialog(Adw.Window):
     def _on_device_selected(self, list_box, row) -> None:
         if row:
             self.selected_device = self.detected_devices[row.hardware_id]
-            row._expander.set_expanded(True)
+            if hasattr(row, "_expander"):
+                row._expander.set_expanded(True)
 
             idx = 0
             while True:
@@ -815,7 +930,10 @@ class HardwareSetupDialog(Adw.Window):
             self.mode_combo_model.append("Keyboard")
             self._configure_mode_values.append("keyboard")
 
-        if not self._configure_mode_values:
+        if not self._configure_mode_values and self._show_raw_evdev_devices:
+            self.mode_combo_model.append("Custom")
+            self._configure_mode_values = ["custom"]
+        elif not self._configure_mode_values:
             self.mode_combo_model.append("Mouse")
             self._configure_mode_values = ["mouse"]
 
@@ -835,6 +953,8 @@ class HardwareSetupDialog(Adw.Window):
             return "mouse"
         if "keyboard" in self._configure_mode_values:
             return "keyboard"
+        if "custom" in self._configure_mode_values:
+            return "custom"
         return self._configure_mode_values[0]
 
     def _on_mode_changed(self, combo, param) -> None:
@@ -849,12 +969,16 @@ class HardwareSetupDialog(Adw.Window):
         is_mouse = self._configure_mode == "mouse"
         is_mouse_keyboard = self._configure_mode == "mouse_keyboard"
         is_gamepad = self._configure_mode == "gamepad"
+        is_custom = self._configure_mode == "custom"
         self.keyboard_mode_info.set_visible(is_keyboard)
         self.mouse_mode_info.set_visible(is_mouse)
         self.mouse_keyboard_mode_info.set_visible(is_mouse_keyboard)
         self.gamepad_mode_info.set_visible(is_gamepad)
+        self.custom_mode_info.set_visible(is_custom)
         if is_gamepad:
             self.describe_subtitle.set_label("Review the detected controller controls")
+        elif is_custom:
+            self.describe_subtitle.set_label("Create an empty profile for this raw device")
         elif is_mouse_keyboard:
             self.describe_subtitle.set_label("Create a standard keyboard and mouse profile")
         elif is_keyboard:
@@ -1083,6 +1207,9 @@ class HardwareSetupDialog(Adw.Window):
                 return
             if self._configure_mode == "mouse_keyboard":
                 self._save_mouse_keyboard_config()
+                return
+            if self._configure_mode == "custom":
+                self._save_custom_config()
                 return
             self._save_mouse_config()
 
@@ -1359,6 +1486,25 @@ class HardwareSetupDialog(Adw.Window):
 
         self.hardware_manager.save_hardware(config)
 
+        self.emit("device-created", config)
+        self.close()
+
+    def _save_custom_config(self) -> None:
+        selected_device = self.selected_device
+        if selected_device is None:
+            return
+
+        interfaces = list(self.discovered_interfaces.values())
+        config = HardwareConfig(
+            vendor_id=selected_device["vendor_id"],
+            product_id=selected_device["product_id"],
+            name=selected_device["name"],
+            evdev_devices=self._build_evdev_devices(interfaces),
+            buttons=[],
+            id=self._selected_config_id(selected_device),
+        )
+
+        self.hardware_manager.save_hardware(config)
         self.emit("device-created", config)
         self.close()
 

--- a/keymasq/gui/wizards/hardware_setup.py
+++ b/keymasq/gui/wizards/hardware_setup.py
@@ -542,9 +542,8 @@ class HardwareSetupDialog(Adw.Dialog):
                     phys=phys,
                     path=path,
                 )
-                if not self._show_raw_evdev_devices and (
-                    identity_key in configured_identity_keys
-                    or (not has_config_inventory and self._hardware_config_exists(vid_pid))
+                if identity_key in configured_identity_keys or (
+                    not has_config_inventory and self._hardware_config_exists(vid_pid)
                 ):
                     continue
                 hardware_id = pending_identity_hardware_ids.get(identity_key)
@@ -653,9 +652,8 @@ class HardwareSetupDialog(Adw.Dialog):
                 phys=phys,
                 path=path,
             )
-            if not self._show_raw_evdev_devices and (
-                identity_key in configured_identity_keys
-                or (not has_config_inventory and self._hardware_config_exists(vid_pid))
+            if identity_key in configured_identity_keys or (
+                not has_config_inventory and self._hardware_config_exists(vid_pid)
             ):
                 continue
             hardware_id = pending_identity_hardware_ids.get(identity_key)

--- a/keymasq/session/manager/commands.py
+++ b/keymasq/session/manager/commands.py
@@ -627,9 +627,12 @@ async def _handle_capture_commands(
     request: JsonObject,
 ) -> JsonObject | None:
     if command == "list_devices_for_recording":
+        device_types = ["keyboard", "gamepad", "mouse"]
+        if bool(request.get("include_other", False)):
+            device_types = ["keyboard", "gamepad", "mouse", "touchpad", "pointstick", "other"]
         devices = await runtime_recording.get_devices_for_recording(
             manager,
-            ["keyboard", "gamepad", "mouse"],
+            device_types,
             include_grabbed=True,
         )
         manager.recording_state.devices_cache = devices

--- a/tests/gui/test_hardware_setup_dialog.py
+++ b/tests/gui/test_hardware_setup_dialog.py
@@ -169,7 +169,7 @@ class TestHardwareSetupDialog:
 
         assert dialog.raw_evdev_check.get_sensitive() is True
 
-    def test_raw_evdev_mode_keeps_configured_event_nodes(self, monkeypatch):
+    def test_raw_evdev_mode_skips_configured_event_nodes(self, monkeypatch):
         gi.require_version("Gtk", "4.0")
         from gi.repository import Gtk
 
@@ -223,9 +223,8 @@ class TestHardwareSetupDialog:
         detected_devices: dict[str, dict] = {}
 
         assert dialog._detect_devices_via_session(detected_devices) is True
-        assert set(detected_devices) == {"1234:1002@2", "1234:1002@3"}
-        assert detected_devices["1234:1002@2"]["paths"] == ["/dev/input/event20"]
-        assert detected_devices["1234:1002@3"]["paths"] == ["/dev/input/event21"]
+        assert set(detected_devices) == {"1234:1002@2"}
+        assert detected_devices["1234:1002@2"]["paths"] == ["/dev/input/event21"]
 
     def test_raw_unknown_device_uses_custom_empty_profile_mode(self, monkeypatch):
         gi.require_version("Gtk", "4.0")

--- a/tests/gui/test_hardware_setup_dialog.py
+++ b/tests/gui/test_hardware_setup_dialog.py
@@ -2,6 +2,349 @@
 from tests.gui.support import *
 
 class TestHardwareSetupDialog:
+    def test_hardware_setup_uses_inline_adw_dialog(self, monkeypatch):
+        gi.require_version("Adw", "1")
+        gi.require_version("Gtk", "4.0")
+        from gi.repository import Adw, Gtk
+
+        from keymasq.gui.wizards.hardware_setup import HardwareSetupDialog
+
+        monkeypatch.setattr(HardwareSetupDialog, "_detect_devices", lambda self: None)
+
+        dialog = HardwareSetupDialog(Gtk.Window(), SimpleNamespace())
+
+        assert isinstance(dialog, Adw.Dialog)
+        assert not isinstance(dialog, Gtk.Window)
+
+    def test_hardware_setup_escape_closes_dialog(self, monkeypatch):
+        gi.require_version("Gdk", "4.0")
+        gi.require_version("Gtk", "4.0")
+        from gi.repository import Gdk, Gtk
+
+        from keymasq.gui.wizards.hardware_setup import HardwareSetupDialog
+
+        monkeypatch.setattr(HardwareSetupDialog, "_detect_devices", lambda self: None)
+
+        dialog = HardwareSetupDialog(Gtk.Window(), SimpleNamespace())
+        closed: list[bool] = []
+        dialog.close = lambda: closed.append(True)  # type: ignore[method-assign]
+
+        handled = dialog._on_key_pressed(
+            Gtk.EventControllerKey.new(),
+            Gdk.KEY_Escape,
+            0,
+            Gdk.ModifierType(0),
+        )
+
+        assert handled is True
+        assert closed == [True]
+
+    def test_hardware_setup_close_stops_active_capture(self, monkeypatch):
+        gi.require_version("Gtk", "4.0")
+        from gi.repository import Gtk
+
+        from keymasq.gui.wizards.hardware_setup import HardwareSetupDialog
+
+        monkeypatch.setattr(HardwareSetupDialog, "_detect_devices", lambda self: None)
+
+        dialog = HardwareSetupDialog(Gtk.Window(), SimpleNamespace())
+        stopped: list[bool] = []
+        dialog._capturing = True
+        dialog._stop_capture = lambda: stopped.append(True)  # type: ignore[method-assign]
+
+        dialog._on_closed()
+
+        assert stopped == [True]
+
+    def test_uinput_identity_groups_same_model_over_unstable_event_path(self):
+        from keymasq.gui.wizards.hardware_setup import _logical_hardware_identity_key
+
+        first_key = _logical_hardware_identity_key(
+            model_id="1234:1001",
+            device_types=["gamepad"],
+            stable_path="/dev/input/event30",
+            phys="py-evdev-uinput",
+        )
+        second_key = _logical_hardware_identity_key(
+            model_id="1234:1001",
+            device_types=["keyboard"],
+            stable_path="/dev/input/event7",
+            phys="py-evdev-uinput",
+        )
+        other_model_key = _logical_hardware_identity_key(
+            model_id="046d:c24f",
+            device_types=["gamepad"],
+            stable_path="/dev/input/event29",
+            phys="py-evdev-uinput",
+        )
+
+        assert first_key == second_key
+        assert first_key == "uinput-model:1234:1001"
+        assert other_model_key == "uinput-model:046d:c24f"
+
+    def test_raw_evdev_mode_requests_other_devices_and_disables_grouping(
+        self, monkeypatch
+    ):
+        gi.require_version("Gtk", "4.0")
+        from gi.repository import Gtk
+
+        from keymasq.gui.wizards import hardware_setup as hardware_setup_mod
+        from keymasq.gui.wizards.hardware_setup import HardwareSetupDialog
+
+        requests: list[dict] = []
+
+        def fake_session_request(payload, timeout=3.0):
+            requests.append(dict(payload))
+            return {
+                "status": "ok",
+                "devices": [
+                    {
+                        "path": "/dev/input/event20",
+                        "stable_path": "/dev/input/event20",
+                        "name": "Virtgaming Generic Joystick",
+                        "phys": "py-evdev-uinput",
+                        "vendor_id": "1234",
+                        "product_id": "1002",
+                        "device_type": "other",
+                        "device_types": ["other"],
+                    },
+                    {
+                        "path": "/dev/input/event21",
+                        "stable_path": "/dev/input/event21",
+                        "name": "Virtgaming Generic Joystick Keyboard",
+                        "phys": "py-evdev-uinput",
+                        "vendor_id": "1234",
+                        "product_id": "1002",
+                        "device_type": "keyboard",
+                        "device_types": ["keyboard"],
+                    },
+                ],
+            }
+
+        monkeypatch.setattr(HardwareSetupDialog, "_detect_devices", lambda self: None)
+        monkeypatch.setattr(hardware_setup_mod, "session_request", fake_session_request)
+
+        dialog = HardwareSetupDialog(Gtk.Window(), SimpleNamespace(get_hardware=lambda _id: None))
+        dialog._show_raw_evdev_devices = True
+        detected_devices: dict[str, dict] = {}
+
+        assert dialog._detect_devices_via_session(detected_devices) is True
+
+        assert requests == [
+            {"command": "list_devices_for_recording", "include_other": True}
+        ]
+        assert set(detected_devices) == {"1234:1002", "1234:1002@2"}
+        assert detected_devices["1234:1002"]["paths"] == ["/dev/input/event20"]
+        assert detected_devices["1234:1002@2"]["paths"] == ["/dev/input/event21"]
+
+    def test_raw_evdev_toggle_is_disabled_during_detection(self, monkeypatch):
+        gi.require_version("Gtk", "4.0")
+        from gi.repository import Gtk
+
+        from keymasq.gui.wizards import hardware_setup as hardware_setup_mod
+        from keymasq.gui.wizards.hardware_setup import HardwareSetupDialog
+
+        original_detect = HardwareSetupDialog._detect_devices
+        monkeypatch.setattr(HardwareSetupDialog, "_detect_devices", lambda self: None)
+        dialog = HardwareSetupDialog(Gtk.Window(), SimpleNamespace())
+        monkeypatch.setattr(HardwareSetupDialog, "_detect_devices", original_detect)
+
+        scheduled: list[tuple[object, object, object]] = []
+        monkeypatch.setattr(
+            hardware_setup_mod,
+            "run_gui_task",
+            lambda worker, callback, on_done=None: scheduled.append(
+                (worker, callback, on_done)
+            ),
+        )
+
+        assert dialog.raw_evdev_check.get_sensitive() is True
+
+        dialog._detect_devices()
+
+        assert dialog.raw_evdev_check.get_sensitive() is False
+        assert len(scheduled) == 1
+
+        dialog._on_detected_devices_done()
+
+        assert dialog.raw_evdev_check.get_sensitive() is True
+
+    def test_raw_evdev_mode_keeps_configured_event_nodes(self, monkeypatch):
+        gi.require_version("Gtk", "4.0")
+        from gi.repository import Gtk
+
+        from keymasq.common.models import DeviceType, EvdevDevice, HardwareConfig
+        from keymasq.gui.wizards import hardware_setup as hardware_setup_mod
+        from keymasq.gui.wizards.hardware_setup import HardwareSetupDialog
+
+        monkeypatch.setattr(HardwareSetupDialog, "_detect_devices", lambda self: None)
+        monkeypatch.setattr(
+            hardware_setup_mod,
+            "session_request",
+            lambda _payload, timeout=3.0: {
+                "status": "ok",
+                "devices": [
+                    {
+                        "path": "/dev/input/event20",
+                        "stable_path": "/dev/input/event20",
+                        "name": "Virtgaming Generic Joystick",
+                        "phys": "py-evdev-uinput",
+                        "vendor_id": "1234",
+                        "product_id": "1002",
+                        "device_type": "other",
+                        "device_types": ["other"],
+                    },
+                    {
+                        "path": "/dev/input/event21",
+                        "stable_path": "/dev/input/event21",
+                        "name": "Virtgaming Generic Joystick Keyboard",
+                        "phys": "py-evdev-uinput",
+                        "vendor_id": "1234",
+                        "product_id": "1002",
+                        "device_type": "keyboard",
+                        "device_types": ["keyboard"],
+                    },
+                ],
+            },
+        )
+
+        configured = HardwareConfig(
+            vendor_id="1234",
+            product_id="1002",
+            name="Virtgaming Generic Joystick",
+            evdev_devices=[
+                EvdevDevice(path="/dev/input/event20", device_type=DeviceType.OTHER)
+            ],
+            buttons=[],
+        )
+        hardware_manager = SimpleNamespace(list_hardware=lambda: [configured])
+        dialog = HardwareSetupDialog(Gtk.Window(), hardware_manager)
+        dialog._show_raw_evdev_devices = True
+        detected_devices: dict[str, dict] = {}
+
+        assert dialog._detect_devices_via_session(detected_devices) is True
+        assert set(detected_devices) == {"1234:1002@2", "1234:1002@3"}
+        assert detected_devices["1234:1002@2"]["paths"] == ["/dev/input/event20"]
+        assert detected_devices["1234:1002@3"]["paths"] == ["/dev/input/event21"]
+
+    def test_raw_unknown_device_uses_custom_empty_profile_mode(self, monkeypatch):
+        gi.require_version("Gtk", "4.0")
+        from gi.repository import Gtk
+
+        from keymasq.common.models import DeviceType
+        from keymasq.gui.wizards.hardware_setup import HardwareSetupDialog
+
+        class _HardwareManager:
+            def __init__(self) -> None:
+                self.saved = []
+
+            def save_hardware(self, config) -> None:
+                self.saved.append(config)
+
+        monkeypatch.setattr(HardwareSetupDialog, "_detect_devices", lambda self: None)
+
+        hardware_manager = _HardwareManager()
+        dialog = HardwareSetupDialog(Gtk.Window(), hardware_manager)
+        dialog._show_raw_evdev_devices = True
+        dialog.selected_device = {
+            "vendor_id": "1234",
+            "product_id": "1002",
+            "name": "Raw Device",
+            "interfaces": [
+                {
+                    "device_type": DeviceType.OTHER,
+                    "device_types": ["other"],
+                }
+            ],
+        }
+        dialog.discovered_interfaces = {
+            "event20": {
+                "id": "event20",
+                "stable_path": "/dev/input/event20",
+                "path": "/dev/input/event20",
+                "name": "Raw Device",
+                "device_type": DeviceType.OTHER,
+                "device_types": ["other"],
+            }
+        }
+        emitted = []
+        dialog.emit = lambda signal, config: emitted.append((signal, config))
+        dialog.close = lambda: None
+
+        dialog._refresh_configure_modes()
+        dialog._save_custom_config()
+
+        assert dialog._configure_mode_values == ["custom"]
+        assert dialog._configure_mode == "custom"
+        assert dialog.describe_subtitle.get_label() == "Create an empty profile for this raw device"
+        saved = hardware_manager.saved[0]
+        assert saved.evdev_devices[0].device_type == DeviceType.OTHER
+        assert saved.buttons == []
+        assert emitted == [("device-created", saved)]
+
+    def test_raw_evdev_rows_hide_interface_expander(self, monkeypatch):
+        gi.require_version("Gtk", "4.0")
+        from gi.repository import Gtk
+
+        from keymasq.gui.wizards.hardware_setup import HardwareSetupDialog
+
+        monkeypatch.setattr(HardwareSetupDialog, "_detect_devices", lambda self: None)
+
+        dialog = HardwareSetupDialog(Gtk.Window(), SimpleNamespace())
+
+        dialog._show_raw_evdev_devices = False
+        assert dialog._should_show_interface_expander([{}, {}]) is True
+
+        dialog._show_raw_evdev_devices = True
+        assert dialog._should_show_interface_expander([{}]) is False
+        assert dialog._should_show_interface_expander([{}, {}]) is False
+
+    def test_selecting_row_without_expander_still_enables_next(self, monkeypatch):
+        gi.require_version("Gtk", "4.0")
+        from gi.repository import Gtk
+
+        from keymasq.gui.wizards.hardware_setup import HardwareSetupDialog
+
+        monkeypatch.setattr(HardwareSetupDialog, "_detect_devices", lambda self: None)
+
+        dialog = HardwareSetupDialog(Gtk.Window(), SimpleNamespace())
+        dialog.detected_devices = {
+            "1234:1002": {
+                "vendor_id": "1234",
+                "product_id": "1002",
+                "hardware_id": "1234:1002",
+                "interfaces": [],
+            }
+        }
+        dialog._discover_interfaces = lambda: None  # type: ignore[method-assign]
+        dialog._refresh_configure_modes = lambda: None  # type: ignore[method-assign]
+        row = Gtk.ListBoxRow()
+        row.hardware_id = "1234:1002"
+
+        dialog._on_device_selected(dialog.device_list, row)
+
+        assert dialog.selected_device is dialog.detected_devices["1234:1002"]
+        assert dialog.next_btn.get_sensitive() is True
+
+    def test_hardware_setup_close_without_active_capture_does_not_stop_capture(
+        self, monkeypatch
+    ):
+        gi.require_version("Gtk", "4.0")
+        from gi.repository import Gtk
+
+        from keymasq.gui.wizards.hardware_setup import HardwareSetupDialog
+
+        monkeypatch.setattr(HardwareSetupDialog, "_detect_devices", lambda self: None)
+
+        dialog = HardwareSetupDialog(Gtk.Window(), SimpleNamespace())
+        stopped: list[bool] = []
+        dialog._capture_hardware_id = "1234:1002"
+        dialog._stop_capture = lambda: stopped.append(True)  # type: ignore[method-assign]
+
+        dialog._on_closed()
+
+        assert stopped == []
+
     def test_refresh_configure_modes_offers_gamepad_first(self, monkeypatch):
         gi.require_version("Gtk", "4.0")
         from gi.repository import Gtk
@@ -92,7 +435,9 @@ class TestHardwareSetupDialog:
             == "045e:02a1@2"
         )
 
-    def test_detect_devices_via_session_skips_virtual_uinput_devices(self, monkeypatch):
+    def test_detect_devices_via_session_skips_keymasq_virtual_uinput_devices(
+        self, monkeypatch
+    ):
         gi.require_version("Gtk", "4.0")
         from gi.repository import Gtk
 
@@ -112,6 +457,27 @@ class TestHardwareSetupDialog:
                 "device_types": ["gamepad"],
             },
             {
+                "path": "/dev/input/event23",
+                "name": "Xbox 360 Controller",
+                "phys": "py-evdev-uinput",
+                "vendor_id": "045e",
+                "product_id": "028e",
+                "device_type": "gamepad",
+                "device_types": ["gamepad"],
+                "recording_kind": "keymasq_output",
+            },
+            {
+                "path": "/dev/input/event24",
+                "name": "Logitech G920 Driving Force Racing Wheel for Xbox One",
+                "phys": "py-evdev-uinput",
+                "vendor_id": "046d",
+                "product_id": "c262",
+                "device_type": "gamepad",
+                "device_types": ["gamepad"],
+                "recording_kind": "keymasq_passthrough",
+                "source_hardware_id": "046d:c262",
+            },
+            {
                 "path": "/dev/input/event10",
                 "name": "Real USB Mouse",
                 "phys": "usb-0000:00:14.0-1/input0",
@@ -119,6 +485,15 @@ class TestHardwareSetupDialog:
                 "product_id": "5678",
                 "device_type": "mouse",
                 "device_types": ["mouse"],
+            },
+            {
+                "path": "/dev/input/event28",
+                "name": "Logitech G920 Driving Force Racing Wheel for Xbox One",
+                "phys": "py-evdev-uinput",
+                "vendor_id": "046d",
+                "product_id": "c262",
+                "device_type": "gamepad",
+                "device_types": ["gamepad"],
             },
             {
                 "path": "/dev/input/event11",
@@ -165,8 +540,56 @@ class TestHardwareSetupDialog:
                         "device_types": ["mouse"],
                     }
                 ],
-            }
+            },
+            "046d:c262": {
+                "name": "Logitech G920 Driving Force Racing Wheel for Xbox One",
+                "display_name": "Logitech G920 Driving Force Racing Wheel for Xbox One",
+                "hardware_id": "046d:c262",
+                "model_id": "046d:c262",
+                "vendor_id": "046d",
+                "product_id": "c262",
+                "paths": ["/dev/input/event28"],
+                "interfaces": [
+                    {
+                        "path": "/dev/input/event28",
+                        "stable_path": "/dev/input/event28",
+                        "name": "Logitech G920 Driving Force Racing Wheel for Xbox One",
+                        "phys": "py-evdev-uinput",
+                        "device_type": DeviceType.GAMEPAD,
+                        "device_types": ["gamepad"],
+                    }
+                ],
+            },
         }
+
+    def test_local_detection_only_skips_uinput_devices_outside_raw_mode(self, monkeypatch):
+        gi.require_version("Gtk", "4.0")
+        from gi.repository import Gtk
+
+        from keymasq.gui.wizards.hardware_setup import HardwareSetupDialog
+
+        monkeypatch.setattr(HardwareSetupDialog, "_detect_devices", lambda self: None)
+
+        dialog = HardwareSetupDialog(Gtk.Window(), SimpleNamespace())
+        device = SimpleNamespace(
+            name="Logitech G920 Driving Force Racing Wheel for Xbox One",
+            phys="py-evdev-uinput",
+        )
+
+        dialog._show_raw_evdev_devices = False
+        assert dialog._should_skip_detected_device(device) is True
+
+        dialog._show_raw_evdev_devices = True
+        assert dialog._should_skip_detected_device(device) is False
+        assert (
+            dialog._should_skip_detected_device_info(
+                {
+                    "name": "Logitech G920 Driving Force Racing Wheel for Xbox One",
+                    "phys": "py-evdev-uinput",
+                }
+            )
+            is False
+        )
 
     def test_detect_devices_via_session_skips_touchpads_but_keeps_other_interfaces(
         self, monkeypatch
@@ -349,6 +772,57 @@ class TestHardwareSetupDialog:
             device["interfaces"][0]["device_type"]
             for device in detected_devices.values()
         } == {DeviceType.GAMEPAD}
+
+    def test_detect_devices_via_session_keeps_uinput_gamepads_with_shared_phys_separate(
+        self, monkeypatch
+    ):
+        gi.require_version("Gtk", "4.0")
+        from gi.repository import Gtk
+
+        from keymasq.gui.wizards import hardware_setup as hardware_setup_mod
+        from keymasq.gui.wizards.hardware_setup import HardwareSetupDialog
+
+        monkeypatch.setattr(HardwareSetupDialog, "_detect_devices", lambda self: None)
+        monkeypatch.setattr(
+            hardware_setup_mod,
+            "session_request",
+            lambda _payload, timeout=3.0: {
+                "status": "ok",
+                "devices": [
+                    {
+                        "path": "/dev/input/event29",
+                        "stable_path": "/dev/input/event29",
+                        "name": "Logitech G29 Driving Force Racing Wheel",
+                        "phys": "py-evdev-uinput",
+                        "vendor_id": "046d",
+                        "product_id": "c24f",
+                        "device_type": "gamepad",
+                        "device_types": ["gamepad"],
+                    },
+                    {
+                        "path": "/dev/input/event30",
+                        "stable_path": "/dev/input/event30",
+                        "name": "Virtgaming Xbox-Style Gamepad",
+                        "phys": "py-evdev-uinput",
+                        "vendor_id": "1234",
+                        "product_id": "1001",
+                        "device_type": "gamepad",
+                        "device_types": ["gamepad"],
+                    },
+                ],
+            },
+        )
+
+        dialog = HardwareSetupDialog(Gtk.Window(), SimpleNamespace(get_hardware=lambda _id: None))
+        detected_devices: dict[str, dict] = {}
+
+        assert dialog._detect_devices_via_session(detected_devices) is True
+
+        assert set(detected_devices) == {"046d:c24f", "1234:1001"}
+        assert detected_devices["046d:c24f"]["name"] == "Logitech G29 Driving Force Racing Wheel"
+        assert detected_devices["046d:c24f"]["paths"] == ["/dev/input/event29"]
+        assert detected_devices["1234:1001"]["name"] == "Virtgaming Xbox-Style Gamepad"
+        assert detected_devices["1234:1001"]["paths"] == ["/dev/input/event30"]
 
     def test_detect_devices_via_session_numbers_next_duplicate_gamepad_slot(
         self, monkeypatch

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -191,6 +191,64 @@ def test_detect_input_classes_reports_touchpad_without_mouse() -> None:
     assert primary_input_class(classes) == DeviceType.OTHER
 
 
+def test_detect_input_classes_reports_generic_joystick_axes_as_gamepad() -> None:
+    caps = {
+        evdev.ecodes.EV_KEY: [
+            evdev.ecodes.BTN_TRIGGER,
+            evdev.ecodes.BTN_THUMB,
+            evdev.ecodes.BTN_TOP,
+            evdev.ecodes.BTN_BASE,
+        ],
+        evdev.ecodes.EV_ABS: [
+            evdev.ecodes.ABS_X,
+            evdev.ecodes.ABS_Y,
+            evdev.ecodes.ABS_RZ,
+            evdev.ecodes.ABS_THROTTLE,
+            evdev.ecodes.ABS_HAT0X,
+            evdev.ecodes.ABS_HAT0Y,
+        ],
+    }
+
+    classes = detect_input_classes_from_capabilities(caps)
+
+    assert classes == ["gamepad"]
+    assert primary_input_class(classes) == DeviceType.GAMEPAD
+
+
+def test_detect_input_classes_reports_abs_xy_joystick_as_gamepad() -> None:
+    caps = {
+        evdev.ecodes.EV_KEY: [
+            evdev.ecodes.BTN_TRIGGER,
+        ],
+        evdev.ecodes.EV_ABS: [
+            evdev.ecodes.ABS_X,
+            evdev.ecodes.ABS_Y,
+        ],
+    }
+
+    classes = detect_input_classes_from_capabilities(caps)
+
+    assert classes == ["gamepad"]
+    assert primary_input_class(classes) == DeviceType.GAMEPAD
+
+
+def test_detect_input_classes_does_not_treat_plain_absolute_pointer_as_gamepad() -> None:
+    caps = {
+        evdev.ecodes.EV_KEY: [
+            evdev.ecodes.BTN_TOUCH,
+        ],
+        evdev.ecodes.EV_ABS: [
+            evdev.ecodes.ABS_X,
+            evdev.ecodes.ABS_Y,
+        ],
+    }
+
+    classes = detect_input_classes_from_capabilities(caps)
+
+    assert classes == ["other"]
+    assert primary_input_class(classes) == DeviceType.OTHER
+
+
 def test_classify_event_device_type_uses_event_shape_for_combo_devices() -> None:
     device_types = ["mouse", "keyboard", "pointstick"]
 


### PR DESCRIPTION
## Summary
- Add a raw evdev mode to the hardware setup wizard so unknown controller-style devices can be added as empty custom profiles.
- Keep keymasq virtual devices hidden by default, while allowing raw uinput-backed devices and multi-interface controllers to appear when raw mode is enabled.
- Update device identity handling so raw event nodes are tracked separately and configured raw devices are not duplicated across setup runs.
- Switch the hardware setup flow to an inline `Adw.Dialog`, add Escape-to-close behavior, and stop active capture cleanly when the dialog closes.
- Document the new gamepad/raw-device behavior in `docs/GAMEPAD.md` and expand GUI/session coverage for the new paths.

## Testing
- Existing and new tests were added in `tests/gui/test_hardware_setup_dialog.py` and `tests/test_devices.py` to cover raw-device detection, filtering, and custom profile creation.
- Session-side recording device selection was updated to support `include_other` for raw evdev discovery.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Raw input device mode for advanced hardware setup, plus a “Custom” mode for unknown devices

* **Improvements**
  * Inline hardware setup dialog with Escape-to-close and improved capture lifecycle
  * Better device classification to more accurately distinguish gamepads, touchpads, and absolute-pointer devices
  * UI: option to show raw evdev devices and adjusted device listing behavior

* **Documentation**
  * Guidance on using third‑party controllers/wheels that report gamepad capabilities

* **Tests**
  * Expanded tests for hardware setup flows and gamepad detection logic

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nyrda/keymasq/pull/106?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->