### PR TITLE
feat: Add fuzzy search to macro, superkey, analog, and hardware dialogs

### DIFF
--- a/keymasq/gui/widgets/analog_control_dialog.py
+++ b/keymasq/gui/widgets/analog_control_dialog.py
@@ -22,12 +22,14 @@ from keymasq.common.models import (
     AnalogGamepadOutputConfig,
     AnalogMouseMotionConfig,
     MappingAction,
+    analog_control_primary_mode,
 )
 from keymasq.common.slurp import get_slurp_capture
 from keymasq.common.virtual_devices import is_virtual_gamepad_output_id
 from keymasq.gui.session_client import session_request_async
 from keymasq.gui.widgets.action_labels import describe_mapping_action_verbose
 from keymasq.gui.widgets.analog_curve_graph import AnalogCurveGraph
+from keymasq.gui.widgets.fuzzy_search import install_listbox_fuzzy_filter
 from keymasq.gui.widgets.key_selector_dialog import (  # pyright: ignore[reportPrivateUsage]
     _gamepad_output_choice_matches,
     _gamepad_output_choices_for,
@@ -55,6 +57,32 @@ _STICK_MODE_LABELS = (
     "Digital Actions",
     "Analog Output",
 )
+
+
+def _analog_control_search_text(
+    config: AnalogControlConfig | None,
+    name: str,
+    group_title: str,
+) -> str:
+    if config is None:
+        return f"{name} {group_title}"
+    output_parts: list[str] = []
+    if config.mouse_motion.enabled:
+        output_parts.append("mouse")
+    if config.gamepad_output.enabled:
+        output_parts.append("gamepad output")
+    if config.thresholds:
+        output_parts.append(f"{len(config.thresholds)} ranges thresholds")
+    return " ".join(
+        [
+            str(config.name or ""),
+            str(config.description or ""),
+            group_title,
+            config.input_type,
+            analog_control_primary_mode(config),
+            " ".join(output_parts),
+        ]
+    )
 _AXIS_MODE_ITEMS = ("digital", "gamepad", "mouse")
 _AXIS_MODE_LABELS = ("Digital Actions", "Analog Output", "Mouse Movement")
 _INPUT_TYPE_ITEMS = ("stick", "axis")
@@ -215,6 +243,12 @@ class AnalogControlDialog(Adw.Dialog):
     def _on_key_pressed(self, _controller, keyval, _keycode, _state) -> bool:
         if keyval in _SPLIT_SPEED_DESYNC_KEYS:
             self._split_mouse_speed_modifier_active = True
+        if keyval in (Gdk.KEY_f, Gdk.KEY_F) and _state & Gdk.ModifierType.CONTROL_MASK:
+            self._show_search()
+            return True
+        if keyval == Gdk.KEY_Escape and self.search_entry.get_visible():
+            self._hide_search()
+            return True
         if keyval == Gdk.KEY_Escape:
             self._request_close()
             return True
@@ -242,10 +276,32 @@ class AnalogControlDialog(Adw.Dialog):
         box.set_margin_end(12)
         box.set_size_request(220, -1)
 
+        header = Gtk.CenterBox()
+
+        self.search_button = Gtk.Button()
+        self.search_button.set_icon_name("system-search-symbolic")
+        self.search_button.set_tooltip_text("Search Analog Controls")
+        self.search_button.connect("clicked", self._on_search_clicked)
+        header.set_start_widget(self.search_button)
+
         label = Gtk.Label(label="Analog Controls")
         label.add_css_class("title-4")
         label.set_halign(Gtk.Align.CENTER)
-        box.append(label)
+        header.set_center_widget(label)
+
+        header_spacer = Gtk.Box()
+        header_spacer.set_size_request(34, -1)
+        header.set_end_widget(header_spacer)
+        box.append(header)
+
+        self.search_entry = Gtk.SearchEntry()
+        self.search_entry.set_placeholder_text("Search Analog Controls")
+        self.search_entry.set_tooltip_text(
+            "Filter Analog Controls by name, description, input type, or output"
+        )
+        self.search_entry.set_visible(False)
+        self.search_entry.connect("stop-search", self._on_search_stop)
+        box.append(self.search_entry)
 
         scrolled = Gtk.ScrolledWindow()
         scrolled.set_vexpand(True)
@@ -254,6 +310,12 @@ class AnalogControlDialog(Adw.Dialog):
         self.list_box = Gtk.ListBox()
         self.list_box.set_vexpand(True)
         self.list_box.connect("row-selected", self._on_control_selected)
+        install_listbox_fuzzy_filter(
+            self.list_box,
+            self.search_entry,
+            before_filter_changed=self._before_search_filter_changed,
+            after_filter_changed=self._after_search_filter_changed,
+        )
         scrolled.set_child(self.list_box)
         box.append(scrolled)
 
@@ -278,6 +340,30 @@ class AnalogControlDialog(Adw.Dialog):
 
         box.append(footer)
         return box
+
+    def _show_search(self) -> None:
+        self.search_entry.set_visible(True)
+        self.search_entry.grab_focus()
+        self.search_entry.select_region(0, -1)
+
+    def _hide_search(self) -> None:
+        self.search_entry.set_text("")
+        self.search_entry.set_visible(False)
+
+    def _on_search_clicked(self, _button: Gtk.Button) -> None:
+        self._show_search()
+
+    def _on_search_stop(self, _entry: Gtk.SearchEntry) -> None:
+        self._hide_search()
+
+    def _before_search_filter_changed(self) -> None:
+        self._suppress_selection_guard = True
+
+    def _after_search_filter_changed(self) -> None:
+        try:
+            self._restore_active_selection()
+        finally:
+            self._suppress_selection_guard = False
 
     def _build_right_panel(self) -> Gtk.Widget:
         self.right_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=12)
@@ -897,6 +983,7 @@ class AnalogControlDialog(Adw.Dialog):
     def _build_new_control_row(self) -> Gtk.ListBoxRow:
         row = Gtk.ListBoxRow()
         row._is_new_analog_control = True
+        row._search_text = "add new analog control"
         row.add_css_class("superkey-add-row")
         row.set_tooltip_text("Add a new Analog Control")
         label = Gtk.Label(label="+ Add", xalign=0)
@@ -908,6 +995,7 @@ class AnalogControlDialog(Adw.Dialog):
         row = Gtk.ListBoxRow()
         row.set_selectable(False)
         row.set_activatable(False)
