### PR TITLE
Combo: add optional hardware/source scope and match-across-devices flag

### DIFF
--- a/docs/COMBOS.md
+++ b/docs/COMBOS.md
@@ -124,10 +124,61 @@ output. This means:
   supported horizontal scroll directions. A wheel tick finishes the captured
   step immediately.
 - The captured trigger is stored with the exact device identity (`hardware_id`,
-  input source, and evdev code), so matching at runtime is precise.
+  input source, and evdev code), so matching at runtime is precise by default.
+- You can set a combo to match across devices. In that mode Keymasq keeps the
+  captured `hardware_id` and `source` in the profile, but ignores them when
+  sending the combo to the runtime. The same key or button can then match on any
+  event device that is already grabbed by your active configuration. This does
+  not cause extra devices to be grabbed.
+- `source` is also optional. Keeping it is useful because it narrows matching
+  and grabbing to one configured evdev interface, such as a keyboard interface
+  or a mouse interface. Omitting it makes the combo match the evdev code on any
+  grabbed interface in scope.
 
 Capture uses the same security model as macro recording — it observes original
 input and requires the recording unlock flow.
+
+## Trigger Scope
+
+Every combo event has one required field and two optional scope fields:
+
+- `evdev` is required. It is the key, button, or supported wheel direction.
+- `hardware_id` is optional. When present, the event only matches that hardware
+  config. When omitted or empty, it matches any already-grabbed hardware.
+- `source` is optional. It is the `id` of a specific evdev input event device
+  configured under the hardware config's `[[hardware.evdev.devices]]` entries,
+  such as `kbd`, `mouse`, or `media`. It is a Keymasq interface label, not a
+  kernel hardware identity. When present, the event only matches that
+  configured event device. This can reduce unnecessary interface grabs for
+  concrete combos and avoid ambiguity on hardware with multiple input event
+  devices. When omitted or empty, it matches any grabbed event device in the
+  hardware scope.
+
+This means the same trigger can be scoped differently:
+
+```toml
+# Any already-grabbed device/interface that emits key_f13.
+{ evdev = "key_f13" }
+
+# Any already-grabbed hardware, but only on interfaces labeled "kbd".
+{ source = "kbd", evdev = "key_f13" }
+
+# This hardware only, any already-grabbed interface.
+{ hardware_id = "abcd:ef01", evdev = "key_f13" }
+
+# This hardware and this configured interface.
+{ hardware_id = "abcd:ef01", source = "kbd", evdev = "key_f13" }
+```
+
+Optional scope never causes extra devices to be grabbed. If the relevant input
+is not already grabbed by mappings, force-grab, device inspector, or another
+active configuration path, the combo will not see it.
+
+The combo-level `match_across_devices = true` option is the reversible way to
+make a captured combo portable. The GUI uses this for **Match Across Devices**:
+it preserves captured event scope in storage, then the session sends the daemon
+a runtime combo with empty `hardware_id` and `source` fields. Hand-edited combos
+may also omit either field directly when that wildcard behavior is desired.
 
 ## Actions
 
@@ -253,6 +304,7 @@ macros or super keys.
 [[combos]]
 id = "combo_1"
 name = "Alt+R -> 1 -> Move 20,20"
