### PR TITLE
Add logical device paths for devices without by-id symlinks

### DIFF
--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -229,6 +229,14 @@ instead. `by-path` is stable across reboots as long as the device stays in the
 same USB or PCI path. If you move the receiver or device to another port, the
 `by-path` link changes and you must update the config again.
 
+If Linux does not expose a `/dev/input/by-id/...` link at all, Keymasq stores a
+logical path such as `keymasq:2dc8:3106` instead of the unstable
+`/dev/input/eventN` node. This is not a real filesystem path. At runtime,
+`keymasqd` resolves it by matching live evdev devices with the configured
+vendor/product IDs and interface metadata. This is best-effort: if you use
+multiple identical devices and need stable separation, configure explicit
+`by-id`, `by-path`, or event paths for the numbered hardware configs.
+
 Edit the affected hardware file:
 
 ```bash

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -206,7 +206,8 @@ Some devices do not expose enough stable identity data for Linux to distinguish
 two physical units of the same model. This usually happens when both devices
 report the same USB vendor ID, product ID, name, and serial number. Keymasq can
 keep separate numbered hardware IDs such as `045e:02a1` and `045e:02a1@2`, but
-the saved evdev path still has to point at the intended physical interface.
+those IDs are also profile/config keys. Changing a hardware ID requires the
+matching profile device layer to use the same ID.
 
 Symptoms:
 
@@ -233,9 +234,14 @@ If Linux does not expose a `/dev/input/by-id/...` link at all, Keymasq stores a
 logical path such as `keymasq:2dc8:3106` instead of the unstable
 `/dev/input/eventN` node. This is not a real filesystem path. At runtime,
 `keymasqd` resolves it by matching live evdev devices with the configured
-vendor/product IDs and interface metadata. This is best-effort: if you use
-multiple identical devices and need stable separation, configure explicit
-`by-id`, `by-path`, or event paths for the numbered hardware configs.
+vendor/product IDs and interface metadata such as type, `phys`, and
+capabilities.
+
+For logical paths, a numbered hardware ID such as `045e:02a1@2` is only a
+best-effort duplicate hint. It is not a serial number. If the requested numbered
+candidate is unavailable, `keymasqd` may choose the best unclaimed matching
+candidate instead. This keeps reconnects usable, but it cannot make two
+perfectly identical unserialized devices reliably distinguishable.
 
 Edit the affected hardware file:
 

--- a/docs/agents/hardware.txt
+++ b/docs/agents/hardware.txt
@@ -10,10 +10,8 @@ Hardware files live at:
 
 The hardware ID is `vendor_id:product_id`, for example `046d:c08b`.
 Profile mappings refer to these IDs under `[devices."<hardware_id>"]`.
-For duplicate devices with the same vendor/product IDs, use an explicit
-`hardware_id` such as `046d:c08b@2` in the hardware file. When an evdev entry
-uses `keymasq:<vendor_id>:<product_id>`, the suffix selects the Nth matching
-runtime interface instead of falling back to the first identical device.
+For duplicate devices with the same vendor/product IDs, use `@N` hardware IDs
+such as `046d:c08b@2`. The hardware ID is the config/profile key.
 
 Only edit hardware config when adding or fixing physical button/key
 definitions. For normal remaps, edit profiles instead.
@@ -85,17 +83,17 @@ evdev_code = 2
 - `name`: display name
 - `vendor_id`: USB/vendor ID string
 - `product_id`: USB/product ID string
-- `hardware_id`: optional explicit ID, mainly for duplicate devices such as
-  `046d:c08b@2`; the vendor/product prefix must match
+- `hardware_id`: optional explicit config/profile key, usually for duplicates
+  such as `046d:c08b@2`; the vendor/product prefix must match
 - `image`: optional image filename
 
 `[hardware.evdev].devices` entries:
 
-- `path`: stable `/dev/input/by-id/...` path, explicit `/dev/input/by-path/...`
-  or `/dev/input/eventN` override, or Keymasq logical path
-  `keymasq:<vendor_id>:<product_id>` when Linux exposes no by-id link
+- `path`: `/dev/input/by-id/...`, `/dev/input/by-path/...`,
+  `/dev/input/eventN`, or logical `keymasq:<vendor_id>:<product_id>`
 - `type`: `keyboard`, `mouse`, `gamepad`, or `other`
 - `id`: optional source interface ID used by buttons
+- `phys`: optional kernel physical/topology hint
 - `capabilities`: optional capability list
 
 `[[hardware.layout.buttons]]` entries:

--- a/docs/agents/hardware.txt
+++ b/docs/agents/hardware.txt
@@ -85,7 +85,9 @@ evdev_code = 2
 
 `[hardware.evdev].devices` entries:
 
-- `path`: stable `/dev/input/by-id/...` path
+- `path`: stable `/dev/input/by-id/...` path, explicit `/dev/input/by-path/...`
+  or `/dev/input/eventN` override, or Keymasq logical path
+  `keymasq:<vendor_id>:<product_id>` when Linux exposes no by-id link
 - `type`: `keyboard`, `mouse`, `gamepad`, or `other`
 - `id`: optional source interface ID used by buttons
 - `capabilities`: optional capability list

--- a/docs/agents/hardware.txt
+++ b/docs/agents/hardware.txt
@@ -10,6 +10,10 @@ Hardware files live at:
 
 The hardware ID is `vendor_id:product_id`, for example `046d:c08b`.
 Profile mappings refer to these IDs under `[devices."<hardware_id>"]`.
+For duplicate devices with the same vendor/product IDs, use an explicit
+`hardware_id` such as `046d:c08b@2` in the hardware file. When an evdev entry
+uses `keymasq:<vendor_id>:<product_id>`, the suffix selects the Nth matching
+runtime interface instead of falling back to the first identical device.
 
 Only edit hardware config when adding or fixing physical button/key
 definitions. For normal remaps, edit profiles instead.
@@ -81,6 +85,8 @@ evdev_code = 2
 - `name`: display name
 - `vendor_id`: USB/vendor ID string
 - `product_id`: USB/product ID string
+- `hardware_id`: optional explicit ID, mainly for duplicate devices such as
+  `046d:c08b@2`; the vendor/product prefix must match
 - `image`: optional image filename
 
 `[hardware.evdev].devices` entries:

--- a/keymasq/common/devices.py
+++ b/keymasq/common/devices.py
@@ -10,6 +10,7 @@ import evdev
 from keymasq.common.models import DeviceType
 
 INPUT_CLASS_ORDER = ("mouse", "touchpad", "keyboard", "gamepad", "pointstick", "other")
+KEYMASQ_DEVICE_PATH_PREFIX = "keymasq:"
 INPUT_CLASS_LABELS = {
     "mouse": "Mouse",
     "touchpad": "Touchpad",
@@ -456,6 +457,43 @@ def resolve_stable_path(event_path: str) -> str:
     if not event_path:
         return event_path
     return _resolve_stable_path_cached(str(event_path))
+
+
+def is_keymasq_device_path(path: str) -> bool:
+    return str(path or "").strip().lower().startswith(KEYMASQ_DEVICE_PATH_PREFIX)
+
+
+def make_keymasq_device_path(vendor_id: str, product_id: str) -> str:
+    return (
+        f"{KEYMASQ_DEVICE_PATH_PREFIX}"
+        f"{str(vendor_id or '').strip().lower()}:{str(product_id or '').strip().lower()}"
+    )
+
+
+def parse_keymasq_device_path(path: str) -> tuple[str, str] | None:
+    normalized = str(path or "").strip().lower()
+    if not normalized.startswith(KEYMASQ_DEVICE_PATH_PREFIX):
+        return None
+    parts = normalized.removeprefix(KEYMASQ_DEVICE_PATH_PREFIX).split(":")
+    if len(parts) != 2:
+        return None
+    vendor_id, product_id = (part.strip() for part in parts)
+    if not re.fullmatch(r"[0-9a-f]{1,4}", vendor_id) or not re.fullmatch(
+        r"[0-9a-f]{1,4}", product_id
+    ):
+        return None
+    return vendor_id.zfill(4), product_id.zfill(4)
+
+
+def is_by_id_path(path: str) -> bool:
+    return "/dev/input/by-id/" in str(path or "")
+
+
+def config_path_for_detected_event(event_path: str, vendor_id: str, product_id: str) -> str:
+    stable_path = resolve_stable_path(event_path)
+    if is_by_id_path(stable_path):
+        return stable_path
+    return make_keymasq_device_path(vendor_id, product_id)
 
 
 def clear_device_path_cache() -> None:

--- a/keymasq/gui/widgets/device_tab.py
+++ b/keymasq/gui/widgets/device_tab.py
@@ -1,3 +1,4 @@
+import logging
 import re
 import shlex
 from typing import cast
@@ -58,6 +59,7 @@ _ANALOG_LAYOUT_ORDER = {
     "right_stick": 3,
 }
 _TRAILING_NUMBER_RE = re.compile(r"^(?P<prefix>.*?)(?P<number>\d+)\s*$")
+log = logging.getLogger(__name__)
 
 
 def _make_capture_status_row(status_label: Gtk.Label) -> Gtk.Box:
@@ -553,6 +555,13 @@ class DeviceTab(ProfileManagedTab):
         message.set_halign(Gtk.Align.START)
         content.append(message)
 
+        error_label = Gtk.Label()
+        error_label.add_css_class("error")
+        error_label.set_halign(Gtk.Align.START)
+        error_label.set_wrap(True)
+        error_label.set_visible(False)
+        content.append(error_label)
+
         delete_profiles_check = Gtk.CheckButton(label="Remove device mappings from profiles")
         delete_profiles_check.set_active(True)
         content.append(delete_profiles_check)
@@ -572,6 +581,7 @@ class DeviceTab(ProfileManagedTab):
             self._on_confirm_delete_device,
             dialog,
             delete_profiles_check,
+            error_label,
         )
         btn_box.append(delete_btn)
 
@@ -581,24 +591,59 @@ class DeviceTab(ProfileManagedTab):
         dialog.present(self.get_root())
 
     def _on_confirm_delete_device(
-        self, button: Gtk.Button, dialog: Adw.Dialog, delete_profiles_check: Gtk.CheckButton
+        self,
+        button: Gtk.Button,
+        dialog: Adw.Dialog,
+        delete_profiles_check: Gtk.CheckButton,
+        error_label: Gtk.Label | None = None,
     ) -> None:
         delete_profiles = delete_profiles_check.get_active()
         hardware_id = self.device.hardware_id
 
         button.set_sensitive(False)
+        if error_label is not None:
+            error_label.set_visible(False)
         session_request_async(
             {
                 "command": "release_device",
                 "hardware_id": hardware_id,
                 "immediate": True,
             },
-            lambda _result: self._delete_device_after_release(
+            lambda result: self._on_delete_device_release_response(
+                result,
+                button,
                 hardware_id,
                 delete_profiles,
                 dialog,
+                error_label,
             ),
         )
+
+    def _on_delete_device_release_response(
+        self,
+        result: JsonDict | None,
+        button: Gtk.Button,
+        hardware_id: str,
+        delete_profiles: bool,
+        dialog: Adw.Dialog,
+        error_label: Gtk.Label | None,
+    ) -> bool:
+        if isinstance(result, dict) and result.get("status") == "ok":
+            return self._delete_device_after_release(
+                hardware_id,
+                delete_profiles,
+                dialog,
+            )
+
+        message = "No response from keymasq-session"
+        if isinstance(result, dict):
+            message = str(result.get("error") or result.get("message") or "release failed")
+        log.warning("Failed to release device %s before delete: %s", hardware_id, message)
+        button.set_sensitive(True)
+        if error_label is not None:
+            error_label.set_label(f"Failed to release device: {message}")
+            error_label.set_visible(True)
+        return False
 
     def _delete_device_after_release(
         self,

--- a/keymasq/gui/widgets/device_tab.py
+++ b/keymasq/gui/widgets/device_tab.py
@@ -586,6 +586,26 @@ class DeviceTab(ProfileManagedTab):
         delete_profiles = delete_profiles_check.get_active()
         hardware_id = self.device.hardware_id
 
+        button.set_sensitive(False)
+        session_request_async(
+            {
+                "command": "release_device",
+                "hardware_id": hardware_id,
+                "immediate": True,
+            },
+            lambda _result: self._delete_device_after_release(
+                hardware_id,
+                delete_profiles,
+                dialog,
+            ),
+        )
+
+    def _delete_device_after_release(
+        self,
+        hardware_id: str,
+        delete_profiles: bool,
+        dialog: Adw.Dialog,
+    ) -> bool:
         if delete_profiles:
             assert self.profile_manager is not None
             self.profile_manager.remove_device_layers(hardware_id)
@@ -600,6 +620,7 @@ class DeviceTab(ProfileManagedTab):
         if root and hasattr(root, "stack"):
             root.stack.remove(self)
             root._check_empty_state()
+        return False
 
     def _setup_button_grid(self) -> None:
         scrolled = Gtk.ScrolledWindow()

--- a/keymasq/gui/wizards/hardware_setup.py
+++ b/keymasq/gui/wizards/hardware_setup.py
@@ -131,7 +131,8 @@ def _interface_id_for_config(iface: dict, used_ids: set[str]) -> str:
     stable_path = str(iface.get("stable_path", "") or "")
     config_path = str(iface.get("config_path", "") or "")
     if is_by_id_path(stable_path) or is_by_id_path(config_path):
-        return _dedupe_interface_id(get_interface_id(stable_path or config_path), used_ids)
+        by_id_path = stable_path if is_by_id_path(stable_path) else config_path
+        return _dedupe_interface_id(get_interface_id(by_id_path), used_ids)
     return _dedupe_interface_id(
         _fallback_interface_id_for_type(primary_input_class(iface.get("device_types"))),
         used_ids,

--- a/keymasq/gui/wizards/hardware_setup.py
+++ b/keymasq/gui/wizards/hardware_setup.py
@@ -29,6 +29,7 @@ from keymasq.common.devices import (
     input_class_label,
     is_by_id_path,
     is_low_res_wheel_evdev,
+    make_keymasq_device_path,
     normalize_input_classes,
     ordered_gamepad_button_names,
     primary_input_class,
@@ -137,6 +138,41 @@ def _interface_id_for_config(iface: dict, used_ids: set[str]) -> str:
         _fallback_interface_id_for_type(primary_input_class(iface.get("device_types"))),
         used_ids,
     )
+
+
+def _config_path_for_detected_interface(
+    vendor_id: str,
+    product_id: str,
+    stable_path: str,
+) -> str:
+    if is_by_id_path(stable_path):
+        return stable_path
+    return make_keymasq_device_path(vendor_id, product_id)
+
+
+def _interface_source_fields(dev: dict[str, Any]) -> dict[str, object]:
+    fields: dict[str, object] = {}
+    if bool(dev.get("grabbed_by_keymasq", False)):
+        fields["grabbed_by_keymasq"] = True
+    for key in (
+        "source_hardware_id",
+        "source_interface_id",
+        "source_stable_path",
+        "source_path",
+    ):
+        value = str(dev.get(key, "") or "")
+        if value:
+            fields[key] = value
+    return fields
+
+
+def _in_use_row_key(hardware_id: str, path: str, stable_path: str) -> str:
+    suffix = path or stable_path or "in-use"
+    return f"{hardware_id}#{suffix}"
+
+
+def _raw_row_key(path: str, stable_path: str) -> str:
+    return f"raw:{stable_path or path}"
 
 
 def _logical_hardware_identity_key(
@@ -491,6 +527,21 @@ class HardwareSetupDialog(Adw.Dialog):
             vidpid.set_halign(Gtk.Align.START)
             row_box.append(vidpid)
 
+            raw_summary = self._raw_device_summary(interfaces)
+            if raw_summary:
+                raw_label = Gtk.Label(label=raw_summary)
+                raw_label.add_css_class("dim-label")
+                raw_label.add_css_class("caption")
+                raw_label.set_halign(Gtk.Align.START)
+                row_box.append(raw_label)
+
+            in_use_summary = self._device_in_use_summary(dev_info)
+            if in_use_summary:
+                in_use = Gtk.Label(label=in_use_summary)
+                in_use.add_css_class("caption")
+                in_use.set_halign(Gtk.Align.START)
+                row_box.append(in_use)
+
             expander: Gtk.Expander | None = None
             if self._should_show_interface_expander(interfaces):
                 interface_expander = Gtk.Expander(label="Evdev devices")
@@ -501,10 +552,11 @@ class HardwareSetupDialog(Adw.Dialog):
                 iface_box.set_margin_start(12)
 
                 for iface in interfaces:
-                    iface_name = Gtk.Label(label=f"- {iface['name']}")
-                    iface_name.add_css_class("caption")
-                    iface_name.set_halign(Gtk.Align.START)
-                    iface_box.append(iface_name)
+                    for detail in self._interface_detail_lines(iface):
+                        iface_detail = Gtk.Label(label=detail)
+                        iface_detail.add_css_class("caption")
+                        iface_detail.set_halign(Gtk.Align.START)
+                        iface_box.append(iface_detail)
 
                 interface_expander.set_child(iface_box)
                 row_box.append(interface_expander)
@@ -557,7 +609,62 @@ class HardwareSetupDialog(Adw.Dialog):
         self._detect_devices()
 
     def _should_show_interface_expander(self, interfaces: list[dict]) -> bool:
-        return not self._show_raw_evdev_devices and len(interfaces) > 1
+        if self._show_raw_evdev_devices:
+            return False
+        return bool(interfaces)
+
+    def _raw_device_summary(self, interfaces: list[dict]) -> str:
+        if not self._show_raw_evdev_devices or not interfaces:
+            return ""
+        iface = interfaces[0]
+        parts = [str(iface.get("path", "") or "")]
+        stable_path = str(iface.get("stable_path", "") or "")
+        if stable_path and stable_path not in parts:
+            parts.append(stable_path)
+        phys = str(iface.get("phys", "") or "")
+        if phys:
+            parts.append(phys)
+        return " · ".join(part for part in parts if part)
+
+    def _device_in_use(self, dev_info: dict) -> bool:
+        return any(
+            bool(iface.get("grabbed_by_keymasq", False))
+            or bool(iface.get("configured_hardware_id", False))
+            for iface in dev_info.get("interfaces", [])
+            if isinstance(iface, dict)
+        )
+
+    def _device_in_use_summary(self, dev_info: dict) -> str:
+        for iface in dev_info.get("interfaces", []):
+            if not isinstance(iface, dict) or not bool(iface.get("grabbed_by_keymasq", False)):
+                configured_hardware_id = str(iface.get("configured_hardware_id", "") or "")
+                if configured_hardware_id:
+                    return f"Configured as {configured_hardware_id}"
+                continue
+            hardware_id = str(iface.get("source_hardware_id", "") or "")
+            interface_id = str(iface.get("source_interface_id", "") or "")
+            if hardware_id and interface_id:
+                return f"In use by {hardware_id} ({interface_id})"
+            if hardware_id:
+                return f"In use by {hardware_id}"
+            return "In use by Keymasq"
+        return ""
+
+    def _interface_detail_lines(self, iface: dict) -> list[str]:
+        lines = [f"- {iface.get('name', '') or iface.get('path', '')}"]
+        path = str(iface.get("path", "") or "")
+        stable_path = str(iface.get("stable_path", "") or "")
+        phys = str(iface.get("phys", "") or "")
+        if path:
+            lines.append(f"  path: {path}")
+        if stable_path and stable_path != path:
+            lines.append(f"  stable: {stable_path}")
+        if phys:
+            lines.append(f"  phys: {phys}")
+        in_use = self._device_in_use_summary({"interfaces": [iface]})
+        if in_use:
+            lines.append(f"  {in_use}")
+        return lines
 
     def _detected_identity_key(
         self,
@@ -583,7 +690,7 @@ class HardwareSetupDialog(Adw.Dialog):
         detected_devices: dict[str, dict],
     ) -> None:
         used_hardware_ids = self._configured_hardware_ids()
-        configured_identity_keys = self._configured_identity_keys()
+        configured_identity_hardware_ids = self._configured_identity_hardware_ids()
         pending_identity_hardware_ids: dict[str, str] = {}
         has_config_inventory = callable(getattr(self.hardware_manager, "list_hardware", None))
 
@@ -614,15 +721,28 @@ class HardwareSetupDialog(Adw.Dialog):
                     phys=phys,
                     path=path,
                 )
-                if identity_key in configured_identity_keys or (
-                    not has_config_inventory and self._hardware_config_exists(vid_pid)
+                configured_hardware_id = configured_identity_hardware_ids.get(identity_key, "")
+                if not self._show_raw_evdev_devices and (
+                    configured_hardware_id
+                    or (not has_config_inventory and self._hardware_config_exists(vid_pid))
                 ):
                     continue
-                hardware_id = pending_identity_hardware_ids.get(identity_key)
-                if hardware_id is None:
-                    hardware_id = self._allocate_hardware_id(vid_pid, used_hardware_ids)
-                    used_hardware_ids.add(hardware_id)
-                    pending_identity_hardware_ids[identity_key] = hardware_id
+                if self._show_raw_evdev_devices and configured_hardware_id:
+                    hardware_id = configured_hardware_id
+                    device_key = _in_use_row_key(hardware_id, path, stable_path)
+                    configured_fields = {"configured_hardware_id": hardware_id}
+                elif self._show_raw_evdev_devices:
+                    hardware_id = vid_pid
+                    device_key = _raw_row_key(path, stable_path)
+                    configured_fields = {}
+                else:
+                    hardware_id = pending_identity_hardware_ids.get(identity_key)
+                    if hardware_id is None:
+                        hardware_id = self._allocate_hardware_id(vid_pid, used_hardware_ids)
+                        used_hardware_ids.add(hardware_id)
+                        pending_identity_hardware_ids[identity_key] = hardware_id
+                    device_key = hardware_id
+                    configured_fields = {}
                 device_type = primary_input_class(device_types)
                 lsusb_entry = lsusb_map.get(vid_pid)
                 display_name = (
@@ -632,8 +752,8 @@ class HardwareSetupDialog(Adw.Dialog):
                     lsusb_entry["name"] if lsusb_entry and lsusb_entry["name"] else device.name
                 )
 
-                if hardware_id not in detected_devices:
-                    detected_devices[hardware_id] = {
+                if device_key not in detected_devices:
+                    detected_devices[device_key] = {
                         "name": human_name,
                         "display_name": display_name,
                         "hardware_id": hardware_id,
@@ -649,12 +769,13 @@ class HardwareSetupDialog(Adw.Dialog):
                                 "phys": phys,
                                 "device_type": device_type,
                                 "device_types": device_types,
+                                **configured_fields,
                             }
                         ],
                     }
                 else:
-                    detected_devices[hardware_id]["paths"].append(path)
-                    detected_devices[hardware_id]["interfaces"].append(
+                    detected_devices[device_key]["paths"].append(path)
+                    detected_devices[device_key]["interfaces"].append(
                         {
                             "path": path,
                             "stable_path": stable_path,
@@ -662,6 +783,7 @@ class HardwareSetupDialog(Adw.Dialog):
                             "phys": phys,
                             "device_type": device_type,
                             "device_types": device_types,
+                            **configured_fields,
                         }
                     )
 
@@ -680,7 +802,7 @@ class HardwareSetupDialog(Adw.Dialog):
             return False
 
         used_hardware_ids = self._configured_hardware_ids()
-        configured_identity_keys = self._configured_identity_keys()
+        configured_identity_hardware_ids = self._configured_identity_hardware_ids()
         pending_identity_hardware_ids: dict[str, str] = {}
         has_config_inventory = callable(getattr(self.hardware_manager, "list_hardware", None))
 
@@ -724,18 +846,38 @@ class HardwareSetupDialog(Adw.Dialog):
                 phys=phys,
                 path=path,
             )
-            if identity_key in configured_identity_keys or (
-                not has_config_inventory and self._hardware_config_exists(vid_pid)
+            configured_hardware_id = configured_identity_hardware_ids.get(identity_key, "")
+            if not self._show_raw_evdev_devices and (
+                configured_hardware_id
+                or (not has_config_inventory and self._hardware_config_exists(vid_pid))
             ):
                 continue
-            hardware_id = pending_identity_hardware_ids.get(identity_key)
-            if hardware_id is None:
-                hardware_id = self._allocate_hardware_id(vid_pid, used_hardware_ids)
-                used_hardware_ids.add(hardware_id)
-                pending_identity_hardware_ids[identity_key] = hardware_id
+            source_fields = _interface_source_fields(dev)
+            is_grabbed = bool(source_fields.get("grabbed_by_keymasq", False))
+            source_hardware_id = str(source_fields.get("source_hardware_id", "") or "")
+            if self._show_raw_evdev_devices and is_grabbed and source_hardware_id:
+                hardware_id = source_hardware_id
+                device_key = _in_use_row_key(hardware_id, path, stable_path)
+                configured_fields: dict[str, object] = {}
+            elif self._show_raw_evdev_devices and configured_hardware_id:
+                hardware_id = configured_hardware_id
+                device_key = _in_use_row_key(hardware_id, path, stable_path)
+                configured_fields = {"configured_hardware_id": hardware_id}
+            elif self._show_raw_evdev_devices:
+                hardware_id = vid_pid
+                device_key = _raw_row_key(path, stable_path)
+                configured_fields = {}
+            else:
+                hardware_id = pending_identity_hardware_ids.get(identity_key)
+                if hardware_id is None:
+                    hardware_id = self._allocate_hardware_id(vid_pid, used_hardware_ids)
+                    used_hardware_ids.add(hardware_id)
+                    pending_identity_hardware_ids[identity_key] = hardware_id
+                device_key = hardware_id
+                configured_fields = {}
 
-            if hardware_id not in detected_devices:
-                detected_devices[hardware_id] = {
+            if device_key not in detected_devices:
+                detected_devices[device_key] = {
                     "name": name,
                     "display_name": name,
                     "hardware_id": hardware_id,
@@ -751,6 +893,8 @@ class HardwareSetupDialog(Adw.Dialog):
                             "phys": phys,
                             "device_type": dtype,
                             "device_types": device_types,
+                            **source_fields,
+                            **configured_fields,
                         }
                     ]
                     if path
@@ -758,8 +902,8 @@ class HardwareSetupDialog(Adw.Dialog):
                 }
             else:
                 if path:
-                    detected_devices[hardware_id]["paths"].append(path)
-                    detected_devices[hardware_id]["interfaces"].append(
+                    detected_devices[device_key]["paths"].append(path)
+                    detected_devices[device_key]["interfaces"].append(
                         {
                             "path": path,
                             "stable_path": stable_path,
@@ -767,6 +911,8 @@ class HardwareSetupDialog(Adw.Dialog):
                             "phys": phys,
                             "device_type": dtype,
                             "device_types": device_types,
+                            **source_fields,
+                            **configured_fields,
                         }
                     )
 
@@ -836,33 +982,39 @@ class HardwareSetupDialog(Adw.Dialog):
         return set()
 
     def _configured_identity_keys(self) -> set[str]:
+        return set(self._configured_identity_hardware_ids())
+
+    def _configured_identity_hardware_ids(self) -> dict[str, str]:
         list_hardware = getattr(self.hardware_manager, "list_hardware", None)
         if not callable(list_hardware):
-            return set()
+            return {}
         try:
             configs = cast(list[object], list_hardware())
         except Exception:
-            return set()
+            return {}
 
-        keys: set[str] = set()
+        keys: dict[str, str] = {}
         for config in configs:
             model_id = str(getattr(config, "model_id", "") or "")
             if not model_id:
                 continue
+            hardware_id = str(getattr(config, "hardware_id", "") or model_id)
             for device in getattr(config, "evdev_devices", []):
                 path = str(getattr(device, "path", "") or "")
                 if not path:
                     continue
                 device_type = getattr(getattr(device, "device_type", None), "value", None)
                 device_types = [str(device_type or "other")]
-                keys.update(self._configured_raw_identity_keys(path))
-                keys.add(
+                for key in self._configured_raw_identity_keys(path):
+                    keys.setdefault(key, hardware_id)
+                keys.setdefault(
                     _logical_hardware_identity_key(
                         model_id=model_id,
                         device_types=device_types,
                         stable_path=self._configured_device_stable_path(path),
                         phys=self._configured_device_phys(device),
-                    )
+                    ),
+                    hardware_id,
                 )
         return keys
 
@@ -938,6 +1090,8 @@ class HardwareSetupDialog(Adw.Dialog):
     def _selected_config_id(self, selected_device: DetectedDevice) -> str | None:
         model_id = f"{selected_device['vendor_id']}:{selected_device['product_id']}"
         hardware_id = str(selected_device.get("hardware_id") or model_id)
+        if self._show_raw_evdev_devices and not self._device_in_use(selected_device):
+            hardware_id = self._allocate_hardware_id(model_id, self._configured_hardware_ids())
         return hardware_id if hardware_id != model_id else None
 
     def _on_device_selected(self, list_box, row) -> None:
@@ -957,7 +1111,7 @@ class HardwareSetupDialog(Adw.Dialog):
 
             self._discover_interfaces()
             self._refresh_configure_modes()
-            self.next_btn.set_sensitive(True)
+            self.next_btn.set_sensitive(not self._device_in_use(self.selected_device))
 
     def _interface_device_types(self, iface: dict) -> list[str]:
         return normalize_input_classes(iface.get("device_types"), iface.get("device_type"))
@@ -1142,16 +1296,8 @@ class HardwareSetupDialog(Adw.Dialog):
             if not raw_path:
                 continue
             stable_path = str(iface.get("stable_path", "") or resolve_stable_path(raw_path))
-            default_config_path = (
-                stable_path
-                if self._show_raw_evdev_devices or is_by_id_path(stable_path)
-                else f"keymasq:{vid}:{pid}"
-            )
-            config_path = str(
-                stable_path
-                if self._show_raw_evdev_devices and not is_by_id_path(stable_path)
-                else iface.get("config_path") or default_config_path
-            )
+            default_config_path = _config_path_for_detected_interface(vid, pid, stable_path)
+            config_path = str(iface.get("config_path") or default_config_path)
             capability_names, raw_capabilities = self._read_interface_capabilities(raw_path)
             interfaces.append(
                 {
@@ -1162,6 +1308,7 @@ class HardwareSetupDialog(Adw.Dialog):
                     "phys": str(iface.get("phys", "") or ""),
                     "capabilities": capability_names,
                     "raw_capabilities": raw_capabilities,
+                    **_interface_source_fields(iface),
                 }
             )
 
@@ -1170,10 +1317,10 @@ class HardwareSetupDialog(Adw.Dialog):
             for iface in interfaces:
                 raw_path = str(iface.get("path", "") or "")
                 stable_path = str(iface.get("stable_path", "") or raw_path)
-                iface["config_path"] = (
-                    stable_path
-                    if self._show_raw_evdev_devices or is_by_id_path(stable_path)
-                    else f"keymasq:{vid}:{pid}"
+                iface["config_path"] = _config_path_for_detected_interface(
+                    vid,
+                    pid,
+                    stable_path,
                 )
         iface_info_by_path = {
             iface.get("path"): {
@@ -1205,6 +1352,7 @@ class HardwareSetupDialog(Adw.Dialog):
                 "path": iface["path"],
                 "name": iface["name"],
                 "phys": str(iface.get("phys", "") or ""),
+                **_interface_source_fields(iface),
                 "device_type": iface_info_by_path.get(iface["path"], {}).get(
                     "device_type",
                     DeviceType.OTHER,

--- a/keymasq/gui/wizards/hardware_setup.py
+++ b/keymasq/gui/wizards/hardware_setup.py
@@ -27,6 +27,7 @@ from keymasq.common.devices import (
     gamepad_button_label,
     get_interface_id,
     input_class_label,
+    is_by_id_path,
     is_low_res_wheel_evdev,
     normalize_input_classes,
     ordered_gamepad_button_names,
@@ -100,6 +101,41 @@ def _by_id_device_stem(stable_path: str) -> str:
 
 def _looks_like_by_id_path(stable_path: str) -> bool:
     return "/by-id/" in str(stable_path or "")
+
+
+def _fallback_interface_id_for_type(device_type: DeviceType) -> str:
+    if device_type == DeviceType.GAMEPAD:
+        return "gamepad"
+    if device_type == DeviceType.KEYBOARD:
+        return "kbd"
+    if device_type == DeviceType.MOUSE:
+        return "mouse"
+    return "input"
+
+
+def _dedupe_interface_id(base_id: str, used_ids: set[str]) -> str:
+    clean = re.sub(r"[^a-zA-Z0-9_]+", "_", str(base_id or "").strip().lower()).strip("_")
+    candidate = clean or "input"
+    if candidate not in used_ids:
+        used_ids.add(candidate)
+        return candidate
+    index = 2
+    while f"{candidate}_{index}" in used_ids:
+        index += 1
+    deduped = f"{candidate}_{index}"
+    used_ids.add(deduped)
+    return deduped
+
+
+def _interface_id_for_config(iface: dict, used_ids: set[str]) -> str:
+    stable_path = str(iface.get("stable_path", "") or "")
+    config_path = str(iface.get("config_path", "") or "")
+    if is_by_id_path(stable_path) or is_by_id_path(config_path):
+        return _dedupe_interface_id(get_interface_id(stable_path or config_path), used_ids)
+    return _dedupe_interface_id(
+        _fallback_interface_id_for_type(primary_input_class(iface.get("device_types"))),
+        used_ids,
+    )
 
 
 def _logical_hardware_identity_key(
@@ -1105,12 +1141,22 @@ class HardwareSetupDialog(Adw.Dialog):
             if not raw_path:
                 continue
             stable_path = str(iface.get("stable_path", "") or resolve_stable_path(raw_path))
+            default_config_path = (
+                stable_path
+                if self._show_raw_evdev_devices or is_by_id_path(stable_path)
+                else f"keymasq:{vid}:{pid}"
+            )
+            config_path = str(
+                stable_path
+                if self._show_raw_evdev_devices and not is_by_id_path(stable_path)
+                else iface.get("config_path") or default_config_path
+            )
             capability_names, raw_capabilities = self._read_interface_capabilities(raw_path)
             interfaces.append(
                 {
                     "path": raw_path,
                     "stable_path": stable_path,
-                    "id": get_interface_id(stable_path),
+                    "config_path": config_path,
                     "name": str(iface.get("name", "") or raw_path),
                     "phys": str(iface.get("phys", "") or ""),
                     "capabilities": capability_names,
@@ -1120,6 +1166,14 @@ class HardwareSetupDialog(Adw.Dialog):
 
         if not interfaces:
             interfaces = find_all_interfaces(vid, pid)
+            for iface in interfaces:
+                raw_path = str(iface.get("path", "") or "")
+                stable_path = str(iface.get("stable_path", "") or raw_path)
+                iface["config_path"] = (
+                    stable_path
+                    if self._show_raw_evdev_devices or is_by_id_path(stable_path)
+                    else f"keymasq:{vid}:{pid}"
+                )
         iface_info_by_path = {
             iface.get("path"): {
                 "device_type": iface.get("device_type", DeviceType.OTHER),
@@ -1127,8 +1181,16 @@ class HardwareSetupDialog(Adw.Dialog):
             }
             for iface in self.selected_device.get("interfaces", [])
         }
+        used_interface_ids: set[str] = set()
         for iface in interfaces:
-            raw_iface_id = str(iface.get("id", "") or "default")
+            merged_iface = {
+                **iface,
+                "device_types": iface_info_by_path.get(iface["path"], {}).get(
+                    "device_types",
+                    iface.get("device_types", ["other"]),
+                ),
+            }
+            raw_iface_id = _interface_id_for_config(merged_iface, used_interface_ids)
             iface_key = raw_iface_id
             duplicate_index = 2
             while iface_key in self.discovered_interfaces:
@@ -1138,6 +1200,7 @@ class HardwareSetupDialog(Adw.Dialog):
             self.discovered_interfaces[iface_key] = {
                 "id": raw_iface_id,
                 "stable_path": iface["stable_path"],
+                "config_path": str(iface.get("config_path") or iface["stable_path"]),
                 "path": iface["path"],
                 "name": iface["name"],
                 "phys": str(iface.get("phys", "") or ""),
@@ -1331,14 +1394,45 @@ class HardwareSetupDialog(Adw.Dialog):
         self._capture_remaining_ids = [
             btn["id"] for btn in self.button_definitions[self.current_button_index :]
         ]
+        capture_interfaces = [
+            iface
+            for iface in self.discovered_interfaces.values()
+            if str(
+                iface.get("config_path")
+                or iface.get("stable_path")
+                or iface.get("path")
+                or ""
+            )
+        ]
         session_request_async(
             {
                 "command": "begin_capture",
                 "hardware_id": self._capture_hardware_id,
                 "evdev_paths": [
-                    str(iface.get("stable_path") or iface.get("path") or "")
-                    for iface in self.discovered_interfaces.values()
-                    if str(iface.get("stable_path") or iface.get("path") or "")
+                    str(
+                        iface.get("config_path")
+                        or iface.get("stable_path")
+                        or iface.get("path")
+                        or ""
+                    )
+                    for iface in capture_interfaces
+                ],
+                "evdev_interfaces": [
+                    {
+                        "id": str(iface.get("id", "") or ""),
+                        "path": str(
+                            iface.get("config_path")
+                            or iface.get("stable_path")
+                            or iface.get("path")
+                            or ""
+                        ),
+                        "type": str(
+                            primary_input_class(iface.get("device_types")).value
+                        ),
+                        "phys": str(iface.get("phys", "") or ""),
+                        "capabilities": list(iface.get("capabilities", [])),
+                    }
+                    for iface in capture_interfaces
                 ],
             },
             self._on_capture_begin_response,
@@ -1501,9 +1595,16 @@ class HardwareSetupDialog(Adw.Dialog):
         source_to_interface = {}
         for btn_def in self.button_definitions:
             source = btn_def.get("source")
-            stable_path = btn_def.get("stable_path")
-            if source and stable_path:
-                source_to_interface[source] = stable_path
+            source_iface = self.discovered_interfaces.get(str(source or ""))
+            config_path = (
+                source_iface.get("config_path")
+                or source_iface.get("stable_path")
+                or source_iface.get("path")
+                if isinstance(source_iface, dict)
+                else btn_def.get("stable_path")
+            )
+            if source and config_path:
+                source_to_interface[source] = config_path
 
         discovered_by_source = {
             str(iface.get("id", "") or ""): iface for iface in self.discovered_interfaces.values()
@@ -1522,6 +1623,7 @@ class HardwareSetupDialog(Adw.Dialog):
                     device_type=device_type,
                     id=iface_id,
                     phys=str(iface_info.get("phys", "") or "") or None,
+                    capabilities=list(iface_info.get("capabilities", [])),
                 )
             )
 
@@ -1708,8 +1810,10 @@ class HardwareSetupDialog(Adw.Dialog):
         for interface_list in interface_lists:
             for iface in interface_list:
                 iface_id = str(iface.get("id", "") or "")
-                stable_path = str(iface.get("stable_path", "") or "")
-                key = (iface_id, stable_path)
+                config_path = str(
+                    iface.get("config_path", "") or iface.get("stable_path", "") or ""
+                )
+                key = (iface_id, config_path)
                 if key in seen_keys:
                     continue
                 seen_keys.add(key)
@@ -1734,13 +1838,13 @@ class HardwareSetupDialog(Adw.Dialog):
     def _build_evdev_devices(self, interfaces: list[dict]) -> list[EvdevDevice]:
         evdev_devices = []
         for iface in interfaces:
-            stable_path = str(iface.get("stable_path", "") or "")
+            config_path = str(iface.get("config_path", "") or iface.get("stable_path", "") or "")
             iface_id = str(iface.get("id", "") or "")
-            if not stable_path or not iface_id:
+            if not config_path or not iface_id:
                 continue
             evdev_devices.append(
                 EvdevDevice(
-                    path=stable_path,
+                    path=config_path,
                     device_type=primary_input_class(iface.get("device_types")),
                     id=iface_id,
                     phys=str(iface.get("phys", "") or "") or None,
@@ -1945,14 +2049,14 @@ class HardwareSetupDialog(Adw.Dialog):
 
         evdev_devices = []
         for iface in gamepad_interfaces:
-            stable_path = str(iface.get("stable_path", "") or "")
+            config_path = str(iface.get("config_path", "") or iface.get("stable_path", "") or "")
             iface_id = str(iface.get("id", "") or "")
-            if not stable_path or not iface_id:
+            if not config_path or not iface_id:
                 continue
             dev_type = primary_input_class(iface.get("device_types"))
             evdev_devices.append(
                 EvdevDevice(
-                    path=stable_path,
+                    path=config_path,
                     device_type=dev_type,
                     id=iface_id,
                     phys=str(iface.get("phys", "") or "") or None,

--- a/keymasq/gui/wizards/hardware_setup.py
+++ b/keymasq/gui/wizards/hardware_setup.py
@@ -636,7 +636,9 @@ class HardwareSetupDialog(Adw.Dialog):
 
     def _device_in_use_summary(self, dev_info: dict) -> str:
         for iface in dev_info.get("interfaces", []):
-            if not isinstance(iface, dict) or not bool(iface.get("grabbed_by_keymasq", False)):
+            if not isinstance(iface, dict):
+                continue
+            if not bool(iface.get("grabbed_by_keymasq", False)):
                 configured_hardware_id = str(iface.get("configured_hardware_id", "") or "")
                 if configured_hardware_id:
                     return f"Configured as {configured_hardware_id}"

--- a/keymasq/gui/wizards/hardware_setup.py
+++ b/keymasq/gui/wizards/hardware_setup.py
@@ -634,7 +634,8 @@ class HardwareSetupDialog(Adw.Dialog):
             if isinstance(iface, dict)
         )
 
-    def _device_in_use_summary(self, dev_info: dict) -> str:
+    @staticmethod
+    def _device_in_use_summary(dev_info: dict) -> str:
         for iface in dev_info.get("interfaces", []):
             if not isinstance(iface, dict):
                 continue
@@ -1747,13 +1748,15 @@ class HardwareSetupDialog(Adw.Dialog):
         for btn_def in self.button_definitions:
             source = btn_def.get("source")
             source_iface = self.discovered_interfaces.get(str(source or ""))
-            config_path = (
-                source_iface.get("config_path")
-                or source_iface.get("stable_path")
-                or source_iface.get("path")
-                if isinstance(source_iface, dict)
-                else btn_def.get("stable_path")
-            )
+            if isinstance(source_iface, dict):
+                config_path = (
+                    source_iface.get("config_path")
+                    or source_iface.get("stable_path")
+                    or source_iface.get("path")
+                    or btn_def.get("stable_path")
+                )
+            else:
+                config_path = btn_def.get("stable_path")
             if source and config_path:
                 source_to_interface[source] = config_path
 

--- a/keymasq/gui/wizards/hardware_setup.py
+++ b/keymasq/gui/wizards/hardware_setup.py
@@ -181,6 +181,7 @@ def _logical_hardware_identity_key(
     device_types: list[str],
     stable_path: str,
     phys: str = "",
+    path: str = "",
 ) -> str:
     normalized_types = normalize_input_classes(device_types)
     if "gamepad" in normalized_types and _looks_like_by_id_path(stable_path):
@@ -192,6 +193,9 @@ def _logical_hardware_identity_key(
         return f"uinput-model:{model_id}"
     if phys_base and not _is_usb_phys(phys_base):
         return f"phys:{phys_base}"
+    path_key = str(stable_path or path or "").strip()
+    if path_key:
+        return f"path:{path_key}"
     return f"model:{model_id}"
 
 
@@ -685,6 +689,7 @@ class HardwareSetupDialog(Adw.Dialog):
             device_types=device_types,
             stable_path=stable_path,
             phys=phys,
+            path=path,
         )
 
     def _detect_devices_locally(
@@ -1016,6 +1021,7 @@ class HardwareSetupDialog(Adw.Dialog):
                         device_types=device_types,
                         stable_path=self._configured_device_stable_path(path),
                         phys=self._configured_device_phys(device),
+                        path=path,
                     ),
                     hardware_id,
                 )
@@ -1833,12 +1839,16 @@ class HardwareSetupDialog(Adw.Dialog):
             return
 
         keyboard_interfaces = self._interfaces_for_roles({"keyboard"})
+        interfaces = self._merge_interface_lists(
+            keyboard_interfaces,
+            list(self.discovered_interfaces.values()),
+        )
 
         primary_keyboard_source = ""
         if keyboard_interfaces:
             primary_keyboard_source = str(keyboard_interfaces[0].get("id", "") or "")
 
-        evdev_devices = self._build_evdev_devices(keyboard_interfaces)
+        evdev_devices = self._build_evdev_devices(interfaces)
 
         buttons = self._build_standard_keyboard_buttons(primary_keyboard_source)
 
@@ -1861,6 +1871,10 @@ class HardwareSetupDialog(Adw.Dialog):
             return
 
         mouse_interfaces = self._interfaces_for_roles({"mouse", "pointstick"})
+        interfaces = self._merge_interface_lists(
+            mouse_interfaces,
+            list(self.discovered_interfaces.values()),
+        )
         primary_mouse_source = ""
         if mouse_interfaces:
             primary_mouse_source = str(mouse_interfaces[0].get("id", "") or "")
@@ -1869,7 +1883,7 @@ class HardwareSetupDialog(Adw.Dialog):
             vendor_id=selected_device["vendor_id"],
             product_id=selected_device["product_id"],
             name=selected_device["name"],
-            evdev_devices=self._build_evdev_devices(mouse_interfaces),
+            evdev_devices=self._build_evdev_devices(interfaces),
             buttons=self._build_standard_mouse_buttons(
                 primary_mouse_source,
                 include_horizontal=self._interfaces_have_capability(
@@ -1900,7 +1914,11 @@ class HardwareSetupDialog(Adw.Dialog):
         if mouse_interfaces:
             primary_mouse_source = str(mouse_interfaces[0].get("id", "") or "")
 
-        interfaces = self._merge_interface_lists(mouse_interfaces, keyboard_interfaces)
+        interfaces = self._merge_interface_lists(
+            mouse_interfaces,
+            keyboard_interfaces,
+            list(self.discovered_interfaces.values()),
+        )
         buttons = self._build_standard_mouse_buttons(
             primary_mouse_source,
             include_horizontal=self._interfaces_have_capability(
@@ -2200,29 +2218,16 @@ class HardwareSetupDialog(Adw.Dialog):
             return
 
         gamepad_interfaces = self._gamepad_interfaces()
-
-        evdev_devices = []
-        for iface in gamepad_interfaces:
-            config_path = str(iface.get("config_path", "") or iface.get("stable_path", "") or "")
-            iface_id = str(iface.get("id", "") or "")
-            if not config_path or not iface_id:
-                continue
-            dev_type = primary_input_class(iface.get("device_types"))
-            evdev_devices.append(
-                EvdevDevice(
-                    path=config_path,
-                    device_type=dev_type,
-                    id=iface_id,
-                    phys=str(iface.get("phys", "") or "") or None,
-                    capabilities=list(iface.get("capabilities", [])),
-                )
-            )
+        interfaces = self._merge_interface_lists(
+            gamepad_interfaces,
+            list(self.discovered_interfaces.values()),
+        )
 
         config = HardwareConfig(
             vendor_id=selected_device["vendor_id"],
             product_id=selected_device["product_id"],
             name=selected_device["name"],
-            evdev_devices=evdev_devices,
+            evdev_devices=self._build_evdev_devices(interfaces),
             buttons=self._build_gamepad_buttons(gamepad_interfaces),
             analog_inputs=self._build_gamepad_analog_inputs(gamepad_interfaces),
             id=self._selected_config_id(selected_device),

--- a/keymasq/keymasqd/capture_manager.py
+++ b/keymasq/keymasqd/capture_manager.py
@@ -16,11 +16,14 @@ import evdev
 
 from keymasq.common.devices import (
     clear_device_path_cache,
+    detect_input_classes,
     get_interface_id,
     normalize_wheel_value,
+    primary_input_class,
     resolve_stable_path,
     wheel_button_id,
 )
+from keymasq.keymasqd.runtime import device_path_resolver
 
 log = logging.getLogger("keymasq.keymasqd.capture_manager")
 type JsonObject = dict[str, object]
@@ -49,6 +52,8 @@ class _CaptureInputDevice(Protocol):
 
     def capabilities(self) -> Mapping[int, Sequence[object]]: ...
 
+    def input_props(self) -> Iterable[int]: ...
+
     def absinfo(self, axis: int) -> object: ...
 
 
@@ -74,6 +79,7 @@ class CaptureSession:
     notify_loop: asyncio.AbstractEventLoop | None = None
     notify_event: asyncio.Event | None = None
     path_hardware_ids: dict[str, str] = field(default_factory=dict)
+    path_sources: dict[str, str] = field(default_factory=dict)
     mode: str = "button"
 
 
@@ -91,14 +97,17 @@ class CaptureManager:
         self,
         hardware_id: str,
         evdev_paths: list[str] | None = None,
+        evdev_interfaces: list[JsonObject] | None = None,
         mode: str = "button",
     ) -> JsonObject:
         mode = _capture_mode(mode)
-        matched = (
-            self._find_devices_by_paths(evdev_paths)
-            if evdev_paths
-            else self._find_devices(*self._parse_hardware_id(hardware_id))
-        )
+        path_sources: dict[str, str] = {}
+        if evdev_interfaces:
+            matched, path_sources = self._find_devices_by_interfaces(evdev_interfaces)
+        elif evdev_paths:
+            matched = self._find_devices_by_paths(evdev_paths)
+        else:
+            matched = self._find_devices(*self._parse_hardware_id(hardware_id))
         if not matched:
             raise ValueError(f"No devices found for {hardware_id}")
 
@@ -125,6 +134,7 @@ class CaptureManager:
             hardware_id=hardware_id,
             devices=grabbed,
             started_at=time.time(),
+            path_sources=path_sources,
             mode=mode,
         )
 
@@ -148,7 +158,7 @@ class CaptureManager:
             if event is None:
                 continue
 
-            parsed = self._parse_event(device, event, session.mode)
+            parsed = self._parse_event(device, event, session.mode, session.path_sources)
             if parsed is not None:
                 return {"captured": parsed}
 
@@ -161,12 +171,19 @@ class CaptureManager:
         allow_empty: bool = False,
         hardware_ids: set[str] | None = None,
         hardware_paths: Mapping[str, Sequence[str]] | None = None,
+        hardware_interfaces: Mapping[str, Sequence[JsonObject]] | None = None,
         authorization: _ComboCaptureAuthorization | None = None,
     ) -> JsonObject:
         if not self._consume_combo_capture_authorization(authorization):
             raise PermissionError("combo_capture_denied: missing authorization")
 
-        path_hardware_ids = _hardware_path_lookup(hardware_paths or {})
+        path_sources: dict[str, str] = {}
+        if hardware_interfaces:
+            path_hardware_ids, path_sources = self._hardware_interface_lookup(
+                hardware_interfaces
+            )
+        else:
+            path_hardware_ids = _hardware_path_lookup(hardware_paths or {})
         matched = self._find_combo_devices(
             exclude_paths=exclude_paths or set(),
             hardware_ids=hardware_ids or set(),
@@ -195,6 +212,7 @@ class CaptureManager:
             event_queue=queue.SimpleQueue(),
             stop_event=threading.Event(),
             path_hardware_ids=path_hardware_ids,
+            path_sources=path_sources,
         )
         self._sessions[token] = session
         self._start_combo_reader(session)
@@ -252,7 +270,7 @@ class CaptureManager:
             if event is None:
                 continue
 
-            parsed = self._parse_combo_event(device, event)
+            parsed = self._parse_combo_event(device, event, path_sources=session.path_sources)
             if parsed is not None:
                 return {"event": parsed}
 
@@ -343,6 +361,7 @@ class CaptureManager:
                             device,
                             event,
                             session.path_hardware_ids,
+                            session.path_sources,
                         )
                         if parsed is None:
                             continue
@@ -411,6 +430,63 @@ class CaptureManager:
                 continue
         return devices
 
+    def _find_devices_by_interfaces(
+        self,
+        evdev_interfaces: list[JsonObject],
+    ) -> tuple[list[_CaptureInputDevice], dict[str, str]]:
+        clear_device_path_cache()
+        list_devices = cast(Callable[[], list[str]], evdev.list_devices)
+        resolved = device_path_resolver.resolve_evdev_interfaces(
+            evdev_interfaces,
+            device_paths_fn=list_devices,
+            device_input_fn=lambda path: cast(
+                device_path_resolver.InputDeviceLike,
+                evdev.InputDevice(path),
+            ),
+            detect_input_classes_fn=detect_input_classes,
+            primary_input_class_fn=primary_input_class,
+        )
+        devices: list[_CaptureInputDevice] = []
+        path_sources: dict[str, str] = {}
+        for interface in resolved:
+            try:
+                device = cast(_CaptureInputDevice, evdev.InputDevice(interface.path))
+                devices.append(device)
+                if interface.interface_id:
+                    path_sources[device.path] = interface.interface_id
+            except Exception:
+                continue
+        return devices, path_sources
+
+    def _hardware_interface_lookup(
+        self,
+        hardware_interfaces: Mapping[str, Sequence[JsonObject]],
+    ) -> tuple[dict[str, str], dict[str, str]]:
+        path_hardware_ids: dict[str, str] = {}
+        path_sources: dict[str, str] = {}
+        clear_device_path_cache()
+        list_devices = cast(Callable[[], list[str]], evdev.list_devices)
+        for hardware_id, interfaces in hardware_interfaces.items():
+            normalized_hardware_id = str(hardware_id or "").lower()
+            if not normalized_hardware_id:
+                continue
+            resolved = device_path_resolver.resolve_evdev_interfaces(
+                list(interfaces),
+                device_paths_fn=list_devices,
+                device_input_fn=lambda path: cast(
+                    device_path_resolver.InputDeviceLike,
+                    evdev.InputDevice(path),
+                ),
+                detect_input_classes_fn=detect_input_classes,
+                primary_input_class_fn=primary_input_class,
+            )
+            for interface in resolved:
+                for alias in _path_aliases(interface.path):
+                    path_hardware_ids[alias] = normalized_hardware_id
+                    if interface.interface_id:
+                        path_sources[alias] = interface.interface_id
+        return path_hardware_ids, path_sources
+
     def _find_combo_devices(
         self,
         exclude_paths: set[str],
@@ -464,6 +540,7 @@ class CaptureManager:
         device: _CaptureInputDevice,
         event: evdev.InputEvent,
         mode: str = "button",
+        path_sources: Mapping[str, str] | None = None,
     ) -> JsonObject | None:
         if mode == "analog":
             if event.type != evdev.ecodes.EV_ABS:
@@ -473,7 +550,7 @@ class CaptureManager:
                 "evdev": evdev_name,
                 "code": int(event.code),
                 "value": int(event.value),
-                "source": self._source_for_path(device.path),
+                "source": self._source_for_device(device, path_sources),
                 "stable_path": resolve_stable_path(device.path),
                 "device_path": device.path,
             }
@@ -487,7 +564,7 @@ class CaptureManager:
             return {
                 "evdev": evdev_name,
                 "code": int(event.code),
-                "source": self._source_for_path(device.path),
+                "source": self._source_for_device(device, path_sources),
                 "stable_path": resolve_stable_path(device.path),
                 "device_path": device.path,
             }
@@ -503,7 +580,7 @@ class CaptureManager:
                     "code": int(event.code),
                     "direction": direction,
                     "value": value,
-                    "source": self._source_for_path(device.path),
+                    "source": self._source_for_device(device, path_sources),
                     "stable_path": resolve_stable_path(device.path),
                     "device_path": device.path,
                 }
@@ -517,7 +594,7 @@ class CaptureManager:
                     "code": int(event.code),
                     "direction": direction,
                     "value": value,
-                    "source": self._source_for_path(device.path),
+                    "source": self._source_for_device(device, path_sources),
                     "stable_path": resolve_stable_path(device.path),
                     "device_path": device.path,
                 }
@@ -529,6 +606,7 @@ class CaptureManager:
         device: _CaptureInputDevice,
         event: evdev.InputEvent,
         path_hardware_ids: Mapping[str, str] | None = None,
+        path_sources: Mapping[str, str] | None = None,
     ) -> JsonObject | None:
         hardware_id = _hardware_id_for_device(device, path_hardware_ids or {})
         if event.type == evdev.ecodes.EV_REL:
@@ -547,7 +625,7 @@ class CaptureManager:
                 "code": int(event.code),
                 "value": 1,
                 "hardware_id": hardware_id,
-                "source": self._source_for_path(device.path),
+                "source": self._source_for_device(device, path_sources),
                 "stable_path": resolve_stable_path(device.path),
                 "device_path": device.path,
             }
@@ -563,10 +641,20 @@ class CaptureManager:
             "code": int(event.code),
             "value": int(event.value),
             "hardware_id": hardware_id,
-            "source": self._source_for_path(device.path),
+            "source": self._source_for_device(device, path_sources),
             "stable_path": resolve_stable_path(device.path),
             "device_path": device.path,
         }
+
+    def _source_for_device(
+        self,
+        device: _CaptureInputDevice,
+        path_sources: Mapping[str, str] | None,
+    ) -> str:
+        configured = str((path_sources or {}).get(device.path, "") or "")
+        if configured:
+            return configured
+        return self._source_for_path(device.path)
 
     def _source_for_path(self, device_path: str) -> str:
         stable_path = resolve_stable_path(device_path)

--- a/keymasq/keymasqd/capture_manager.py
+++ b/keymasq/keymasqd/capture_manager.py
@@ -57,6 +57,20 @@ class _CaptureInputDevice(Protocol):
     def absinfo(self, axis: int) -> object: ...
 
 
+def _device_path_resolver_deps() -> device_path_resolver.DevicePathResolverDeps:
+    list_devices = cast(Callable[[], list[str]], evdev.list_devices)
+    return device_path_resolver.DevicePathResolverDeps(
+        device_paths_fn=list_devices,
+        device_input_fn=lambda path: cast(
+            device_path_resolver.InputDeviceLike,
+            evdev.InputDevice(path),
+        ),
+        detect_input_classes_fn=detect_input_classes,
+        primary_input_class_fn=primary_input_class,
+        resolve_stable_path_fn=resolve_stable_path,
+    )
+
+
 def _event_code_name(event_type: int, code: int) -> str:
     bytype = cast(dict[int, dict[int, object]], evdev.ecodes.bytype)
     code_name = bytype.get(event_type, {}).get(code, str(code))
@@ -439,17 +453,10 @@ class CaptureManager:
         evdev_interfaces: list[JsonObject],
     ) -> tuple[list[_CaptureInputDevice], dict[str, str]]:
         clear_device_path_cache()
-        list_devices = cast(Callable[[], list[str]], evdev.list_devices)
         resolved = device_path_resolver.resolve_evdev_interfaces(
             evdev_interfaces,
+            deps=_device_path_resolver_deps(),
             hardware_id=hardware_id,
-            device_paths_fn=list_devices,
-            device_input_fn=lambda path: cast(
-                device_path_resolver.InputDeviceLike,
-                evdev.InputDevice(path),
-            ),
-            detect_input_classes_fn=detect_input_classes,
-            primary_input_class_fn=primary_input_class,
         )
         devices: list[_CaptureInputDevice] = []
         path_sources: dict[str, str] = {}
@@ -470,21 +477,15 @@ class CaptureManager:
         path_hardware_ids: dict[str, str] = {}
         path_sources: dict[str, str] = {}
         clear_device_path_cache()
-        list_devices = cast(Callable[[], list[str]], evdev.list_devices)
+        deps = _device_path_resolver_deps()
         for hardware_id, interfaces in hardware_interfaces.items():
             normalized_hardware_id = str(hardware_id or "").lower()
             if not normalized_hardware_id:
                 continue
             resolved = device_path_resolver.resolve_evdev_interfaces(
                 list(interfaces),
+                deps=deps,
                 hardware_id=normalized_hardware_id,
-                device_paths_fn=list_devices,
-                device_input_fn=lambda path: cast(
-                    device_path_resolver.InputDeviceLike,
-                    evdev.InputDevice(path),
-                ),
-                detect_input_classes_fn=detect_input_classes,
-                primary_input_class_fn=primary_input_class,
             )
             for interface in resolved:
                 for alias in _path_aliases(interface.path):

--- a/keymasq/keymasqd/capture_manager.py
+++ b/keymasq/keymasqd/capture_manager.py
@@ -103,7 +103,10 @@ class CaptureManager:
         mode = _capture_mode(mode)
         path_sources: dict[str, str] = {}
         if evdev_interfaces:
-            matched, path_sources = self._find_devices_by_interfaces(evdev_interfaces)
+            matched, path_sources = self._find_devices_by_interfaces(
+                hardware_id,
+                evdev_interfaces,
+            )
         elif evdev_paths:
             matched = self._find_devices_by_paths(evdev_paths)
         else:
@@ -432,12 +435,14 @@ class CaptureManager:
 
     def _find_devices_by_interfaces(
         self,
+        hardware_id: str,
         evdev_interfaces: list[JsonObject],
     ) -> tuple[list[_CaptureInputDevice], dict[str, str]]:
         clear_device_path_cache()
         list_devices = cast(Callable[[], list[str]], evdev.list_devices)
         resolved = device_path_resolver.resolve_evdev_interfaces(
             evdev_interfaces,
+            hardware_id=hardware_id,
             device_paths_fn=list_devices,
             device_input_fn=lambda path: cast(
                 device_path_resolver.InputDeviceLike,
@@ -472,6 +477,7 @@ class CaptureManager:
                 continue
             resolved = device_path_resolver.resolve_evdev_interfaces(
                 list(interfaces),
+                hardware_id=normalized_hardware_id,
                 device_paths_fn=list_devices,
                 device_input_fn=lambda path: cast(
                     device_path_resolver.InputDeviceLike,

--- a/keymasq/keymasqd/capture_manager.py
+++ b/keymasq/keymasqd/capture_manager.py
@@ -489,6 +489,8 @@ class CaptureManager:
             )
             for interface in resolved:
                 for alias in _path_aliases(interface.path):
+                    if alias in path_hardware_ids:
+                        continue
                     path_hardware_ids[alias] = normalized_hardware_id
                     if interface.interface_id:
                         path_sources[alias] = interface.interface_id

--- a/keymasq/keymasqd/daemon.py
+++ b/keymasq/keymasqd/daemon.py
@@ -86,6 +86,7 @@ class _DaemonDeviceManager(Protocol):
         button_values: dict[str, int] | None = None,
         analog_inputs: JsonObject | None = None,
         force_grab_unmapped: bool = False,
+        evdev_interfaces: list[JsonObject] | None = None,
     ) -> JsonObject: ...
 
     async def release_device(

--- a/keymasq/keymasqd/daemon_capture_commands.py
+++ b/keymasq/keymasqd/daemon_capture_commands.py
@@ -51,6 +51,7 @@ class _CaptureCommandCaptureManager(Protocol):
         self,
         hardware_id: str,
         evdev_paths: list[str] | None = None,
+        evdev_interfaces: JsonObjectList | None = None,
         mode: str = "button",
     ) -> JsonObject: ...
 
@@ -100,23 +101,23 @@ async def handle_capture_command(
     if command_type == CommandType.CAPTURE_BEGIN:
         hardware_id = str(data.get("hardware_id", ""))
         evdev_paths = str_list(data.get("evdev_paths", []))
+        evdev_interfaces = json_object_list(data.get("evdev_interfaces", []))
         mode = str(data.get("mode", "button") or "button")
-        if evdev_paths:
-            if mode == "button":
-                return await asyncio.to_thread(
-                    daemon.capture_manager.begin,
-                    hardware_id,
-                    evdev_paths,
-                )
+        if evdev_paths and not evdev_interfaces and mode == "button":
             return await asyncio.to_thread(
                 daemon.capture_manager.begin,
                 hardware_id,
                 evdev_paths,
-                mode,
             )
-        if mode == "button":
+        if not evdev_paths and not evdev_interfaces and mode == "button":
             return await asyncio.to_thread(daemon.capture_manager.begin, hardware_id)
-        return await asyncio.to_thread(daemon.capture_manager.begin, hardware_id, None, mode)
+        return await asyncio.to_thread(
+            daemon.capture_manager.begin,
+            hardware_id,
+            evdev_paths=evdev_paths or None,
+            evdev_interfaces=evdev_interfaces or None,
+            mode=mode,
+        )
 
     if command_type == CommandType.CAPTURE_READ:
         token = str(data.get("token", ""))
@@ -133,8 +134,15 @@ async def handle_capture_command(
             if str(hardware_id).strip()
         }
         hardware_paths = _hardware_paths(data.get("hardware_paths", {}))
+        hardware_interfaces = _hardware_interfaces(data.get("hardware_interfaces", {}))
         timeout_s = float_like(data.get("timeout_s", 15.0), 15.0)
-        return await capture_combo(daemon, hardware_ids, timeout_s, hardware_paths)
+        return await capture_combo(
+            daemon,
+            hardware_ids,
+            timeout_s,
+            hardware_paths,
+            hardware_interfaces,
+        )
 
     return None
 
@@ -161,6 +169,7 @@ async def capture_combo(
     hardware_ids: set[str],
     timeout_s: float,
     hardware_paths: dict[str, list[str]] | None = None,
+    hardware_interfaces: dict[str, JsonObjectList] | None = None,
 ) -> JsonObject:
     if not hardware_ids:
         raise ValueError("capture_combo requires at least one hardware_id")
@@ -185,6 +194,7 @@ async def capture_combo(
             hardware_ids,
             authorization=authorization,
             hardware_paths=hardware_paths or {},
+            hardware_interfaces=hardware_interfaces or {},
         )
         daemon.capture_manager.register_combo_notifier(token, loop, notify_event)
         warnings = str_list(capture_result.get("warnings", []))
@@ -275,6 +285,20 @@ def _hardware_paths(value: object) -> dict[str, list[str]]:
             path_values = str_list(paths)
         if path_values:
             result[normalized] = path_values
+    return result
+
+
+def _hardware_interfaces(value: object) -> dict[str, JsonObjectList]:
+    if not isinstance(value, dict):
+        return {}
+    result: dict[str, JsonObjectList] = {}
+    for hardware_id, interfaces in cast(dict[object, object], value).items():
+        normalized = str(hardware_id or "").lower()
+        if not normalized:
+            continue
+        interface_values = json_object_list(interfaces)
+        if interface_values:
+            result[normalized] = interface_values
     return result
 
 

--- a/keymasq/keymasqd/daemon_device_commands.py
+++ b/keymasq/keymasqd/daemon_device_commands.py
@@ -25,6 +25,7 @@ class _DeviceCommandManager(Protocol):
         button_values: dict[str, int] | None = None,
         analog_inputs: JsonObject | None = None,
         force_grab_unmapped: bool = False,
+        evdev_interfaces: list[JsonObject] | None = None,
     ) -> JsonObject: ...
 
     async def release_device(
@@ -103,6 +104,7 @@ async def handle_device_command(
             button_values=int_dict(data.get("button_values", {})),
             analog_inputs=json_object(data.get("analog_inputs", {})),
             force_grab_unmapped=bool(data.get("force_grab_unmapped", False)),
+            evdev_interfaces=json_object_list(data.get("evdev_interfaces", [])),
         )
 
     if command_type == CommandType.RELEASE_DEVICE:

--- a/keymasq/keymasqd/device_manager.py
+++ b/keymasq/keymasqd/device_manager.py
@@ -47,6 +47,7 @@ from keymasq.keymasqd.recording import RecordingManager
 from keymasq.keymasqd.runtime import actions as runtime_actions
 from keymasq.keymasqd.runtime import adapters as runtime_adapters
 from keymasq.keymasqd.runtime import combos as runtime_combos
+from keymasq.keymasqd.runtime import device_path_resolver
 from keymasq.keymasqd.runtime import grab_lifecycle as runtime_grab_lifecycle
 from keymasq.keymasqd.runtime import grabbed_device as runtime_grabbed_device
 from keymasq.keymasqd.runtime import macros as runtime_macros
@@ -177,6 +178,16 @@ def _topology_runtime_deps() -> runtime_topology.TopologyRuntimeDeps:
         resolve_stable_path_fn=resolve_stable_path,
         get_interface_id_fn=get_interface_id,
         release_interface_fn=runtime_grab_lifecycle.release_interface_unlocked,
+    )
+
+
+def _device_path_resolver_deps() -> device_path_resolver.DevicePathResolverDeps:
+    return device_path_resolver.DevicePathResolverDeps(
+        device_paths_fn=_device_paths,
+        device_input_fn=_device_input,
+        detect_input_classes_fn=detect_input_classes,
+        primary_input_class_fn=primary_input_class,
+        resolve_stable_path_fn=resolve_stable_path,
     )
 
 
@@ -631,10 +642,7 @@ class DeviceManager:
                 desired_grab_config_cls=DesiredGrabConfig,
                 clear_device_path_cache_fn=clear_device_path_cache,
                 resolve_stable_path_fn=resolve_stable_path,
-                device_paths_fn=_device_paths,
-                device_input_fn=_device_input,
-                detect_input_classes_fn=detect_input_classes,
-                primary_input_class_fn=primary_input_class,
+                device_path_resolver_deps=_device_path_resolver_deps(),
                 grabbed_device_cls=GrabbedDevice,
                 get_interface_id_fn=get_interface_id,
                 str_value_fn=_str_value,

--- a/keymasq/keymasqd/device_manager.py
+++ b/keymasq/keymasqd/device_manager.py
@@ -89,6 +89,8 @@ class _ManagedInputDevice(Protocol):
 
     def capabilities(self) -> dict[int, Sequence[object]]: ...
 
+    def input_props(self) -> Sequence[int]: ...
+
     def async_read_loop(self) -> AsyncIterator[evdev.InputEvent]: ...
 
     def fileno(self) -> int: ...
@@ -609,6 +611,7 @@ class DeviceManager:
         button_values: dict[str, int] | None = None,
         analog_inputs: dict[str, object] | None = None,
         force_grab_unmapped: bool = False,
+        evdev_interfaces: list[JsonObject] | None = None,
     ) -> JsonObject:
         async with self._op_lock:
             result = await runtime_grab_lifecycle.grab_device_unlocked(
@@ -620,10 +623,14 @@ class DeviceManager:
                 button_values,
                 analog_inputs,
                 force_grab_unmapped,
+                evdev_interfaces=evdev_interfaces,
                 update_desired=True,
                 desired_grab_config_cls=DesiredGrabConfig,
                 clear_device_path_cache_fn=clear_device_path_cache,
                 resolve_stable_path_fn=resolve_stable_path,
+                device_paths_fn=_device_paths,
+                device_input_fn=_device_input,
+                detect_input_classes_fn=detect_input_classes,
                 primary_input_class_fn=primary_input_class,
                 grabbed_device_cls=GrabbedDevice,
                 get_interface_id_fn=get_interface_id,

--- a/keymasq/keymasqd/device_manager.py
+++ b/keymasq/keymasqd/device_manager.py
@@ -172,6 +172,8 @@ def _topology_runtime_deps() -> runtime_topology.TopologyRuntimeDeps:
         clear_device_path_cache_fn=clear_device_path_cache,
         device_paths_fn=_device_paths,
         device_input_fn=_device_input,
+        detect_input_classes_fn=detect_input_classes,
+        primary_input_class_fn=primary_input_class,
         resolve_stable_path_fn=resolve_stable_path,
         get_interface_id_fn=get_interface_id,
         release_interface_fn=runtime_grab_lifecycle.release_interface_unlocked,
@@ -271,6 +273,7 @@ class DesiredGrabConfig:
     button_values: dict[str, int] = field(default_factory=dict)
     analog_inputs: dict[str, object] = field(default_factory=dict)
     force_grab_unmapped: bool = False
+    evdev_interfaces: list[JsonObject] = field(default_factory=list)
 
 
 @dataclass

--- a/keymasq/keymasqd/runtime/device_path_resolver.py
+++ b/keymasq/keymasqd/runtime/device_path_resolver.py
@@ -1,5 +1,6 @@
 import logging
 import re
+import threading
 from collections.abc import Callable, Iterable, Mapping, Sequence
 from dataclasses import dataclass
 from typing import Protocol, cast
@@ -50,6 +51,63 @@ class _Candidate:
     device_type: DeviceType
     capabilities: set[str]
     score: tuple[int, int, int]
+
+
+@dataclass(frozen=True)
+class CachedDeviceInfo:
+    path: str
+    vendor_id: str
+    product_id: str
+    phys: str
+    device_type: DeviceType
+    capabilities: set[str]
+    is_virtual: bool
+
+
+_CACHE_LOCK = threading.Lock()
+_CACHED_DEVICES: dict[str, CachedDeviceInfo] = {}
+
+
+def refresh_cached_devices_sync(
+    *,
+    device_paths_fn: Callable[[], list[str]],
+    device_input_fn: Callable[[str], InputDeviceLike],
+    detect_input_classes_fn: Callable[[InputDeviceLike], list[str]],
+    primary_input_class_fn: Callable[[Iterable[str | DeviceType] | None], DeviceType],
+) -> dict[str, CachedDeviceInfo]:
+    devices: dict[str, CachedDeviceInfo] = {}
+    for path in sorted(device_paths_fn()):
+        device: InputDeviceLike | None = None
+        try:
+            device = device_input_fn(path)
+            info = device.info
+            caps = device.capabilities()
+            devices[path] = CachedDeviceInfo(
+                path=path,
+                vendor_id=f"{info.vendor:04x}",
+                product_id=f"{info.product:04x}",
+                phys=str(getattr(device, "phys", "") or "").strip(),
+                device_type=primary_input_class_fn(detect_input_classes_fn(device)),
+                capabilities=_normalize_capability_names(
+                    capability_names_from_capabilities(caps)
+                ),
+                is_virtual=_is_keymasq_virtual_device(device),
+            )
+        except Exception:
+            continue
+        finally:
+            if device is not None:
+                _close_device(device)
+
+    with _CACHE_LOCK:
+        _CACHED_DEVICES.clear()
+        _CACHED_DEVICES.update(devices)
+    return devices
+
+
+def cached_devices_snapshot() -> dict[str, CachedDeviceInfo]:
+    with _CACHE_LOCK:
+        return dict(_CACHED_DEVICES)
 
 
 def interface_descriptors_from_paths(paths: list[str]) -> list[JsonObject]:
@@ -140,46 +198,35 @@ def _resolve_keymasq_path(
         return None
     vendor_id, product_id = parsed
     candidates: list[_Candidate] = []
+    cached_devices = cached_devices_snapshot()
     for path in sorted(device_paths_fn()):
         if path in selected_paths:
             continue
-        device: InputDeviceLike | None = None
-        try:
-            device = device_input_fn(path)
-            if _is_keymasq_virtual_device(device):
-                continue
-            info = device.info
-            if f"{info.vendor:04x}" != vendor_id or f"{info.product:04x}" != product_id:
-                continue
-            caps = device.capabilities()
-            capability_names = _normalize_capability_names(capability_names_from_capabilities(caps))
-            detected_type = primary_input_class_fn(detect_input_classes_fn(device))
-            phys = str(getattr(device, "phys", "") or "").strip()
-            type_match = configured_type != DeviceType.OTHER and detected_type == configured_type
-            type_score = int(configured_type == DeviceType.OTHER or type_match)
-            phys_score = int(bool(configured_phys) and phys == configured_phys)
-            cap_score = len(configured_caps & capability_names)
-            has_selector = (
-                configured_type != DeviceType.OTHER
-                or bool(configured_phys)
-                or bool(configured_caps)
-            )
-            if has_selector and not (type_match or phys_score or cap_score):
-                continue
-            candidates.append(
-                _Candidate(
-                    path=path,
-                    phys=phys,
-                    device_type=detected_type,
-                    capabilities=capability_names,
-                    score=(type_score, phys_score, cap_score),
-                )
-            )
-        except Exception:
+        cached = cached_devices.get(path)
+        if cached is None or cached.is_virtual:
             continue
-        finally:
-            if device is not None:
-                _close_device(device)
+        if cached.vendor_id != vendor_id or cached.product_id != product_id:
+            continue
+        type_match = configured_type != DeviceType.OTHER and cached.device_type == configured_type
+        type_score = int(configured_type == DeviceType.OTHER or type_match)
+        phys_score = int(bool(configured_phys) and cached.phys == configured_phys)
+        cap_score = len(configured_caps & cached.capabilities)
+        has_selector = (
+            configured_type != DeviceType.OTHER
+            or bool(configured_phys)
+            or bool(configured_caps)
+        )
+        if has_selector and not (type_match or phys_score or cap_score):
+            continue
+        candidates.append(
+            _Candidate(
+                path=path,
+                phys=cached.phys,
+                device_type=cached.device_type,
+                capabilities=cached.capabilities,
+                score=(type_score, phys_score, cap_score),
+            )
+        )
 
     if not candidates:
         return None

--- a/keymasq/keymasqd/runtime/device_path_resolver.py
+++ b/keymasq/keymasqd/runtime/device_path_resolver.py
@@ -251,6 +251,8 @@ def _resolve_keymasq_path(
         if path in selected_paths:
             continue
         cached = cached_devices.get(path)
+        if cached is None and not cached_devices:
+            cached = _probe_cached_device(path, deps)
         if cached is None or cached.is_virtual:
             continue
         if cached.vendor_id != vendor_id or cached.product_id != product_id:
@@ -345,6 +347,33 @@ def _resolve_keymasq_path(
             [candidate.path for candidate in available_candidates],
         )
     return best
+
+
+def _probe_cached_device(
+    path: str,
+    deps: DevicePathResolverDeps,
+) -> CachedDeviceInfo | None:
+    device: InputDeviceLike | None = None
+    try:
+        device = deps.device_input_fn(path)
+        info = device.info
+        caps = device.capabilities()
+        return CachedDeviceInfo(
+            path=path,
+            vendor_id=f"{info.vendor:04x}",
+            product_id=f"{info.product:04x}",
+            phys=str(getattr(device, "phys", "") or "").strip(),
+            device_type=deps.primary_input_class_fn(deps.detect_input_classes_fn(device)),
+            capabilities=_normalize_capability_names(
+                capability_names_from_capabilities(caps)
+            ),
+            is_virtual=_is_keymasq_virtual_device(device),
+        )
+    except Exception:
+        return None
+    finally:
+        if device is not None:
+            _close_device(device)
 
 
 def _is_excluded_path(

--- a/keymasq/keymasqd/runtime/device_path_resolver.py
+++ b/keymasq/keymasqd/runtime/device_path_resolver.py
@@ -110,6 +110,11 @@ def cached_devices_snapshot() -> dict[str, CachedDeviceInfo]:
         return dict(_CACHED_DEVICES)
 
 
+def clear_cached_devices() -> None:
+    with _CACHE_LOCK:
+        _CACHED_DEVICES.clear()
+
+
 def interface_descriptors_from_paths(paths: list[str]) -> list[JsonObject]:
     return [
         {"path": str(path), "id": "", "type": "", "capabilities": []}

--- a/keymasq/keymasqd/runtime/device_path_resolver.py
+++ b/keymasq/keymasqd/runtime/device_path_resolver.py
@@ -280,22 +280,24 @@ def _resolve_keymasq_path(
         ]
         if instance_index >= len(matching_instances):
             log.info(
-                "No %s instance %d match from candidates %s",
+                "No %s instance %d match from candidates %s; using best unclaimed match %s",
                 configured_path,
                 instance_index + 1,
                 [candidate.path for candidate in matching_instances],
+                available_candidates[0].path,
             )
-            return None
+            return available_candidates[0]
         for candidate in matching_instances[instance_index:]:
             if not candidate.claimed:
                 return candidate
         log.info(
-            "No unclaimed %s instance %d match from candidates %s",
+            "No unclaimed %s instance %d match from candidates %s; using best unclaimed match %s",
             configured_path,
             instance_index + 1,
             [candidate.path for candidate in matching_instances],
+            available_candidates[0].path,
         )
-        return None
+        return available_candidates[0]
 
     best = available_candidates[0]
     if len(available_candidates) > 1 and available_candidates[1].score == best.score:

--- a/keymasq/keymasqd/runtime/device_path_resolver.py
+++ b/keymasq/keymasqd/runtime/device_path_resolver.py
@@ -2,7 +2,7 @@ import logging
 import re
 import threading
 from collections.abc import Callable, Iterable, Mapping, Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Protocol, cast
 
 from keymasq.common.devices import (
@@ -72,6 +72,59 @@ class CachedDeviceInfo:
     is_virtual: bool
 
 
+@dataclass
+class DeviceCache:
+    _lock: threading.Lock = field(default_factory=threading.Lock)
+    _devices: dict[str, CachedDeviceInfo] = field(default_factory=dict)
+
+    def refresh_sync(
+        self,
+        *,
+        device_paths_fn: Callable[[], list[str]],
+        device_input_fn: Callable[[str], InputDeviceLike],
+        detect_input_classes_fn: Callable[[InputDeviceLike], list[str]],
+        primary_input_class_fn: Callable[
+            [Iterable[str | DeviceType] | None], DeviceType
+        ],
+    ) -> dict[str, CachedDeviceInfo]:
+        devices: dict[str, CachedDeviceInfo] = {}
+        for path in sorted(device_paths_fn()):
+            device: InputDeviceLike | None = None
+            try:
+                device = device_input_fn(path)
+                info = device.info
+                caps = device.capabilities()
+                devices[path] = CachedDeviceInfo(
+                    path=path,
+                    vendor_id=f"{info.vendor:04x}",
+                    product_id=f"{info.product:04x}",
+                    phys=str(getattr(device, "phys", "") or "").strip(),
+                    device_type=primary_input_class_fn(detect_input_classes_fn(device)),
+                    capabilities=_normalize_capability_names(
+                        capability_names_from_capabilities(caps)
+                    ),
+                    is_virtual=_is_keymasq_virtual_device(device),
+                )
+            except Exception:
+                continue
+            finally:
+                if device is not None:
+                    _close_device(device)
+
+        with self._lock:
+            self._devices.clear()
+            self._devices.update(devices)
+        return devices
+
+    def snapshot(self) -> dict[str, CachedDeviceInfo]:
+        with self._lock:
+            return dict(self._devices)
+
+    def clear(self) -> None:
+        with self._lock:
+            self._devices.clear()
+
+
 @dataclass(frozen=True)
 class DevicePathResolverDeps:
     device_paths_fn: Callable[[], list[str]]
@@ -79,10 +132,10 @@ class DevicePathResolverDeps:
     detect_input_classes_fn: Callable[[InputDeviceLike], list[str]]
     primary_input_class_fn: Callable[[Iterable[str | DeviceType] | None], DeviceType]
     resolve_stable_path_fn: Callable[[str], str] | None = None
+    cache: DeviceCache | None = None
 
 
-_CACHE_LOCK = threading.Lock()
-_CACHED_DEVICES: dict[str, CachedDeviceInfo] = {}
+_DEFAULT_CACHE = DeviceCache()
 
 
 def refresh_cached_devices_sync(
@@ -92,44 +145,20 @@ def refresh_cached_devices_sync(
     detect_input_classes_fn: Callable[[InputDeviceLike], list[str]],
     primary_input_class_fn: Callable[[Iterable[str | DeviceType] | None], DeviceType],
 ) -> dict[str, CachedDeviceInfo]:
-    devices: dict[str, CachedDeviceInfo] = {}
-    for path in sorted(device_paths_fn()):
-        device: InputDeviceLike | None = None
-        try:
-            device = device_input_fn(path)
-            info = device.info
-            caps = device.capabilities()
-            devices[path] = CachedDeviceInfo(
-                path=path,
-                vendor_id=f"{info.vendor:04x}",
-                product_id=f"{info.product:04x}",
-                phys=str(getattr(device, "phys", "") or "").strip(),
-                device_type=primary_input_class_fn(detect_input_classes_fn(device)),
-                capabilities=_normalize_capability_names(
-                    capability_names_from_capabilities(caps)
-                ),
-                is_virtual=_is_keymasq_virtual_device(device),
-            )
-        except Exception:
-            continue
-        finally:
-            if device is not None:
-                _close_device(device)
-
-    with _CACHE_LOCK:
-        _CACHED_DEVICES.clear()
-        _CACHED_DEVICES.update(devices)
-    return devices
+    return _DEFAULT_CACHE.refresh_sync(
+        device_paths_fn=device_paths_fn,
+        device_input_fn=device_input_fn,
+        detect_input_classes_fn=detect_input_classes_fn,
+        primary_input_class_fn=primary_input_class_fn,
+    )
 
 
 def cached_devices_snapshot() -> dict[str, CachedDeviceInfo]:
-    with _CACHE_LOCK:
-        return dict(_CACHED_DEVICES)
+    return _DEFAULT_CACHE.snapshot()
 
 
 def clear_cached_devices() -> None:
-    with _CACHE_LOCK:
-        _CACHED_DEVICES.clear()
+    _DEFAULT_CACHE.clear()
 
 
 def interface_descriptors_from_paths(paths: list[str]) -> list[JsonObject]:
@@ -217,7 +246,7 @@ def _resolve_keymasq_path(
         return None
     vendor_id, product_id = parsed
     candidates: list[_Candidate] = []
-    cached_devices = cached_devices_snapshot()
+    cached_devices = (deps.cache or _DEFAULT_CACHE).snapshot()
     for path in sorted(deps.device_paths_fn()):
         if path in selected_paths:
             continue

--- a/keymasq/keymasqd/runtime/device_path_resolver.py
+++ b/keymasq/keymasqd/runtime/device_path_resolver.py
@@ -1,4 +1,5 @@
 import logging
+import re
 from collections.abc import Callable, Iterable, Mapping, Sequence
 from dataclasses import dataclass
 from typing import Protocol, cast
@@ -62,6 +63,7 @@ def interface_descriptors_from_paths(paths: list[str]) -> list[JsonObject]:
 def resolve_evdev_interfaces(
     interfaces: list[JsonObject],
     *,
+    hardware_id: str | None = None,
     device_paths_fn: Callable[[], list[str]],
     device_input_fn: Callable[[str], InputDeviceLike],
     detect_input_classes_fn: Callable[[InputDeviceLike], list[str]],
@@ -98,6 +100,7 @@ def resolve_evdev_interfaces(
             configured_phys=configured_phys,
             configured_caps=configured_caps,
             selected_paths=selected_paths,
+            hardware_id=hardware_id,
             device_paths_fn=device_paths_fn,
             device_input_fn=device_input_fn,
             detect_input_classes_fn=detect_input_classes_fn,
@@ -126,6 +129,7 @@ def _resolve_keymasq_path(
     configured_phys: str,
     configured_caps: set[str],
     selected_paths: set[str],
+    hardware_id: str | None,
     device_paths_fn: Callable[[], list[str]],
     device_input_fn: Callable[[str], InputDeviceLike],
     detect_input_classes_fn: Callable[[InputDeviceLike], list[str]],
@@ -187,6 +191,26 @@ def _resolve_keymasq_path(
             candidate.path,
         )
     )
+    instance_index = _numbered_hardware_instance_index(
+        hardware_id,
+        vendor_id=vendor_id,
+        product_id=product_id,
+    )
+    if instance_index is not None:
+        best_score = candidates[0].score
+        matching_instances = [
+            candidate for candidate in candidates if candidate.score == best_score
+        ]
+        if instance_index >= len(matching_instances):
+            log.info(
+                "No %s instance %d match from candidates %s",
+                configured_path,
+                instance_index + 1,
+                [candidate.path for candidate in matching_instances],
+            )
+            return None
+        return matching_instances[instance_index]
+
     best = candidates[0]
     if len(candidates) > 1 and candidates[1].score == best.score:
         log.warning(
@@ -196,6 +220,27 @@ def _resolve_keymasq_path(
             [candidate.path for candidate in candidates],
         )
     return best
+
+
+def _numbered_hardware_instance_index(
+    hardware_id: str | None,
+    *,
+    vendor_id: str,
+    product_id: str,
+) -> int | None:
+    normalized = str(hardware_id or "").strip().lower()
+    match = re.fullmatch(
+        r"([0-9a-f]{1,4}):([0-9a-f]{1,4})@([1-9][0-9]*)",
+        normalized,
+    )
+    if match is None:
+        return None
+
+    hardware_vendor, hardware_product, instance_text = match.groups()
+    if hardware_vendor.zfill(4) != vendor_id or hardware_product.zfill(4) != product_id:
+        return None
+
+    return int(instance_text) - 1
 
 
 def _close_device(device: object) -> None:

--- a/keymasq/keymasqd/runtime/device_path_resolver.py
+++ b/keymasq/keymasqd/runtime/device_path_resolver.py
@@ -1,0 +1,242 @@
+import logging
+from collections.abc import Callable, Iterable, Mapping, Sequence
+from dataclasses import dataclass
+from typing import Protocol, cast
+
+from keymasq.common.devices import (
+    canonical_gamepad_button_name,
+    capability_names_from_capabilities,
+    is_gamepad_button_name,
+    is_keymasq_device_path,
+    parse_keymasq_device_path,
+)
+from keymasq.common.models import DeviceType
+
+log = logging.getLogger("keymasqd.device_path_resolver")
+type JsonObject = dict[str, object]
+
+
+class _DeviceInfo(Protocol):
+    vendor: int
+    product: int
+
+
+class InputDeviceLike(Protocol):
+    path: str
+    name: str | None
+
+    @property
+    def info(self) -> _DeviceInfo: ...
+
+    def input_props(self) -> Iterable[int]: ...
+
+    def capabilities(self) -> Mapping[int, Sequence[object]]: ...
+
+
+@dataclass(frozen=True)
+class ResolvedInterface:
+    path: str
+    configured_path: str
+    interface_id: str
+    device_type: DeviceType
+    capabilities: list[str]
+
+
+@dataclass(frozen=True)
+class _Candidate:
+    path: str
+    phys: str
+    device_type: DeviceType
+    capabilities: set[str]
+    score: tuple[int, int, int]
+
+
+def interface_descriptors_from_paths(paths: list[str]) -> list[JsonObject]:
+    return [
+        {"path": str(path), "id": "", "type": "", "capabilities": []}
+        for path in paths
+        if str(path or "").strip()
+    ]
+
+
+def resolve_evdev_interfaces(
+    interfaces: list[JsonObject],
+    *,
+    device_paths_fn: Callable[[], list[str]],
+    device_input_fn: Callable[[str], InputDeviceLike],
+    detect_input_classes_fn: Callable[[InputDeviceLike], list[str]],
+    primary_input_class_fn: Callable[[Iterable[str | DeviceType] | None], DeviceType],
+) -> list[ResolvedInterface]:
+    resolved: list[ResolvedInterface] = []
+    selected_paths: set[str] = set()
+
+    for descriptor in interfaces:
+        configured_path = str(descriptor.get("path", "") or "").strip()
+        if not configured_path:
+            continue
+        interface_id = str(descriptor.get("id", "") or "").strip().lower()
+        configured_type = _device_type(descriptor.get("type"))
+        configured_phys = str(descriptor.get("phys", "") or "").strip()
+        configured_caps = _capability_set(descriptor.get("capabilities"))
+
+        if not is_keymasq_device_path(configured_path):
+            resolved.append(
+                ResolvedInterface(
+                    path=configured_path,
+                    configured_path=configured_path,
+                    interface_id=interface_id,
+                    device_type=configured_type,
+                    capabilities=sorted(configured_caps),
+                )
+            )
+            selected_paths.add(configured_path)
+            continue
+
+        candidate = _resolve_keymasq_path(
+            configured_path,
+            configured_type=configured_type,
+            configured_phys=configured_phys,
+            configured_caps=configured_caps,
+            selected_paths=selected_paths,
+            device_paths_fn=device_paths_fn,
+            device_input_fn=device_input_fn,
+            detect_input_classes_fn=detect_input_classes_fn,
+            primary_input_class_fn=primary_input_class_fn,
+        )
+        if candidate is None:
+            continue
+        selected_paths.add(candidate.path)
+        resolved.append(
+            ResolvedInterface(
+                path=candidate.path,
+                configured_path=configured_path,
+                interface_id=interface_id,
+                device_type=configured_type,
+                capabilities=sorted(configured_caps),
+            )
+        )
+
+    return resolved
+
+
+def _resolve_keymasq_path(
+    configured_path: str,
+    *,
+    configured_type: DeviceType,
+    configured_phys: str,
+    configured_caps: set[str],
+    selected_paths: set[str],
+    device_paths_fn: Callable[[], list[str]],
+    device_input_fn: Callable[[str], InputDeviceLike],
+    detect_input_classes_fn: Callable[[InputDeviceLike], list[str]],
+    primary_input_class_fn: Callable[[Iterable[str | DeviceType] | None], DeviceType],
+) -> _Candidate | None:
+    parsed = parse_keymasq_device_path(configured_path)
+    if parsed is None:
+        return None
+    vendor_id, product_id = parsed
+    candidates: list[_Candidate] = []
+    for path in sorted(device_paths_fn()):
+        if path in selected_paths:
+            continue
+        device: InputDeviceLike | None = None
+        try:
+            device = device_input_fn(path)
+            if _is_keymasq_virtual_device(device):
+                continue
+            info = device.info
+            if f"{info.vendor:04x}" != vendor_id or f"{info.product:04x}" != product_id:
+                continue
+            caps = device.capabilities()
+            capability_names = _normalize_capability_names(capability_names_from_capabilities(caps))
+            detected_type = primary_input_class_fn(detect_input_classes_fn(device))
+            phys = str(getattr(device, "phys", "") or "").strip()
+            type_match = configured_type != DeviceType.OTHER and detected_type == configured_type
+            type_score = int(configured_type == DeviceType.OTHER or type_match)
+            phys_score = int(bool(configured_phys) and phys == configured_phys)
+            cap_score = len(configured_caps & capability_names)
+            has_selector = (
+                configured_type != DeviceType.OTHER
+                or bool(configured_phys)
+                or bool(configured_caps)
+            )
+            if has_selector and not (type_match or phys_score or cap_score):
+                continue
+            candidates.append(
+                _Candidate(
+                    path=path,
+                    phys=phys,
+                    device_type=detected_type,
+                    capabilities=capability_names,
+                    score=(type_score, phys_score, cap_score),
+                )
+            )
+        except Exception:
+            continue
+        finally:
+            if device is not None:
+                _close_device(device)
+
+    if not candidates:
+        return None
+    candidates.sort(
+        key=lambda candidate: (
+            -candidate.score[0],
+            -candidate.score[1],
+            -candidate.score[2],
+            candidate.path,
+        )
+    )
+    best = candidates[0]
+    if len(candidates) > 1 and candidates[1].score == best.score:
+        log.warning(
+            "Ambiguous %s match; using %s from candidates %s",
+            configured_path,
+            best.path,
+            [candidate.path for candidate in candidates],
+        )
+    return best
+
+
+def _close_device(device: object) -> None:
+    close = getattr(device, "close", None)
+    if not callable(close):
+        return
+    try:
+        close()
+    except Exception:
+        pass
+
+
+def _is_keymasq_virtual_device(device: object) -> bool:
+    phys = str(getattr(device, "phys", "") or "").lower()
+    name = str(getattr(device, "name", "") or "").lower()
+    return phys == "py-evdev-uinput" or name.startswith("keymasq-")
+
+
+def _device_type(value: object) -> DeviceType:
+    if isinstance(value, DeviceType):
+        return value
+    try:
+        return DeviceType(str(value or "other"))
+    except ValueError:
+        return DeviceType.OTHER
+
+
+def _capability_set(value: object) -> set[str]:
+    if not isinstance(value, list):
+        return set()
+    items = cast(list[object], value)
+    return _normalize_capability_names(str(item) for item in items)
+
+
+def _normalize_capability_names(names: Iterable[object]) -> set[str]:
+    normalized: set[str] = set()
+    for item in names:
+        name = str(item).strip().lower()
+        if not name:
+            continue
+        normalized.add(name)
+        if is_gamepad_button_name(name):
+            normalized.add(canonical_gamepad_button_name(name))
+    return normalized

--- a/keymasq/keymasqd/runtime/device_path_resolver.py
+++ b/keymasq/keymasqd/runtime/device_path_resolver.py
@@ -45,12 +45,19 @@ class ResolvedInterface:
 
 
 @dataclass(frozen=True)
+class _MatchScore:
+    type_match: int
+    phys_match: int
+    cap_overlap: int
+
+
+@dataclass(frozen=True)
 class _Candidate:
     path: str
     phys: str
     device_type: DeviceType
     capabilities: set[str]
-    score: tuple[int, int, int]
+    score: _MatchScore
     claimed: bool = False
 
 
@@ -63,6 +70,15 @@ class CachedDeviceInfo:
     device_type: DeviceType
     capabilities: set[str]
     is_virtual: bool
+
+
+@dataclass(frozen=True)
+class DevicePathResolverDeps:
+    device_paths_fn: Callable[[], list[str]]
+    device_input_fn: Callable[[str], InputDeviceLike]
+    detect_input_classes_fn: Callable[[InputDeviceLike], list[str]]
+    primary_input_class_fn: Callable[[Iterable[str | DeviceType] | None], DeviceType]
+    resolve_stable_path_fn: Callable[[str], str] | None = None
 
 
 _CACHE_LOCK = threading.Lock()
@@ -127,13 +143,9 @@ def interface_descriptors_from_paths(paths: list[str]) -> list[JsonObject]:
 def resolve_evdev_interfaces(
     interfaces: list[JsonObject],
     *,
+    deps: DevicePathResolverDeps,
     hardware_id: str | None = None,
     excluded_paths: Iterable[str] | None = None,
-    resolve_stable_path_fn: Callable[[str], str] | None = None,
-    device_paths_fn: Callable[[], list[str]],
-    device_input_fn: Callable[[str], InputDeviceLike],
-    detect_input_classes_fn: Callable[[InputDeviceLike], list[str]],
-    primary_input_class_fn: Callable[[Iterable[str | DeviceType] | None], DeviceType],
 ) -> list[ResolvedInterface]:
     resolved: list[ResolvedInterface] = []
     selected_paths: set[str] = set()
@@ -171,11 +183,7 @@ def resolve_evdev_interfaces(
             selected_paths=selected_paths,
             excluded_paths=normalized_excluded_paths,
             hardware_id=hardware_id,
-            resolve_stable_path_fn=resolve_stable_path_fn,
-            device_paths_fn=device_paths_fn,
-            device_input_fn=device_input_fn,
-            detect_input_classes_fn=detect_input_classes_fn,
-            primary_input_class_fn=primary_input_class_fn,
+            deps=deps,
         )
         if candidate is None:
             continue
@@ -202,11 +210,7 @@ def _resolve_keymasq_path(
     selected_paths: set[str],
     excluded_paths: set[str],
     hardware_id: str | None,
-    resolve_stable_path_fn: Callable[[str], str] | None,
-    device_paths_fn: Callable[[], list[str]],
-    device_input_fn: Callable[[str], InputDeviceLike],
-    detect_input_classes_fn: Callable[[InputDeviceLike], list[str]],
-    primary_input_class_fn: Callable[[Iterable[str | DeviceType] | None], DeviceType],
+    deps: DevicePathResolverDeps,
 ) -> _Candidate | None:
     parsed = parse_keymasq_device_path(configured_path)
     if parsed is None:
@@ -214,7 +218,7 @@ def _resolve_keymasq_path(
     vendor_id, product_id = parsed
     candidates: list[_Candidate] = []
     cached_devices = cached_devices_snapshot()
-    for path in sorted(device_paths_fn()):
+    for path in sorted(deps.device_paths_fn()):
         if path in selected_paths:
             continue
         cached = cached_devices.get(path)
@@ -239,11 +243,15 @@ def _resolve_keymasq_path(
                 phys=cached.phys,
                 device_type=cached.device_type,
                 capabilities=cached.capabilities,
-                score=(type_score, phys_score, cap_score),
+                score=_MatchScore(
+                    type_match=type_score,
+                    phys_match=phys_score,
+                    cap_overlap=cap_score,
+                ),
                 claimed=_is_excluded_path(
                     path,
                     excluded_paths,
-                    resolve_stable_path_fn=resolve_stable_path_fn,
+                    resolve_stable_path_fn=deps.resolve_stable_path_fn,
                 ),
             )
         )
@@ -252,9 +260,9 @@ def _resolve_keymasq_path(
         return None
     candidates.sort(
         key=lambda candidate: (
-            -candidate.score[0],
-            -candidate.score[1],
-            -candidate.score[2],
+            -candidate.score.type_match,
+            -candidate.score.phys_match,
+            -candidate.score.cap_overlap,
             candidate.path,
         )
     )

--- a/keymasq/keymasqd/runtime/device_path_resolver.py
+++ b/keymasq/keymasqd/runtime/device_path_resolver.py
@@ -51,6 +51,7 @@ class _Candidate:
     device_type: DeviceType
     capabilities: set[str]
     score: tuple[int, int, int]
+    claimed: bool = False
 
 
 @dataclass(frozen=True)
@@ -127,6 +128,8 @@ def resolve_evdev_interfaces(
     interfaces: list[JsonObject],
     *,
     hardware_id: str | None = None,
+    excluded_paths: Iterable[str] | None = None,
+    resolve_stable_path_fn: Callable[[str], str] | None = None,
     device_paths_fn: Callable[[], list[str]],
     device_input_fn: Callable[[str], InputDeviceLike],
     detect_input_classes_fn: Callable[[InputDeviceLike], list[str]],
@@ -134,6 +137,9 @@ def resolve_evdev_interfaces(
 ) -> list[ResolvedInterface]:
     resolved: list[ResolvedInterface] = []
     selected_paths: set[str] = set()
+    normalized_excluded_paths = {
+        path for value in excluded_paths or [] if (path := str(value or "").strip())
+    }
 
     for descriptor in interfaces:
         configured_path = str(descriptor.get("path", "") or "").strip()
@@ -163,7 +169,9 @@ def resolve_evdev_interfaces(
             configured_phys=configured_phys,
             configured_caps=configured_caps,
             selected_paths=selected_paths,
+            excluded_paths=normalized_excluded_paths,
             hardware_id=hardware_id,
+            resolve_stable_path_fn=resolve_stable_path_fn,
             device_paths_fn=device_paths_fn,
             device_input_fn=device_input_fn,
             detect_input_classes_fn=detect_input_classes_fn,
@@ -192,7 +200,9 @@ def _resolve_keymasq_path(
     configured_phys: str,
     configured_caps: set[str],
     selected_paths: set[str],
+    excluded_paths: set[str],
     hardware_id: str | None,
+    resolve_stable_path_fn: Callable[[str], str] | None,
     device_paths_fn: Callable[[], list[str]],
     device_input_fn: Callable[[str], InputDeviceLike],
     detect_input_classes_fn: Callable[[InputDeviceLike], list[str]],
@@ -230,6 +240,11 @@ def _resolve_keymasq_path(
                 device_type=cached.device_type,
                 capabilities=cached.capabilities,
                 score=(type_score, phys_score, cap_score),
+                claimed=_is_excluded_path(
+                    path,
+                    excluded_paths,
+                    resolve_stable_path_fn=resolve_stable_path_fn,
+                ),
             )
         )
 
@@ -243,6 +258,16 @@ def _resolve_keymasq_path(
             candidate.path,
         )
     )
+    available_candidates = [
+        candidate for candidate in candidates if not candidate.claimed
+    ]
+    if not available_candidates:
+        log.info(
+            "No unclaimed %s match from candidates %s",
+            configured_path,
+            [candidate.path for candidate in candidates],
+        )
+        return None
     instance_index = _numbered_hardware_instance_index(
         hardware_id,
         vendor_id=vendor_id,
@@ -261,17 +286,43 @@ def _resolve_keymasq_path(
                 [candidate.path for candidate in matching_instances],
             )
             return None
-        return matching_instances[instance_index]
+        for candidate in matching_instances[instance_index:]:
+            if not candidate.claimed:
+                return candidate
+        log.info(
+            "No unclaimed %s instance %d match from candidates %s",
+            configured_path,
+            instance_index + 1,
+            [candidate.path for candidate in matching_instances],
+        )
+        return None
 
-    best = candidates[0]
-    if len(candidates) > 1 and candidates[1].score == best.score:
+    best = available_candidates[0]
+    if len(available_candidates) > 1 and available_candidates[1].score == best.score:
         log.warning(
             "Ambiguous %s match; using %s from candidates %s",
             configured_path,
             best.path,
-            [candidate.path for candidate in candidates],
+            [candidate.path for candidate in available_candidates],
         )
     return best
+
+
+def _is_excluded_path(
+    path: str,
+    excluded_paths: set[str],
+    *,
+    resolve_stable_path_fn: Callable[[str], str] | None,
+) -> bool:
+    if path in excluded_paths:
+        return True
+    if resolve_stable_path_fn is None:
+        return False
+    try:
+        stable_path = resolve_stable_path_fn(path)
+    except Exception:
+        return False
+    return stable_path in excluded_paths
 
 
 def _numbered_hardware_instance_index(

--- a/keymasq/keymasqd/runtime/grab_lifecycle.py
+++ b/keymasq/keymasqd/runtime/grab_lifecycle.py
@@ -104,9 +104,12 @@ async def grab_device_unlocked(
         if evdev_interfaces
         else device_path_resolver.interface_descriptors_from_paths(evdev_paths)
     )
+    excluded_paths = grabbed_paths_for_other_hardware(manager, hardware_id)
     resolved_interfaces = device_path_resolver.resolve_evdev_interfaces(
         raw_interfaces,
         hardware_id=hardware_id,
+        excluded_paths=excluded_paths,
+        resolve_stable_path_fn=resolve_stable_path_fn,
         device_paths_fn=device_paths_fn,
         device_input_fn=device_input_fn,
         detect_input_classes_fn=detect_input_classes_fn,
@@ -392,6 +395,20 @@ async def grab_device_unlocked(
         "skipped_count": skipped_count,
         "waiting_for_device": waiting_for_device,
     }
+
+
+def grabbed_paths_for_other_hardware(manager: _GrabManager, hardware_id: str) -> set[str]:
+    requested_hardware_id = str(hardware_id or "").strip().lower()
+    paths: set[str] = set()
+    for grabbed_hardware_id, devices in manager.grabbed_devices.items():
+        if str(grabbed_hardware_id or "").strip().lower() == requested_hardware_id:
+            continue
+        for device in devices:
+            for attr in ("path", "stable_path"):
+                path = str(getattr(device, attr, "") or "").strip()
+                if path:
+                    paths.add(path)
+    return paths
 
 
 async def grab_with_retry(

--- a/keymasq/keymasqd/runtime/grab_lifecycle.py
+++ b/keymasq/keymasqd/runtime/grab_lifecycle.py
@@ -1,6 +1,6 @@
 import asyncio
 import logging
-from collections.abc import Awaitable, Callable, Sequence
+from collections.abc import Awaitable, Callable, Iterable, Sequence
 from typing import Any, cast
 
 import evdev
@@ -12,6 +12,7 @@ from keymasq.keymasqd.output_helpers import resolve_output_code
 from keymasq.keymasqd.runtime import actions as runtime_actions
 from keymasq.keymasqd.runtime import adapters as runtime_adapters
 from keymasq.keymasqd.runtime import combos as runtime_combos
+from keymasq.keymasqd.runtime import device_path_resolver
 from keymasq.keymasqd.runtime import outputs as runtime_outputs
 
 log = logging.getLogger("keymasqd.devices")
@@ -24,7 +25,10 @@ type IntOrNoneFn = Callable[..., int | None]
 type FloatValueFn = Callable[..., float]
 type ResolveStablePathFn = Callable[[str], str]
 type GetInterfaceIdFn = Callable[[str], str | None]
-type PrimaryInputClassFn = Callable[[set[DeviceType]], DeviceType]
+type PrimaryInputClassFn = Callable[[Iterable[str | DeviceType] | None], DeviceType]
+type DevicePathsFn = Callable[[], list[str]]
+type DeviceInputFn = Callable[[str], device_path_resolver.InputDeviceLike]
+type DetectInputClassesFn = Callable[[device_path_resolver.InputDeviceLike], list[str]]
 type FireAndObserve = Callable[[Awaitable[object], str], asyncio.Task[object]]
 type DesiredGrabConfigFactory = Callable[..., object]
 type GrabbedDeviceFactory = Callable[..., Any]
@@ -73,10 +77,14 @@ async def grab_device_unlocked(
     analog_inputs: dict[str, object] | None,
     force_grab_unmapped: bool,
     *,
+    evdev_interfaces: list[JsonObject] | None = None,
     update_desired: bool,
     desired_grab_config_cls: DesiredGrabConfigFactory,
     clear_device_path_cache_fn: Callable[[], None],
     resolve_stable_path_fn: ResolveStablePathFn,
+    device_paths_fn: DevicePathsFn,
+    device_input_fn: DeviceInputFn,
+    detect_input_classes_fn: DetectInputClassesFn,
     primary_input_class_fn: PrimaryInputClassFn,
     grabbed_device_cls: GrabbedDeviceFactory,
     get_interface_id_fn: GetInterfaceIdFn,
@@ -91,8 +99,24 @@ async def grab_device_unlocked(
     clear_device_path_cache_fn()
     cancel_pending_hardware_release(manager, hardware_id)
 
-    requested_paths = {
-        resolve_stable_path_fn(str(path)) for path in evdev_paths if str(path or "").strip()
+    raw_interfaces = (
+        evdev_interfaces
+        if evdev_interfaces
+        else device_path_resolver.interface_descriptors_from_paths(evdev_paths)
+    )
+    resolved_interfaces = device_path_resolver.resolve_evdev_interfaces(
+        raw_interfaces,
+        device_paths_fn=device_paths_fn,
+        device_input_fn=device_input_fn,
+        detect_input_classes_fn=detect_input_classes_fn,
+        primary_input_class_fn=primary_input_class_fn,
+    )
+    requested_interface_paths = [
+        resolve_stable_path_fn(interface.path) for interface in resolved_interfaces
+    ]
+    requested_paths = set(requested_interface_paths)
+    resolved_by_path = {
+        resolve_stable_path_fn(interface.path): interface for interface in resolved_interfaces
     }
     mapped_evdev_names = {name.lower() for name in button_map.values()}
     resolved_button_codes = {
@@ -129,7 +153,15 @@ async def grab_device_unlocked(
     existing_by_path = {
         device.path: device for device in manager.grabbed_devices.get(hardware_id, [])
     }
-    for device in existing_by_path.values():
+    for path, device in existing_by_path.items():
+        resolved_interface = resolved_by_path.get(path)
+        interface_id = str(
+            (resolved_interface.interface_id if resolved_interface else "")
+            or get_interface_id_fn(path)
+            or ""
+        ).lower()
+        if interface_id:
+            device.interface_id = interface_id
         device.update_button_map(button_map, resolved_button_codes, resolved_button_values)
         update_analog_inputs = getattr(device, "update_analog_inputs", None)
         if callable(update_analog_inputs):
@@ -197,7 +229,12 @@ async def grab_device_unlocked(
             raw_device = manager._device_input(path)
             available_count += 1
             caps = raw_device.capabilities()
-            interface_id = str(get_interface_id_fn(path) or "").lower()
+            resolved_interface = resolved_by_path.get(path)
+            interface_id = str(
+                (resolved_interface.interface_id if resolved_interface else "")
+                or get_interface_id_fn(path)
+                or ""
+            ).lower()
             interface_mapped_bindings = button_mapped_bindings | analog_input_bindings(
                 analog_inputs or {},
                 source=interface_id,
@@ -270,6 +307,7 @@ async def grab_device_unlocked(
                     mouse_rel_suppression_start_callback=lambda: None,
                     diagnostics_recorder=diagnostics_recorder,
                     runtime_cleanup_callback=runtime_cleanup_callback,
+                    interface_id=interface_id,
                 )
                 await grab_with_retry(
                     device,
@@ -309,7 +347,9 @@ async def grab_device_unlocked(
                 runtime_outputs.destroy_global_uinputs(manager, log=log)
             raise
 
-    waiting_for_device = bool(requested_paths and available_count == 0 and not devices)
+    waiting_for_device = bool(
+        (requested_paths or raw_interfaces) and available_count == 0 and not devices
+    )
     if (
         not waiting_for_device
         and hardware_id not in manager.grabbed_devices

--- a/keymasq/keymasqd/runtime/grab_lifecycle.py
+++ b/keymasq/keymasqd/runtime/grab_lifecycle.py
@@ -116,6 +116,12 @@ async def grab_device_unlocked(
         resolve_stable_path_fn(interface.path) for interface in resolved_interfaces
     ]
     requested_paths = set(requested_interface_paths)
+    raw_interface_paths = {
+        path
+        for descriptor in raw_interfaces
+        if (path := str(descriptor.get("path", "") or "").strip())
+    }
+    desired_paths = requested_paths | raw_interface_paths
     resolved_by_path = {
         resolve_stable_path_fn(interface.path): interface for interface in resolved_interfaces
     }
@@ -134,14 +140,15 @@ async def grab_device_unlocked(
     analog_bindings = analog_input_bindings(analog_inputs or {})
     mapped_bindings = button_mapped_bindings | analog_bindings
     if update_desired:
-        manager.grab_state.desired_paths[hardware_id] = set(requested_paths)
+        manager.grab_state.desired_paths[hardware_id] = set(desired_paths)
         manager.grab_state.desired_grabs[hardware_id] = desired_grab_config_cls(
-            paths=set(requested_paths),
+            paths=set(desired_paths),
             button_map=dict(button_map),
             button_codes=dict(resolved_button_codes),
             button_values=dict(resolved_button_values),
             analog_inputs=dict(analog_inputs or {}),
             force_grab_unmapped=bool(force_grab_unmapped),
+            evdev_interfaces=list(raw_interfaces) if evdev_interfaces is not None else [],
         )
     log.info(
         "Grab request for %s: paths=%d mapped_evdev_names=%d mapped_bindings=%d",

--- a/keymasq/keymasqd/runtime/grab_lifecycle.py
+++ b/keymasq/keymasqd/runtime/grab_lifecycle.py
@@ -1,12 +1,12 @@
 import asyncio
 import logging
-from collections.abc import Awaitable, Callable, Iterable, Sequence
+from collections.abc import Awaitable, Callable, Sequence
 from typing import Any, cast
 
 import evdev
 
 from keymasq.common.devices import resolve_evdev_code, resolve_evdev_event_type
-from keymasq.common.models import DeviceType, MappingAction
+from keymasq.common.models import MappingAction
 from keymasq.keymasqd.combo_engine import ComboDecision
 from keymasq.keymasqd.output_helpers import resolve_output_code
 from keymasq.keymasqd.runtime import actions as runtime_actions
@@ -25,10 +25,6 @@ type IntOrNoneFn = Callable[..., int | None]
 type FloatValueFn = Callable[..., float]
 type ResolveStablePathFn = Callable[[str], str]
 type GetInterfaceIdFn = Callable[[str], str | None]
-type PrimaryInputClassFn = Callable[[Iterable[str | DeviceType] | None], DeviceType]
-type DevicePathsFn = Callable[[], list[str]]
-type DeviceInputFn = Callable[[str], device_path_resolver.InputDeviceLike]
-type DetectInputClassesFn = Callable[[device_path_resolver.InputDeviceLike], list[str]]
 type FireAndObserve = Callable[[Awaitable[object], str], asyncio.Task[object]]
 type DesiredGrabConfigFactory = Callable[..., object]
 type GrabbedDeviceFactory = Callable[..., Any]
@@ -82,10 +78,7 @@ async def grab_device_unlocked(
     desired_grab_config_cls: DesiredGrabConfigFactory,
     clear_device_path_cache_fn: Callable[[], None],
     resolve_stable_path_fn: ResolveStablePathFn,
-    device_paths_fn: DevicePathsFn,
-    device_input_fn: DeviceInputFn,
-    detect_input_classes_fn: DetectInputClassesFn,
-    primary_input_class_fn: PrimaryInputClassFn,
+    device_path_resolver_deps: device_path_resolver.DevicePathResolverDeps,
     grabbed_device_cls: GrabbedDeviceFactory,
     get_interface_id_fn: GetInterfaceIdFn,
     str_value_fn: StrValueFn,
@@ -107,13 +100,9 @@ async def grab_device_unlocked(
     excluded_paths = grabbed_paths_for_other_hardware(manager, hardware_id)
     resolved_interfaces = device_path_resolver.resolve_evdev_interfaces(
         raw_interfaces,
+        deps=device_path_resolver_deps,
         hardware_id=hardware_id,
         excluded_paths=excluded_paths,
-        resolve_stable_path_fn=resolve_stable_path_fn,
-        device_paths_fn=device_paths_fn,
-        device_input_fn=device_input_fn,
-        detect_input_classes_fn=detect_input_classes_fn,
-        primary_input_class_fn=primary_input_class_fn,
     )
     requested_interface_paths = [
         resolve_stable_path_fn(interface.path) for interface in resolved_interfaces
@@ -267,7 +256,9 @@ async def grab_device_unlocked(
                     )
                     created_global_uinputs = True
                 detected_types = manager._detect_device_types(raw_device)
-                detected_type = primary_input_class_fn(detected_types)
+                detected_type = device_path_resolver_deps.primary_input_class_fn(
+                    detected_types
+                )
 
                 def mapping_getter(hid: str = hardware_id) -> dict[str, MappingAction]:
                     return manager.active_mappings.get(hid, {})

--- a/keymasq/keymasqd/runtime/grab_lifecycle.py
+++ b/keymasq/keymasqd/runtime/grab_lifecycle.py
@@ -106,6 +106,7 @@ async def grab_device_unlocked(
     )
     resolved_interfaces = device_path_resolver.resolve_evdev_interfaces(
         raw_interfaces,
+        hardware_id=hardware_id,
         device_paths_fn=device_paths_fn,
         device_input_fn=device_input_fn,
         detect_input_classes_fn=detect_input_classes_fn,

--- a/keymasq/keymasqd/runtime/grabbed_device.py
+++ b/keymasq/keymasqd/runtime/grabbed_device.py
@@ -207,11 +207,12 @@ class GrabbedDevice:
         button_codes: dict[str, int] | None = None,
         button_values: dict[str, int] | None = None,
         analog_inputs: dict[str, object] | None = None,
+        interface_id: str | None = None,
     ) -> None:
         self.path = path
         self.hardware_id = hardware_id
         self.stable_path = resolve_stable_path(path)
-        self.interface_id = str(get_interface_id(self.stable_path) or "").lower()
+        self.interface_id = str(interface_id or get_interface_id(self.stable_path) or "").lower()
         self.button_map: dict[str, str] = {}
         self.evdev_to_button: dict[str, str] = {}
         self.event_binding_to_button: dict[tuple[int, int, int | None], str] = {}

--- a/keymasq/keymasqd/runtime/topology.py
+++ b/keymasq/keymasqd/runtime/topology.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from keymasq.common.ipc import CommandType
 from keymasq.keymasqd.runtime import adapters as runtime_adapters
+from keymasq.keymasqd.runtime import device_path_resolver
 
 type JsonObject = dict[str, object]
 type Snapshot = dict[str, Any]
@@ -17,6 +18,8 @@ type DeviceInputFn = Callable[[str], Any]
 type ResolveStablePathFn = Callable[[str], str]
 type GetInterfaceIdFn = Callable[[str], str | None]
 type ReleaseInterfaceFn = Callable[[Any, str, str], Awaitable[None]]
+type DetectInputClassesFn = Callable[[Any], list[str]]
+type PrimaryInputClassFn = Callable[[Any], Any]
 
 
 @dataclass(frozen=True)
@@ -35,6 +38,8 @@ class TopologyRuntimeDeps:
     clear_device_path_cache_fn: ClearDevicePathCacheFn
     device_paths_fn: DevicePathsFn
     device_input_fn: DeviceInputFn
+    detect_input_classes_fn: DetectInputClassesFn
+    primary_input_class_fn: PrimaryInputClassFn
     resolve_stable_path_fn: ResolveStablePathFn
     get_interface_id_fn: GetInterfaceIdFn
     release_interface_fn: ReleaseInterfaceFn
@@ -57,6 +62,8 @@ async def start_topology_watcher(
         clear_device_path_cache_fn=deps.clear_device_path_cache_fn,
         device_paths_fn=deps.device_paths_fn,
         device_input_fn=deps.device_input_fn,
+        detect_input_classes_fn=deps.detect_input_classes_fn,
+        primary_input_class_fn=deps.primary_input_class_fn,
         resolve_stable_path_fn=deps.resolve_stable_path_fn,
         get_interface_id_fn=deps.get_interface_id_fn,
         log=log,
@@ -108,6 +115,8 @@ async def topology_watch_loop(
                     clear_device_path_cache_fn=deps.clear_device_path_cache_fn,
                     device_paths_fn=deps.device_paths_fn,
                     device_input_fn=deps.device_input_fn,
+                    detect_input_classes_fn=deps.detect_input_classes_fn,
+                    primary_input_class_fn=deps.primary_input_class_fn,
                     resolve_stable_path_fn=deps.resolve_stable_path_fn,
                     get_interface_id_fn=deps.get_interface_id_fn,
                     log=log,
@@ -270,19 +279,25 @@ def scan_live_interfaces_sync(
     clear_device_path_cache_fn: ClearDevicePathCacheFn,
     device_paths_fn: DevicePathsFn,
     device_input_fn: DeviceInputFn,
+    detect_input_classes_fn: DetectInputClassesFn,
+    primary_input_class_fn: PrimaryInputClassFn,
     resolve_stable_path_fn: ResolveStablePathFn,
     get_interface_id_fn: GetInterfaceIdFn,
     log: logging.Logger,
 ) -> Snapshot:
     clear_device_path_cache_fn()
     snapshot: Snapshot = {}
+    cached_devices = device_path_resolver.refresh_cached_devices_sync(
+        device_paths_fn=device_paths_fn,
+        device_input_fn=device_input_fn,
+        detect_input_classes_fn=detect_input_classes_fn,
+        primary_input_class_fn=primary_input_class_fn,
+    )
 
-    for path in device_paths_fn():
+    for path, device_info in cached_devices.items():
         try:
-            device = device_input_fn(path)
-            info = device.info
-            vendor_id = f"{info.vendor:04x}"
-            product_id = f"{info.product:04x}"
+            vendor_id = device_info.vendor_id
+            product_id = device_info.product_id
             hardware_id = f"{vendor_id}:{product_id}"
             stable_path = resolve_stable_path_fn(path)
             snapshot[stable_path] = LiveInterfaceInfo(

--- a/keymasq/keymasqd/runtime/topology.py
+++ b/keymasq/keymasqd/runtime/topology.py
@@ -219,7 +219,7 @@ def build_topology_events(
 
     for stable_path in sorted(previous.keys() - current.keys()):
         info = previous[stable_path]
-        if info.hardware_id not in desired_hardware_ids:
+        if not hardware_id_matches_desired(info.hardware_id, desired_hardware_ids):
             continue
         events.append(
             (
@@ -230,7 +230,7 @@ def build_topology_events(
 
     for stable_path in sorted(current.keys() - previous.keys()):
         info = current[stable_path]
-        if info.hardware_id not in desired_hardware_ids:
+        if not hardware_id_matches_desired(info.hardware_id, desired_hardware_ids):
             continue
         events.append(
             (
@@ -240,6 +240,18 @@ def build_topology_events(
         )
 
     return events
+
+
+def hardware_id_matches_desired(hardware_id: str, desired_hardware_ids: set[str]) -> bool:
+    normalized = str(hardware_id or "").strip().lower()
+    if not normalized:
+        return False
+    if normalized in desired_hardware_ids:
+        return True
+    return any(
+        str(desired or "").strip().lower().startswith(f"{normalized}@")
+        for desired in desired_hardware_ids
+    )
 
 
 def live_interface_payload(info: Any) -> JsonObject:

--- a/keymasq/session/manager/commands.py
+++ b/keymasq/session/manager/commands.py
@@ -772,11 +772,22 @@ async def _handle_capture_commands(
             for path in json_list(request.get("evdev_paths"))
             if str_value(path, "")
         ]
+        evdev_interfaces_raw = request.get("evdev_interfaces")
+        evdev_interfaces = (
+            [
+                cast(JsonObject, item)
+                for item in json_list(evdev_interfaces_raw)
+                if isinstance(item, dict)
+            ]
+            if evdev_interfaces_raw is not None
+            else None
+        )
         mode = str_value(request.get("mode"), "button")
         return await runtime_recording.capture_begin_for_paths(
             manager,
             hardware_id,
             evdev_paths,
+            evdev_interfaces=evdev_interfaces,
             mode=mode,
         )
 

--- a/keymasq/session/manager/commands.py
+++ b/keymasq/session/manager/commands.py
@@ -127,6 +127,31 @@ async def _handle_profile_commands(
         await manager.reload_profiles()
         return {"status": "ok"}
 
+    if command == "release_device":
+        hardware_id = str_value(request.get("hardware_id"), "").strip()
+        if not hardware_id:
+            return {"status": "error", "message": "missing hardware_id"}
+        immediate = bool(request.get("immediate", True))
+        try:
+            result = await manager.client.send_command(
+                Command(
+                    command=CommandType.RELEASE_DEVICE,
+                    data={"hardware_id": hardware_id, "immediate": immediate},
+                )
+            )
+        except Exception:
+            return {"status": "error", "message": "Daemon unavailable"}
+        if result.status != "ok":
+            return {
+                "status": "error",
+                "message": result.error or f"Failed to release {hardware_id}",
+            }
+        runtime_profiles.clear_hardware_runtime_state(manager, hardware_id)
+        response_data = json_object(result.data)
+        response = response_data if response_data else {}
+        response["status"] = "ok"
+        return response
+
     if command in {"reevaluate_profiles", "reevaluate_hardware"}:
         log.info("Global profile reevaluate requested")
         await asyncio.to_thread(manager.reload_config_from_disk)

--- a/keymasq/session/manager/core.py
+++ b/keymasq/session/manager/core.py
@@ -516,7 +516,7 @@ class SessionManager:
         ]
         for hardware_id in stale_ids:
             log.info(f"Hardware removed for {hardware_id}, deactivating profile")
-            await runtime_profiles.deactivate_profile(self, hardware_id)
+            await runtime_profiles.deactivate_profile(self, hardware_id, immediate=True)
             self.profile_state.resolved_devices.pop(hardware_id, None)
 
         await runtime_profiles.reevaluate_profiles(self, reason="config reload")

--- a/keymasq/session/manager/profiles.py
+++ b/keymasq/session/manager/profiles.py
@@ -513,7 +513,6 @@ async def apply_resolved_device_profile(
 
     if not resolved.has_effective_mapping and not inspector_active:
         cancel_grab_retry(manager, hardware_id)
-        manager.profile_state.grab_waiting_devices.discard(hardware_id)
         if hardware_id in manager.profile_state.grabbed_devices:
             await deactivate_profile(
                 manager,
@@ -521,6 +520,8 @@ async def apply_resolved_device_profile(
                 immediate=True,
                 generation=generation,
             )
+        elif hardware_id not in manager.profile_state.last_sent_grab_signatures:
+            manager.profile_state.grab_waiting_devices.discard(hardware_id)
         return
 
     new_interfaces = (
@@ -538,6 +539,34 @@ async def apply_resolved_device_profile(
         force_grab_unmapped=inspector_active,
     )
     grab_signature = grab_device_payload_signature(grab_payload)
+    if not new_interfaces and not inspector_active:
+        if manager.profile_state.last_sent_grab_signatures.get(hardware_id) != grab_signature:
+            log.warning(
+                (
+                    "No configured interfaces selected for %s "
+                    "(mappings=%d combo_sources=%s configured_interfaces=%s); "
+                    "skipping daemon grab"
+                ),
+                hardware_id,
+                len(resolved.mappings),
+                sorted(resolved.combo_sources),
+                sorted(all_configured_interfaces(hardware_config)),
+            )
+            manager.profile_state.last_sent_grab_signatures[hardware_id] = grab_signature
+        return
+
+    if (
+        hardware_id in manager.profile_state.grab_waiting_devices
+        and hardware_id not in manager.profile_state.grabbed_devices
+    ):
+        log.debug("Skipping pending grab for unavailable device %s", hardware_id)
+        maybe_notify_profile_activation(
+            manager,
+            hardware_config.name,
+            old_profile_names,
+            resolved,
+        )
+        return
 
     if hardware_id in manager.profile_state.grabbed_devices:
         if set(current_interfaces.keys()) == set(new_interfaces.keys()):
@@ -664,7 +693,17 @@ async def apply_resolved_device_profile(
             else:
                 manager.profile_state.grabbed_devices.discard(hardware_id)
                 manager.profile_state.grabbed_interfaces.pop(hardware_id, None)
-                manager.profile_state.last_sent_grab_signatures.pop(hardware_id, None)
+                waiting_for_device = bool(
+                    result_data is not None and result_data.get("waiting_for_device")
+                )
+                if waiting_for_device:
+                    manager.profile_state.grab_waiting_devices.add(hardware_id)
+                    manager.profile_state.last_sent_grab_signatures[hardware_id] = (
+                        grab_signature
+                    )
+                else:
+                    manager.profile_state.grab_waiting_devices.discard(hardware_id)
+                    manager.profile_state.last_sent_grab_signatures.pop(hardware_id, None)
                 log.warning(
                     (
                         "keymasqd grab returned zero interfaces for %s "

--- a/keymasq/session/manager/profiles.py
+++ b/keymasq/session/manager/profiles.py
@@ -981,10 +981,20 @@ def grab_device_payload_signature(payload: JsonObject) -> str:
 
 
 def _signature_evdev_interfaces(value: object) -> list[object]:
-    interfaces: list[object] = [
-        dict(cast(JsonObject, item)) if isinstance(item, dict) else item
-        for item in _json_list(value)
-    ]
+    interfaces: list[object] = []
+    for item in _json_list(value):
+        if not isinstance(item, dict):
+            interfaces.append(item)
+            continue
+
+        iface = dict(cast(JsonObject, item))
+        capabilities = iface.get("capabilities")
+        if isinstance(capabilities, list):
+            iface["capabilities"] = sorted(
+                str(capability) for capability in cast(list[object], capabilities)
+            )
+        interfaces.append(iface)
+
     return sorted(
         interfaces,
         key=lambda item: json.dumps(item, sort_keys=True, separators=(",", ":")),

--- a/keymasq/session/manager/profiles.py
+++ b/keymasq/session/manager/profiles.py
@@ -949,7 +949,9 @@ def build_grab_device_payload(
 def grab_device_payload_signature(payload: JsonObject) -> str:
     signature_payload = {
         "evdev_paths": sorted(str(path) for path in _json_list(payload.get("evdev_paths"))),
-        "evdev_interfaces": payload.get("evdev_interfaces", []),
+        "evdev_interfaces": _signature_evdev_interfaces(
+            payload.get("evdev_interfaces")
+        ),
         "button_map": payload.get("button_map", {}),
         "button_codes": payload.get("button_codes", {}),
         "button_values": payload.get("button_values", {}),
@@ -957,6 +959,17 @@ def grab_device_payload_signature(payload: JsonObject) -> str:
         "force_grab_unmapped": bool(payload.get("force_grab_unmapped", False)),
     }
     return json.dumps(signature_payload, sort_keys=True, separators=(",", ":"))
+
+
+def _signature_evdev_interfaces(value: object) -> list[object]:
+    interfaces: list[object] = [
+        dict(cast(JsonObject, item)) if isinstance(item, dict) else item
+        for item in _json_list(value)
+    ]
+    return sorted(
+        interfaces,
+        key=lambda item: json.dumps(item, sort_keys=True, separators=(",", ":")),
+    )
 
 
 async def update_grab_device_payload(

--- a/keymasq/session/manager/profiles.py
+++ b/keymasq/session/manager/profiles.py
@@ -421,9 +421,17 @@ async def _reevaluate_profiles(
         - active_hardware_ids
     )
     for hardware_id in stale_ids:
+        release_succeeded = True
         if hardware_id in manager.profile_state.grabbed_devices:
-            await deactivate_profile(manager, hardware_id, immediate=True, generation=generation)
+            release_succeeded = await deactivate_profile(
+                manager,
+                hardware_id,
+                immediate=True,
+                generation=generation,
+            )
             raise_if_stale_profile_apply(manager, generation)
+        if not release_succeeded:
+            continue
         manager.profile_state.resolved_devices.pop(hardware_id, None)
         clear_hardware_runtime_state(manager, hardware_id)
 
@@ -1113,12 +1121,12 @@ async def deactivate_profile(
     immediate: bool = False,
     *,
     generation: int | None = None,
-) -> None:
+) -> bool:
     raise_if_stale_profile_apply(manager, generation)
     cancel_grab_retry(manager, hardware_id)
     manager.profile_state.grab_waiting_devices.discard(hardware_id)
     if hardware_id not in manager.profile_state.grabbed_devices:
-        return
+        return True
 
     try:
         result = await manager.client.send_command(
@@ -1130,13 +1138,15 @@ async def deactivate_profile(
         raise_if_stale_profile_apply(manager, generation)
         if result.status != "ok":
             log.error("Failed to release device %s: %s", hardware_id, result.error)
-            return
+            return False
         clear_hardware_runtime_state(manager, hardware_id)
     except Exception as e:
         log.error("Failed to release device %s: %s", hardware_id, e)
+        return False
 
     runtime_payloads.clear_exec_refs(manager, hardware_id)
     log.info("Deactivated grabbed mapping for %s", hardware_id)
+    return True
 
 
 def maybe_notify_profile_activation(

--- a/keymasq/session/manager/profiles.py
+++ b/keymasq/session/manager/profiles.py
@@ -802,6 +802,30 @@ def all_configured_interfaces(hardware_config: HardwareConfig) -> dict[str, str]
     }
 
 
+def configured_interface_descriptors(
+    hardware_config: HardwareConfig,
+    selected_sources: set[str] | None,
+) -> list[JsonObject]:
+    descriptors: list[JsonObject] = []
+    for dev in hardware_config.evdev_devices:
+        interface_id = str(getattr(dev, "id", "") or "")
+        path = str(getattr(dev, "path", "") or "").strip()
+        if not interface_id or not path:
+            continue
+        if selected_sources is not None and interface_id not in selected_sources:
+            continue
+        descriptors.append(
+            {
+                "id": interface_id,
+                "path": path,
+                "type": getattr(getattr(dev, "device_type", None), "value", "other"),
+                "phys": str(getattr(dev, "phys", "") or ""),
+                "capabilities": list(getattr(dev, "capabilities", []) or []),
+            }
+        )
+    return descriptors
+
+
 def _device_inspector_active(manager: "SessionManager", hardware_id: str) -> bool:
     inspector_state = getattr(manager, "device_inspector_state", None)
     active_hardware_ids = (
@@ -825,9 +849,14 @@ def build_grab_device_payload(
     force_grab_unmapped: bool = False,
 ) -> JsonObject:
     analog_inputs = getattr(hardware_config, "analog_inputs", []) or []
+    selected_sources = set(interfaces.keys())
     return {
         "hardware_id": hardware_id,
         "evdev_paths": list(interfaces.values()),
+        "evdev_interfaces": configured_interface_descriptors(
+            hardware_config,
+            selected_sources,
+        ),
         "button_map": {b.id: b.evdev for b in hardware_config.buttons},
         "button_codes": manager.resolved_button_codes(hardware_config.buttons),
         "button_values": {
@@ -880,6 +909,7 @@ def build_grab_device_payload(
 def grab_device_payload_signature(payload: JsonObject) -> str:
     signature_payload = {
         "evdev_paths": sorted(str(path) for path in _json_list(payload.get("evdev_paths"))),
+        "evdev_interfaces": payload.get("evdev_interfaces", []),
         "button_map": payload.get("button_map", {}),
         "button_codes": payload.get("button_codes", {}),
         "button_values": payload.get("button_values", {}),

--- a/keymasq/session/manager/profiles.py
+++ b/keymasq/session/manager/profiles.py
@@ -558,6 +558,7 @@ async def apply_resolved_device_profile(
     if (
         hardware_id in manager.profile_state.grab_waiting_devices
         and hardware_id not in manager.profile_state.grabbed_devices
+        and manager.profile_state.last_sent_grab_signatures.get(hardware_id) == grab_signature
     ):
         log.debug("Skipping pending grab for unavailable device %s", hardware_id)
         maybe_notify_profile_activation(

--- a/keymasq/session/manager/profiles.py
+++ b/keymasq/session/manager/profiles.py
@@ -223,6 +223,16 @@ def invalidate_grabbed_state(manager: "SessionManager") -> None:
     manager.profile_state.last_sent_combo_signature = ""
 
 
+def clear_hardware_runtime_state(manager: "SessionManager", hardware_id: str) -> None:
+    cancel_grab_retry(manager, hardware_id)
+    manager.profile_state.grabbed_devices.discard(hardware_id)
+    manager.profile_state.grabbed_interfaces.pop(hardware_id, None)
+    manager.profile_state.grab_waiting_devices.discard(hardware_id)
+    manager.profile_state.last_sent_grab_signatures.pop(hardware_id, None)
+    manager.profile_state.last_sent_mapping_signatures.pop(hardware_id, None)
+    runtime_payloads.clear_exec_refs(manager, hardware_id)
+
+
 def invalidate_runtime_payload_signatures(manager: "SessionManager") -> None:
     manager.profile_state.last_sent_mapping_signatures.clear()
     manager.profile_state.last_sent_combo_signature = ""
@@ -398,15 +408,24 @@ async def _reevaluate_profiles(
         )
         raise_if_stale_profile_apply(manager, generation)
 
-    stale_ids = [
-        hardware_id
-        for hardware_id in list(manager.profile_state.resolved_devices)
-        if hardware_id not in set(hardware_ids)
-    ]
+    active_hardware_ids = set(hardware_ids)
+    stale_ids = sorted(
+        (
+            set(manager.profile_state.resolved_devices)
+            | set(manager.profile_state.grabbed_devices)
+            | set(manager.profile_state.grabbed_interfaces)
+            | set(manager.profile_state.grab_waiting_devices)
+            | set(manager.profile_state.last_sent_grab_signatures)
+            | set(manager.profile_state.last_sent_mapping_signatures)
+        )
+        - active_hardware_ids
+    )
     for hardware_id in stale_ids:
+        if hardware_id in manager.profile_state.grabbed_devices:
+            await deactivate_profile(manager, hardware_id, immediate=True, generation=generation)
+            raise_if_stale_profile_apply(manager, generation)
         manager.profile_state.resolved_devices.pop(hardware_id, None)
-        manager.profile_state.last_sent_grab_signatures.pop(hardware_id, None)
-        manager.profile_state.last_sent_mapping_signatures.pop(hardware_id, None)
+        clear_hardware_runtime_state(manager, hardware_id)
 
     await update_combos(manager, resolved.combos, generation=generation)
     raise_if_stale_profile_apply(manager, generation)
@@ -1102,10 +1121,7 @@ async def deactivate_profile(
         if result.status != "ok":
             log.error("Failed to release device %s: %s", hardware_id, result.error)
             return
-        manager.profile_state.grabbed_devices.discard(hardware_id)
-        manager.profile_state.grabbed_interfaces.pop(hardware_id, None)
-        manager.profile_state.last_sent_grab_signatures.pop(hardware_id, None)
-        manager.profile_state.last_sent_mapping_signatures.pop(hardware_id, None)
+        clear_hardware_runtime_state(manager, hardware_id)
     except Exception as e:
         log.error("Failed to release device %s: %s", hardware_id, e)
 

--- a/keymasq/session/manager/profiles.py
+++ b/keymasq/session/manager/profiles.py
@@ -815,7 +815,7 @@ def get_interfaces_to_grab(
         else:
             return interface_to_path
 
-    log.info(
+    log.debug(
         (
             "Interface selection for %s profile=%s: total_ifaces=%d "
             "mapped_buttons=%d resolved_sources=%d"

--- a/keymasq/session/manager/recording.py
+++ b/keymasq/session/manager/recording.py
@@ -593,10 +593,16 @@ async def capture_begin_for_paths(
     hardware_id: str,
     evdev_paths: list[str],
     *,
+    evdev_interfaces: list[JsonObject] | None = None,
     mode: str = "button",
 ) -> JsonObject:
-    if not evdev_paths:
+    explicit_evdev_paths = bool(evdev_paths)
+    if not explicit_evdev_paths:
         evdev_paths = _hardware_evdev_paths(manager, hardware_id)
+    if evdev_interfaces is None and explicit_evdev_paths:
+        evdev_interfaces = _evdev_interfaces_for_paths(manager, hardware_id, evdev_paths)
+    elif evdev_interfaces is None:
+        evdev_interfaces = _hardware_evdev_interfaces(manager, hardware_id)
     if not evdev_paths and _requires_explicit_evdev_paths(hardware_id):
         return {
             "status": "error",
@@ -611,6 +617,11 @@ async def capture_begin_for_paths(
                     "hardware_id": hardware_id,
                     **({"mode": mode} if mode != "button" else {}),
                     **({"evdev_paths": evdev_paths} if evdev_paths else {}),
+                    **(
+                        {"evdev_interfaces": evdev_interfaces}
+                        if evdev_interfaces
+                        else {}
+                    ),
                 },
             )
         )
@@ -726,12 +737,18 @@ async def capture_combo(
             for hardware_id in hardware_ids
             if (paths := _hardware_evdev_paths(manager, hardware_id))
         }
+        hardware_interfaces = {
+            hardware_id: interfaces
+            for hardware_id in hardware_ids
+            if (interfaces := _hardware_evdev_interfaces(manager, hardware_id))
+        }
         result = await manager.client.send_command(
             Command(
                 command=CommandType.CAPTURE_COMBO,
                 data={
                     "hardware_ids": hardware_ids,
                     "hardware_paths": hardware_paths,
+                    "hardware_interfaces": hardware_interfaces,
                     "timeout_s": float(timeout_s),
                 },
             )
@@ -777,6 +794,55 @@ def _hardware_evdev_paths(manager: "SessionManager", hardware_id: str) -> list[s
         for device in getattr(hardware, "evdev_devices", [])
         if (path := str_value(getattr(device, "path", ""), ""))
     ]
+
+
+def _hardware_evdev_interfaces(
+    manager: "SessionManager", hardware_id: str
+) -> list[JsonObject]:
+    hardware = manager.hardware.get_hardware(hardware_id)
+    if hardware is None:
+        return []
+    interfaces: list[JsonObject] = []
+    for device in getattr(hardware, "evdev_devices", []):
+        device_id = str_value(getattr(device, "id", ""), "")
+        if not device_id:
+            continue
+        path = str_value(getattr(device, "path", ""), "")
+        if not path:
+            continue
+        interfaces.append(
+            {
+                "id": device_id,
+                "path": path,
+                "type": getattr(getattr(device, "device_type", None), "value", "other"),
+                "phys": str_value(getattr(device, "phys", ""), ""),
+                "capabilities": list(getattr(device, "capabilities", []) or []),
+            }
+        )
+    return interfaces
+
+
+def _evdev_interfaces_for_paths(
+    manager: "SessionManager",
+    hardware_id: str,
+    evdev_paths: list[str],
+) -> list[JsonObject]:
+    configured_by_path: dict[str, list[JsonObject]] = {}
+    for interface in _hardware_evdev_interfaces(manager, hardware_id):
+        path = str_value(interface.get("path"), "")
+        if not path:
+            continue
+        configured_by_path.setdefault(path, []).append(interface)
+
+    interfaces: list[JsonObject] = []
+    for path in evdev_paths:
+        normalized_path = str_value(path, "")
+        if not normalized_path:
+            continue
+        configured = configured_by_path.get(normalized_path, [])
+        if configured:
+            interfaces.append(configured.pop(0))
+    return interfaces
 
 
 def _requires_explicit_evdev_paths(hardware_id: str) -> bool:

--- a/keymasq/session/manager/recording.py
+++ b/keymasq/session/manager/recording.py
@@ -1291,12 +1291,6 @@ async def get_devices_for_recording(
     if result.status != "ok" or result_data is None:
         return []
 
-    grabbed_paths = {
-        path
-        for interface_map in manager.profile_state.grabbed_interfaces.values()
-        for path in interface_map.values()
-    }
-
     devices: list[JsonObject] = []
     for raw_device in json_list(result_data.get("devices")):
         d = json_object(raw_device)
@@ -1309,9 +1303,7 @@ async def get_devices_for_recording(
         if not path or not set(device_types).intersection(resolved_types):
             continue
 
-        is_grabbed = bool(d.get("grabbed_by_keymasq", False)) or path in grabbed_paths
-        if stable_path in grabbed_paths:
-            is_grabbed = True
+        is_grabbed = bool(d.get("grabbed_by_keymasq", False))
         if is_grabbed and not include_grabbed:
             continue
 

--- a/tests/gui/test_device_tab_widget.py
+++ b/tests/gui/test_device_tab_widget.py
@@ -657,6 +657,87 @@ class TestDeviceTabWidget:
         assert root.checked == 1
         assert closed == [True]
 
+    def test_device_tab_delete_keeps_config_when_release_fails(
+        self, temp_config_dir, monkeypatch
+    ):
+        from gi.repository import Adw, Gtk
+
+        from keymasq.common.models import ButtonDefinition, HardwareConfig
+        from keymasq.gui.widgets import device_tab as device_tab_module
+        from keymasq.gui.widgets.device_tab import DeviceTab
+
+        class _HardwareManager:
+            def __init__(self) -> None:
+                self.deleted: list[str] = []
+
+            def delete_hardware(self, hardware_id: str) -> None:
+                self.deleted.append(hardware_id)
+
+        class _ProfileManager:
+            def __init__(self) -> None:
+                self.removed: list[str] = []
+
+            def list_profiles(self) -> list[object]:
+                return []
+
+            def remove_device_layers(self, hardware_id: str) -> None:
+                self.removed.append(hardware_id)
+
+        device = HardwareConfig(
+            vendor_id="1234",
+            product_id="5678",
+            name="Test Mouse",
+            evdev_devices=[],
+            buttons=[ButtonDefinition(id="btn_back", label="Back", evdev="btn_side")],
+        )
+
+        hardware_manager = _HardwareManager()
+        profile_manager = _ProfileManager()
+        tab = DeviceTab(
+            device=device,
+            profile_manager=profile_manager,
+            hardware_manager=hardware_manager,
+            demo_mode=True,
+        )
+
+        requests: list[dict] = []
+
+        def fake_session_request_async(payload, callback):
+            requests.append(payload)
+            callback({"status": "error", "error": "release failed"})
+
+        monkeypatch.setattr(
+            device_tab_module,
+            "session_request_async",
+            fake_session_request_async,
+        )
+
+        dialog = Adw.Dialog()
+        closed: list[bool] = []
+        dialog.close = lambda: closed.append(True)  # type: ignore[method-assign]
+        delete_profiles_check = Gtk.CheckButton()
+        delete_profiles_check.set_active(True)
+        delete_button = Gtk.Button()
+        error_label = Gtk.Label()
+        error_label.set_visible(False)
+
+        tab._on_confirm_delete_device(
+            delete_button,
+            dialog,
+            delete_profiles_check,
+            error_label,
+        )
+
+        assert delete_button.get_sensitive() is True
+        assert error_label.get_visible() is True
+        assert "release failed" in error_label.get_label()
+        assert profile_manager.removed == []
+        assert hardware_manager.deleted == []
+        assert requests == [
+            {"command": "release_device", "hardware_id": "1234:5678", "immediate": True}
+        ]
+        assert closed == []
+
     def test_device_tab_rename_device_updates_hardware_runtime_and_header(
         self, temp_config_dir, monkeypatch
     ):

--- a/tests/gui/test_device_tab_widget.py
+++ b/tests/gui/test_device_tab_widget.py
@@ -626,10 +626,15 @@ class TestDeviceTabWidget:
         )
 
         reload_requests: list[dict] = []
+
+        def fake_session_request_async(payload, callback):
+            reload_requests.append(payload)
+            callback({"status": "ok"})
+
         monkeypatch.setattr(
             device_tab_module,
             "session_request_async",
-            lambda payload, callback: reload_requests.append(payload),
+            fake_session_request_async,
         )
 
         root = _Root()
@@ -644,7 +649,10 @@ class TestDeviceTabWidget:
 
         assert profile_manager.removed == ["1234:5678"]
         assert hardware_manager.deleted == ["1234:5678"]
-        assert reload_requests == [{"command": "reload"}]
+        assert reload_requests == [
+            {"command": "release_device", "hardware_id": "1234:5678", "immediate": True},
+            {"command": "reload"},
+        ]
         assert root.stack.removed == [tab]
         assert root.checked == 1
         assert closed == [True]

--- a/tests/gui/test_hardware_setup_dialog.py
+++ b/tests/gui/test_hardware_setup_dialog.py
@@ -522,7 +522,6 @@ class TestHardwareSetupDialog:
         from keymasq.gui.wizards.hardware_setup import HardwareSetupDialog
 
         summary = HardwareSetupDialog._device_in_use_summary(
-            None,
             {
                 "interfaces": [
                     "invalid",

--- a/tests/gui/test_hardware_setup_dialog.py
+++ b/tests/gui/test_hardware_setup_dialog.py
@@ -186,9 +186,9 @@ class TestHardwareSetupDialog:
         assert requests == [
             {"command": "list_devices_for_recording", "include_other": True}
         ]
-        assert set(detected_devices) == {"1234:1002", "1234:1002@2"}
-        assert detected_devices["1234:1002"]["paths"] == ["/dev/input/event20"]
-        assert detected_devices["1234:1002@2"]["paths"] == ["/dev/input/event21"]
+        assert set(detected_devices) == {"raw:/dev/input/event20", "raw:/dev/input/event21"}
+        assert detected_devices["raw:/dev/input/event20"]["paths"] == ["/dev/input/event20"]
+        assert detected_devices["raw:/dev/input/event21"]["paths"] == ["/dev/input/event21"]
 
     def test_raw_evdev_toggle_is_disabled_during_detection(self, monkeypatch):
         gi.require_version("Gtk", "4.0")
@@ -222,7 +222,7 @@ class TestHardwareSetupDialog:
 
         assert dialog.raw_evdev_check.get_sensitive() is True
 
-    def test_raw_evdev_mode_skips_configured_event_nodes(self, monkeypatch):
+    def test_raw_evdev_mode_keeps_configured_event_nodes_visible(self, monkeypatch):
         gi.require_version("Gtk", "4.0")
         from gi.repository import Gtk
 
@@ -276,8 +276,77 @@ class TestHardwareSetupDialog:
         detected_devices: dict[str, dict] = {}
 
         assert dialog._detect_devices_via_session(detected_devices) is True
-        assert set(detected_devices) == {"1234:1002@2"}
-        assert detected_devices["1234:1002@2"]["paths"] == ["/dev/input/event21"]
+        assert set(detected_devices) == {
+            "1234:1002#/dev/input/event20",
+            "raw:/dev/input/event21",
+        }
+        assert detected_devices["1234:1002#/dev/input/event20"]["paths"] == [
+            "/dev/input/event20"
+        ]
+        assert detected_devices["1234:1002#/dev/input/event20"]["interfaces"][0][
+            "configured_hardware_id"
+        ] == "1234:1002"
+        assert detected_devices["raw:/dev/input/event21"]["paths"] == ["/dev/input/event21"]
+
+    def test_raw_evdev_mode_keeps_grabbed_rows_without_consuming_duplicate_id(
+        self, monkeypatch
+    ):
+        gi.require_version("Gtk", "4.0")
+        from gi.repository import Gtk
+
+        from keymasq.gui.wizards import hardware_setup as hardware_setup_mod
+        from keymasq.gui.wizards.hardware_setup import HardwareSetupDialog
+
+        monkeypatch.setattr(HardwareSetupDialog, "_detect_devices", lambda self: None)
+        monkeypatch.setattr(
+            hardware_setup_mod,
+            "session_request",
+            lambda _payload, timeout=3.0: {
+                "status": "ok",
+                "devices": [
+                    {
+                        "path": "/dev/input/event20",
+                        "stable_path": "/dev/input/event20",
+                        "name": "Xbox 360 Wireless Receiver",
+                        "phys": "usb-0000:0e:00.3-1.2/input0",
+                        "vendor_id": "045e",
+                        "product_id": "02a1",
+                        "device_type": "gamepad",
+                        "device_types": ["gamepad"],
+                        "grabbed_by_keymasq": True,
+                        "source_hardware_id": "045e:02a1",
+                        "source_interface_id": "gamepad",
+                    },
+                    {
+                        "path": "/dev/input/event21",
+                        "stable_path": "/dev/input/event21",
+                        "name": "Xbox 360 Wireless Receiver",
+                        "phys": "usb-0000:0e:00.3-1.3/input0",
+                        "vendor_id": "045e",
+                        "product_id": "02a1",
+                        "device_type": "gamepad",
+                        "device_types": ["gamepad"],
+                    },
+                ],
+            },
+        )
+
+        hardware_manager = SimpleNamespace(list_hardware_ids=lambda: ["045e:02a1"])
+        dialog = HardwareSetupDialog(Gtk.Window(), hardware_manager)
+        dialog._show_raw_evdev_devices = True
+        detected_devices: dict[str, dict] = {}
+
+        assert dialog._detect_devices_via_session(detected_devices) is True
+
+        assert set(detected_devices) == {
+            "045e:02a1#/dev/input/event20",
+            "raw:/dev/input/event21",
+        }
+        assert detected_devices["045e:02a1#/dev/input/event20"]["hardware_id"] == "045e:02a1"
+        assert detected_devices["045e:02a1#/dev/input/event20"]["interfaces"][0][
+            "grabbed_by_keymasq"
+        ] is True
+        assert detected_devices["raw:/dev/input/event21"]["paths"] == ["/dev/input/event21"]
 
     def test_raw_unknown_device_uses_custom_empty_profile_mode(self, monkeypatch):
         gi.require_version("Gtk", "4.0")
@@ -334,7 +403,7 @@ class TestHardwareSetupDialog:
         assert saved.buttons == []
         assert emitted == [("device-created", saved)]
 
-    def test_raw_evdev_discovery_preserves_raw_config_paths(self, monkeypatch):
+    def test_raw_evdev_discovery_uses_logical_config_path_without_by_id(self, monkeypatch):
         gi.require_version("Gtk", "4.0")
         from gi.repository import Gtk
 
@@ -368,7 +437,7 @@ class TestHardwareSetupDialog:
         dialog._discover_interfaces()
 
         raw_iface = next(iter(dialog.discovered_interfaces.values()))
-        assert raw_iface["config_path"] == "/dev/input/event20"
+        assert raw_iface["config_path"] == "keymasq:1234:1002"
 
         dialog.selected_device = {
             "vendor_id": "1234",
@@ -390,9 +459,9 @@ class TestHardwareSetupDialog:
         dialog._discover_interfaces()
 
         fallback_iface = next(iter(dialog.discovered_interfaces.values()))
-        assert fallback_iface["config_path"] == "/dev/input/event21"
+        assert fallback_iface["config_path"] == "keymasq:1234:1002"
 
-    def test_raw_evdev_rows_hide_interface_expander(self, monkeypatch):
+    def test_normal_rows_show_interface_expander_and_raw_rows_use_summary(self, monkeypatch):
         gi.require_version("Gtk", "4.0")
         from gi.repository import Gtk
 
@@ -403,11 +472,51 @@ class TestHardwareSetupDialog:
         dialog = HardwareSetupDialog(Gtk.Window(), SimpleNamespace())
 
         dialog._show_raw_evdev_devices = False
+        assert dialog._should_show_interface_expander([{}]) is True
         assert dialog._should_show_interface_expander([{}, {}]) is True
 
         dialog._show_raw_evdev_devices = True
         assert dialog._should_show_interface_expander([{}]) is False
         assert dialog._should_show_interface_expander([{}, {}]) is False
+
+    def test_selecting_in_use_raw_row_disables_next(self, monkeypatch):
+        gi.require_version("Gtk", "4.0")
+        from gi.repository import Gtk
+
+        from keymasq.gui.wizards.hardware_setup import HardwareSetupDialog
+
+        monkeypatch.setattr(HardwareSetupDialog, "_detect_devices", lambda self: None)
+
+        dialog = HardwareSetupDialog(Gtk.Window(), SimpleNamespace())
+        dialog._show_raw_evdev_devices = True
+        dialog._discover_interfaces = lambda: None  # type: ignore[method-assign]
+        dialog._refresh_configure_modes = lambda: None  # type: ignore[method-assign]
+        dialog.detected_devices = {
+            "045e:02a1#/dev/input/event20": {
+                "vendor_id": "045e",
+                "product_id": "02a1",
+                "name": "Xbox 360 Wireless Receiver",
+                "interfaces": [
+                    {
+                        "path": "/dev/input/event20",
+                        "grabbed_by_keymasq": True,
+                        "source_hardware_id": "045e:02a1",
+                        "source_interface_id": "gamepad",
+                    }
+                ],
+            }
+        }
+        row = Gtk.ListBoxRow()
+        row.hardware_id = "045e:02a1#/dev/input/event20"
+        dialog.device_list.append(row)
+
+        dialog._on_device_selected(None, row)
+
+        assert dialog.selected_device is dialog.detected_devices[row.hardware_id]
+        assert dialog.next_btn.get_sensitive() is False
+        assert dialog._device_in_use_summary(dialog.selected_device) == (
+            "In use by 045e:02a1 (gamepad)"
+        )
 
     def test_selecting_row_without_expander_still_enables_next(self, monkeypatch):
         gi.require_version("Gtk", "4.0")
@@ -540,6 +649,32 @@ class TestHardwareSetupDialog:
                     "vendor_id": "045e",
                     "product_id": "02a1",
                     "hardware_id": "045e:02a1@2",
+                }
+            )
+            == "045e:02a1@2"
+        )
+
+    def test_raw_selected_config_id_allocates_lowest_free_id(self, monkeypatch):
+        gi.require_version("Gtk", "4.0")
+        from gi.repository import Gtk
+
+        from keymasq.gui.wizards.hardware_setup import HardwareSetupDialog
+
+        monkeypatch.setattr(HardwareSetupDialog, "_detect_devices", lambda self: None)
+
+        dialog = HardwareSetupDialog(
+            Gtk.Window(),
+            SimpleNamespace(list_hardware_ids=lambda: ["045e:02a1"]),
+        )
+        dialog._show_raw_evdev_devices = True
+
+        assert (
+            dialog._selected_config_id(
+                {
+                    "vendor_id": "045e",
+                    "product_id": "02a1",
+                    "hardware_id": "045e:02a1",
+                    "interfaces": [{"path": "/dev/input/event28"}],
                 }
             )
             == "045e:02a1@2"

--- a/tests/gui/test_hardware_setup_dialog.py
+++ b/tests/gui/test_hardware_setup_dialog.py
@@ -518,6 +518,21 @@ class TestHardwareSetupDialog:
             "In use by 045e:02a1 (gamepad)"
         )
 
+    def test_device_in_use_summary_ignores_non_dict_interfaces(self):
+        from keymasq.gui.wizards.hardware_setup import HardwareSetupDialog
+
+        summary = HardwareSetupDialog._device_in_use_summary(
+            None,
+            {
+                "interfaces": [
+                    "invalid",
+                    {"configured_hardware_id": "045e:02a1"},
+                ]
+            },
+        )
+
+        assert summary == "Configured as 045e:02a1"
+
     def test_selecting_row_without_expander_still_enables_next(self, monkeypatch):
         gi.require_version("Gtk", "4.0")
         from gi.repository import Gtk

--- a/tests/gui/test_hardware_setup_dialog.py
+++ b/tests/gui/test_hardware_setup_dialog.py
@@ -1208,7 +1208,7 @@ class TestHardwareSetupDialog:
         assert dialog._detect_devices_via_session(detected_devices) is False
         assert detected_devices == {}
 
-    def test_detect_devices_via_session_ignores_unstable_usb_phys_for_identity(
+    def test_detect_devices_via_session_keeps_no_by_id_usb_event_nodes_separate(
         self, monkeypatch
     ):
         gi.require_version("Gtk", "4.0")
@@ -1251,8 +1251,9 @@ class TestHardwareSetupDialog:
 
         assert dialog._detect_devices_via_session(detected_devices) is True
 
-        assert set(detected_devices) == {"1234:5678"}
-        assert len(detected_devices["1234:5678"]["interfaces"]) == 2
+        assert set(detected_devices) == {"1234:5678", "1234:5678@2"}
+        assert detected_devices["1234:5678"]["paths"] == ["/dev/input/event10"]
+        assert detected_devices["1234:5678@2"]["paths"] == ["/dev/input/event11"]
 
     def test_save_gamepad_config_builds_buttons_from_capabilities(self, monkeypatch):
         gi.require_version("Gtk", "4.0")
@@ -1463,6 +1464,62 @@ class TestHardwareSetupDialog:
         assert saved.buttons[7].source == "kbd"
         assert saved.buttons[7].id == "key_esc"
         assert emitted == [("device-created", saved)]
+
+    def test_save_mouse_config_keeps_grouped_keyboard_interface(self, monkeypatch):
+        gi.require_version("Gtk", "4.0")
+        from gi.repository import Gtk
+
+        from keymasq.common.models import DeviceType
+        from keymasq.gui.wizards.hardware_setup import HardwareSetupDialog
+
+        class _HardwareManager:
+            def __init__(self) -> None:
+                self.saved = []
+
+            def save_hardware(self, config) -> None:
+                self.saved.append(config)
+
+        monkeypatch.setattr(HardwareSetupDialog, "_detect_devices", lambda self: None)
+
+        hardware_manager = _HardwareManager()
+        dialog = HardwareSetupDialog(Gtk.Window(), hardware_manager)
+        dialog.selected_device = {
+            "vendor_id": "1532",
+            "product_id": "00b4",
+            "name": "Razer Naga",
+        }
+        dialog.discovered_interfaces = {
+            "mouse": {
+                "id": "mouse",
+                "stable_path": "/dev/input/by-id/usb-Razer_Naga-event-mouse",
+                "path": "/dev/input/event5",
+                "name": "Razer Naga",
+                "device_type": DeviceType.MOUSE,
+                "device_types": ["mouse"],
+                "capabilities": ["btn_left", "btn_right", "rel_wheel"],
+            },
+            "kbd": {
+                "id": "kbd",
+                "stable_path": "/dev/input/by-id/usb-Razer_Naga-if02-event-kbd",
+                "path": "/dev/input/event7",
+                "name": "Razer Naga",
+                "device_type": DeviceType.KEYBOARD,
+                "device_types": ["keyboard"],
+                "capabilities": ["key_a"],
+            },
+        }
+        dialog.emit = lambda _signal, _config: None
+        dialog.close = lambda: None
+
+        dialog._save_mouse_config()
+
+        saved = hardware_manager.saved[0]
+        assert [device.id for device in saved.evdev_devices] == ["mouse", "kbd"]
+        assert [device.device_type for device in saved.evdev_devices] == [
+            DeviceType.MOUSE,
+            DeviceType.KEYBOARD,
+        ]
+        assert [button.source for button in saved.buttons] == ["mouse"] * len(saved.buttons)
 
     def test_standard_mouse_template_adds_horizontal_wheel_when_supported(self, monkeypatch):
         gi.require_version("Gtk", "4.0")

--- a/tests/gui/test_hardware_setup_dialog.py
+++ b/tests/gui/test_hardware_setup_dialog.py
@@ -82,6 +82,45 @@ class TestHardwareSetupDialog:
         assert first_key == "uinput-model:1234:1001"
         assert other_model_key == "uinput-model:046d:c24f"
 
+    def test_interface_id_for_config_uses_type_without_by_id(self):
+        from keymasq.gui.wizards.hardware_setup import _interface_id_for_config
+
+        used_ids: set[str] = set()
+
+        first = _interface_id_for_config(
+            {
+                "stable_path": "/dev/input/event7",
+                "config_path": "keymasq:2dc8:3106",
+                "device_types": ["gamepad"],
+            },
+            used_ids,
+        )
+        second = _interface_id_for_config(
+            {
+                "stable_path": "/dev/input/event8",
+                "config_path": "keymasq:2dc8:3106",
+                "device_types": ["gamepad"],
+            },
+            used_ids,
+        )
+
+        assert first == "gamepad"
+        assert second == "gamepad_2"
+
+    def test_interface_id_for_config_uses_by_id_suffix(self):
+        from keymasq.gui.wizards.hardware_setup import _interface_id_for_config
+
+        iface_id = _interface_id_for_config(
+            {
+                "stable_path": "/dev/input/by-id/usb-Test-if02-event-joystick",
+                "config_path": "/dev/input/by-id/usb-Test-if02-event-joystick",
+                "device_types": ["gamepad"],
+            },
+            set(),
+        )
+
+        assert iface_id == "if02_joystick"
+
     def test_raw_evdev_mode_requests_other_devices_and_disables_grouping(
         self, monkeypatch
     ):
@@ -280,6 +319,64 @@ class TestHardwareSetupDialog:
         assert saved.evdev_devices[0].device_type == DeviceType.OTHER
         assert saved.buttons == []
         assert emitted == [("device-created", saved)]
+
+    def test_raw_evdev_discovery_preserves_raw_config_paths(self, monkeypatch):
+        gi.require_version("Gtk", "4.0")
+        from gi.repository import Gtk
+
+        from keymasq.common.models import DeviceType
+        from keymasq.gui.wizards import hardware_setup as hardware_setup_mod
+        from keymasq.gui.wizards.hardware_setup import HardwareSetupDialog
+
+        monkeypatch.setattr(HardwareSetupDialog, "_detect_devices", lambda self: None)
+        monkeypatch.setattr(
+            HardwareSetupDialog,
+            "_read_interface_capabilities",
+            lambda self, _path: ([], {}),
+        )
+
+        dialog = HardwareSetupDialog(Gtk.Window(), SimpleNamespace())
+        dialog._show_raw_evdev_devices = True
+        dialog.selected_device = {
+            "vendor_id": "1234",
+            "product_id": "1002",
+            "interfaces": [
+                {
+                    "path": "/dev/input/event20",
+                    "stable_path": "/dev/input/event20",
+                    "name": "Raw Device",
+                    "device_type": DeviceType.OTHER,
+                    "device_types": ["other"],
+                }
+            ],
+        }
+
+        dialog._discover_interfaces()
+
+        raw_iface = next(iter(dialog.discovered_interfaces.values()))
+        assert raw_iface["config_path"] == "/dev/input/event20"
+
+        dialog.selected_device = {
+            "vendor_id": "1234",
+            "product_id": "1002",
+            "interfaces": [],
+        }
+        monkeypatch.setattr(
+            hardware_setup_mod,
+            "find_all_interfaces",
+            lambda _vid, _pid: [
+                {
+                    "path": "/dev/input/event21",
+                    "stable_path": "/dev/input/event21",
+                    "name": "Raw Device Keyboard",
+                }
+            ],
+        )
+
+        dialog._discover_interfaces()
+
+        fallback_iface = next(iter(dialog.discovered_interfaces.values()))
+        assert fallback_iface["config_path"] == "/dev/input/event21"
 
     def test_raw_evdev_rows_hide_interface_expander(self, monkeypatch):
         gi.require_version("Gtk", "4.0")
@@ -1526,6 +1623,7 @@ def test_hardware_setup_capture_flow_records_buttons_and_saves(monkeypatch):
             "id": "mouse",
             "stable_path": "/dev/input/by-id/test-mouse",
             "device_types": ["mouse"],
+            "capabilities": ["btn_left", "rel_x"],
         }
     }
     dialog._capture_hardware_id = "1234:5678"
@@ -1555,6 +1653,7 @@ def test_hardware_setup_capture_flow_records_buttons_and_saves(monkeypatch):
     saved = hardware_manager.saved[0]
     assert saved.id is None
     assert saved.evdev_devices[0].device_type == DeviceType.MOUSE
+    assert saved.evdev_devices[0].capabilities == ["btn_left", "rel_x"]
     assert saved.buttons[0].id == "btn_left"
     assert saved.buttons[0].evdev == "btn_left"
     assert requests == [
@@ -1562,7 +1661,16 @@ def test_hardware_setup_capture_flow_records_buttons_and_saves(monkeypatch):
             "command": "begin_capture",
             "hardware_id": "1234:5678",
             "evdev_paths": ["/dev/input/by-id/test-mouse"],
-        },
+            "evdev_interfaces": [
+                    {
+                        "id": "mouse",
+                        "path": "/dev/input/by-id/test-mouse",
+                        "type": "mouse",
+                        "phys": "",
+                        "capabilities": ["btn_left", "rel_x"],
+                    }
+                ],
+            },
         {"command": "capture_read", "hardware_id": "1234:5678"},
         {"command": "end_capture", "hardware_id": "1234:5678"},
     ]

--- a/tests/gui/test_hardware_setup_dialog.py
+++ b/tests/gui/test_hardware_setup_dialog.py
@@ -121,6 +121,20 @@ class TestHardwareSetupDialog:
 
         assert iface_id == "if02_joystick"
 
+    def test_interface_id_for_config_prefers_by_id_config_path(self):
+        from keymasq.gui.wizards.hardware_setup import _interface_id_for_config
+
+        iface_id = _interface_id_for_config(
+            {
+                "stable_path": "/dev/input/event20",
+                "config_path": "/dev/input/by-id/usb-Test-if03-event-kbd",
+                "device_types": ["keyboard"],
+            },
+            set(),
+        )
+
+        assert iface_id == "if03_kbd"
+
     def test_raw_evdev_mode_requests_other_devices_and_disables_grouping(
         self, monkeypatch
     ):

--- a/tests/keymasqd/test_daemon_capture_commands.py
+++ b/tests/keymasqd/test_daemon_capture_commands.py
@@ -3,8 +3,10 @@ from tests.keymasqd.daemon_support import *
 
 import evdev
 
+from keymasq.common.devices import detect_input_classes, primary_input_class
 from keymasq.keymasqd import capture_manager as capture_manager_module
 from keymasq.keymasqd.capture_manager import CaptureManager
+from keymasq.keymasqd.runtime import device_path_resolver
 
 @pytest.mark.asyncio
 async def test_macro_play_by_name_loads_store_and_forwards_runtime_options(daemon_testbed):
@@ -320,6 +322,12 @@ def test_capture_manager_resolves_logical_combo_interfaces(monkeypatch):
         capture_manager_module.evdev,
         "InputDevice",
         lambda path: devices[path],
+    )
+    device_path_resolver.refresh_cached_devices_sync(
+        device_paths_fn=capture_manager_module.evdev.list_devices,
+        device_input_fn=capture_manager_module.evdev.InputDevice,
+        detect_input_classes_fn=detect_input_classes,
+        primary_input_class_fn=primary_input_class,
     )
 
     manager = CaptureManager()

--- a/tests/keymasqd/test_daemon_capture_commands.py
+++ b/tests/keymasqd/test_daemon_capture_commands.py
@@ -1,6 +1,11 @@
 # ruff: noqa: F403, F405, I001
 from tests.keymasqd.daemon_support import *
 
+import evdev
+
+from keymasq.keymasqd import capture_manager as capture_manager_module
+from keymasq.keymasqd.capture_manager import CaptureManager
+
 @pytest.mark.asyncio
 async def test_macro_play_by_name_loads_store_and_forwards_runtime_options(daemon_testbed):
     daemon, device_manager, _recording_manager, macro_store, _capture_manager = daemon_testbed
@@ -150,7 +155,7 @@ async def test_start_recording_resolves_recording_ids_before_start(daemon_testbe
             CommandType.CAPTURE_COMBO,
             {"hardware_ids": ["1234:5678"], "timeout_s": 9.0},
             "_capture_combo",
-            ({"1234:5678"}, 9.0, {}),
+            ({"1234:5678"}, 9.0, {}, {}),
             {"events": [{"evdev": "key_a", "hardware_id": "1234:5678", "source": "kbd"}]},
         ),
     ],
@@ -202,6 +207,29 @@ async def test_capture_begin_forwards_explicit_evdev_paths(daemon_testbed):
 
 
 @pytest.mark.asyncio
+async def test_capture_begin_forwards_evdev_interfaces(daemon_testbed):
+    daemon, _device_manager, _recording_manager, _macro_store, capture_manager = daemon_testbed
+    interfaces = [{"id": "gamepad", "path": "keymasq:2dc8:3106", "type": "gamepad"}]
+
+    result = await daemon._handle_command(
+        CommandType.CAPTURE_BEGIN,
+        {
+            "hardware_id": "2dc8:3106",
+            "evdev_paths": ["keymasq:2dc8:3106"],
+            "evdev_interfaces": interfaces,
+        },
+    )
+
+    assert result == {"token": "cap-token"}
+    capture_manager.begin.assert_called_once_with(
+        "2dc8:3106",
+        evdev_paths=["keymasq:2dc8:3106"],
+        evdev_interfaces=interfaces,
+        mode="button",
+    )
+
+
+@pytest.mark.asyncio
 async def test_capture_combo_forwards_explicit_hardware_paths(daemon_testbed, monkeypatch):
     daemon, _device_manager, _recording_manager, _macro_store, _capture_manager = daemon_testbed
     capture_combo = AsyncMock(return_value={"events": []})
@@ -222,7 +250,96 @@ async def test_capture_combo_forwards_explicit_hardware_paths(daemon_testbed, mo
         {"1234:5678@2"},
         2.0,
         {"1234:5678@2": ["/dev/input/by-path/test-event-kbd"]},
+        {},
     )
+
+
+@pytest.mark.asyncio
+async def test_capture_combo_forwards_hardware_interfaces(daemon_testbed, monkeypatch):
+    daemon, _device_manager, _recording_manager, _macro_store, _capture_manager = daemon_testbed
+    interfaces = {
+        "2dc8:3106": [
+            {
+                "id": "gamepad",
+                "path": "keymasq:2dc8:3106",
+                "type": "gamepad",
+                "phys": "bluetooth/input0",
+                "capabilities": ["btn_south"],
+            }
+        ]
+    }
+    capture_combo = AsyncMock(return_value={"events": []})
+    monkeypatch.setattr(daemon_capture_commands, "capture_combo", capture_combo)
+
+    result = await daemon._handle_command(
+        CommandType.CAPTURE_COMBO,
+        {
+            "hardware_ids": ["2dc8:3106"],
+            "hardware_interfaces": interfaces,
+            "timeout_s": 2.0,
+        },
+    )
+
+    assert result == {"events": []}
+    capture_combo.assert_awaited_once_with(
+        daemon,
+        {"2dc8:3106"},
+        2.0,
+        {},
+        interfaces,
+    )
+
+
+def test_capture_manager_resolves_logical_combo_interfaces(monkeypatch):
+    class FakeDevice:
+        def __init__(self, path: str, *, phys: str) -> None:
+            self.path = path
+            self.name = "Bluetooth Pad"
+            self.phys = phys
+            self.info = SimpleNamespace(vendor=0x2DC8, product=0x3106)
+
+        def capabilities(self):
+            return {
+                evdev.ecodes.EV_KEY: [evdev.ecodes.BTN_SOUTH],
+                evdev.ecodes.EV_ABS: [evdev.ecodes.ABS_X],
+            }
+
+        def input_props(self):
+            return []
+
+    devices = {
+        "/dev/input/event2": FakeDevice("/dev/input/event2", phys="bluetooth/input1"),
+        "/dev/input/event9": FakeDevice("/dev/input/event9", phys="bluetooth/input0"),
+    }
+    monkeypatch.setattr(
+        capture_manager_module.evdev,
+        "list_devices",
+        lambda: list(devices),
+    )
+    monkeypatch.setattr(
+        capture_manager_module.evdev,
+        "InputDevice",
+        lambda path: devices[path],
+    )
+
+    manager = CaptureManager()
+    path_hardware_ids, path_sources = manager._hardware_interface_lookup(
+        {
+            "2dc8:3106": [
+                {
+                    "id": "gamepad",
+                    "path": "keymasq:2dc8:3106",
+                    "type": "gamepad",
+                    "phys": "bluetooth/input0",
+                    "capabilities": ["btn_south"],
+                }
+            ]
+        }
+    )
+
+    assert path_hardware_ids["/dev/input/event9"] == "2dc8:3106"
+    assert "/dev/input/event2" not in path_hardware_ids
+    assert path_sources["/dev/input/event9"] == "gamepad"
 
 
 @pytest.mark.asyncio

--- a/tests/keymasqd/test_daemon_capture_commands.py
+++ b/tests/keymasqd/test_daemon_capture_commands.py
@@ -353,6 +353,38 @@ def test_capture_manager_resolves_logical_combo_interfaces(monkeypatch):
         device_path_resolver.clear_cached_devices()
 
 
+def test_capture_manager_hardware_interface_lookup_keeps_first_alias_owner(monkeypatch):
+    manager = CaptureManager()
+    calls: list[str] = []
+
+    def fake_resolve_evdev_interfaces(_interfaces, **kwargs):
+        hardware_id = str(kwargs["hardware_id"])
+        calls.append(hardware_id)
+        return [
+            SimpleNamespace(
+                path="/dev/input/event9",
+                interface_id=f"{hardware_id}-source",
+            )
+        ]
+
+    monkeypatch.setattr(
+        capture_manager_module.device_path_resolver,
+        "resolve_evdev_interfaces",
+        fake_resolve_evdev_interfaces,
+    )
+
+    path_hardware_ids, path_sources = manager._hardware_interface_lookup(
+        {
+            "2dc8:3106": [{"path": "keymasq:2dc8:3106"}],
+            "2dc8:3106@2": [{"path": "keymasq:2dc8:3106"}],
+        }
+    )
+
+    assert calls == ["2dc8:3106", "2dc8:3106@2"]
+    assert path_hardware_ids["/dev/input/event9"] == "2dc8:3106"
+    assert path_sources["/dev/input/event9"] == "2dc8:3106-source"
+
+
 @pytest.mark.asyncio
 async def test_capture_combo_waits_on_event_not_sleep(daemon_testbed, monkeypatch):
     daemon, device_manager, _recording_manager, _macro_store, capture_manager = daemon_testbed

--- a/tests/keymasqd/test_daemon_capture_commands.py
+++ b/tests/keymasqd/test_daemon_capture_commands.py
@@ -330,24 +330,27 @@ def test_capture_manager_resolves_logical_combo_interfaces(monkeypatch):
         primary_input_class_fn=primary_input_class,
     )
 
-    manager = CaptureManager()
-    path_hardware_ids, path_sources = manager._hardware_interface_lookup(
-        {
-            "2dc8:3106": [
-                {
-                    "id": "gamepad",
-                    "path": "keymasq:2dc8:3106",
-                    "type": "gamepad",
-                    "phys": "bluetooth/input0",
-                    "capabilities": ["btn_south"],
-                }
-            ]
-        }
-    )
+    try:
+        manager = CaptureManager()
+        path_hardware_ids, path_sources = manager._hardware_interface_lookup(
+            {
+                "2dc8:3106": [
+                    {
+                        "id": "gamepad",
+                        "path": "keymasq:2dc8:3106",
+                        "type": "gamepad",
+                        "phys": "bluetooth/input0",
+                        "capabilities": ["btn_south"],
+                    }
+                ]
+            }
+        )
 
-    assert path_hardware_ids["/dev/input/event9"] == "2dc8:3106"
-    assert "/dev/input/event2" not in path_hardware_ids
-    assert path_sources["/dev/input/event9"] == "gamepad"
+        assert path_hardware_ids["/dev/input/event9"] == "2dc8:3106"
+        assert "/dev/input/event2" not in path_hardware_ids
+        assert path_sources["/dev/input/event9"] == "gamepad"
+    finally:
+        device_path_resolver.clear_cached_devices()
 
 
 @pytest.mark.asyncio

--- a/tests/keymasqd/test_device_manager_core.py
+++ b/tests/keymasqd/test_device_manager_core.py
@@ -323,13 +323,14 @@ class TestDeviceManager:
     ) -> None:
         manager = DeviceManager()
         monkeypatch.setattr(dm.evdev, "list_devices", lambda: [])
+        evdev_interfaces = [
+            {"id": "gamepad", "path": "keymasq:2dc8:3106", "type": "gamepad"}
+        ]
 
         result = await manager.grab_device(
             hardware_id="2dc8:3106",
             evdev_paths=["keymasq:2dc8:3106"],
-            evdev_interfaces=[
-                {"id": "gamepad", "path": "keymasq:2dc8:3106", "type": "gamepad"}
-            ],
+            evdev_interfaces=evdev_interfaces,
             button_map={"btn_south": "btn_south"},
         )
 
@@ -340,6 +341,13 @@ class TestDeviceManager:
             "skipped_count": 0,
             "waiting_for_device": True,
         }
+        assert manager.grab_state.desired_paths["2dc8:3106"] == {"keymasq:2dc8:3106"}
+        assert manager.grab_state.desired_grabs["2dc8:3106"] == DesiredGrabConfig(
+            paths={"keymasq:2dc8:3106"},
+            button_map={"btn_south": "btn_south"},
+            force_grab_unmapped=False,
+            evdev_interfaces=evdev_interfaces,
+        )
 
     @pytest.mark.asyncio
     async def test_grab_device_resolves_keymasq_path_and_uses_configured_interface_id(
@@ -356,6 +364,12 @@ class TestDeviceManager:
             ldm.device_path_resolver,
             "_is_keymasq_virtual_device",
             lambda _d: False,
+        )
+        ldm.device_path_resolver.refresh_cached_devices_sync(
+            device_paths_fn=dm._device_paths,
+            device_input_fn=dm._device_input,
+            detect_input_classes_fn=dm.detect_input_classes,
+            primary_input_class_fn=dm.primary_input_class,
         )
 
         result = await manager.grab_device(
@@ -395,6 +409,12 @@ class TestDeviceManager:
             ldm.device_path_resolver,
             "_is_keymasq_virtual_device",
             lambda _d: False,
+        )
+        ldm.device_path_resolver.refresh_cached_devices_sync(
+            device_paths_fn=dm._device_paths,
+            device_input_fn=dm._device_input,
+            detect_input_classes_fn=dm.detect_input_classes,
+            primary_input_class_fn=dm.primary_input_class,
         )
 
         await manager.grab_device(

--- a/tests/keymasqd/test_device_manager_core.py
+++ b/tests/keymasqd/test_device_manager_core.py
@@ -973,6 +973,40 @@ class TestListDevices:
             deps=dm._topology_runtime_deps(),
         )
 
+    def test_topology_events_match_numbered_desired_hardware_id(self) -> None:
+        manager = SimpleNamespace(_command_type=CommandType)
+        snapshot = {
+            "/dev/input/by-id/test-pad": dm.LiveInterfaceInfo(
+                hardware_id="1234:5678",
+                vendor_id="1234",
+                product_id="5678",
+                stable_path="/dev/input/by-id/test-pad",
+                path="/dev/input/event10",
+                interface_id="gamepad",
+            )
+        }
+
+        events = tdm.build_topology_events(
+            manager,
+            {},
+            snapshot,
+            {"1234:5678@2"},
+        )
+
+        assert events == [
+            (
+                CommandType.DEVICE_CONNECTED,
+                {
+                    "hardware_id": "1234:5678",
+                    "vendor_id": "1234",
+                    "product_id": "5678",
+                    "path": "/dev/input/event10",
+                    "stable_path": "/dev/input/by-id/test-pad",
+                    "interface_id": "gamepad",
+                },
+            )
+        ]
+
 
 class TestMacroControlActions:
     @pytest.mark.asyncio

--- a/tests/keymasqd/test_device_manager_core.py
+++ b/tests/keymasqd/test_device_manager_core.py
@@ -317,6 +317,127 @@ class TestDeviceManager:
         create_global_uinputs.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_grab_device_waits_when_keymasq_path_is_unresolved(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        manager = DeviceManager()
+        monkeypatch.setattr(dm.evdev, "list_devices", lambda: [])
+
+        result = await manager.grab_device(
+            hardware_id="2dc8:3106",
+            evdev_paths=["keymasq:2dc8:3106"],
+            evdev_interfaces=[
+                {"id": "gamepad", "path": "keymasq:2dc8:3106", "type": "gamepad"}
+            ],
+            button_map={"btn_south": "btn_south"},
+        )
+
+        assert result == {
+            "grabbed": True,
+            "hardware_id": "2dc8:3106",
+            "grabbed_count": 0,
+            "skipped_count": 0,
+            "waiting_for_device": True,
+        }
+
+    @pytest.mark.asyncio
+    async def test_grab_device_resolves_keymasq_path_and_uses_configured_interface_id(
+        self,
+        manager,
+        virtual_mouse,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        device_path = virtual_mouse.device.path
+        info = virtual_mouse.device.info
+        logical_path = f"keymasq:{info.vendor:04x}:{info.product:04x}"
+        monkeypatch.setattr(dm.evdev, "list_devices", lambda: [device_path])
+        monkeypatch.setattr(
+            ldm.device_path_resolver,
+            "_is_keymasq_virtual_device",
+            lambda _d: False,
+        )
+
+        result = await manager.grab_device(
+            hardware_id=f"{info.vendor:04x}:{info.product:04x}",
+            evdev_paths=[logical_path],
+            evdev_interfaces=[
+                {
+                    "id": "mouse",
+                    "path": logical_path,
+                    "type": "mouse",
+                    "capabilities": ["btn_left"],
+                }
+            ],
+            button_map={"btn_left": "btn_left"},
+        )
+
+        assert result["grabbed_count"] == 1
+        grabbed = manager.grabbed_devices[f"{info.vendor:04x}:{info.product:04x}"][0]
+        assert grabbed.path == device_path
+        assert grabbed.interface_id == "mouse"
+
+        await manager.release_device(f"{info.vendor:04x}:{info.product:04x}")
+
+    @pytest.mark.asyncio
+    async def test_grab_device_updates_existing_interface_id(
+        self,
+        manager,
+        virtual_mouse,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        device_path = virtual_mouse.device.path
+        info = virtual_mouse.device.info
+        hardware_id = f"{info.vendor:04x}:{info.product:04x}"
+        logical_path = f"keymasq:{hardware_id}"
+        monkeypatch.setattr(dm.evdev, "list_devices", lambda: [device_path])
+        monkeypatch.setattr(
+            ldm.device_path_resolver,
+            "_is_keymasq_virtual_device",
+            lambda _d: False,
+        )
+
+        await manager.grab_device(
+            hardware_id=hardware_id,
+            evdev_paths=[logical_path],
+            evdev_interfaces=[
+                {"id": "mouse", "path": logical_path, "type": "mouse"},
+            ],
+            button_map={"btn_left": "btn_left"},
+        )
+        grabbed = manager.grabbed_devices[hardware_id][0]
+        assert grabbed.interface_id == "mouse"
+
+        result = await manager.grab_device(
+            hardware_id=hardware_id,
+            evdev_paths=[logical_path],
+            evdev_interfaces=[
+                {"id": "pointer", "path": logical_path, "type": "mouse"},
+            ],
+            button_map={"btn_left": "btn_left"},
+            analog_inputs={
+                "stick": {
+                    "source": "pointer",
+                    "type": "stick",
+                    "axes": [
+                        {
+                            "role": "x",
+                            "evdev": "abs_x",
+                            "evdev_code": evdev.ecodes.ABS_X,
+                        }
+                    ],
+                }
+            },
+        )
+
+        assert result["grabbed_count"] == 1
+        assert manager.grabbed_devices[hardware_id][0] is grabbed
+        assert grabbed.interface_id == "pointer"
+        assert grabbed.analog_input_types["stick"] == "stick"
+
+        await manager.release_device(hardware_id)
+
+    @pytest.mark.asyncio
     async def test_grab_device_still_errors_when_present_interfaces_match_no_buttons(
         self,
         monkeypatch: pytest.MonkeyPatch,

--- a/tests/keymasqd/test_device_manager_core.py
+++ b/tests/keymasqd/test_device_manager_core.py
@@ -366,7 +366,7 @@ class TestDeviceManager:
         def fake_resolve_evdev_interfaces(interfaces, **kwargs):
             captured["interfaces"] = interfaces
             captured["excluded_paths"] = kwargs.get("excluded_paths")
-            captured["resolve_stable_path_fn"] = kwargs.get("resolve_stable_path_fn")
+            captured["deps"] = kwargs.get("deps")
             return []
 
         monkeypatch.setattr(
@@ -391,7 +391,9 @@ class TestDeviceManager:
             "/dev/input/event2",
             "/dev/input/by-id/claimed-pad",
         }
-        assert captured["resolve_stable_path_fn"] is dm.resolve_stable_path
+        deps = captured["deps"]
+        assert isinstance(deps, ldm.device_path_resolver.DevicePathResolverDeps)
+        assert deps.resolve_stable_path_fn is dm.resolve_stable_path
 
     @pytest.mark.asyncio
     async def test_grab_device_resolves_keymasq_path_and_uses_configured_interface_id(

--- a/tests/keymasqd/test_device_manager_core.py
+++ b/tests/keymasqd/test_device_manager_core.py
@@ -350,6 +350,50 @@ class TestDeviceManager:
         )
 
     @pytest.mark.asyncio
+    async def test_grab_device_excludes_paths_grabbed_by_other_hardware(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        manager = DeviceManager()
+        manager.grabbed_devices["other"] = [
+            SimpleNamespace(
+                path="/dev/input/event2",
+                stable_path="/dev/input/by-id/claimed-pad",
+            )
+        ]
+        captured: dict[str, object] = {}
+
+        def fake_resolve_evdev_interfaces(interfaces, **kwargs):
+            captured["interfaces"] = interfaces
+            captured["excluded_paths"] = kwargs.get("excluded_paths")
+            captured["resolve_stable_path_fn"] = kwargs.get("resolve_stable_path_fn")
+            return []
+
+        monkeypatch.setattr(
+            ldm.device_path_resolver,
+            "resolve_evdev_interfaces",
+            fake_resolve_evdev_interfaces,
+        )
+        evdev_interfaces = [
+            {"id": "gamepad", "path": "keymasq:2dc8:3106", "type": "gamepad"}
+        ]
+
+        result = await manager.grab_device(
+            hardware_id="2dc8:3106",
+            evdev_paths=["keymasq:2dc8:3106"],
+            evdev_interfaces=evdev_interfaces,
+            button_map={"btn_south": "btn_south"},
+        )
+
+        assert result["waiting_for_device"] is True
+        assert captured["interfaces"] == evdev_interfaces
+        assert captured["excluded_paths"] == {
+            "/dev/input/event2",
+            "/dev/input/by-id/claimed-pad",
+        }
+        assert captured["resolve_stable_path_fn"] is dm.resolve_stable_path
+
+    @pytest.mark.asyncio
     async def test_grab_device_resolves_keymasq_path_and_uses_configured_interface_id(
         self,
         manager,

--- a/tests/keymasqd/test_device_path_resolver.py
+++ b/tests/keymasqd/test_device_path_resolver.py
@@ -40,9 +40,10 @@ class _FakeDevice:
         self.close_count += 1
 
 
-def _resolve(interfaces, devices):
+def _resolve(interfaces, devices, hardware_id: str | None = None):
     return resolve_evdev_interfaces(
         interfaces,
+        hardware_id=hardware_id,
         device_paths_fn=lambda: list(devices),
         device_input_fn=lambda path: devices[path],
         detect_input_classes_fn=detect_input_classes,
@@ -242,6 +243,35 @@ def test_equal_candidates_pick_deterministic_first_and_do_not_duplicate() -> Non
         "/dev/input/event2",
         "/dev/input/event9",
     ]
+
+
+def test_numbered_hardware_id_selects_matching_keymasq_instance() -> None:
+    devices = {
+        "/dev/input/event9": _FakeDevice("/dev/input/event9"),
+        "/dev/input/event2": _FakeDevice("/dev/input/event2"),
+    }
+
+    resolved = _resolve(
+        [{"id": "gamepad", "path": "keymasq:2dc8:3106", "type": "gamepad"}],
+        devices,
+        hardware_id="2dc8:3106@2",
+    )
+
+    assert [interface.path for interface in resolved] == ["/dev/input/event9"]
+
+
+def test_numbered_hardware_id_out_of_range_does_not_fall_back_to_first() -> None:
+    devices = {
+        "/dev/input/event2": _FakeDevice("/dev/input/event2"),
+    }
+
+    resolved = _resolve(
+        [{"id": "gamepad", "path": "keymasq:2dc8:3106", "type": "gamepad"}],
+        devices,
+        hardware_id="2dc8:3106@2",
+    )
+
+    assert resolved == []
 
 
 def test_unresolved_keymasq_path_returns_no_interface() -> None:

--- a/tests/keymasqd/test_device_path_resolver.py
+++ b/tests/keymasqd/test_device_path_resolver.py
@@ -352,7 +352,7 @@ def test_numbered_hardware_id_counts_claimed_instances_but_returns_unclaimed() -
     assert [interface.path for interface in resolved] == ["/dev/input/event9"]
 
 
-def test_numbered_hardware_id_out_of_range_does_not_fall_back_to_first() -> None:
+def test_numbered_hardware_id_out_of_range_falls_back_to_best_unclaimed() -> None:
     devices = {
         "/dev/input/event2": _FakeDevice("/dev/input/event2"),
     }
@@ -363,7 +363,7 @@ def test_numbered_hardware_id_out_of_range_does_not_fall_back_to_first() -> None
         hardware_id="2dc8:3106@2",
     )
 
-    assert resolved == []
+    assert [interface.path for interface in resolved] == ["/dev/input/event2"]
 
 
 def test_unresolved_keymasq_path_returns_no_interface() -> None:

--- a/tests/keymasqd/test_device_path_resolver.py
+++ b/tests/keymasqd/test_device_path_resolver.py
@@ -1,0 +1,253 @@
+from types import SimpleNamespace
+
+import evdev
+
+from keymasq.common.devices import detect_input_classes, primary_input_class
+from keymasq.common.models import DeviceType
+from keymasq.keymasqd.runtime.device_path_resolver import (
+    resolve_evdev_interfaces,
+)
+
+
+class _FakeDevice:
+    def __init__(
+        self,
+        path: str,
+        *,
+        vendor: int = 0x2DC8,
+        product: int = 0x3106,
+        name: str = "Bluetooth Pad",
+        phys: str = "bluetooth/input0",
+        caps: dict[int, list[int]] | None = None,
+    ) -> None:
+        self.path = path
+        self.info = SimpleNamespace(vendor=vendor, product=product)
+        self.name = name
+        self.phys = phys
+        self._caps = caps or {
+            evdev.ecodes.EV_KEY: [evdev.ecodes.BTN_SOUTH],
+            evdev.ecodes.EV_ABS: [evdev.ecodes.ABS_X, evdev.ecodes.ABS_Y],
+        }
+        self.close_count = 0
+
+    def capabilities(self):
+        return self._caps
+
+    def input_props(self):
+        return []
+
+    def close(self) -> None:
+        self.close_count += 1
+
+
+def _resolve(interfaces, devices):
+    return resolve_evdev_interfaces(
+        interfaces,
+        device_paths_fn=lambda: list(devices),
+        device_input_fn=lambda path: devices[path],
+        detect_input_classes_fn=detect_input_classes,
+        primary_input_class_fn=primary_input_class,
+    )
+
+
+def test_literal_path_resolves_unchanged() -> None:
+    resolved = _resolve(
+        [{"id": "gamepad", "path": "/dev/input/by-id/test", "type": "gamepad"}],
+        {},
+    )
+
+    assert resolved[0].path == "/dev/input/by-id/test"
+    assert resolved[0].interface_id == "gamepad"
+
+
+def test_keymasq_path_resolves_matching_vid_pid() -> None:
+    devices = {
+        "/dev/input/event1": _FakeDevice("/dev/input/event1", vendor=0x9999),
+        "/dev/input/event2": _FakeDevice("/dev/input/event2"),
+    }
+
+    resolved = _resolve(
+        [{"id": "gamepad", "path": "keymasq:2dc8:3106", "type": "gamepad"}],
+        devices,
+    )
+
+    assert [interface.path for interface in resolved] == ["/dev/input/event2"]
+    assert devices["/dev/input/event1"].close_count == 1
+    assert devices["/dev/input/event2"].close_count == 1
+
+
+def test_keymasq_path_closes_devices_after_scan_errors() -> None:
+    class _FailingDevice(_FakeDevice):
+        def capabilities(self):
+            raise OSError("capability read failed")
+
+    devices = {
+        "/dev/input/event1": _FakeDevice("/dev/input/event1", vendor=0x9999),
+        "/dev/input/event2": _FailingDevice("/dev/input/event2"),
+        "/dev/input/event3": _FakeDevice("/dev/input/event3"),
+    }
+
+    resolved = _resolve(
+        [{"id": "gamepad", "path": "keymasq:2dc8:3106", "type": "gamepad"}],
+        devices,
+    )
+
+    assert [interface.path for interface in resolved] == ["/dev/input/event3"]
+    assert {path: device.close_count for path, device in devices.items()} == {
+        "/dev/input/event1": 1,
+        "/dev/input/event2": 1,
+        "/dev/input/event3": 1,
+    }
+
+
+def test_keymasq_path_skips_virtual_devices() -> None:
+    devices = {
+        "/dev/input/event1": _FakeDevice("/dev/input/event1", phys="py-evdev-uinput"),
+        "/dev/input/event2": _FakeDevice("/dev/input/event2"),
+    }
+
+    resolved = _resolve(
+        [{"id": "gamepad", "path": "keymasq:2dc8:3106", "type": "gamepad"}],
+        devices,
+    )
+
+    assert [interface.path for interface in resolved] == ["/dev/input/event2"]
+
+
+def test_type_and_capability_scores_choose_best_candidate() -> None:
+    keyboard_caps = {evdev.ecodes.EV_KEY: [evdev.ecodes.KEY_A]}
+    weak_gamepad_caps = {
+        evdev.ecodes.EV_KEY: [evdev.ecodes.BTN_NORTH],
+        evdev.ecodes.EV_ABS: [evdev.ecodes.ABS_X],
+    }
+    best_gamepad_caps = {
+        evdev.ecodes.EV_KEY: [evdev.ecodes.BTN_SOUTH, evdev.ecodes.BTN_EAST],
+        evdev.ecodes.EV_ABS: [evdev.ecodes.ABS_X],
+    }
+    devices = {
+        "/dev/input/event1": _FakeDevice("/dev/input/event1", caps=keyboard_caps),
+        "/dev/input/event2": _FakeDevice("/dev/input/event2", caps=weak_gamepad_caps),
+        "/dev/input/event3": _FakeDevice("/dev/input/event3", caps=best_gamepad_caps),
+    }
+
+    resolved = _resolve(
+        [
+            {
+                "id": "gamepad",
+                "path": "keymasq:2dc8:3106",
+                "type": DeviceType.GAMEPAD.value,
+                "capabilities": ["btn_south", "btn_east"],
+            }
+        ],
+        devices,
+    )
+
+    assert [interface.path for interface in resolved] == ["/dev/input/event3"]
+
+
+def test_metadata_descriptor_does_not_pick_same_vid_pid_without_any_match() -> None:
+    keyboard_caps = {evdev.ecodes.EV_KEY: [evdev.ecodes.KEY_A]}
+    devices = {
+        "/dev/input/event1": _FakeDevice(
+            "/dev/input/event1",
+            caps=keyboard_caps,
+            phys="bluetooth/input1",
+        ),
+    }
+
+    resolved = _resolve(
+        [
+            {
+                "id": "gamepad",
+                "path": "keymasq:2dc8:3106",
+                "type": DeviceType.GAMEPAD.value,
+                "phys": "bluetooth/input0",
+                "capabilities": ["btn_south", "abs_x"],
+            }
+        ],
+        devices,
+    )
+
+    assert resolved == []
+
+
+def test_other_type_descriptor_requires_phys_or_capability_match() -> None:
+    keyboard_caps = {evdev.ecodes.EV_KEY: [evdev.ecodes.KEY_A]}
+    devices = {
+        "/dev/input/event1": _FakeDevice(
+            "/dev/input/event1",
+            caps=keyboard_caps,
+            phys="bluetooth/input1",
+        ),
+    }
+
+    resolved = _resolve(
+        [
+            {
+                "id": "input",
+                "path": "keymasq:2dc8:3106",
+                "type": DeviceType.OTHER.value,
+                "phys": "bluetooth/input0",
+                "capabilities": ["btn_south"],
+            }
+        ],
+        devices,
+    )
+
+    assert resolved == []
+
+
+def test_phys_match_breaks_type_and_capability_ties() -> None:
+    devices = {
+        "/dev/input/event2": _FakeDevice(
+            "/dev/input/event2",
+            phys="bluetooth/input1",
+        ),
+        "/dev/input/event9": _FakeDevice(
+            "/dev/input/event9",
+            phys="bluetooth/input0",
+        ),
+    }
+
+    resolved = _resolve(
+        [
+            {
+                "id": "gamepad",
+                "path": "keymasq:2dc8:3106",
+                "type": "gamepad",
+                "phys": "bluetooth/input0",
+            }
+        ],
+        devices,
+    )
+
+    assert [interface.path for interface in resolved] == ["/dev/input/event9"]
+
+
+def test_equal_candidates_pick_deterministic_first_and_do_not_duplicate() -> None:
+    devices = {
+        "/dev/input/event9": _FakeDevice("/dev/input/event9"),
+        "/dev/input/event2": _FakeDevice("/dev/input/event2"),
+    }
+
+    resolved = _resolve(
+        [
+            {"id": "gamepad", "path": "keymasq:2dc8:3106", "type": "gamepad"},
+            {"id": "gamepad_2", "path": "keymasq:2dc8:3106", "type": "gamepad"},
+        ],
+        devices,
+    )
+
+    assert [interface.path for interface in resolved] == [
+        "/dev/input/event2",
+        "/dev/input/event9",
+    ]
+
+
+def test_unresolved_keymasq_path_returns_no_interface() -> None:
+    resolved = _resolve(
+        [{"id": "gamepad", "path": "keymasq:2dc8:3106", "type": "gamepad"}],
+        {"/dev/input/event1": _FakeDevice("/dev/input/event1", vendor=0x9999)},
+    )
+
+    assert resolved == []

--- a/tests/keymasqd/test_device_path_resolver.py
+++ b/tests/keymasqd/test_device_path_resolver.py
@@ -127,6 +127,26 @@ def test_keymasq_path_uses_cached_probe_metadata() -> None:
     assert devices["/dev/input/event2"].close_count == 1
 
 
+def test_keymasq_path_probes_device_when_cache_misses() -> None:
+    devices = {
+        "/dev/input/event2": _FakeDevice("/dev/input/event2"),
+    }
+
+    resolved = resolve_evdev_interfaces(
+        [{"id": "gamepad", "path": "keymasq:2dc8:3106", "type": "gamepad"}],
+        deps=DevicePathResolverDeps(
+            device_paths_fn=lambda: list(devices),
+            device_input_fn=lambda path: devices[path],
+            detect_input_classes_fn=detect_input_classes,
+            primary_input_class_fn=primary_input_class,
+            cache=DeviceCache(),
+        ),
+    )
+
+    assert [interface.path for interface in resolved] == ["/dev/input/event2"]
+    assert devices["/dev/input/event2"].close_count == 1
+
+
 def test_keymasq_path_closes_devices_after_scan_errors() -> None:
     class _FailingDevice(_FakeDevice):
         def capabilities(self):

--- a/tests/keymasqd/test_device_path_resolver.py
+++ b/tests/keymasqd/test_device_path_resolver.py
@@ -5,6 +5,7 @@ import evdev
 from keymasq.common.devices import detect_input_classes, primary_input_class
 from keymasq.common.models import DeviceType
 from keymasq.keymasqd.runtime.device_path_resolver import (
+    DevicePathResolverDeps,
     refresh_cached_devices_sync,
     resolve_evdev_interfaces,
 )
@@ -56,13 +57,15 @@ def _resolve(
     )
     return resolve_evdev_interfaces(
         interfaces,
+        deps=DevicePathResolverDeps(
+            device_paths_fn=lambda: list(devices),
+            device_input_fn=lambda path: devices[path],
+            detect_input_classes_fn=detect_input_classes,
+            primary_input_class_fn=primary_input_class,
+            resolve_stable_path_fn=resolve_stable_path_fn,
+        ),
         hardware_id=hardware_id,
         excluded_paths=excluded_paths,
-        resolve_stable_path_fn=resolve_stable_path_fn,
-        device_paths_fn=lambda: list(devices),
-        device_input_fn=lambda path: devices[path],
-        detect_input_classes_fn=detect_input_classes,
-        primary_input_class_fn=primary_input_class,
     )
 
 
@@ -108,10 +111,12 @@ def test_keymasq_path_uses_cached_probe_metadata() -> None:
 
     resolved = resolve_evdev_interfaces(
         [{"id": "gamepad", "path": "keymasq:2dc8:3106", "type": "gamepad"}],
-        device_paths_fn=lambda: list(devices),
-        device_input_fn=fail_input_device,
-        detect_input_classes_fn=detect_input_classes,
-        primary_input_class_fn=primary_input_class,
+        deps=DevicePathResolverDeps(
+            device_paths_fn=lambda: list(devices),
+            device_input_fn=fail_input_device,
+            detect_input_classes_fn=detect_input_classes,
+            primary_input_class_fn=primary_input_class,
+        ),
     )
 
     assert [interface.path for interface in resolved] == ["/dev/input/event2"]

--- a/tests/keymasqd/test_device_path_resolver.py
+++ b/tests/keymasqd/test_device_path_resolver.py
@@ -5,8 +5,8 @@ import evdev
 from keymasq.common.devices import detect_input_classes, primary_input_class
 from keymasq.common.models import DeviceType
 from keymasq.keymasqd.runtime.device_path_resolver import (
+    DeviceCache,
     DevicePathResolverDeps,
-    refresh_cached_devices_sync,
     resolve_evdev_interfaces,
 )
 
@@ -49,7 +49,8 @@ def _resolve(
     excluded_paths=None,
     resolve_stable_path_fn=None,
 ):
-    refresh_cached_devices_sync(
+    cache = DeviceCache()
+    cache.refresh_sync(
         device_paths_fn=lambda: list(devices),
         device_input_fn=lambda path: devices[path],
         detect_input_classes_fn=detect_input_classes,
@@ -63,6 +64,7 @@ def _resolve(
             detect_input_classes_fn=detect_input_classes,
             primary_input_class_fn=primary_input_class,
             resolve_stable_path_fn=resolve_stable_path_fn,
+            cache=cache,
         ),
         hardware_id=hardware_id,
         excluded_paths=excluded_paths,
@@ -99,7 +101,8 @@ def test_keymasq_path_uses_cached_probe_metadata() -> None:
     devices = {
         "/dev/input/event2": _FakeDevice("/dev/input/event2"),
     }
-    refresh_cached_devices_sync(
+    cache = DeviceCache()
+    cache.refresh_sync(
         device_paths_fn=lambda: list(devices),
         device_input_fn=lambda path: devices[path],
         detect_input_classes_fn=detect_input_classes,
@@ -116,6 +119,7 @@ def test_keymasq_path_uses_cached_probe_metadata() -> None:
             device_input_fn=fail_input_device,
             detect_input_classes_fn=detect_input_classes,
             primary_input_class_fn=primary_input_class,
+            cache=cache,
         ),
     )
 

--- a/tests/keymasqd/test_device_path_resolver.py
+++ b/tests/keymasqd/test_device_path_resolver.py
@@ -41,7 +41,13 @@ class _FakeDevice:
         self.close_count += 1
 
 
-def _resolve(interfaces, devices, hardware_id: str | None = None):
+def _resolve(
+    interfaces,
+    devices,
+    hardware_id: str | None = None,
+    excluded_paths=None,
+    resolve_stable_path_fn=None,
+):
     refresh_cached_devices_sync(
         device_paths_fn=lambda: list(devices),
         device_input_fn=lambda path: devices[path],
@@ -51,6 +57,8 @@ def _resolve(interfaces, devices, hardware_id: str | None = None):
     return resolve_evdev_interfaces(
         interfaces,
         hardware_id=hardware_id,
+        excluded_paths=excluded_paths,
+        resolve_stable_path_fn=resolve_stable_path_fn,
         device_paths_fn=lambda: list(devices),
         device_input_fn=lambda path: devices[path],
         detect_input_classes_fn=detect_input_classes,
@@ -278,6 +286,41 @@ def test_equal_candidates_pick_deterministic_first_and_do_not_duplicate() -> Non
     ]
 
 
+def test_keymasq_path_skips_excluded_candidate() -> None:
+    devices = {
+        "/dev/input/event9": _FakeDevice("/dev/input/event9"),
+        "/dev/input/event2": _FakeDevice("/dev/input/event2"),
+    }
+
+    resolved = _resolve(
+        [{"id": "gamepad", "path": "keymasq:2dc8:3106", "type": "gamepad"}],
+        devices,
+        excluded_paths={"/dev/input/event2"},
+    )
+
+    assert [interface.path for interface in resolved] == ["/dev/input/event9"]
+
+
+def test_keymasq_path_skips_excluded_stable_path_alias() -> None:
+    devices = {
+        "/dev/input/event9": _FakeDevice("/dev/input/event9"),
+        "/dev/input/event2": _FakeDevice("/dev/input/event2"),
+    }
+    stable_paths = {
+        "/dev/input/event2": "/dev/input/by-id/claimed-pad",
+        "/dev/input/event9": "/dev/input/event9",
+    }
+
+    resolved = _resolve(
+        [{"id": "gamepad", "path": "keymasq:2dc8:3106", "type": "gamepad"}],
+        devices,
+        excluded_paths={"/dev/input/by-id/claimed-pad"},
+        resolve_stable_path_fn=lambda path: stable_paths[path],
+    )
+
+    assert [interface.path for interface in resolved] == ["/dev/input/event9"]
+
+
 def test_numbered_hardware_id_selects_matching_keymasq_instance() -> None:
     devices = {
         "/dev/input/event9": _FakeDevice("/dev/input/event9"),
@@ -288,6 +331,22 @@ def test_numbered_hardware_id_selects_matching_keymasq_instance() -> None:
         [{"id": "gamepad", "path": "keymasq:2dc8:3106", "type": "gamepad"}],
         devices,
         hardware_id="2dc8:3106@2",
+    )
+
+    assert [interface.path for interface in resolved] == ["/dev/input/event9"]
+
+
+def test_numbered_hardware_id_counts_claimed_instances_but_returns_unclaimed() -> None:
+    devices = {
+        "/dev/input/event9": _FakeDevice("/dev/input/event9"),
+        "/dev/input/event2": _FakeDevice("/dev/input/event2"),
+    }
+
+    resolved = _resolve(
+        [{"id": "gamepad", "path": "keymasq:2dc8:3106", "type": "gamepad"}],
+        devices,
+        hardware_id="2dc8:3106@2",
+        excluded_paths={"/dev/input/event2"},
     )
 
     assert [interface.path for interface in resolved] == ["/dev/input/event9"]

--- a/tests/keymasqd/test_device_path_resolver.py
+++ b/tests/keymasqd/test_device_path_resolver.py
@@ -5,6 +5,7 @@ import evdev
 from keymasq.common.devices import detect_input_classes, primary_input_class
 from keymasq.common.models import DeviceType
 from keymasq.keymasqd.runtime.device_path_resolver import (
+    refresh_cached_devices_sync,
     resolve_evdev_interfaces,
 )
 
@@ -41,6 +42,12 @@ class _FakeDevice:
 
 
 def _resolve(interfaces, devices, hardware_id: str | None = None):
+    refresh_cached_devices_sync(
+        device_paths_fn=lambda: list(devices),
+        device_input_fn=lambda path: devices[path],
+        detect_input_classes_fn=detect_input_classes,
+        primary_input_class_fn=primary_input_class,
+    )
     return resolve_evdev_interfaces(
         interfaces,
         hardware_id=hardware_id,
@@ -74,6 +81,32 @@ def test_keymasq_path_resolves_matching_vid_pid() -> None:
 
     assert [interface.path for interface in resolved] == ["/dev/input/event2"]
     assert devices["/dev/input/event1"].close_count == 1
+    assert devices["/dev/input/event2"].close_count == 1
+
+
+def test_keymasq_path_uses_cached_probe_metadata() -> None:
+    devices = {
+        "/dev/input/event2": _FakeDevice("/dev/input/event2"),
+    }
+    refresh_cached_devices_sync(
+        device_paths_fn=lambda: list(devices),
+        device_input_fn=lambda path: devices[path],
+        detect_input_classes_fn=detect_input_classes,
+        primary_input_class_fn=primary_input_class,
+    )
+
+    def fail_input_device(_path: str):
+        raise AssertionError("resolver must not probe devices on request path")
+
+    resolved = resolve_evdev_interfaces(
+        [{"id": "gamepad", "path": "keymasq:2dc8:3106", "type": "gamepad"}],
+        device_paths_fn=lambda: list(devices),
+        device_input_fn=fail_input_device,
+        detect_input_classes_fn=detect_input_classes,
+        primary_input_class_fn=primary_input_class,
+    )
+
+    assert [interface.path for interface in resolved] == ["/dev/input/event2"]
     assert devices["/dev/input/event2"].close_count == 1
 
 

--- a/tests/session/test_session_manager_command_runtime.py
+++ b/tests/session/test_session_manager_command_runtime.py
@@ -58,6 +58,40 @@ async def test_handle_session_request_set_settings_does_not_broadcast_on_daemon_
 
 
 @pytest.mark.asyncio
+async def test_release_device_command_forwards_to_daemon_and_clears_runtime_state() -> None:
+    manager = SessionManager()
+    hardware_id = "045e:02a1"
+    manager.profile_state.grabbed_devices.add(hardware_id)
+    manager.profile_state.grabbed_interfaces[hardware_id] = {
+        "gamepad": "/dev/input/event20"
+    }
+    manager.profile_state.grab_waiting_devices.add(hardware_id)
+    manager.profile_state.last_sent_grab_signatures[hardware_id] = "grab"
+    manager.profile_state.last_sent_mapping_signatures[hardware_id] = "mapping"
+    manager.client.send_command = AsyncMock(
+        return_value=Response(status="ok", data={"released": True})
+    )
+    peer = PeerCredentials(pid=1, uid=1000, gid=1000)
+
+    result = await manager._handle_session_request(
+        {"command": "release_device", "hardware_id": hardware_id},
+        "client",
+        peer,
+        object(),
+    )
+
+    assert result == {"released": True, "status": "ok"}
+    sent = manager.client.send_command.await_args.args[0]
+    assert sent.command == CommandType.RELEASE_DEVICE
+    assert sent.data == {"hardware_id": hardware_id, "immediate": True}
+    assert hardware_id not in manager.profile_state.grabbed_devices
+    assert hardware_id not in manager.profile_state.grabbed_interfaces
+    assert hardware_id not in manager.profile_state.grab_waiting_devices
+    assert hardware_id not in manager.profile_state.last_sent_grab_signatures
+    assert hardware_id not in manager.profile_state.last_sent_mapping_signatures
+
+
+@pytest.mark.asyncio
 async def test_handle_session_request_refresh_compositor_forces_binding_retry(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/session/test_session_manager_command_runtime.py
+++ b/tests/session/test_session_manager_command_runtime.py
@@ -1105,6 +1105,181 @@ async def test_begin_capture_for_numbered_hardware_uses_configured_paths() -> No
 
 
 @pytest.mark.asyncio
+async def test_begin_capture_with_paths_uses_configured_interfaces_when_omitted() -> None:
+    manager = SessionManager()
+    hardware_id = "2dc8:3106"
+    manager.hardware.get_hardware = lambda _hardware_id: SimpleNamespace(  # type: ignore[assignment]
+        evdev_devices=[
+            SimpleNamespace(
+                id="gamepad",
+                path="keymasq:2dc8:3106",
+                device_type=SimpleNamespace(value="gamepad"),
+                phys="bluetooth/input0",
+                capabilities=["btn_south"],
+            )
+        ]
+    )
+    manager.client.send_command = AsyncMock(
+        return_value=Response(status="ok", data={"token": "capture-token", "warnings": []})
+    )
+    peer = PeerCredentials(pid=1, uid=1000, gid=1000)
+    writer = object()
+    manager.unlock_state.refresh_owner = {
+        "uid": peer.uid,
+        "pid": peer.pid,
+        "writer_id": id(writer),
+        "lease_id": "lease-test",
+    }
+
+    result = await manager._handle_session_request(
+        {
+            "command": "begin_capture",
+            "hardware_id": hardware_id,
+            "evdev_paths": ["keymasq:2dc8:3106"],
+            "mode": "analog",
+        },
+        "client",
+        peer,
+        writer,
+    )
+
+    assert result["status"] == "ok"
+    sent = manager.client.send_command.await_args.args[0]
+    assert sent.command == CommandType.CAPTURE_BEGIN
+    assert sent.data == {
+        "hardware_id": hardware_id,
+        "mode": "analog",
+        "evdev_paths": ["keymasq:2dc8:3106"],
+        "evdev_interfaces": [
+            {
+                "id": "gamepad",
+                "path": "keymasq:2dc8:3106",
+                "type": "gamepad",
+                "phys": "bluetooth/input0",
+                "capabilities": ["btn_south"],
+            }
+        ],
+    }
+
+
+@pytest.mark.asyncio
+async def test_begin_capture_with_explicit_path_does_not_use_saved_interface() -> None:
+    manager = SessionManager()
+    hardware_id = "2dc8:3106"
+    manager.hardware.get_hardware = lambda _hardware_id: SimpleNamespace(  # type: ignore[assignment]
+        evdev_devices=[
+            SimpleNamespace(
+                id="gamepad",
+                path="keymasq:2dc8:3106",
+                device_type=SimpleNamespace(value="gamepad"),
+                phys="bluetooth/input0",
+                capabilities=["btn_south"],
+            )
+        ]
+    )
+    manager.client.send_command = AsyncMock(
+        return_value=Response(status="ok", data={"token": "capture-token", "warnings": []})
+    )
+    peer = PeerCredentials(pid=1, uid=1000, gid=1000)
+    writer = object()
+    manager.unlock_state.refresh_owner = {
+        "uid": peer.uid,
+        "pid": peer.pid,
+        "writer_id": id(writer),
+        "lease_id": "lease-test",
+    }
+
+    result = await manager._handle_session_request(
+        {
+            "command": "begin_capture",
+            "hardware_id": hardware_id,
+            "evdev_paths": ["/dev/input/event17"],
+        },
+        "client",
+        peer,
+        writer,
+    )
+
+    assert result["status"] == "ok"
+    sent = manager.client.send_command.await_args.args[0]
+    assert sent.command == CommandType.CAPTURE_BEGIN
+    assert sent.data == {
+        "hardware_id": hardware_id,
+        "evdev_paths": ["/dev/input/event17"],
+    }
+
+
+@pytest.mark.asyncio
+async def test_begin_capture_with_duplicate_logical_paths_preserves_interfaces() -> None:
+    manager = SessionManager()
+    hardware_id = "2dc8:3106"
+    manager.hardware.get_hardware = lambda _hardware_id: SimpleNamespace(  # type: ignore[assignment]
+        evdev_devices=[
+            SimpleNamespace(
+                id="gamepad",
+                path="keymasq:2dc8:3106",
+                device_type=SimpleNamespace(value="gamepad"),
+                phys="bluetooth/input0",
+                capabilities=["btn_south"],
+            ),
+            SimpleNamespace(
+                id="kbd",
+                path="keymasq:2dc8:3106",
+                device_type=SimpleNamespace(value="keyboard"),
+                phys="bluetooth/input1",
+                capabilities=["key_a"],
+            ),
+        ]
+    )
+    manager.client.send_command = AsyncMock(
+        return_value=Response(status="ok", data={"token": "capture-token", "warnings": []})
+    )
+    peer = PeerCredentials(pid=1, uid=1000, gid=1000)
+    writer = object()
+    manager.unlock_state.refresh_owner = {
+        "uid": peer.uid,
+        "pid": peer.pid,
+        "writer_id": id(writer),
+        "lease_id": "lease-test",
+    }
+
+    result = await manager._handle_session_request(
+        {
+            "command": "begin_capture",
+            "hardware_id": hardware_id,
+            "evdev_paths": ["keymasq:2dc8:3106", "keymasq:2dc8:3106"],
+        },
+        "client",
+        peer,
+        writer,
+    )
+
+    assert result["status"] == "ok"
+    sent = manager.client.send_command.await_args.args[0]
+    assert sent.command == CommandType.CAPTURE_BEGIN
+    assert sent.data == {
+        "hardware_id": hardware_id,
+        "evdev_paths": ["keymasq:2dc8:3106", "keymasq:2dc8:3106"],
+        "evdev_interfaces": [
+            {
+                "id": "gamepad",
+                "path": "keymasq:2dc8:3106",
+                "type": "gamepad",
+                "phys": "bluetooth/input0",
+                "capabilities": ["btn_south"],
+            },
+            {
+                "id": "kbd",
+                "path": "keymasq:2dc8:3106",
+                "type": "keyboard",
+                "phys": "bluetooth/input1",
+                "capabilities": ["key_a"],
+            },
+        ],
+    }
+
+
+@pytest.mark.asyncio
 async def test_begin_capture_for_numbered_hardware_requires_configured_paths() -> None:
     manager = SessionManager()
     hardware_id = "1234:5678@2"
@@ -1314,7 +1489,15 @@ async def test_capture_combo_session_command_round_trip() -> None:
     manager = SessionManager()
     manager.hardware.list_hardware_ids = lambda: ["1234:5678"]  # type: ignore[assignment]
     manager.hardware.get_hardware = lambda _hardware_id: SimpleNamespace(  # type: ignore[assignment]
-        evdev_devices=[SimpleNamespace(path="/dev/input/by-id/test-kbd")]
+        evdev_devices=[
+            SimpleNamespace(
+                id="kbd",
+                path="/dev/input/by-id/test-kbd",
+                device_type=SimpleNamespace(value="keyboard"),
+                phys="usb/input0",
+                capabilities=["key_a"],
+            )
+        ]
     )
     manager.profiles.get_profile = Mock(
         return_value=SimpleNamespace(config=SimpleNamespace(device_layers={"1234:5678": object()}))
@@ -1359,3 +1542,14 @@ async def test_capture_combo_session_command_round_trip() -> None:
     sent = manager.client.send_command.await_args.args[0]
     assert sent.command == CommandType.CAPTURE_COMBO
     assert sent.data["hardware_paths"] == {"1234:5678": ["/dev/input/by-id/test-kbd"]}
+    assert sent.data["hardware_interfaces"] == {
+        "1234:5678": [
+            {
+                "id": "kbd",
+                "path": "/dev/input/by-id/test-kbd",
+                "type": "keyboard",
+                "phys": "usb/input0",
+                "capabilities": ["key_a"],
+            }
+        ]
+    }

--- a/tests/session/test_session_manager_connect_loop.py
+++ b/tests/session/test_session_manager_connect_loop.py
@@ -2,6 +2,7 @@
 from tests.session.command_support import *
 from unittest.mock import call
 import keymasq.session.manager.core as session_core_module
+from keymasq.common.ipc import CommandType
 
 
 @pytest.mark.asyncio
@@ -85,3 +86,33 @@ async def test_connect_loop_requests_session_restart_after_established_disconnec
     )
     activate_initial_profiles.assert_awaited_once_with(manager)
     refresh_devices.assert_awaited_once_with(manager)
+
+
+@pytest.mark.asyncio
+async def test_reload_profiles_releases_removed_hardware_immediately(monkeypatch) -> None:
+    manager = SessionManager()
+    hardware_id = "045e:02a1"
+    manager.profile_state.grabbed_devices.add(hardware_id)
+    manager.profile_state.grabbed_interfaces[hardware_id] = {
+        "gamepad": "/dev/input/event20"
+    }
+    manager.reload_config_from_disk = Mock()  # type: ignore[method-assign]
+    manager.hardware.list_hardware_ids = Mock(return_value=[])  # type: ignore[method-assign]
+    manager.client.send_command = AsyncMock(
+        return_value=Response(status="ok", data={"released": True})
+    )
+    reevaluate_profiles = AsyncMock()
+    monkeypatch.setattr(
+        session_core_module.runtime_profiles,
+        "reevaluate_profiles",
+        reevaluate_profiles,
+    )
+
+    await manager.reload_profiles()
+
+    sent = manager.client.send_command.await_args.args[0]
+    assert sent.command == CommandType.RELEASE_DEVICE
+    assert sent.data == {"hardware_id": hardware_id, "immediate": True}
+    assert hardware_id not in manager.profile_state.grabbed_devices
+    assert hardware_id not in manager.profile_state.grabbed_interfaces
+    reevaluate_profiles.assert_awaited_once_with(manager, reason="config reload")

--- a/tests/session/test_session_manager_profile_apply.py
+++ b/tests/session/test_session_manager_profile_apply.py
@@ -1,4 +1,6 @@
 # ruff: noqa: F403, F405, I001
+import logging
+
 from tests.session.profile_support import *
 
 @pytest.mark.asyncio
@@ -270,7 +272,185 @@ async def test_apply_resolved_device_profile_waits_when_daemon_reports_no_live_i
     manager.client.send_command.assert_awaited_once()
     assert hardware_id not in manager.profile_state.grabbed_devices
     assert hardware_id not in manager.profile_state.grabbed_interfaces
+    assert hardware_id in manager.profile_state.grab_waiting_devices
+    assert hardware_id in manager.profile_state.last_sent_grab_signatures
     assert manager.profile_state.last_sent_mapping_signatures == {}
+
+
+@pytest.mark.asyncio
+async def test_apply_resolved_device_profile_skips_unchanged_waiting_device() -> None:
+    manager = SessionManager()
+    hardware_id = "1234:5678@2"
+    resolved = ResolvedDeviceProfile(
+        hardware_id=hardware_id,
+        active_profile_names=["Desktop"],
+        mappings={"btn_south": MappingAction(action_type=ActionType.KEYBOARD, target="key_f13")},
+    )
+    manager.hardware.get_hardware = lambda _hardware_id: SimpleNamespace(  # type: ignore[assignment]
+        hardware_id=hardware_id,
+        name="Test Pad 2",
+        evdev_devices=[
+            SimpleNamespace(
+                id="gamepad",
+                path="keymasq:1234:5678",
+                device_type=SimpleNamespace(value="gamepad"),
+                phys="",
+                capabilities=[],
+            )
+        ],
+        buttons=[
+            SimpleNamespace(
+                id="btn_south",
+                evdev="btn_south",
+                source="gamepad",
+                evdev_value=None,
+            )
+        ],
+        analog_inputs=[],
+    )
+    manager.client.send_command = AsyncMock(
+        return_value=Response(status="ok", data={"grabbed_count": 0, "waiting_for_device": True})
+    )
+
+    await session_profiles_module.apply_resolved_device_profile(manager, hardware_id, resolved)
+    await session_profiles_module.apply_resolved_device_profile(manager, hardware_id, resolved)
+
+    manager.client.send_command.assert_awaited_once()
+    assert hardware_id in manager.profile_state.grab_waiting_devices
+
+
+@pytest.mark.asyncio
+async def test_apply_resolved_device_profile_keeps_waiting_cache_across_inactive_window() -> None:
+    manager = SessionManager()
+    hardware_id = "1234:5678@2"
+    mapped = ResolvedDeviceProfile(
+        hardware_id=hardware_id,
+        active_profile_names=["Desktop"],
+        mappings={"btn_south": MappingAction(action_type=ActionType.KEYBOARD, target="key_f13")},
+    )
+    inactive = ResolvedDeviceProfile(
+        hardware_id=hardware_id,
+        active_profile_names=[],
+    )
+    manager.hardware.get_hardware = lambda _hardware_id: SimpleNamespace(  # type: ignore[assignment]
+        hardware_id=hardware_id,
+        name="Test Pad 2",
+        evdev_devices=[
+            SimpleNamespace(
+                id="gamepad",
+                path="keymasq:1234:5678",
+                device_type=SimpleNamespace(value="gamepad"),
+                phys="",
+                capabilities=[],
+            )
+        ],
+        buttons=[
+            SimpleNamespace(
+                id="btn_south",
+                evdev="btn_south",
+                source="gamepad",
+                evdev_value=None,
+            )
+        ],
+        analog_inputs=[],
+    )
+    manager.client.send_command = AsyncMock(
+        return_value=Response(status="ok", data={"grabbed_count": 0, "waiting_for_device": True})
+    )
+
+    await session_profiles_module.apply_resolved_device_profile(manager, hardware_id, mapped)
+    await session_profiles_module.apply_resolved_device_profile(manager, hardware_id, inactive)
+    await session_profiles_module.apply_resolved_device_profile(manager, hardware_id, mapped)
+
+    manager.client.send_command.assert_awaited_once()
+    assert hardware_id in manager.profile_state.grab_waiting_devices
+
+
+@pytest.mark.asyncio
+async def test_apply_resolved_device_profile_skips_waiting_device_when_payload_changes() -> None:
+    manager = SessionManager()
+    hardware_id = "1234:5678@2"
+    mapped = ResolvedDeviceProfile(
+        hardware_id=hardware_id,
+        active_profile_names=["Desktop"],
+        mappings={"btn_south": MappingAction(action_type=ActionType.KEYBOARD, target="key_f13")},
+    )
+    changed = ResolvedDeviceProfile(
+        hardware_id=hardware_id,
+        active_profile_names=["Gaming"],
+        mappings={"btn_south": MappingAction(action_type=ActionType.MOUSE, target="btn_left")},
+        combo_event_count=1,
+        combo_sources={"gamepad"},
+    )
+    manager.hardware.get_hardware = lambda _hardware_id: SimpleNamespace(  # type: ignore[assignment]
+        hardware_id=hardware_id,
+        name="Test Pad 2",
+        evdev_devices=[
+            SimpleNamespace(
+                id="gamepad",
+                path="keymasq:1234:5678",
+                device_type=SimpleNamespace(value="gamepad"),
+                phys="",
+                capabilities=[],
+            )
+        ],
+        buttons=[
+            SimpleNamespace(
+                id="btn_south",
+                evdev="btn_south",
+                source="gamepad",
+                evdev_value=None,
+            )
+        ],
+        analog_inputs=[],
+    )
+    manager.client.send_command = AsyncMock(
+        return_value=Response(status="ok", data={"grabbed_count": 0, "waiting_for_device": True})
+    )
+
+    await session_profiles_module.apply_resolved_device_profile(manager, hardware_id, mapped)
+    await session_profiles_module.apply_resolved_device_profile(manager, hardware_id, changed)
+
+    manager.client.send_command.assert_awaited_once()
+    assert hardware_id in manager.profile_state.grab_waiting_devices
+
+
+@pytest.mark.asyncio
+async def test_apply_resolved_device_profile_does_not_grab_empty_interface_selection(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    manager = SessionManager()
+    hardware_id = "1234:5678@2"
+    resolved = ResolvedDeviceProfile(
+        hardware_id=hardware_id,
+        active_profile_names=["Desktop"],
+        combo_event_count=1,
+        combo_sources={"if02_joystick"},
+    )
+    manager.hardware.get_hardware = lambda _hardware_id: SimpleNamespace(  # type: ignore[assignment]
+        hardware_id=hardware_id,
+        name="Test Pad 2",
+        evdev_devices=[
+            SimpleNamespace(
+                id="joystick",
+                path="keymasq:1234:5678",
+                device_type=SimpleNamespace(value="gamepad"),
+                phys="",
+                capabilities=[],
+            )
+        ],
+        buttons=[],
+        analog_inputs=[],
+    )
+    manager.client.send_command = AsyncMock()
+
+    with caplog.at_level(logging.WARNING, logger="keymasq-session"):
+        await session_profiles_module.apply_resolved_device_profile(manager, hardware_id, resolved)
+        await session_profiles_module.apply_resolved_device_profile(manager, hardware_id, resolved)
+
+    manager.client.send_command.assert_not_awaited()
+    assert "No configured interfaces selected for 1234:5678@2" in caplog.text
+    assert caplog.text.count("No configured interfaces selected for 1234:5678@2") == 1
 
 
 @pytest.mark.asyncio

--- a/tests/session/test_session_manager_profile_apply.py
+++ b/tests/session/test_session_manager_profile_apply.py
@@ -367,7 +367,7 @@ async def test_apply_resolved_device_profile_keeps_waiting_cache_across_inactive
 
 
 @pytest.mark.asyncio
-async def test_apply_resolved_device_profile_skips_waiting_device_when_payload_changes() -> None:
+async def test_apply_resolved_device_profile_resends_waiting_device_when_payload_changes() -> None:
     manager = SessionManager()
     hardware_id = "1234:5678@2"
     mapped = ResolvedDeviceProfile(
@@ -411,7 +411,7 @@ async def test_apply_resolved_device_profile_skips_waiting_device_when_payload_c
     await session_profiles_module.apply_resolved_device_profile(manager, hardware_id, mapped)
     await session_profiles_module.apply_resolved_device_profile(manager, hardware_id, changed)
 
-    manager.client.send_command.assert_awaited_once()
+    assert manager.client.send_command.await_count == 2
     assert hardware_id in manager.profile_state.grab_waiting_devices
 
 

--- a/tests/session/test_session_manager_profile_apply.py
+++ b/tests/session/test_session_manager_profile_apply.py
@@ -226,6 +226,32 @@ def test_grab_device_payload_signature_normalizes_interface_order() -> None:
     ) == session_profiles_module.grab_device_payload_signature(second)
 
 
+def test_grab_device_payload_signature_normalizes_interface_capability_order() -> None:
+    interface = {
+        "id": "gamepad",
+        "path": "keymasq:2dc8:3106",
+        "type": "gamepad",
+        "capabilities": ["btn_south", "btn_east"],
+    }
+    first = {
+        "evdev_paths": ["keymasq:2dc8:3106"],
+        "evdev_interfaces": [interface],
+    }
+    second = {
+        **first,
+        "evdev_interfaces": [
+            {
+                **interface,
+                "capabilities": ["btn_east", "btn_south"],
+            }
+        ],
+    }
+
+    assert session_profiles_module.grab_device_payload_signature(
+        first
+    ) == session_profiles_module.grab_device_payload_signature(second)
+
+
 @pytest.mark.asyncio
 async def test_apply_resolved_device_profile_retries_after_grab_timeout() -> None:
     manager = SessionManager()

--- a/tests/session/test_session_manager_profile_apply.py
+++ b/tests/session/test_session_manager_profile_apply.py
@@ -208,6 +208,24 @@ def test_grab_device_payload_signature_includes_interface_descriptors() -> None:
     ) != session_profiles_module.grab_device_payload_signature(changed_payload)
 
 
+def test_grab_device_payload_signature_normalizes_interface_order() -> None:
+    first = {
+        "evdev_paths": ["keymasq:2dc8:3106"],
+        "evdev_interfaces": [
+            {"id": "buttons", "path": "keymasq:2dc8:3106", "type": "gamepad"},
+            {"id": "axes", "path": "keymasq:2dc8:3106", "type": "gamepad"},
+        ],
+    }
+    second = {
+        **first,
+        "evdev_interfaces": list(reversed(first["evdev_interfaces"])),
+    }
+
+    assert session_profiles_module.grab_device_payload_signature(
+        first
+    ) == session_profiles_module.grab_device_payload_signature(second)
+
+
 @pytest.mark.asyncio
 async def test_apply_resolved_device_profile_retries_after_grab_timeout() -> None:
     manager = SessionManager()

--- a/tests/session/test_session_manager_profile_apply.py
+++ b/tests/session/test_session_manager_profile_apply.py
@@ -154,11 +154,56 @@ async def test_apply_resolved_device_profile_force_grabs_all_interfaces_for_insp
     ]
     grab_data = sent[0].args[0].data
     assert grab_data["evdev_paths"] == ["/dev/input/event10", "/dev/input/event11"]
+    assert grab_data["evdev_interfaces"] == [
+        {
+            "id": "buttons",
+            "path": "/dev/input/event10",
+            "type": "gamepad",
+            "phys": "",
+            "capabilities": [],
+        },
+        {
+            "id": "axes",
+            "path": "/dev/input/event11",
+            "type": "gamepad",
+            "phys": "",
+            "capabilities": [],
+        },
+    ]
     assert grab_data["force_grab_unmapped"] is True
     assert manager.profile_state.grabbed_interfaces[hardware_id] == {
         "buttons": "/dev/input/event10",
         "axes": "/dev/input/event11",
     }
+
+
+def test_grab_device_payload_signature_includes_interface_descriptors() -> None:
+    payload = {
+        "evdev_paths": ["keymasq:2dc8:3106"],
+        "evdev_interfaces": [
+            {
+                "id": "gamepad",
+                "path": "keymasq:2dc8:3106",
+                "type": "gamepad",
+                "capabilities": ["btn_south"],
+            }
+        ],
+    }
+    changed_payload = {
+        **payload,
+        "evdev_interfaces": [
+            {
+                "id": "gamepad_2",
+                "path": "keymasq:2dc8:3106",
+                "type": "gamepad",
+                "capabilities": ["btn_south"],
+            }
+        ],
+    }
+
+    assert session_profiles_module.grab_device_payload_signature(
+        payload
+    ) != session_profiles_module.grab_device_payload_signature(changed_payload)
 
 
 @pytest.mark.asyncio

--- a/tests/session/test_session_manager_profile_resolution.py
+++ b/tests/session/test_session_manager_profile_resolution.py
@@ -482,6 +482,38 @@ async def test_reevaluate_profiles_releases_removed_hardware_config() -> None:
 
 
 @pytest.mark.asyncio
+async def test_reevaluate_profiles_keeps_stale_grab_state_when_release_fails() -> None:
+    manager = SessionManager()
+    hardware_id = "045e:02a1"
+    manager.hardware.list_hardware_ids = lambda: []  # type: ignore[assignment]
+    manager.profiles.resolve_active_profiles = lambda *_args, **_kwargs: ResolvedProfiles(  # type: ignore[assignment]
+        active_profiles=[],
+        devices={},
+        combos=[],
+    )
+    manager.profile_state.resolved_devices[hardware_id] = ResolvedDeviceProfile(
+        hardware_id=hardware_id
+    )
+    manager.profile_state.grabbed_devices.add(hardware_id)
+    manager.profile_state.grabbed_interfaces[hardware_id] = {
+        "gamepad": "/dev/input/event20"
+    }
+    manager.profile_state.last_sent_grab_signatures[hardware_id] = "grab"
+    manager.profile_state.last_sent_mapping_signatures[hardware_id] = "mapping"
+    manager.client.send_command = AsyncMock(
+        return_value=Response(status="error", error="release failed")
+    )
+
+    await session_profiles_module.reevaluate_profiles(manager)
+
+    assert hardware_id in manager.profile_state.resolved_devices
+    assert hardware_id in manager.profile_state.grabbed_devices
+    assert hardware_id in manager.profile_state.grabbed_interfaces
+    assert hardware_id in manager.profile_state.last_sent_grab_signatures
+    assert hardware_id in manager.profile_state.last_sent_mapping_signatures
+
+
+@pytest.mark.asyncio
 async def test_reevaluate_profiles_releases_removed_hardware_without_resolved_cache() -> None:
     manager = SessionManager()
     hardware_id = "045e:02a1"

--- a/tests/session/test_session_manager_profile_resolution.py
+++ b/tests/session/test_session_manager_profile_resolution.py
@@ -443,6 +443,81 @@ async def test_reevaluate_profiles_broadcast_omits_window_state() -> None:
 
 
 @pytest.mark.asyncio
+async def test_reevaluate_profiles_releases_removed_hardware_config() -> None:
+    manager = SessionManager()
+    hardware_id = "045e:02a1"
+    manager.hardware.list_hardware_ids = lambda: []  # type: ignore[assignment]
+    manager.profiles.resolve_active_profiles = lambda *_args, **_kwargs: ResolvedProfiles(  # type: ignore[assignment]
+        active_profiles=[],
+        devices={},
+        combos=[],
+    )
+    manager.profile_state.resolved_devices[hardware_id] = ResolvedDeviceProfile(
+        hardware_id=hardware_id
+    )
+    manager.profile_state.grabbed_devices.add(hardware_id)
+    manager.profile_state.grabbed_interfaces[hardware_id] = {
+        "gamepad": "/dev/input/event20"
+    }
+    manager.profile_state.last_sent_grab_signatures[hardware_id] = "grab"
+    manager.profile_state.last_sent_mapping_signatures[hardware_id] = "mapping"
+    manager.client.send_command = AsyncMock(
+        return_value=Response(status="ok", data={"released": True})
+    )
+
+    await session_profiles_module.reevaluate_profiles(manager)
+
+    sent = next(
+        call.args[0]
+        for call in manager.client.send_command.await_args_list
+        if call.args[0].command == CommandType.RELEASE_DEVICE
+    )
+    assert sent.command == CommandType.RELEASE_DEVICE
+    assert sent.data == {"hardware_id": hardware_id, "immediate": True}
+    assert hardware_id not in manager.profile_state.resolved_devices
+    assert hardware_id not in manager.profile_state.grabbed_devices
+    assert hardware_id not in manager.profile_state.grabbed_interfaces
+    assert hardware_id not in manager.profile_state.last_sent_grab_signatures
+    assert hardware_id not in manager.profile_state.last_sent_mapping_signatures
+
+
+@pytest.mark.asyncio
+async def test_reevaluate_profiles_releases_removed_hardware_without_resolved_cache() -> None:
+    manager = SessionManager()
+    hardware_id = "045e:02a1"
+    manager.hardware.list_hardware_ids = lambda: []  # type: ignore[assignment]
+    manager.profiles.resolve_active_profiles = lambda *_args, **_kwargs: ResolvedProfiles(  # type: ignore[assignment]
+        active_profiles=[],
+        devices={},
+        combos=[],
+    )
+    manager.profile_state.grabbed_devices.add(hardware_id)
+    manager.profile_state.grabbed_interfaces[hardware_id] = {
+        "gamepad": "/dev/input/event20"
+    }
+    manager.profile_state.grab_waiting_devices.add(hardware_id)
+    manager.profile_state.last_sent_grab_signatures[hardware_id] = "grab"
+    manager.profile_state.last_sent_mapping_signatures[hardware_id] = "mapping"
+    manager.client.send_command = AsyncMock(
+        return_value=Response(status="ok", data={"released": True})
+    )
+
+    await session_profiles_module.reevaluate_profiles(manager)
+
+    sent = next(
+        call.args[0]
+        for call in manager.client.send_command.await_args_list
+        if call.args[0].command == CommandType.RELEASE_DEVICE
+    )
+    assert sent.data == {"hardware_id": hardware_id, "immediate": True}
+    assert hardware_id not in manager.profile_state.grabbed_devices
+    assert hardware_id not in manager.profile_state.grabbed_interfaces
+    assert hardware_id not in manager.profile_state.grab_waiting_devices
+    assert hardware_id not in manager.profile_state.last_sent_grab_signatures
+    assert hardware_id not in manager.profile_state.last_sent_mapping_signatures
+
+
+@pytest.mark.asyncio
 async def test_reevaluate_profiles_plays_lifecycle_macros_once_per_transition(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/session/test_session_manager_recording_settings.py
+++ b/tests/session/test_session_manager_recording_settings.py
@@ -180,6 +180,43 @@ async def test_start_recording_sends_selected_devices_from_cache() -> None:
 
 
 @pytest.mark.asyncio
+async def test_get_devices_for_recording_uses_daemon_grabbed_state_only() -> None:
+    manager = SessionManager()
+    manager.profile_state.grabbed_interfaces["045e:02a1"] = {
+        "gamepad": "/dev/input/event20"
+    }
+    manager.client.send_command = AsyncMock(
+        return_value=Response(
+            status="ok",
+            data={
+                "devices": [
+                    {
+                        "path": "/dev/input/event20",
+                        "stable_path": "/dev/input/event20",
+                        "name": "Xbox 360 Wireless Receiver",
+                        "vendor_id": "045e",
+                        "product_id": "02a1",
+                        "device_type": "gamepad",
+                        "device_types": ["gamepad"],
+                        "grabbed_by_keymasq": False,
+                    }
+                ]
+            },
+        )
+    )
+
+    devices = await session_recording_module.get_devices_for_recording(
+        manager,
+        ["gamepad"],
+        include_grabbed=True,
+    )
+
+    assert devices[0]["grabbed_by_keymasq"] is False
+    assert devices[0]["source_hardware_id"] == ""
+    assert devices[0]["source_interface_id"] == ""
+
+
+@pytest.mark.asyncio
 async def test_start_recording_defaults_to_recommended_sources_only() -> None:
     manager = SessionManager()
     sent_payloads: list[dict[str, object]] = []

--- a/tests/test_capture_manager.py
+++ b/tests/test_capture_manager.py
@@ -124,8 +124,9 @@ def test_capture_manager_resolves_keymasq_paths(monkeypatch) -> None:
         primary_input_class_fn=primary_input_class,
     )
 
+    manager = CaptureManager()
+    token: str | None = None
     try:
-        manager = CaptureManager()
         begin = manager.begin(
             "2dc8:3106",
             evdev_interfaces=[
@@ -143,6 +144,8 @@ def test_capture_manager_resolves_keymasq_paths(monkeypatch) -> None:
         assert captured["evdev"] == "key_a"
         assert captured["source"] == "gamepad"
     finally:
+        if token is not None:
+            manager.end(token)
         device_path_resolver.clear_cached_devices()
 
 

--- a/tests/test_capture_manager.py
+++ b/tests/test_capture_manager.py
@@ -4,7 +4,9 @@ from unittest.mock import Mock
 import evdev
 import pytest
 
+from keymasq.common.devices import detect_input_classes, primary_input_class
 from keymasq.keymasqd.capture_manager import CaptureManager
+from keymasq.keymasqd.runtime import device_path_resolver
 
 
 class _FakeInfo:
@@ -115,6 +117,12 @@ def test_capture_manager_resolves_keymasq_paths(monkeypatch) -> None:
 
     monkeypatch.setattr(evdev, "list_devices", lambda: ["/dev/input/event7"])
     monkeypatch.setattr(evdev, "InputDevice", lambda path: fake)
+    device_path_resolver.refresh_cached_devices_sync(
+        device_paths_fn=evdev.list_devices,
+        device_input_fn=evdev.InputDevice,
+        detect_input_classes_fn=detect_input_classes,
+        primary_input_class_fn=primary_input_class,
+    )
 
     manager = CaptureManager()
     begin = manager.begin(

--- a/tests/test_capture_manager.py
+++ b/tests/test_capture_manager.py
@@ -109,6 +109,32 @@ def test_capture_manager_begin_can_target_explicit_paths(monkeypatch) -> None:
     assert captured["evdev"] == "key_a"
 
 
+def test_capture_manager_resolves_keymasq_paths(monkeypatch) -> None:
+    key_event = evdev.InputEvent(0, 0, evdev.ecodes.EV_KEY, evdev.ecodes.KEY_A, 1)
+    fake = _FakeDevice("/dev/input/event7", 0x2DC8, 0x3106, [key_event])
+
+    monkeypatch.setattr(evdev, "list_devices", lambda: ["/dev/input/event7"])
+    monkeypatch.setattr(evdev, "InputDevice", lambda path: fake)
+
+    manager = CaptureManager()
+    begin = manager.begin(
+        "2dc8:3106",
+        evdev_interfaces=[
+            {
+                "id": "gamepad",
+                "path": "keymasq:2dc8:3106",
+                "type": "keyboard",
+                "capabilities": ["key_a"],
+            }
+        ],
+    )
+    token = str(begin["token"])
+
+    captured = cast(dict[str, object], manager.read(token)["captured"])
+    assert captured["evdev"] == "key_a"
+    assert captured["source"] == "gamepad"
+
+
 def test_capture_manager_analog_mode_reads_abs_events(monkeypatch) -> None:
     abs_event = evdev.InputEvent(0, 0, evdev.ecodes.EV_ABS, evdev.ecodes.ABS_X, 12000)
     key_event = evdev.InputEvent(0, 0, evdev.ecodes.EV_KEY, evdev.ecodes.KEY_A, 1)

--- a/tests/test_capture_manager.py
+++ b/tests/test_capture_manager.py
@@ -124,23 +124,26 @@ def test_capture_manager_resolves_keymasq_paths(monkeypatch) -> None:
         primary_input_class_fn=primary_input_class,
     )
 
-    manager = CaptureManager()
-    begin = manager.begin(
-        "2dc8:3106",
-        evdev_interfaces=[
-            {
-                "id": "gamepad",
-                "path": "keymasq:2dc8:3106",
-                "type": "keyboard",
-                "capabilities": ["key_a"],
-            }
-        ],
-    )
-    token = str(begin["token"])
+    try:
+        manager = CaptureManager()
+        begin = manager.begin(
+            "2dc8:3106",
+            evdev_interfaces=[
+                {
+                    "id": "gamepad",
+                    "path": "keymasq:2dc8:3106",
+                    "type": "keyboard",
+                    "capabilities": ["key_a"],
+                }
+            ],
+        )
+        token = str(begin["token"])
 
-    captured = cast(dict[str, object], manager.read(token)["captured"])
-    assert captured["evdev"] == "key_a"
-    assert captured["source"] == "gamepad"
+        captured = cast(dict[str, object], manager.read(token)["captured"])
+        assert captured["evdev"] == "key_a"
+        assert captured["source"] == "gamepad"
+    finally:
+        device_path_resolver.clear_cached_devices()
 
 
 def test_capture_manager_analog_mode_reads_abs_events(monkeypatch) -> None:

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -8,9 +8,12 @@ import pytest
 from keymasq.common.devices import (
     classify_event_device_type,
     clear_device_path_cache,
+    config_path_for_detected_event,
     detect_input_classes_from_capabilities,
     find_all_interfaces,
     get_interface_id,
+    make_keymasq_device_path,
+    parse_keymasq_device_path,
     primary_input_class,
     resolve_stable_path,
 )
@@ -104,6 +107,42 @@ def test_resolve_stable_path_skips_symlink_read_errors(monkeypatch: pytest.Monke
     assert resolve_stable_path("/dev/input/event9") == "/dev/input/event9"
 
     clear_device_path_cache()
+
+
+def test_keymasq_device_path_helpers() -> None:
+    assert make_keymasq_device_path("2DC8", "3106") == "keymasq:2dc8:3106"
+    assert parse_keymasq_device_path("keymasq:2dc8:3106") == ("2dc8", "3106")
+    assert parse_keymasq_device_path("keymasq:dc8:1") == ("0dc8", "0001")
+    assert parse_keymasq_device_path("keymasq:2dc8") is None
+    assert parse_keymasq_device_path("/dev/input/event1") is None
+
+
+def test_config_path_for_detected_event_prefers_by_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "keymasq.common.devices.resolve_stable_path",
+        lambda _path: "/dev/input/by-id/usb-Test-event-joystick",
+    )
+
+    assert (
+        config_path_for_detected_event("/dev/input/event5", "2dc8", "3106")
+        == "/dev/input/by-id/usb-Test-event-joystick"
+    )
+
+
+def test_config_path_for_detected_event_uses_keymasq_path_without_by_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "keymasq.common.devices.resolve_stable_path",
+        lambda path: path,
+    )
+
+    assert (
+        config_path_for_detected_event("/dev/input/event5", "2dc8", "3106")
+        == "keymasq:2dc8:3106"
+    )
 
 
 def test_find_all_interfaces_filters_matching_devices(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_session_hardware.py
+++ b/tests/test_session_hardware.py
@@ -191,6 +191,36 @@ def test_hardware_manager_save_load_and_delete_round_trip(temp_config_dir) -> No
     assert manager.delete_hardware("1111:2222") is False
 
 
+def test_hardware_manager_preserves_keymasq_logical_path(temp_config_dir) -> None:
+    manager = HardwareManager()
+    config = HardwareConfig(
+        vendor_id="2dc8",
+        product_id="3106",
+        name="Bluetooth Pad",
+        evdev_devices=[
+            EvdevDevice(
+                path="keymasq:2dc8:3106",
+                device_type=DeviceType.GAMEPAD,
+                id="gamepad",
+                capabilities=["btn_south", "abs_x"],
+            ),
+            EvdevDevice(
+                path="/dev/input/by-path/pci-test-event-joystick",
+                device_type=DeviceType.GAMEPAD,
+                id="manual_path",
+            ),
+        ],
+        buttons=[],
+    )
+
+    manager.save_hardware(config)
+
+    text = (temp_config_dir / "hardware" / "2dc8_3106.toml").read_text(encoding="utf-8")
+    assert 'path = "keymasq:2dc8:3106"' in text
+    assert 'path = "/dev/input/by-path/pci-test-event-joystick"' in text
+    assert HardwareManager().get_hardware("2dc8:3106") == config
+
+
 def test_hardware_manager_preserves_explicit_hardware_id(temp_config_dir) -> None:
     manager = HardwareManager()
     config = HardwareConfig(


### PR DESCRIPTION
## Summary

- Devices without `/dev/input/by-id/` symlinks (common for some gamepads, adapters, and USB hubs) now get a stable logical path `keymasq:<vendor_id>:<product_id>` instead of an unstable `/dev/input/eventN` node
- New `device_path_resolver` module resolves logical paths at runtime by matching vendor/product IDs against live evdev devices, with scoring for type, phys, and capabilities
- Hardware setup wizard uses logical paths by default when no by-id link exists; raw event paths are only used when explicitly enabled
- Capture manager and combo capture accept interface descriptors alongside raw paths, enabling proper source tracking and hardware ID resolution for logical-path devices
- Session manager sends interface metadata (id, type, phys, capabilities) during device grab and combo capture
- Agent docs updated to document the new path format

## Testing

- `./scripts/check.sh full` — passes all lint, type-check, and test suites
- `tests/keymasqd/test_device_path_resolver.py` — 253 lines covering parsing, resolution, candidate scoring, and ambiguity handling
- `tests/test_devices.py` — validates `make_keymasq_device_path`, `parse_keymasq_device_path`, `is_by_id_path`, and `config_path_for_detected_event`
- `tests/gui/test_hardware_setup_dialog.py` — updated for logical path generation in wizard
- `tests/keymasqd/test_daemon_capture_commands.py` — covers capture begin with interface descriptors
- `tests/keymasqd/test_device_manager_core.py` — covers grab with evdev_interfaces
- `tests/session/test_session_manager_command_runtime.py` and `tests/session/test_session_manager_profile_apply.py` — session sends interface metadata
- Manual test: Verified a device with no by-id link gets `keymasq:2dc8:3106` in config and resolves correctly at runtime