### PR TITLE
Defer SYN inside passthrough frames to batch with source SYN_REPORT

### DIFF
--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -137,6 +137,8 @@ Diagnostics measure Keymasq's daemon-side handling time for events that pass
 through grabbed devices. They are not the full time from your finger movement to
 the game or desktop reacting. They do not include USB polling, compositor/game
 processing, rendering, display latency, or the physical switch/button travel.
+For passthrough devices, normal input events and their source `SYN_REPORT`
+frame flush are measured separately so multi-event device frames stay intact.
 
 ### Mainline Diagnostics
 
@@ -148,6 +150,7 @@ input overhead.
 | `passthrough_fast` | An event passed through when the grabbed device has no active mapping work for it. | Moving an unmapped mouse, or clicking an unmapped button on a grabbed device. |
 | `passthrough_mapped` | An event passed through while a mapping profile is loaded, but this specific input has no remap action. | Moving the mouse while only one side button is remapped. |
 | `passthrough_other` | A non-key, non-relative event passed through. | An uncommon device event such as an absolute axis update. |
+| `passthrough_syn` | A pending passthrough frame was flushed at the source device's `SYN_REPORT`. | The frame boundary after grouped touchpad, mouse, or gamepad events. |
 | `wheel_passthrough` | A mouse wheel event passed through by an explicit passthrough mapping. | Scrolling normally when the wheel has a passthrough action. |
 | `action_*` | A configured remap action ran. The suffix names the action type. | Pressing a remapped button, a suppressed key, or a mapped wheel direction. |
 
@@ -180,7 +183,7 @@ These labels are mostly for development and bug reports.
 
 | Label | What it means | Example |
 |---|---|---|
-| `syn` | A Linux synchronization event was received and ignored by the remap logic. | The separator event that follows a group of mouse movement or key events. |
+| `syn` | A Linux synchronization event was received without a pending passthrough frame to flush. | A separator event that did not emit output. |
 | `wheel_high_res_suppressed` | A high-resolution wheel event was suppressed because the matching low-resolution wheel event is being handled. | A mouse wheel that reports both high-res and normal scroll events. |
 | `combo_recalled_repeat_suppressed` | A repeat event was suppressed for a combo trigger key that Keymasq temporarily recalled. | Holding a key involved in combo recall long enough for keyboard repeat to start. |
 | `combo_recalled_release_suppressed` | A release event was suppressed after combo recall cleanup. | Releasing a combo trigger key that Keymasq already restored synthetically. |

--- a/keymasq/keymasqd/device_manager.py
+++ b/keymasq/keymasqd/device_manager.py
@@ -356,7 +356,13 @@ def _diagnostics_label_enabled(label: str, categories: set[str]) -> bool:
 def _diagnostics_label_is_mainline(label: str) -> bool:
     return (
         label.startswith("action_")
-        or label in {"passthrough_fast", "passthrough_mapped", "passthrough_other"}
+        or label
+        in {
+            "passthrough_fast",
+            "passthrough_mapped",
+            "passthrough_other",
+            "passthrough_syn",
+        }
         or label == "wheel_passthrough"
     )
 

--- a/keymasq/keymasqd/runtime/analog_controls.py
+++ b/keymasq/keymasqd/runtime/analog_controls.py
@@ -16,7 +16,10 @@ from keymasq.common.models import (
     analog_gamepad_output_distance,
 )
 from keymasq.keymasqd.runtime import grabbed_device_actions as runtime_actions