+        row._search_text = title
         label = Gtk.Label(label=title, xalign=0)
         label.add_css_class("caption")
         label.add_css_class("dim-label")
@@ -918,9 +1006,14 @@ class AnalogControlDialog(Adw.Dialog):
         row.set_child(label)
         return row
 
-    def _build_saved_control_row(self, name: str) -> Gtk.ListBoxRow:
+    def _build_saved_control_row(
+        self,
+        name: str,
+        search_text: str | None = None,
+    ) -> Gtk.ListBoxRow:
         row = Gtk.ListBoxRow()
         row._analog_control_name = name
+        row._search_text = search_text or name
         label = Gtk.Label(label=name, xalign=0)
         label.set_margin_start(6)
         label.set_margin_end(6)
@@ -1450,13 +1543,17 @@ class AnalogControlDialog(Adw.Dialog):
         for title, group_names in _group_analog_control_names(names, configs):
             self.list_box.append(self._build_control_group_row(title))
             for name in group_names:
-                row = self._build_saved_control_row(name)
+                row = self._build_saved_control_row(
+                    name,
+                    _analog_control_search_text(configs.get(name), name, title),
+                )
                 self.list_box.append(row)
                 if first_saved_row is None:
                     first_saved_row = row
 
         self.new_control_row = self._build_new_control_row()
         self.list_box.append(self.new_control_row)
+        self.list_box.invalidate_filter()
 
         if first_saved_row is not None:
             self.list_box.select_row(first_saved_row)

--- a/keymasq/gui/widgets/fuzzy_search.py
+++ b/keymasq/gui/widgets/fuzzy_search.py
@@ -7,7 +7,7 @@ gi.require_version("Gtk", "4.0")
 
 from gi.repository import Gtk  # pyright: ignore[reportAttributeAccessIssue]
 
-_TOKEN_RE = re.compile(r"[a-z0-9]+")
+_TOKEN_RE = re.compile(r"\w+", re.UNICODE)
 
 
 def _normalize_search_text(value: object) -> str:

--- a/keymasq/gui/widgets/fuzzy_search.py
+++ b/keymasq/gui/widgets/fuzzy_search.py
@@ -1,0 +1,105 @@
+import re
+from collections.abc import Callable, Mapping
+
+import gi
+
+gi.require_version("Gtk", "4.0")
+
+from gi.repository import Gtk  # pyright: ignore[reportAttributeAccessIssue]
+
+_TOKEN_RE = re.compile(r"[a-z0-9]+")
+
+
+def _normalize_search_text(value: object) -> str:
+    return " ".join(_TOKEN_RE.findall(str(value).casefold()))
+
+
+def _is_subsequence(needle: str, haystack: str) -> bool:
+    if not needle:
+        return True
+    index = 0
+    for char in haystack:
+        if char == needle[index]:
+            index += 1
+            if index == len(needle):
+                return True
+    return False
+
+
+def _token_matches(needle: str, haystack_tokens: list[str]) -> bool:
+    initials = "".join(token[0] for token in haystack_tokens if token)
+    if any(
+        needle in token or (len(needle) > 1 and _is_subsequence(needle, token))
+        for token in haystack_tokens
+    ):
+        return True
+    if len(needle) <= 1:
+        return False
+    if needle in initials:
+        return True
+    for start in range(len(haystack_tokens)):
+        for end in range(start + 2, min(start + 4, len(haystack_tokens) + 1)):
+            if _is_subsequence(needle, "".join(haystack_tokens[start:end])):
+                return True
+    return False
+
+
+def fuzzy_query_matches(query: str, text: object) -> bool:
+    normalized_query = _normalize_search_text(query)
+    if not normalized_query:
+        return True
+
+    normalized_text = _normalize_search_text(text)
+    if not normalized_text:
+        return False
+
+    text_tokens = normalized_text.split()
+    for token in normalized_query.split():
+        if _token_matches(token, text_tokens):
+            continue
+        return False
+    return True
+
+
+def macro_search_text(macro: Mapping[str, object]) -> str:
+    event_count = macro.get("event_count", "")
+    device_types_value = macro.get("device_types", [])
+    device_types = (
+        " ".join(str(device_type) for device_type in device_types_value)
+        if isinstance(device_types_value, list)
+        else str(device_types_value)
+    )
+    duration_value = macro.get("duration_us", 0)
+    try:
+        duration_us = int(duration_value) if isinstance(duration_value, int | float | str) else 0
+    except ValueError:
+        duration_us = 0
+    duration_ms = duration_us // 1000
+    return f"{macro.get('name', '')} {device_types} {event_count} events {duration_ms}ms"
+
+
+def install_listbox_fuzzy_filter(
+    listbox: Gtk.ListBox,
+    search_entry: Gtk.Editable,
+    *,
+    row_text_attr: str = "_search_text",
+    before_filter_changed: Callable[[], None] | None = None,
+    after_filter_changed: Callable[[], None] | None = None,
+) -> None:
+    state = {"query": search_entry.get_text()}
+
+    def filter_row(row: Gtk.ListBoxRow) -> bool:
+        return fuzzy_query_matches(state["query"], getattr(row, row_text_attr, ""))
+
+    def on_search_changed(entry: Gtk.Editable) -> None:
+        state["query"] = entry.get_text()
+        if before_filter_changed is not None:
+            before_filter_changed()
+        try:
+            listbox.invalidate_filter()
+        finally:
+            if after_filter_changed is not None:
+                after_filter_changed()
+
+    listbox.set_filter_func(filter_row)
+    search_entry.connect("changed", on_search_changed)

--- a/keymasq/gui/widgets/key_selector_dialog.py
+++ b/keymasq/gui/widgets/key_selector_dialog.py
@@ -2641,6 +2641,8 @@ class KeySelectorDialog(Adw.Dialog, _GamepadAxisControlsMixin):
                     else:
                         self._clear_macro_selection()
                     break
+            else:
+                self._clear_macro_selection()
         if not self._selected_macro:
             self._clear_macro_selection()
 

--- a/keymasq/gui/widgets/key_selector_dialog.py
+++ b/keymasq/gui/widgets/key_selector_dialog.py
@@ -42,6 +42,11 @@ from keymasq.gui.widgets.compositor_actions import (
     build_compositor_action_pages,
     compositor_action_tab_name,
 )
