### PR TITLE
Extract shared device layout and pointer control utilities

### DIFF
--- a/keymasq/gui/widgets/device_control_layout.py
+++ b/keymasq/gui/widgets/device_control_layout.py
@@ -1,0 +1,51 @@
+from collections.abc import Callable, Iterable
+
+from keymasq.common.devices import is_gamepad_button_name
+from keymasq.common.models import DeviceType, HardwareConfig
+
+KEYBOARD_LAYOUT_KEY_THRESHOLD = 40
+
+POINTER_MAIN_BUTTON_IDS = {"btn_left", "btn_right", "btn_middle"}
+POINTER_SCROLL_KEYWORDS = {"scroll", "wheel"}
+POINTER_SIDE_BUTTON_IDS = {
+    "btn_side",
+    "btn_extra",
+    "btn_4",
+    "btn_forward",
+    "btn_back",
+}
+
+
+def device_layout_kind(device: HardwareConfig) -> str:
+    key_count = sum(1 for button in device.buttons if button.id.startswith("key_"))
+    if key_count >= KEYBOARD_LAYOUT_KEY_THRESHOLD:
+        return "keyboard"
+    if any(evdev_device.device_type == DeviceType.GAMEPAD for evdev_device in device.evdev_devices):
+        return "gamepad"
+    if any(is_gamepad_button_name(button.evdev) for button in device.buttons):
+        return "gamepad"
+    return "mouse"
+
+
+def group_pointer_controls[T](
+    controls: Iterable[T],
+    *,
+    id_for_control: Callable[[T], str],
+) -> tuple[list[T], list[T], list[T], list[T]]:
+    main_buttons: list[T] = []
+    scroll_buttons: list[T] = []
+    side_buttons: list[T] = []
+    extra_buttons: list[T] = []
+
+    for control in controls:
+        control_id = id_for_control(control).lower()
+        if control_id in POINTER_MAIN_BUTTON_IDS:
+            main_buttons.append(control)
+        elif any(keyword in control_id for keyword in POINTER_SCROLL_KEYWORDS):
+            scroll_buttons.append(control)
+        elif control_id in POINTER_SIDE_BUTTON_IDS:
+            side_buttons.append(control)
+        else:
+            extra_buttons.append(control)
+
+    return main_buttons, scroll_buttons, side_buttons, extra_buttons

--- a/keymasq/gui/widgets/device_inspector_window.py
+++ b/keymasq/gui/widgets/device_inspector_window.py
@@ -9,8 +9,7 @@ gi.require_version("Adw", "1")
 
 from gi.repository import Adw, Gdk, GLib, Gtk, Pango  # pyright: ignore[reportAttributeAccessIssue]
 
