### PR TITLE
Add runtime Device Inspector for per-device mapping and event tracing

### DIFF
--- a/docs/DEVICE_INSPECTOR.md
+++ b/docs/DEVICE_INSPECTOR.md
@@ -1,0 +1,57 @@
+# Device Inspector
+
+The Device Inspector is a floating read-only window for checking one configured
+device at runtime.
+
+Open it from a device tab with the inspect button. Keymasq uses the same
+recording unlock flow as macro recording and live input capture before the
+window can start, because the inspector observes original hardware events.
+
+## What It Shows
+
+- the final resolved mapping for the selected device
+- the profiles that produced those final mappings
+- raw events from the inspected device, in an evtest-style stream
+- configured analog inputs, such as sticks and triggers, with live values
+
+The mapping view is read-only. To change a mapping, close the inspector, edit
+the device tab, then open the inspector again.
+
+The analog viewer only shows inputs already configured in the hardware setup.
+Unknown raw axis events still appear in the raw event stream so you can identify
+which event names and codes to add to the device setup.
+
+The raw event stream shows buttons and keys by default. Axes, mouse movement,
+and `EV_SYN` reports can be enabled from the filter buttons in the inspector.
+The window keeps the most recent 100 events per filter category and displays
+the most recent 100 events that match the active filters.
+
+## Suppression Mode
+
+The inspector has a suppression switch for testing mappings safely. When
+suppression is on:
+
+- events from the inspected hardware ID are still shown in the inspector
+- normal remap output from that hardware ID is blocked
+- macros and combos are not part of the inspector flow
+- any raw `KEY_ESC` press seen by `keymasqd` turns active inspector suppression
+  off, even when the suppressed device is a mouse
+
+The Escape press is consumed by the inspector escape path and is not emitted as
+normal output. Escape release events and non-Escape events do not disable
+suppression.
+
+Suppression is scoped to the inspected hardware ID. Closing the inspector stops
+inspection, clears suppression for that hardware ID, and lets the session apply
+the normal profile grab state again.
+
+## Security
+
+Starting the inspector and enabling suppression are sensitive session commands
+when `[recording_guard].unlock_required = true`. They require the active GUI
+recording-unlock owner, just like macro recording and live input capture.
+
+The inspector force-grabs configured interfaces for the selected device while it
+is open so raw events can be observed even if the current profile has no mapping
+on a particular interface. It does not guess or create new controls from unknown
+events.

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -235,6 +235,8 @@ When `unlock_required = true`:
 - macro recording requires an unlock
 - live key/button capture requires an unlock
 - combo capture requires an unlock
+- starting the Device Inspector and enabling its suppression mode require an
+  unlock
 
 Template-based hardware creation in the GUI does not require unlock. The unlock
 gate applies to original-input observation flows, not to writing normal

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -45,6 +45,17 @@ Both services support `-v` and `-vv`.
 - `keymasq-session -v`: more detailed session and compositor logging,
   including daemon event flow.
 
+## Inspect a Device
+
+Use the Device Inspector from a device tab when you need to see the final
+resolved mapping and the raw events coming from that device. Enable suppression
+inside the inspector to test inputs without emitting remapped output. Press
+Escape on any grabbed keyboard to turn suppression off.
+
+Unknown raw axis events appear in the event stream. Add the relevant event names
+and codes to the hardware setup, then reopen the inspector to see them in the
+configured axes viewer.
+
 ## Run services manually with verbosity
 
 For short debugging sessions, stop the systemd service and run the process

--- a/docs/index.md
+++ b/docs/index.md
@@ -34,6 +34,8 @@ and multi-step automation.
 - [Combos](COMBOS.md) — trigger actions or superkeys from any input combination, even across devices.
 - [Macros](MACROS.md) — record, edit, and play back input sequences.
 - [Gamepad](GAMEPAD.md) — controller remapping, analog controls, and virtual gamepads.
+- [Device Inspector](DEVICE_INSPECTOR.md) — inspect final mappings, raw events,
+  and configured analog inputs for one device.
 
 ## Desktop support
 

--- a/keymasq/common/ipc.py
+++ b/keymasq/common/ipc.py
@@ -49,6 +49,12 @@ class CommandType(Enum):
     SET_DIAGNOSTICS = "set_diagnostics"
     SET_VIRTUAL_GAMEPADS = "set_virtual_gamepads"
     DIAGNOSTICS_SNAPSHOT = "diagnostics_snapshot"
+    DEVICE_INSPECTOR_START = "device_inspector_start"
+    DEVICE_INSPECTOR_STOP = "device_inspector_stop"
+    DEVICE_INSPECTOR_ENABLE_SUPPRESSION = "device_inspector_enable_suppression"
+    DEVICE_INSPECTOR_DISABLE_SUPPRESSION = "device_inspector_disable_suppression"
+    DEVICE_INSPECTOR_EVENT = "device_inspector_event"
+    DEVICE_INSPECTOR_STATUS = "device_inspector_status"
     REFRESH_RECORDING_UNLOCK = "refresh_recording_unlock"
     LOCK_RECORDING_UNLOCK = "lock_recording_unlock"
 

--- a/keymasq/gui/style.css
+++ b/keymasq/gui/style.css
@@ -224,6 +224,82 @@ button.square-key-button {
   font-feature-settings: "tnum" 1;
 }
 