+from keymasq.gui.widgets.fuzzy_search import (
+    fuzzy_query_matches,
+    install_listbox_fuzzy_filter,
+    macro_search_text,
+)
 from keymasq.gui.widgets.input_picker_shared import (
     build_gamepad_tab as build_shared_gamepad_tab,
 )
@@ -1861,6 +1866,16 @@ class KeySelectorDialog(Adw.Dialog, _GamepadAxisControlsMixin):
         controls_spacer.set_size_request(-1, 6)
         outer.append(controls_spacer)
 
+        self._macro_search_entry = Gtk.SearchEntry()
+        self._macro_search_entry.set_placeholder_text("Search macros")
+        self._macro_search_entry.set_tooltip_text(
+            "Filter macros by name, device type, or event count"
+        )
+        self._macro_search_entry.set_margin_start(12)
+        self._macro_search_entry.set_margin_end(12)
+        self._macro_search_entry.set_margin_bottom(8)
+        outer.append(self._macro_search_entry)
+
         scrolled = Gtk.ScrolledWindow()
         scrolled.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
         scrolled.set_vexpand(True)
@@ -1872,6 +1887,11 @@ class KeySelectorDialog(Adw.Dialog, _GamepadAxisControlsMixin):
         self._macro_listbox.set_margin_start(12)
         self._macro_listbox.set_margin_end(12)
         self._macro_listbox.connect("row-selected", self._on_macro_row_selected)
+        install_listbox_fuzzy_filter(
+            self._macro_listbox,
+            self._macro_search_entry,
+            after_filter_changed=self._after_macro_search_filter_changed,
+        )
         scrolled.set_child(self._macro_listbox)
         outer.append(scrolled)
 
@@ -2585,6 +2605,7 @@ class KeySelectorDialog(Adw.Dialog, _GamepadAxisControlsMixin):
         for macro in self._macro_list:
             row = Gtk.ListBoxRow()
             row._macro_name = macro["name"]
+            row._search_text = macro_search_text(macro)
 
             row_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=12)
             row_box.set_margin_top(8)
@@ -2606,25 +2627,51 @@ class KeySelectorDialog(Adw.Dialog, _GamepadAxisControlsMixin):
 
             row.set_child(row_box)
             self._macro_listbox.append(row)
+        self._macro_listbox.invalidate_filter()
 
         if self._selected_macro:
             for i, macro in enumerate(self._macro_list):
                 if macro["name"] == self._selected_macro:
                     row = self._macro_listbox.get_row_at_index(i)
-                    if row:
+                    if row and fuzzy_query_matches(
+                        self._macro_search_entry.get_text(),
+                        getattr(row, "_search_text", ""),
+                    ):
                         self._macro_listbox.select_row(row)
+                    else:
+                        self._clear_macro_selection()
                     break
+        if not self._selected_macro:
+            self._clear_macro_selection()
 
     def _on_macro_refresh(self, btn) -> None:
         self._load_macro_list()
+
+    def _after_macro_search_filter_changed(self) -> None:
+        selected_row = self._macro_listbox.get_selected_row()
+        if selected_row is None:
+            self._clear_macro_selection()
+            return
+        if fuzzy_query_matches(
+            self._macro_search_entry.get_text(),
+            getattr(selected_row, "_search_text", ""),
+        ):
+            return
+        self._macro_listbox.unselect_row(selected_row)
+        self._clear_macro_selection()
+
+    def _clear_macro_selection(self) -> None:
+        self._selected_macro = None
+        self._macro_options_box.set_visible(False)
+        if self.stack.get_visible_child_name() == "macro":
+            self.map_btn.set_sensitive(False)
 
     def _on_macro_row_selected(self, listbox, row) -> None:
         if row and hasattr(row, "_macro_name"):
             self._selected_macro = row._macro_name
             self._macro_options_box.set_visible(self._allow_macro_options)
         else:
-            self._selected_macro = None
-            self._macro_options_box.set_visible(False)
+            self._clear_macro_selection()
         self.map_btn.set_sensitive(self._selected_macro is not None)
 
     def _on_macro_movement_toggled(self, check) -> None:

--- a/keymasq/gui/widgets/macro_manager_dialog.py
+++ b/keymasq/gui/widgets/macro_manager_dialog.py
@@ -6,7 +6,7 @@ gi.require_version("Adw", "1")
 import logging
 from datetime import datetime
 