-from keymasq.common.devices import is_gamepad_button_name
-from keymasq.common.models import ActionType, DeviceType, HardwareConfig, MappingAction
+from keymasq.common.models import ActionType, HardwareConfig, MappingAction
 from keymasq.gui.icons import device_icon_names, image_from_icon_names
 from keymasq.gui.session_client import (
     JsonDict,
@@ -19,6 +18,10 @@ from keymasq.gui.session_client import (
     unregister_session_event_callback,
 )
 from keymasq.gui.widgets.action_labels import describe_mapping_action_compact
+from keymasq.gui.widgets.device_control_layout import (
+    device_layout_kind,
+    group_pointer_controls,
+)
 
 EVENT_ROW_LIMIT = 100
 EVENT_RENDER_THROTTLE_MS = 33
@@ -178,9 +181,7 @@ def _mapping_action_from_payload(action: object) -> MappingAction | None:
     analog_control_names: list[str] = []
     raw_analog_control_names = action.get("analog_control_names", [])
     if isinstance(raw_analog_control_names, list):
-        analog_control_names = [
-            str(name) for name in raw_analog_control_names if str(name).strip()
-        ]
+        analog_control_names = [str(name) for name in raw_analog_control_names if str(name).strip()]
     keys: list[str] | None = None
     raw_keys = action.get("keys", [])
     if isinstance(raw_keys, list):
@@ -227,7 +228,7 @@ class DeviceInspectorWindow(Adw.Window):
         self._stop_sent = False
         self._syncing_suppression = False
         self._snapshot: JsonDict = {}
-        self._device_kind = _device_layout_kind(device)
+        self._device_kind = device_layout_kind(device)
         self._control_widgets: dict[str, Gtk.Widget] = {}
         self._event_history_by_category: dict[str, list[JsonDict]] = {
             filter_id: [] for filter_id, _label, _active in EVENT_FILTERS
@@ -266,7 +267,7 @@ class DeviceInspectorWindow(Adw.Window):
         header = Adw.HeaderBar()
 
         self._header_device_icon = image_from_icon_names(
-            *device_icon_names(device_kind=_device_layout_kind(self.device)),
+            *device_icon_names(device_kind=device_layout_kind(self.device)),
             pixel_size=24,
         )
         self._header_device_icon.set_valign(Gtk.Align.CENTER)
@@ -300,6 +301,9 @@ class DeviceInspectorWindow(Adw.Window):
         header.pack_end(switch_box)
 
         toolbar.add_top_bar(header)
+        key_controller = Gtk.EventControllerKey()
+        key_controller.connect("key-pressed", self._on_key_pressed)
+        self.add_controller(key_controller)
 
         window_width, _window_height = _inspector_default_size(self._device_kind)
         live_panel_width = (
@@ -497,7 +501,7 @@ class DeviceInspectorWindow(Adw.Window):
         profile_label.set_halign(Gtk.Align.START)
         self._mapping_box.append(profile_label)
 
-        if self._is_keyboard_snapshot(buttons):
+        if self._device_kind == "keyboard":
             self._render_keyboard_buttons(buttons)
         else:
             self._render_pointer_buttons(buttons)
@@ -549,26 +553,15 @@ class DeviceInspectorWindow(Adw.Window):
             self._append_flow_section("Extra Keys", extras, is_keyboard=True)
 
     def _render_pointer_buttons(self, buttons: list[JsonDict]) -> None:
-        main_ids = {"btn_left", "btn_right", "btn_middle"}
-        main_buttons: list[JsonDict] = []
-        wheel_buttons: list[JsonDict] = []
-        thumb_buttons: list[JsonDict] = []
-        extra_buttons: list[JsonDict] = []
-        for button in buttons:
-            button_id = _text(button.get("id")).lower()
-            if button_id in main_ids:
-                main_buttons.append(button)
-            elif "scroll" in button_id or "wheel" in button_id:
-                wheel_buttons.append(button)
-            elif button_id in {"btn_side", "btn_extra", "btn_4", "btn_forward", "btn_back"}:
-                thumb_buttons.append(button)
-            else:
-                extra_buttons.append(button)
+        main_buttons, scroll_buttons, side_buttons, extra_buttons = group_pointer_controls(
+            buttons,
+            id_for_control=lambda button: _text(button.get("id")),
+        )
         for title, group in (
-            ("Main Buttons", main_buttons),
-            ("Wheel / Scroll", wheel_buttons),
-            ("Thumb Buttons", thumb_buttons),
             ("Extra Buttons", extra_buttons),
+            ("Main Buttons", main_buttons),
+            ("Scroll", scroll_buttons),
+            ("Side Buttons", side_buttons),
         ):
             if group:
                 self._append_flow_section(title, group, is_keyboard=False)
@@ -671,10 +664,7 @@ class DeviceInspectorWindow(Adw.Window):
             analog_id=analog_id,
             analog_type=analog_type,
             axes=axes,
-            normalized={
-                role: _normalize_axis(axis, 0, analog_type)
-                for role, axis in axes.items()
-            },
+            normalized={role: _normalize_axis(axis, 0, analog_type) for role, axis in axes.items()},
         )
 
         section = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=6)
@@ -719,9 +709,7 @@ class DeviceInspectorWindow(Adw.Window):
         values = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=2)
         values.set_halign(Gtk.Align.CENTER)
         for role in sorted(axes):
-            label = Gtk.Label(
-                label=_axis_value_label(role, 0, viewer.normalized.get(role, 0.0))
-            )
+            label = Gtk.Label(label=_axis_value_label(role, 0, viewer.normalized.get(role, 0.0)))
             label.add_css_class("caption")
             label.add_css_class("dim-label")
             label.add_css_class("inspector-axis-value")
@@ -955,6 +943,31 @@ class DeviceInspectorWindow(Adw.Window):
         switch.set_sensitive(False)
         session_request_async(payload, self._on_suppression_response, timeout=3.0)
 