+match_across_devices = true
 
 [[combos.steps]]
 events = [
@@ -272,9 +324,11 @@ x = 20
 y = 20
 ```
 
-Each step stores the exact `hardware_id`, input source, and evdev code that
-was captured. This is not a user interface — prefer the GUI for creating and
-editing combos.
+Each event stores the captured `evdev` code and may also store `hardware_id`
+and `source` for more precise scope. If `hardware_id` or `source` is omitted or
+empty, that part of the scope is treated as a wildcard over already-grabbed
+inputs. If `match_across_devices = true`, stored `hardware_id` and `source`
+values are preserved but ignored at runtime.
 
 ## Security Notes
 

--- a/docs/agents/superkeys-combos.txt
+++ b/docs/agents/superkeys-combos.txt
@@ -90,9 +90,24 @@ inputs together should trigger one action.
 
 Combo events store captured hardware identity and evdev input names:
 
-- `hardware_id`: device hardware ID such as `046d:c548`
-- `source`: optional evdev device source ID from the hardware file
+- `hardware_id`: optional device hardware ID such as `046d:c548`; omit or
+  leave empty to match any already-grabbed device without causing extra grabs
+- `source`: optional `id` of a specific evdev input event device configured in
+  the hardware file's `[[hardware.evdev.devices]]` entries; keeping it narrows
+  matching and grab selection to that configured event device, omitting it
+  matches any grabbed event device in scope
 - `evdev`: evdev input name such as `key_leftalt`, `key_r`, or `btn_side`
+
+Only `evdev` is required. Optional `hardware_id` and `source` are scope
+constraints, not extra-grab requests. If they are omitted, Keymasq only matches
+events from devices/interfaces that are already grabbed by the active runtime
+configuration.
+
+Use combo-level `match_across_devices = true` when a captured combo should work
+on any already-grabbed device while preserving the captured `hardware_id` and
+`source` values in storage. At runtime the session sends that combo to the
+daemon with empty hardware/source scope. Hand-edited combos may still omit either
+scope field directly.
 
 One-step chord example: press mouse back and forward together to play a macro.
 
@@ -143,8 +158,10 @@ Optional combo fields:
 ```toml
 recall_trigger_keys = true
 restore_trigger_keys = ["key_leftalt"]
+match_across_devices = true
 ```
 
 Prefer the GUI for creating combos when possible because it captures exact
 `hardware_id`, `source`, and `evdev` values. Agents should preserve existing
-combo IDs and unrelated profile mappings when editing profile TOML.
+combo IDs, captured hardware scope, portable matching flags, and unrelated
+profile mappings when editing profile TOML.

--- a/keymasq/common/models.py
+++ b/keymasq/common/models.py
@@ -871,7 +871,7 @@ class DeviceProfileLayer:
 @dataclass
 class ComboEvent:
     evdev: str
-    hardware_id: str
+    hardware_id: str = ""
     source: str | None = None
 
 
@@ -889,6 +889,7 @@ class ComboConfig:
     action: MappingAction | None = None
     recall_trigger_keys: bool = False
     restore_trigger_keys: list[str] = field(default_factory=list)
+    match_across_devices: bool = False
 
 
 @dataclass

--- a/keymasq/gui/widgets/combo_editor_dialog.py
+++ b/keymasq/gui/widgets/combo_editor_dialog.py
@@ -99,16 +99,46 @@ def combo_event_sort_key(event: ComboEvent) -> str:
     return sort_combo_keys([event.evdev])[0]
 
 
-def combo_event_signature(event: ComboEvent) -> tuple[str, str, str]:
+def combo_event_signature(
+    event: ComboEvent,
+    *,
+    match_across_devices: bool = False,
+) -> tuple[str, str, str]:
     return (
-        str(event.hardware_id or "").lower(),
-        str(event.source or "").lower(),
+        "" if match_across_devices else str(event.hardware_id or "").lower(),
+        "" if match_across_devices else str(event.source or "").lower(),
         normalize_combo_evdev(str(event.evdev or "").lower()),
     )
 
 
-def combo_step_signature(step: ComboStep) -> tuple[tuple[str, str, str], ...]:
-    return tuple(sorted(combo_event_signature(event) for event in step.events))
+def combo_step_signature(
+    step: ComboStep,
+    *,
+    match_across_devices: bool = False,
+) -> tuple[tuple[str, str, str], ...]:
+    return tuple(
+        sorted(
+            combo_event_signature(
+                event,
+                match_across_devices=match_across_devices,
+            )
+            for event in step.events
+        )
+    )
+
+
+def combo_trigger_signature(
+    combo: ComboConfig,
+    *,
+    match_across_devices: bool = False,
+) -> list[tuple[tuple[str, str, str], ...]]:
+    return [
+        combo_step_signature(
+            step,
+            match_across_devices=match_across_devices,
+        )
+        for step in combo.steps
+    ]
 
 
 def combo_step_label(step: ComboStep) -> str:
@@ -135,6 +165,14 @@ def combo_is_single_critical_mouse_trigger(steps: list[ComboStep]) -> bool:
         len(steps) == 1
         and len(steps[0].events) == 1
         and normalize_combo_evdev(steps[0].events[0].evdev) in PROTECTED_BUTTONS
+    )
+
+
+def combo_steps_use_any_device(steps: list[ComboStep]) -> bool:
+    events = [event for step in steps for event in step.events]
+    return bool(events) and all(
+        not str(event.hardware_id or "").strip() and not str(event.source or "").strip()
+        for event in events
     )
 
 
@@ -406,6 +444,20 @@ class ComboEditorDialog(Adw.Dialog):
             self._on_recall_trigger_keys_changed,
         )
         trigger_state_group.add(self.recall_trigger_keys_row)
+
+        self.any_device_row = Adw.SwitchRow(
+            title="Match Across Devices",
+            subtitle="The trigger source can be any grabbed device.",
+        )
+        self.any_device_row.set_active(
+            self._draft.match_across_devices or combo_steps_use_any_device(self._draft.steps)
+        )
+        self.any_device_row.connect(
+            "notify::active",
+            self._on_any_device_changed,
+        )
+        trigger_state_group.add(self.any_device_row)
+
         content.append(trigger_state_group)
 
         self.restore_trigger_keys_group = Adw.PreferencesGroup(
@@ -482,7 +534,9 @@ class ComboEditorDialog(Adw.Dialog):
     def _save_draft(self) -> None:
         name = self.name_entry.get_text().strip()
         self._draft.name = name or combo_default_name(self._draft)
-        self.emit("combo-saved", deepcopy(self._draft))
+        saved = deepcopy(self._draft)
+        saved.match_across_devices = bool(self.any_device_row.get_active())
+        self.emit("combo-saved", saved)
         self.close()
 
     def _show_critical_mouse_combo_warning(self) -> None:
@@ -668,6 +722,14 @@ class ComboEditorDialog(Adw.Dialog):
         self._refresh_restore_trigger_keys()
         self._update_save_button()
 
+    def _on_any_device_changed(
+        self,
+        row: Adw.SwitchRow,
+        _pspec: GObject.ParamSpec,
+    ) -> None:
+        self._draft.match_across_devices = bool(row.get_active())
+        self._update_save_button()
+
     def _on_restore_trigger_key_toggled(
         self,
         button: Gtk.CheckButton,
@@ -714,13 +776,19 @@ class ComboEditorDialog(Adw.Dialog):
         return ""
 
     def _is_exact_duplicate_of_sibling(self) -> bool:
-        current_steps = [combo_step_signature(step) for step in self._draft.steps]
+        current_steps = combo_trigger_signature(
+            self._draft,
+            match_across_devices=bool(self.any_device_row.get_active()),
+        )
         if not current_steps:
             return False
         for combo in self._sibling_combos:
             if combo.id == self._draft.id:
                 continue
-            sibling_steps = [combo_step_signature(step) for step in combo.steps]
+            sibling_steps = combo_trigger_signature(
+                combo,
+                match_across_devices=bool(combo.match_across_devices),
+            )
             if sibling_steps == current_steps:
                 return True
         return False
@@ -802,7 +870,7 @@ class ComboEditorDialog(Adw.Dialog):
                 continue
             evdev = str(item.get("evdev", "") or "")
             hardware_id = str(item.get("hardware_id", "") or "")
-            if not evdev or not hardware_id:
+            if not evdev:
                 continue
             source_raw = item.get("source")
             source = str(source_raw) if source_raw is not None else None

--- a/keymasq/keymasqd/combo_engine.py
+++ b/keymasq/keymasqd/combo_engine.py
@@ -122,6 +122,12 @@ class ComboEngine:
         self._held_binding_any_source_index: dict[
             tuple[str, str], set[RuntimeComboBinding]
         ] = {}
+        self._held_binding_any_hardware_index: dict[
+            tuple[str, str], set[RuntimeComboBinding]
+        ] = {}
+        self._held_binding_any_hardware_any_source_index: dict[
+            str, set[RuntimeComboBinding]
+        ] = {}
 
     def set_combos(
         self,
@@ -163,6 +169,8 @@ class ComboEngine:
         self._held_press_order.clear()
         self._held_binding_index.clear()
         self._held_binding_any_source_index.clear()
+        self._held_binding_any_hardware_index.clear()
+        self._held_binding_any_hardware_any_source_index.clear()
 
     def prime_held_bindings(self, held_bindings: set[RuntimeComboBinding]) -> None:
         for binding in sorted(
@@ -445,8 +453,11 @@ class ComboEngine:
                 kept[combo_id] = candidate
                 continue
 
-            matched_step_binding = True
             if int(event.value) == 0:
+                if event.binding not in candidate.pressed_bindings:
+                    kept[combo_id] = candidate
+                    continue
+                matched_step_binding = True
                 if candidate.action_active:
                     transitions.append(
                         ComboActionTransition(
@@ -568,7 +579,11 @@ class ComboEngine:
 
         for combo in first_step_combos:
             if combo.id in self._candidates:
-                matched_existing_or_activated = True
+                candidate = self._candidates[combo.id]
+                matched_existing_or_activated = (
+                    matched_existing_or_activated
+                    or event.binding in candidate.pressed_bindings
+                )
                 continue
             held_bindings = self._held_bindings_for_step(combo.steps[0], event.binding)
             if held_bindings is None:
@@ -694,7 +709,7 @@ class ComboEngine:
         )
         actual_hardware_id, actual_evdev, actual_source = _normalized_binding_parts(actual)
         return (
-            expected_hardware_id == actual_hardware_id
+            (not expected_hardware_id or expected_hardware_id == actual_hardware_id)
             and expected_evdev == actual_evdev
             and (not expected_source or expected_source == actual_source)
         )
@@ -705,7 +720,7 @@ class ComboEngine:
         binding: RuntimeComboBinding,
     ) -> bool:
         return any(
-            step_binding.hardware_id == binding.hardware_id
+            (not step_binding.hardware_id or step_binding.hardware_id == binding.hardware_id)
             and (not step_binding.source or step_binding.source == binding.source)
             for step_binding in step.bindings
         )
@@ -736,37 +751,31 @@ class ComboEngine:
         return combos
 
     def _binding_matches_any_first_step(self, binding: RuntimeComboBinding) -> bool:
-        hardware_id, normalized, source = _normalized_binding_parts(binding)
-        return bool(
-            self._first_step_binding_index.get((hardware_id, normalized, source))
-            or (
-                source
-                and self._first_step_binding_index.get((hardware_id, normalized, ""))
-            )
-        )
+        return bool(self._candidate_first_step_combo_ids(binding))
 
     def _candidate_first_step_combo_ids(
         self,
         binding: RuntimeComboBinding,
     ) -> list[str]:
         hardware_id, normalized, source = _normalized_binding_parts(binding)
-        specific = self._first_step_binding_index.get((hardware_id, normalized, source), [])
-        if not source:
-            return list(specific)
-
-        wildcard = self._first_step_binding_index.get((hardware_id, normalized, ""), [])
-        if not wildcard:
-            return list(specific)
-        if not specific:
-            return list(wildcard)
-
         seen: set[str] = set()
         combo_ids: list[str] = []
-        for combo_id in (*specific, *wildcard):
-            if combo_id in seen:
-                continue
-            seen.add(combo_id)
-            combo_ids.append(combo_id)
+        hardware_keys = [hardware_id]
+        if hardware_id:
+            hardware_keys.append("")
+        source_keys = [source]
+        if source:
+            source_keys.append("")
+        for hardware_key in hardware_keys:
+            for source_key in source_keys:
+                for combo_id in self._first_step_binding_index.get(
+                    (hardware_key, normalized, source_key),
+                    [],
+                ):
+                    if combo_id in seen:
+                        continue
+                    seen.add(combo_id)
+                    combo_ids.append(combo_id)
         return combo_ids
 
     def _held_bindings_for_step(
@@ -803,17 +812,38 @@ class ComboEngine:
         expected: RuntimeComboBinding,
     ) -> set[RuntimeComboBinding]:
         hardware_id, normalized, source = _normalized_binding_parts(expected)
-        if source:
+        if hardware_id and source:
             return self._held_binding_index.get((hardware_id, normalized, source), set())
-        return self._held_binding_any_source_index.get((hardware_id, normalized), set())
+        if hardware_id:
+            return self._held_binding_any_source_index.get((hardware_id, normalized), set())
+        if source:
+            return self._held_binding_any_hardware_index.get((normalized, source), set())
+        return self._held_binding_any_hardware_any_source_index.get(normalized, set())
 
     def _index_held_binding(self, binding: RuntimeComboBinding) -> None:
-        specific_key, generic_key = self._held_binding_index_keys(binding)
+        (
+            specific_key,
+            generic_key,
+            any_hardware_key,
+            any_hardware_any_source_key,
+        ) = self._held_binding_index_keys(binding)
         self._held_binding_index.setdefault(specific_key, set()).add(binding)
         self._held_binding_any_source_index.setdefault(generic_key, set()).add(binding)
+        self._held_binding_any_hardware_index.setdefault(any_hardware_key, set()).add(
+            binding
+        )
+        self._held_binding_any_hardware_any_source_index.setdefault(
+            any_hardware_any_source_key,
+            set(),
+        ).add(binding)
 
     def _deindex_held_binding(self, binding: RuntimeComboBinding) -> None:
-        specific_key, generic_key = self._held_binding_index_keys(binding)
+        (
+            specific_key,
+            generic_key,
+            any_hardware_key,
+            any_hardware_any_source_key,
+        ) = self._held_binding_index_keys(binding)
 
         specific_bucket = self._held_binding_index.get(specific_key)
         if specific_bucket is not None:
@@ -827,18 +857,44 @@ class ComboEngine:
             if not generic_bucket:
                 self._held_binding_any_source_index.pop(generic_key, None)
 
+        any_hardware_bucket = self._held_binding_any_hardware_index.get(any_hardware_key)
+        if any_hardware_bucket is not None:
+            any_hardware_bucket.discard(binding)
+            if not any_hardware_bucket:
+                self._held_binding_any_hardware_index.pop(any_hardware_key, None)
+
+        any_hardware_any_source_bucket = (
+            self._held_binding_any_hardware_any_source_index.get(
+                any_hardware_any_source_key
+            )
+        )
+        if any_hardware_any_source_bucket is not None:
+            any_hardware_any_source_bucket.discard(binding)
+            if not any_hardware_any_source_bucket:
+                self._held_binding_any_hardware_any_source_index.pop(
+                    any_hardware_any_source_key,
+                    None,
+                )
+
     def _rebuild_held_binding_indexes(self) -> None:
         self._held_binding_index.clear()
         self._held_binding_any_source_index.clear()
+        self._held_binding_any_hardware_index.clear()
+        self._held_binding_any_hardware_any_source_index.clear()
         for binding in self._held_bindings:
             self._index_held_binding(binding)
 
     def _held_binding_index_keys(
         self,
         binding: RuntimeComboBinding,
-    ) -> tuple[tuple[str, str, str], tuple[str, str]]:
+    ) -> tuple[tuple[str, str, str], tuple[str, str], tuple[str, str], str]:
         hardware_id, normalized, source = _normalized_binding_parts(binding)
-        return (hardware_id, normalized, source), (hardware_id, normalized)
+        return (
+            (hardware_id, normalized, source),
+            (hardware_id, normalized),
+            (normalized, source),
+            normalized,
+        )
 
     def _dedupe_recall_events(
         self,

--- a/keymasq/keymasqd/device_manager.py
+++ b/keymasq/keymasqd/device_manager.py
@@ -930,7 +930,7 @@ class DeviceManager:
                         hardware_id = _str_value(event_dict.get("hardware_id"), "").lower()
                         evdev_name = _str_value(event_dict.get("evdev"), "").lower()
                         source = _str_value(event_dict.get("source"), "").lower()
-                        if not hardware_id or not evdev_name:
+                        if not evdev_name:
                             continue
                         bindings.append(
                             RuntimeComboBinding(
@@ -1122,7 +1122,10 @@ class DeviceManager:
             return False
         if not is_emergency_cancel_combo_evdevs(binding.evdev for binding in step.bindings):
             return False
-        return all(binding.hardware_id in keyboard_hardware_ids for binding in step.bindings)
+        return all(
+            not binding.hardware_id or binding.hardware_id in keyboard_hardware_ids
+            for binding in step.bindings
+        )
 
     async def set_diagnostics(
         self,

--- a/keymasq/keymasqd/runtime/combos.py
+++ b/keymasq/keymasqd/runtime/combos.py
@@ -96,6 +96,7 @@ class ComboActionState:
     source_device: str | None = None
     source_button: str | None = None
     trigger_binding: RuntimeComboBinding | None = None
+    trigger_bindings: list[RuntimeComboBinding] = field(default_factory=list)
     child_combo_ids: list[str] = field(default_factory=list)
     machine: SuperkeyMachine | None = None
     recalled_bindings: list[RuntimeComboBinding] = field(default_factory=list)
@@ -110,6 +111,9 @@ class ComboRuntimeState:
     timeout_task: asyncio.Task[None] | None = None
     active_actions: dict[str, ComboActionState] = field(default_factory=dict)
     superkey_machines: dict[str, SuperkeyMachine] = field(default_factory=dict)
+    superkey_machine_bindings: dict[str, tuple[RuntimeComboBinding, ...]] = field(
+        default_factory=dict
+    )
     held_output_keys: dict[str, set[int]] = field(
         default_factory=lambda: {
             "keyboard": set(),
@@ -638,26 +642,24 @@ def _combo_superkey_config(
     )
 
 
-def _combo_matches_binding_scope(
-    combo: RuntimeCombo,
+def _binding_matches_scope(
+    binding: RuntimeComboBinding | None,
     hardware_id: str,
     source: str | None,
 ) -> bool:
-    """Return whether a combo includes a binding for this already-normalized scope.
+    """Return whether a concrete runtime binding belongs to this normalized scope.
 
     ``hardware_id`` must already use the runtime's canonical casing, and ``source``
     must be pre-normalized the same way or left as ``None`` to match any source.
     This helper only coerces falsey values to ``""`` for comparison.
     """
+    if binding is None:
+        return False
     normalized_hardware_id = str(hardware_id or "")
     normalized_source = None if source is None else str(source or "")
-    for step in combo.steps:
-        for binding in step.bindings:
-            if binding.hardware_id != normalized_hardware_id:
-                continue
-            if normalized_source is None or binding.source == normalized_source:
-                return True
-    return False
+    if binding.hardware_id != normalized_hardware_id:
+        return False
+    return normalized_source is None or binding.source == normalized_source
 
 
 async def _combo_superkey_machine(
@@ -665,6 +667,7 @@ async def _combo_superkey_machine(
     combo_id: str,
     action: MappingAction,
     trigger_binding: RuntimeComboBinding,
+    trigger_bindings: Sequence[RuntimeComboBinding],
     *,
     deps: ComboRuntimeDeps,
 ) -> SuperkeyMachine | None:
@@ -673,12 +676,19 @@ async def _combo_superkey_machine(
         return None
 
     trigger_name = f"combo:{combo_id}"
+    machine_bindings = tuple(_ordered_unique_bindings(trigger_bindings or (trigger_binding,)))
     existing = manager.combo_state.superkey_machines.get(combo_id)
     if existing is not None:
-        if existing.config == config and existing.event_name == trigger_name:
+        existing_bindings = manager.combo_state.superkey_machine_bindings.get(combo_id)
+        if (
+            existing.config == config
+            and existing.event_name == trigger_name
+            and existing_bindings == machine_bindings
+        ):
             return existing
         await existing.stop()
         manager.combo_state.superkey_machines.pop(combo_id, None)
+        manager.combo_state.superkey_machine_bindings.pop(combo_id, None)
 
     async def combo_superkey_broadcast(data: dict[str, object]) -> None:
         payload = dict(data)
@@ -719,6 +729,7 @@ async def _combo_superkey_machine(
         ),
     )
     manager.combo_state.superkey_machines[combo_id] = machine
+    manager.combo_state.superkey_machine_bindings[combo_id] = machine_bindings
     return machine
 
 
@@ -905,6 +916,7 @@ async def start_combo_action(
                 combo_id,
                 action,
                 trigger_binding,
+                trigger_bindings,
                 deps=deps,
             )
             if superkey_machine is None:
@@ -1017,6 +1029,7 @@ async def start_combo_action(
             kind="superkey_pattern",
             machine=machine,
             trigger_binding=trigger_binding,
+            trigger_bindings=list(_ordered_unique_bindings(trigger_bindings)),
             source_button=trigger_name,
             recalled_bindings=recalled_bindings,
             restore_bindings=restore_bindings,
@@ -1554,6 +1567,7 @@ async def clear_combo_runtime(
     # machine state and cancel timers during combo runtime reset.
     machines = list(manager.combo_state.superkey_machines.values())
     manager.combo_state.superkey_machines.clear()
+    manager.combo_state.superkey_machine_bindings.clear()
     for machine in machines:
         await machine.stop()
     for held in manager.combo_state.held_output_keys.values():
@@ -1588,6 +1602,7 @@ async def clear_combo_runtime_except(
         if combo_id in preserved:
             continue
         manager.combo_state.superkey_machines.pop(combo_id, None)
+        manager.combo_state.superkey_machine_bindings.pop(combo_id, None)
         await machine.stop()
 
     active_output_roots = {
@@ -1626,14 +1641,22 @@ async def clear_combo_runtime_for_binding_scope(
             combo_id,
             deps=deps,
         )
-    matching_machine_ids = [
-        combo.id
-        for combo in manager.combo_state.active_combos
-        if combo.id in manager.combo_state.superkey_machines
-        and _combo_matches_binding_scope(combo, normalized_hardware_id, normalized_source)
-    ]
+    matching_machine_ids: list[str] = []
+    for combo_id in manager.combo_state.superkey_machines:
+        state = manager.combo_state.active_actions.get(combo_id)
+        bindings = (
+            tuple(state.trigger_bindings)
+            if state is not None and state.trigger_bindings
+            else manager.combo_state.superkey_machine_bindings.get(combo_id, ())
+        )
+        if any(
+            _binding_matches_scope(binding, normalized_hardware_id, normalized_source)
+            for binding in bindings
+        ):
+            matching_machine_ids.append(combo_id)
     for combo_id in matching_machine_ids:
         machine = manager.combo_state.superkey_machines.pop(combo_id, None)
+        manager.combo_state.superkey_machine_bindings.pop(combo_id, None)
         if machine is not None:
             await machine.stop()
     refresh_combo_timeout_watchdog(

--- a/keymasq/session/manager/payloads.py
+++ b/keymasq/session/manager/payloads.py
@@ -95,7 +95,7 @@ def resolved_combos_signature(
                     "evdev": str(event.evdev or ""),
                 }
                 for event in step.events
-                if event.hardware_id and event.evdev
+                if event.evdev
             ]
             if not events:
                 continue
@@ -398,12 +398,13 @@ def resolved_combos_payload(
         for step in combo.steps:
             events: list[dict[str, str]] = []
             for event in step.events:
-                if not event.hardware_id or not event.evdev:
+                if not event.evdev:
                     continue
                 event_data = {
-                    "hardware_id": event.hardware_id,
                     "evdev": event.evdev,
                 }
+                if event.hardware_id:
+                    event_data["hardware_id"] = event.hardware_id
                 if event.source:
                     event_data["source"] = event.source
                 events.append(event_data)

--- a/keymasq/session/profiles.py
+++ b/keymasq/session/profiles.py
@@ -602,7 +602,7 @@ class ProfileManager:
                                 continue
                             evdev = str(event_dict.get("evdev", "") or "")
                             hardware_id = str(event_dict.get("hardware_id", "") or "")
-                            if not evdev or not hardware_id:
+                            if not evdev:
                                 continue
                             source_raw = event_dict.get("source")
                             source = str(source_raw) if source_raw is not None else None
@@ -639,6 +639,9 @@ class ProfileManager:
                     recall_trigger_keys=bool(combo_dict.get("recall_trigger_keys", False)),
                     restore_trigger_keys=normalize_combo_restore_keys(
                         _as_toml_list(combo_dict.get("restore_trigger_keys", []))
+                    ),
+                    match_across_devices=bool(
+                        combo_dict.get("match_across_devices", False)
                     ),
                 )
             )
@@ -851,21 +854,28 @@ class ProfileManager:
                     if not step.events:
                         normalized_steps = []
                         break
+                    effective_step = copy.deepcopy(step)
+                    if combo.match_across_devices:
+                        for event in effective_step.events:
+                            event.hardware_id = ""
+                            event.source = None
                     normalized_events = sorted(
                         (
-                            event.hardware_id,
+                            event.hardware_id or "",
                             event.source or "",
                             normalize_combo_evdev(event.evdev),
                         )
-                        for event in step.events
-                        if event.hardware_id and event.evdev
+                        for event in effective_step.events
+                        if event.evdev
                     )
                     if not normalized_events:
                         normalized_steps = []
                         break
                     normalized_steps.append(tuple(normalized_events))
-                    combo_steps.append(copy.deepcopy(step))
+                    combo_steps.append(effective_step)
                     for hardware_id, _source, _evdev in normalized_events:
+                        if not hardware_id:
+                            continue
                         resolved = devices.setdefault(
                             hardware_id,
                             ResolvedDeviceProfile(hardware_id=hardware_id),
@@ -995,7 +1005,11 @@ class ProfileManager:
                             "events": [
                                 {
                                     "evdev": event.evdev,
-                                    "hardware_id": event.hardware_id,
+                                    **(
+                                        {"hardware_id": event.hardware_id}
+                                        if event.hardware_id
+                                        else {}
+                                    ),
                                     **({"source": event.source} if event.source else {}),
                                 }
                                 for event in step.events
@@ -1016,6 +1030,11 @@ class ProfileManager:
                             )
                         }
                         if combo.restore_trigger_keys
+                        else {}
+                    ),
+                    **(
+                        {"match_across_devices": True}
+                        if combo.match_across_devices
                         else {}
                     ),
                 }

--- a/tests/common/test_profile_manager.py
+++ b/tests/common/test_profile_manager.py
@@ -280,6 +280,108 @@ class TestProfileManager:
         assert resolved.devices["1234:5678"].combo_event_count == 2
         assert resolved.devices["1234:5678"].combo_sources == {"mouse"}
 
+    def test_optional_combo_hardware_id_round_trips_without_grab_inference(
+        self,
+        temp_config_dir,
+    ):
+        manager = ProfileManager()
+        profile = ProfileConfig(
+            name="Portable Combo",
+            enabled=True,
+            is_permanent=True,
+            combos=[
+                ComboConfig(
+                    id="combo-any-kbd",
+                    name="Any Keyboard F13",
+                    steps=[
+                        ComboStep(
+                            events=[
+                                ComboEvent(
+                                    source="kbd",
+                                    evdev="key_f13",
+                                )
+                            ]
+                        )
+                    ],
+                    action=MappingAction(action_type=ActionType.SUPPRESS),
+                )
+            ],
+        )
+        manager.save_profile(profile)
+
+        text = (temp_config_dir / "profiles" / "Portable_Combo.toml").read_text(
+            encoding="utf-8"
+        )
+        assert "hardware_id" not in text
+
+        reloaded = ProfileManager()
+        loaded = reloaded.get_profile("Portable Combo")
+        assert loaded is not None
+        event = loaded.config.combos[0].steps[0].events[0]
+        assert event.hardware_id == ""
+
+        resolved = reloaded.resolve_active_profiles(hardware_ids=["1234:5678"])
+
+        assert len(resolved.combos) == 1
+        assert resolved.combos[0].steps[0].events[0].hardware_id == ""
+        assert resolved.devices["1234:5678"].combo_event_count == 0
+
+    def test_match_across_devices_preserves_storage_scope_but_strips_runtime_scope(
+        self,
+        temp_config_dir,
+    ):
+        manager = ProfileManager()
+        profile = ProfileConfig(
+            name="Portable Captured Combo",
+            enabled=True,
+            is_permanent=True,
+            combos=[
+                ComboConfig(
+                    id="combo-portable",
+                    name="Portable F13",
+                    match_across_devices=True,
+                    steps=[
+                        ComboStep(
+                            events=[
+                                ComboEvent(
+                                    hardware_id="1234:5678",
+                                    source="kbd",
+                                    evdev="key_f13",
+                                )
+                            ]
+                        )
+                    ],
+                    action=MappingAction(action_type=ActionType.SUPPRESS),
+                )
+            ],
+        )
+        manager.save_profile(profile)
+
+        text = (
+            temp_config_dir / "profiles" / "Portable_Captured_Combo.toml"
+        ).read_text(encoding="utf-8")
+        assert "match_across_devices = true" in text
+        assert 'hardware_id = "1234:5678"' in text
+        assert 'source = "kbd"' in text
+
+        reloaded = ProfileManager()
+        loaded = reloaded.get_profile("Portable Captured Combo")
+        assert loaded is not None
+        stored_combo = loaded.config.combos[0]
+        stored_event = stored_combo.steps[0].events[0]
+        assert stored_combo.match_across_devices is True
+        assert stored_event.hardware_id == "1234:5678"
+        assert stored_event.source == "kbd"
+
+        resolved = reloaded.resolve_active_profiles(hardware_ids=["1234:5678"])
+
+        assert len(resolved.combos) == 1
+        runtime_event = resolved.combos[0].steps[0].events[0]
+        assert runtime_event.hardware_id == ""
+        assert runtime_event.source is None
+        assert resolved.devices["1234:5678"].combo_event_count == 0
+        assert resolved.devices["1234:5678"].combo_sources == set()
+
     def test_combo_step_timeout_round_trips_in_profile_storage(self, temp_config_dir):
         manager = ProfileManager()
         profile = ProfileConfig(

--- a/tests/common/test_profile_manager.py
+++ b/tests/common/test_profile_manager.py
@@ -324,6 +324,7 @@ class TestProfileManager:
 
         assert len(resolved.combos) == 1
         assert resolved.combos[0].steps[0].events[0].hardware_id == ""
+        assert resolved.combos[0].steps[0].events[0].source == "kbd"
         assert resolved.devices["1234:5678"].combo_event_count == 0
 
     def test_match_across_devices_preserves_storage_scope_but_strips_runtime_scope(

--- a/tests/gui/test_combo_editor_dialog.py
+++ b/tests/gui/test_combo_editor_dialog.py
@@ -52,6 +52,44 @@ class TestComboEditorDialog:
         assert dialog._draft.steps[0].timeout_ms is None
         assert dialog.capture_status.get_text() == "Added step: A"
 
+    def test_combo_editor_capture_response_accepts_missing_hardware_id(self):
+        from gi.repository import Gtk
+
+        from keymasq.gui.widgets.combo_editor_dialog import ComboEditorDialog
+
+        parent = Gtk.Box()
+        dialog = ComboEditorDialog(parent, profile_name="Desktop")
+
+        dialog._on_capture_combo_response(
+            {
+                "status": "ok",
+                "events": [{"evdev": "key_a", "source": "kbd"}],
+            }
+        )
+
+        assert dialog._draft.steps[0].events[0].evdev == "key_a"
+        assert dialog._draft.steps[0].events[0].hardware_id == ""
+
+    def test_combo_editor_any_device_capture_preserves_device_scope(self):
+        from gi.repository import Gtk
+
+        from keymasq.gui.widgets.combo_editor_dialog import ComboEditorDialog
+
+        parent = Gtk.Box()
+        dialog = ComboEditorDialog(parent, profile_name="Desktop")
+        dialog.any_device_row.set_active(True)
+
+        dialog._on_capture_combo_response(
+            {
+                "status": "ok",
+                "events": [{"evdev": "key_a", "hardware_id": "1234:5678", "source": "kbd"}],
+            }
+        )
+
+        assert dialog._draft.match_across_devices is True
+        assert dialog._draft.steps[0].events[0].hardware_id == "1234:5678"
+        assert dialog._draft.steps[0].events[0].source == "kbd"
+
     def test_combo_editor_capture_request_uses_profile_name(self, monkeypatch):
         from gi.repository import Gtk
 
@@ -181,6 +219,39 @@ class TestComboEditorDialog:
             "key_leftctrl",
             "key_s",
         ]
+
+    def test_combo_editor_any_device_save_preserves_scope_and_sets_flag(self):
+        from gi.repository import Gtk
+
+        from keymasq.common.models import ActionType, ComboEvent, ComboStep, MappingAction
+        from keymasq.gui.widgets.combo_editor_dialog import ComboEditorDialog
+
+        parent = Gtk.Box()
+        dialog = ComboEditorDialog(parent)
+        captured = []
+        dialog.connect("combo-saved", lambda _dialog, combo: captured.append(combo))
+
+        dialog._draft.steps.append(
+            ComboStep(
+                events=[
+                    ComboEvent(evdev="key_a", hardware_id="1234:5678", source="kbd"),
+                ]
+            )
+        )
+        dialog._refresh_trigger_display()
+        dialog._on_action_selected(
+            None,
+            MappingAction(action_type=ActionType.KEYBOARD, target="key_f5"),
+        )
+        dialog.any_device_row.set_active(True)
+        assert dialog._draft.steps[0].events[0].hardware_id == "1234:5678"
+        assert dialog._draft.steps[0].events[0].source == "kbd"
+
+        dialog._on_save_clicked(None)
+
+        assert captured[0].match_across_devices is True
+        assert captured[0].steps[0].events[0].hardware_id == "1234:5678"
+        assert captured[0].steps[0].events[0].source == "kbd"
 
     def test_combo_editor_generates_default_name_when_name_is_empty(self):
         from gi.repository import Gtk
@@ -348,6 +419,59 @@ class TestComboEditorDialog:
                         ComboStep(
                             events=[
                                 ComboEvent(evdev="key_1", hardware_id="1234:5678", source="kbd")
+                            ]
+                        ),
+                    ],
+                    action=MappingAction(action_type=ActionType.KEYBOARD, target="key_f6"),
+                )
+            ],
+        )
+
+        assert dialog.validation_label.get_visible() is True
+        assert "same trigger already exists" in dialog.validation_label.get_text().lower()
+        assert dialog.save_button.get_sensitive() is False
+
+    def test_combo_editor_portable_duplicate_uses_runtime_scope_for_validation(self):
+        from gi.repository import Gtk
+
+        from keymasq.common.models import (
+            ActionType,
+            ComboConfig,
+            ComboEvent,
+            ComboStep,
+            MappingAction,
+        )
+        from keymasq.gui.widgets.combo_editor_dialog import ComboEditorDialog
+
+        parent = Gtk.Box()
+        dialog = ComboEditorDialog(
+            parent,
+            ComboConfig(
+                id="combo-2",
+                name="Portable B",
+                match_across_devices=True,
+                steps=[
+                    ComboStep(
+                        events=[
+                            ComboEvent(evdev="key_f13", hardware_id="3333:4444", source="kbd")
+                        ]
+                    ),
+                ],
+                action=MappingAction(action_type=ActionType.KEYBOARD, target="key_f5"),
+            ),
+            sibling_combos=[
+                ComboConfig(
+                    id="combo-1",
+                    name="Portable A",
+                    match_across_devices=True,
+                    steps=[
+                        ComboStep(
+                            events=[
+                                ComboEvent(
+                                    evdev="key_f13",
+                                    hardware_id="1234:5678",
+                                    source="kbd",
+                                )
                             ]
                         ),
                     ],

--- a/tests/keymasqd/test_combo_action_dispatch.py
+++ b/tests/keymasqd/test_combo_action_dispatch.py
@@ -679,6 +679,178 @@ class TestComboActionDispatch:
         await _runtime_clear_combo_scope(manager, "1234:5678", "kbd")
 
         assert manager.combo_state.superkey_machines == {}
+
+    @pytest.mark.asyncio
+    async def test_clear_combo_scope_keeps_wildcard_pattern_machine_for_other_device(
+        self,
+    ) -> None:
+        manager = DeviceManager()
+        manager.output_state.keyboard_uinput = _FakeUInput()
+        configured = dm.RuntimeComboBinding(hardware_id="", source="", evdev="key_a")
+        trigger = dm.RuntimeComboBinding(
+            hardware_id="1234:5678",
+            source="kbd",
+            evdev="key_a",
+        )
+        action = dm.MappingAction(
+            action_type=ActionType.SUPERKEY,
+            superkey_config=SuperkeyConfig(
+                name="combo-pattern-wildcard-scope",
+                mode=SuperkeyMode.PATTERN,
+                tap_actions=[SuperkeyActionData(action_type="keyboard", target="key_a")],
+                double_tap_actions=[SuperkeyActionData(action_type="keyboard", target="key_b")],
+            ),
+        )
+        manager.active_combos = [
+            dm.RuntimeCombo(
+                id="combo-pattern-wildcard-scope",
+                name="combo-pattern-wildcard-scope",
+                steps=[dm.RuntimeComboStep(bindings=(configured,))],
+                action=action,
+            )
+        ]
+
+        await _runtime_start_combo_action(
+            manager,
+            "combo-pattern-wildcard-scope",
+            action,
+            trigger,
+        )
+
+        await _runtime_clear_combo_scope(manager, "9999:0001", "kbd")
+
+        assert "combo-pattern-wildcard-scope" in manager.combo_state.active_actions
+        assert "combo-pattern-wildcard-scope" in manager.combo_state.superkey_machines
+
+        await _runtime_stop_combo_action(manager, "combo-pattern-wildcard-scope")
+        assert "combo-pattern-wildcard-scope" in manager.combo_state.superkey_machines
+
+        await _runtime_clear_combo_scope(manager, "9999:0001", "kbd")
+        assert "combo-pattern-wildcard-scope" in manager.combo_state.superkey_machines
+
+        await _runtime_clear_combo_scope(manager, "1234:5678", "kbd")
+
+        assert manager.combo_state.superkey_machines == {}
+        assert manager.combo_state.superkey_machine_bindings == {}
+
+    @pytest.mark.asyncio
+    async def test_combo_pattern_superkey_recreates_cached_machine_for_new_trigger_device(
+        self,
+    ) -> None:
+        manager = DeviceManager()
+        manager.output_state.keyboard_uinput = _FakeUInput()
+        configured = dm.RuntimeComboBinding(hardware_id="", source="", evdev="key_a")
+        trigger_a = dm.RuntimeComboBinding(
+            hardware_id="1234:5678",
+            source="kbd",
+            evdev="key_a",
+        )
+        trigger_b = dm.RuntimeComboBinding(
+            hardware_id="9999:0001",
+            source="kbd",
+            evdev="key_a",
+        )
+        action = dm.MappingAction(
+            action_type=ActionType.SUPERKEY,
+            superkey_config=SuperkeyConfig(
+                name="combo-pattern-wildcard-reuse",
+                mode=SuperkeyMode.PATTERN,
+                tap_actions=[SuperkeyActionData(action_type="keyboard", target="key_a")],
+                double_tap_actions=[SuperkeyActionData(action_type="keyboard", target="key_b")],
+            ),
+        )
+        manager.active_combos = [
+            dm.RuntimeCombo(
+                id="combo-pattern-wildcard-reuse",
+                name="combo-pattern-wildcard-reuse",
+                steps=[dm.RuntimeComboStep(bindings=(configured,))],
+                action=action,
+            )
+        ]
+
+        await _runtime_start_combo_action(
+            manager,
+            "combo-pattern-wildcard-reuse",
+            action,
+            trigger_a,
+        )
+        await _runtime_stop_combo_action(manager, "combo-pattern-wildcard-reuse")
+        first_machine = manager.combo_state.superkey_machines[
+            "combo-pattern-wildcard-reuse"
+        ]
+
+        await _runtime_start_combo_action(
+            manager,
+            "combo-pattern-wildcard-reuse",
+            action,
+            trigger_b,
+        )
+        second_machine = manager.combo_state.superkey_machines[
+            "combo-pattern-wildcard-reuse"
+        ]
+
+        assert second_machine is not first_machine
+        assert second_machine.source_device == "9999:0001"
+        assert (
+            manager.combo_state.superkey_machine_bindings["combo-pattern-wildcard-reuse"]
+            == (trigger_b,)
+        )
+
+    @pytest.mark.asyncio
+    async def test_clear_combo_scope_checks_all_cached_pattern_trigger_bindings(
+        self,
+    ) -> None:
+        manager = DeviceManager()
+        manager.output_state.keyboard_uinput = _FakeUInput()
+        configured_a = dm.RuntimeComboBinding(hardware_id="", source="", evdev="key_a")
+        configured_b = dm.RuntimeComboBinding(hardware_id="", source="", evdev="key_b")
+        trigger_a = dm.RuntimeComboBinding(
+            hardware_id="1234:5678",
+            source="kbd",
+            evdev="key_a",
+        )
+        trigger_b = dm.RuntimeComboBinding(
+            hardware_id="9999:0001",
+            source="kbd",
+            evdev="key_b",
+        )
+        action = dm.MappingAction(
+            action_type=ActionType.SUPERKEY,
+            superkey_config=SuperkeyConfig(
+                name="combo-pattern-multi-scope",
+                mode=SuperkeyMode.PATTERN,
+                tap_actions=[SuperkeyActionData(action_type="keyboard", target="key_a")],
+                double_tap_actions=[SuperkeyActionData(action_type="keyboard", target="key_b")],
+            ),
+        )
+        manager.active_combos = [
+            dm.RuntimeCombo(
+                id="combo-pattern-multi-scope",
+                name="combo-pattern-multi-scope",
+                steps=[dm.RuntimeComboStep(bindings=(configured_a, configured_b))],
+                action=action,
+            )
+        ]
+
+        await _runtime_start_combo_action(
+            manager,
+            "combo-pattern-multi-scope",
+            action,
+            trigger_b,
+            trigger_bindings=(trigger_a, trigger_b),
+        )
+        await _runtime_stop_combo_action(manager, "combo-pattern-multi-scope")
+
+        assert (
+            manager.combo_state.superkey_machine_bindings["combo-pattern-multi-scope"]
+            == (trigger_a, trigger_b)
+        )
+
+        await _runtime_clear_combo_scope(manager, "1234:5678", "kbd")
+
+        assert manager.combo_state.superkey_machines == {}
+        assert manager.combo_state.superkey_machine_bindings == {}
+
     @pytest.mark.asyncio
     async def test_combo_pattern_superkey_replaces_stale_cached_machine_when_config_changes(
         self,

--- a/tests/keymasqd/test_combo_engine_overlap.py
+++ b/tests/keymasqd/test_combo_engine_overlap.py
@@ -156,11 +156,27 @@ def test_blank_hardware_id_matches_any_hardware_without_source_guessing():
         0.05,
     )
 
+    second_hardware = _handle(
+        engine,
+        _binding("key_a", hardware_id="5555:6666", source="kbd"),
+        1,
+        0.1,
+    )
+    assert second_hardware.consume_current_event is True
+    assert second_hardware.action_transition is not None
+    assert second_hardware.action_transition.combo_id == "combo-1"
+    _handle(
+        engine,
+        _binding("key_a", hardware_id="5555:6666", source="kbd"),
+        0,
+        0.15,
+    )
+
     wrong_source = _handle(
         engine,
         _binding("key_a", hardware_id="3333:4444", source="mouse"),
         1,
-        0.1,
+        0.2,
     )
     assert wrong_source.consume_current_event is False
     assert wrong_source.passthrough_current_event is False

--- a/tests/keymasqd/test_combo_engine_overlap.py
+++ b/tests/keymasqd/test_combo_engine_overlap.py
@@ -135,6 +135,37 @@ def test_exact_binding_matching_requires_hardware_and_source_match():
     assert wrong_source.passthrough_current_event is False
 
 
+def test_blank_hardware_id_matches_any_hardware_without_source_guessing():
+    engine = ComboEngine()
+    expected = _binding("key_a", hardware_id="", source="kbd")
+    engine.set_combos([_combo("combo-1", (expected,))])
+
+    first_hardware = _handle(
+        engine,
+        _binding("key_a", hardware_id="1111:2222", source="kbd"),
+        1,
+        0.0,
+    )
+    assert first_hardware.consume_current_event is True
+    assert first_hardware.action_transition is not None
+    assert first_hardware.action_transition.combo_id == "combo-1"
+    _handle(
+        engine,
+        _binding("key_a", hardware_id="1111:2222", source="kbd"),
+        0,
+        0.05,
+    )
+
+    wrong_source = _handle(
+        engine,
+        _binding("key_a", hardware_id="3333:4444", source="mouse"),
+        1,
+        0.1,
+    )
+    assert wrong_source.consume_current_event is False
+    assert wrong_source.passthrough_current_event is False
+
+
 def test_modifier_side_is_ignored_for_matching():
     engine = ComboEngine()
     generic_ctrl = _binding("ctrl")
@@ -176,3 +207,25 @@ def test_held_bindings_for_step_respects_source_specific_and_wildcard_matching()
     assert next(iter(wildcard_match)) in {held_aux, held_kbd}
 
 
+def test_held_bindings_for_step_respects_hardware_wildcard_matching():
+    engine = ComboEngine()
+    held_first = _binding("key_leftalt", hardware_id="1111:2222", source="kbd")
+    held_second = _binding("key_leftalt", hardware_id="3333:4444", source="kbd")
+    engine.prime_held_bindings({held_first, held_second})
+
+    source_specific = RuntimeComboStep(
+        bindings=(RuntimeComboBinding("", "key_leftalt", "kbd"),)
+    )
+    source_wildcard = RuntimeComboStep(
+        bindings=(RuntimeComboBinding("", "key_leftalt", ""),)
+    )
+
+    source_specific_match = engine._held_bindings_for_step(source_specific)
+    assert source_specific_match is not None
+    assert len(source_specific_match) == 1
+    assert next(iter(source_specific_match)) in {held_first, held_second}
+
+    source_wildcard_match = engine._held_bindings_for_step(source_wildcard)
+    assert source_wildcard_match is not None
+    assert len(source_wildcard_match) == 1
+    assert next(iter(source_wildcard_match)) in {held_first, held_second}

--- a/tests/keymasqd/test_combo_engine_scope.py
+++ b/tests/keymasqd/test_combo_engine_scope.py
@@ -187,3 +187,30 @@ def test_drop_candidates_for_binding_scope_can_target_specific_source():
     assert release_mouse.action_transition is not None
     assert release_mouse.action_transition.combo_id == "combo-mouse"
     assert release_mouse.action_transition.kind == "release"
+
+
+def test_wildcard_combo_release_from_other_device_does_not_stop_active_combo():
+    engine = ComboEngine()
+    expected = RuntimeComboBinding(hardware_id="", source="", evdev="key_f13")
+    key_a = _binding("key_f13", hardware_id="1111:2222", source="kbd")
+    key_b = _binding("key_f13", hardware_id="3333:4444", source="kbd")
+    engine.set_combos([_combo("combo-any", (expected,))])
+
+    press_a = _handle(engine, key_a, 1, 0.0)
+    assert press_a.consume_current_event is True
+    assert press_a.action_transition is not None
+    assert press_a.action_transition.kind == "press"
+
+    press_b = _handle(engine, key_b, 1, 0.1)
+    assert press_b.consume_current_event is False
+    assert press_b.action_transition is None
+
+    release_b = _handle(engine, key_b, 0, 0.2)
+    assert release_b.consume_current_event is False
+    assert release_b.action_transition is None
+
+    release_a = _handle(engine, key_a, 0, 0.3)
+    assert release_a.consume_current_event is True
+    assert release_a.action_transition is not None
+    assert release_a.action_transition.combo_id == "combo-any"
+    assert release_a.action_transition.kind == "release"

--- a/tests/keymasqd/test_device_manager_combo_matching.py
+++ b/tests/keymasqd/test_device_manager_combo_matching.py
@@ -93,6 +93,37 @@ class TestCombos:
         assert len(manager.active_combos) == 1
         assert manager.active_combos[0].action is not None
         assert manager.active_combos[0].action.profile_name == "Gaming"
+
+    @pytest.mark.asyncio
+    async def test_set_combos_allows_omitted_hardware_id_as_wildcard(self):
+        manager = DeviceManager()
+
+        await manager.set_combos(
+            [
+                {
+                    "id": "combo-any-keyboard",
+                    "name": "Any Keyboard",
+                    "steps": [{"events": [{"source": "kbd", "evdev": "key_f13"}]}],
+                    "action": {"action": "suppress"},
+                }
+            ]
+        )
+
+        assert manager.active_combos[0].steps[0].bindings[0].hardware_id == ""
+
+        pressed = await _runtime_on_device_event(
+            manager,
+            "9999:0001",
+            "/dev/input/event-test",
+            evdev.ecodes.EV_KEY,
+            evdev.ecodes.KEY_F13,
+            1,
+            source="kbd",
+        )
+
+        assert pressed is not None
+        assert pressed.consume_current_event is True
+
     @pytest.mark.asyncio
     async def test_set_combos_reseeds_held_bindings_after_mapping_reset(
         self,

--- a/tests/session/test_session_manager_payloads_extra.py
+++ b/tests/session/test_session_manager_payloads_extra.py
@@ -333,7 +333,10 @@ def test_combo_payloads_filter_invalid_actions_and_track_exec_refs() -> None:
         "profile_name": "Default",
         "steps": [
             {
-                "events": [{"hardware_id": "kbd", "evdev": "key_a", "source": "main"}],
+                "events": [
+                    {"hardware_id": "kbd", "evdev": "key_a", "source": "main"},
+                    {"evdev": "key_b", "source": "ignored"},
+                ],
                 "timeout_ms": 250,
             }
         ],


### PR DESCRIPTION
## Summary

- Makes `hardware_id` optional on combo events; when empty, matches any already-grabbed device
- Adds `source` as an optional evdev interface label scope constraint
- Adds `match_across_devices` combo flag: preserves captured scope in storage but strips `hardware_id`/`source` at runtime
- Expands combo engine indexing to handle all four hardware/source specificity combinations
- Updates `ComboEditorDialog` with a "Match Across Devices" switch and scoped duplicate detection
- Removes the strict `hardware_id` requirement in capture responses, profile loading, and serialization
- Adds `trigger_bindings` to `ComboActionState` for proper superkey machine re-identification
- Updates agent docs (`COMBOS.md`, `superkeys-combos.txt`) with scope semantics
- Adds tests for optional hardware_id round-trip, match-across-devices storage/runtime split, and engine scope lookups

## Testing

- `tests/common/test_profile_manager.py` — new `test_optional_combo_hardware_id_round_trips_without_grab_inference` and `test_match_across_devices_preserves_storage_scope_but_strips_runtime_scope` pass
- `tests/gui/test_combo_editor_dialog.py` — new capture/scope/any-device tests pass
- `tests/keymasqd/test_combo_action_dispatch.py` — new dispatch-vs-scope tests pass
- `tests/keymasqd/test_combo_engine_overlap.py` — new overlap/scope tests pass
- `tests/keymasqd/test_combo_engine_scope.py` — new file with scope lookups passes
- `tests/keymasqd/test_device_manager_combo_matching.py` — new emergency-cancel scoping test passes
- `tests/session/test_session_manager_payloads_extra.py` — existing tests pass
- I ran: manual end-to-end device grab/release cycle with mixed scope combos