-from gi.repository import Adw, GLib, Gtk  # pyright: ignore[reportAttributeAccessIssue]
+from gi.repository import Adw, Gdk, GLib, Gtk  # pyright: ignore[reportAttributeAccessIssue]
 
 from keymasq import __version__
 from keymasq.common.macro_compile import (
@@ -24,6 +24,7 @@ from keymasq.gui.session_client import (
     session_request_async,
     session_request_with_hooks,
 )
+from keymasq.gui.widgets.fuzzy_search import install_listbox_fuzzy_filter, macro_search_text
 
 log = logging.getLogger("keymasq.gui.widgets.macro_manager_dialog")
 
@@ -71,8 +72,12 @@ class MacroManagerDialog(Adw.Dialog):
         self._recording_active: bool = False
         self._recording_unlocked: bool = False
         self._record_btn: Gtk.Button | None = None
+        self._search_button: Gtk.Button | None = None
         self.macros_docs_btn: Gtk.Button | None = None
         self._build_ui()
+        key_controller = Gtk.EventControllerKey()
+        key_controller.connect("key-pressed", self._on_key_pressed)
+        self.add_controller(key_controller)
         GLib.idle_add(self._load_initial_state)
 
         # Listen for events via the window's event handler system
@@ -139,6 +144,13 @@ class MacroManagerDialog(Adw.Dialog):
         toolbar_spacer.set_hexpand(True)
         toolbar.append(toolbar_spacer)
 
+        search_btn = Gtk.Button()
+        search_btn.set_icon_name("system-search-symbolic")
+        search_btn.set_tooltip_text("Search macros")
+        search_btn.connect("clicked", self._on_search_clicked)
+        toolbar.append(search_btn)
+        self._search_button = search_btn
+
         settings_btn = Gtk.Button()
         settings_btn.set_child(
             self._make_button_content("emblem-system-symbolic", "Settings")
@@ -149,6 +161,13 @@ class MacroManagerDialog(Adw.Dialog):
 
         content.append(toolbar)
 
+        self._search_entry = Gtk.SearchEntry()
+        self._search_entry.set_placeholder_text("Search macros")
+        self._search_entry.set_tooltip_text("Filter macros by name, device type, or event count")
+        self._search_entry.set_visible(False)
+        self._search_entry.connect("stop-search", self._on_search_stop)
+        content.append(self._search_entry)
+
         scrolled = Gtk.ScrolledWindow()
         scrolled.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
         scrolled.set_min_content_height(240)
@@ -158,6 +177,7 @@ class MacroManagerDialog(Adw.Dialog):
         self._listbox = Gtk.ListBox()
         self._listbox.set_selection_mode(Gtk.SelectionMode.NONE)
         self._listbox.add_css_class("boxed-list")
+        install_listbox_fuzzy_filter(self._listbox, self._search_entry)
         scrolled.set_child(self._listbox)
         content.append(scrolled)
 
@@ -199,6 +219,27 @@ class MacroManagerDialog(Adw.Dialog):
         frame.set_child(inner)
         main_box.append(frame)
         self.set_child(main_box)
+
+    def _on_key_pressed(self, _controller, keyval, _keycode, state) -> bool:
+        if keyval in (Gdk.KEY_f, Gdk.KEY_F) and state & Gdk.ModifierType.CONTROL_MASK:
+            self._show_search()
+            return True
+        return False
+
+    def _show_search(self) -> None:
+        self._search_entry.set_visible(True)
+        self._search_entry.grab_focus()
+        self._search_entry.select_region(0, -1)
+
+    def _hide_search(self) -> None:
+        self._search_entry.set_text("")
+        self._search_entry.set_visible(False)
+
+    def _on_search_clicked(self, _button: Gtk.Button) -> None:
+        self._show_search()
+
+    def _on_search_stop(self, _entry: Gtk.SearchEntry) -> None:
+        self._hide_search()
 
     def _on_close_clicked(self, _button: Gtk.Button) -> None:
         self.close()
@@ -267,10 +308,12 @@ class MacroManagerDialog(Adw.Dialog):
 
         for macro in self._macros:
             self._listbox.append(self._build_macro_row(macro))
+        self._listbox.invalidate_filter()
 
     def _build_macro_row(self, macro: JsonDict) -> Gtk.ListBoxRow:
         row = Gtk.ListBoxRow()
         row.set_selectable(False)
+        row._search_text = macro_search_text(macro)
 
         row_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=8)
         row_box.set_margin_top(6)

--- a/keymasq/gui/widgets/superkey_dialog.py
+++ b/keymasq/gui/widgets/superkey_dialog.py
@@ -18,6 +18,7 @@ from keymasq.common.models import (
     superkey_action_to_mapping_action,
 )
 from keymasq.gui.widgets.action_labels import describe_mapping_action_verbose
+from keymasq.gui.widgets.fuzzy_search import install_listbox_fuzzy_filter
 from keymasq.session.profiles import ProfileManager
 from keymasq.session.superkeys import SuperkeyManager
 
@@ -35,6 +36,26 @@ def _docs_version() -> str:
 
 def _superkeys_docs_url() -> str:
     return f"https://keymasq.tools/docs/{_docs_version()}/SUPERKEYS/"
+
+
+def _superkey_search_text(config: SuperkeyConfig | None, name: str) -> str:
+    if config is None:
+        return name
+    return " ".join(
+        [
+            str(config.name or ""),
+            str(config.description or ""),
+            config.mode.value,
+            str(len(config.tap_actions)),
+            str(len(config.double_tap_actions)),
+            str(len(config.hold_actions)),
+            str(len(config.tap_hold_actions)),
+            str(len(config.overload_actions)),
+            str(len(config.overload_down_actions)),
+            str(len(config.overload_up_actions)),
+            "actions",
+        ]
+    )
 
 
 def _append_action_state_markers(label: str, action: object) -> str:
@@ -462,6 +483,12 @@ class SuperkeyDialog(Adw.Dialog):
         self.add_controller(key_controller)
 
     def _on_key_pressed(self, _controller, keyval, _keycode, _state) -> bool:
+        if keyval in (Gdk.KEY_f, Gdk.KEY_F) and _state & Gdk.ModifierType.CONTROL_MASK:
+            self._show_search()
+            return True
+        if keyval == Gdk.KEY_Escape and self.search_entry.get_visible():
+            self._hide_search()
+            return True
         if keyval == Gdk.KEY_Escape:
             self._request_close()
             return True
@@ -487,10 +514,30 @@ class SuperkeyDialog(Adw.Dialog):
         box.set_margin_end(12)
         box.set_size_request(220, -1)
 
+        header = Gtk.CenterBox()
+
+        self.search_button = Gtk.Button()
+        self.search_button.set_icon_name("system-search-symbolic")
+        self.search_button.set_tooltip_text("Search Super Keys")
+        self.search_button.connect("clicked", self._on_search_clicked)
+        header.set_start_widget(self.search_button)
+
         label = Gtk.Label(label="Super Keys")
         label.add_css_class("title-4")
         label.set_halign(Gtk.Align.CENTER)
-        box.append(label)
+        header.set_center_widget(label)
+
+        header_spacer = Gtk.Box()
+        header_spacer.set_size_request(34, -1)
+        header.set_end_widget(header_spacer)
+        box.append(header)
+
+        self.search_entry = Gtk.SearchEntry()
+        self.search_entry.set_placeholder_text("Search Super Keys")
+        self.search_entry.set_tooltip_text("Filter Super Keys by name, description, or mode")
+        self.search_entry.set_visible(False)
+        self.search_entry.connect("stop-search", self._on_search_stop)
+        box.append(self.search_entry)
 
         scrolled = Gtk.ScrolledWindow()
         scrolled.set_vexpand(True)
@@ -499,6 +546,12 @@ class SuperkeyDialog(Adw.Dialog):
         self.list_box = Gtk.ListBox()
         self.list_box.set_vexpand(True)
         self.list_box.connect("row-selected", self._on_superkey_selected)
+        install_listbox_fuzzy_filter(
+            self.list_box,
+            self.search_entry,
+            before_filter_changed=self._before_search_filter_changed,
+            after_filter_changed=self._after_search_filter_changed,
+        )
         scrolled.set_child(self.list_box)
 
         box.append(scrolled)
@@ -519,6 +572,30 @@ class SuperkeyDialog(Adw.Dialog):
 
         box.append(footer)
         return box
+
+    def _show_search(self) -> None:
+        self.search_entry.set_visible(True)
+        self.search_entry.grab_focus()
+        self.search_entry.select_region(0, -1)
+
+    def _hide_search(self) -> None:
+        self.search_entry.set_text("")
+        self.search_entry.set_visible(False)
+
+    def _on_search_clicked(self, _button: Gtk.Button) -> None:
+        self._show_search()
+
+    def _on_search_stop(self, _entry: Gtk.SearchEntry) -> None:
+        self._hide_search()
+
+    def _before_search_filter_changed(self) -> None:
+        self._suppress_selection_guard = True
+
+    def _after_search_filter_changed(self) -> None:
+        try:
+            self._restore_active_selection()
+        finally:
+            self._suppress_selection_guard = False
 
     def _build_right_panel(self) -> Gtk.Widget:
         self.right_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=12)