+    def _on_key_pressed(
+        self,
+        _controller: Gtk.EventControllerKey,
+        keyval: int,
+        _keycode: int,
+        _state: Gdk.ModifierType,
+    ) -> bool:
+        if (
+            keyval != Gdk.KEY_Escape
+            or self._closing
+            or not self._suppression_switch.get_active()
+        ):
+            return False
+        self._suppression_switch.set_sensitive(False)
+        session_request_async(
+            {
+                "command": "disable_device_inspector_suppression",
+                "hardware_id": self._hardware_id,
+                "reason": "key_esc",
+            },
+            self._on_suppression_response,
+            timeout=3.0,
+        )
+        return True
+
     def _on_suppression_response(self, result: JsonDict | None) -> bool:
         if self._closing:
             return False
@@ -1021,9 +1034,6 @@ class DeviceInspectorWindow(Adw.Window):
             lambda _result: False,
             timeout=1.5,
         )
-
-    def _is_keyboard_snapshot(self, buttons: list[JsonDict]) -> bool:
-        return sum(1 for button in buttons if _text(button.get("id")).startswith("key_")) >= 12
 
     def _action_label(self, action: object, control: JsonDict) -> str | None:
         mapping = _mapping_action_from_payload(action)
@@ -1157,17 +1167,6 @@ def _level_bar_value(analog_type: str, normalized: float) -> float:
 
 def _axis_value_label(role: str, raw_value: int, normalized: float) -> str:
     return f"{role}: raw {raw_value:6d} | norm {normalized:+.3f}"
-
-
-def _device_layout_kind(device: HardwareConfig) -> str:
-    key_count = sum(1 for button in device.buttons if button.id.startswith("key_"))
-    if key_count >= 40:
-        return "keyboard"
-    if any(evdev_device.device_type == DeviceType.GAMEPAD for evdev_device in device.evdev_devices):
-        return "gamepad"
-    if any(is_gamepad_button_name(button.evdev) for button in device.buttons):
-        return "gamepad"
-    return "mouse"
 
 
 def _inspector_default_size(device_kind: str) -> tuple[int, int]:

--- a/keymasq/gui/widgets/device_tab.py
+++ b/keymasq/gui/widgets/device_tab.py
@@ -39,6 +39,7 @@ from keymasq.gui.session_client import (
     session_request_async,
 )
 from keymasq.gui.widgets.action_labels import describe_mapping_action_compact
+from keymasq.gui.widgets.device_control_layout import device_layout_kind, group_pointer_controls
 from keymasq.gui.widgets.key_selector_dialog import KeySelectorDialog
 from keymasq.gui.widgets.profile_managed_tab import ProfileManagedTab
 from keymasq.session.hardware import HardwareManager
@@ -150,11 +151,7 @@ def _grouped_analog_inputs(
         if matching:
             groups.append((title, matching))
 
-    other = [
-        analog
-        for analog in ordered
-        if str(analog.type).lower() not in {"axis", "stick"}
-    ]
+    other = [analog for analog in ordered if str(analog.type).lower() not in {"axis", "stick"}]
     if other:
         groups.append(("Other", other))
     return groups
@@ -265,10 +262,7 @@ class DeviceTab(ProfileManagedTab):
         return "No profiles are currently applied to this device."
 
     def _active_profiles_layer_tooltip(self) -> str:
-        return (
-            "Applied profiles. Layer order: "
-            + " -> ".join(self._active_profile_names)
-        )
+        return "Applied profiles. Layer order: " + " -> ".join(self._active_profile_names)
 
     def _after_profile_selection_applied(self) -> None:
         for button_id in self._button_widgets:
@@ -293,10 +287,7 @@ class DeviceTab(ProfileManagedTab):
     def _update_header_caption(self) -> None:
         mapped = self._count_mapped_buttons()
         total = len(self.device.buttons) + len(self.device.analog_inputs)
-        base = (
-            f"{self.device.model_id} | {len(self.device.evdev_devices)} evdev, "
-            f"{total} buttons"
-        )
+        base = f"{self.device.model_id} | {len(self.device.evdev_devices)} evdev, {total} buttons"
         if mapped > 0:
             caption = f"{base} · {mapped} mapped"
         else:
@@ -834,24 +825,10 @@ class DeviceTab(ProfileManagedTab):
 
         content = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=10)
 
