### PR TITLE
Preserve analog runtime state across mapping updates

### DIFF
--- a/keymasq/keymasqd/runtime/analog_controls.py
+++ b/keymasq/keymasqd/runtime/analog_controls.py
@@ -149,6 +149,27 @@ def _control_state_key(source_id: str, index: int, total: int) -> str:
     return source_id if total == 1 else f"{source_id}#analog_control#{index}"
 
 
+def analog_state_keys_for_action(source_id: str, action: MappingAction | None) -> set[str]:
+    configs = _action_analog_control_configs(action)
+    return {
+        _control_state_key(source_id, index, len(configs))
+        for index, _config in enumerate(configs)
+    }
+
+
+def preserved_analog_state_keys(
+    old_mapping: dict[str, MappingAction],
+    new_mapping: dict[str, MappingAction],
+) -> set[str]:
+    preserved: set[str] = set()
+    for source_id, old_action in old_mapping.items():
+        new_action = new_mapping.get(source_id)
+        if old_action != new_action:
+            continue
+        preserved.update(analog_state_keys_for_action(source_id, new_action))
+    return preserved
+
+
 def _record_axis_value(
     device_runtime: GrabbedDeviceRuntime,
     state_key: str,
@@ -245,7 +266,9 @@ async def reset_analog_controls(
     device_runtime: GrabbedDeviceRuntime,
     *,
     deps: ActionExecutionDeps,
+    preserve_state_keys: set[str] | None = None,
 ) -> None:
+    preserved = set(preserve_state_keys or ())
     mapping = device_runtime.mapping_getter()
     state_configs: dict[str, tuple[str, AnalogControlConfig]] = {}
     for source_id, action in mapping.items():
@@ -256,8 +279,10 @@ async def reset_analog_controls(
                 config,
             )
 
-    _reset_recorded_gamepad_outputs(device_runtime, deps=deps)
+    _reset_recorded_gamepad_outputs(device_runtime, deps=deps, preserved=preserved)
     for state_key, active in list(device_runtime.state.analog_active_thresholds.items()):
+        if state_key in preserved:
+            continue
         state_config = state_configs.get(state_key)
         config = state_config[1] if state_config is not None else None
         for threshold_key in list(active):
@@ -280,26 +305,44 @@ async def reset_analog_controls(
             )
 
     for state_key, (source_id, config) in state_configs.items():
+        if state_key in preserved:
+            continue
         if analog_control_primary_mode(config) == "gamepad":
             _reset_gamepad_output(device_runtime, state_key, source_id, config, deps=deps)
 
-    for task in list(device_runtime.state.analog_mouse_tasks.values()):
+    tasks_to_cancel = [
+        task
+        for state_key, task in list(device_runtime.state.analog_mouse_tasks.items())
+        if state_key not in preserved
+    ]
+    for task in tasks_to_cancel:
         if not task.done():
             task.cancel()
-    if device_runtime.state.analog_mouse_tasks:
+    if tasks_to_cancel:
         await asyncio.gather(
-            *device_runtime.state.analog_mouse_tasks.values(),
+            *tasks_to_cancel,
             return_exceptions=True,
         )
 
-    device_runtime.state.analog_axis_values.clear()
-    device_runtime.state.analog_active_thresholds.clear()
-    device_runtime.state.analog_active_threshold_actions.clear()
-    device_runtime.state.analog_mouse_tasks.clear()
-    device_runtime.state.analog_mouse_accumulators.clear()
-    device_runtime.state.analog_mouse_area_offsets.clear()
-    device_runtime.state.analog_mouse_area_active.clear()
-    device_runtime.state.analog_gamepad_outputs.clear()
+    _discard_unpreserved_keys(device_runtime.state.analog_axis_values, preserved)
+    _discard_unpreserved_keys(device_runtime.state.analog_active_thresholds, preserved)
+    for threshold_key in list(device_runtime.state.analog_active_threshold_actions):
+        if _threshold_source_key(threshold_key) not in preserved:
+            device_runtime.state.analog_active_threshold_actions.pop(threshold_key, None)
+    _discard_unpreserved_keys(device_runtime.state.analog_mouse_tasks, preserved)
+    _discard_unpreserved_keys(device_runtime.state.analog_mouse_accumulators, preserved)
+    _discard_unpreserved_keys(device_runtime.state.analog_mouse_area_offsets, preserved)
+    device_runtime.state.analog_mouse_area_active.intersection_update(preserved)
+    _discard_unpreserved_keys(device_runtime.state.analog_gamepad_outputs, preserved)
+
+
+def _discard_unpreserved_keys[StateValue](
+    mapping: dict[str, StateValue],
+    preserved: set[str],
+) -> None:
+    for state_key in list(mapping):
+        if state_key not in preserved:
+            mapping.pop(state_key, None)
 
 
 async def _evaluate_thresholds(
@@ -757,6 +800,10 @@ def _threshold_index(threshold_key: str) -> int | None:
         return int(threshold_key.rsplit(":", 1)[1])
     except (IndexError, ValueError):
         return None
+
+
+def _threshold_source_key(threshold_key: str) -> str:
+    return threshold_key.rsplit(":", 1)[0]
 
 
 def _child_event_name(source_id: str, threshold_index: int, action_index: int) -> str:
@@ -1258,8 +1305,12 @@ def _reset_recorded_gamepad_outputs(
     device_runtime: GrabbedDeviceRuntime,
     *,
     deps: ActionExecutionDeps,
+    preserved: set[str] | None = None,
 ) -> None:
+    preserved = preserved or set()
     for source_id, output in list(device_runtime.state.analog_gamepad_outputs.items()):
+        if source_id in preserved:
+            continue
         _write_recorded_gamepad_reset(device_runtime, source_id, output, deps=deps)
 
 

--- a/keymasq/keymasqd/runtime/grab_lifecycle.py
+++ b/keymasq/keymasqd/runtime/grab_lifecycle.py
@@ -705,8 +705,9 @@ async def set_mapping(
                     float_value=float_value_fn,
                 )
 
+        previous_mapping = dict(manager.active_mappings.get(hardware_id, {}))
         manager.active_mappings[hardware_id] = parsed_mapping
         for device in manager.grabbed_devices.get(hardware_id, []):
-            await device.reset_mapping_runtime_state()
+            await device.reset_mapping_runtime_state(previous_mapping=previous_mapping)
         log.info("Updated mapping for %s (%d buttons)", hardware_id, len(parsed_mapping))
         return {"updated": True, "hardware_id": hardware_id}

--- a/keymasq/keymasqd/runtime/grabbed_device.py
+++ b/keymasq/keymasqd/runtime/grabbed_device.py
@@ -298,13 +298,24 @@ class GrabbedDevice:
                     self.analog_axis_calibrations[(str(analog_id), role)] = calibration
         self._refresh_analog_axis_ranges()
 
-    async def reset_mapping_runtime_state(self) -> None:
+    async def reset_mapping_runtime_state(
+        self,
+        previous_mapping: dict[str, MappingAction] | None = None,
+    ) -> None:
         for event_name in self.state.combo_passthrough_held:
             self.state.held_source_keys.add(event_name)
             self.state.held_source_actions.setdefault(event_name, None)
         self.state.combo_passthrough_held.clear()
         self.state.combo_recalled_bindings.clear()
-        await self.reset_analog_controls()
+        preserve_analog_state_keys = (
+            runtime_analog_controls.preserved_analog_state_keys(
+                previous_mapping,
+                self.mapping_getter(),
+            )
+            if previous_mapping is not None
+            else set[str]()
+        )
+        await self.reset_analog_controls(preserve_state_keys=preserve_analog_state_keys)
         await self.reset_superkeys()
         runtime_grab.seed_startup_held_actions(self)
 
@@ -313,10 +324,14 @@ class GrabbedDevice:
             await machine.stop()
         self.state.superkey_machines.clear()
 
-    async def reset_analog_controls(self) -> None:
+    async def reset_analog_controls(
+        self,
+        preserve_state_keys: set[str] | None = None,
+    ) -> None:
         await runtime_analog_controls.reset_analog_controls(
             self,
             deps=runtime_events.build_action_execution_deps(),
+            preserve_state_keys=preserve_state_keys,
         )
 
     async def grab(self) -> None:

--- a/keymasq/session/manager/commands.py
+++ b/keymasq/session/manager/commands.py
@@ -125,6 +125,7 @@ async def _handle_profile_commands(
     if command in {"reevaluate_profiles", "reevaluate_hardware"}:
         log.info("Global profile reevaluate requested")
         await asyncio.to_thread(manager.reload_config_from_disk)
+        runtime_profiles.invalidate_runtime_payload_signatures(manager)
         await runtime_profiles.reevaluate_profiles(manager, reason="session command reevaluate")
         return {"status": "ok"}
 

--- a/tests/keymasqd/test_analog_controls_runtime.py
+++ b/tests/keymasqd/test_analog_controls_runtime.py
@@ -18,6 +18,7 @@ from keymasq.keymasqd.runtime.analog_controls import (
     _motion_delta,
     normalize_axis_value,
     normalize_control_axis_value,
+    preserved_analog_state_keys,
     process_analog_event,
     reset_analog_controls,
 )
@@ -334,6 +335,64 @@ async def test_axis_mouse_motion_uses_direction_and_response_curve() -> None:
         for event_type, code, value in mouse_events
     )
     assert not any(code == evdev.ecodes.REL_X for _event_type, code, _value in mouse_events)
+
+
+def test_preserved_analog_state_keys_only_keeps_unchanged_analog_controls() -> None:
+    analog_action = MappingAction(
+        action_type=ActionType.ANALOG_CONTROL,
+        analog_control_config=AnalogControlConfig(
+            name="Mouse",
+            mouse_motion=AnalogMouseMotionConfig(enabled=True),
+        ),
+    )
+    old_mapping = {
+        "left_stick": analog_action,
+        "right_stick": MappingAction(
+            action_type=ActionType.ANALOG_CONTROL,
+            analog_control_config=AnalogControlConfig(
+                name="Old",
+                mouse_motion=AnalogMouseMotionConfig(enabled=True),
+            ),
+        ),
+    }
+    new_mapping = {
+        "left_stick": analog_action,
+        "right_stick": MappingAction(action_type=ActionType.SUPPRESS),
+        "south": MappingAction(action_type=ActionType.KEYBOARD, target="key_a"),
+    }
+
+    assert preserved_analog_state_keys(old_mapping, new_mapping) == {"left_stick"}
+
+
+@pytest.mark.asyncio
+async def test_reset_analog_controls_preserves_unchanged_mouse_motion() -> None:
+    keyboard = FakeUInput()
+    mapping = {
+        "left_stick": MappingAction(
+            action_type=ActionType.ANALOG_CONTROL,
+            analog_control_config=AnalogControlConfig(
+                name="Stick Mouse",
+                mouse_motion=AnalogMouseMotionConfig(
+                    enabled=True,
+                    speed=10000,
+                    deadzone=0.0,
+                    tick_ms=1,
+                ),
+            ),
+        )
+    }
+    runtime = _runtime(mapping, keyboard)
+
+    assert await process_analog_event(runtime, FakeEvent(32767), "abs_x", mapping, deps=_deps())
+    await asyncio.sleep(0.01)
+    event_count = len(runtime.mouse_uinput.events)
+
+    mapping["south"] = MappingAction(action_type=ActionType.SUPPRESS)
+    await reset_analog_controls(runtime, deps=_deps(), preserve_state_keys={"left_stick"})
+    await asyncio.sleep(0.01)
+    await reset_analog_controls(runtime, deps=_deps())
+
+    assert len(runtime.mouse_uinput.events) > event_count
 
 
 def test_axis_mouse_motion_supports_bidirectional_signed_output() -> None:

--- a/tests/session/test_session_manager_command_runtime.py
+++ b/tests/session/test_session_manager_command_runtime.py
@@ -522,6 +522,35 @@ async def test_runtime_reset_event_invalidates_and_reevaluates(
 
 
 @pytest.mark.asyncio
+async def test_reevaluate_profiles_command_invalidates_runtime_payload_signatures(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = SessionManager()
+    manager.profile_state.last_sent_mapping_signatures["1234:5678"] = "mapping"
+    manager.profile_state.last_sent_combo_signature = "combos"
+    manager.reload_config_from_disk = Mock()  # type: ignore[method-assign]
+    reevaluate_profiles = AsyncMock()
+    monkeypatch.setattr(session_profiles_module, "reevaluate_profiles", reevaluate_profiles)
+    peer = PeerCredentials(pid=1, uid=1000, gid=1000)
+
+    result = await manager._handle_session_request(
+        {"command": "reevaluate_profiles"},
+        "client",
+        peer,
+        object(),
+    )
+
+    assert result == {"status": "ok"}
+    manager.reload_config_from_disk.assert_called_once_with()  # type: ignore[attr-defined]
+    assert manager.profile_state.last_sent_mapping_signatures == {}
+    assert manager.profile_state.last_sent_combo_signature == ""
+    reevaluate_profiles.assert_awaited_once_with(
+        manager,
+        reason="session command reevaluate",
+    )
+
+
+@pytest.mark.asyncio
 async def test_diagnostics_snapshot_event_forwards_to_gui_clients() -> None:
     manager = SessionManager()
     manager.broadcast_to_session_clients = Mock()  # type: ignore[method-assign]


### PR DESCRIPTION
## Summary
- Preserve runtime state for analog controls whose mapping action did not change during a profile remap.
- Keep active analog mouse/gamepad output, thresholds, and related runtime task state intact for preserved controls instead of fully resetting them.
- Invalidate cached runtime payload signatures before profile reevaluation so refreshed profile state is rebuilt consistently.
- Add regression coverage for preserved analog state selection and for `reevaluate_profiles` invalidating session runtime caches.

## Testing
- Added unit coverage in `tests/keymasqd/test_analog_controls_runtime.py` for preserving unchanged analog control state across resets.
- Added unit coverage in `tests/session/test_session_manager_command_runtime.py` for runtime payload signature invalidation on `reevaluate_profiles`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Analog control state is now preserved when device mappings are updated, maintaining threshold tracking and mouse motion across mapping changes.

* **Tests**
  * Added test coverage for analog state preservation during mapping updates and profile re-evaluation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nyrda/keymasq/pull/109?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->