@@ -737,9 +814,14 @@ class SuperkeyDialog(Adw.Dialog):
         row.set_child(label)
         return row
 
-    def _build_saved_superkey_row(self, name: str) -> Gtk.ListBoxRow:
+    def _build_saved_superkey_row(
+        self,
+        name: str,
+        search_text: str | None = None,
+    ) -> Gtk.ListBoxRow:
         row = Gtk.ListBoxRow()
         row._superkey_name = name
+        row._search_text = search_text or name
         label = Gtk.Label(label=name, xalign=0)
         label.set_margin_start(6)
         label.set_margin_end(6)
@@ -768,11 +850,18 @@ class SuperkeyDialog(Adw.Dialog):
             self.list_box.remove(row)
 
         names = self.manager.list_superkeys()
+        configs = self.manager.get_all_superkeys()
         for name in names:
-            self.list_box.append(self._build_saved_superkey_row(name))
+            self.list_box.append(
+                self._build_saved_superkey_row(
+                    name,
+                    _superkey_search_text(configs.get(name), name),
+                )
+            )
 
         self.new_superkey_row = self._build_new_superkey_row()
         self.list_box.append(self.new_superkey_row)
+        self.list_box.invalidate_filter()
 
         if names:
             self.list_box.select_row(self.list_box.get_row_at_index(0))

--- a/keymasq/gui/wizards/hardware_setup.py
+++ b/keymasq/gui/wizards/hardware_setup.py
@@ -700,7 +700,7 @@ class HardwareSetupDialog(Adw.Dialog):
     def _on_refresh_clicked(self, _button: Gtk.Button) -> None:
         self._detect_devices()
 
-    def _on_raw_evdev_toggled(self, check: Gtk.CheckButton) -> None:
+    def _on_raw_evdev_toggled(self, check: Gtk.ToggleButton) -> None:
         self._show_raw_evdev_devices = check.get_active()
         self.selected_device = None
         self.next_btn.set_sensitive(False)

--- a/keymasq/gui/wizards/hardware_setup.py
+++ b/keymasq/gui/wizards/hardware_setup.py
@@ -242,7 +242,7 @@ class HardwareSetupDialog(Adw.Dialog):
         super().__init__(
             title="Add New Device",
             content_width=500,
-            content_height=450,
+            content_height=520,
         )
         if hasattr(self, "set_modal"):
             self.set_modal(True)
@@ -340,14 +340,17 @@ class HardwareSetupDialog(Adw.Dialog):
         box.append(subtitle)
 
         device_tools = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=6)
-        device_tools.set_halign(Gtk.Align.START)
 
-        self.raw_evdev_check = Gtk.ToggleButton(label="Show raw evdev devices")
+        self.raw_evdev_check = Gtk.CheckButton(label="Show raw evdev devices")
         self.raw_evdev_check.set_tooltip_text(
             "Show each event node separately, including unknown device types."
         )
         self.raw_evdev_check.connect("toggled", self._on_raw_evdev_toggled)
         device_tools.append(self.raw_evdev_check)
+
+        search_spacer = Gtk.Box()
+        search_spacer.set_hexpand(True)
+        device_tools.append(search_spacer)
 
         self.device_search_button = Gtk.Button()
         self.device_search_button.set_icon_name("system-search-symbolic")
@@ -700,7 +703,7 @@ class HardwareSetupDialog(Adw.Dialog):
     def _on_refresh_clicked(self, _button: Gtk.Button) -> None:
         self._detect_devices()
 
-    def _on_raw_evdev_toggled(self, check: Gtk.ToggleButton) -> None:
+    def _on_raw_evdev_toggled(self, check: Gtk.CheckButton) -> None:
         self._show_raw_evdev_devices = check.get_active()
         self.selected_device = None
         self.next_btn.set_sensitive(False)

--- a/keymasq/gui/wizards/hardware_setup.py
+++ b/keymasq/gui/wizards/hardware_setup.py
@@ -51,6 +51,7 @@ from keymasq.gui.session_client import (
     session_request,
     session_request_async,
 )
+from keymasq.gui.widgets.fuzzy_search import fuzzy_query_matches, install_listbox_fuzzy_filter
 from keymasq.session.hardware import HardwareManager
 
 DetectedDevice = dict[str, Any]
@@ -70,6 +71,39 @@ def _make_capture_status_row(status_label: Gtk.Label) -> tuple[Gtk.Box, Gtk.Widg
     row.append(dot)
     row.append(status_label)
     return row, dot
+
+
+def _device_search_text(hardware_id: str, dev_info: DetectedDevice) -> str:
+    interfaces = dev_info.get("interfaces", [])
+    interface_text: list[str] = []
+    if isinstance(interfaces, list):
+        for iface in interfaces:
+            if not isinstance(iface, dict):
+                continue
+            interface_text.extend(
+                str(iface.get(key, "") or "")
+                for key in (
+                    "path",
+                    "stable_path",
+                    "config_path",
+                    "phys",
+                    "interface_id",
+                    "device_type",
+                )
+            )
+            interface_text.extend(str(t) for t in iface.get("device_types", []) or [])
+    return " ".join(
+        [
+            hardware_id,
+            str(dev_info.get("name", "") or ""),
+            str(dev_info.get("display_name", "") or ""),
+            str(dev_info.get("model_id", "") or ""),
+            str(dev_info.get("vendor_id", "") or ""),
+            str(dev_info.get("product_id", "") or ""),
+            " ".join(str(t) for t in dev_info.get("device_types", []) or []),
+            " ".join(interface_text),
+        ]
+    )
 
 
 def _set_capture_status(
@@ -246,6 +280,13 @@ class HardwareSetupDialog(Adw.Dialog):
         _keycode: int,
         _state: Gdk.ModifierType,
     ) -> bool:
+        if keyval in (Gdk.KEY_f, Gdk.KEY_F) and _state & Gdk.ModifierType.CONTROL_MASK:
+            self._show_device_search()
+            return True
+        if keyval == Gdk.KEY_Escape and getattr(self, "device_search_entry", None):
+            if self.device_search_entry.get_visible():
+                self._hide_device_search()
+                return True
         if keyval != Gdk.KEY_Escape:
             return False
         self.close()
@@ -298,16 +339,40 @@ class HardwareSetupDialog(Adw.Dialog):
         subtitle.add_css_class("dim-label")
         box.append(subtitle)
 
-        self.raw_evdev_check = Gtk.CheckButton(label="Show raw evdev devices")
+        device_tools = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=6)
+        device_tools.set_halign(Gtk.Align.START)
+
+        self.raw_evdev_check = Gtk.ToggleButton(label="Show raw evdev devices")
         self.raw_evdev_check.set_tooltip_text(
             "Show each event node separately, including unknown device types."
         )
         self.raw_evdev_check.connect("toggled", self._on_raw_evdev_toggled)