-        main_ids = {"btn_left", "btn_right", "btn_middle"}
-        scroll_keywords = {"scroll", "wheel"}
-
-        main_buttons: list[ButtonDefinition] = []
-        scroll_buttons: list[ButtonDefinition] = []
-        other_buttons: list[ButtonDefinition] = []
-        extra_buttons: list[ButtonDefinition] = []
-
-        for button in self.device.buttons:
-            bid = button.id.lower()
-            if bid in main_ids:
-                main_buttons.append(button)
-            elif any(kw in bid for kw in scroll_keywords):
-                scroll_buttons.append(button)
-            elif bid in ("btn_side", "btn_extra", "btn_4", "btn_forward", "btn_back"):
-                other_buttons.append(button)
-            else:
-                extra_buttons.append(button)
+        main_buttons, scroll_buttons, other_buttons, extra_buttons = group_pointer_controls(
+            self.device.buttons,
+            id_for_control=lambda button: button.id,
+        )
 
         self.button_grid = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
 
@@ -1013,11 +990,7 @@ class DeviceTab(ProfileManagedTab):
         return any(is_gamepad_button_name(button.evdev) for button in self.device.buttons)
 
     def device_layout_kind(self) -> str:
-        if self.is_keyboard_hardware():
-            return "keyboard"
-        if self.is_gamepad_hardware():
-            return "gamepad"
-        return "mouse"
+        return device_layout_kind(self.device)
 
     def _append_keyboard_section(
         self,
@@ -2265,10 +2238,7 @@ class DeviceTab(ProfileManagedTab):
         box.set_margin_end(8)
 
         title = Gtk.Label(
-            label=(
-                f"{candidate.get('evdev')} "
-                f"[{candidate.get('source') or 'default'}]"
-            )
+            label=(f"{candidate.get('evdev')} [{candidate.get('source') or 'default'}]")
         )
         title.set_halign(Gtk.Align.START)
         box.append(title)
@@ -2586,6 +2556,7 @@ class DeviceTab(ProfileManagedTab):
             return True
 
         self._add_keys_poll_inflight = True
+
         def on_capture_read(result: JsonDict | None) -> bool:
             return self._on_add_keys_capture_read(
                 result,

--- a/keymasq/gui/widgets/device_tab.py
+++ b/keymasq/gui/widgets/device_tab.py
@@ -13,7 +13,6 @@ from gi.repository import Adw, Gdk, GLib, Gtk, Pango  # pyright: ignore[reportAt
 from keymasq.common.devices import (
     canonical_gamepad_button_name,
     gamepad_button_label,
-    is_gamepad_button_name,
     is_low_res_wheel_evdev,
     normalize_wheel_value,
     resolve_evdev_code,
@@ -923,7 +922,7 @@ class DeviceTab(ProfileManagedTab):
         self.append(scrolled)
 
     def _learn_label_noun(self) -> str:
-        if self.is_keyboard_hardware():
+        if self.device_layout_kind() == "keyboard":
             return "Keys"
         return "Buttons"
 
@@ -980,15 +979,6 @@ class DeviceTab(ProfileManagedTab):
             device.device_type not in {DeviceType.MOUSE, DeviceType.KEYBOARD}
             for device in self.device.evdev_devices
         )
-
-    def is_keyboard_hardware(self) -> bool:
-        key_count = sum(1 for b in self.device.buttons if b.id.startswith("key_"))
-        return key_count >= 40
-
-    def is_gamepad_hardware(self) -> bool:
-        if any(dev.device_type == DeviceType.GAMEPAD for dev in self.device.evdev_devices):
-            return True
-        return any(is_gamepad_button_name(button.evdev) for button in self.device.buttons)
 
     def device_layout_kind(self) -> str:
         return device_layout_kind(self.device)
@@ -2923,7 +2913,7 @@ class DeviceTab(ProfileManagedTab):
         return token.replace("_", " ").strip().title()
 
     def _is_supported_added_input(self, evdev_name: str) -> bool:
-        if self.is_gamepad_hardware():
+        if self.device_layout_kind() == "gamepad":
             return evdev_name.startswith("btn_")
         return (
             evdev_name.startswith("key_")
@@ -3006,7 +2996,7 @@ class DeviceTab(ProfileManagedTab):
         )
 
     def _add_input_summary_text(self) -> str:
-        if self.is_gamepad_hardware():
+        if self.device_layout_kind() == "gamepad":
             return (
                 "Add additional digital gamepad buttons to this config.\n"
                 "Press each requested button when prompted."
@@ -3020,9 +3010,10 @@ class DeviceTab(ProfileManagedTab):
         return "Number of inputs:"
 
     def _capture_waiting_label(self) -> str:
-        if self.is_gamepad_hardware():
+        kind = self.device_layout_kind()
+        if kind == "gamepad":
             return "Recording button presses..."
-        if self.is_keyboard_hardware():
+        if kind == "keyboard":
             return "Recording keys..."
         return "Recording inputs..."
 
@@ -3052,7 +3043,7 @@ class DeviceTab(ProfileManagedTab):
 
         if evdev_name.startswith("key_"):
             return DeviceType.KEYBOARD
-        if self.is_gamepad_hardware():
+        if self.device_layout_kind() == "gamepad":
             return DeviceType.GAMEPAD
         if evdev_name.startswith("btn_") or evdev_name.startswith("rel_"):
             return DeviceType.MOUSE

--- a/keymasq/gui/widgets/device_tab.py
+++ b/keymasq/gui/widgets/device_tab.py
@@ -663,7 +663,8 @@ class DeviceTab(ProfileManagedTab):
         scrolled.set_vexpand(True)
         scrolled.set_margin_top(12)
 
-        self._keyboard_layout_mode = self.is_keyboard_hardware()
+        kind = device_layout_kind(self.device)
+        self._keyboard_layout_mode = kind == "keyboard"
 
         if self._keyboard_layout_mode:
             content = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=10)
@@ -860,7 +861,7 @@ class DeviceTab(ProfileManagedTab):
                     r += 1
                 parent.append(grid)
 
-        if self.is_gamepad_hardware():
+        if kind == "gamepad":
             buttons_by_id = {b.id: b for b in self.device.buttons}
             for title, button_ids, max_cols in [
                 ("Shoulders", ["btn_tl", "btn_tr"], 2),

--- a/tests/gui/test_device_inspector_window.py
+++ b/tests/gui/test_device_inspector_window.py
@@ -17,6 +17,118 @@ def test_inspector_label_sort_key_orders_trailing_numbers_numerically() -> None:
     ]
 
 
+def test_inspector_keeps_many_keyboard_backed_mouse_buttons_in_mouse_layout() -> None:
+    from gi.repository import Gtk
+
+    from keymasq.common.models import ButtonDefinition, DeviceType, EvdevDevice, HardwareConfig
+    from keymasq.gui.widgets.device_inspector_window import DeviceInspectorWindow
+
+    buttons = [
+        ButtonDefinition(
+            id="btn_left",
+            label="Left Click",
+            evdev="btn_left",
+            evdev_code=272,
+            source="mouse",
+        ),
+        ButtonDefinition(
+            id="btn_right",
+            label="Right Click",
+            evdev="btn_right",
+            evdev_code=273,
+            source="mouse",
+        ),
+        ButtonDefinition(
+            id="btn_middle",
+            label="Middle Click",
+            evdev="btn_middle",
+            evdev_code=274,
+            source="mouse",
+        ),
+        ButtonDefinition(
+            id="scroll_up",
+            label="Scroll Up",
+            evdev="rel_wheel",
+            evdev_code=8,
+            evdev_value=1,
+            source="mouse",
+        ),
+        ButtonDefinition(
+            id="btn_side",
+            label="Back",
+            evdev="btn_side",
+            evdev_code=275,
+            source="mouse",
+        ),
+    ]
+    buttons.extend(
+        ButtonDefinition(
+            id=f"key_extra_{index}",
+            label=f"Extra {index}",
+            evdev=f"key_{index}",
+            evdev_code=index,
+            source="keyboard",
+        )
+        for index in range(1, 15)
+    )
+    device = HardwareConfig(
+        vendor_id="1532",
+        product_id="00b4",
+        name="Razer Naga",
+        evdev_devices=[
+            EvdevDevice(
+                path="/dev/input/event10",
+                device_type=DeviceType.MOUSE,
+                id="mouse",
+            ),
+            EvdevDevice(
+                path="/dev/input/event11",
+                device_type=DeviceType.KEYBOARD,
+                id="keyboard",
+            ),
+        ],
+        buttons=buttons,
+    )
+    snapshot = {
+        "active_profiles": ["Default"],
+        "buttons": [
+            {
+                "id": button.id,
+                "label": button.label,
+                "kind": "button",
+                "evdev": button.evdev,
+                "evdev_code": button.evdev_code,
+                "evdev_value": button.evdev_value,
+                "source": button.source,
+                "action": None,
+            }
+            for button in buttons
+        ],
+    }
+
+    window = DeviceInspectorWindow.__new__(DeviceInspectorWindow)
+    window.device = device
+    window._device_kind = "mouse"
+    window._mapping_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
+    window._control_widgets = {}
+
+    window._render_mapping(snapshot)
+
+    section_titles: list[str] = []
+    child = window._mapping_box.get_first_child()
+    while child is not None:
+        if (
+            isinstance(child, Gtk.Label)
+            and child.has_css_class("button-section-title")
+            and child.get_text() != "Resolved Mapping"
+        ):
+            section_titles.append(child.get_text())
+        child = child.get_next_sibling()
+
+    assert section_titles == ["Extra Buttons", "Main Buttons", "Scroll", "Side Buttons"]
+    assert "key_extra_14" in window._control_widgets
+
+
 def _device():
     from keymasq.common.models import (
         AnalogAxisDefinition,
@@ -166,7 +278,7 @@ def _snapshot():
 def test_device_inspector_window_starts_renders_events_and_toggles_suppression(
     monkeypatch,
 ):
-    from gi.repository import Gtk
+    from gi.repository import Gdk, Gtk
 
     from keymasq.gui.widgets import device_inspector_window as inspector_module
     from keymasq.gui.widgets.device_inspector_window import DeviceInspectorWindow
@@ -280,9 +392,7 @@ def test_device_inspector_window_starts_renders_events_and_toggles_suppression(
     assert len(window._event_rows) == 1
     assert len(window._event_history_by_category["button"]) == 1
     assert window._copy_events_button.get_tooltip_text() == "Copy visible events"
-    assert window._visible_event_export_text() == (
-        "#1 btn_south ev_key value=1 source=pad"
-    )
+    assert window._visible_event_export_text() == ("#1 btn_south ev_key value=1 source=pad")
 
     for index in range(120):
         emit(
@@ -342,9 +452,7 @@ def test_device_inspector_window_starts_renders_events_and_toggles_suppression(
 
     window._event_filter_buttons["syn"].set_active(True)
     assert len(window._event_rows) == 100
-    assert "#123 msc_scan ev_msc value=458792 source=pad" in (
-        window._visible_event_export_text()
-    )
+    assert "#123 msc_scan ev_msc value=458792 source=pad" in (window._visible_event_export_text())
 
     emit(
         {
@@ -380,6 +488,15 @@ def test_device_inspector_window_starts_renders_events_and_toggles_suppression(
     assert window._status_label.get_text() == "Inspector Pad - Output suppressed"
     assert window._status_label.has_css_class("inspector-header-suppressed") is True
     assert window._suppression_hint_label.get_visible() is True
+    assert window._on_key_pressed(Gtk.EventControllerKey(), Gdk.KEY_Escape, 0, 0) is True
+    assert requests[-1] == {
+        "command": "disable_device_inspector_suppression",
+        "hardware_id": "1234:5678",
+        "reason": "key_esc",
+    }
+    assert window._suppression_switch.get_active() is False
+
+    window._suppression_switch.set_active(True)
 
     callbacks["device_inspector_status"][0](
         {

--- a/tests/gui/test_gui_device_tab_misc.py
+++ b/tests/gui/test_gui_device_tab_misc.py
@@ -980,7 +980,7 @@ def test_device_tab_renders_analog_controls_for_keyboard_layout(temp_config_dir)
 
     tab = DeviceTab(device=device, profile_manager=None, demo_mode=True)
 
-    assert tab.is_keyboard_hardware() is True
+    assert tab.device_layout_kind() == "keyboard"
     assert "left_stick" in tab._button_widgets
     assert tab._button_widgets["left_stick"]._name_label.get_text() == "Left Stick"
 


### PR DESCRIPTION
## Summary
- Extracted `device_layout_kind()` and `group_pointer_controls()` into a new `device_control_layout.py` module
- Refactored `device_inspector_window.py` and `device_tab.py` to use the shared utilities, removing duplicated classification and grouping logic
- Added test for a keyboard-backed mouse device to verify the inspector uses mouse layout despite many keyboard buttons
- Added Escape key binding to disable suppression mode in `DeviceInspectorWindow`
- Minor formatting cleanups throughout the changed files

## Testing
- Existing GUI test suite passes (`tests/gui/test_device_inspector_window.py`)
- New `test_inspector_keeps_many_keyboard_backed_mouse_buttons_in_mouse_layout` verifies correct section ordering and widget creation
- Escape handler tested via monkeypatched session requests; confirmed it sends `disable_device_inspector_suppression` with reason `key_esc`
- Manual testing of device inspector with keyboard-backed mouse device (e.g., Razer Naga) to confirm layout is mouse
- Pointer control grouping covers main, scroll, side, and extra button categories