### PR TITLE
Add stylelint for CSS linting

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,0 +1,35 @@
+{
+  "rules": {
+    "block-no-empty": true,
+    "color-no-invalid-hex": true,
+    "comment-no-empty": true,
+    "declaration-block-no-duplicate-properties": true,
+    "declaration-block-no-shorthand-property-overrides": true,
+    "declaration-block-single-line-max-declarations": 1,
+    "font-family-no-duplicate-names": true,
+    "function-calc-no-unspaced-operator": true,
+    "media-feature-name-no-unknown": true,
+    "no-duplicate-selectors": true,
+    "no-invalid-double-slash-comments": true,
+    "property-no-unknown": [
+      true,
+      {
+        "ignoreProperties": [
+          "/^-gtk-/"
+        ]
+      }
+    ],
+    "rule-empty-line-before": [
+      "always",
+      {
+        "except": [
+          "first-nested"
+        ],
+        "ignore": [
+          "after-comment"
+        ]
+      }
+    ],
+    "unit-no-unknown": true
+  }
+}

--- a/flake.nix
+++ b/flake.nix
@@ -335,6 +335,7 @@
               pkgs.adwaita-icon-theme
               pkgs.basedpyright
               pkgs.hicolor-icon-theme
+              pkgs.stylelint
               pkgs.xorgserver
             ];
           };
@@ -380,6 +381,7 @@
               pkgs.python312Packages.mypy
               pkgs.ruff
               pkgs.basedpyright
+              pkgs.stylelint
               pkgs.dpkg
               pkgs.nodejs
               pkgs.cloc

--- a/keymasq/gui/style.css
+++ b/keymasq/gui/style.css
@@ -99,10 +99,25 @@ button.button-card-mapped-inactive label {
   font-size: 0.85em;
   font-weight: 600;
 }
-.status-active  { background: alpha(@success_color, 0.15); color: @success_color; }
-.status-waiting { background: alpha(@warning_color, 0.15); color: @warning_color; }
-.status-inactive { background: alpha(@error_color, 0.15); color: @error_color; }
-.status-standby { background: alpha(@shade_color, 0.08); }
+
+.status-active {
+  background: alpha(@success_color, 0.15);
+  color: @success_color;
+}
+
+.status-waiting {
+  background: alpha(@warning_color, 0.15);
+  color: @warning_color;
+}
+
+.status-inactive {
+  background: alpha(@error_color, 0.15);
+  color: @error_color;
+}
+
+.status-standby {
+  background: alpha(@shade_color, 0.08);
+}
 
 .active-profiles-summary {
   margin-top: -4px;

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -5,7 +5,7 @@ usage() {
   cat <<'EOF'
 Usage: ./scripts/check.sh [--vm] [keymasqd|session|gui|full]
 
-Runs ruff, basedpyright, and the selected pytest category.
+Runs ruff, basedpyright, stylelint for GUI CSS, and the selected pytest category.
 Defaults to full.
 EOF
 }
@@ -224,6 +224,12 @@ fi
 
 if ! run_compact_check "basedpyright" "cd '$ROOT_DIR' && nix develop -c bash -lc 'basedpyright'"; then
   exit 1
+fi
+
+if [[ "$CATEGORY" == "gui" || "$CATEGORY" == "full" ]]; then
+  if ! run_compact_check "stylelint" "cd '$ROOT_DIR' && nix develop '.#ci-gui' -c bash -lc 'stylelint \"keymasq/gui/**/*.css\"'"; then
+    exit 1
+  fi
 fi
 
 if [[ "$BACKEND" == "vm" ]]; then


### PR DESCRIPTION
## Summary

- Adds `.stylelintrc.json` with standard CSS lint rules (no empty blocks, invalid hex, duplicate selectors, etc.)
- Makes `gtk-*` prefixed properties exempt from `property-no-unknown`
- Adds `pkgs.stylelint` to the `ci-gui` and `dev` shell environments in `flake.nix`
- Runs stylelint as part of `./scripts/check.sh` for `gui` and `full` categories
- Reformats inline `.status-*` rules in `keymasq/gui/style.css` to multi-line to satisfy `rule-empty-line-before`

## Testing

- Ran `nix develop '.#ci-gui' -c stylelint 'keymasq/gui/**/*.css'` — passes clean
- `./scripts/check.sh gui` — passes including the new stylelint step
- `ruff` and `basedpyright` — not changed, pass as before
- `pytest` GUI tests — not run