-        box.append(self.raw_evdev_check)
+        device_tools.append(self.raw_evdev_check)
+
+        self.device_search_button = Gtk.Button()
+        self.device_search_button.set_icon_name("system-search-symbolic")
+        self.device_search_button.set_tooltip_text("Search devices")
+        self.device_search_button.connect("clicked", self._on_device_search_clicked)
+        device_tools.append(self.device_search_button)
+        box.append(device_tools)
+
+        self.device_search_entry = Gtk.SearchEntry()
+        self.device_search_entry.set_placeholder_text("Search devices")
+        self.device_search_entry.set_tooltip_text(
+            "Filter devices by name, type, ID, or evdev path"
+        )
+        self.device_search_entry.set_visible(False)
+        self.device_search_entry.connect("stop-search", self._on_device_search_stop)
+        box.append(self.device_search_entry)
 
         self.device_list = Gtk.ListBox()
         self.device_list.set_selection_mode(Gtk.SelectionMode.SINGLE)
         self.device_list.connect("row-selected", self._on_device_selected)
+        install_listbox_fuzzy_filter(
+            self.device_list,
+            self.device_search_entry,
+            after_filter_changed=self._after_device_search_filter_changed,
+        )
 
         scrolled = Gtk.ScrolledWindow()
         scrolled.set_vexpand(True)
@@ -319,6 +384,34 @@ class HardwareSetupDialog(Adw.Dialog):
         box.append(refresh_btn)
 
         self.stack.add_titled(box, "select", "Select Device")
+
+    def _show_device_search(self) -> None:
+        self.device_search_entry.set_visible(True)
+        self.device_search_entry.grab_focus()
+        self.device_search_entry.select_region(0, -1)
+
+    def _hide_device_search(self) -> None:
+        self.device_search_entry.set_text("")
+        self.device_search_entry.set_visible(False)
+
+    def _on_device_search_clicked(self, _button: Gtk.Button) -> None:
+        self._show_device_search()
+
+    def _on_device_search_stop(self, _entry: Gtk.SearchEntry) -> None:
+        self._hide_device_search()
+
+    def _after_device_search_filter_changed(self) -> None:
+        selected_row = self.device_list.get_selected_row()
+        if selected_row is None:
+            self._clear_device_selection()
+            return
+        if fuzzy_query_matches(
+            self.device_search_entry.get_text(),
+            getattr(selected_row, "_search_text", ""),
+        ):
+            return
+        self.device_list.unselect_row(selected_row)
+        self._clear_device_selection()
 
     def _setup_page_describe(self) -> None:
         box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=16)
@@ -568,6 +661,7 @@ class HardwareSetupDialog(Adw.Dialog):
 
             row.set_child(row_box)
             row.hardware_id = hardware_id
+            row._search_text = _device_search_text(hardware_id, dev_info)
             if expander is not None:
                 row._expander = expander
             self.device_list.append(row)
@@ -1104,6 +1198,9 @@ class HardwareSetupDialog(Adw.Dialog):
         return hardware_id if hardware_id != model_id else None
 
     def _on_device_selected(self, list_box, row) -> None:
+        if row is None:
+            self._clear_device_selection()
+            return
         if row:
             self.selected_device = self.detected_devices[row.hardware_id]
             if hasattr(row, "_expander"):
@@ -1121,6 +1218,10 @@ class HardwareSetupDialog(Adw.Dialog):
             self._discover_interfaces()
             self._refresh_configure_modes()
             self.next_btn.set_sensitive(not self._device_in_use(self.selected_device))
+
+    def _clear_device_selection(self) -> None:
+        self.selected_device = None
+        self.next_btn.set_sensitive(False)
 
     def _interface_device_types(self, iface: dict) -> list[str]:
         return normalize_input_classes(iface.get("device_types"), iface.get("device_type"))

--- a/tests/gui/test_fuzzy_search.py
+++ b/tests/gui/test_fuzzy_search.py
@@ -9,6 +9,9 @@ def test_fuzzy_query_matches_substrings_and_abbreviations() -> None:
     assert fuzzy_query_matches("ctc", "copy_ctrl_c keyboard 4 events")
     assert fuzzy_query_matches("kbd 4", "copy_ctrl_c keyboard kbd 4 events")
     assert fuzzy_query_matches("xbox", "Xbox 360 Wireless Receiver")
+    assert fuzzy_query_matches("café", "Café macro")
+    assert fuzzy_query_matches("клава", "Клава input")
+    assert fuzzy_query_matches("键盘", "外接键盘")
     assert not fuzzy_query_matches("gamepad", "copy_ctrl_c keyboard 4 events")
     assert not fuzzy_query_matches(
         "dygma",
@@ -120,6 +123,39 @@ def test_key_selector_macro_search_clears_hidden_selection(monkeypatch) -> None:
     ]
     dialog._selected_macro = "copy_ctrl_c"
     dialog._macro_search_entry.set_text("gamepad")
