### PR TITLE
Auto-reload user config on file changes with error rollback

### DIFF
--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -264,11 +264,14 @@ For multi-interface devices, update every relevant entry in the hardware file
 and keep the existing `id` values unchanged. Profile mappings refer to those
 `id` values and to the hardware ID, not to the path string.
 
-After editing, restart the user session service so Keymasq reloads the hardware
-configuration:
+After editing, `keymasq-session` should reload the hardware configuration
+automatically. If the edited TOML has a syntax or load error, Keymasq keeps the
+previous active configuration, logs the error, and shows a desktop notification.
+Fix the file and save it again to retry the reload. You can also force a reload
+without restarting services:
 
 ```bash
-systemctl --user restart keymasq-session
+systemctl --user kill --signal=HUP keymasq-session
 ```
 
 ### `keymasq-session` user service does not start

--- a/keymasq/session/analog_controls.py
+++ b/keymasq/session/analog_controls.py
@@ -22,6 +22,7 @@ from keymasq.common.models import (
     profile_deactivation_policy_to_dict,
     validate_analog_control_config,
 )
+from keymasq.session.config_errors import ConfigLoadError, ConfigLoadFailure
 
 log = logging.getLogger("keymasq-session.analog_controls")
 type TomlDict = dict[str, object]
@@ -56,17 +57,26 @@ class AnalogControlManager:
         self._analog_controls: dict[str, AnalogControlConfig] = {}
         self._load_all()
 
-    def _load_all(self) -> None:
-        self._analog_controls.clear()
+    def _load_all(self, *, strict: bool = False) -> None:
+        loaded_analog_controls: dict[str, AnalogControlConfig] = {}
+        failures: list[ConfigLoadFailure] = []
+
         if not paths.ANALOG_CONTROLS_DIR.exists():
+            self._analog_controls = loaded_analog_controls
             return
         for config_file in paths.ANALOG_CONTROLS_DIR.glob("*.toml"):
             try:
                 config = self._load_analog_control(config_file)
                 if config is not None:
-                    self._analog_controls[config.name] = config
+                    loaded_analog_controls[config.name] = config
             except Exception as exc:
                 log.error("Failed to load analog control %s: %s", config_file, exc)
+                failures.append(ConfigLoadFailure(config_file, str(exc)))
+
+        if strict and failures:
+            raise ConfigLoadError("analog control", failures)
+
+        self._analog_controls = loaded_analog_controls
 
     def _load_analog_control(self, path: Path) -> AnalogControlConfig | None:
         with open(path, "rb") as f:
@@ -278,6 +288,15 @@ class AnalogControlManager:
 
     def get_all_analog_controls(self) -> dict[str, AnalogControlConfig]:
         return self._analog_controls.copy()
+
+    def snapshot_analog_controls(self) -> dict[str, AnalogControlConfig]:
+        return self._analog_controls.copy()
+
+    def restore_analog_controls(
+        self,
+        analog_controls: dict[str, AnalogControlConfig],
+    ) -> None:
+        self._analog_controls = analog_controls.copy()
 
     def save_analog_control(
         self,
@@ -497,7 +516,7 @@ class AnalogControlManager:
         )
 
     def reload(self) -> None:
-        self._load_all()
+        self._load_all(strict=True)
         log.info("Reloaded all analog controls")
 
 

--- a/keymasq/session/config_errors.py
+++ b/keymasq/session/config_errors.py
@@ -1,0 +1,16 @@
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class ConfigLoadFailure:
+    path: Path
+    message: str
+
+
+class ConfigLoadError(RuntimeError):
+    def __init__(self, config_kind: str, failures: list[ConfigLoadFailure]) -> None:
+        self.config_kind = config_kind
+        self.failures = tuple(failures)
+        details = "; ".join(f"{failure.path}: {failure.message}" for failure in failures)
+        super().__init__(f"Failed to load {config_kind} config: {details}")

--- a/keymasq/session/hardware.py
+++ b/keymasq/session/hardware.py
@@ -16,6 +16,7 @@ from keymasq.common.models import (
     EvdevDevice,
     HardwareConfig,
 )