-from keymasq.keymasqd.runtime.grabbed_device_outputs import track_abs_state
+from keymasq.keymasqd.runtime.grabbed_device_outputs import (
+    syn_if_passthrough_frame_closed,
+    track_abs_state,
+)
 from keymasq.keymasqd.runtime.grabbed_device_types import (
     ActionExecutionDeps,
     AnalogGamepadOutputState,
@@ -1144,7 +1147,7 @@ def _write_gamepad_axes(
             _clear_tracked_abs_state(device_runtime, target_bucket, axis_code)
         else:
             track_abs_state(device_runtime, axis_code, value, bucket=target_bucket)
-    writer.syn()
+    syn_if_passthrough_frame_closed(target_uinput, writer)
     device_runtime.state.analog_gamepad_outputs[state_key] = AnalogGamepadOutputState(
         output_id=_resolved_gamepad_output_id(device_runtime, config),
         reset_axes=(
@@ -1281,7 +1284,7 @@ def _write_recorded_gamepad_reset(
     for axis_code, value in output.reset_axes:
         writer.write(deps.evdev_mod.ecodes.EV_ABS, int(axis_code), int(value))
         _clear_tracked_abs_state(device_runtime, target_bucket, int(axis_code))
-    writer.syn()
+    syn_if_passthrough_frame_closed(target_uinput, writer)
 
 
 def _clear_tracked_abs_state(

--- a/keymasq/keymasqd/runtime/combos.py
+++ b/keymasq/keymasqd/runtime/combos.py
@@ -38,6 +38,7 @@ from keymasq.keymasqd.runtime.action_runner import (
     dispatch_action_trigger,
     is_hold_macro_action,
 )
+from keymasq.keymasqd.runtime.grabbed_device_outputs import syn_if_passthrough_frame_closed
 from keymasq.keymasqd.runtime.mouse_actions import (
     rapidfire_relative_pulses,
     resolve_mouse_output_target,
@@ -1778,7 +1779,7 @@ def write_combo_key(
     if writer is None:
         return
     writer.write(deps.evdev_mod.ecodes.EV_KEY, int(code), int(value))
-    writer.syn()
+    syn_if_passthrough_frame_closed(uinput_dev, writer)
 
 
 def write_combo_relative(
@@ -1808,7 +1809,7 @@ def write_combo_axis(
     if writer is None:
         return
     writer.write(deps.evdev_mod.ecodes.EV_ABS, int(axis_code), int(value))
-    writer.syn()
+    syn_if_passthrough_frame_closed(uinput_dev, writer)
 
 
 def emit_combo_mouse_move(

--- a/keymasq/keymasqd/runtime/grabbed_device.py
+++ b/keymasq/keymasqd/runtime/grabbed_device.py
@@ -401,6 +401,8 @@ class GrabbedDevice:
                     self.uinput.close()
                 except Exception:
                     pass
+                finally:
+                    runtime_outputs.unregister_passthrough_frame_output(self.uinput)
                 self.uinput = None
             raise
 
@@ -443,6 +445,8 @@ class GrabbedDevice:
                 self.uinput.close()
             except Exception as exc:
                 log.warning("Failed to close passthrough uinput for %s: %s", self.path, exc)
+            finally:
+                runtime_outputs.unregister_passthrough_frame_output(self.uinput)
 
         self.device = None
         self.uinput = None

--- a/keymasq/keymasqd/runtime/grabbed_device_actions.py
+++ b/keymasq/keymasqd/runtime/grabbed_device_actions.py
@@ -64,7 +64,13 @@ async def execute_action(
     uinput_writer = deps.uinput_writer
     fire_and_observe_fn = deps.fire_and_observe_fn
     if action.action_type == ActionType.PASSTHROUGH:
-        passthrough(device_runtime, event, evdev_mod=evdev_mod, uinput_writer=uinput_writer)
+        passthrough(
+            device_runtime,
+            event,
+            evdev_mod=evdev_mod,
+            uinput_writer=uinput_writer,
+            sync=False,
+        )
 
     elif action.action_type == ActionType.SUPPRESS:
         pass

--- a/keymasq/keymasqd/runtime/grabbed_device_events.py
+++ b/keymasq/keymasqd/runtime/grabbed_device_events.py
@@ -409,6 +409,13 @@ async def process_event(
         return
 
     if event.type == evdev_mod.ecodes.EV_SYN:
+        if int(event.code) == int(getattr(evdev_mod.ecodes, "SYN_REPORT", 0)):
+            runtime_outputs.flush_passthrough_frame(
+                device_runtime.uinput,
+                uinput_writer=identity_uinput_writer,
+            )
+        else:
+            runtime_outputs.mark_passthrough_frame_closed(device_runtime.uinput)
         _record_diagnostics(device_runtime, "syn", started_ns, time_mod=time_mod)
         return
 
@@ -438,6 +445,7 @@ async def process_event(
             event,
             evdev_mod=evdev_mod,
             uinput_writer=identity_uinput_writer,
+            sync=False,
         )
         _record_diagnostics(device_runtime, "passthrough_other", started_ns, time_mod=time_mod)
         return
@@ -451,6 +459,7 @@ async def process_event(
             event,
             evdev_mod=evdev_mod,
             uinput_writer=identity_uinput_writer,
+            sync=False,
         )
         if int(event.value) == 0:
             device_runtime.state.combo_passthrough_held.discard(event_name)
@@ -517,6 +526,7 @@ async def process_event(
             event,
             evdev_mod=evdev_mod,
             uinput_writer=identity_uinput_writer,
+            sync=False,
         )
         diag_label = "combo_passthrough" if combo_passthrough_requested else "passthrough_fast"
         _record_diagnostics(device_runtime, diag_label, started_ns, time_mod=time_mod)
@@ -572,6 +582,7 @@ async def process_event(
             event,
             evdev_mod=evdev_mod,
             uinput_writer=identity_uinput_writer,
+            sync=False,
         )
         diag_label = "combo_passthrough" if combo_passthrough_requested else "passthrough_mapped"
 
@@ -717,6 +728,7 @@ async def _process_wheel_pulse_event(
             event,
             evdev_mod=evdev_mod,
             uinput_writer=identity_uinput_writer,
+            sync=False,
         )
         return "wheel_passthrough"
     if action.action_type == ActionType.SUPPRESS:

--- a/keymasq/keymasqd/runtime/grabbed_device_events.py
+++ b/keymasq/keymasqd/runtime/grabbed_device_events.py
@@ -410,7 +410,10 @@ async def process_event(
 
     if event.type == evdev_mod.ecodes.EV_SYN:
         diag_label = "syn"
-        if int(event.code) == int(getattr(evdev_mod.ecodes, "SYN_REPORT", 0)):
+        event_code = int(event.code)
+        syn_report = int(getattr(evdev_mod.ecodes, "SYN_REPORT", 0))
+        syn_mt_report = int(getattr(evdev_mod.ecodes, "SYN_MT_REPORT", 0))
+        if event_code == syn_report:
             passthrough_frame_open = runtime_outputs.passthrough_frame_open(
                 device_runtime.uinput
             )
@@ -420,6 +423,11 @@ async def process_event(
             )
             if passthrough_frame_open:
                 diag_label = "passthrough_syn"
+        elif event_code == syn_mt_report:
+            writer = identity_uinput_writer(device_runtime.uinput)
+            if writer is not None:
+                writer.write(evdev_mod.ecodes.EV_SYN, event_code, int(event.value))
+                runtime_outputs.mark_passthrough_frame_open(device_runtime.uinput)
         else:
             runtime_outputs.mark_passthrough_frame_closed(device_runtime.uinput)
         _record_diagnostics(device_runtime, diag_label, started_ns, time_mod=time_mod)

--- a/keymasq/keymasqd/runtime/grabbed_device_events.py
+++ b/keymasq/keymasqd/runtime/grabbed_device_events.py
@@ -409,14 +409,20 @@ async def process_event(
         return
 
     if event.type == evdev_mod.ecodes.EV_SYN:
+        diag_label = "syn"
         if int(event.code) == int(getattr(evdev_mod.ecodes, "SYN_REPORT", 0)):
+            passthrough_frame_open = runtime_outputs.passthrough_frame_open(
+                device_runtime.uinput
+            )
             runtime_outputs.flush_passthrough_frame(
                 device_runtime.uinput,
                 uinput_writer=identity_uinput_writer,
             )
+            if passthrough_frame_open:
+                diag_label = "passthrough_syn"
         else:
             runtime_outputs.mark_passthrough_frame_closed(device_runtime.uinput)
-        _record_diagnostics(device_runtime, "syn", started_ns, time_mod=time_mod)
+        _record_diagnostics(device_runtime, diag_label, started_ns, time_mod=time_mod)
         return
 
     if event.type == evdev_mod.ecodes.EV_ABS and (

--- a/keymasq/keymasqd/runtime/grabbed_device_outputs.py
+++ b/keymasq/keymasqd/runtime/grabbed_device_outputs.py
@@ -15,6 +15,64 @@ from keymasq.keymasqd.runtime.grabbed_device_types import (
 )
 
 log = logging.getLogger("keymasqd.devices")
+_PASSTHROUGH_FRAME_OUTPUTS: dict[int, object] = {}
+
+
+def _output_id(uinput_dev: object | None) -> int | None:
+    if uinput_dev is None:
+        return None
+    return id(uinput_dev)
+
+
+def mark_passthrough_frame_open(uinput_dev: object | None) -> None:
+    output_id = _output_id(uinput_dev)
+    if output_id is None:
+        return
+    _PASSTHROUGH_FRAME_OUTPUTS[output_id] = uinput_dev
+
+
+def mark_passthrough_frame_closed(uinput_dev: object | None) -> None:
+    output_id = _output_id(uinput_dev)
+    if output_id is None:
+        return
+    if _PASSTHROUGH_FRAME_OUTPUTS.get(output_id) is uinput_dev:
+        _PASSTHROUGH_FRAME_OUTPUTS.pop(output_id, None)
+
+
+def unregister_passthrough_frame_output(uinput_dev: object | None) -> None:
+    mark_passthrough_frame_closed(uinput_dev)
+
+
+def passthrough_frame_open(uinput_dev: object | None) -> bool:
+    output_id = _output_id(uinput_dev)
+    if output_id is None:
+        return False
+    return _PASSTHROUGH_FRAME_OUTPUTS.get(output_id) is uinput_dev
+
+
+def syn_if_passthrough_frame_closed(
+    uinput_dev: object | None,
+    writer: WritableUInput,
+    *,
+    force: bool = False,
+) -> None:
+    if force or not passthrough_frame_open(uinput_dev):
+        writer.syn()
+
+
+def flush_passthrough_frame(
+    uinput_dev: object | None,
+    *,
+    uinput_writer: UInputWriter,
+) -> None:
+    if not passthrough_frame_open(uinput_dev):
+        return
+    writer = uinput_writer(uinput_dev)
+    if writer is None:
+        mark_passthrough_frame_closed(uinput_dev)
+        return
+    writer.syn()
+    mark_passthrough_frame_closed(uinput_dev)
 
 
 def bucket_for_uinput(
@@ -76,12 +134,16 @@ def write_abs_axis(
     evdev_mod: EvdevModule,
     uinput_writer: UInputWriter,
     bucket: str | None = None,
+    defer_syn_to_passthrough_frame: bool = True,
 ) -> None:
     writer = uinput_writer(uinput_dev)
     if writer is None:
         return
     writer.write(evdev_mod.ecodes.EV_ABS, int(axis_code), int(value))
-    writer.syn()
+    if defer_syn_to_passthrough_frame:
+        syn_if_passthrough_frame_closed(uinput_dev, writer)
+    else:
+        writer.syn()
     track_abs_state(device_runtime, int(axis_code), int(value), bucket=bucket)
 
 
@@ -94,12 +156,18 @@ def write_key(
     evdev_mod: EvdevModule,
     uinput_writer: UInputWriter,
     bucket: str | None = None,
+    sync: bool = True,
+    defer_syn_to_passthrough_frame: bool = True,
 ) -> None:
     writer = uinput_writer(uinput_dev)
     if writer is None:
         return
     writer.write(evdev_mod.ecodes.EV_KEY, int(code), int(value))
-    writer.syn()
+    if sync:
+        if defer_syn_to_passthrough_frame:
+            syn_if_passthrough_frame_closed(uinput_dev, writer)
+        else:
+            writer.syn()
     track_key_state(device_runtime, uinput_dev, int(code), int(value), bucket=bucket)
 
 
@@ -166,6 +234,7 @@ def passthrough(
     *,
     evdev_mod: EvdevModule,
     uinput_writer: UInputWriter,
+    sync: bool = True,
 ) -> None:
     if (
         device_runtime.suppress_rel_getter
@@ -182,14 +251,21 @@ def passthrough(
             int(event.value),
             evdev_mod=evdev_mod,
             uinput_writer=uinput_writer,
+            sync=sync,
+            defer_syn_to_passthrough_frame=False,
         )
+        if not sync:
+            mark_passthrough_frame_open(device_runtime.uinput)
         return
     uinput = device_runtime.uinput
     writer = uinput_writer(uinput)
     if writer is None:
         return
     writer.write(event.type, event.code, event.value)
-    writer.syn()
+    if sync:
+        writer.syn()
+    else:
+        mark_passthrough_frame_open(uinput)
 
 
 def ensure_abs_axis_released(

--- a/keymasq/keymasqd/runtime/macros.py
+++ b/keymasq/keymasqd/runtime/macros.py
@@ -11,6 +11,7 @@ from keymasq.common.models import (
     DEFAULT_MACRO_LOOP_STOP_BEHAVIOR,
     normalize_macro_loop_stop_behavior,
 )
+from keymasq.keymasqd.runtime.grabbed_device_outputs import syn_if_passthrough_frame_closed
 
 type JsonObject = dict[str, object]
 type IntValueFn = Callable[[object, int], int]
@@ -424,7 +425,7 @@ async def play_macro_task(
                                 evdev_mod.ecodes.REL_Y,
                                 y,
                             )
-                            output.syn()
+                            syn_if_passthrough_frame_closed(uinput, output)
                     continue
                 if action_type:
                     timeline_offset_s += await run_macro_control_action(
@@ -488,7 +489,7 @@ async def play_macro_task(
                 if output is None:
                     continue
                 output.write(event_type, event_code, event_value)
-                output.syn()
+                syn_if_passthrough_frame_closed(uinput, output)
                 if event_type == evdev_mod.ecodes.EV_KEY:
                     if event_value == 1:
                         track_macro_key_press(manager, instance_id, output_class, event_code)
@@ -736,7 +737,7 @@ def release_macro_held_for_instance(
         if not uinput:
             continue
         try:
-            uinput.syn()
+            syn_if_passthrough_frame_closed(uinput, uinput)
         except Exception:
             pass
 

--- a/keymasq/keymasqd/runtime/macros.py
+++ b/keymasq/keymasqd/runtime/macros.py
@@ -678,14 +678,23 @@ def release_macro_held_for_instance(
         return
 
     uinputs = {
-        "keyboard": deps.uinput_writer(manager.output_state.keyboard_uinput),
-        "mouse": deps.uinput_writer(manager.output_state.mouse_uinput),
-        "gamepad": deps.uinput_writer(manager.output_state.gamepad_uinput),
+        "keyboard": (
+            manager.output_state.keyboard_uinput,
+            deps.uinput_writer(manager.output_state.keyboard_uinput),
+        ),
+        "mouse": (
+            manager.output_state.mouse_uinput,
+            deps.uinput_writer(manager.output_state.mouse_uinput),
+        ),
+        "gamepad": (
+            manager.output_state.gamepad_uinput,
+            deps.uinput_writer(manager.output_state.gamepad_uinput),
+        ),
     }
     for output_id, uinput_dev in getattr(
         manager.output_state, "virtual_gamepad_uinputs", {}
     ).items():
-        uinputs[f"gamepad:{output_id}"] = deps.uinput_writer(uinput_dev)
+        uinputs[f"gamepad:{output_id}"] = (uinput_dev, deps.uinput_writer(uinput_dev))
     for key in [*held, *held_abs]:
         device_class = str(key[0])
         output_id = gamepad_output_class(device_class)
@@ -695,7 +704,11 @@ def release_macro_held_for_instance(
             output_id,
             context="macro cleanup",
         )
-        uinputs[device_class] = deps.uinput_writer(target.uinput) if target is not None else None
+        raw_uinput = target.uinput if target is not None else None
+        uinputs[device_class] = (
+            raw_uinput,
+            deps.uinput_writer(raw_uinput),
+        )
     synced: set[str] = set()
     held_refcount = manager.macro_state.held_refcount
     held_abs_refcount = manager.macro_state.held_abs_refcount
@@ -705,11 +718,14 @@ def release_macro_held_for_instance(
         if count <= 1:
             held_refcount.pop(key, None)
             device_class, code = key
-            uinput = uinputs.get(device_class)
-            if not uinput:
+            uinput_pair = uinputs.get(device_class)
+            if not uinput_pair:
+                continue
+            _raw_uinput, writer = uinput_pair
+            if not writer:
                 continue
             try:
-                uinput.write(deps.evdev_mod.ecodes.EV_KEY, int(code), 0)
+                writer.write(deps.evdev_mod.ecodes.EV_KEY, int(code), 0)
                 synced.add(device_class)
             except Exception:
                 continue
@@ -721,11 +737,14 @@ def release_macro_held_for_instance(
         if count <= 1:
             held_abs_refcount.pop(key, None)
             device_class, code = key
-            uinput = uinputs.get(device_class)
-            if not uinput:
+            uinput_pair = uinputs.get(device_class)
+            if not uinput_pair:
+                continue
+            _raw_uinput, writer = uinput_pair
+            if not writer:
                 continue
             try:
-                uinput.write(deps.evdev_mod.ecodes.EV_ABS, int(code), 0)
+                writer.write(deps.evdev_mod.ecodes.EV_ABS, int(code), 0)
                 synced.add(device_class)
             except Exception:
                 continue
@@ -733,11 +752,14 @@ def release_macro_held_for_instance(
             held_abs_refcount[key] = count - 1
 
     for device_class in synced:
-        uinput = uinputs.get(device_class)
-        if not uinput:
+        uinput_pair = uinputs.get(device_class)
+        if not uinput_pair:
+            continue
+        raw_uinput, writer = uinput_pair
+        if not writer:
             continue
         try:
-            syn_if_passthrough_frame_closed(uinput, uinput)
+            syn_if_passthrough_frame_closed(raw_uinput, writer)
         except Exception:
             pass
 

--- a/keymasq/keymasqd/superkey_state.py
+++ b/keymasq/keymasqd/superkey_state.py
@@ -4,7 +4,7 @@ import logging
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Protocol, cast
+from typing import Any, Protocol, cast
 
 import evdev
 
@@ -33,6 +33,14 @@ from keymasq.keymasqd.runtime.mouse_actions import (
 )
 
 log = logging.getLogger("keymasqd.superkey")
+
+
+def _syn_if_passthrough_frame_closed(uinput: object) -> None:
+    from keymasq.keymasqd.runtime.grabbed_device_outputs import (
+        syn_if_passthrough_frame_closed,
+    )
+
+    syn_if_passthrough_frame_closed(uinput, cast(Any, uinput))
 
 
 class SuperkeyState(Enum):
@@ -453,7 +461,7 @@ class SuperkeyMachine:
                 )
             if should_emit:
                 uinput.write(evdev.ecodes.EV_ABS, axis_code, int(action.axis_value))
-                uinput.syn()
+                _syn_if_passthrough_frame_closed(uinput)
             return
 
         if action.action_type in ("keyboard", "mouse", "gamepad"):
@@ -482,7 +490,7 @@ class SuperkeyMachine:
                 should_emit = self.key_event_tracker(bucket, int(code), 1)
             if should_emit:
                 uinput.write(evdev.ecodes.EV_KEY, code, 1)
-                uinput.syn()
+                _syn_if_passthrough_frame_closed(uinput)
 
     async def _execute_action_up(self, action: SuperkeyActionData) -> None:
         if action.action_type in (
@@ -518,7 +526,7 @@ class SuperkeyMachine:
                 should_emit = self.axis_event_tracker(bucket, int(axis_code), 0)
             if should_emit:
                 uinput.write(evdev.ecodes.EV_ABS, axis_code, 0)
-                uinput.syn()
+                _syn_if_passthrough_frame_closed(uinput)
             return
 
         if action.action_type in ("keyboard", "mouse", "gamepad"):
@@ -541,7 +549,7 @@ class SuperkeyMachine:
                 should_emit = self.key_event_tracker(bucket, int(code), 0)
             if should_emit:
                 uinput.write(evdev.ecodes.EV_KEY, code, 0)
-                uinput.syn()
+                _syn_if_passthrough_frame_closed(uinput)
 
     def _get_uinput(self, action_type: str) -> _WritableUInput | None:
         if action_type == "keyboard":

--- a/nix/daemon-session-integration-test/support.py
+++ b/nix/daemon-session-integration-test/support.py
@@ -608,11 +608,18 @@ type = "key"
     def wait_for_active_profile(self, profile_name: str, *, enabled: bool) -> None:
         deadline = time.monotonic() + 5
         last: dict[str, Any] | None = None
+        matched_at: float | None = None
         while time.monotonic() < deadline:
             last = self.request({"command": "get_active_profiles"}, ok=False)
             active = set(str(name) for name in last.get("active_profiles", []))
             if (profile_name in active) is enabled:
-                return
+                now = time.monotonic()
+                if matched_at is not None and now - matched_at >= 0.15:
+                    return
+                if matched_at is None:
+                    matched_at = now
+            else:
+                matched_at = None
             time.sleep(0.1)
         raise AssertionError(f"profile {profile_name} enabled={enabled} not observed: {last}")
 

--- a/tests/keymasqd/test_device_manager_core.py
+++ b/tests/keymasqd/test_device_manager_core.py
@@ -510,12 +510,14 @@ class TestListDevices:
         manager.diagnostics_state.enabled = True
 
         manager._record_diagnostic("passthrough_mapped", 10.0)
+        manager._record_diagnostic("passthrough_syn", 15.0)
         manager._record_diagnostic("action_key", 20.0)
         manager._record_diagnostic("combo_passthrough", 30.0)
         manager._record_diagnostic("syn", 40.0)
 
         assert set(manager.diagnostics_state.samples) == {
             "passthrough_mapped",
+            "passthrough_syn",
             "action_key",
         }
 

--- a/tests/keymasqd/test_grabbed_device_runtime_helpers.py
+++ b/tests/keymasqd/test_grabbed_device_runtime_helpers.py
@@ -26,6 +26,15 @@ class _FailingWriteUInput(_FakeUInput):
         raise OSError("uinput disconnected")
 
 
+class _CountingUInput(_FakeUInput):
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self.syn_count = 0
+
+    def syn(self) -> None:
+        self.syn_count += 1
+
+
 class TestGrabbedDeviceHelpers:
     def test_find_action_for_event_prefers_evdev_code_over_alias_name(
         self,
@@ -46,6 +55,88 @@ class TestGrabbedDeviceHelpers:
         )
 
         assert _runtime_find_grabbed_action_for_event(device, event, mapping) == mapping["south"]
+
+    @pytest.mark.asyncio
+    async def test_passthrough_preserves_source_syn_report_frame(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        passthrough = _CountingUInput()
+        device = _make_grabbed_device(monkeypatch)
+        device.uinput = passthrough  # type: ignore[assignment]
+
+        deps = gde.build_event_processing_deps(log=logging.getLogger("test"))
+
+        await gde.process_event(
+            device,
+            evdev.InputEvent(0, 0, evdev.ecodes.EV_ABS, evdev.ecodes.ABS_X, 10),
+            deps=deps,
+        )
+        await gde.process_event(
+            device,
+            evdev.InputEvent(0, 0, evdev.ecodes.EV_ABS, evdev.ecodes.ABS_Y, 20),
+            deps=deps,
+        )
+
+        assert passthrough.writes == [
+            (evdev.ecodes.EV_ABS, evdev.ecodes.ABS_X, 10),
+            (evdev.ecodes.EV_ABS, evdev.ecodes.ABS_Y, 20),
+        ]
+        assert passthrough.syn_count == 0
+        assert gdo.passthrough_frame_open(passthrough)
+
+        await gde.process_event(
+            device,
+            evdev.InputEvent(0, 0, evdev.ecodes.EV_SYN, evdev.ecodes.SYN_REPORT, 0),
+            deps=deps,
+        )
+
+        assert passthrough.syn_count == 1
+        assert not gdo.passthrough_frame_open(passthrough)
+
+    @pytest.mark.asyncio
+    async def test_generated_gamepad_output_defers_syn_inside_passthrough_frame(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        target_uinput = _CountingUInput()
+
+        def resolve_gamepad_output(_output_id: str | None, _context: str) -> SimpleNamespace:
+            return SimpleNamespace(uinput=target_uinput, bucket="gamepad:target")
+
+        device = _make_grabbed_device(
+            monkeypatch,
+            gamepad_output_resolver=resolve_gamepad_output,
+        )
+        action = MappingAction(
+            action_type=ActionType.GAMEPAD_AXIS,
+            target="abs_x",
+            axis_value=32767,
+            output_id="target",
+        )
+        event = evdev.InputEvent(0, 0, evdev.ecodes.EV_KEY, evdev.ecodes.BTN_SOUTH, 1)
+
+        gdo.mark_passthrough_frame_open(target_uinput)
+        await gda.execute_action(
+            device,
+            action,
+            event,
+            "btn_south",
+            deps=gde.build_action_execution_deps(),
+        )
+
+        assert target_uinput.writes == [
+            (evdev.ecodes.EV_ABS, evdev.ecodes.ABS_X, 32767)
+        ]
+        assert target_uinput.syn_count == 0
+
+        gdo.flush_passthrough_frame(
+            target_uinput,
+            uinput_writer=gdt.identity_uinput_writer,
+        )
+
+        assert target_uinput.syn_count == 1
+        assert not gdo.passthrough_frame_open(target_uinput)
     def test_device_has_mapped_buttons_matches_by_code_when_names_differ(self) -> None:
         caps = {
             evdev.ecodes.EV_KEY: [evdev.ecodes.BTN_SOUTH],

--- a/tests/keymasqd/test_grabbed_device_runtime_helpers.py
+++ b/tests/keymasqd/test_grabbed_device_runtime_helpers.py
@@ -78,6 +78,17 @@ class TestGrabbedDeviceHelpers:
             evdev.InputEvent(0, 0, evdev.ecodes.EV_ABS, evdev.ecodes.ABS_X, 10),
             deps=deps,
         )
+        syn_mt_report = getattr(evdev.ecodes, "SYN_MT_REPORT", None)
+        if syn_mt_report is None:
+            pytest.skip("evdev does not expose SYN_MT_REPORT")
+        await gde.process_event(
+            device,
+            evdev.InputEvent(0, 0, evdev.ecodes.EV_SYN, int(syn_mt_report), 0),
+            deps=deps,
+        )
+        assert gdo.passthrough_frame_open(passthrough)
+        assert passthrough.syn_count == 0
+
         await gde.process_event(
             device,
             evdev.InputEvent(0, 0, evdev.ecodes.EV_ABS, evdev.ecodes.ABS_Y, 20),
@@ -86,6 +97,7 @@ class TestGrabbedDeviceHelpers:
 
         assert passthrough.writes == [
             (evdev.ecodes.EV_ABS, evdev.ecodes.ABS_X, 10),
+            (evdev.ecodes.EV_SYN, int(syn_mt_report), 0),
             (evdev.ecodes.EV_ABS, evdev.ecodes.ABS_Y, 20),
         ]
         assert passthrough.syn_count == 0
@@ -101,9 +113,43 @@ class TestGrabbedDeviceHelpers:
         assert not gdo.passthrough_frame_open(passthrough)
         assert [label for label, _duration_us in diagnostics] == [
             "passthrough_other",
+            "syn",
             "passthrough_other",
             "passthrough_syn",
         ]
+
+    @pytest.mark.asyncio
+    async def test_passthrough_syn_mt_report_opens_frame_for_empty_contact_update(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        syn_mt_report = getattr(evdev.ecodes, "SYN_MT_REPORT", None)
+        if syn_mt_report is None:
+            pytest.skip("evdev does not expose SYN_MT_REPORT")
+
+        passthrough = _CountingUInput()
+        device = _make_grabbed_device(monkeypatch)
+        device.uinput = passthrough  # type: ignore[assignment]
+        deps = gde.build_event_processing_deps(log=logging.getLogger("test"))
+
+        await gde.process_event(
+            device,
+            evdev.InputEvent(0, 0, evdev.ecodes.EV_SYN, int(syn_mt_report), 0),
+            deps=deps,
+        )
+
+        assert passthrough.writes == [(evdev.ecodes.EV_SYN, int(syn_mt_report), 0)]
+        assert passthrough.syn_count == 0
+        assert gdo.passthrough_frame_open(passthrough)
+
+        await gde.process_event(
+            device,
+            evdev.InputEvent(0, 0, evdev.ecodes.EV_SYN, evdev.ecodes.SYN_REPORT, 0),
+            deps=deps,
+        )
+
+        assert passthrough.syn_count == 1
+        assert not gdo.passthrough_frame_open(passthrough)
 
     @pytest.mark.asyncio
     async def test_generated_gamepad_output_defers_syn_inside_passthrough_frame(

--- a/tests/keymasqd/test_grabbed_device_runtime_helpers.py
+++ b/tests/keymasqd/test_grabbed_device_runtime_helpers.py
@@ -62,7 +62,13 @@ class TestGrabbedDeviceHelpers:
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         passthrough = _CountingUInput()
-        device = _make_grabbed_device(monkeypatch)
+        diagnostics: list[tuple[str, float]] = []
+        device = _make_grabbed_device(
+            monkeypatch,
+            diagnostics_recorder=lambda label, duration_us: diagnostics.append(
+                (label, duration_us)
+            ),
+        )
         device.uinput = passthrough  # type: ignore[assignment]
 
         deps = gde.build_event_processing_deps(log=logging.getLogger("test"))
@@ -93,6 +99,11 @@ class TestGrabbedDeviceHelpers:
 
         assert passthrough.syn_count == 1
         assert not gdo.passthrough_frame_open(passthrough)
+        assert [label for label, _duration_us in diagnostics] == [
+            "passthrough_other",
+            "passthrough_other",
+            "passthrough_syn",
+        ]
 
     @pytest.mark.asyncio
     async def test_generated_gamepad_output_defers_syn_inside_passthrough_frame(

--- a/tests/keymasqd/test_macro_backend_recording.py
+++ b/tests/keymasqd/test_macro_backend_recording.py
@@ -879,6 +879,39 @@ async def test_macro_cleanup_releases_unmatched_held_keys() -> None:
     )
 
 
+def test_macro_cleanup_sync_uses_raw_uinput_with_non_identity_writer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = DeviceManager()
+    raw_keyboard = MagicMock()
+    writer = MagicMock()
+    manager.output_state.keyboard_uinput = raw_keyboard
+    manager.macro_state.instance_held[1] = {("keyboard", evdev.ecodes.KEY_B)}
+    manager.macro_state.held_refcount[("keyboard", evdev.ecodes.KEY_B)] = 1
+    sync_calls: list[tuple[object, object]] = []
+
+    base_deps = dm._macro_runtime_deps()
+    deps = mdm.MacroRuntimeDeps(
+        asyncio_mod=base_deps.asyncio_mod,
+        evdev_mod=base_deps.evdev_mod,
+        uinput_writer=lambda raw: writer if raw is raw_keyboard else None,
+        log=base_deps.log,
+        int_value_fn=base_deps.int_value_fn,
+        str_value_fn=base_deps.str_value_fn,
+    )
+    monkeypatch.setattr(
+        mdm,
+        "syn_if_passthrough_frame_closed",
+        lambda raw_uinput, output_writer: sync_calls.append((raw_uinput, output_writer)),
+    )
+
+    mdm.release_macro_held_for_instance(manager, 1, deps=deps)
+
+    writer.write.assert_called_once_with(evdev.ecodes.EV_KEY, evdev.ecodes.KEY_B, 0)
+    assert sync_calls == [(raw_keyboard, writer)]
+    assert manager.macro_state.held_refcount == {}
+
+
 @pytest.mark.asyncio
 async def test_release_all_devices_cleans_up_macro_and_grabbed_state() -> None:
     manager = DeviceManager()


### PR DESCRIPTION
This fixes touchpad pass-through and improves latency a bit.

## Summary

- Defers `SYN_REPORT` emissions inside passthrough frames so multi-event device frames (touchpad, mouse, gamepad) stay intact on output
- Adds `passthrough_syn` diagnostic label to distinguish frame-flush SYN events from standalone ones
- Adds `passthrough_frame_open`/`flush_passthrough_frame`/`syn_if_passthrough_frame_closed` helpers in `grabbed_device_outputs.py`
- Applies deferral to passthrough events, combo writes, gamepad axis writes, macro playback, and superkey output
- Updates PERFORMANCE.md to document `passthrough_syn` and updated existing `syn` label meaning

## Testing

- `test_passthrough_preserves_source_syn_report_frame` — verifies ABS events are batched without intermediate SYN and flushed only on source `SYN_REPORT`
- `test_generated_gamepad_output_defers_syn_inside_passthrough_frame` — verifies gamepad axis output defers SYN inside an open passthrough frame
- `test_diagnostics_sample_include_passthrough_syn` — verifies `passthrough_syn` is treated as a mainline diagnostic label
- Ran `./scripts/check.sh full` — all tests passing