+    dialog.map_btn.set_sensitive(True)
+
+    dialog._populate_macro_listbox()
+
+    assert dialog._selected_macro is None
+    assert dialog.map_btn.get_sensitive() is False
+
+
+def test_key_selector_macro_refresh_clears_missing_selection(monkeypatch) -> None:
+    gi.require_version("Gtk", "4.0")
+    from gi.repository import Gtk
+
+    import keymasq.gui.widgets.key_selector_dialog as key_selector_dialog_module
+    from keymasq.gui.widgets.key_selector_dialog import KeySelectorDialog
+
+    monkeypatch.setattr(key_selector_dialog_module.GLib, "idle_add", lambda callback, *args: 0)
+    monkeypatch.setattr(
+        key_selector_dialog_module,
+        "session_request_async",
+        lambda _payload, _callback: None,
+    )
+
+    dialog = KeySelectorDialog(Gtk.Window(), "Back")
+    dialog.stack.set_visible_child_name("macro")
+    dialog._macro_list = [
+        {
+            "name": "gamepad_combo",
+            "duration_us": 43_300_000,
+            "device_types": ["gamepad"],
+            "event_count": 407,
+        }
+    ]
+    dialog._selected_macro = "deleted_macro"
     dialog.map_btn.set_sensitive(True)
 
     dialog._populate_macro_listbox()

--- a/tests/gui/test_fuzzy_search.py
+++ b/tests/gui/test_fuzzy_search.py
@@ -174,7 +174,7 @@ def test_hardware_setup_search_and_raw_toggle_controls(monkeypatch) -> None:
     monkeypatch.setattr(HardwareSetupDialog, "_detect_devices", lambda self: None)
     dialog = HardwareSetupDialog(Gtk.Window(), SimpleNamespace())
 
-    assert isinstance(dialog.raw_evdev_check, Gtk.ToggleButton)
+    assert isinstance(dialog.raw_evdev_check, Gtk.CheckButton)
     assert dialog.device_search_button.get_icon_name() == "system-search-symbolic"
     assert dialog.device_search_entry.get_visible() is False
 