+from keymasq.session.config_errors import ConfigLoadError, ConfigLoadFailure
 
 log = logging.getLogger("keymasq-session.hardware")
 
@@ -35,20 +36,29 @@ class HardwareManager:
         self._cache: dict[str, HardwareConfig] = {}
         self._load_all()
 
-    def _load_all(self) -> None:
+    def _load_all(self, *, strict: bool = False) -> None:
+        loaded_cache: dict[str, HardwareConfig] = {}
+        failures: list[ConfigLoadFailure] = []
+
         if not paths.HARDWARE_DIR.exists():
+            self._cache = loaded_cache
             return
 
         for config_file in paths.HARDWARE_DIR.glob("*.toml"):
             try:
                 config = self._load_config(config_file)
-                self._cache[config.hardware_id] = config
+                loaded_cache[config.hardware_id] = config
             except Exception as e:
                 log.error(f"Failed to load {config_file}: {e}")
+                failures.append(ConfigLoadFailure(config_file, str(e)))
+
+        if strict and failures:
+            raise ConfigLoadError("hardware", failures)
+
+        self._cache = loaded_cache
 
     def reload(self) -> None:
-        self._cache.clear()
-        self._load_all()
+        self._load_all(strict=True)
 
     def _load_config(self, path: Path) -> HardwareConfig:
         with open(path, "rb") as f:
@@ -134,6 +144,12 @@ class HardwareManager:
 
     def get_hardware(self, hardware_id: str) -> HardwareConfig | None:
         return self._cache.get(hardware_id)
+
+    def snapshot_hardware(self) -> dict[str, HardwareConfig]:
+        return self._cache.copy()
+
+    def restore_hardware(self, hardware: dict[str, HardwareConfig]) -> None:
+        self._cache = hardware.copy()
 
     def list_hardware(self) -> list[HardwareConfig]:
         return list(self._cache.values())