+.inspector-control-card:hover {
+  cursor: default;
+}
+
+.inspector-header-title {
+  color: @window_fg_color;
+  font-size: 1.08em;
+  font-weight: 700;
+}
+
+.inspector-header-monitoring {
+  color: @window_fg_color;
+}
+
+.inspector-header-suppressed {
+  color: @warning_color;
+}
+
+.inspector-header-stopped {
+  color: @error_color;
+}
+
+.inspector-suppression-hint {
+  color: @error_color;
+  font-weight: 600;
+  opacity: 0.85;
+}
+
+.inspector-event-filter-button {
+  min-width: 0;
+  padding-left: 10px;
+  padding-right: 10px;
+}
+
+.inspector-copy-button {
+  min-width: 0;
+  min-height: 0;
+  padding: 2px 4px;
+}
+
+.inspector-control-active {
+  border-left-color: @accent_color;
+  background: alpha(@accent_color, 0.22);
+  opacity: 1;
+}
+
+.inspector-event-row {
+  padding: 0;
+}
+
+.inspector-event-row-pressed {
+  background: alpha(@accent_color, 0.12);
+}
+
+.inspector-axis-section {
+  padding: 8px 0;
+  border-top: 1px solid alpha(@borders, 0.28);
+}
+
+.inspector-axis-section:first-child {
+  border-top: none;
+}
+
+.inspector-axis-pad {
+  border-radius: 6px;
+  background: alpha(@shade_color, 0.08);
+}
+
+.inspector-axis-bar trough {
+  min-height: 12px;
+}
+
+.inspector-axis-value {
+  font-family: monospace;
+}
+
 button.media-key-button {
   padding: 6px 8px;
   min-width: 112px;

--- a/keymasq/gui/style.css
+++ b/keymasq/gui/style.css
@@ -292,6 +292,7 @@ button.square-key-button {
   background: alpha(@shade_color, 0.08);
 }
 
+/* stylelint-disable-next-line selector-type-no-unknown */
 .inspector-axis-bar trough {
   min-height: 12px;
 }

--- a/keymasq/gui/widgets/device_inspector_window.py
+++ b/keymasq/gui/widgets/device_inspector_window.py
@@ -1,0 +1,1167 @@
+from dataclasses import dataclass, field
+from typing import Any, cast
+
+import gi
+
+gi.require_version("Gtk", "4.0")
+gi.require_version("Adw", "1")
+
+from gi.repository import Adw, Gdk, GLib, Gtk, Pango  # pyright: ignore[reportAttributeAccessIssue]
+
+from keymasq.common.devices import is_gamepad_button_name
+from keymasq.common.models import ActionType, DeviceType, HardwareConfig, MappingAction
+from keymasq.gui.icons import device_icon_names, image_from_icon_names
+from keymasq.gui.session_client import (
+    JsonDict,
+    register_session_event_callback,
+    session_request_async,
+    unregister_session_event_callback,
+)
+from keymasq.gui.widgets.action_labels import describe_mapping_action_compact
+
+EVENT_ROW_LIMIT = 100
+EVENT_RENDER_THROTTLE_MS = 33
+DEFAULT_STICK_MIN = -32768
+DEFAULT_STICK_MAX = 32767
+DEFAULT_AXIS_MIN = 0
+DEFAULT_AXIS_MAX = 255
+KEYBOARD_WINDOW_WIDTH = 1180
+KEYBOARD_WINDOW_HEIGHT = 800
+MOUSE_WINDOW_WIDTH = 820
+MOUSE_WINDOW_HEIGHT = 750
+GAMEPAD_WINDOW_WIDTH = 1120
+GAMEPAD_WINDOW_HEIGHT = 800
+RAW_EVENTS_PANEL_WIDTH = 340
+AXES_PANEL_WIDTH = 270
+MAPPING_CARD_WIDTH = 122
+MAPPING_NAME_CHARS = 14
+MAPPING_ACTION_CHARS = 15
+MAPPING_GRID_GAP = 6
+EVENT_FILTERS: tuple[tuple[str, str, bool], ...] = (
+    ("button", "Keys", True),
+    ("axis", "Axes", False),
+    ("mousemove", "Move", False),
+    ("syn", "Syn", False),
+    ("other", "Other", False),
+)
+
+KEYBOARD_SECTIONS: tuple[tuple[str, tuple[tuple[str, ...], ...], bool, int], ...] = (
+    (
+        "Number Keys",
+        (
+            ("key_1", "key_2", "key_3", "key_4", "key_5", "key_minus"),
+            ("key_6", "key_7", "key_8", "key_9", "key_0", "key_equal"),
+        ),
+        True,
+        6,
+    ),
+    (
+        "Keyboard (Left)",
+        (
+            ("key_esc", "key_grave"),
+            ("key_tab", "key_q", "key_w", "key_e", "key_r", "key_t"),
+            ("key_capslock", "key_a", "key_s", "key_d", "key_f", "key_g"),
+            ("key_leftshift", "key_z", "key_x", "key_c", "key_v", "key_b"),
+            ("key_leftctrl", "key_leftmeta", "key_leftalt", "key_space"),
+        ),
+        True,
+        6,
+    ),
+    (
+        "Keyboard (Right)",
+        (
+            ("key_backspace", "key_y", "key_u", "key_i", "key_o", "key_p"),
+            ("key_enter", "key_h", "key_j", "key_k", "key_l"),
+            ("key_n", "key_m", "key_rightshift"),
+            ("key_rightmeta", "key_rightalt", "key_rightctrl"),
+        ),
+        False,
+        6,
+    ),
+    (
+        "Symbols",
+        (
+            (
+                "key_leftbrace",
+                "key_rightbrace",
+                "key_backslash",
+                "key_semicolon",
+                "key_apostrophe",
+            ),
+            ("key_comma", "key_dot", "key_slash"),
+        ),
+        False,
+        5,
+    ),
+    (
+        "F Row",
+        (
+            ("key_f1", "key_f2", "key_f3", "key_f4", "key_f5", "key_f6"),
+            ("key_f7", "key_f8", "key_f9", "key_f10", "key_f11", "key_f12"),
+        ),
+        False,
+        6,
+    ),
+    (
+        "Navigation",
+        (
+            ("key_up", "key_down"),
+            ("key_left", "key_right"),
+            ("key_sysrq", "key_scrolllock", "key_pause"),
+            ("key_insert", "key_home", "key_pageup"),
+            ("key_delete", "key_end", "key_pagedown"),
+        ),
+        False,
+        4,
+    ),
+    (
+        "Special",
+        (
+            ("key_numlock", "key_kpslash", "key_kpasterisk", "key_kpminus"),
+            ("key_kp7", "key_kp8", "key_kp9", "key_kpplus"),
+            ("key_kp4", "key_kp5", "key_kp6"),
+            ("key_kp1", "key_kp2", "key_kp3", "key_kpenter"),
+            ("key_kp0", "key_kpdot"),
+        ),
+        False,
+        4,
+    ),
+)
+
+
+@dataclass
+class AnalogViewer:
+    analog_id: str
+    analog_type: str
+    axes: dict[str, JsonDict]
+    value_labels: dict[str, Gtk.Label] = field(default_factory=dict)
+    drawing_area: Gtk.DrawingArea | None = None
+    level_bar: Gtk.LevelBar | None = None
+    normalized: dict[str, float] = field(default_factory=dict)
+
+
+def _text(value: object, default: str = "") -> str:
+    if value is None:
+        return default
+    return str(value)
+
+
+def _int_or_none(value: object) -> int | None:
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return None
+    try:
+        return int(cast(int | float | str | bytes, value))
+    except (TypeError, ValueError):
+        return None
+
+
+def _bool_value(value: object) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "on"}
+    return bool(value)
+
+
+def _mapping_action_from_payload(action: object) -> MappingAction | None:
+    if not isinstance(action, dict):
+        return None
+    try:
+        action_type = ActionType(_text(action.get("action"), "passthrough"))
+    except ValueError:
+        return None
+
+    analog_control_names: list[str] = []
+    raw_analog_control_names = action.get("analog_control_names", [])
+    if isinstance(raw_analog_control_names, list):
+        analog_control_names = [
+            str(name) for name in raw_analog_control_names if str(name).strip()
+        ]
+    keys: list[str] | None = None
+    raw_keys = action.get("keys", [])
+    if isinstance(raw_keys, list):
+        keys = [str(key) for key in raw_keys if str(key).strip()]
+    move_x = _int_or_none(action.get("x"))
+    move_y = _int_or_none(action.get("y"))
+    axis_value = _int_or_none(action.get("value"))
+    rapidfire_hold_ms = _int_or_none(action.get("rapidfire_hold_ms"))
+    rapidfire_wait_ms = _int_or_none(action.get("rapidfire_wait_ms"))
+    tap_hold_ms = _int_or_none(action.get("tap_hold_ms"))
+
+    return MappingAction(
+        action_type=action_type,
+        target=_text(action.get("target")) or None,
+        output_id=_text(action.get("output_id")) or None,
+        keys=keys,
+        cmd=_text(action.get("cmd")) or None,
+        superkey_name=_text(action.get("superkey_name")) or None,
+        analog_control_names=analog_control_names,
+        macro_name=_text(action.get("macro_name"), _text(action.get("target"))) or None,
+        profile_name=_text(action.get("profile_name"), _text(action.get("target"))) or None,
+        compositor_id=_text(action.get("compositor")) or None,
+        compositor_dispatcher=_text(action.get("dispatcher")) or None,
+        compositor_args=_text(action.get("args")) or None,
+        move_x=move_x if move_x is not None else 0,
+        move_y=move_y if move_y is not None else 0,
+        axis_value=axis_value if axis_value is not None else 0,
+        rapidfire_enabled=_bool_value(action.get("rapidfire_enabled")),
+        rapidfire_hold_ms=rapidfire_hold_ms if rapidfire_hold_ms is not None else 20,
+        rapidfire_wait_ms=rapidfire_wait_ms if rapidfire_wait_ms is not None else 20,
+        tap_enabled=_bool_value(action.get("tap_enabled")),
+        tap_hold_ms=tap_hold_ms if tap_hold_ms is not None else 10,
+    )
+
+
+class DeviceInspectorWindow(Adw.Window):
+    def __init__(self, parent: Gtk.Window, device: HardwareConfig):
+        super().__init__()
+        self._parent = parent
+        self.device = device
+        self._hardware_id = device.hardware_id
+        self._closing = False
+        self._finalized = False
+        self._stop_sent = False
+        self._syncing_suppression = False
+        self._snapshot: JsonDict = {}
+        self._device_kind = _device_layout_kind(device)
+        self._control_widgets: dict[str, Gtk.Widget] = {}
+        self._event_history_by_category: dict[str, list[JsonDict]] = {
+            filter_id: [] for filter_id, _label, _active in EVENT_FILTERS
+        }
+        self._event_order = 0
+        self._event_rows: list[Gtk.ListBoxRow] = []
+        self._event_filter_buttons: dict[str, Gtk.ToggleButton] = {}
+        self._event_render_source_id = 0
+        self._analog_viewers: dict[str, AnalogViewer] = {}
+        self._flash_timeout_ids: dict[str, int] = {}
+
+        self.set_title(f"Inspect {device.name}")
+        window_width, window_height = _inspector_default_size(self._device_kind)
+        self.set_default_size(window_width, window_height)
+        self.set_transient_for(parent)
+        self.set_modal(False)
+
+        self._build_ui()
+
+        register_session_event_callback("device_inspector_event", self._on_inspector_event)
+        register_session_event_callback("device_inspector_status", self._on_inspector_status)
+        register_session_event_callback("profiles_changed", self._on_profiles_changed)
+        register_session_event_callback("runtime_reset", self._on_runtime_reset)
+        register_session_event_callback("keymasqd_status", self._on_keymasqd_status)
+        self.connect("close-request", self._on_close_request)
+        self.connect("destroy", self._on_destroy)
+
+        session_request_async(
+            {"command": "start_device_inspector", "hardware_id": self._hardware_id},
+            self._on_start_response,
+            timeout=6.0,
+        )
+
+    def _build_ui(self) -> None:
+        toolbar = Adw.ToolbarView()
+        header = Adw.HeaderBar()
+
+        self._header_device_icon = image_from_icon_names(
+            *device_icon_names(device_kind=_device_layout_kind(self.device)),
+            pixel_size=24,
+        )
+        self._header_device_icon.set_valign(Gtk.Align.CENTER)
+        header.pack_start(self._header_device_icon)
+
+        self._status_label = Gtk.Label(label="Starting inspector")
+        self._status_label.add_css_class("inspector-header-title")
+        self._status_label.set_halign(Gtk.Align.START)
+        self._status_label.set_hexpand(True)
+        self._status_label.set_ellipsize(Pango.EllipsizeMode.END)
+        self._status_label.set_max_width_chars(54)
+        header.pack_start(self._status_label)
+        self._header_title_spacer = Gtk.Box()
+        header.set_title_widget(self._header_title_spacer)
+
+        switch_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=8)
+        switch_box.set_valign(Gtk.Align.CENTER)
+        self._suppression_hint_label = Gtk.Label(label="Esc stops suppression")
+        self._suppression_hint_label.add_css_class("caption")
+        self._suppression_hint_label.add_css_class("inspector-suppression-hint")
+        self._suppression_hint_label.set_visible(False)
+        self._suppression_hint_label.set_halign(Gtk.Align.END)
+        switch_box.append(self._suppression_hint_label)
+        switch_label = Gtk.Label(label="Suppress output")
+        switch_label.set_halign(Gtk.Align.END)
+        switch_box.append(switch_label)
+        self._suppression_switch = Gtk.Switch()
+        self._suppression_switch.set_valign(Gtk.Align.CENTER)
+        self._suppression_switch.connect("notify::active", self._on_suppression_toggled)
+        switch_box.append(self._suppression_switch)
+        header.pack_end(switch_box)
+
+        toolbar.add_top_bar(header)
+
+        window_width, _window_height = _inspector_default_size(self._device_kind)
+        live_panel_width = (
+            AXES_PANEL_WIDTH + RAW_EVENTS_PANEL_WIDTH
+            if self._device_kind == "gamepad"
+            else RAW_EVENTS_PANEL_WIDTH
+        )
+        self._paned = Gtk.Paned(orientation=Gtk.Orientation.HORIZONTAL)
+        self._paned.set_position(window_width - live_panel_width)
+        self._paned.set_wide_handle(True)
+        self._paned.set_resize_start_child(True)
+        self._paned.set_resize_end_child(False)
+        self._paned.set_shrink_start_child(True)
+        self._paned.set_shrink_end_child(False)
+
+        mapping_scrolled = Gtk.ScrolledWindow()
+        mapping_scrolled.set_policy(Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.AUTOMATIC)
+        self._mapping_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=10)
+        self._mapping_box.set_margin_top(14)
+        self._mapping_box.set_margin_bottom(14)
+        self._mapping_box.set_margin_start(14)
+        self._mapping_box.set_margin_end(14)
+        mapping_scrolled.set_child(self._mapping_box)
+        self._paned.set_start_child(mapping_scrolled)
+
+        if self._device_kind == "gamepad":
+            live_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=0)
+            live_box.set_size_request(live_panel_width, -1)
+            live_box.set_hexpand(False)
+            axes_parent = self._build_live_panel_column(AXES_PANEL_WIDTH)
+            events_parent = self._build_live_panel_column(RAW_EVENTS_PANEL_WIDTH)
+            live_box.append(axes_parent)
+            separator = Gtk.Separator(orientation=Gtk.Orientation.VERTICAL)
+            live_box.append(separator)
+            live_box.append(events_parent)
+        else:
+            live_box = self._build_live_panel_column(RAW_EVENTS_PANEL_WIDTH)
+            axes_parent = live_box
+            events_parent = live_box
+
+        self._axes_title = Gtk.Label(label="Configured Axes")
+        self._axes_title.add_css_class("button-section-title")
+        self._axes_title.set_halign(Gtk.Align.START)
+        self._axes_title.set_visible(False)
+        axes_parent.append(self._axes_title)
+
+        self._axes_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=10)
+        self._axes_box.set_visible(False)
+        axes_parent.append(self._axes_box)
+
+        events_header = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=6)
+        events_header.set_halign(Gtk.Align.FILL)
+
+        events_title = Gtk.Label(label="Raw Events")
+        events_title.add_css_class("button-section-title")
+        events_title.set_halign(Gtk.Align.START)
+        events_title.set_hexpand(False)
+        events_header.append(events_title)
+
+        self._copy_events_button = Gtk.Button()
+        self._copy_events_button.set_tooltip_text("Copy visible events")
+        self._copy_events_button.add_css_class("flat")
+        self._copy_events_button.add_css_class("inspector-copy-button")
+        self._copy_events_button.set_child(
+            image_from_icon_names("edit-copy-symbolic", "edit-paste-symbolic", pixel_size=14)
+        )
+        self._copy_events_button.connect("clicked", self._on_copy_events_clicked)
+        events_header.append(self._copy_events_button)
+        events_parent.append(events_header)
+
+        filter_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=0)
+        filter_box.add_css_class("linked")
+        for filter_id, label, active in EVENT_FILTERS:
+            button = Gtk.ToggleButton(label=label)
+            button.add_css_class("inspector-event-filter-button")
+            button.set_active(active)
+            button.connect("toggled", self._on_event_filter_toggled)
+            filter_box.append(button)
+            self._event_filter_buttons[filter_id] = button
+        events_parent.append(filter_box)
+
+        self._event_list = Gtk.ListBox()
+        self._event_list.set_selection_mode(Gtk.SelectionMode.NONE)
+        self._event_list.add_css_class("boxed-list")
+
+        event_scrolled = Gtk.ScrolledWindow()
+        event_scrolled.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
+        event_scrolled.set_vexpand(True)
+        event_scrolled.set_child(self._event_list)
+        events_parent.append(event_scrolled)
+        self._paned.set_end_child(live_box)
+
+        toolbar.set_content(self._paned)
+        self.set_content(toolbar)
+
+    def _build_live_panel_column(self, width: int) -> Gtk.Box:
+        column = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=12)
+        column.set_size_request(width, -1)
+        column.set_hexpand(False)
+        column.set_margin_top(14)
+        column.set_margin_bottom(14)
+        column.set_margin_start(14)
+        column.set_margin_end(14)
+        return column
+
+    def _on_start_response(self, result: JsonDict | None) -> bool:
+        if self._closing:
+            return False
+        if not result or result.get("status") != "ok":
+            self._set_status_title(
+                _text((result or {}).get("message"), "Inspector could not start"),
+                "stopped",
+            )
+            self._suppression_switch.set_sensitive(False)
+            return False
+        self._apply_snapshot(result)
+        return False
+
+    def _request_snapshot(self) -> None:
+        if self._closing:
+            return
+        session_request_async(
+            {"command": "get_device_inspector_snapshot", "hardware_id": self._hardware_id},
+            self._on_snapshot_response,
+            timeout=3.0,
+        )
+
+    def _on_snapshot_response(self, result: JsonDict | None) -> bool:
+        if self._closing:
+            return False
+        if result and result.get("status") == "ok":
+            self._apply_snapshot(result)
+        return False
+
+    def _apply_snapshot(self, snapshot: JsonDict) -> None:
+        self._snapshot = dict(snapshot)
+        self._sync_status(snapshot)
+        self._render_mapping(snapshot)
+        self._render_axes(snapshot)
+
+    def _sync_status(self, data: JsonDict) -> None:
+        active = bool(data.get("active", True))
+        suppressed = bool(data.get("suppressed", False))
+        if active:
+            state = "suppressed" if suppressed else "monitoring"
+            text = f"{self.device.name} - {'Output suppressed' if suppressed else 'Monitoring'}"
+        else:
+            state = "stopped"
+            text = f"{self.device.name} - Stopped"
+        self._set_status_title(text, state)
+        self._syncing_suppression = True
+        try:
+            if self._suppression_switch.get_active() != suppressed:
+                self._suppression_switch.set_active(suppressed)
+        finally:
+            self._syncing_suppression = False
+        self._suppression_switch.set_sensitive(active and not self._closing)
+        self._suppression_hint_label.set_visible(active and suppressed)
+
+    def _set_status_title(self, text: str, state: str) -> None:
+        self._status_label.set_text(text)
+        self._status_label.set_tooltip_text(text)
+        for css_class in (
+            "inspector-header-monitoring",
+            "inspector-header-suppressed",
+            "inspector-header-stopped",
+        ):
+            self._status_label.remove_css_class(css_class)
+        self._status_label.add_css_class(
+            {
+                "suppressed": "inspector-header-suppressed",
+                "stopped": "inspector-header-stopped",
+            }.get(state, "inspector-header-monitoring")
+        )
+
+    def _render_mapping(self, snapshot: JsonDict) -> None:
+        self._clear_box(self._mapping_box)
+        self._control_widgets.clear()
+        buttons = [item for item in _list_of_dicts(snapshot.get("buttons"))]
+        analog_inputs = [item for item in _list_of_dicts(snapshot.get("analog_inputs"))]
+
+        title = Gtk.Label(label="Resolved Mapping")
+        title.add_css_class("button-section-title")
+        title.set_halign(Gtk.Align.START)
+        self._mapping_box.append(title)
+
+        profiles = snapshot.get("active_profiles")
+        profile_label = Gtk.Label(
+            label=", ".join(str(name) for name in profiles)
+            if isinstance(profiles, list) and profiles
+            else "No active profiles"
+        )
+        profile_label.add_css_class("caption")
+        profile_label.add_css_class("dim-label")
+        profile_label.set_halign(Gtk.Align.START)
+        self._mapping_box.append(profile_label)
+
+        if self._is_keyboard_snapshot(buttons):
+            self._render_keyboard_buttons(buttons)
+        else:
+            self._render_pointer_buttons(buttons)
+
+        if analog_inputs:
+            analog_label = Gtk.Label(label="Analog Inputs")
+            analog_label.add_css_class("button-section-title")
+            analog_label.set_halign(Gtk.Align.START)
+            analog_label.set_margin_top(8)
+            self._mapping_box.append(analog_label)
+            grid = Gtk.Grid(column_spacing=MAPPING_GRID_GAP, row_spacing=MAPPING_GRID_GAP)
+            grid.set_halign(Gtk.Align.START)
+            for index, analog in enumerate(analog_inputs):
+                widget = self._create_control_card(analog, is_keyboard=False)
+                grid.attach(widget, index % 2, index // 2, 1, 1)
+                self._control_widgets[_text(analog.get("id"))] = widget
+            self._mapping_box.append(grid)
+
+    def _render_keyboard_buttons(self, buttons: list[JsonDict]) -> None:
+        buttons_by_id = {_text(button.get("id")): button for button in buttons}
+        used_ids: set[str] = set()
+        for title, layout_rows, expanded, max_cols in KEYBOARD_SECTIONS:
+            grid = Gtk.Grid(column_spacing=MAPPING_GRID_GAP, row_spacing=MAPPING_GRID_GAP)
+            grid.set_halign(Gtk.Align.START)
+            for row_index, row_items in enumerate(layout_rows):
+                for col_index, button_id in enumerate(row_items):
+                    button = buttons_by_id.get(button_id)
+                    if button is None:
+                        spacer = Gtk.Box()
+                        spacer.set_size_request(MAPPING_CARD_WIDTH, -1)
+                        grid.attach(spacer, col_index, row_index, 1, 1)
+                        continue
+                    widget = self._create_control_card(button, is_keyboard=True)
+                    grid.attach(widget, col_index, row_index, 1, 1)
+                    self._control_widgets[button_id] = widget
+                    used_ids.add(button_id)
+                for col_index in range(len(row_items), max_cols):
+                    spacer = Gtk.Box()
+                    spacer.set_size_request(MAPPING_CARD_WIDTH, -1)
+                    grid.attach(spacer, col_index, row_index, 1, 1)
+            expander = Gtk.Expander(label=title)
+            expander.add_css_class("device-section-expander")
+            expander.set_expanded(expanded)
+            expander.set_child(grid)
+            self._mapping_box.append(expander)
+
+        extras = [button for button in buttons if _text(button.get("id")) not in used_ids]
+        if extras:
+            self._append_flow_section("Extra Keys", extras, is_keyboard=True)
+
+    def _render_pointer_buttons(self, buttons: list[JsonDict]) -> None:
+        main_ids = {"btn_left", "btn_right", "btn_middle"}
+        main_buttons: list[JsonDict] = []
+        wheel_buttons: list[JsonDict] = []
+        thumb_buttons: list[JsonDict] = []
+        extra_buttons: list[JsonDict] = []
+        for button in buttons:
+            button_id = _text(button.get("id")).lower()
+            if button_id in main_ids:
+                main_buttons.append(button)
+            elif "scroll" in button_id or "wheel" in button_id:
+                wheel_buttons.append(button)
+            elif button_id in {"btn_side", "btn_extra", "btn_4", "btn_forward", "btn_back"}:
+                thumb_buttons.append(button)
+            else:
+                extra_buttons.append(button)
+        for title, group in (
+            ("Main Buttons", main_buttons),
+            ("Wheel / Scroll", wheel_buttons),
+            ("Thumb Buttons", thumb_buttons),
+            ("Extra Buttons", extra_buttons),
+        ):
+            if group:
+                self._append_flow_section(title, group, is_keyboard=False)
+
+    def _append_flow_section(
+        self,
+        title: str,
+        controls: list[JsonDict],
+        *,
+        is_keyboard: bool,
+    ) -> None:
+        label = Gtk.Label(label=title)
+        label.add_css_class("button-section-title")
+        label.set_halign(Gtk.Align.START)
+        self._mapping_box.append(label)
+
+        grid = Gtk.Grid(column_spacing=MAPPING_GRID_GAP, row_spacing=MAPPING_GRID_GAP)
+        grid.set_halign(Gtk.Align.START)
+        max_cols = 4 if is_keyboard else 3
+        sorted_controls = sorted(controls, key=lambda item: _text(item.get("label")))
+        for index, control in enumerate(sorted_controls):
+            widget = self._create_control_card(control, is_keyboard=is_keyboard)
+            grid.attach(widget, index % max_cols, index // max_cols, 1, 1)
+            self._control_widgets[_text(control.get("id"))] = widget
+        self._mapping_box.append(grid)
+
+    def _create_control_card(self, control: JsonDict, *, is_keyboard: bool) -> Gtk.Button:
+        action = control.get("action")
+        mapped = isinstance(action, dict)
+        button = Gtk.Button()
+        button.add_css_class("card")
+        button.add_css_class("inspector-control-card")
+        button.add_css_class("button-card-mapped-active" if mapped else "button-card-passthrough")
+        button.set_focusable(False)
+        button.set_size_request(MAPPING_CARD_WIDTH, -1)
+        button.set_halign(Gtk.Align.START)
+        button.set_hexpand(False)
+
+        box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=4)
+        box.set_margin_top(6)
+        box.set_margin_bottom(7)
+        horizontal_padding = 7
+        box.set_margin_start(horizontal_padding)
+        box.set_margin_end(horizontal_padding)
+        box.set_size_request(MAPPING_CARD_WIDTH - (horizontal_padding * 2), -1)
+
+        name_label = Gtk.Label(label=_text(control.get("label"), _text(control.get("id"))))
+        name_label.add_css_class("heading")
+        name_label.set_xalign(0.0)
+        name_label.set_ellipsize(Pango.EllipsizeMode.END)
+        name_label.set_width_chars(1)
+        name_label.set_max_width_chars(MAPPING_NAME_CHARS)
+        box.append(name_label)
+
+        action_text = self._action_label(action, control) or self._passthrough_label(control)
+        action_label = Gtk.Label(label=_ellipsize_middle(action_text, MAPPING_ACTION_CHARS))
+        action_label.add_css_class("caption")
+        action_label.add_css_class("button-card-action-label")
+        action_label.set_xalign(0.0)
+        action_label.set_ellipsize(Pango.EllipsizeMode.MIDDLE)
+        action_label.set_width_chars(1)
+        action_label.set_max_width_chars(MAPPING_ACTION_CHARS)
+        if not mapped:
+            action_label.add_css_class("dim-label")
+        box.append(action_label)
+
+        profile_name = _text(control.get("profile_name"))
+        tooltip = action_text
+        if profile_name:
+            tooltip = f"{tooltip}\nProfile: {profile_name}"
+        source = _text(control.get("source"))
+        if source:
+            tooltip = f"{tooltip}\nSource: {source}"
+        button.set_tooltip_text(tooltip)
+        button.set_child(box)
+        return button
+
+    def _render_axes(self, snapshot: JsonDict) -> None:
+        self._clear_box(self._axes_box)
+        self._analog_viewers.clear()
+        analogs = [item for item in _list_of_dicts(snapshot.get("analog_inputs"))]
+        self._axes_title.set_visible(bool(analogs))
+        self._axes_box.set_visible(bool(analogs))
+        if not analogs:
+            return
+
+        for analog in analogs:
+            viewer = self._create_analog_viewer(analog)
+            self._analog_viewers[viewer.analog_id] = viewer
+
+    def _create_analog_viewer(self, analog: JsonDict) -> AnalogViewer:
+        analog_id = _text(analog.get("id"))
+        analog_type = _text(analog.get("type"), "axis").lower()
+        axes = {
+            _text(axis.get("role")): axis
+            for axis in _list_of_dicts(analog.get("axes"))
+            if _text(axis.get("role"))
+        }
+        viewer = AnalogViewer(
+            analog_id=analog_id,
+            analog_type=analog_type,
+            axes=axes,
+            normalized={
+                role: _normalize_axis(axis, 0, analog_type)
+                for role, axis in axes.items()
+            },
+        )
+
+        section = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=6)
+        section.add_css_class("inspector-axis-section")
+
+        title = Gtk.Label(label=_text(analog.get("label"), analog_id))
+        title.add_css_class("heading")
+        title.set_halign(Gtk.Align.CENTER)
+        section.append(title)
+
+        if analog_type == "stick" and {"x", "y"} <= set(axes):
+            area = Gtk.DrawingArea()
+            area.set_content_width(150)
+            area.set_content_height(150)
+            area.set_halign(Gtk.Align.CENTER)
+            area.add_css_class("inspector-axis-pad")
+
+            def draw_stick(
+                _area: Gtk.DrawingArea,
+                cr: Any,
+                width: int,
+                height: int,
+                _data: object,
+            ) -> None:
+                self._draw_stick(viewer, cr, width, height)
+
+            area.set_draw_func(draw_stick, None)
+            viewer.drawing_area = area
+            section.append(area)
+        else:
+            bar = Gtk.LevelBar()
+            bar.set_min_value(0.0)
+            bar.set_max_value(1.0)
+            first_role = sorted(axes)[0] if axes else ""
+            bar.set_value(_level_bar_value(analog_type, viewer.normalized.get(first_role, 0.0)))
+            bar.add_css_class("inspector-axis-bar")
+            bar.set_halign(Gtk.Align.CENTER)
+            bar.set_size_request(220, -1)
+            viewer.level_bar = bar
+            section.append(bar)
+
+        values = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=2)
+        values.set_halign(Gtk.Align.CENTER)
+        for role in sorted(axes):
+            label = Gtk.Label(
+                label=_axis_value_label(role, 0, viewer.normalized.get(role, 0.0))
+            )
+            label.add_css_class("caption")
+            label.add_css_class("dim-label")
+            label.add_css_class("inspector-axis-value")
+            label.set_xalign(0.5)
+            label.set_width_chars(29)
+            label.set_max_width_chars(29)
+            values.append(label)
+            viewer.value_labels[role] = label
+        section.append(values)
+        self._axes_box.append(section)
+        return viewer
+
+    def _draw_stick(self, viewer: AnalogViewer, cr: Any, width: int, height: int) -> None:
+        size = min(width, height)
+        cx = width / 2.0
+        cy = height / 2.0
+        radius = max(10.0, (size / 2.0) - 10.0)
+
+        cr.set_line_width(1.0)
+        cr.set_source_rgba(0.45, 0.45, 0.45, 0.28)
+        cr.arc(cx, cy, radius, 0, 6.28318)
+        cr.fill_preserve()
+        cr.set_source_rgba(0.45, 0.45, 0.45, 0.55)
+        cr.stroke()
+
+        cr.set_source_rgba(0.45, 0.45, 0.45, 0.35)
+        cr.move_to(cx - radius, cy)
+        cr.line_to(cx + radius, cy)
+        cr.move_to(cx, cy - radius)
+        cr.line_to(cx, cy + radius)
+        cr.stroke()
+
+        x = max(-1.0, min(1.0, viewer.normalized.get("x", 0.0)))
+        y = max(-1.0, min(1.0, viewer.normalized.get("y", 0.0)))
+        cr.set_source_rgba(0.0, 0.45, 0.85, 0.95)
+        cr.arc(cx + x * radius, cy + y * radius, 6.0, 0, 6.28318)
+        cr.fill()
+
+    def _on_inspector_event(self, event: JsonDict) -> bool:
+        if _text(event.get("hardware_id")) != self._hardware_id:
+            return False
+        self._store_event(event)
+
+        control_id = _text(event.get("control_id"))
+        event_type = _text(event.get("type_name")).lower()
+        value = int(event.get("value", 0) or 0)
+        if control_id:
+            if event_type == "ev_key":
+                self._set_control_active(control_id, value != 0)
+            else:
+                self._flash_control(control_id)
+
+        analog_id = _text(event.get("analog_id"))
+        role = _text(event.get("analog_role"))
+        if analog_id and role:
+            self._update_analog_value(analog_id, role, value)
+            self._flash_control(analog_id)
+        return False
+
+    def _store_event(self, event: JsonDict) -> None:
+        category = _event_filter_category(event)
+        if not category:
+            return
+
+        stored = dict(event)
+        self._event_order += 1
+        stored["_inspector_order"] = self._event_order
+        history = self._event_history_by_category.setdefault(category, [])
+        history.insert(0, stored)
+        del history[EVENT_ROW_LIMIT:]
+
+        if not self._event_filter_active(category):
+            return
+        if category == "button":
+            self._render_event_rows()
+        else:
+            self._queue_event_render()
+
+    def _prepend_event_row(self, event: JsonDict) -> None:
+        row = Gtk.ListBoxRow()
+        row.set_selectable(False)
+        row.add_css_class("inspector-event-row")
+        if int(event.get("value", 0) or 0) == 1:
+            row.add_css_class("inspector-event-row-pressed")
+
+        grid = Gtk.Grid(column_spacing=10, row_spacing=2)
+        grid.set_margin_top(5)
+        grid.set_margin_bottom(5)
+        grid.set_margin_start(8)
+        grid.set_margin_end(8)
+
+        sequence = int(event.get("sequence", 0) or 0)
+        event_type = _text(event.get("type_name"), _text(event.get("type")))
+        code_name = _text(event.get("code_name"), _text(event.get("code")))
+        value = _text(event.get("value"), "0")
+        source = _text(event.get("source"))
+
+        sequence_label = Gtk.Label(label=f"#{sequence}" if sequence else "")
+        sequence_label.add_css_class("caption")
+        sequence_label.add_css_class("dim-label")
+        sequence_label.set_xalign(0.0)
+        grid.attach(sequence_label, 0, 0, 1, 2)
+
+        code_label = Gtk.Label(label=code_name)
+        code_label.add_css_class("heading")
+        code_label.set_xalign(0.0)
+        code_label.set_hexpand(True)
+        code_label.set_ellipsize(Pango.EllipsizeMode.MIDDLE)
+        grid.attach(code_label, 1, 0, 1, 1)
+
+        detail_text = f"{event_type} value={value}"
+        if source:
+            detail_text = f"{detail_text} source={source}"
+        details = Gtk.Label(label=detail_text)
+        details.add_css_class("caption")
+        details.add_css_class("dim-label")
+        details.set_xalign(0.0)
+        details.set_ellipsize(Pango.EllipsizeMode.MIDDLE)
+        grid.attach(details, 1, 1, 1, 1)
+
+        row.set_child(grid)
+        self._event_list.insert(row, 0)
+        self._event_rows.insert(0, row)
+        while len(self._event_rows) > EVENT_ROW_LIMIT:
+            old = self._event_rows.pop()
+            self._event_list.remove(old)
+
+    def _on_event_filter_toggled(self, _button: Gtk.ToggleButton) -> None:
+        self._cancel_event_render()
+        self._render_event_rows()
+
+    def _on_copy_events_clicked(self, _button: Gtk.Button) -> None:
+        display = Gdk.Display.get_default()
+        if display is None:
+            return
+        display.get_clipboard().set(self._visible_event_export_text())
+
+    def _visible_event_export_text(self) -> str:
+        return "\n".join(_event_export_line(event) for event in self._visible_event_history())
+
+    def _render_event_rows(self) -> None:
+        for row in list(self._event_rows):
+            self._event_list.remove(row)
+        self._event_rows.clear()
+        for event in reversed(self._visible_event_history()):
+            self._prepend_event_row(event)
+
+    def _visible_event_history(self) -> list[JsonDict]:
+        events: list[JsonDict] = []
+        for category, history in self._event_history_by_category.items():
+            if self._event_filter_active(category):
+                events.extend(history)
+        events.sort(
+            key=lambda event: _int_or_none(event.get("_inspector_order")) or 0,
+            reverse=True,
+        )
+        return events[:EVENT_ROW_LIMIT]
+
+    def _event_filter_active(self, category: str) -> bool:
+        button = self._event_filter_buttons.get(category)
+        return bool(button and button.get_active())
+
+    def _queue_event_render(self) -> None:
+        if self._event_render_source_id:
+            return
+        self._event_render_source_id = GLib.timeout_add(
+            EVENT_RENDER_THROTTLE_MS,
+            self._flush_event_render,
+        )
+
+    def _flush_event_render(self) -> bool:
+        self._event_render_source_id = 0
+        if not self._closing:
+            self._render_event_rows()
+        return False
+
+    def _cancel_event_render(self) -> None:
+        if not self._event_render_source_id:
+            return
+        GLib.source_remove(self._event_render_source_id)
+        self._event_render_source_id = 0
+
+    def _update_analog_value(self, analog_id: str, role: str, value: int) -> None:
+        viewer = self._analog_viewers.get(analog_id)
+        if viewer is None:
+            return
+        axis = viewer.axes.get(role)
+        if axis is None:
+            return
+        normalized = _normalize_axis(axis, value, viewer.analog_type)
+        viewer.normalized[role] = normalized
+        value_label = viewer.value_labels.get(role)
+        if value_label is not None:
+            value_label.set_text(_axis_value_label(role, value, normalized))
+        if viewer.drawing_area is not None:
+            viewer.drawing_area.queue_draw()
+        if viewer.level_bar is not None:
+            viewer.level_bar.set_value(_level_bar_value(viewer.analog_type, normalized))
+
+    def _on_inspector_status(self, event: JsonDict) -> bool:
+        if _text(event.get("hardware_id")) != self._hardware_id:
+            return False
+        self._sync_status(event)
+        return False
+
+    def _on_profiles_changed(self, _event: JsonDict) -> bool:
+        self._request_snapshot()
+        return False
+
+    def _on_runtime_reset(self, _event: JsonDict) -> bool:
+        self._request_snapshot()
+        return False
+
+    def _on_keymasqd_status(self, event: JsonDict) -> bool:
+        if not bool(event.get("connected", False)):
+            self._set_status_title(f"{self.device.name} - Daemon disconnected", "stopped")
+            self._suppression_switch.set_sensitive(False)
+        return False
+
+    def _on_suppression_toggled(self, switch: Gtk.Switch, _param: object) -> None:
+        if self._syncing_suppression or self._closing:
+            return
+        command = (
+            "enable_device_inspector_suppression"
+            if switch.get_active()
+            else "disable_device_inspector_suppression"
+        )
+        payload: JsonDict = {"command": command, "hardware_id": self._hardware_id}
+        if command == "disable_device_inspector_suppression":
+            payload["reason"] = "manual"
+        switch.set_sensitive(False)
+        session_request_async(payload, self._on_suppression_response, timeout=3.0)
+
+    def _on_suppression_response(self, result: JsonDict | None) -> bool:
+        if self._closing:
+            return False
+        if result and result.get("status") == "ok":
+            self._sync_status(result)
+        else:
+            self._request_snapshot()
+        return False
+
+    def _set_control_active(self, control_id: str, active: bool) -> None:
+        widget = self._control_widgets.get(control_id)
+        if widget is None:
+            return
+        if active:
+            widget.add_css_class("inspector-control-active")
+        else:
+            widget.remove_css_class("inspector-control-active")
+
+    def _flash_control(self, control_id: str) -> None:
+        widget = self._control_widgets.get(control_id)
+        if widget is None:
+            return
+        widget.add_css_class("inspector-control-active")
+        old_source = self._flash_timeout_ids.pop(control_id, 0)
+        if old_source:
+            GLib.source_remove(old_source)
+
+        def clear() -> bool:
+            widget.remove_css_class("inspector-control-active")
+            self._flash_timeout_ids.pop(control_id, None)
+            return False
+
+        self._flash_timeout_ids[control_id] = GLib.timeout_add(180, clear)
+
+    def _on_close_request(self, *_args: object) -> bool:
+        self._finalize()
+        return False
+
+    def _on_destroy(self, *_args: object) -> None:
+        self._finalize()
+
+    def _finalize(self) -> None:
+        if self._finalized:
+            return
+        self._finalized = True
+        self._closing = True
+        self._cancel_event_render()
+        for source_id in list(self._flash_timeout_ids.values()):
+            GLib.source_remove(source_id)
+        self._flash_timeout_ids.clear()
+        unregister_session_event_callback("device_inspector_event", self._on_inspector_event)
+        unregister_session_event_callback("device_inspector_status", self._on_inspector_status)
+        unregister_session_event_callback("profiles_changed", self._on_profiles_changed)
+        unregister_session_event_callback("runtime_reset", self._on_runtime_reset)
+        unregister_session_event_callback("keymasqd_status", self._on_keymasqd_status)
+        self._stop_inspector()
+
+    def _stop_inspector(self) -> None:
+        if self._stop_sent:
+            return
+        self._stop_sent = True
+        session_request_async(
+            {"command": "stop_device_inspector", "hardware_id": self._hardware_id},
+            lambda _result: False,
+            timeout=1.5,
+        )
+
+    def _is_keyboard_snapshot(self, buttons: list[JsonDict]) -> bool:
+        return sum(1 for button in buttons if _text(button.get("id")).startswith("key_")) >= 12
+
+    def _action_label(self, action: object, control: JsonDict) -> str | None:
+        mapping = _mapping_action_from_payload(action)
+        if mapping is None:
+            return None
+        if mapping.action_type == ActionType.PASSTHROUGH:
+            return self._passthrough_label(control)
+        return describe_mapping_action_compact(mapping, include_state=True)
+
+    def _passthrough_label(self, control: JsonDict) -> str:
+        if _text(control.get("kind")) == "analog":
+            if _text(control.get("type")) == "axis":
+                return "Axis passthrough"
+            return "Analog passthrough"
+        evdev = _text(control.get("evdev"))
+        evdev_value = _int_or_none(control.get("evdev_value"))
+        if evdev == "rel_wheel" and evdev_value is not None:
+            return "Scroll Up" if evdev_value > 0 else "Scroll Down"
+        if evdev == "rel_hwheel" and evdev_value is not None:
+            return "Scroll Right" if evdev_value > 0 else "Scroll Left"
+        return f"Passthrough: {evdev or _text(control.get('id'), '?')}"
+
+    def _clear_box(self, box: Gtk.Box) -> None:
+        child = box.get_first_child()
+        while child is not None:
+            next_child = child.get_next_sibling()
+            box.remove(child)
+            child = next_child
+
+
+def _list_of_dicts(value: object) -> list[JsonDict]:
+    if not isinstance(value, list):
+        return []
+    return [cast(JsonDict, item) for item in value if isinstance(item, dict)]
+
+
+def _ellipsize_middle(text: str, max_chars: int) -> str:
+    if len(text) <= max_chars:
+        return text
+    if max_chars <= 3:
+        return text[:max_chars]
+    head = max(1, (max_chars - 3) // 2)
+    tail = max(1, max_chars - 3 - head)
+    return f"{text[:head]}...{text[-tail:]}"
+
+
+def _event_filter_category(event: JsonDict) -> str:
+    event_type = _text(event.get("type_name"), _text(event.get("type"))).lower()
+    code_name = _text(event.get("code_name"), _text(event.get("code"))).lower()
+    if event_type in {"ev_key", "1"}:
+        return "button"
+    if event_type in {"ev_syn", "0"} or (
+        event_type in {"ev_msc", "4"} and code_name in {"msc_scan", "4"}
+    ):
+        return "syn"
+    if event_type in {"ev_abs", "3"}:
+        return "axis"
+    if event_type in {"ev_rel", "2"}:
+        if code_name in {"rel_x", "rel_y"}:
+            return "mousemove"
+        return "axis"
+    return "other"
+
+
+def _event_export_line(event: JsonDict) -> str:
+    sequence = int(event.get("sequence", 0) or 0)
+    code_name = _text(event.get("code_name"), _text(event.get("code"), "unknown"))
+    event_type = _text(event.get("type_name"), _text(event.get("type"), "unknown"))
+    value = _text(event.get("value"), "0")
+    source = _text(event.get("source"))
+    parts = [f"#{sequence}" if sequence else "#-", code_name, event_type, f"value={value}"]
+    if source:
+        parts.append(f"source={source}")
+    return " ".join(parts)
+
+
+def _axis_min_max(axis: JsonDict, analog_type: str) -> tuple[int, int]:
+    minimum = _int_or_none(axis.get("minimum"))
+    maximum = _int_or_none(axis.get("maximum"))
+    if minimum is None or maximum is None or maximum <= minimum:
+        if analog_type == "axis":
+            return DEFAULT_AXIS_MIN, DEFAULT_AXIS_MAX
+        return DEFAULT_STICK_MIN, DEFAULT_STICK_MAX
+    return minimum, maximum
+
+
+def _normalize_axis(axis: JsonDict, value: int, analog_type: str) -> float:
+    minimum, maximum = _axis_min_max(axis, analog_type)
+    if analog_type == "axis":
+        rest = _int_or_none(axis.get("rest"))
+        if rest is None:
+            rest = minimum if minimum >= 0 else 0
+        positive_span = float(maximum) - float(rest)
+        negative_span = float(minimum) - float(rest)
+        active_span = positive_span if abs(positive_span) >= abs(negative_span) else negative_span
+        if abs(active_span) < 1.0:
+            active_span = float(maximum) - float(minimum)
+        if abs(active_span) < 1.0:
+            return 0.0
+        normalized = (float(value) - float(rest)) / active_span
+        return max(0.0, min(1.0, normalized))
+
+    center = _int_or_none(axis.get("center"))
+    midpoint = float(center) if center is not None else (float(minimum) + float(maximum)) / 2.0
+    raw = float(value)
+    if raw < midpoint:
+        span = max(1.0, midpoint - float(minimum))
+        normalized = (raw - midpoint) / span
+    else:
+        span = max(1.0, float(maximum) - midpoint)
+        normalized = (raw - midpoint) / span
+    if bool(axis.get("invert", False)):
+        normalized = -normalized
+    return max(-1.0, min(1.0, normalized))
+
+
+def _level_bar_value(analog_type: str, normalized: float) -> float:
+    if analog_type == "axis":
+        return max(0.0, min(1.0, normalized))
+    return max(0.0, min(1.0, (normalized + 1.0) / 2.0))
+
+
+def _axis_value_label(role: str, raw_value: int, normalized: float) -> str:
+    return f"{role}: raw {raw_value:6d} | norm {normalized:+.3f}"
+
+
+def _device_layout_kind(device: HardwareConfig) -> str:
+    key_count = sum(1 for button in device.buttons if button.id.startswith("key_"))
+    if key_count >= 40:
+        return "keyboard"
+    if any(evdev_device.device_type == DeviceType.GAMEPAD for evdev_device in device.evdev_devices):
+        return "gamepad"
+    if any(is_gamepad_button_name(button.evdev) for button in device.buttons):
+        return "gamepad"
+    return "mouse"
+
+
+def _inspector_default_size(device_kind: str) -> tuple[int, int]:
+    if device_kind == "keyboard":
+        return KEYBOARD_WINDOW_WIDTH, KEYBOARD_WINDOW_HEIGHT
+    if device_kind == "gamepad":
+        return GAMEPAD_WINDOW_WIDTH, GAMEPAD_WINDOW_HEIGHT
+    return MOUSE_WINDOW_WIDTH, MOUSE_WINDOW_HEIGHT

--- a/keymasq/gui/widgets/device_inspector_window.py
+++ b/keymasq/gui/widgets/device_inspector_window.py
@@ -1,3 +1,4 @@
+import re
 from dataclasses import dataclass, field
 from typing import Any, cast
 
@@ -37,6 +38,7 @@ MAPPING_CARD_WIDTH = 122
 MAPPING_NAME_CHARS = 14
 MAPPING_ACTION_CHARS = 15
 MAPPING_GRID_GAP = 6
+TRAILING_NUMBER_RE = re.compile(r"^(?P<prefix>.*?)(?P<number>\d+)\s*$")
 EVENT_FILTERS: tuple[tuple[str, str, bool], ...] = (
     ("button", "Keys", True),
     ("axis", "Axes", False),
@@ -586,7 +588,7 @@ class DeviceInspectorWindow(Adw.Window):
         grid = Gtk.Grid(column_spacing=MAPPING_GRID_GAP, row_spacing=MAPPING_GRID_GAP)
         grid.set_halign(Gtk.Align.START)
         max_cols = 4 if is_keyboard else 3
-        sorted_controls = sorted(controls, key=lambda item: _text(item.get("label")))
+        sorted_controls = sorted(controls, key=lambda item: _label_sort_key(item.get("label")))
         for index, control in enumerate(sorted_controls):
             widget = self._create_control_card(control, is_keyboard=is_keyboard)
             grid.attach(widget, index % max_cols, index // max_cols, 1, 1)
@@ -1096,6 +1098,15 @@ def _event_export_line(event: JsonDict) -> str:
     if source:
         parts.append(f"source={source}")
     return " ".join(parts)
+
+
+def _label_sort_key(label: object) -> tuple[str, int, int, str]:
+    text = _text(label).strip()
+    lowered = text.lower()
+    match = TRAILING_NUMBER_RE.match(lowered)
+    if match:
+        return (match.group("prefix").strip(), 0, int(match.group("number")), lowered)
+    return (lowered, 1, 0, lowered)
 
 
 def _axis_min_max(axis: JsonDict, analog_type: str) -> tuple[int, int]:

--- a/keymasq/gui/widgets/device_tab.py
+++ b/keymasq/gui/widgets/device_tab.py
@@ -31,7 +31,7 @@ from keymasq.common.models import (
     MappingAction,
     is_protected_button,
 )
-from keymasq.gui.icons import device_icon_names, image_from_icon_names
+from keymasq.gui.icons import device_icon_names, image_from_icon_names, resolve_icon_name
 from keymasq.gui.session_client import (
     JsonDict,
     session_request_async,
@@ -43,12 +43,12 @@ from keymasq.session.hardware import HardwareManager
 from keymasq.session.profiles import ProfileInfo, ProfileManager
 
 _ADD_INPUTS_TOOLTIP = "Capture additional physical buttons or keys for this device"
-_KEYBOARD_BUTTON_CARD_WIDTH = 112
-_KEYBOARD_LABEL_CHARS = 12
-_KEYBOARD_ACTION_SUMMARY_CHARS = 16
-_POINTER_BUTTON_CARD_WIDTH = 187
-_POINTER_NAME_LABEL_CHARS = 20
-_POINTER_ACTION_SUMMARY_CHARS = 24
+_MAPPING_BUTTON_CARD_WIDTH = 122
+_MAPPING_LABEL_CHARS = 14
+_MAPPING_ACTION_SUMMARY_CHARS = 15
+_MOUSE_MAPPING_BUTTON_CARD_WIDTH = 187
+_MOUSE_MAPPING_LABEL_CHARS = 20
+_MOUSE_MAPPING_ACTION_SUMMARY_CHARS = 24
 _ACTION_SUMMARY_MARKER = "..."
 _ANALOG_LAYOUT_ORDER = {
     "left_trigger": 0,
@@ -392,6 +392,20 @@ class DeviceTab(ProfileManagedTab):
         name_row.append(self.device_name_label)
 
         if not self.demo_mode:
+            inspect_btn = Gtk.Button(
+                icon_name=resolve_icon_name(
+                    "edit-find-symbolic",
+                    "system-search-symbolic",
+                    "zoom-in-symbolic",
+                    "dialog-information-symbolic",
+                )
+            )
+            inspect_btn.set_tooltip_text("Inspect device")
+            inspect_btn.add_css_class("flat")
+            inspect_btn.set_valign(Gtk.Align.CENTER)
+            inspect_btn.connect("clicked", self._on_inspect_device_clicked)
+            name_row.append(inspect_btn)
+
             delete_btn = Gtk.Button(icon_name="user-trash-symbolic")
             delete_btn.set_tooltip_text("Delete device")
             delete_btn.add_css_class("destructive-action")
@@ -437,6 +451,12 @@ class DeviceTab(ProfileManagedTab):
         if iface_count > 1:
             return f"Always grab all {iface_count} interfaces of {device.name}"
         return f"Always grab {device.name}"
+
+    def _on_inspect_device_clicked(self, _button: Gtk.Button) -> None:
+        root = self.main_window or self.get_root()
+        opener = getattr(root, "open_device_inspector", None)
+        if callable(opener):
+            opener(self.device)
 
     def _on_device_name_right_clicked(self, click, n_press, x, y) -> None:
         if n_press != 1 or self.demo_mode:
@@ -944,7 +964,7 @@ class DeviceTab(ProfileManagedTab):
                 button = buttons_by_id.get(button_id)
                 if button is None:
                     spacer = Gtk.Box()
-                    spacer.set_size_request(92, -1)
+                    spacer.set_size_request(_MAPPING_BUTTON_CARD_WIDTH, -1)
                     grid.attach(spacer, col_i, row_i, 1, 1)
                 else:
                     widget = self._create_button_widget(button)
@@ -955,7 +975,7 @@ class DeviceTab(ProfileManagedTab):
 
             while col_i < max_cols:
                 spacer = Gtk.Box()
-                spacer.set_size_request(92, -1)
+                spacer.set_size_request(_MAPPING_BUTTON_CARD_WIDTH, -1)
                 grid.attach(spacer, col_i, row_i, 1, 1)
                 col_i += 1
 
@@ -996,9 +1016,19 @@ class DeviceTab(ProfileManagedTab):
             parent.append(expander)
 
     def _button_card_width(self) -> int:
-        if self._keyboard_layout_mode:
-            return _KEYBOARD_BUTTON_CARD_WIDTH
-        return _POINTER_BUTTON_CARD_WIDTH
+        if self.device_layout_kind() == "mouse":
+            return _MOUSE_MAPPING_BUTTON_CARD_WIDTH
+        return _MAPPING_BUTTON_CARD_WIDTH
+
+    def _mapping_label_chars(self) -> int:
+        if self.device_layout_kind() == "mouse":
+            return _MOUSE_MAPPING_LABEL_CHARS
+        return _MAPPING_LABEL_CHARS
+
+    def _mapping_action_summary_chars(self) -> int:
+        if self.device_layout_kind() == "mouse":
+            return _MOUSE_MAPPING_ACTION_SUMMARY_CHARS
+        return _MAPPING_ACTION_SUMMARY_CHARS
 
     def _create_button_widget(self, button) -> Gtk.Button:
         protected = is_protected_button(button.id)
@@ -1026,11 +1056,7 @@ class DeviceTab(ProfileManagedTab):
         name_label.set_xalign(0.0)
         name_label.set_ellipsize(Pango.EllipsizeMode.END)
         name_label.set_width_chars(1)
-        name_label.set_max_width_chars(
-            _KEYBOARD_LABEL_CHARS
-            if self._keyboard_layout_mode
-            else _POINTER_NAME_LABEL_CHARS
-        )
+        name_label.set_max_width_chars(self._mapping_label_chars())
         header.append(name_label)
 
         name_right_click = Gtk.GestureClick()
@@ -1056,11 +1082,7 @@ class DeviceTab(ProfileManagedTab):
         action_label.set_single_line_mode(True)
         action_label.set_ellipsize(Pango.EllipsizeMode.MIDDLE)
         action_label.set_width_chars(1)
-        action_label.set_max_width_chars(
-            _KEYBOARD_ACTION_SUMMARY_CHARS
-            if self._keyboard_layout_mode
-            else _POINTER_ACTION_SUMMARY_CHARS
-        )
+        action_label.set_max_width_chars(self._mapping_action_summary_chars())
         box.append(action_label)
 
         action_right_click = Gtk.GestureClick()
@@ -1128,7 +1150,7 @@ class DeviceTab(ProfileManagedTab):
         name_label.set_xalign(0.0)
         name_label.set_ellipsize(Pango.EllipsizeMode.END)
         name_label.set_width_chars(1)
-        name_label.set_max_width_chars(_POINTER_NAME_LABEL_CHARS)
+        name_label.set_max_width_chars(self._mapping_label_chars())
         box.append(name_label)
         name_right_click = Gtk.GestureClick()
         name_right_click.set_button(3)
@@ -1145,7 +1167,7 @@ class DeviceTab(ProfileManagedTab):
         action_label.set_single_line_mode(True)
         action_label.set_ellipsize(Pango.EllipsizeMode.MIDDLE)
         action_label.set_width_chars(1)
-        action_label.set_max_width_chars(_POINTER_ACTION_SUMMARY_CHARS)
+        action_label.set_max_width_chars(self._mapping_action_summary_chars())
         box.append(action_label)
 
         btn._action_label = action_label
@@ -1579,12 +1601,7 @@ class DeviceTab(ProfileManagedTab):
         return f"→ {self._label_from_evdev(button.evdev)}"
 
     def _set_action_label_text(self, label: Gtk.Label, text: str) -> None:
-        max_chars = (
-            _KEYBOARD_ACTION_SUMMARY_CHARS
-            if self._keyboard_layout_mode
-            else _POINTER_ACTION_SUMMARY_CHARS
-        )
-        display_text = _display_action_summary(text, max_chars)
+        display_text = _display_action_summary(text, self._mapping_action_summary_chars())
         label.set_text(display_text)
         label.set_tooltip_text(text if display_text != text else None)
 

--- a/keymasq/gui/widgets/device_tab.py
+++ b/keymasq/gui/widgets/device_tab.py
@@ -1,3 +1,4 @@
+import re
 import shlex
 from typing import cast
 
@@ -56,6 +57,7 @@ _ANALOG_LAYOUT_ORDER = {
     "left_stick": 2,
     "right_stick": 3,
 }
+_TRAILING_NUMBER_RE = re.compile(r"^(?P<prefix>.*?)(?P<number>\d+)\s*$")
 
 
 def _make_capture_status_row(status_label: Gtk.Label) -> Gtk.Box:
@@ -154,6 +156,15 @@ def _grouped_analog_inputs(
     if other:
         groups.append(("Other", other))
     return groups
+
+
+def _label_sort_key(label: object) -> tuple[str, int, int, str]:
+    text = str(label or "").strip()
+    lowered = text.lower()
+    match = _TRAILING_NUMBER_RE.match(lowered)
+    if match:
+        return (match.group("prefix").strip(), 0, int(match.group("number")), lowered)
+    return (lowered, 1, 0, lowered)
 
 
 def _display_action_summary(text: str, max_chars: int) -> str:
@@ -760,10 +771,10 @@ class DeviceTab(ProfileManagedTab):
         main_ids = {"btn_left", "btn_right", "btn_middle"}
         scroll_keywords = {"scroll", "wheel"}
 
-        main_buttons = []
-        scroll_buttons = []
-        other_buttons = []
-        extra_buttons = []
+        main_buttons: list[ButtonDefinition] = []
+        scroll_buttons: list[ButtonDefinition] = []
+        other_buttons: list[ButtonDefinition] = []
+        extra_buttons: list[ButtonDefinition] = []
 
         for button in self.device.buttons:
             bid = button.id.lower()
@@ -778,7 +789,12 @@ class DeviceTab(ProfileManagedTab):
 
         self.button_grid = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
 
-        def _add_section(title: str, buttons: list, parent: Gtk.Box, max_cols: int = 4) -> None:
+        def _add_section(
+            title: str,
+            buttons: list[ButtonDefinition],
+            parent: Gtk.Box,
+            max_cols: int = 4,
+        ) -> None:
             if not buttons:
                 return
             if title:
@@ -821,7 +837,10 @@ class DeviceTab(ProfileManagedTab):
                         section_buttons.append(button)
                 _add_section(title, section_buttons, content, max_cols=max_cols)
 
-            extras = sorted(buttons_by_id.values(), key=lambda button: button.label.lower())
+            extras = sorted(
+                buttons_by_id.values(),
+                key=lambda button: _label_sort_key(button.label),
+            )
             if extras:
                 self._append_other_buttons_section(
                     content,
@@ -841,7 +860,12 @@ class DeviceTab(ProfileManagedTab):
             extra_expander = Gtk.Expander(label=f"Extra Buttons ({len(extra_buttons)})")
             extra_expander.set_expanded(True)
             extra_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=4)
-            _add_section("", extra_buttons, extra_box, max_cols=3)
+            _add_section(
+                "",
+                sorted(extra_buttons, key=lambda button: _label_sort_key(button.label)),
+                extra_box,
+                max_cols=3,
+            )
             extra_expander.set_child(extra_box)
             content.append(extra_expander)
 
@@ -997,7 +1021,7 @@ class DeviceTab(ProfileManagedTab):
         col = 0
         row = 0
         max_cols = 6
-        for button in sorted(extras, key=lambda b: b.label.lower()):
+        for button in sorted(extras, key=lambda b: _label_sort_key(b.label)):
             widget = self._create_button_widget(button)
             grid.attach(widget, col, row, 1, 1)
             self._button_widgets[button.id] = widget

--- a/keymasq/gui/window.py
+++ b/keymasq/gui/window.py
@@ -107,6 +107,7 @@ class MainWindow(Adw.ApplicationWindow):
         self._profile_reload_pending = False
         self._destroyed = False
         self.combo_tab: ComboTab | None = None
+        self._device_inspector_windows: dict[str, Gtk.Window] = {}
 
         self.set_title("Keymasq")
         self.set_default_size(760, 1000)
@@ -591,6 +592,9 @@ class MainWindow(Adw.ApplicationWindow):
         self._gnome_setup_poll_source_id = self._remove_timeout_source(
             self._gnome_setup_poll_source_id
         )
+        for inspector_window in list(self._device_inspector_windows.values()):
+            inspector_window.close()
+        self._device_inspector_windows.clear()
 
         if self.demo_mode:
             return
@@ -1022,6 +1026,49 @@ class MainWindow(Adw.ApplicationWindow):
         page = self.stack.get_page(child)
         if page is not None:
             page.set_title(name)
+
+    def open_device_inspector(self, device) -> None:
+        hardware_id = str(getattr(device, "hardware_id", "") or "").strip()
+        if not hardware_id:
+            return
+        existing = self._device_inspector_windows.get(hardware_id)
+        if existing is not None:
+            if bool(getattr(existing, "_closing", False)):
+                self._device_inspector_windows.pop(hardware_id, None)
+            else:
+                existing.present()
+                return
+
+        if self.demo_mode:
+            self._show_demo_notification("Device inspector is not available in demo mode")
+            return
+
+        if not self._device_inspector_unlock_ready():
+            self.present_unlock_dialog(on_success=lambda: self.open_device_inspector(device))
+            return
+
+        from keymasq.gui.widgets.device_inspector_window import DeviceInspectorWindow
+
+        inspector = DeviceInspectorWindow(self, device)
+        self._device_inspector_windows[hardware_id] = inspector
+
+        def on_close_request(window: Gtk.Window) -> bool:
+            if self._device_inspector_windows.get(hardware_id) is window:
+                self._device_inspector_windows.pop(hardware_id, None)
+            return False
+
+        def on_destroy(window: Gtk.Window) -> None:
+            if self._device_inspector_windows.get(hardware_id) is window:
+                self._device_inspector_windows.pop(hardware_id, None)
+
+        inspector.connect("close-request", on_close_request)
+        inspector.connect("destroy", on_destroy)
+        inspector.present()
+
+    def _device_inspector_unlock_ready(self) -> bool:
+        if not self._recording_unlock_required:
+            return True
+        return self._recording_unlocked and self._recording_refresh_owner
 
     def _queue_profile_reload(self) -> None:
         if self._destroyed:

--- a/keymasq/keymasqd/daemon.py
+++ b/keymasq/keymasqd/daemon.py
@@ -134,6 +134,18 @@ class _DaemonDeviceManager(Protocol):
         categories: Sequence[object] | None = None,
     ) -> JsonObject: ...
 
+    async def start_device_inspector(self, hardware_id: str) -> JsonObject: ...
+
+    async def stop_device_inspector(self, hardware_id: str) -> JsonObject: ...
+
+    async def enable_device_inspector_suppression(self, hardware_id: str) -> JsonObject: ...
+
+    async def disable_device_inspector_suppression(
+        self,
+        hardware_id: str,
+        reason: str = "manual",
+    ) -> JsonObject: ...
+
     def complete_macro_exec_wait(self, wait_id: str, returncode: int) -> JsonObject: ...
 
 
@@ -432,6 +444,8 @@ class Daemon:
             CommandType.CAPTURE_READ,
             CommandType.CAPTURE_END,
             CommandType.CAPTURE_COMBO,
+            CommandType.DEVICE_INSPECTOR_START,
+            CommandType.DEVICE_INSPECTOR_ENABLE_SUPPRESSION,
         }
 
         tier2_commands = {
@@ -514,6 +528,8 @@ class Daemon:
             CommandType.MACRO_GET,
             CommandType.MACRO_CREATE,
             CommandType.MACRO_UPDATE,
+            CommandType.DEVICE_INSPECTOR_START,
+            CommandType.DEVICE_INSPECTOR_ENABLE_SUPPRESSION,
         }
         if command_type not in sensitive_commands:
             return

--- a/keymasq/keymasqd/daemon_device_commands.py
+++ b/keymasq/keymasqd/daemon_device_commands.py
@@ -48,6 +48,18 @@ class _DeviceCommandManager(Protocol):
 
     async def set_virtual_gamepads(self, count: object) -> JsonObject: ...
 
+    async def start_device_inspector(self, hardware_id: str) -> JsonObject: ...
+
+    async def stop_device_inspector(self, hardware_id: str) -> JsonObject: ...
+
+    async def enable_device_inspector_suppression(self, hardware_id: str) -> JsonObject: ...
+
+    async def disable_device_inspector_suppression(
+        self,
+        hardware_id: str,
+        reason: str = "manual",
+    ) -> JsonObject: ...
+
 
 class _DeviceCommandMacroStore(Protocol):
     def get(self, name: str) -> JsonObject: ...
@@ -120,5 +132,26 @@ async def handle_device_command(
 
     if command_type == CommandType.SET_VIRTUAL_GAMEPADS:
         return await daemon.device_manager.set_virtual_gamepads(data.get("count"))
+
+    if command_type == CommandType.DEVICE_INSPECTOR_START:
+        return await daemon.device_manager.start_device_inspector(
+            hardware_id=str_value(data["hardware_id"]),
+        )
+
+    if command_type == CommandType.DEVICE_INSPECTOR_STOP:
+        return await daemon.device_manager.stop_device_inspector(
+            hardware_id=str_value(data["hardware_id"]),
+        )
+
+    if command_type == CommandType.DEVICE_INSPECTOR_ENABLE_SUPPRESSION:
+        return await daemon.device_manager.enable_device_inspector_suppression(
+            hardware_id=str_value(data["hardware_id"]),
+        )
+
+    if command_type == CommandType.DEVICE_INSPECTOR_DISABLE_SUPPRESSION:
+        return await daemon.device_manager.disable_device_inspector_suppression(
+            hardware_id=str_value(data["hardware_id"]),
+            reason=str_value(data.get("reason", "manual"), "manual"),
+        )
 
     return None

--- a/keymasq/keymasqd/device_manager.py
+++ b/keymasq/keymasqd/device_manager.py
@@ -442,6 +442,9 @@ class DeviceManager:
         )
         self.combo_state = runtime_combos.ComboRuntimeState()
         self._configured_combos: list[RuntimeCombo] = []
+        self.device_inspector_active_hardware_ids: set[str] = set()
+        self.device_inspector_suppressed_hardware_ids: set[str] = set()
+        self._device_inspector_event_sequence = 0
         self.topology_state = TopologyRuntimeState(
             poll_s=max(0.05, float(topology_poll_s)),
             debounce_s=max(0.05, float(topology_debounce_s)),
@@ -680,6 +683,119 @@ class DeviceManager:
             self.broadcast_callback(event_type, data),
             f"{event_type.value} broadcast",
         )
+
+    def device_inspector_active(self, hardware_id: str) -> bool:
+        return str(hardware_id or "").strip() in self.device_inspector_active_hardware_ids
+
+    def device_inspector_suppressed(self, hardware_id: str) -> bool:
+        return str(hardware_id or "").strip() in self.device_inspector_suppressed_hardware_ids
+
+    def device_inspector_suppressed_hardware_ids_snapshot(self) -> set[str]:
+        return set(self.device_inspector_suppressed_hardware_ids)
+
+    def broadcast_device_inspector_event(self, payload: JsonObject) -> None:
+        hardware_id = str(payload.get("hardware_id", "") or "").strip()
+        if not hardware_id or not self.device_inspector_active(hardware_id):
+            return
+        self._device_inspector_event_sequence += 1
+        event_payload = dict(payload)
+        event_payload["sequence"] = self._device_inspector_event_sequence
+        self._broadcast_runtime_event(CommandType.DEVICE_INSPECTOR_EVENT, event_payload)
+
+    def _broadcast_device_inspector_status(self, hardware_id: str, reason: str) -> None:
+        normalized_hardware_id = str(hardware_id or "").strip()
+        self._broadcast_runtime_event(
+            CommandType.DEVICE_INSPECTOR_STATUS,
+            {
+                "hardware_id": normalized_hardware_id,
+                "active": self.device_inspector_active(normalized_hardware_id),
+                "suppressed": self.device_inspector_suppressed(normalized_hardware_id),
+                "reason": str(reason or ""),
+            },
+        )
+
+    async def start_device_inspector(self, hardware_id: str) -> JsonObject:
+        normalized_hardware_id = str(hardware_id or "").strip()
+        if not normalized_hardware_id:
+            raise ValueError("hardware_id required")
+        async with self._op_lock:
+            self.device_inspector_active_hardware_ids.add(normalized_hardware_id)
+            self._broadcast_device_inspector_status(normalized_hardware_id, "start")
+        return {
+            "status": "ok",
+            "hardware_id": normalized_hardware_id,
+            "active": True,
+            "suppressed": self.device_inspector_suppressed(normalized_hardware_id),
+        }
+
+    async def stop_device_inspector(self, hardware_id: str) -> JsonObject:
+        normalized_hardware_id = str(hardware_id or "").strip()
+        if not normalized_hardware_id:
+            raise ValueError("hardware_id required")
+        async with self._op_lock:
+            was_suppressed = self.device_inspector_suppressed(normalized_hardware_id)
+            self.device_inspector_suppressed_hardware_ids.discard(normalized_hardware_id)
+            self.device_inspector_active_hardware_ids.discard(normalized_hardware_id)
+            if was_suppressed:
+                await self._reset_device_inspector_runtime_unlocked(normalized_hardware_id)
+                await self._refresh_combo_runtime_unlocked()
+            self._broadcast_device_inspector_status(normalized_hardware_id, "stop")
+        return {
+            "status": "ok",
+            "hardware_id": normalized_hardware_id,
+            "active": False,
+            "suppressed": False,
+        }
+
+    async def enable_device_inspector_suppression(self, hardware_id: str) -> JsonObject:
+        normalized_hardware_id = str(hardware_id or "").strip()
+        if not normalized_hardware_id:
+            raise ValueError("hardware_id required")
+        async with self._op_lock:
+            self.device_inspector_active_hardware_ids.add(normalized_hardware_id)
+            self.device_inspector_suppressed_hardware_ids.add(normalized_hardware_id)
+            await self._reset_device_inspector_runtime_unlocked(normalized_hardware_id)
+            await self._refresh_combo_runtime_unlocked()
+            self._broadcast_device_inspector_status(normalized_hardware_id, "enable_suppression")
+        return {
+            "status": "ok",
+            "hardware_id": normalized_hardware_id,
+            "active": True,
+            "suppressed": True,
+        }
+
+    async def disable_device_inspector_suppression(
+        self,
+        hardware_id: str,
+        reason: str = "manual",
+    ) -> JsonObject:
+        normalized_hardware_id = str(hardware_id or "").strip()
+        if not normalized_hardware_id:
+            raise ValueError("hardware_id required")
+        async with self._op_lock:
+            self.device_inspector_active_hardware_ids.add(normalized_hardware_id)
+            was_suppressed = normalized_hardware_id in self.device_inspector_suppressed_hardware_ids
+            self.device_inspector_suppressed_hardware_ids.discard(normalized_hardware_id)
+            if was_suppressed:
+                await self._reset_device_inspector_runtime_unlocked(normalized_hardware_id)
+                await self._refresh_combo_runtime_unlocked()
+            self._broadcast_device_inspector_status(normalized_hardware_id, reason)
+        return {
+            "status": "ok",
+            "hardware_id": normalized_hardware_id,
+            "active": True,
+            "suppressed": False,
+            "reason": str(reason or ""),
+        }
+
+    async def _reset_device_inspector_runtime_unlocked(self, hardware_id: str) -> None:
+        for device in self.grabbed_devices.get(hardware_id, []):
+            release_tracked_outputs = getattr(device, "release_tracked_outputs", None)
+            if callable(release_tracked_outputs):
+                release_tracked_outputs()
+            reset_mapping_runtime_state = getattr(device, "reset_mapping_runtime_state", None)
+            if callable(reset_mapping_runtime_state):
+                await cast(Awaitable[object], reset_mapping_runtime_state())
 
     async def set_mapping(
         self,

--- a/keymasq/keymasqd/device_manager.py
+++ b/keymasq/keymasqd/device_manager.py
@@ -662,6 +662,8 @@ class DeviceManager:
             fire_and_observe_fn=_fire_and_observe,
         )
         async with self._op_lock:
+            self.device_inspector_active_hardware_ids.clear()
+            self.device_inspector_suppressed_hardware_ids.clear()
             await self._refresh_combo_runtime_unlocked()
 
     async def emergency_reset(self) -> JsonObject:
@@ -773,7 +775,6 @@ class DeviceManager:
         if not normalized_hardware_id:
             raise ValueError("hardware_id required")
         async with self._op_lock:
-            self.device_inspector_active_hardware_ids.add(normalized_hardware_id)
             was_suppressed = normalized_hardware_id in self.device_inspector_suppressed_hardware_ids
             self.device_inspector_suppressed_hardware_ids.discard(normalized_hardware_id)
             if was_suppressed:
@@ -783,7 +784,7 @@ class DeviceManager:
         return {
             "status": "ok",
             "hardware_id": normalized_hardware_id,
-            "active": True,
+            "active": self.device_inspector_active(normalized_hardware_id),
             "suppressed": False,
             "reason": str(reason or ""),
         }

--- a/keymasq/keymasqd/runtime/grab_lifecycle.py
+++ b/keymasq/keymasqd/runtime/grab_lifecycle.py
@@ -254,6 +254,13 @@ async def grab_device_unlocked(
                     recording_manager=manager.recording_manager,
                     macro_player=manager.play_macro,
                     emergency_resetter=manager.emergency_reset,
+                    inspector_event_callback=manager.broadcast_device_inspector_event,
+                    inspector_active_getter=manager.device_inspector_active,
+                    inspector_suppression_getter=manager.device_inspector_suppressed,
+                    inspector_suppressed_ids_getter=(
+                        manager.device_inspector_suppressed_hardware_ids_snapshot
+                    ),
+                    inspector_suppression_disabler=manager.disable_device_inspector_suppression,
                     suppress_rel_getter=lambda: manager.macro_state.mouse_rel_suppressed,
                     mouse_rel_suppression_start_callback=lambda: None,
                     diagnostics_recorder=diagnostics_recorder,

--- a/keymasq/keymasqd/runtime/grabbed_device.py
+++ b/keymasq/keymasqd/runtime/grabbed_device.py
@@ -31,6 +31,11 @@ from keymasq.keymasqd.runtime.grabbed_device_types import (
     BroadcastCallback,
     CursorPositionSetter,
     DeviceEventCallback,
+    DeviceInspectorActiveGetter,
+    DeviceInspectorEventCallback,
+    DeviceInspectorSuppressedIdsGetter,
+    DeviceInspectorSuppressionDisabler,
+    DeviceInspectorSuppressionGetter,
     EmergencyResetter,
     GrabbedDeviceState,
     MacroPlayer,
@@ -185,6 +190,11 @@ class GrabbedDevice:
         recording_manager: RecordingManager | None = None,
         macro_player: MacroPlayer | None = None,
         emergency_resetter: EmergencyResetter | None = None,
+        inspector_event_callback: DeviceInspectorEventCallback | None = None,
+        inspector_active_getter: DeviceInspectorActiveGetter | None = None,
+        inspector_suppression_getter: DeviceInspectorSuppressionGetter | None = None,
+        inspector_suppressed_ids_getter: DeviceInspectorSuppressedIdsGetter | None = None,
+        inspector_suppression_disabler: DeviceInspectorSuppressionDisabler | None = None,
         suppress_rel_getter: Callable[[], bool] | None = None,
         mouse_rel_suppression_start_callback: Callable[[], None] | None = None,
         diagnostics_recorder: Callable[[str, float], None] | None = None,
@@ -225,6 +235,11 @@ class GrabbedDevice:
         self.recording_manager: RecordingManager | None = recording_manager
         self.macro_player = macro_player
         self.emergency_resetter = emergency_resetter
+        self.inspector_event_callback = inspector_event_callback
+        self.inspector_active_getter = inspector_active_getter
+        self.inspector_suppression_getter = inspector_suppression_getter
+        self.inspector_suppressed_ids_getter = inspector_suppressed_ids_getter
+        self.inspector_suppression_disabler = inspector_suppression_disabler
         self.suppress_rel_getter = suppress_rel_getter
         self.mouse_rel_suppression_start_callback = mouse_rel_suppression_start_callback
         self.diagnostics_recorder = diagnostics_recorder

--- a/keymasq/keymasqd/runtime/grabbed_device_events.py
+++ b/keymasq/keymasqd/runtime/grabbed_device_events.py
@@ -327,6 +327,140 @@ def get_key_name(code: int, *, evdev_mod: EvdevModule) -> str | None:
         return None
 
 
+def _inspector_active(device_runtime: GrabbedDeviceRuntime) -> bool:
+    getter = device_runtime.inspector_active_getter
+    return bool(getter and getter(device_runtime.hardware_id))
+
+
+def _inspector_suppressed(device_runtime: GrabbedDeviceRuntime) -> bool:
+    getter = device_runtime.inspector_suppression_getter
+    return bool(getter and getter(device_runtime.hardware_id))
+
+
+def _inspector_suppressed_hardware_ids(device_runtime: GrabbedDeviceRuntime) -> set[str]:
+    getter = device_runtime.inspector_suppressed_ids_getter
+    if getter is None:
+        return {device_runtime.hardware_id} if _inspector_suppressed(device_runtime) else set()
+    suppressed_ids: set[str] = set()
+    for hardware_id in getter():
+        normalized = str(hardware_id or "").strip()
+        if normalized:
+            suppressed_ids.add(normalized)
+    return suppressed_ids
+
+
+def _event_time_us(event: InputEventLike) -> int:
+    sec = cast(object, getattr(event, "sec", None))
+    usec = cast(object, getattr(event, "usec", None))
+    if sec is None or usec is None:
+        return 0
+    try:
+        return int(cast(int | float | str | bytes, sec)) * 1_000_000 + int(
+            cast(int | float | str | bytes, usec)
+        )
+    except (TypeError, ValueError):
+        return 0
+
+
+def _event_type_name(event_type: int, *, evdev_mod: EvdevModule) -> str:
+    raw_events_obj = cast(object, getattr(evdev_mod.ecodes, "EV", {}))
+    if isinstance(raw_events_obj, dict):
+        raw_events = cast(dict[object, object], raw_events_obj)
+        value = raw_events.get(int(event_type))
+        if value is not None:
+            return str(value)
+    return str(int(event_type))
+
+
+def _inspector_control_id(
+    device_runtime: GrabbedDeviceRuntime,
+    event: InputEventLike,
+    event_name: str,
+    *,
+    evdev_mod: EvdevModule,
+) -> str:
+    normalized_value = normalize_evdev_binding_value(int(event.type), int(event.value))
+    button_id = device_runtime.event_binding_to_button.get(
+        (int(event.type), int(event.code), normalized_value)
+    )
+    if button_id:
+        return button_id
+    button_id = device_runtime.event_code_to_button.get((int(event.type), int(event.code)))
+    if button_id:
+        return button_id
+    if int(event.type) == int(evdev_mod.ecodes.EV_KEY):
+        return device_runtime.evdev_to_button.get(event_name.lower(), "")
+    return ""
+
+
+def _broadcast_inspector_event(
+    device_runtime: GrabbedDeviceRuntime,
+    event: InputEventLike,
+    event_name: str,
+    *,
+    evdev_mod: EvdevModule,
+) -> None:
+    callback = device_runtime.inspector_event_callback
+    if callback is None or not _inspector_active(device_runtime):
+        return
+
+    control_id = _inspector_control_id(
+        device_runtime,
+        event,
+        event_name,
+        evdev_mod=evdev_mod,
+    )
+    analog_id = ""
+    analog_role = ""
+    analog_binding = device_runtime.analog_axis_bindings.get((int(event.type), int(event.code)))
+    if analog_binding is not None:
+        analog_id, analog_role = analog_binding
+
+    action_type = ""
+    mapping = device_runtime.mapping_getter()
+    mapped_id = analog_id or control_id
+    if mapped_id:
+        action = mapping.get(mapped_id)
+        if action is not None:
+            action_type = action.action_type.value
+
+    callback(
+        {
+            "hardware_id": device_runtime.hardware_id,
+            "path": device_runtime.path,
+            "stable_path": device_runtime.stable_path,
+            "source": device_runtime.interface_id,
+            "time_us": _event_time_us(event),
+            "type": int(event.type),
+            "type_name": _event_type_name(int(event.type), evdev_mod=evdev_mod),
+            "code": int(event.code),
+            "code_name": event_name,
+            "value": int(event.value),
+            "control_id": control_id,
+            "analog_id": analog_id,
+            "analog_role": analog_role,
+            "action_type": action_type,
+            "suppressed": _inspector_suppressed(device_runtime),
+        }
+    )
+
+
+def _is_inspector_escape_press(
+    event: InputEventLike,
+    event_name: str,
+    *,
+    evdev_mod: EvdevModule,
+) -> bool:
+    return (
+        int(event.type) == int(evdev_mod.ecodes.EV_KEY)
+        and int(event.value) == 1
+        and (
+            event_name == "key_esc"
+            or int(event.code) == int(getattr(evdev_mod.ecodes, "KEY_ESC", -1))
+        )
+    )
+
+
 async def process_event(
     device_runtime: GrabbedDeviceRuntime,
     event: InputEventLike,
@@ -342,6 +476,12 @@ async def process_event(
     suppress_recalled_release_passthrough = False
 
     event_name = get_event_name(event, evdev_mod=evdev_mod)
+    _broadcast_inspector_event(
+        device_runtime,
+        event,
+        event_name,
+        evdev_mod=evdev_mod,
+    )
     _log_raw_hardware_event(
         device_runtime,
         event,
@@ -349,6 +489,31 @@ async def process_event(
         evdev_mod=evdev_mod,
         log=deps.log,
     )
+    suppressed_hardware_ids = _inspector_suppressed_hardware_ids(device_runtime)
+    if suppressed_hardware_ids and _is_inspector_escape_press(
+        event,
+        event_name,
+        evdev_mod=evdev_mod,
+    ):
+        disabler = device_runtime.inspector_suppression_disabler
+        if disabler is not None:
+            for hardware_id in sorted(suppressed_hardware_ids):
+                await disabler(hardware_id, "key_esc")
+        _record_diagnostics(
+            device_runtime,
+            "inspector_escape_key",
+            started_ns,
+            time_mod=time_mod,
+        )
+        return
+    if _inspector_suppressed(device_runtime):
+        _record_diagnostics(
+            device_runtime,
+            "inspector_suppressed",
+            started_ns,
+            time_mod=time_mod,
+        )
+        return
     if event.type == evdev_mod.ecodes.EV_KEY:
         if int(event.value) == 1:
             device_runtime.state.held_source_keys.add(event_name)

--- a/keymasq/keymasqd/runtime/grabbed_device_types.py
+++ b/keymasq/keymasqd/runtime/grabbed_device_types.py
@@ -26,6 +26,11 @@ type MappingGetter = Callable[[], dict[str, MappingAction]]
 type DeviceEventCallback = Callable[..., Awaitable[ComboDecision | bool | None]]
 type MacroPlayer = Callable[..., Awaitable[dict[str, object]]]
 type EmergencyResetter = Callable[[], Awaitable[dict[str, object]]]
+type DeviceInspectorEventCallback = Callable[[dict[str, object]], None]
+type DeviceInspectorActiveGetter = Callable[[str], bool]
+type DeviceInspectorSuppressionGetter = Callable[[str], bool]
+type DeviceInspectorSuppressedIdsGetter = Callable[[], set[str]]
+type DeviceInspectorSuppressionDisabler = Callable[[str, str], Awaitable[dict[str, object]]]
 type FireAndObserve = Callable[[Awaitable[object], str], asyncio.Task[object]]
 type RuntimeCleanupCallback = Callable[[str, str | None], Awaitable[None]]
 _T = TypeVar("_T")
@@ -286,6 +291,25 @@ class GrabbedDeviceRuntime(Protocol):
 
     @property
     def emergency_resetter(self) -> EmergencyResetter | None: ...
+
+    @property
+    def inspector_event_callback(self) -> DeviceInspectorEventCallback | None: ...
+
+    @property
+    def inspector_active_getter(self) -> DeviceInspectorActiveGetter | None: ...
+
+    @property
+    def inspector_suppression_getter(self) -> DeviceInspectorSuppressionGetter | None: ...
+
+    @property
+    def inspector_suppressed_ids_getter(
+        self,
+    ) -> DeviceInspectorSuppressedIdsGetter | None: ...
+
+    @property
+    def inspector_suppression_disabler(
+        self,
+    ) -> DeviceInspectorSuppressionDisabler | None: ...
 
     @property
     def suppress_rel_getter(self) -> Callable[[], bool] | None: ...

--- a/keymasq/session/manager/commands.py
+++ b/keymasq/session/manager/commands.py
@@ -10,6 +10,7 @@ from keymasq.common.virtual_devices import MAX_VIRTUAL_GAMEPADS, MIN_VIRTUAL_GAM
 from keymasq.session.settings import save_global_settings, save_virtual_gamepad_count
 
 from . import compositor as runtime_compositor
+from . import device_inspector as runtime_device_inspector
 from . import profiles as runtime_profiles
 from . import recording as runtime_recording
 from .common import (
@@ -91,6 +92,10 @@ async def handle_session_request(
     if command == "set_diagnostics":
         return await _handle_set_diagnostics(manager, request)
 
+    result = await _handle_device_inspector_commands(manager, command, request, peer, writer)
+    if result is not None:
+        return result
+
     return {"error": f"Unknown command: {command}"}
 
 
@@ -171,6 +176,54 @@ async def _handle_virtual_gamepad_commands(
         "min_count": MIN_VIRTUAL_GAMEPADS,
         "max_count": MAX_VIRTUAL_GAMEPADS,
     }
+
+
+async def _handle_device_inspector_commands(
+    manager: "SessionManager",
+    command: str,
+    request: JsonObject,
+    peer: PeerCredentials,
+    writer: asyncio.StreamWriter,
+) -> JsonObject | None:
+    if command not in {
+        "get_device_inspector_snapshot",
+        "start_device_inspector",
+        "stop_device_inspector",
+        "enable_device_inspector_suppression",
+        "disable_device_inspector_suppression",
+    }:
+        return None
+
+    hardware_id = str_value(request.get("hardware_id"), "").strip()
+    if not hardware_id:
+        return {"status": "error", "message": "missing hardware_id"}
+
+    if command == "get_device_inspector_snapshot":
+        return runtime_device_inspector.build_device_inspector_snapshot(manager, hardware_id)
+    if command == "start_device_inspector":
+        return await runtime_device_inspector.start_device_inspector(
+            manager,
+            hardware_id,
+            peer,
+            writer,
+        )
+    if command == "stop_device_inspector":
+        return await runtime_device_inspector.stop_device_inspector(
+            manager,
+            hardware_id,
+            writer,
+        )
+    if command == "enable_device_inspector_suppression":
+        return await runtime_device_inspector.enable_device_inspector_suppression(
+            manager,
+            hardware_id,
+            writer,
+        )
+    return await runtime_device_inspector.disable_device_inspector_suppression(
+        manager,
+        hardware_id,
+        reason=str_value(request.get("reason", "manual"), "manual"),
+    )
 
 
 async def _handle_settings_commands(

--- a/keymasq/session/manager/core.py
+++ b/keymasq/session/manager/core.py
@@ -396,7 +396,16 @@ class SessionManager:
         self.broadcast_to_session_clients(cast(JsonObject, message))
 
     def broadcast_to_session_clients(self, message: JsonObject) -> None:
+        self.broadcast_to_session_client_ids(message, None)
+
+    def broadcast_to_session_client_ids(
+        self,
+        message: JsonObject,
+        writer_ids: set[int] | None,
+    ) -> None:
         for writer in list(self.session_clients):
+            if writer_ids is not None and id(writer) not in writer_ids:
+                continue
             try:
                 writer.write(json.dumps(message).encode() + b"\n")
                 task = self.session_client_drain_tasks.get(writer)

--- a/keymasq/session/manager/core.py
+++ b/keymasq/session/manager/core.py
@@ -41,6 +41,7 @@ from keymasq.session.superkeys import SuperkeyManager
 
 from . import commands as session_commands
 from . import compositor as runtime_compositor
+from . import device_inspector as runtime_device_inspector
 from . import events as runtime_events
 from . import profiles as runtime_profiles
 from . import recording as runtime_recording
@@ -48,6 +49,7 @@ from .common import JsonObject
 from .state import (
     CaptureRuntimeState,
     CompositorRuntimeState,
+    DeviceInspectorRuntimeState,
     EventRuntimeState,
     ExecRuntimeState,
     ProfileRuntimeState,
@@ -110,6 +112,7 @@ class SessionManager:
 
         self.exec_state = ExecRuntimeState()
         self.event_state = EventRuntimeState()
+        self.device_inspector_state = DeviceInspectorRuntimeState()
         self.recording_state = RecordingRuntimeState()
         self.unlock_state = UnlockRuntimeState()
         runtime_recording.load_recording_settings_from_disk(self)
@@ -363,6 +366,8 @@ class SessionManager:
         except Exception as e:
             log.debug(f"Session client error: {e}")
         finally:
+            with contextlib.suppress(Exception):
+                await runtime_device_inspector.clear_device_inspectors_for_writer(self, writer)
             await runtime_recording.discard_pending_macro_save_if_writer(self, writer)
             await runtime_recording.clear_recording_refresh_owner_if_writer(self, peer, writer)
             self._drop_session_client_writer(writer)
@@ -589,6 +594,9 @@ class SessionManager:
         self.profile_state.last_sent_combo_signature = ""
         self.profile_state.active_profile_names.clear()
         self.profile_state.resolved_devices.clear()
+        self.device_inspector_state.active_hardware_ids.clear()
+        self.device_inspector_state.suppressed_hardware_ids.clear()
+        self.device_inspector_state.owners_by_hardware_id.clear()
         self.recording_state.devices_cache.clear()
         self.recording_state.selected_devices_cache.clear()
         self.recording_state.devices_cache_ready = False

--- a/keymasq/session/manager/device_inspector.py
+++ b/keymasq/session/manager/device_inspector.py
@@ -1,0 +1,415 @@
+import asyncio
+import logging
+from typing import TYPE_CHECKING, cast
+
+from keymasq.common.ipc import Command, CommandType
+from keymasq.common.models import (
+    ActionType,
+    AnalogAxisDefinition,
+    AnalogInputDefinition,
+    ButtonDefinition,
+    MappingAction,
+)
+from keymasq.common.security import PeerCredentials
+from keymasq.session.profiles import ResolvedDeviceProfile
+
+from . import profiles as runtime_profiles
+from .common import JsonObject, json_object, str_value
+
+if TYPE_CHECKING:
+    from .core import SessionManager
+
+log = logging.getLogger("keymasq-session.device_inspector")
+
+
+def _normalize_hardware_id(hardware_id: object) -> str:
+    return str(hardware_id or "").strip()
+
+
+def _writer_id(writer: asyncio.StreamWriter) -> int:
+    return id(writer)
+
+
+def device_inspector_active(manager: "SessionManager", hardware_id: str) -> bool:
+    normalized = _normalize_hardware_id(hardware_id)
+    return normalized in manager.device_inspector_state.active_hardware_ids
+
+
+def device_inspector_suppressed(manager: "SessionManager", hardware_id: str) -> bool:
+    normalized = _normalize_hardware_id(hardware_id)
+    return normalized in manager.device_inspector_state.suppressed_hardware_ids
+
+
+def update_status_from_daemon_event(manager: "SessionManager", data: JsonObject) -> None:
+    hardware_id = _normalize_hardware_id(data.get("hardware_id"))
+    if not hardware_id:
+        return
+
+    if bool(data.get("active", False)):
+        manager.device_inspector_state.active_hardware_ids.add(hardware_id)
+    else:
+        manager.device_inspector_state.active_hardware_ids.discard(hardware_id)
+        manager.device_inspector_state.owners_by_hardware_id.pop(hardware_id, None)
+
+    if bool(data.get("suppressed", False)):
+        manager.device_inspector_state.suppressed_hardware_ids.add(hardware_id)
+    else:
+        manager.device_inspector_state.suppressed_hardware_ids.discard(hardware_id)
+
+
+async def start_device_inspector(
+    manager: "SessionManager",
+    hardware_id: str,
+    peer: PeerCredentials,
+    writer: asyncio.StreamWriter,
+) -> JsonObject:
+    normalized = _normalize_hardware_id(hardware_id)
+    if not normalized:
+        return {"status": "error", "message": "missing hardware_id"}
+    if manager.hardware.get_hardware(normalized) is None:
+        return {"status": "error", "message": f"Unknown hardware_id: {normalized}"}
+
+    owners = manager.device_inspector_state.owners_by_hardware_id.setdefault(normalized, set())
+    owners.add(_writer_id(writer))
+    manager.device_inspector_state.active_hardware_ids.add(normalized)
+
+    result = await _send_inspector_command(
+        manager,
+        CommandType.DEVICE_INSPECTOR_START,
+        {"hardware_id": normalized},
+    )
+    if result.get("status") != "ok":
+        owners.discard(_writer_id(writer))
+        if not owners:
+            manager.device_inspector_state.owners_by_hardware_id.pop(normalized, None)
+            manager.device_inspector_state.active_hardware_ids.discard(normalized)
+            manager.device_inspector_state.suppressed_hardware_ids.discard(normalized)
+        return result
+
+    update_status_from_daemon_event(manager, result)
+    await runtime_profiles.reevaluate_profiles(
+        manager,
+        reason=f"device inspector start {normalized}",
+    )
+    snapshot = build_device_inspector_snapshot(manager, normalized)
+    snapshot["owner_pid"] = int(peer.pid)
+    snapshot["owner_uid"] = int(peer.uid)
+    return snapshot
+
+
+async def stop_device_inspector(
+    manager: "SessionManager",
+    hardware_id: str,
+    writer: asyncio.StreamWriter,
+) -> JsonObject:
+    normalized = _normalize_hardware_id(hardware_id)
+    if not normalized:
+        return {"status": "error", "message": "missing hardware_id"}
+
+    removed_last_owner = _drop_owner(manager, normalized, _writer_id(writer))
+    if not removed_last_owner:
+        snapshot = build_device_inspector_snapshot(manager, normalized)
+        snapshot["status"] = "ok"
+        return snapshot
+
+    return await _stop_device_inspector_unlocked(
+        manager,
+        normalized,
+        reason=f"device inspector stop {normalized}",
+    )
+
+
+async def enable_device_inspector_suppression(
+    manager: "SessionManager",
+    hardware_id: str,
+    writer: asyncio.StreamWriter,
+) -> JsonObject:
+    normalized = _normalize_hardware_id(hardware_id)
+    if not normalized:
+        return {"status": "error", "message": "missing hardware_id"}
+    if manager.hardware.get_hardware(normalized) is None:
+        return {"status": "error", "message": f"Unknown hardware_id: {normalized}"}
+
+    manager.device_inspector_state.owners_by_hardware_id.setdefault(normalized, set()).add(
+        _writer_id(writer)
+    )
+    manager.device_inspector_state.active_hardware_ids.add(normalized)
+
+    if normalized not in manager.profile_state.grabbed_devices:
+        await runtime_profiles.reevaluate_profiles(
+            manager,
+            reason=f"device inspector suppression grab {normalized}",
+        )
+
+    result = await _send_inspector_command(
+        manager,
+        CommandType.DEVICE_INSPECTOR_ENABLE_SUPPRESSION,
+        {"hardware_id": normalized},
+    )
+    if result.get("status") != "ok":
+        return result
+
+    update_status_from_daemon_event(manager, result)
+    snapshot = build_device_inspector_snapshot(manager, normalized)
+    snapshot["reason"] = "enable_suppression"
+    return snapshot
+
+
+async def disable_device_inspector_suppression(
+    manager: "SessionManager",
+    hardware_id: str,
+    reason: str = "manual",
+) -> JsonObject:
+    normalized = _normalize_hardware_id(hardware_id)
+    if not normalized:
+        return {"status": "error", "message": "missing hardware_id"}
+
+    result = await _send_inspector_command(
+        manager,
+        CommandType.DEVICE_INSPECTOR_DISABLE_SUPPRESSION,
+        {"hardware_id": normalized, "reason": str(reason or "manual")},
+    )
+    if result.get("status") != "ok":
+        return result
+
+    update_status_from_daemon_event(manager, result)
+    snapshot = build_device_inspector_snapshot(manager, normalized)
+    if snapshot.get("status") != "ok":
+        return result
+    snapshot["reason"] = str(reason or "manual")
+    return snapshot
+
+
+async def clear_device_inspectors_for_writer(
+    manager: "SessionManager",
+    writer: asyncio.StreamWriter,
+) -> None:
+    writer_id = _writer_id(writer)
+    for hardware_id, owners in list(manager.device_inspector_state.owners_by_hardware_id.items()):
+        if writer_id not in owners:
+            continue
+        owners.discard(writer_id)
+        if owners:
+            continue
+        await _stop_device_inspector_unlocked(
+            manager,
+            hardware_id,
+            reason=f"device inspector owner disconnected {hardware_id}",
+        )
+
+
+async def _stop_device_inspector_unlocked(
+    manager: "SessionManager",
+    hardware_id: str,
+    *,
+    reason: str,
+) -> JsonObject:
+    manager.device_inspector_state.owners_by_hardware_id.pop(hardware_id, None)
+    manager.device_inspector_state.active_hardware_ids.discard(hardware_id)
+    manager.device_inspector_state.suppressed_hardware_ids.discard(hardware_id)
+
+    result = await _send_inspector_command(
+        manager,
+        CommandType.DEVICE_INSPECTOR_STOP,
+        {"hardware_id": hardware_id},
+    )
+    await runtime_profiles.reevaluate_profiles(manager, reason=reason)
+    if result.get("status") == "ok":
+        update_status_from_daemon_event(manager, result)
+        return {
+            "status": "ok",
+            "hardware_id": hardware_id,
+            "active": False,
+            "suppressed": False,
+        }
+    return result
+
+
+def _drop_owner(manager: "SessionManager", hardware_id: str, writer_id: int) -> bool:
+    owners = manager.device_inspector_state.owners_by_hardware_id.get(hardware_id)
+    if owners is None:
+        return True
+    owners.discard(writer_id)
+    if owners:
+        return False
+    manager.device_inspector_state.owners_by_hardware_id.pop(hardware_id, None)
+    return True
+
+
+async def _send_inspector_command(
+    manager: "SessionManager",
+    command_type: CommandType,
+    data: JsonObject,
+) -> JsonObject:
+    try:
+        result = await manager.client.send_command(Command(command=command_type, data=data))
+    except Exception:
+        return {"status": "error", "message": "Daemon unavailable"}
+
+    result_data = json_object(result.data)
+    if result.status == "ok":
+        return {"status": "ok", **(result_data or {})}
+    return {"status": "error", "message": result.error or "device inspector command failed"}
+
+
+def build_device_inspector_snapshot(
+    manager: "SessionManager",
+    hardware_id: str,
+) -> JsonObject:
+    normalized = _normalize_hardware_id(hardware_id)
+    hardware = manager.hardware.get_hardware(normalized)
+    if hardware is None:
+        return {"status": "error", "message": f"Unknown hardware_id: {normalized}"}
+
+    resolved = manager.profile_state.resolved_devices.get(
+        normalized,
+        ResolvedDeviceProfile(normalized),
+    )
+    mapping_profile_names = cast(
+        dict[str, str],
+        getattr(resolved, "mapping_profile_names", {}) or {},
+    )
+
+    return {
+        "status": "ok",
+        "hardware_id": normalized,
+        "device_name": hardware.name,
+        "model_id": hardware.model_id,
+        "active": device_inspector_active(manager, normalized),
+        "suppressed": device_inspector_suppressed(manager, normalized),
+        "active_profiles": list(resolved.active_profile_names),
+        "interfaces": [_serialize_interface(device) for device in hardware.evdev_devices],
+        "buttons": [
+            _serialize_button(button, resolved, mapping_profile_names)
+            for button in hardware.buttons
+        ],
+        "analog_inputs": [
+            _serialize_analog_input(analog, resolved, mapping_profile_names)
+            for analog in hardware.analog_inputs
+        ],
+    }
+
+
+def _serialize_interface(device: object) -> JsonObject:
+    device_type = getattr(device, "device_type", "")
+    device_type_value = getattr(device_type, "value", str(device_type or ""))
+    return {
+        "id": str_value(getattr(device, "id", ""), ""),
+        "path": str_value(getattr(device, "path", ""), ""),
+        "type": str(device_type_value or ""),
+        "phys": str_value(getattr(device, "phys", ""), ""),
+        "capabilities": [
+            str(item)
+            for item in cast(list[object], getattr(device, "capabilities", []) or [])
+        ],
+    }
+
+
+def _serialize_button(
+    button: ButtonDefinition,
+    resolved: ResolvedDeviceProfile,
+    mapping_profile_names: dict[str, str],
+) -> JsonObject:
+    mapping = resolved.mappings.get(button.id)
+    return {
+        "id": button.id,
+        "label": button.label,
+        "kind": "button",
+        "evdev": button.evdev,
+        "evdev_code": button.evdev_code,
+        "evdev_value": button.evdev_value,
+        "source": button.source or "",
+        "zone": button.zone or "",
+        "row": button.row,
+        "col": button.col,
+        "type": button.type or "",
+        "profile_name": mapping_profile_names.get(button.id, ""),
+        "action": _serialize_action(mapping) if mapping is not None else None,
+    }
+
+
+def _serialize_analog_input(
+    analog: AnalogInputDefinition,
+    resolved: ResolvedDeviceProfile,
+    mapping_profile_names: dict[str, str],
+) -> JsonObject:
+    mapping = resolved.mappings.get(analog.id)
+    return {
+        "id": analog.id,
+        "label": analog.label,
+        "kind": "analog",
+        "type": analog.type,
+        "source": analog.source or "",
+        "profile_name": mapping_profile_names.get(analog.id, ""),
+        "action": _serialize_action(mapping) if mapping is not None else None,
+        "axes": [_serialize_axis(axis) for axis in analog.axes],
+    }
+
+
+def _serialize_axis(axis: AnalogAxisDefinition) -> JsonObject:
+    return {
+        "role": axis.role,
+        "evdev": axis.evdev,
+        "evdev_code": axis.evdev_code,
+        "minimum": axis.minimum,
+        "maximum": axis.maximum,
+        "center": axis.center,
+        "rest": axis.rest,
+        "invert": bool(axis.invert),
+    }
+
+
+def _serialize_action(action: MappingAction | None) -> JsonObject | None:
+    if action is None:
+        return None
+
+    action_data: JsonObject = {"action": action.action_type.value}
+    _set_optional(action_data, "target", action.target)
+    _set_optional(action_data, "output_id", action.output_id)
+    if action.keys:
+        action_data["keys"] = list(action.keys)
+    _set_optional(action_data, "cmd", action.cmd)
+    _set_optional(action_data, "superkey_name", action.superkey_name)
+    if action.analog_control_names:
+        action_data["analog_control_names"] = list(action.analog_control_names)
+    if action.action_type == ActionType.MACRO:
+        action_data["target"] = action.macro_name or ""
+        action_data["replay_mouse_movement"] = bool(action.macro_replay_mouse_movement)
+        action_data["replay_mouse_clicks"] = bool(action.macro_replay_mouse_clicks)
+        action_data["speed"] = float(action.macro_speed)
+        action_data["loop_mode"] = action.macro_loop_mode
+        action_data["loop_count"] = int(action.macro_loop_count)
+        action_data["loop_stop_behavior"] = action.macro_loop_stop_behavior
+        action_data["move_to_start"] = bool(action.macro_move_to_start)
+        action_data["start_x"] = int(action.macro_start_x)
+        action_data["start_y"] = int(action.macro_start_y)
+        action_data["block_mouse_movement"] = bool(action.macro_block_mouse_movement)
+    if action.action_type in (ActionType.MOUSE_MOVE_REL, ActionType.MOUSE_MOVE_ABS):
+        action_data["x"] = int(action.move_x)
+        action_data["y"] = int(action.move_y)
+    if action.action_type == ActionType.GAMEPAD_AXIS:
+        action_data["value"] = int(action.axis_value)
+    if action.action_type in (
+        ActionType.PROFILE_ENABLE,
+        ActionType.PROFILE_DISABLE,
+        ActionType.PROFILE_TOGGLE,
+    ):
+        action_data["profile_name"] = action.profile_name or ""
+        action_data["target"] = action.profile_name or ""
+    if action.action_type == ActionType.COMPOSITOR_DISPATCH:
+        _set_optional(action_data, "compositor", action.compositor_id)
+        action_data["dispatcher"] = action.compositor_dispatcher or ""
+        action_data["args"] = action.compositor_args or ""
+    if action.rapidfire_enabled:
+        action_data["rapidfire_enabled"] = True
+        action_data["rapidfire_hold_ms"] = int(action.rapidfire_hold_ms)
+        action_data["rapidfire_wait_ms"] = int(action.rapidfire_wait_ms)
+    if action.tap_enabled:
+        action_data["tap_enabled"] = True
+        action_data["tap_hold_ms"] = int(action.tap_hold_ms)
+    return action_data
+
+
+def _set_optional(action_data: JsonObject, key: str, value: object) -> None:
+    if value is not None and str(value):
+        action_data[key] = str(value)

--- a/keymasq/session/manager/device_inspector.py
+++ b/keymasq/session/manager/device_inspector.py
@@ -57,6 +57,17 @@ def update_status_from_daemon_event(manager: "SessionManager", data: JsonObject)
         manager.device_inspector_state.suppressed_hardware_ids.discard(hardware_id)
 
 
+def broadcast_event_to_owners(manager: "SessionManager", data: JsonObject) -> None:
+    hardware_id = _normalize_hardware_id(data.get("hardware_id"))
+    if not hardware_id:
+        return
+    owner_ids = manager.device_inspector_state.owners_by_hardware_id.get(hardware_id, set())
+    if not owner_ids:
+        return
+
+    manager.broadcast_to_session_client_ids({"event": "device_inspector_event", **data}, owner_ids)
+
+
 async def start_device_inspector(
     manager: "SessionManager",
     hardware_id: str,
@@ -130,16 +141,29 @@ async def enable_device_inspector_suppression(
     if manager.hardware.get_hardware(normalized) is None:
         return {"status": "error", "message": f"Unknown hardware_id: {normalized}"}
 
-    manager.device_inspector_state.owners_by_hardware_id.setdefault(normalized, set()).add(
-        _writer_id(writer)
-    )
+    writer_id = _writer_id(writer)
+    owners = manager.device_inspector_state.owners_by_hardware_id.setdefault(normalized, set())
+    had_owner = writer_id in owners
+    was_active = normalized in manager.device_inspector_state.active_hardware_ids
+    owners.add(writer_id)
     manager.device_inspector_state.active_hardware_ids.add(normalized)
 
+    await runtime_profiles.reevaluate_profiles(
+        manager,
+        reason=f"device inspector suppression grab {normalized}",
+    )
     if normalized not in manager.profile_state.grabbed_devices:
-        await runtime_profiles.reevaluate_profiles(
+        await _rollback_suppression_enable_state(
             manager,
-            reason=f"device inspector suppression grab {normalized}",
+            normalized,
+            writer_id,
+            had_owner=had_owner,
+            was_active=was_active,
         )
+        return {
+            "status": "error",
+            "message": f"Device inspector could not grab {normalized} for suppression",
+        }
 
     result = await _send_inspector_command(
         manager,
@@ -147,6 +171,13 @@ async def enable_device_inspector_suppression(
         {"hardware_id": normalized},
     )
     if result.get("status") != "ok":
+        await _rollback_suppression_enable_state(
+            manager,
+            normalized,
+            writer_id,
+            had_owner=had_owner,
+            was_active=was_active,
+        )
         return result
 
     update_status_from_daemon_event(manager, result)
@@ -234,6 +265,31 @@ def _drop_owner(manager: "SessionManager", hardware_id: str, writer_id: int) -> 
         return False
     manager.device_inspector_state.owners_by_hardware_id.pop(hardware_id, None)
     return True
+
+
+async def _rollback_suppression_enable_state(
+    manager: "SessionManager",
+    hardware_id: str,
+    writer_id: int,
+    *,
+    had_owner: bool,
+    was_active: bool,
+) -> None:
+    if not had_owner:
+        _drop_owner(manager, hardware_id, writer_id)
+    if not was_active:
+        manager.device_inspector_state.active_hardware_ids.discard(hardware_id)
+        manager.device_inspector_state.suppressed_hardware_ids.discard(hardware_id)
+        await runtime_profiles.reevaluate_profiles(
+            manager,
+            reason=f"device inspector suppression rollback {hardware_id}",
+        )
+
+
+def clear_all_device_inspector_state(manager: "SessionManager") -> None:
+    manager.device_inspector_state.active_hardware_ids.clear()
+    manager.device_inspector_state.suppressed_hardware_ids.clear()
+    manager.device_inspector_state.owners_by_hardware_id.clear()
 
 
 async def _send_inspector_command(

--- a/keymasq/session/manager/device_inspector.py
+++ b/keymasq/session/manager/device_inspector.py
@@ -120,7 +120,8 @@ async def stop_device_inspector(
     removed_last_owner = _drop_owner(manager, normalized, _writer_id(writer))
     if not removed_last_owner:
         snapshot = build_device_inspector_snapshot(manager, normalized)
-        snapshot["status"] = "ok"
+        if snapshot.get("status") != "error":
+            snapshot["status"] = "ok"
         return snapshot
 
     return await _stop_device_inspector_unlocked(
@@ -222,11 +223,18 @@ async def clear_device_inspectors_for_writer(
         owners.discard(writer_id)
         if owners:
             continue
-        await _stop_device_inspector_unlocked(
-            manager,
-            hardware_id,
-            reason=f"device inspector owner disconnected {hardware_id}",
-        )
+        try:
+            await _stop_device_inspector_unlocked(
+                manager,
+                hardware_id,
+                reason=f"device inspector owner disconnected {hardware_id}",
+            )
+        except Exception as exc:
+            log.warning(
+                "Failed to stop device inspector for disconnected owner hardware_id=%s: %s",
+                hardware_id,
+                exc,
+            )
 
 
 async def _stop_device_inspector_unlocked(

--- a/keymasq/session/manager/events.py
+++ b/keymasq/session/manager/events.py
@@ -166,7 +166,7 @@ async def handle_event(
         return
 
     if event_type == CommandType.DEVICE_INSPECTOR_EVENT:
-        manager.broadcast_to_session_clients({"event": "device_inspector_event", **data})
+        runtime_device_inspector.broadcast_event_to_owners(manager, data)
         return
 
     if event_type == CommandType.DEVICE_INSPECTOR_STATUS:
@@ -384,6 +384,7 @@ def handle_macro_playback_cancelled_event(
 
 
 async def handle_runtime_reset_event(manager: "SessionManager", data: JsonObject) -> None:
+    runtime_device_inspector.clear_all_device_inspector_state(manager)
     manager.broadcast_to_session_clients({"event": "runtime_reset", **data})
     manager.send_notification(
         "Keymasq: Emergency Reset",

--- a/keymasq/session/manager/events.py
+++ b/keymasq/session/manager/events.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Any
 from keymasq.common.ipc import Command, CommandType
 
 from . import compositor as runtime_compositor
+from . import device_inspector as runtime_device_inspector
 from . import profiles as runtime_profiles
 from . import recording as runtime_recording
 from .common import JsonObject
@@ -162,6 +163,15 @@ async def handle_event(
 
     if event_type == CommandType.DIAGNOSTICS_SNAPSHOT:
         manager.broadcast_to_session_clients({"event": "diagnostics_snapshot", **data})
+        return
+
+    if event_type == CommandType.DEVICE_INSPECTOR_EVENT:
+        manager.broadcast_to_session_clients({"event": "device_inspector_event", **data})
+        return
+
+    if event_type == CommandType.DEVICE_INSPECTOR_STATUS:
+        runtime_device_inspector.update_status_from_daemon_event(manager, data)
+        manager.broadcast_to_session_clients({"event": "device_inspector_status", **data})
         return
 
     if event_type == CommandType.RECORDING_STARTED:

--- a/keymasq/session/manager/profiles.py
+++ b/keymasq/session/manager/profiles.py
@@ -62,11 +62,30 @@ def build_active_profiles_payload(manager: "SessionManager") -> JsonObject:
     devices: dict[str, JsonObject] = {}
     for hardware_id, resolved in sorted(manager.profile_state.resolved_devices.items()):
         hardware = manager.hardware.get_hardware(hardware_id)
+        inspector_state = getattr(manager, "device_inspector_state", None)
+        active_hardware_ids = (
+            getattr(inspector_state, "active_hardware_ids", set[str]())
+            if inspector_state is not None
+            else set[str]()
+        )
+        suppressed_hardware_ids = (
+            getattr(inspector_state, "suppressed_hardware_ids", set[str]())
+            if inspector_state is not None
+            else set[str]()
+        )
+        inspector_active = bool(
+            inspector_state is not None and hardware_id in active_hardware_ids
+        )
+        inspector_suppressed = bool(
+            inspector_state is not None and hardware_id in suppressed_hardware_ids
+        )
         devices[hardware_id] = {
             "device_name": hardware.name if hardware else hardware_id,
             "profiles": list(resolved.active_profile_names),
             "mapping_count": resolved.mapping_count,
             "always_grab_all": resolved.always_grab_all,
+            "device_inspector_active": inspector_active,
+            "device_inspector_suppressed": inspector_suppressed,
         }
 
     return {
@@ -435,8 +454,9 @@ async def apply_resolved_device_profile(
     old_resolved = manager.profile_state.resolved_devices.get(hardware_id)
     old_profile_names = old_resolved.active_profile_names if old_resolved else []
     manager.profile_state.resolved_devices[hardware_id] = resolved
+    inspector_active = _device_inspector_active(manager, hardware_id)
 
-    if not resolved.has_effective_mapping:
+    if not resolved.has_effective_mapping and not inspector_active:
         cancel_grab_retry(manager, hardware_id)
         manager.profile_state.grab_waiting_devices.discard(hardware_id)
         if hardware_id in manager.profile_state.grabbed_devices:
@@ -448,7 +468,11 @@ async def apply_resolved_device_profile(
             )
         return
 
-    new_interfaces = get_interfaces_to_grab(hardware_config, resolved)
+    new_interfaces = (
+        all_configured_interfaces(hardware_config)
+        if inspector_active
+        else get_interfaces_to_grab(hardware_config, resolved)
+    )
     current_interfaces = manager.profile_state.grabbed_interfaces.get(hardware_id, {})
     grab_payload = build_grab_device_payload(
         manager,
@@ -456,6 +480,7 @@ async def apply_resolved_device_profile(
         hardware_config,
         resolved,
         new_interfaces,
+        force_grab_unmapped=inspector_active,
     )
     grab_signature = grab_device_payload_signature(grab_payload)
 
@@ -669,10 +694,7 @@ def get_interfaces_to_grab(
     hardware_config: HardwareConfig,
     resolved: ResolvedDeviceProfile,
 ) -> dict[str, str]:
-    interface_to_path: dict[str, str] = {}
-    for dev in hardware_config.evdev_devices:
-        if dev.id:
-            interface_to_path[dev.id] = dev.path
+    interface_to_path = all_configured_interfaces(hardware_config)
 
     if resolved.always_grab_all:
         return interface_to_path
@@ -717,12 +739,35 @@ def get_interfaces_to_grab(
     }
 
 
+def all_configured_interfaces(hardware_config: HardwareConfig) -> dict[str, str]:
+    return {
+        dev.id: dev.path
+        for dev in hardware_config.evdev_devices
+        if dev.id and str(dev.path or "").strip()
+    }
+
+
+def _device_inspector_active(manager: "SessionManager", hardware_id: str) -> bool:
+    inspector_state = getattr(manager, "device_inspector_state", None)
+    active_hardware_ids = (
+        getattr(inspector_state, "active_hardware_ids", set[str]())
+        if inspector_state is not None
+        else set[str]()
+    )
+    return bool(
+        inspector_state is not None
+        and str(hardware_id or "").strip() in active_hardware_ids
+    )
+
+
 def build_grab_device_payload(
     manager: "SessionManager",
     hardware_id: str,
     hardware_config: HardwareConfig,
     resolved: ResolvedDeviceProfile,
     interfaces: dict[str, str],
+    *,
+    force_grab_unmapped: bool = False,
 ) -> JsonObject:
     analog_inputs = getattr(hardware_config, "analog_inputs", []) or []
     return {
@@ -773,7 +818,7 @@ def build_grab_device_payload(
             }
             for analog in analog_inputs
         },
-        "force_grab_unmapped": bool(resolved.combo_event_count),
+        "force_grab_unmapped": bool(force_grab_unmapped) or bool(resolved.combo_event_count),
     }
 
 

--- a/keymasq/session/manager/recording.py
+++ b/keymasq/session/manager/recording.py
@@ -53,6 +53,8 @@ def is_sensitive_session_command(
         "capture_read",
         "end_capture",
         "capture_combo",
+        "start_device_inspector",
+        "enable_device_inspector_suppression",
     }:
         return True
 

--- a/keymasq/session/manager/state.py
+++ b/keymasq/session/manager/state.py
@@ -58,6 +58,13 @@ class UnlockRuntimeState:
 
 
 @dataclass
+class DeviceInspectorRuntimeState:
+    active_hardware_ids: set[str] = field(default_factory=set)
+    suppressed_hardware_ids: set[str] = field(default_factory=set)
+    owners_by_hardware_id: dict[str, set[int]] = field(default_factory=dict)
+
+
+@dataclass
 class ProfileRuntimeState:
     grabbed_devices: set[str] = field(default_factory=set)
     grabbed_interfaces: dict[str, dict[str, str]] = field(default_factory=dict)

--- a/keymasq/session/profiles.py
+++ b/keymasq/session/profiles.py
@@ -71,6 +71,7 @@ class ResolvedDeviceProfile:
     hardware_id: str
     active_profile_names: list[str] = field(default_factory=list)
     mappings: dict[str, MappingAction] = field(default_factory=dict)
+    mapping_profile_names: dict[str, str] = field(default_factory=dict)
     always_grab_all: bool = False
     notify_profiles: list[str] = field(default_factory=list)
     combo_event_count: int = 0
@@ -769,8 +770,10 @@ class ProfileManager:
                 for button_id, action in layer.mappings.items():
                     if action.action_type == ActionType.PASSTHROUGH:
                         resolved.mappings.pop(button_id, None)
+                        resolved.mapping_profile_names.pop(button_id, None)
                     else:
                         resolved.mappings[button_id] = copy.deepcopy(action)
+                        resolved.mapping_profile_names[button_id] = profile.name
             devices[hardware_id] = resolved
 
         for profile in active_profiles:

--- a/tests/gui/test_device_inspector_window.py
+++ b/tests/gui/test_device_inspector_window.py
@@ -4,6 +4,19 @@ from tests.gui.support import *
 gi.require_version("Gtk", "4.0")
 
 
+def test_inspector_label_sort_key_orders_trailing_numbers_numerically() -> None:
+    from keymasq.gui.widgets.device_inspector_window import _label_sort_key
+
+    labels = ["Extra Button 1", "Extra Button 10", "Extra Button 2", "Back"]
+
+    assert sorted(labels, key=_label_sort_key) == [
+        "Back",
+        "Extra Button 1",
+        "Extra Button 2",
+        "Extra Button 10",
+    ]
+
+
 def _device():
     from keymasq.common.models import (
         AnalogAxisDefinition,

--- a/tests/gui/test_device_inspector_window.py
+++ b/tests/gui/test_device_inspector_window.py
@@ -1,0 +1,388 @@
+# ruff: noqa: F403, F405
+from tests.gui.support import *
+
+gi.require_version("Gtk", "4.0")
+
+
+def _device():
+    from keymasq.common.models import (
+        AnalogAxisDefinition,
+        AnalogInputDefinition,
+        ButtonDefinition,
+        DeviceType,
+        EvdevDevice,
+        HardwareConfig,
+    )
+
+    return HardwareConfig(
+        vendor_id="1234",
+        product_id="5678",
+        name="Inspector Pad",
+        evdev_devices=[
+            EvdevDevice(
+                path="/dev/input/event10",
+                device_type=DeviceType.GAMEPAD,
+                id="pad",
+            )
+        ],
+        buttons=[
+            ButtonDefinition(
+                id="btn_south",
+                label="A",
+                evdev="btn_south",
+                evdev_code=304,
+                source="pad",
+            )
+        ],
+        analog_inputs=[
+            AnalogInputDefinition(
+                id="left_stick",
+                label="Left Stick",
+                type="stick",
+                source="pad",
+                axes=[
+                    AnalogAxisDefinition(
+                        role="x",
+                        evdev="abs_x",
+                        evdev_code=0,
+                        minimum=-32768,
+                        maximum=32767,
+                        center=0,
+                    ),
+                    AnalogAxisDefinition(
+                        role="y",
+                        evdev="abs_y",
+                        evdev_code=1,
+                        minimum=-32768,
+                        maximum=32767,
+                        center=0,
+                    ),
+                ],
+            ),
+            AnalogInputDefinition(
+                id="left_trigger",
+                label="Left Trigger",
+                type="axis",
+                source="pad",
+                axes=[
+                    AnalogAxisDefinition(
+                        role="x",
+                        evdev="abs_z",
+                        evdev_code=2,
+                        minimum=0,
+                        maximum=255,
+                    ),
+                ],
+            ),
+        ],
+    )
+
+
+def _snapshot():
+    return {
+        "status": "ok",
+        "hardware_id": "1234:5678",
+        "device_name": "Inspector Pad",
+        "model_id": "1234:5678",
+        "active": True,
+        "suppressed": False,
+        "active_profiles": ["Desktop"],
+        "interfaces": [{"id": "pad", "path": "/dev/input/event10", "type": "gamepad"}],
+        "buttons": [
+            {
+                "id": "btn_south",
+                "label": "A",
+                "kind": "button",
+                "evdev": "btn_south",
+                "evdev_code": 304,
+                "source": "pad",
+                "profile_name": "Desktop",
+                "action": {"action": "keyboard", "target": "key_space"},
+            }
+        ],
+        "analog_inputs": [
+            {
+                "id": "left_stick",
+                "label": "Left Stick",
+                "kind": "analog",
+                "type": "stick",
+                "source": "pad",
+                "profile_name": "",
+                "action": None,
+                "axes": [
+                    {
+                        "role": "x",
+                        "evdev": "abs_x",
+                        "evdev_code": 0,
+                        "minimum": -32768,
+                        "maximum": 32767,
+                        "center": 0,
+                    },
+                    {
+                        "role": "y",
+                        "evdev": "abs_y",
+                        "evdev_code": 1,
+                        "minimum": -32768,
+                        "maximum": 32767,
+                        "center": 0,
+                    },
+                ],
+            },
+            {
+                "id": "left_trigger",
+                "label": "Left Trigger",
+                "kind": "analog",
+                "type": "axis",
+                "source": "pad",
+                "profile_name": "",
+                "action": None,
+                "axes": [
+                    {
+                        "role": "x",
+                        "evdev": "abs_z",
+                        "evdev_code": 2,
+                        "minimum": 0,
+                        "maximum": 255,
+                    },
+                ],
+            },
+        ],
+    }
+
+
+def test_device_inspector_window_starts_renders_events_and_toggles_suppression(
+    monkeypatch,
+):
+    from gi.repository import Gtk
+
+    from keymasq.gui.widgets import device_inspector_window as inspector_module
+    from keymasq.gui.widgets.device_inspector_window import DeviceInspectorWindow
+
+    callbacks = {}
+    requests = []
+
+    def fake_register(event, callback):
+        callbacks.setdefault(event, []).append(callback)
+
+    def fake_unregister(event, callback):
+        registered = callbacks.get(event, [])
+        if callback in registered:
+            registered.remove(callback)
+
+    def fake_request_async(payload, callback, timeout=5.0):
+        requests.append(dict(payload))
+        command = payload.get("command")
+        if command == "start_device_inspector":
+            callback(_snapshot())
+        elif command == "enable_device_inspector_suppression":
+            callback(
+                {
+                    "status": "ok",
+                    "hardware_id": "1234:5678",
+                    "active": True,
+                    "suppressed": True,
+                }
+            )
+        elif command == "disable_device_inspector_suppression":
+            callback(
+                {
+                    "status": "ok",
+                    "hardware_id": "1234:5678",
+                    "active": True,
+                    "suppressed": False,
+                }
+            )
+        else:
+            callback({"status": "ok"})
+
+    monkeypatch.setattr(inspector_module, "register_session_event_callback", fake_register)
+    monkeypatch.setattr(inspector_module, "unregister_session_event_callback", fake_unregister)
+    monkeypatch.setattr(inspector_module, "session_request_async", fake_request_async)
+
+    window = DeviceInspectorWindow(Gtk.Window(), _device())
+
+    assert requests[0]["command"] == "start_device_inspector"
+    assert "btn_south" in window._control_widgets
+    assert "left_stick" in window._analog_viewers
+    assert "left_trigger" in window._analog_viewers
+    assert window._header_device_icon.get_pixel_size() == 24
+    assert window._paned.get_position() == 510
+    assert window._paned.get_resize_start_child() is True
+    assert window._paned.get_resize_end_child() is False
+    trigger_viewer = window._analog_viewers["left_trigger"]
+    trigger_level_bar = trigger_viewer.level_bar
+    assert trigger_level_bar is not None
+    assert trigger_level_bar.get_value() == pytest.approx(0.0)
+    assert trigger_viewer.value_labels["x"].get_text() == "x: raw      0 | norm +0.000"
+    assert window._status_label.get_text() == "Inspector Pad - Monitoring"
+    assert window._status_label.get_halign() == Gtk.Align.START
+    assert window._status_label.get_hexpand() is True
+    assert window._header_title_spacer.get_parent() is not None
+    assert window._status_label.has_css_class("inspector-header-title") is True
+    assert window._status_label.has_css_class("inspector-header-monitoring") is True
+    assert window._status_label.has_css_class("dim-label") is False
+    assert window._axes_title.get_visible() is True
+    assert window._axes_box.get_visible() is True
+    window._render_axes({"analog_inputs": []})
+    assert window._axes_title.get_visible() is False
+    assert window._axes_box.get_visible() is False
+    assert window._axes_box.get_first_child() is None
+    window._render_axes(_snapshot())
+    assert window._axes_title.get_visible() is True
+    assert window._axes_box.get_visible() is True
+    trigger_viewer = window._analog_viewers["left_trigger"]
+    trigger_level_bar = trigger_viewer.level_bar
+    assert trigger_level_bar is not None
+    assert (
+        window._action_label(
+            {"action": "compositor_dispatch", "dispatcher": "workspace", "args": "1"},
+            {},
+        )
+        == "🪟 workspace 1"
+    )
+    assert window._action_label({"action": "exec", "cmd": "grimblast copy area"}, {}) == (
+        "▶ grimblast copy area"
+    )
+
+    def emit(event):
+        callbacks["device_inspector_event"][0](
+            {
+                "event": "device_inspector_event",
+                "hardware_id": "1234:5678",
+                **event,
+            }
+        )
+
+    emit(
+        {
+            "sequence": 1,
+            "type_name": "ev_key",
+            "code_name": "btn_south",
+            "control_id": "btn_south",
+            "value": 1,
+            "source": "pad",
+        }
+    )
+
+    assert len(window._event_rows) == 1
+    assert len(window._event_history_by_category["button"]) == 1
+    assert window._copy_events_button.get_tooltip_text() == "Copy visible events"
+    assert window._visible_event_export_text() == (
+        "#1 btn_south ev_key value=1 source=pad"
+    )
+
+    for index in range(120):
+        emit(
+            {
+                "sequence": index + 2,
+                "type_name": "ev_rel",
+                "code_name": "rel_x",
+                "value": 4,
+                "source": "pad",
+            }
+        )
+
+    assert len(window._event_history_by_category["mousemove"]) == 100
+    assert len(window._event_history_by_category["button"]) == 1
+    assert len(window._event_rows) == 1
+
+    emit(
+        {
+            "sequence": 122,
+            "type_name": "ev_abs",
+            "code_name": "abs_x",
+            "analog_id": "left_stick",
+            "analog_role": "x",
+            "value": 14000,
+            "source": "pad",
+        }
+    )
+
+    assert len(window._event_history_by_category["axis"]) == 1
+    assert len(window._event_rows) == 1
+    assert window._analog_viewers["left_stick"].value_labels["x"].get_text() == (
+        "x: raw  14000 | norm +0.427"
+    )
+
+    emit(
+        {
+            "sequence": 123,
+            "type_name": "ev_msc",
+            "code_name": "msc_scan",
+            "value": 458792,
+            "source": "pad",
+        }
+    )
+
+    assert len(window._event_history_by_category["syn"]) == 1
+    assert len(window._event_rows) == 1
+
+    window._update_analog_value("left_trigger", "x", 128)
+    assert trigger_viewer.value_labels["x"].get_text() == "x: raw    128 | norm +0.502"
+    assert trigger_level_bar.get_value() == pytest.approx(128 / 255)
+
+    window._event_filter_buttons["axis"].set_active(True)
+    assert len(window._event_rows) == 2
+
+    window._event_filter_buttons["mousemove"].set_active(True)
+    assert len(window._event_rows) == 100
+
+    window._event_filter_buttons["syn"].set_active(True)
+    assert len(window._event_rows) == 100
+    assert "#123 msc_scan ev_msc value=458792 source=pad" in (
+        window._visible_event_export_text()
+    )
+
+    emit(
+        {
+            "sequence": 124,
+            "type_name": "ev_rel",
+            "code_name": "rel_x",
+            "value": 6,
+            "source": "pad",
+        }
+    )
+
+    assert window._event_render_source_id
+
+    for index in range(105):
+        emit(
+            {
+                "sequence": index + 125,
+                "type_name": "ev_key",
+                "code_name": "btn_south",
+                "control_id": "btn_south",
+                "value": 1,
+                "source": "pad",
+            }
+        )
+
+    assert len(window._event_history_by_category["button"]) == 100
+    assert len(window._event_history_by_category["mousemove"]) == 100
+    assert len(window._event_rows) == 100
+
+    window._suppression_switch.set_active(True)
+    assert requests[-1]["command"] == "enable_device_inspector_suppression"
+    assert window._suppression_switch.get_active() is True
+    assert window._status_label.get_text() == "Inspector Pad - Output suppressed"
+    assert window._status_label.has_css_class("inspector-header-suppressed") is True
+    assert window._suppression_hint_label.get_visible() is True
+
+    callbacks["device_inspector_status"][0](
+        {
+            "event": "device_inspector_status",
+            "hardware_id": "1234:5678",
+            "active": True,
+            "suppressed": False,
+            "reason": "key_esc",
+        }
+    )
+
+    assert window._suppression_switch.get_active() is False
+    assert window._status_label.get_text() == "Inspector Pad - Monitoring"
+    assert window._status_label.has_css_class("inspector-header-monitoring") is True
+    assert window._suppression_hint_label.get_visible() is False
+    assert window._on_close_request() is False
+    assert requests[-1]["command"] == "stop_device_inspector"
+    assert callbacks["device_inspector_event"] == []
+    window._on_destroy()

--- a/tests/gui/test_device_tab_widget.py
+++ b/tests/gui/test_device_tab_widget.py
@@ -79,6 +79,40 @@ class TestDeviceTabWidget:
 
         assert tab._supports_analog_learning() is False
 
+    def test_device_tab_inspect_button_delegates_to_main_window(self):
+        from keymasq.common.models import ButtonDefinition, DeviceType, EvdevDevice, HardwareConfig
+        from keymasq.gui.widgets.device_tab import DeviceTab
+
+        calls = []
+
+        class MainWindow:
+            def open_device_inspector(self, device):
+                calls.append(device)
+
+        device = HardwareConfig(
+            vendor_id="1234",
+            product_id="5678",
+            name="Mouse",
+            evdev_devices=[
+                EvdevDevice(
+                    path="/dev/input/event4",
+                    device_type=DeviceType.MOUSE,
+                    id="mouse",
+                )
+            ],
+            buttons=[ButtonDefinition(id="btn_back", label="Back", evdev="btn_side")],
+        )
+        tab = DeviceTab(
+            device=device,
+            profile_manager=None,
+            main_window=MainWindow(),
+            demo_mode=False,
+        )
+
+        tab._on_inspect_device_clicked(None)  # type: ignore[arg-type]
+
+        assert calls == [device]
+
     def test_numbered_hardware_id_header_keeps_path_in_tooltip(self):
         from keymasq.common.models import ButtonDefinition, DeviceType, EvdevDevice, HardwareConfig
         from keymasq.gui.widgets.device_tab import DeviceTab

--- a/tests/gui/test_device_tab_widget.py
+++ b/tests/gui/test_device_tab_widget.py
@@ -2,6 +2,18 @@
 from tests.gui.support import *
 
 class TestDeviceTabWidget:
+    def test_mapping_label_sort_key_orders_trailing_numbers_numerically(self):
+        from keymasq.gui.widgets.device_tab import _label_sort_key
+
+        labels = ["Extra Button 1", "Extra Button 10", "Extra Button 2", "Back"]
+
+        assert sorted(labels, key=_label_sort_key) == [
+            "Back",
+            "Extra Button 1",
+            "Extra Button 2",
+            "Extra Button 10",
+        ]
+
     def test_device_tab_creation(self):
         from gi.repository import Gtk
 

--- a/tests/gui/test_main_window.py
+++ b/tests/gui/test_main_window.py
@@ -108,6 +108,92 @@ class TestMainWindow:
         assert add_calls == [True]
         assert unlock_calls == []
 
+    def test_main_window_device_inspector_uses_unlock_flow(self, temp_config_dir):
+        from keymasq.common.models import ButtonDefinition, HardwareConfig
+        from keymasq.gui.window import MainWindow
+
+        window = MainWindow(demo_mode=True)
+        window.demo_mode = False
+        window._recording_unlock_required = True
+        window._recording_unlocked = False
+        window._recording_refresh_owner = False
+        unlock_callbacks = []
+        window.present_unlock_dialog = (  # type: ignore[method-assign]
+            lambda on_success=None: unlock_callbacks.append(on_success)
+        )
+        device = HardwareConfig(
+            vendor_id="1234",
+            product_id="5678",
+            name="Mouse",
+            evdev_devices=[],
+            buttons=[ButtonDefinition(id="btn_back", label="Back", evdev="btn_side")],
+        )
+
+        window.open_device_inspector(device)
+
+        assert len(unlock_callbacks) == 1
+        assert window._device_inspector_windows == {}
+
+    def test_main_window_device_inspector_reuses_open_window(
+        self,
+        temp_config_dir,
+        monkeypatch,
+    ):
+        from keymasq.common.models import ButtonDefinition, HardwareConfig
+        from keymasq.gui.widgets import device_inspector_window as inspector_module
+        from keymasq.gui.window import MainWindow
+
+        window = MainWindow(demo_mode=True)
+        window.demo_mode = False
+        window._recording_unlock_required = False
+        present_calls = []
+        close_callbacks = []
+
+        class FakeInspector:
+            def __init__(self, parent, device):
+                self.parent = parent
+                self.device = device
+
+            def connect(self, signal, callback):
+                if signal == "close-request":
+                    close_callbacks.append((self, callback))
+                return 1
+
+            def present(self):
+                present_calls.append(self.device.hardware_id)
+
+            def close(self):
+                pass
+
+        monkeypatch.setattr(inspector_module, "DeviceInspectorWindow", FakeInspector)
+
+        device = HardwareConfig(
+            vendor_id="1234",
+            product_id="5678",
+            name="Mouse",
+            evdev_devices=[],
+            buttons=[ButtonDefinition(id="btn_back", label="Back", evdev="btn_side")],
+        )
+
+        window.open_device_inspector(device)
+        window.open_device_inspector(device)
+
+        assert present_calls == [device.hardware_id, device.hardware_id]
+        assert len(window._device_inspector_windows) == 1
+
+        inspector = window._device_inspector_windows[device.hardware_id]
+        assert close_callbacks[-1][1](inspector) is False
+        assert window._device_inspector_windows == {}
+
+        window.open_device_inspector(device)
+
+        assert len(window._device_inspector_windows) == 1
+        assert present_calls == [
+            device.hardware_id,
+            device.hardware_id,
+            device.hardware_id,
+        ]
+
     def test_main_window_menu_reflects_saved_appearance(self, temp_config_dir):
         from keymasq.gui.preferences import save_appearance_mode
         from keymasq.gui.window import MainWindow

--- a/tests/keymasqd/daemon_support.py
+++ b/tests/keymasqd/daemon_support.py
@@ -36,6 +36,14 @@ def daemon_testbed(monkeypatch):
         cancel_macro_playback=AsyncMock(return_value={"canceled": True}),
         emergency_reset=AsyncMock(return_value={"reset": True}),
         set_diagnostics=AsyncMock(return_value={"status": "ok"}),
+        start_device_inspector=AsyncMock(return_value={"status": "ok", "active": True}),
+        stop_device_inspector=AsyncMock(return_value={"status": "ok", "active": False}),
+        enable_device_inspector_suppression=AsyncMock(
+            return_value={"status": "ok", "suppressed": True}
+        ),
+        disable_device_inspector_suppression=AsyncMock(
+            return_value={"status": "ok", "suppressed": False}
+        ),
         complete_macro_exec_wait=Mock(return_value={"completed": True}),
         initialize_output_devices=Mock(return_value=None),
         shutdown_output_devices=Mock(return_value=None),

--- a/tests/keymasqd/test_daemon_runtime_unlock.py
+++ b/tests/keymasqd/test_daemon_runtime_unlock.py
@@ -32,6 +32,56 @@ async def test_set_diagnostics_forwards_categories(daemon_testbed):
 
 
 @pytest.mark.asyncio
+async def test_device_inspector_commands_forward_to_device_manager(daemon_testbed):
+    daemon, device_manager, _recording_manager, _macro_store, _capture_manager = daemon_testbed
+
+    await daemon._handle_command(
+        CommandType.DEVICE_INSPECTOR_START,
+        {"hardware_id": "1234:5678"},
+    )
+    await daemon._handle_command(
+        CommandType.DEVICE_INSPECTOR_ENABLE_SUPPRESSION,
+        {"hardware_id": "1234:5678"},
+    )
+    await daemon._handle_command(
+        CommandType.DEVICE_INSPECTOR_DISABLE_SUPPRESSION,
+        {"hardware_id": "1234:5678", "reason": "key_esc"},
+    )
+    await daemon._handle_command(
+        CommandType.DEVICE_INSPECTOR_STOP,
+        {"hardware_id": "1234:5678"},
+    )
+
+    device_manager.start_device_inspector.assert_awaited_once_with(  # type: ignore[attr-defined]
+        hardware_id="1234:5678"
+    )
+    device_manager.enable_device_inspector_suppression.assert_awaited_once_with(  # type: ignore[attr-defined]
+        hardware_id="1234:5678"
+    )
+    device_manager.disable_device_inspector_suppression.assert_awaited_once_with(  # type: ignore[attr-defined]
+        hardware_id="1234:5678",
+        reason="key_esc",
+    )
+    device_manager.stop_device_inspector.assert_awaited_once_with(  # type: ignore[attr-defined]
+        hardware_id="1234:5678"
+    )
+
+
+@pytest.mark.asyncio
+async def test_device_inspector_start_requires_recording_unlock(daemon_testbed, monkeypatch):
+    daemon, _device_manager, _recording_manager, _macro_store, _capture_manager = daemon_testbed
+    daemon.security_policy = SecurityPolicy(recording_unlock_required=True)
+    monkeypatch.setattr(daemon, "_recording_unlocked_for_uid", lambda _uid: (False, 0, "none"))
+
+    with pytest.raises(PermissionError, match="recording_locked"):
+        await daemon._handle_command(
+            CommandType.DEVICE_INSPECTOR_START,
+            {"hardware_id": "1234:5678"},
+            client=_client(),
+        )
+
+
+@pytest.mark.asyncio
 async def test_macro_exec_complete_forwards_wait_id_and_returncode(daemon_testbed):
     daemon, device_manager, _recording_manager, _macro_store, _capture_manager = daemon_testbed
 

--- a/tests/keymasqd/test_device_manager_core.py
+++ b/tests/keymasqd/test_device_manager_core.py
@@ -29,6 +29,59 @@ async def test_set_cursor_position_reports_missing_mouse_uinput() -> None:
     }
 
 
+@pytest.mark.asyncio
+async def test_device_inspector_suppression_status_broadcasts() -> None:
+    manager = DeviceManager()
+    broadcasts: list[tuple[CommandType, dict[str, object]]] = []
+    manager._broadcast_runtime_event = lambda event_type, data: broadcasts.append(  # type: ignore[method-assign]
+        (event_type, data)
+    )
+
+    started = await manager.start_device_inspector("1234:5678")
+    enabled = await manager.enable_device_inspector_suppression("1234:5678")
+    disabled = await manager.disable_device_inspector_suppression("1234:5678", "key_esc")
+
+    assert started["active"] is True
+    assert started["suppressed"] is False
+    assert enabled["suppressed"] is True
+    assert disabled == {
+        "status": "ok",
+        "hardware_id": "1234:5678",
+        "active": True,
+        "suppressed": False,
+        "reason": "key_esc",
+    }
+    assert broadcasts == [
+        (
+            CommandType.DEVICE_INSPECTOR_STATUS,
+            {
+                "hardware_id": "1234:5678",
+                "active": True,
+                "suppressed": False,
+                "reason": "start",
+            },
+        ),
+        (
+            CommandType.DEVICE_INSPECTOR_STATUS,
+            {
+                "hardware_id": "1234:5678",
+                "active": True,
+                "suppressed": True,
+                "reason": "enable_suppression",
+            },
+        ),
+        (
+            CommandType.DEVICE_INSPECTOR_STATUS,
+            {
+                "hardware_id": "1234:5678",
+                "active": True,
+                "suppressed": False,
+                "reason": "key_esc",
+            },
+        ),
+    ]
+
+
 @pytest.mark.skipif(not os.access("/dev/uinput", os.W_OK), reason="No uinput access")
 class TestDeviceManager:
     @pytest.fixture

--- a/tests/keymasqd/test_device_manager_core.py
+++ b/tests/keymasqd/test_device_manager_core.py
@@ -82,6 +82,49 @@ async def test_device_inspector_suppression_status_broadcasts() -> None:
     ]
 
 
+@pytest.mark.asyncio
+async def test_device_inspector_disable_does_not_activate_inactive_inspector() -> None:
+    manager = DeviceManager()
+    broadcasts: list[tuple[CommandType, dict[str, object]]] = []
+    manager._broadcast_runtime_event = lambda event_type, data: broadcasts.append(  # type: ignore[method-assign]
+        (event_type, data)
+    )
+
+    disabled = await manager.disable_device_inspector_suppression("1234:5678", "manual")
+
+    assert disabled == {
+        "status": "ok",
+        "hardware_id": "1234:5678",
+        "active": False,
+        "suppressed": False,
+        "reason": "manual",
+    }
+    assert "1234:5678" not in manager.device_inspector_active_hardware_ids
+    assert broadcasts == [
+        (
+            CommandType.DEVICE_INSPECTOR_STATUS,
+            {
+                "hardware_id": "1234:5678",
+                "active": False,
+                "suppressed": False,
+                "reason": "manual",
+            },
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_release_all_devices_clears_device_inspector_state() -> None:
+    manager = DeviceManager()
+    manager.device_inspector_active_hardware_ids.add("1234:5678")
+    manager.device_inspector_suppressed_hardware_ids.add("1234:5678")
+
+    await manager.release_all_devices()
+
+    assert manager.device_inspector_active_hardware_ids == set()
+    assert manager.device_inspector_suppressed_hardware_ids == set()
+
+
 @pytest.mark.skipif(not os.access("/dev/uinput", os.W_OK), reason="No uinput access")
 class TestDeviceManager:
     @pytest.fixture

--- a/tests/keymasqd/test_grabbed_device_runtime_helpers.py
+++ b/tests/keymasqd/test_grabbed_device_runtime_helpers.py
@@ -36,6 +36,102 @@ class _CountingUInput(_FakeUInput):
 
 
 class TestGrabbedDeviceHelpers:
+    @pytest.mark.asyncio
+    async def test_inspector_suppressed_key_esc_press_disables_suppression(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        events: list[dict[str, object]] = []
+        diagnostics: list[str] = []
+        disable_suppression = AsyncMock(
+            return_value={"status": "ok", "suppressed": False, "reason": "key_esc"}
+        )
+        passthrough = _FakeUInput()
+        device = _make_grabbed_device(
+            monkeypatch,
+            inspector_event_callback=events.append,
+            inspector_active_getter=lambda _hardware_id: True,
+            inspector_suppression_getter=lambda _hardware_id: True,
+            inspector_suppression_disabler=disable_suppression,
+            diagnostics_recorder=lambda label, _duration_us: diagnostics.append(label),
+        )
+        device.uinput = passthrough  # type: ignore[assignment]
+
+        await _runtime_process_grabbed_event(
+            device,
+            evdev.InputEvent(0, 0, evdev.ecodes.EV_KEY, evdev.ecodes.KEY_ESC, 1),
+        )
+
+        disable_suppression.assert_awaited_once_with("1234:5678", "key_esc")
+        assert events[0]["code_name"] == "key_esc"
+        assert events[0]["suppressed"] is True
+        assert passthrough.writes == []
+        assert diagnostics == ["inspector_escape_key"]
+        cast(AsyncMock, device.event_callback).assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_inspector_key_esc_press_disables_other_suppressed_device(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        diagnostics: list[str] = []
+        disable_suppression = AsyncMock(return_value={"status": "ok"})
+        passthrough = _FakeUInput()
+        device = _make_grabbed_device(
+            monkeypatch,
+            inspector_active_getter=lambda _hardware_id: False,
+            inspector_suppression_getter=lambda _hardware_id: False,
+            inspector_suppressed_ids_getter=lambda: {"mouse-hid"},
+            inspector_suppression_disabler=disable_suppression,
+            diagnostics_recorder=lambda label, _duration_us: diagnostics.append(label),
+        )
+        device.uinput = passthrough  # type: ignore[assignment]
+
+        await _runtime_process_grabbed_event(
+            device,
+            evdev.InputEvent(0, 0, evdev.ecodes.EV_KEY, evdev.ecodes.KEY_ESC, 1),
+        )
+
+        disable_suppression.assert_awaited_once_with("mouse-hid", "key_esc")
+        assert passthrough.writes == []
+        assert diagnostics == ["inspector_escape_key"]
+        cast(AsyncMock, device.event_callback).assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_inspector_suppressed_non_escape_and_escape_release_do_not_disable(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        events: list[dict[str, object]] = []
+        diagnostics: list[str] = []
+        disable_suppression = AsyncMock(return_value={"status": "ok"})
+        passthrough = _FakeUInput()
+        device = _make_grabbed_device(
+            monkeypatch,
+            inspector_event_callback=events.append,
+            inspector_active_getter=lambda _hardware_id: True,
+            inspector_suppression_getter=lambda _hardware_id: True,
+            inspector_suppression_disabler=disable_suppression,
+            diagnostics_recorder=lambda label, _duration_us: diagnostics.append(label),
+        )
+        device.uinput = passthrough  # type: ignore[assignment]
+
+        await _runtime_process_grabbed_event(
+            device,
+            evdev.InputEvent(0, 0, evdev.ecodes.EV_KEY, evdev.ecodes.KEY_A, 1),
+        )
+        await _runtime_process_grabbed_event(
+            device,
+            evdev.InputEvent(0, 0, evdev.ecodes.EV_KEY, evdev.ecodes.KEY_ESC, 0),
+        )
+
+        disable_suppression.assert_not_awaited()
+        assert [event["code_name"] for event in events] == ["key_a", "key_esc"]
+        assert [event["suppressed"] for event in events] == [True, True]
+        assert passthrough.writes == []
+        assert diagnostics == ["inspector_suppressed", "inspector_suppressed"]
+        cast(AsyncMock, device.event_callback).assert_not_awaited()
+
     def test_find_action_for_event_prefers_evdev_code_over_alias_name(
         self,
         monkeypatch: pytest.MonkeyPatch,

--- a/tests/session/test_session_manager_command_runtime.py
+++ b/tests/session/test_session_manager_command_runtime.py
@@ -5,6 +5,7 @@ from tests.session.command_support import *
 from keymasq.common import paths
 from keymasq.common.ipc import CommandType
 import keymasq.session.manager.commands as session_commands_module
+import keymasq.session.manager.device_inspector as session_device_inspector_module
 
 
 @pytest.mark.asyncio
@@ -645,6 +646,70 @@ async def test_device_inspector_status_forwards_to_gui_clients() -> None:
     )
     assert "1234:5678" in manager.device_inspector_state.active_hardware_ids
     assert "1234:5678" not in manager.device_inspector_state.suppressed_hardware_ids
+
+
+@pytest.mark.asyncio
+async def test_stop_device_inspector_preserves_error_snapshot(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = SessionManager()
+    hardware_id = "1234:5678"
+    writer = object()
+    manager.device_inspector_state.owners_by_hardware_id[hardware_id] = {id(writer), 2}
+
+    monkeypatch.setattr(
+        session_device_inspector_module,
+        "build_device_inspector_snapshot",
+        lambda _manager, _hardware_id: {
+            "status": "error",
+            "message": "snapshot failed",
+        },
+    )
+
+    result = await session_device_inspector_module.stop_device_inspector(
+        manager,
+        hardware_id,
+        writer,  # type: ignore[arg-type]
+    )
+
+    assert result == {"status": "error", "message": "snapshot failed"}
+
+
+@pytest.mark.asyncio
+async def test_clear_device_inspectors_for_writer_continues_after_stop_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = SessionManager()
+    writer = object()
+    writer_id = id(writer)
+    stopped: list[str] = []
+    manager.device_inspector_state.owners_by_hardware_id.update(
+        {
+            "bad": {writer_id},
+            "good": {writer_id},
+        }
+    )
+
+    async def stop(
+        _manager: SessionManager,
+        hardware_id: str,
+        *,
+        reason: str,
+    ) -> dict[str, object]:
+        stopped.append(hardware_id)
+        if hardware_id == "bad":
+            raise RuntimeError("stop failed")
+        return {"status": "ok", "reason": reason}
+
+    monkeypatch.setattr(session_device_inspector_module, "_stop_device_inspector_unlocked", stop)
+
+    await session_device_inspector_module.clear_device_inspectors_for_writer(
+        manager,
+        writer,  # type: ignore[arg-type]
+    )
+
+    assert stopped == ["bad", "good"]
+    assert manager.device_inspector_state.owners_by_hardware_id["bad"] == set()
 
 
 @pytest.mark.asyncio

--- a/tests/session/test_session_manager_command_runtime.py
+++ b/tests/session/test_session_manager_command_runtime.py
@@ -549,6 +549,177 @@ async def test_diagnostics_snapshot_event_forwards_to_gui_clients() -> None:
 
 
 @pytest.mark.asyncio
+async def test_device_inspector_disable_session_command_forwards_reason() -> None:
+    manager = SessionManager()
+    manager.client = SimpleNamespace(
+        send_command=AsyncMock(return_value=Response(status="ok", data={"status": "ok"}))
+    )
+    peer = PeerCredentials(pid=1, uid=1000, gid=1000)
+
+    result = await manager._handle_session_request(
+        {
+            "command": "disable_device_inspector_suppression",
+            "hardware_id": "1234:5678",
+            "reason": "key_esc",
+        },
+        "client",
+        peer,
+        object(),  # type: ignore[arg-type]
+    )
+
+    sent = manager.client.send_command.await_args.args[0]
+    assert result == {"status": "ok"}
+    assert sent.command == CommandType.DEVICE_INSPECTOR_DISABLE_SUPPRESSION
+    assert sent.data == {"hardware_id": "1234:5678", "reason": "key_esc"}
+
+
+@pytest.mark.asyncio
+async def test_device_inspector_events_forward_to_gui_clients() -> None:
+    manager = SessionManager()
+    manager.broadcast_to_session_clients = Mock()  # type: ignore[method-assign]
+
+    await session_events_module.handle_event(
+        manager,
+        CommandType.DEVICE_INSPECTOR_EVENT,
+        {
+            "hardware_id": "1234:5678",
+            "code_name": "key_esc",
+            "value": 1,
+            "suppressed": True,
+        },
+    )
+    await session_events_module.handle_event(
+        manager,
+        CommandType.DEVICE_INSPECTOR_STATUS,
+        {
+            "hardware_id": "1234:5678",
+            "active": True,
+            "suppressed": False,
+            "reason": "key_esc",
+        },
+    )
+
+    assert [
+        args.args[0] for args in manager.broadcast_to_session_clients.call_args_list  # type: ignore[attr-defined]
+    ] == [
+        {
+            "event": "device_inspector_event",
+            "hardware_id": "1234:5678",
+            "code_name": "key_esc",
+            "value": 1,
+            "suppressed": True,
+        },
+        {
+            "event": "device_inspector_status",
+            "hardware_id": "1234:5678",
+            "active": True,
+            "suppressed": False,
+            "reason": "key_esc",
+        },
+    ]
+    assert "1234:5678" in manager.device_inspector_state.active_hardware_ids
+    assert "1234:5678" not in manager.device_inspector_state.suppressed_hardware_ids
+
+
+@pytest.mark.asyncio
+async def test_start_device_inspector_returns_snapshot_and_forces_profile_reevaluate(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from keymasq.common.models import (
+        ActionType,
+        AnalogAxisDefinition,
+        AnalogInputDefinition,
+        ButtonDefinition,
+        DeviceType,
+        EvdevDevice,
+        HardwareConfig,
+        MappingAction,
+    )
+    from keymasq.session.profiles import ResolvedDeviceProfile
+
+    manager = SessionManager()
+    manager.security_policy.recording_unlock_required = False
+    hardware_id = "1234:5678"
+    manager.hardware.get_hardware = lambda _hardware_id: HardwareConfig(  # type: ignore[assignment]
+        vendor_id="1234",
+        product_id="5678",
+        name="Inspector Pad",
+        evdev_devices=[
+            EvdevDevice(
+                path="/dev/input/event10",
+                device_type=DeviceType.GAMEPAD,
+                id="pad",
+            )
+        ],
+        buttons=[
+            ButtonDefinition(
+                id="btn_south",
+                label="A",
+                evdev="btn_south",
+                evdev_code=304,
+                source="pad",
+            )
+        ],
+        analog_inputs=[
+            AnalogInputDefinition(
+                id="left_stick",
+                label="Left Stick",
+                type="stick",
+                source="pad",
+                axes=[
+                    AnalogAxisDefinition(role="x", evdev="abs_x", evdev_code=0),
+                    AnalogAxisDefinition(role="y", evdev="abs_y", evdev_code=1),
+                ],
+            )
+        ],
+    )
+    manager.profile_state.resolved_devices[hardware_id] = ResolvedDeviceProfile(
+        hardware_id=hardware_id,
+        active_profile_names=["Desktop"],
+        mappings={
+            "btn_south": MappingAction(action_type=ActionType.KEYBOARD, target="key_space")
+        },
+        mapping_profile_names={"btn_south": "Desktop"},
+    )
+    manager.client.send_command = AsyncMock(
+        return_value=Response(
+            status="ok",
+            data={"hardware_id": hardware_id, "active": True, "suppressed": False},
+        )
+    )
+    reevaluate_profiles = AsyncMock()
+    monkeypatch.setattr(session_profiles_module, "reevaluate_profiles", reevaluate_profiles)
+
+    result = await manager._handle_session_request(
+        {"command": "start_device_inspector", "hardware_id": hardware_id},
+        "client",
+        PeerCredentials(pid=1, uid=1000, gid=1000),
+        object(),  # type: ignore[arg-type]
+    )
+
+    sent = manager.client.send_command.await_args.args[0]
+    assert sent.command == CommandType.DEVICE_INSPECTOR_START
+    assert sent.data == {"hardware_id": hardware_id}
+    reevaluate_profiles.assert_awaited_once_with(
+        manager,
+        reason=f"device inspector start {hardware_id}",
+    )
+    assert result["status"] == "ok"
+    assert result["active"] is True
+    assert result["suppressed"] is False
+    assert result["device_name"] == "Inspector Pad"
+    assert result["active_profiles"] == ["Desktop"]
+    buttons = cast(list[dict[str, object]], result["buttons"])
+    action = cast(dict[str, object], buttons[0]["action"])
+    analog_inputs = cast(list[dict[str, object]], result["analog_inputs"])
+    axes = cast(list[dict[str, object]], analog_inputs[0]["axes"])
+    assert buttons[0]["profile_name"] == "Desktop"
+    assert action["target"] == "key_space"
+    assert axes[0]["evdev"] == "abs_x"
+    assert hardware_id in manager.device_inspector_state.active_hardware_ids
+
+
+@pytest.mark.asyncio
 async def test_get_status_reports_effective_unlock_when_unlock_not_required(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/session/test_session_manager_command_runtime.py
+++ b/tests/session/test_session_manager_command_runtime.py
@@ -1,4 +1,6 @@
 # ruff: noqa: F403, F405, I001
+import json
+
 from tests.session.command_support import *
 from keymasq.common import paths
 from keymasq.common.ipc import CommandType
@@ -500,9 +502,8 @@ async def test_runtime_reset_event_invalidates_and_reevaluates(
     reevaluate_profiles = AsyncMock()
     monkeypatch.setattr(session_profiles_module, "reevaluate_profiles", reevaluate_profiles)
 
-    await session_events_module.handle_event(
+    await session_events_module.handle_runtime_reset_event(
         manager,
-        CommandType.RUNTIME_RESET,
         {"reason": "emergency_reset"},
     )
     await asyncio.sleep(0)
@@ -574,9 +575,23 @@ async def test_device_inspector_disable_session_command_forwards_reason() -> Non
 
 
 @pytest.mark.asyncio
-async def test_device_inspector_events_forward_to_gui_clients() -> None:
+async def test_device_inspector_events_forward_only_to_owner_clients() -> None:
     manager = SessionManager()
-    manager.broadcast_to_session_clients = Mock()  # type: ignore[method-assign]
+
+    class Writer:
+        def __init__(self) -> None:
+            self.writes: list[bytes] = []
+
+        def write(self, data: bytes) -> None:
+            self.writes.append(data)
+
+        async def drain(self) -> None:
+            return None
+
+    owner = Writer()
+    other = Writer()
+    manager.session_clients.update({owner, other})  # type: ignore[arg-type]
+    manager.device_inspector_state.owners_by_hardware_id["1234:5678"] = {id(owner)}
 
     await session_events_module.handle_event(
         manager,
@@ -588,6 +603,26 @@ async def test_device_inspector_events_forward_to_gui_clients() -> None:
             "suppressed": True,
         },
     )
+
+    assert other.writes == []
+    assert len(owner.writes) == 1
+    assert json.loads(owner.writes[0]) == {
+        "event": "device_inspector_event",
+        "hardware_id": "1234:5678",
+        "code_name": "key_esc",
+        "value": 1,
+        "suppressed": True,
+    }
+
+    for task in list(manager.session_client_drain_tasks.values()):
+        await task
+
+
+@pytest.mark.asyncio
+async def test_device_inspector_status_forwards_to_gui_clients() -> None:
+    manager = SessionManager()
+    manager.broadcast_to_session_clients = Mock()  # type: ignore[method-assign]
+
     await session_events_module.handle_event(
         manager,
         CommandType.DEVICE_INSPECTOR_STATUS,
@@ -599,16 +634,7 @@ async def test_device_inspector_events_forward_to_gui_clients() -> None:
         },
     )
 
-    assert [
-        args.args[0] for args in manager.broadcast_to_session_clients.call_args_list  # type: ignore[attr-defined]
-    ] == [
-        {
-            "event": "device_inspector_event",
-            "hardware_id": "1234:5678",
-            "code_name": "key_esc",
-            "value": 1,
-            "suppressed": True,
-        },
+    manager.broadcast_to_session_clients.assert_called_once_with(  # type: ignore[attr-defined]
         {
             "event": "device_inspector_status",
             "hardware_id": "1234:5678",
@@ -616,9 +642,36 @@ async def test_device_inspector_events_forward_to_gui_clients() -> None:
             "suppressed": False,
             "reason": "key_esc",
         },
-    ]
+    )
     assert "1234:5678" in manager.device_inspector_state.active_hardware_ids
     assert "1234:5678" not in manager.device_inspector_state.suppressed_hardware_ids
+
+
+@pytest.mark.asyncio
+async def test_runtime_reset_clears_session_device_inspector_state(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = SessionManager()
+    manager.broadcast_to_session_clients = Mock()  # type: ignore[method-assign]
+    manager.send_notification = Mock()  # type: ignore[method-assign]
+    reevaluate_profiles = AsyncMock()
+    monkeypatch.setattr(session_profiles_module, "reevaluate_profiles", reevaluate_profiles)
+    manager.device_inspector_state.active_hardware_ids.add("1234:5678")
+    manager.device_inspector_state.suppressed_hardware_ids.add("1234:5678")
+    manager.device_inspector_state.owners_by_hardware_id["1234:5678"] = {1}
+
+    await session_events_module.handle_runtime_reset_event(
+        manager,
+        {"reason": "emergency_reset"},
+    )
+
+    assert manager.device_inspector_state.active_hardware_ids == set()
+    assert manager.device_inspector_state.suppressed_hardware_ids == set()
+    assert manager.device_inspector_state.owners_by_hardware_id == {}
+    manager.broadcast_to_session_clients.assert_called_once_with(  # type: ignore[attr-defined]
+        {"event": "runtime_reset", "reason": "emergency_reset"}
+    )
+    reevaluate_profiles.assert_awaited_once_with(manager, reason="runtime reset")
 
 
 @pytest.mark.asyncio
@@ -717,6 +770,146 @@ async def test_start_device_inspector_returns_snapshot_and_forces_profile_reeval
     assert action["target"] == "key_space"
     assert axes[0]["evdev"] == "abs_x"
     assert hardware_id in manager.device_inspector_state.active_hardware_ids
+
+
+@pytest.mark.asyncio
+async def test_enable_device_inspector_suppression_requires_successful_grab(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from keymasq.common.models import DeviceType, EvdevDevice, HardwareConfig
+
+    manager = SessionManager()
+    manager.security_policy.recording_unlock_required = False
+    hardware_id = "1234:5678"
+    writer = object()
+    manager.hardware.get_hardware = lambda _hardware_id: HardwareConfig(  # type: ignore[assignment]
+        vendor_id="1234",
+        product_id="5678",
+        name="Inspector Pad",
+        evdev_devices=[
+            EvdevDevice(path="/dev/input/event10", device_type=DeviceType.GAMEPAD, id="pad")
+        ],
+        buttons=[],
+    )
+    manager.client.send_command = AsyncMock(return_value=Response(status="ok", data={}))
+    reevaluate_profiles = AsyncMock()
+    monkeypatch.setattr(session_profiles_module, "reevaluate_profiles", reevaluate_profiles)
+
+    result = await manager._handle_session_request(
+        {"command": "enable_device_inspector_suppression", "hardware_id": hardware_id},
+        "client",
+        PeerCredentials(pid=1, uid=1000, gid=1000),
+        writer,  # type: ignore[arg-type]
+    )
+
+    assert result["status"] == "error"
+    assert "could not grab" in str(result["message"])
+    assert reevaluate_profiles.await_count == 2
+    assert reevaluate_profiles.await_args_list[0].kwargs == {
+        "reason": f"device inspector suppression grab {hardware_id}"
+    }
+    assert reevaluate_profiles.await_args_list[1].kwargs == {
+        "reason": f"device inspector suppression rollback {hardware_id}"
+    }
+    manager.client.send_command.assert_not_awaited()
+    assert hardware_id not in manager.device_inspector_state.active_hardware_ids
+    assert manager.device_inspector_state.owners_by_hardware_id == {}
+
+
+@pytest.mark.asyncio
+async def test_enable_device_inspector_suppression_rolls_back_on_daemon_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from keymasq.common.models import DeviceType, EvdevDevice, HardwareConfig
+
+    manager = SessionManager()
+    manager.security_policy.recording_unlock_required = False
+    hardware_id = "1234:5678"
+    writer = object()
+    manager.hardware.get_hardware = lambda _hardware_id: HardwareConfig(  # type: ignore[assignment]
+        vendor_id="1234",
+        product_id="5678",
+        name="Inspector Pad",
+        evdev_devices=[
+            EvdevDevice(path="/dev/input/event10", device_type=DeviceType.GAMEPAD, id="pad")
+        ],
+        buttons=[],
+    )
+    manager.profile_state.grabbed_devices.add(hardware_id)
+    manager.client.send_command = AsyncMock(
+        return_value=Response(status="error", error="daemon rejected suppression")
+    )
+    reevaluate_profiles = AsyncMock()
+    monkeypatch.setattr(session_profiles_module, "reevaluate_profiles", reevaluate_profiles)
+
+    result = await manager._handle_session_request(
+        {"command": "enable_device_inspector_suppression", "hardware_id": hardware_id},
+        "client",
+        PeerCredentials(pid=1, uid=1000, gid=1000),
+        writer,  # type: ignore[arg-type]
+    )
+
+    assert result == {
+        "status": "error",
+        "message": "daemon rejected suppression",
+    }
+    assert reevaluate_profiles.await_count == 2
+    assert reevaluate_profiles.await_args_list[0].kwargs == {
+        "reason": f"device inspector suppression grab {hardware_id}"
+    }
+    assert reevaluate_profiles.await_args_list[1].kwargs == {
+        "reason": f"device inspector suppression rollback {hardware_id}"
+    }
+    assert hardware_id not in manager.device_inspector_state.active_hardware_ids
+    assert manager.device_inspector_state.owners_by_hardware_id == {}
+
+
+@pytest.mark.asyncio
+async def test_enable_device_inspector_suppression_preserves_existing_inspector_on_daemon_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from keymasq.common.models import DeviceType, EvdevDevice, HardwareConfig
+
+    manager = SessionManager()
+    manager.security_policy.recording_unlock_required = False
+    hardware_id = "1234:5678"
+    writer = object()
+    writer_id = id(writer)
+    manager.hardware.get_hardware = lambda _hardware_id: HardwareConfig(  # type: ignore[assignment]
+        vendor_id="1234",
+        product_id="5678",
+        name="Inspector Pad",
+        evdev_devices=[
+            EvdevDevice(path="/dev/input/event10", device_type=DeviceType.GAMEPAD, id="pad")
+        ],
+        buttons=[],
+    )
+    manager.profile_state.grabbed_devices.add(hardware_id)
+    manager.device_inspector_state.active_hardware_ids.add(hardware_id)
+    manager.device_inspector_state.owners_by_hardware_id[hardware_id] = {writer_id}
+    manager.client.send_command = AsyncMock(
+        return_value=Response(status="error", error="daemon rejected suppression")
+    )
+    reevaluate_profiles = AsyncMock()
+    monkeypatch.setattr(session_profiles_module, "reevaluate_profiles", reevaluate_profiles)
+
+    result = await manager._handle_session_request(
+        {"command": "enable_device_inspector_suppression", "hardware_id": hardware_id},
+        "client",
+        PeerCredentials(pid=1, uid=1000, gid=1000),
+        writer,  # type: ignore[arg-type]
+    )
+
+    assert result == {
+        "status": "error",
+        "message": "daemon rejected suppression",
+    }
+    reevaluate_profiles.assert_awaited_once_with(
+        manager,
+        reason=f"device inspector suppression grab {hardware_id}",
+    )
+    assert hardware_id in manager.device_inspector_state.active_hardware_ids
+    assert manager.device_inspector_state.owners_by_hardware_id[hardware_id] == {writer_id}
 
 
 @pytest.mark.asyncio

--- a/tests/session/test_session_manager_profile_apply.py
+++ b/tests/session/test_session_manager_profile_apply.py
@@ -105,6 +105,63 @@ async def test_apply_resolved_device_profile_uses_extended_grab_timeout() -> Non
 
 
 @pytest.mark.asyncio
+async def test_apply_resolved_device_profile_force_grabs_all_interfaces_for_inspector() -> None:
+    from keymasq.common.models import ButtonDefinition, DeviceType, EvdevDevice, HardwareConfig
+
+    manager = SessionManager()
+    hardware_id = "1234:5678"
+    resolved = ResolvedDeviceProfile(hardware_id=hardware_id)
+    manager.device_inspector_state.active_hardware_ids.add(hardware_id)
+    manager.hardware.get_hardware = lambda _hardware_id: HardwareConfig(  # type: ignore[assignment]
+        vendor_id="1234",
+        product_id="5678",
+        name="Split Pad",
+        evdev_devices=[
+            EvdevDevice(
+                path="/dev/input/event10",
+                device_type=DeviceType.GAMEPAD,
+                id="buttons",
+            ),
+            EvdevDevice(
+                path="/dev/input/event11",
+                device_type=DeviceType.GAMEPAD,
+                id="axes",
+            ),
+        ],
+        buttons=[
+            ButtonDefinition(
+                id="btn_south",
+                label="A",
+                evdev="btn_south",
+                evdev_code=304,
+                source="buttons",
+            )
+        ],
+    )
+    manager.client.send_command = AsyncMock(
+        side_effect=[
+            Response(status="ok", data={"grabbed_count": 2}),
+            Response(status="ok", data={"updated": True}),
+        ]
+    )
+
+    await session_profiles_module.apply_resolved_device_profile(manager, hardware_id, resolved)
+
+    sent = manager.client.send_command.await_args_list
+    assert [call.args[0].command for call in sent] == [
+        CommandType.GRAB_DEVICE,
+        CommandType.SET_MAPPING,
+    ]
+    grab_data = sent[0].args[0].data
+    assert grab_data["evdev_paths"] == ["/dev/input/event10", "/dev/input/event11"]
+    assert grab_data["force_grab_unmapped"] is True
+    assert manager.profile_state.grabbed_interfaces[hardware_id] == {
+        "buttons": "/dev/input/event10",
+        "axes": "/dev/input/event11",
+    }
+
+
+@pytest.mark.asyncio
 async def test_apply_resolved_device_profile_retries_after_grab_timeout() -> None:
     manager = SessionManager()
     hardware_id = "1234:5678"
@@ -364,4 +421,3 @@ async def test_apply_resolved_device_profile_refreshes_same_interface_grab_confi
     assert manager.profile_state.last_sent_grab_signatures[hardware_id] == (
         session_profiles_module.grab_device_payload_signature(grab_data)
     )
-


### PR DESCRIPTION
## Summary
- Add a new Device Inspector window to inspect one configured device at runtime, showing resolved mappings, raw event streams, and configured analog inputs.
- Wire a new inspector command flow through `keymasqd` and the session manager, including scoped event delivery, per-hardware-ID suppression, and reset-on-close behavior.
- Require the existing recording-unlock flow for starting the inspector and enabling suppression, matching other original-input observation paths.
- Update the GUI device tab and main window to launch and manage the inspector, plus add styling for the new panel layout.
- Document the inspector workflow, suppression behavior, and security requirements in `docs/`.
- Add coverage for daemon runtime unlock handling, device manager behavior, session command handling, and the new GUI window.

## Testing
- Not run in this branch review.
- Added/updated pytest coverage for keymasqd runtime helpers, daemon unlock gating, session command flow, profile application, device tab behavior, and the Device Inspector window.
- Existing documentation and UI paths were updated to reflect the new inspector and suppression semantics.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Device Inspector window: view resolved mappings, live raw events, and analog axis viewers with normalization, visual levels, filtering, and export/copy of visible events.
  * Inspect button on device tabs opens/reuses an inspector window; demo mode blocks opening.
  * Suppression mode to test inputs without emitting remapped output; Escape clears suppression on grabbed keyboards.

* **Behavior Changes**
  * Inspector opening/enabling suppression requires recording-unlock when configured; inspector may force grabbing all device interfaces.

* **Documentation**
  * User guide, troubleshooting, and security notes updated for Device Inspector and unlock requirements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nyrda/keymasq/pull/110?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->