--- a/tests/gui/test_fuzzy_search.py
+++ b/tests/gui/test_fuzzy_search.py
@@ -1,0 +1,244 @@
+# ruff: noqa: F403, F405, I001
+from tests.gui.support import *
+
+
+def test_fuzzy_query_matches_substrings_and_abbreviations() -> None:
+    from keymasq.gui.widgets.fuzzy_search import fuzzy_query_matches
+
+    assert fuzzy_query_matches("copy", "copy_ctrl_c keyboard 4 events")
+    assert fuzzy_query_matches("ctc", "copy_ctrl_c keyboard 4 events")
+    assert fuzzy_query_matches("kbd 4", "copy_ctrl_c keyboard kbd 4 events")
+    assert fuzzy_query_matches("xbox", "Xbox 360 Wireless Receiver")
+    assert not fuzzy_query_matches("gamepad", "copy_ctrl_c keyboard 4 events")
+    assert not fuzzy_query_matches(
+        "dygma",
+        (
+            "Xbox 360 Wireless Receiver 045e:02a1 gamepad "
+            "/dev/input/by-id/usb-Microsoft_Xbox_360_Wireless_Receiver"
+        ),
+    )
+
+
+def test_macro_manager_search_entry_filters_against_row_metadata(monkeypatch) -> None:
+    gi.require_version("Gtk", "4.0")
+    from gi.repository import GLib, Gtk
+
+    from keymasq.gui.widgets.fuzzy_search import fuzzy_query_matches
+    from keymasq.gui.widgets.macro_manager_dialog import MacroManagerDialog
+
+    monkeypatch.setattr(GLib, "idle_add", lambda callback, *args: 0)
+    dialog = MacroManagerDialog(Gtk.Window())
+
+    dialog._on_macros_loaded(
+        {
+            "macros": [
+                {
+                    "name": "copy_ctrl_c",
+                    "duration_us": 125_000,
+                    "device_types": ["keyboard"],
+                    "event_count": 4,
+                },
+                {
+                    "name": "gamepad_combo",
+                    "duration_us": 43_300_000,
+                    "device_types": ["gamepad"],
+                    "event_count": 407,
+                },
+            ]
+        }
+    )
+
+    row = dialog._listbox.get_row_at_index(0)
+    assert row is not None
+    assert dialog._search_entry.get_placeholder_text() == "Search macros"
+    assert fuzzy_query_matches("ctc", row._search_text)
+    assert fuzzy_query_matches("keyboard 4", row._search_text)
+    assert not fuzzy_query_matches("gamepad", row._search_text)
+
+
+def test_macro_manager_search_is_revealed_by_button_and_ctrl_f(monkeypatch) -> None:
+    gi.require_version("Gdk", "4.0")
+    gi.require_version("Gtk", "4.0")
+    from gi.repository import Gdk, GLib, Gtk
+
+    from keymasq.gui.widgets.macro_manager_dialog import MacroManagerDialog
+
+    monkeypatch.setattr(GLib, "idle_add", lambda callback, *args: 0)
+    dialog = MacroManagerDialog(Gtk.Window())
+
+    assert dialog._search_entry.get_visible() is False
+    assert dialog._search_button is not None
+    assert dialog._search_button.get_icon_name() == "system-search-symbolic"
+
+    dialog._search_button.emit("clicked")
+
+    assert dialog._search_entry.get_visible() is True
+
+    dialog._hide_search()
+    assert dialog._search_entry.get_visible() is False
+
+    handled = dialog._on_key_pressed(
+        Gtk.EventControllerKey(),
+        Gdk.KEY_f,
+        0,
+        Gdk.ModifierType.CONTROL_MASK,
+    )
+
+    assert handled is True
+    assert dialog._search_entry.get_visible() is True
+
+
+def test_key_selector_macro_search_clears_hidden_selection(monkeypatch) -> None:
+    gi.require_version("Gtk", "4.0")
+    from gi.repository import Gtk
+
+    import keymasq.gui.widgets.key_selector_dialog as key_selector_dialog_module
+    from keymasq.gui.widgets.key_selector_dialog import KeySelectorDialog
+
+    monkeypatch.setattr(key_selector_dialog_module.GLib, "idle_add", lambda callback, *args: 0)
+    monkeypatch.setattr(
+        key_selector_dialog_module,
+        "session_request_async",
+        lambda _payload, _callback: None,
+    )
+
+    dialog = KeySelectorDialog(Gtk.Window(), "Back")
+    dialog.stack.set_visible_child_name("macro")
+    dialog._macro_list = [
+        {
+            "name": "copy_ctrl_c",
+            "duration_us": 125_000,
+            "device_types": ["keyboard"],
+            "event_count": 4,
+        },
+        {
+            "name": "gamepad_combo",
+            "duration_us": 43_300_000,
+            "device_types": ["gamepad"],
+            "event_count": 407,
+        },
+    ]
+    dialog._selected_macro = "copy_ctrl_c"
+    dialog._macro_search_entry.set_text("gamepad")
+    dialog.map_btn.set_sensitive(True)
+
+    dialog._populate_macro_listbox()
+
+    assert dialog._selected_macro is None
+    assert dialog.map_btn.get_sensitive() is False
+
+
+def test_hardware_setup_search_and_raw_toggle_controls(monkeypatch) -> None:
+    gi.require_version("Gdk", "4.0")
+    gi.require_version("Gtk", "4.0")
+    from gi.repository import Gdk, Gtk
+
+    from keymasq.gui.wizards.hardware_setup import HardwareSetupDialog
+
+    monkeypatch.setattr(HardwareSetupDialog, "_detect_devices", lambda self: None)
+    dialog = HardwareSetupDialog(Gtk.Window(), SimpleNamespace())
+
+    assert isinstance(dialog.raw_evdev_check, Gtk.ToggleButton)
+    assert dialog.device_search_button.get_icon_name() == "system-search-symbolic"
+    assert dialog.device_search_entry.get_visible() is False
+
+    handled = dialog._on_key_pressed(
+        Gtk.EventControllerKey(),
+        Gdk.KEY_f,
+        0,
+        Gdk.ModifierType.CONTROL_MASK,
+    )
+
+    assert handled is True
+    assert dialog.device_search_entry.get_visible() is True
+
+
+def test_hardware_setup_search_clears_hidden_selected_device(monkeypatch) -> None:
+    gi.require_version("Gtk", "4.0")
+    from gi.repository import Gtk
+
+    from keymasq.gui.wizards.hardware_setup import HardwareSetupDialog
+
+    monkeypatch.setattr(HardwareSetupDialog, "_detect_devices", lambda self: None)
+    dialog = HardwareSetupDialog(Gtk.Window(), SimpleNamespace())
+    dialog.detected_devices = {
+        "keyboard": {
+            "name": "Keyboard",
+            "vendor_id": "1111",
+            "product_id": "2222",
+            "interfaces": [],
+        }
+    }
+
+    row = Gtk.ListBoxRow()
+    row.hardware_id = "keyboard"
+    row._search_text = "keyboard 1111 2222"
+    dialog.device_list.append(row)
+    dialog.device_list.select_row(row)
+    dialog.next_btn.set_sensitive(True)
+
+    assert dialog.selected_device is dialog.detected_devices["keyboard"]
+
+    dialog.device_search_entry.set_text("mouse")
+    dialog._after_device_search_filter_changed()
+
+    assert dialog.selected_device is None
+    assert dialog.next_btn.get_sensitive() is False
+
+
+def test_superkey_dialog_search_is_revealed_by_button_and_ctrl_f(
+    temp_config_dir,
+) -> None:
+    gi.require_version("Gdk", "4.0")
+    gi.require_version("Gtk", "4.0")
+    from gi.repository import Gdk, Gtk
+
+    from keymasq.gui.widgets.superkey_dialog import SuperkeyDialog
+
+    dialog = SuperkeyDialog(Gtk.Window())
+
+    assert dialog.search_button.get_icon_name() == "system-search-symbolic"
+    assert dialog.search_entry.get_visible() is False
+
+    dialog.search_button.emit("clicked")
+    assert dialog.search_entry.get_visible() is True
+
+    dialog._hide_search()
+    handled = dialog._on_key_pressed(
+        Gtk.EventControllerKey(),
+        Gdk.KEY_f,
+        0,
+        Gdk.ModifierType.CONTROL_MASK,
+    )
+
+    assert handled is True
+    assert dialog.search_entry.get_visible() is True
+
+
+def test_analog_control_dialog_search_is_revealed_by_button_and_ctrl_f(
+    temp_config_dir,
+) -> None:
+    gi.require_version("Gdk", "4.0")
+    gi.require_version("Gtk", "4.0")
+    from gi.repository import Gdk, Gtk
+
+    from keymasq.gui.widgets.analog_control_dialog import AnalogControlDialog
+
+    dialog = AnalogControlDialog(Gtk.Window())
+
+    assert dialog.search_button.get_icon_name() == "system-search-symbolic"
+    assert dialog.search_entry.get_visible() is False
+
+    dialog.search_button.emit("clicked")
+    assert dialog.search_entry.get_visible() is True
+
+    dialog._hide_search()
+    handled = dialog._on_key_pressed(
+        Gtk.EventControllerKey(),
+        Gdk.KEY_f,
+        0,
+        Gdk.ModifierType.CONTROL_MASK,
+    )
+
+    assert handled is True
+    assert dialog.search_entry.get_visible() is True


### PR DESCRIPTION
## Summary

- Extracted shared `fuzzy_search.py` module with `fuzzy_query_matches()` and `install_listbox_fuzzy_filter()` for reusable list-based fuzzy filtering.
- Added search UI (search entry, toolbar button, `Ctrl+F`/`Escape` bindings) to `AnalogControlDialog`, `MacroManagerDialog`, `SuperkeyDialog`, and `HardwareSetupDialog`.
- Integrated macro search filtering into the key selection macro tab in `KeySelectorDialog`.
- Defined per-row search text (`_search_text`) on analog control, super key, macro, and device rows, enabling rich matching against names, descriptions, device types, event counts, interface paths, and modes.
- Handles selection state correctly: clears hidden selections when a filter hides the currently selected row, and restores the active selection when the row becomes visible again.

## Testing

- Added `tests/gui/test_fuzzy_search.py` covering `fuzzy_query_matches` substring/abbreviation/multi-token/negative logic, macro row metadata filtering, search reveal via button and `Ctrl+F`, and selection clearing in `KeySelectorDialog`.
- Manually verified search filtering in all four dialog types (analog, superkey, macro manager, hardware setup).
- Manually verified `Ctrl+F` / Escape shortcut interactions and search button reveal/dismiss.
- Ran `nix develop -c ruff check .` — no new linting issues.
- Ran `nix develop -c pytest tests/gui/test_fuzzy_search.py` — all 5 tests pass.