--- a/keymasq/session/manager/commands.py
+++ b/keymasq/session/manager/commands.py
@@ -124,8 +124,12 @@ async def _handle_profile_commands(
         return await runtime_profiles.set_profile_enabled(manager, profile_name, enabled)
 
     if command == "reload":
-        await manager.reload_profiles()
-        return {"status": "ok"}
+        if await manager.reload_profiles():
+            return {"status": "ok"}
+        return {
+            "status": "error",
+            "message": "Failed to reload config; keeping previous active config",
+        }
 
     if command == "release_device":
         hardware_id = str_value(request.get("hardware_id"), "").strip()
@@ -154,7 +158,15 @@ async def _handle_profile_commands(
 
     if command in {"reevaluate_profiles", "reevaluate_hardware"}:
         log.info("Global profile reevaluate requested")
-        await asyncio.to_thread(manager.reload_config_from_disk)
+        try:
+            await asyncio.to_thread(manager.reload_config_from_disk)
+        except Exception as exc:
+            log.exception("Failed to reload user config from disk for reevaluate request")
+            manager.send_notification(
+                "Keymasq Config Error",
+                "Failed to reload config; keeping the previous active config. See logs.",
+            )
+            return {"status": "error", "message": str(exc)}
         runtime_profiles.invalidate_runtime_payload_signatures(manager)
         await runtime_profiles.reevaluate_profiles(manager, reason="session command reevaluate")
         return {"status": "ok"}

--- a/keymasq/session/manager/core.py
+++ b/keymasq/session/manager/core.py
@@ -710,6 +710,9 @@ class SessionManager:
         self.config_reload_timer = None
         if not self.running:
             return
+        if self.reload_task is not None and not self.reload_task.done():
+            log.debug("Config reload already running; skipping scheduled reload")
+            return
         log.info("Detected user config file change; reloading")
         self.reload_task = asyncio.create_task(self.reload_profiles())
 

--- a/keymasq/session/manager/core.py
+++ b/keymasq/session/manager/core.py
@@ -1,13 +1,16 @@
 import argparse
 import asyncio
 import contextlib
+import ctypes
 import json
 import logging
 import os
 import signal
 import socket
+import struct
 import sys
 import traceback
+from pathlib import Path
 from typing import cast
 
 from keymasq.common.asyncio_runtime import ensure_uvloop
@@ -17,10 +20,15 @@ from keymasq.common.models import (
     ButtonDefinition,
 )
 from keymasq.common.paths import (
+    ANALOG_CONTROLS_DIR,
     CONFIG_DIR,
+    HARDWARE_DIR,
+    PROFILES_DIR,
     SECURITY_POLICY_PATH,
     SESSION_SOCKET_PATH,
+    SETTINGS_PATH,
     SOCKET_PATH,
+    SUPERKEYS_DIR,
     ensure_session_socket_dir,
 )
 from keymasq.common.security import (
@@ -62,6 +70,31 @@ GRAB_DEVICE_TIMEOUT_S = 330.0
 GRAB_RETRY_DELAY_S = 5.0
 TOPOLOGY_REFRESH_DEBOUNCE_S = 0.5
 TOPOLOGY_REFRESH_RETRY_S = 1.0
+CONFIG_RELOAD_DEBOUNCE_S = 0.5
+IN_ACCESS = 0x00000001
+IN_ATTRIB = 0x00000004
+IN_CLOSE_WRITE = 0x00000008
+IN_CREATE = 0x00000100
+IN_DELETE = 0x00000200
+IN_DELETE_SELF = 0x00000400
+IN_MOVE_SELF = 0x00000800
+IN_MOVED_FROM = 0x00000040
+IN_MOVED_TO = 0x00000080
+IN_IGNORED = 0x00008000
+IN_ISDIR = 0x40000000
+IN_NONBLOCK = 0x00000800
+IN_CLOEXEC = 0x00080000
+INOTIFY_EVENT_STRUCT = struct.Struct("iIII")
+INOTIFY_WATCH_MASK = (
+    IN_ATTRIB
+    | IN_CLOSE_WRITE
+    | IN_CREATE
+    | IN_DELETE
+    | IN_DELETE_SELF
+    | IN_MOVE_SELF
+    | IN_MOVED_FROM
+    | IN_MOVED_TO
+)
 
 
 class SessionManager:
@@ -93,8 +126,11 @@ class SessionManager:
             "KEYMASQ_SESSION_RESTART_ON_DAEMON_DISCONNECT"
         )
         self.restart_requested = False
-        self.reload_task: asyncio.Task[None] | None = None
+        self.reload_task: asyncio.Task[bool] | None = None
         self.reload_pending = False
+        self.config_reload_timer: asyncio.TimerHandle | None = None
+        self.config_watch_fd: int | None = None
+        self.config_watch_watches: dict[int, Path] = {}
         self.verbosity = verbosity
 
         self.profile_state = ProfileRuntimeState()
@@ -149,6 +185,7 @@ class SessionManager:
         await self._start_session_server()
 
         self.connect_task = asyncio.create_task(self.connect_loop())
+        self._start_config_watcher()
         self.compositor_state.supervisor_task = asyncio.create_task(
             runtime_compositor.compositor_supervisor_loop(self)
         )
@@ -177,6 +214,8 @@ class SessionManager:
 
         if self.action_handler is not None:
             await self.action_handler.cancel_background_tasks()
+
+        self._stop_config_watcher()
 
         profile_apply_task = self.profile_state.apply_task
         if profile_apply_task:
@@ -498,13 +537,31 @@ class SessionManager:
         log.info("Received reload signal (SIGHUP)")
         self.reload_task = asyncio.create_task(self.reload_profiles())
 
-    async def reload_profiles(self) -> None:
+    async def reload_profiles(self) -> bool:
         await asyncio.sleep(0.05)
 
         self.reload_pending = False
 
-        await asyncio.to_thread(self.reload_config_from_disk)
+        try:
+            await asyncio.to_thread(self.reload_config_from_disk)
+        except Exception as exc:
+            log.exception(
+                "Failed to reload user config from disk; keeping previous active config"
+            )
+            self.send_notification(
+                "Keymasq Config Error",
+                "Failed to reload config; keeping the previous active config. See logs.",
+            )
+            self.broadcast_to_session_clients(
+                {
+                    "event": "config_reload_failed",
+                    "status": "error",
+                    "message": str(exc),
+                }
+            )
+            return False
         log.info("Reloaded all superkeys, analog controls, profiles and hardware configs")
+        self.broadcast_to_session_clients({"event": "config_reloaded", "status": "ok"})
         await self._sync_virtual_gamepads_to_daemon()
         runtime_profiles.invalidate_runtime_payload_signatures(self)
 
@@ -520,15 +577,141 @@ class SessionManager:
             self.profile_state.resolved_devices.pop(hardware_id, None)
 
         await runtime_profiles.reevaluate_profiles(self, reason="config reload")
+        return True
 
     def reload_config_from_disk(self) -> None:
-        self.security_policy = load_security_policy(SECURITY_POLICY_PATH)
-        self.superkeys.reload()
-        self.analog_controls.reload()
-        self.profiles.reload()
-        self.hardware.reload()
-        settings = load_global_settings()
-        self.virtual_gamepad_count = settings.virtual_gamepad_count
+        superkeys_snapshot = self.superkeys.snapshot_superkeys()
+        analog_controls_snapshot = self.analog_controls.snapshot_analog_controls()
+        profiles_snapshot = self.profiles.snapshot_profiles()
+        hardware_snapshot = self.hardware.snapshot_hardware()
+        old_virtual_gamepad_count = self.virtual_gamepad_count
+
+        try:
+            self.superkeys.reload()
+            self.analog_controls.reload()
+            self.profiles.reload()
+            self.hardware.reload()
+            settings = load_global_settings(strict=True)
+            self.virtual_gamepad_count = settings.virtual_gamepad_count
+        except Exception:
+            self.superkeys.restore_superkeys(superkeys_snapshot)
+            self.analog_controls.restore_analog_controls(analog_controls_snapshot)
+            self.profiles.restore_profiles(profiles_snapshot)
+            self.hardware.restore_hardware(hardware_snapshot)
+            self.virtual_gamepad_count = old_virtual_gamepad_count
+            raise
+
+    def _start_config_watcher(self) -> None:
+        try:
+            fd = _inotify_init()
+        except OSError as exc:
+            log.warning("Failed to start user config watcher: %s", exc)
+            return
+
+        self.config_watch_fd = fd
+        self._refresh_config_watches()
+        try:
+            asyncio.get_running_loop().add_reader(fd, self._handle_config_watch_events)
+        except Exception as exc:
+            log.warning("Failed to register user config watcher: %s", exc)
+            self._stop_config_watcher()
+
+    def _stop_config_watcher(self) -> None:
+        timer = self.config_reload_timer
+        if timer is not None:
+            timer.cancel()
+            self.config_reload_timer = None
+
+        fd = self.config_watch_fd
+        if fd is None:
+            return
+
+        with contextlib.suppress(Exception):
+            asyncio.get_running_loop().remove_reader(fd)
+        with contextlib.suppress(OSError):
+            os.close(fd)
+        self.config_watch_fd = None
+        self.config_watch_watches.clear()
+
+    def _refresh_config_watches(self) -> None:
+        fd = self.config_watch_fd
+        if fd is None:
+            return
+
+        watched_paths = set(self.config_watch_watches.values())
+        for path in (CONFIG_DIR, PROFILES_DIR, HARDWARE_DIR, SUPERKEYS_DIR, ANALOG_CONTROLS_DIR):
+            if path in watched_paths:
+                continue
+            try:
+                wd = _inotify_add_watch(fd, path, INOTIFY_WATCH_MASK)
+            except OSError as exc:
+                log.debug("Failed to watch config path %s: %s", path, exc)
+                continue
+            self.config_watch_watches[wd] = path
+
+    def _handle_config_watch_events(self) -> None:
+        fd = self.config_watch_fd
+        if fd is None:
+            return
+
+        try:
+            data = os.read(fd, 65536)
+        except BlockingIOError:
+            return
+        except OSError as exc:
+            log.warning("User config watcher failed: %s", exc)
+            self._stop_config_watcher()
+            return
+
+        should_reload = False
+        offset = 0
+        while offset + INOTIFY_EVENT_STRUCT.size <= len(data):
+            wd, mask, _cookie, name_len = INOTIFY_EVENT_STRUCT.unpack_from(data, offset)
+            offset += INOTIFY_EVENT_STRUCT.size
+            raw_name = data[offset : offset + name_len]
+            offset += name_len
+            name = raw_name.split(b"\0", 1)[0].decode(errors="replace")
+            watched_path = self.config_watch_watches.get(wd)
+            if mask & IN_IGNORED:
+                self.config_watch_watches.pop(wd, None)
+            if watched_path is None:
+                continue
+            if self._config_watch_event_is_relevant(watched_path, name, mask):
+                should_reload = True
+
+        self._refresh_config_watches()
+        if should_reload:
+            self._schedule_config_reload()
+
+    def _config_watch_event_is_relevant(self, watched_path: Path, name: str, mask: int) -> bool:
+        if watched_path == CONFIG_DIR:
+            if name == SETTINGS_PATH.name:
+                return True
+            return bool(mask & IN_ISDIR) and name in {
+                PROFILES_DIR.name,
+                HARDWARE_DIR.name,
+                SUPERKEYS_DIR.name,
+                ANALOG_CONTROLS_DIR.name,
+            }
+        if name:
+            return name.endswith(".toml")
+        return bool(mask & (IN_DELETE_SELF | IN_MOVE_SELF | IN_ATTRIB))
+
+    def _schedule_config_reload(self) -> None:
+        timer = self.config_reload_timer
+        if timer is not None:
+            timer.cancel()
+        self.config_reload_timer = asyncio.get_running_loop().call_later(
+            CONFIG_RELOAD_DEBOUNCE_S,
+            self._run_scheduled_config_reload,
+        )
+
+    def _run_scheduled_config_reload(self) -> None:
+        self.config_reload_timer = None
+        if not self.running:
+            return
+        log.info("Detected user config file change; reloading")
+        self.reload_task = asyncio.create_task(self.reload_profiles())
 
     async def _sync_virtual_gamepads_to_daemon(self) -> None:
         if not self.connected:
@@ -637,6 +820,31 @@ class SessionManager:
             await self.dbus.notify(title, message, app_name="keymasq", timeout_ms=5000)
         except Exception as e:
             log.debug(f"Failed to send notification: {e}")
+
+
+def _inotify_init() -> int:
+    libc = ctypes.CDLL(None, use_errno=True)
+    inotify_init1 = libc.inotify_init1
+    inotify_init1.argtypes = [ctypes.c_int]
+    inotify_init1.restype = ctypes.c_int
+    fd = int(inotify_init1(IN_NONBLOCK | IN_CLOEXEC))
+    if fd < 0:
+        errno = ctypes.get_errno()
+        raise OSError(errno, os.strerror(errno))
+    return fd
+
+
+def _inotify_add_watch(fd: int, path: Path, mask: int) -> int:
+    libc = ctypes.CDLL(None, use_errno=True)
+    inotify_add_watch = libc.inotify_add_watch
+    inotify_add_watch.argtypes = [ctypes.c_int, ctypes.c_char_p, ctypes.c_uint32]
+    inotify_add_watch.restype = ctypes.c_int
+    wd = int(inotify_add_watch(fd, os.fsencode(path), mask))
+    if wd < 0:
+        errno = ctypes.get_errno()
+        raise OSError(errno, os.strerror(errno), str(path))
+    return wd
+
 
 def main() -> None:
     parser = argparse.ArgumentParser(

--- a/keymasq/session/profiles.py
+++ b/keymasq/session/profiles.py
@@ -30,6 +30,7 @@ from keymasq.common.models import (
     profile_deactivation_policy_to_dict,
     resolve_rapidfire_fields,
 )
+from keymasq.session.config_errors import ConfigLoadError, ConfigLoadFailure
 
 log = logging.getLogger("keymasq-session.profiles")
 
@@ -128,28 +129,44 @@ class ProfileManager:
         self._load_all()
         self._ensure_default_profile_exists()
 
-    def _load_all(self) -> None:
-        self._profiles.clear()
+    def _load_all(self, *, strict: bool = False) -> None:
+        loaded_profiles: dict[str, ProfileInfo] = {}
+        failures: list[ConfigLoadFailure] = []
 
         if not paths.PROFILES_DIR.exists():
+            self._profiles = loaded_profiles
             return
 
         for profile_file in sorted(paths.PROFILES_DIR.glob("*.toml")):
             try:
                 config = self._load_profile(profile_file)
-                self._add_loaded_profile(ProfileInfo(path=profile_file, config=config))
+                self._add_loaded_profile(
+                    ProfileInfo(path=profile_file, config=config),
+                    loaded_profiles,
+                )
             except Exception as e:
                 log.error("Failed to load %s: %s", profile_file, e)
+                failures.append(ConfigLoadFailure(profile_file, str(e)))
 
-    def _add_loaded_profile(self, profile: ProfileInfo) -> None:
-        existing = self._profiles.get(profile.config.name)
+        if strict and failures:
+            raise ConfigLoadError("profile", failures)
+
+        self._profiles = loaded_profiles
+
+    def _add_loaded_profile(
+        self,
+        profile: ProfileInfo,
+        profiles: dict[str, ProfileInfo] | None = None,
+    ) -> None:
+        target_profiles = self._profiles if profiles is None else profiles
+        existing = target_profiles.get(profile.config.name)
         if existing is None:
-            self._profiles[profile.config.name] = profile
+            target_profiles[profile.config.name] = profile
             return
 
         selected = self._select_duplicate_profile(existing, profile)
         ignored = profile if selected is existing else existing
-        self._profiles[profile.config.name] = selected
+        target_profiles[profile.config.name] = selected
         log.warning(
             "Ignoring duplicate profile name '%s' from %s; using %s",
             profile.config.name,
@@ -174,7 +191,7 @@ class ProfileManager:
         return first
 
     def reload(self) -> None:
-        self._load_all()
+        self._load_all(strict=True)
         self._ensure_default_profile_exists()
 
     def _ensure_default_profile_exists(self) -> None:
@@ -632,6 +649,12 @@ class ProfileManager:
 
     def get_all_profiles(self) -> dict[str, ProfileInfo]:
         return self._profiles.copy()
+
+    def snapshot_profiles(self) -> dict[str, ProfileInfo]:
+        return self._profiles.copy()
+
+    def restore_profiles(self, profiles: dict[str, ProfileInfo]) -> None:
+        self._profiles = profiles.copy()
 
     def get_profile(self, profile_name: str) -> ProfileInfo | None:
         return self._profiles.get(profile_name)

--- a/keymasq/session/settings.py
+++ b/keymasq/session/settings.py
@@ -26,7 +26,7 @@ def _settings_path() -> Path:
     return paths.CONFIG_DIR / "settings.toml"
 
 
-def load_global_settings() -> GlobalSettings:
+def load_global_settings(*, strict: bool = False) -> GlobalSettings:
     settings_path = _settings_path()
     if not settings_path.exists():
         return GlobalSettings()
@@ -35,6 +35,8 @@ def load_global_settings() -> GlobalSettings:
             data = cast(dict[str, object], tomllib.load(config_file))
         return global_settings_from_toml(data)
     except Exception as exc:
+        if strict:
+            raise
         log.warning(
             "Failed to load settings from %s: %s; using defaults",
             settings_path,

--- a/keymasq/session/superkeys.py
+++ b/keymasq/session/superkeys.py
@@ -22,6 +22,7 @@ from keymasq.common.models import (
     resolve_rapidfire_fields,
     superkey_action_to_mapping_action,
 )
+from keymasq.session.config_errors import ConfigLoadError, ConfigLoadFailure
 
 log = logging.getLogger("keymasq-session.superkeys")
 type TomlDict = dict[str, object]
@@ -70,19 +71,27 @@ class SuperkeyManager:
         self._superkeys: dict[str, SuperkeyConfig] = {}
         self._load_all()
 
-    def _load_all(self) -> None:
-        self._superkeys.clear()
+    def _load_all(self, *, strict: bool = False) -> None:
+        loaded_superkeys: dict[str, SuperkeyConfig] = {}
+        failures: list[ConfigLoadFailure] = []
 
         if not paths.SUPERKEYS_DIR.exists():
+            self._superkeys = loaded_superkeys
             return
 
         for superkey_file in paths.SUPERKEYS_DIR.glob("*.toml"):
             try:
                 config = self._load_superkey(superkey_file)
                 if config:
-                    self._superkeys[config.name] = config
+                    loaded_superkeys[config.name] = config
             except Exception as e:
                 log.error(f"Failed to load superkey {superkey_file}: {e}")
+                failures.append(ConfigLoadFailure(superkey_file, str(e)))
+
+        if strict and failures:
+            raise ConfigLoadError("superkey", failures)
+
+        self._superkeys = loaded_superkeys
 
     def _load_superkey(self, path: Path) -> SuperkeyConfig | None:
         with open(path, "rb") as f:
@@ -300,6 +309,12 @@ class SuperkeyManager:
 
     def get_all_superkeys(self) -> dict[str, SuperkeyConfig]:
         return self._superkeys.copy()
+
+    def snapshot_superkeys(self) -> dict[str, SuperkeyConfig]:
+        return self._superkeys.copy()
+
+    def restore_superkeys(self, superkeys: dict[str, SuperkeyConfig]) -> None:
+        self._superkeys = superkeys.copy()
 
     def save_superkey(self, config: SuperkeyConfig, *, replacing_name: str | None = None) -> None:
         paths.ensure_config_dirs()
@@ -544,5 +559,5 @@ class SuperkeyManager:
         )
 
     def reload(self) -> None:
-        self._load_all()
+        self._load_all(strict=True)
         log.info("Reloaded all superkeys")

--- a/tests/test_session_manager_core.py
+++ b/tests/test_session_manager_core.py
@@ -267,24 +267,27 @@ def test_reload_config_from_disk_rolls_back_user_config_on_failure(
     old_superkey = SuperkeyConfig(name="OldSuper", mode=SuperkeyMode.PATTERN)
     manager.superkeys.restore_superkeys({"OldSuper": old_superkey})
     manager.virtual_gamepad_count = 2
+    reload_calls: list[str] = []
 
     def reload_superkeys() -> None:
+        reload_calls.append("superkeys")
         manager.superkeys.restore_superkeys(
             {"NewSuper": SuperkeyConfig(name="NewSuper", mode=SuperkeyMode.PATTERN)}
         )
 
+    def reload_profiles() -> None:
+        reload_calls.append("profiles")
+        raise ValueError("bad profile TOML")
+
     monkeypatch.setattr(manager.superkeys, "reload", reload_superkeys)
     monkeypatch.setattr(manager.analog_controls, "reload", lambda: None)
-    monkeypatch.setattr(
-        manager.profiles,
-        "reload",
-        lambda: (_ for _ in ()).throw(ValueError("bad profile TOML")),
-    )
+    monkeypatch.setattr(manager.profiles, "reload", reload_profiles)
     monkeypatch.setattr(manager.hardware, "reload", lambda: None)
 
     with pytest.raises(ValueError, match="bad profile TOML"):
         manager.reload_config_from_disk()
 
+    assert reload_calls == ["superkeys", "profiles"]
     assert manager.profiles.get_profile("Old") is not None
     assert manager.superkeys.get_superkey("OldSuper") is old_superkey
     assert manager.superkeys.get_superkey("NewSuper") is None

--- a/tests/test_session_manager_core.py
+++ b/tests/test_session_manager_core.py
@@ -1,14 +1,16 @@
 import asyncio
 import json
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, Mock
 
 import pytest
 
 import keymasq.session.manager.core as session_manager_core_module
 import keymasq.session.manager.events as session_events_module
 import keymasq.session.manager.profiles as session_profiles_module
+from keymasq.common.models import ProfileConfig, SuperkeyConfig, SuperkeyMode
 from keymasq.common.security import PeerCredentials
 from keymasq.session.manager import SessionManager
+from keymasq.session.profiles import ProfileInfo
 
 
 class _FakeKeymasqdClient:
@@ -221,6 +223,72 @@ async def test_reload_profiles_invalidates_runtime_payload_signatures(
     assert manager.profile_state.last_sent_mapping_signatures == {}
     assert manager.profile_state.last_sent_combo_signature == ""
     reevaluate_profiles.assert_awaited_once_with(manager, reason="config reload")
+
+
+@pytest.mark.asyncio
+async def test_reload_profiles_failure_keeps_previous_config_and_notifies(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = SessionManager()
+    manager.send_notification = Mock()  # type: ignore[method-assign]
+    manager.broadcast_to_session_clients = Mock()  # type: ignore[method-assign]
+    reevaluate_profiles = AsyncMock()
+
+    monkeypatch.setattr(
+        manager,
+        "reload_config_from_disk",
+        lambda: (_ for _ in ()).throw(ValueError("bad profile TOML")),
+    )
+    monkeypatch.setattr(session_profiles_module, "reevaluate_profiles", reevaluate_profiles)
+
+    await manager.reload_profiles()
+
+    manager.send_notification.assert_called_once_with(  # type: ignore[attr-defined]
+        "Keymasq Config Error",
+        "Failed to reload config; keeping the previous active config. See logs.",
+    )
+    manager.broadcast_to_session_clients.assert_called_once()  # type: ignore[attr-defined]
+    reevaluate_profiles.assert_not_awaited()
+
+
+def test_reload_config_from_disk_rolls_back_user_config_on_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = SessionManager()
+    old_profile = ProfileConfig(name="Old", enabled=True, is_permanent=True)
+    manager.profiles.restore_profiles(
+        {
+            "Old": ProfileInfo(
+                path=session_manager_core_module.CONFIG_DIR / "old.toml",
+                config=old_profile,
+            )
+        }
+    )
+    old_superkey = SuperkeyConfig(name="OldSuper", mode=SuperkeyMode.PATTERN)
+    manager.superkeys.restore_superkeys({"OldSuper": old_superkey})
+    manager.virtual_gamepad_count = 2
+
+    def reload_superkeys() -> None:
+        manager.superkeys.restore_superkeys(
+            {"NewSuper": SuperkeyConfig(name="NewSuper", mode=SuperkeyMode.PATTERN)}
+        )
+
+    monkeypatch.setattr(manager.superkeys, "reload", reload_superkeys)
+    monkeypatch.setattr(manager.analog_controls, "reload", lambda: None)
+    monkeypatch.setattr(
+        manager.profiles,
+        "reload",
+        lambda: (_ for _ in ()).throw(ValueError("bad profile TOML")),
+    )
+    monkeypatch.setattr(manager.hardware, "reload", lambda: None)
+
+    with pytest.raises(ValueError, match="bad profile TOML"):
+        manager.reload_config_from_disk()
+
+    assert manager.profiles.get_profile("Old") is not None
+    assert manager.superkeys.get_superkey("OldSuper") is old_superkey
+    assert manager.superkeys.get_superkey("NewSuper") is None
+    assert manager.virtual_gamepad_count == 2
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Watch config directories (profiles, hardware, superkeys, analog controls) via inotify and auto-reload on file changes
- Add snapshot/restore rollback pattern to all config managers — on any reload failure, the previous active config is preserved
- Add `strict` mode to config load paths: fail-fast during reloads, silent fallback during startup
- Emit `config_reloaded` / `config_reload_failed` events to session clients
- Show desktop notification when a reload fails
- Debounce config reloads (0.5s) to avoid thrashing

## Testing

- `test_reload_profiles_failure_keeps_previous_config_and_notifies` — SIGHUP reload failure preserves old config and sends notification
- `test_reload_config_from_disk_rolls_back_user_config_on_failure` — partial reload failure rolls back all config managers atomically
- `test_session_manager_core.py` — existing tests pass
- Manual: edit a `.toml` file under config dirs, verify auto-reload and rollback on malformed saves
- Not run: inotify edge cases (directory rename, symlink, permission errors)