### PR TITLE
Add combo inspector window for viewing active combos across profiles

### DIFF
--- a/docs/COMBOS.md
+++ b/docs/COMBOS.md
@@ -17,6 +17,16 @@ macro, a shell command, or anything else Keymasq can map to.
 Combos are stored inside profiles. They can include events from multiple
 devices, so a combo can combine a keyboard key and a mouse button if needed.
 
+The Combos tab edits the combos stored in one selected profile. Use the inspect
+button in the Combos tab to open a read-only active combo inspector. The
+inspector shows the combos currently resolved from all active layered profiles,
+including the source profile for each combo. If two active profiles define the
+same trigger, only the later winning combo appears there. Prefix-overlap
+between different combo triggers remains valid and is not treated as a conflict.
+The inspector keeps a small in-window history of unique active-combo snapshots,
+so rule-based profiles can still be inspected after focus changes back to the
+Keymasq window.
+
 ## Quick Start: Your First Combo
 
 1. Open the Keymasq GUI and go to the **Combo** tab.

--- a/docs/COMBOS.md
+++ b/docs/COMBOS.md
@@ -17,16 +17,6 @@ macro, a shell command, or anything else Keymasq can map to.
 Combos are stored inside profiles. They can include events from multiple
 devices, so a combo can combine a keyboard key and a mouse button if needed.
 
-The Combos tab edits the combos stored in one selected profile. Use the inspect
-button in the Combos tab to open a read-only active combo inspector. The
-inspector shows the combos currently resolved from all active layered profiles,
-including the source profile for each combo. If two active profiles define the
-same trigger, only the later winning combo appears there. Prefix-overlap
-between different combo triggers remains valid and is not treated as a conflict.
-The inspector keeps a small in-window history of unique active-combo snapshots,
-so rule-based profiles can still be inspected after focus changes back to the
-Keymasq window.
-
 ## Quick Start: Your First Combo
 
 1. Open the Keymasq GUI and go to the **Combo** tab.

--- a/keymasq/gui/style.css
+++ b/keymasq/gui/style.css
@@ -203,6 +203,10 @@ button.button-card-mapped-inactive label {
   cursor: pointer;
 }
 
+.combo-row-readonly:hover {
+  cursor: default;
+}
+
 .combo-row:active {
   background: alpha(@accent_color, 0.14);
 }

--- a/keymasq/gui/widgets/combo_inspector_window.py
+++ b/keymasq/gui/widgets/combo_inspector_window.py
@@ -1,0 +1,853 @@
+import json
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, cast
+
+import gi
+
+gi.require_version("Gtk", "4.0")
+gi.require_version("Adw", "1")
+
+from gi.repository import Adw, Gdk, Gtk, Pango  # pyright: ignore[reportAttributeAccessIssue]
+
+from keymasq.common.models import (
+    DEFAULT_MACRO_LOOP_STOP_BEHAVIOR,
+    ActionType,
+    ComboConfig,
+    ComboEvent,
+    ComboStep,
+    MappingAction,
+    parse_profile_deactivation_policy,
+)
+from keymasq.gui.icons import combo_icon_names, image_from_icon_names
+from keymasq.gui.session_client import (
+    JsonDict,
+    register_session_event_callback,
+    session_request_async,
+    unregister_session_event_callback,
+)
+from keymasq.gui.widgets.combo_editor_dialog import (
+    combo_action_label,
+    combo_default_name,
+    combo_key_label,
+    combo_step_label,
+    combo_trigger_label,
+    describe_mapping_action,
+)
+from keymasq.gui.widgets.combo_tab import combo_search_text
+from keymasq.gui.widgets.fuzzy_search import fuzzy_query_matches, install_listbox_fuzzy_filter
+
+
+@dataclass
+class ComboInspectorItem:
+    combo_id: str
+    name: str
+    profile_name: str
+    steps: list[ComboStep]
+    action: MappingAction | None
+    order: int
+    recall_trigger_keys: bool = False
+    restore_trigger_keys: list[str] | None = None
+    step_tooltips: list[str] | None = None
+    search_text: str = ""
+
+
+@dataclass
+class ComboInspectorSnapshot:
+    signature: str
+    seen_at: str
+    active_profiles: list[str]
+    items: list[ComboInspectorItem]
+
+
+SNAPSHOT_HISTORY_LIMIT = 12
+
+
+class ComboInspectorWindow(Adw.Window):
+    def __init__(self, parent: Gtk.Window):
+        super().__init__()
+        self._parent = parent
+        self._closing = False
+        self._finalized = False
+        self._items: list[ComboInspectorItem] = []
+        self._active_profiles: list[str] = []
+        self._snapshots: list[ComboInspectorSnapshot] = []
+        self._latest_snapshot_signature = ""
+        self._selected_snapshot_signature = ""
+        self._follow_latest_snapshot = True
+        self._syncing_snapshot_selector = False
+
+        self.set_title("Inspect Active Combos")
+        self.set_default_size(780, 520)
+        self.set_transient_for(parent)
+        self.set_modal(False)
+
+        self._build_ui()
+
+        register_session_event_callback("profiles_changed", self._on_profiles_changed)
+        register_session_event_callback("runtime_reset", self._on_runtime_reset)
+        register_session_event_callback("keymasqd_status", self._on_keymasqd_status)
+        self.connect("close-request", self._on_close_request)
+        self.connect("destroy", self._on_destroy)
+
+        self._request_snapshot()
+
+    def _build_ui(self) -> None:
+        toolbar = Adw.ToolbarView()
+        header = Adw.HeaderBar()
+
+        icon = image_from_icon_names(*combo_icon_names(), pixel_size=24)
+        icon.set_valign(Gtk.Align.CENTER)
+        header.pack_start(icon)
+
+        self._status_label = Gtk.Label(label="Loading active combos")
+        self._status_label.add_css_class("inspector-header-title")
+        self._status_label.set_halign(Gtk.Align.START)
+        self._status_label.set_hexpand(True)
+        self._status_label.set_ellipsize(Pango.EllipsizeMode.END)
+        self._status_label.set_max_width_chars(54)
+        header.pack_start(self._status_label)
+        header.set_title_widget(Gtk.Box())
+
+        self.snapshot_dropdown = Gtk.DropDown()
+        self.snapshot_dropdown.set_tooltip_text("Select a captured active-combo snapshot")
+        self.snapshot_dropdown.set_size_request(230, -1)
+        self.snapshot_dropdown.connect("notify::selected", self._on_snapshot_selected)
+        header.pack_end(self.snapshot_dropdown)
+
+        self.search_button = Gtk.Button()
+        self.search_button.set_icon_name("system-search-symbolic")
+        self.search_button.set_tooltip_text("Search active combos")
+        self.search_button.connect("clicked", self._on_search_clicked)
+        header.pack_end(self.search_button)
+
+        toolbar.add_top_bar(header)
+
+        key_controller = Gtk.EventControllerKey()
+        key_controller.connect("key-pressed", self._on_key_pressed)
+        self.add_controller(key_controller)
+
+        content = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=10)
+        content.set_margin_top(14)
+        content.set_margin_bottom(14)
+        content.set_margin_start(14)
+        content.set_margin_end(14)
+
+        active_profile_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=6)
+        active_title = Gtk.Label(label="Active profiles:")
+        active_title.add_css_class("caption")
+        active_title.add_css_class("dim-label")
+        active_profile_box.append(active_title)
+
+        self.active_profiles_label = Gtk.Label(label="None")
+        self.active_profiles_label.add_css_class("caption")
+        self.active_profiles_label.set_ellipsize(Pango.EllipsizeMode.END)
+        self.active_profiles_label.set_hexpand(True)
+        self.active_profiles_label.set_halign(Gtk.Align.START)
+        active_profile_box.append(self.active_profiles_label)
+        content.append(active_profile_box)
+
+        self.search_entry = Gtk.SearchEntry()
+        self.search_entry.set_placeholder_text("Search active combos")
+        self.search_entry.set_tooltip_text(
+            "Filter active combos by name, trigger, action, profile, device, or source"
+        )
+        self.search_entry.set_visible(False)
+        self.search_entry.connect("stop-search", self._on_search_stop)
+        content.append(self.search_entry)
+
+        toolbar_row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=8)
+        self.section_label = Gtk.Label(label="Active Combos")
+        self.section_label.add_css_class("heading")
+        self.section_label.set_hexpand(True)
+        self.section_label.set_halign(Gtk.Align.START)
+        toolbar_row.append(self.section_label)
+        content.append(toolbar_row)
+
+        self.column_header = self._create_column_header()
+        content.append(self.column_header)
+
+        self.combo_listbox = Gtk.ListBox()
+        self.combo_listbox.set_selection_mode(Gtk.SelectionMode.NONE)
+        self.combo_listbox.add_css_class("boxed-list")
+        install_listbox_fuzzy_filter(
+            self.combo_listbox,
+            self.search_entry,
+            after_filter_changed=self._after_search_filter_changed,
+        )
+
+        scrolled = Gtk.ScrolledWindow()
+        scrolled.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
+        scrolled.set_vexpand(True)
+        scrolled.set_child(self.combo_listbox)
+        content.append(scrolled)
+
+        toolbar.set_content(content)
+        self.set_content(toolbar)
+
+    def _create_column_header(self) -> Gtk.Box:
+        col_header = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=12)
+        col_header.add_css_class("combo-column-header")
+
+        name_label = Gtk.Label(label="Name")
+        name_label.add_css_class("combo-col-btn")
+        name_label.set_hexpand(True)
+        name_label.set_halign(Gtk.Align.START)
+        col_header.append(name_label)
+
+        trigger_label = Gtk.Label(label="Trigger")
+        trigger_label.add_css_class("combo-col-btn")
+        trigger_label.set_halign(Gtk.Align.START)
+        col_header.append(trigger_label)
+
+        action_label = Gtk.Label(label="Action")
+        action_label.add_css_class("combo-col-btn")
+        action_label.set_size_request(180, -1)
+        action_label.set_halign(Gtk.Align.END)
+        col_header.append(action_label)
+        return col_header
+
+    def _request_snapshot(self) -> None:
+        if self._closing:
+            return
+        session_request_async(
+            {"command": "get_combo_inspector_snapshot"},
+            self._on_snapshot_response,
+            timeout=3.0,
+        )
+
+    def _on_snapshot_response(self, result: JsonDict | None) -> bool:
+        if self._closing:
+            return False
+        if not result or result.get("status") != "ok":
+            message = _text((result or {}).get("message"), "Combo inspector unavailable")
+            self._set_status_title(message, "stopped")
+            self._items = []
+            self._active_profiles = []
+            self._sync_active_profile_label()
+            self._render_combo_list()
+            return False
+        self._apply_snapshot(result)
+        return False
+
+    def _apply_snapshot(self, snapshot: JsonDict) -> None:
+        new_snapshot = _snapshot_from_payload(snapshot)
+        self._store_snapshot(new_snapshot)
+        selected = self._selected_snapshot()
+        if selected is not None:
+            self._show_snapshot(selected)
+
+    def _store_snapshot(self, snapshot: ComboInspectorSnapshot) -> None:
+        self._latest_snapshot_signature = snapshot.signature
+        self._snapshots = [
+            existing
+            for existing in self._snapshots
+            if existing.signature != snapshot.signature
+        ]
+        self._snapshots.insert(0, snapshot)
+        del self._snapshots[SNAPSHOT_HISTORY_LIMIT:]
+
+        selected_still_exists = any(
+            existing.signature == self._selected_snapshot_signature
+            for existing in self._snapshots
+        )
+        if not selected_still_exists:
+            self._follow_latest_snapshot = True
+
+        if self._follow_latest_snapshot or not self._selected_snapshot_signature:
+            self._selected_snapshot_signature = snapshot.signature
+            self._follow_latest_snapshot = True
+        elif self._selected_snapshot_signature == snapshot.signature:
+            self._follow_latest_snapshot = True
+
+        self._refresh_snapshot_dropdown()
+
+    def _selected_snapshot(self) -> ComboInspectorSnapshot | None:
+        for snapshot in self._snapshots:
+            if snapshot.signature == self._selected_snapshot_signature:
+                return snapshot
+        return self._snapshots[0] if self._snapshots else None
+
+    def _show_snapshot(self, snapshot: ComboInspectorSnapshot) -> None:
+        self._selected_snapshot_signature = snapshot.signature
+        self._follow_latest_snapshot = snapshot.signature == self._latest_snapshot_signature
+        self._active_profiles = list(snapshot.active_profiles)
+        self._items = list(snapshot.items)
+        self._sync_active_profile_label()
+        count = len(self._items)
+        suffix = "combo" if count == 1 else "combos"
+        if self._follow_latest_snapshot:
+            title = f"Active Combos - {count} {suffix}"
+        else:
+            title = f"Active Combos Snapshot - {count} {suffix}"
+        self._set_status_title(title, "monitoring")
+        self._render_combo_list()
+
+    def _refresh_snapshot_dropdown(self) -> None:
+        strings = Gtk.StringList()
+        for snapshot in self._snapshots:
+            strings.append(self._snapshot_dropdown_label(snapshot))
+
+        selected_index = 0
+        for index, snapshot in enumerate(self._snapshots):
+            if snapshot.signature == self._selected_snapshot_signature:
+                selected_index = index
+                break
+
+        self._syncing_snapshot_selector = True
+        try:
+            self.snapshot_dropdown.set_model(strings)
+            self.snapshot_dropdown.set_sensitive(len(self._snapshots) > 1)
+            if self._snapshots:
+                self.snapshot_dropdown.set_selected(selected_index)
+        finally:
+            self._syncing_snapshot_selector = False
+
+    def _snapshot_dropdown_label(self, snapshot: ComboInspectorSnapshot) -> str:
+        prefix = (
+            "Now"
+            if snapshot.signature == self._latest_snapshot_signature
+            else snapshot.seen_at
+        )
+        summary = _profile_summary(snapshot.active_profiles)
+        count = len(snapshot.items)
+        suffix = "combo" if count == 1 else "combos"
+        return f"{prefix}: {summary} ({count} {suffix})"
+
+    def _on_snapshot_selected(self, dropdown: Gtk.DropDown, _param: object) -> None:
+        if self._syncing_snapshot_selector:
+            return
+        selected = dropdown.get_selected()
+        if selected >= len(self._snapshots):
+            return
+        self._show_snapshot(self._snapshots[selected])
+
+    def _sync_active_profile_label(self) -> None:
+        if not self._active_profiles:
+            self.active_profiles_label.set_text("None")
+            self.active_profiles_label.set_tooltip_text("No profiles are active.")
+            return
+        visible_names = self._active_profiles[:3]
+        summary = ", ".join(visible_names)
+        if len(self._active_profiles) > len(visible_names):
+            summary += f", +{len(self._active_profiles) - len(visible_names)}"
+        self.active_profiles_label.set_text(summary)
+        self.active_profiles_label.set_tooltip_text(
+            "Layer order: " + " -> ".join(self._active_profiles)
+        )
+
+    def _set_status_title(self, text: str, state: str) -> None:
+        self._status_label.set_text(text)
+        self._status_label.set_tooltip_text(text)
+        for css_class in (
+            "inspector-header-monitoring",
+            "inspector-header-suppressed",
+            "inspector-header-stopped",
+        ):
+            self._status_label.remove_css_class(css_class)
+        self._status_label.add_css_class(
+            {
+                "stopped": "inspector-header-stopped",
+            }.get(state, "inspector-header-monitoring")
+        )
+
+    def _render_combo_list(self) -> None:
+        while row := self.combo_listbox.get_first_child():
+            self.combo_listbox.remove(row)
+
+        for item in self._items:
+            self.combo_listbox.append(self._create_combo_row(item))
+        self._update_combo_list_state(has_combos=bool(self._items))
+
+    def _create_combo_row(self, item: ComboInspectorItem) -> Gtk.ListBoxRow:
+        row = Gtk.ListBoxRow()
+        row.set_selectable(False)
+        row._combo_id = item.combo_id  # type: ignore[attr-defined]
+        row._search_text = item.search_text  # type: ignore[attr-defined]
+
+        box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=12)
+        box.add_css_class("combo-row")
+        box.add_css_class("combo-row-readonly")
+
+        name_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=2)
+        name_box.set_hexpand(True)
+        name_box.set_halign(Gtk.Align.START)
+
+        name_label = Gtk.Label(label=item.name)
+        name_label.set_halign(Gtk.Align.START)
+        name_label.set_xalign(0.0)
+        name_label.set_ellipsize(Pango.EllipsizeMode.END)
+        name_label.add_css_class("heading")
+        name_box.append(name_label)
+
+        profile_label = Gtk.Label(label=f"Profile: {item.profile_name or '?'}")
+        profile_label.set_halign(Gtk.Align.START)
+        profile_label.set_xalign(0.0)
+        profile_label.set_ellipsize(Pango.EllipsizeMode.END)
+        profile_label.add_css_class("caption")
+        profile_label.add_css_class("dim-label")
+        name_box.append(profile_label)
+        box.append(name_box)
+
+        trigger_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=4)
+        trigger_box.set_halign(Gtk.Align.START)
+        for index, step in enumerate(item.steps):
+            pill = Gtk.Label(label=combo_step_label(step))
+            pill.add_css_class("combo-step-pill")
+            if item.step_tooltips and index < len(item.step_tooltips):
+                pill.set_tooltip_text(item.step_tooltips[index])
+            trigger_box.append(pill)
+            if index < len(item.steps) - 1:
+                arrow = Gtk.Label(label="\u2192")
+                arrow.add_css_class("dim-label")
+                trigger_box.append(arrow)
+        box.append(trigger_box)
+
+        action_label = Gtk.Label(label=describe_mapping_action(item.action))
+        action_label.set_width_chars(22)
+        action_label.set_max_width_chars(22)
+        action_label.set_ellipsize(Pango.EllipsizeMode.END)
+        action_label.set_halign(Gtk.Align.END)
+        action_label.set_xalign(1.0)
+        action_label.add_css_class("dim-label")
+        action_label.add_css_class("caption")
+        box.append(action_label)
+
+        row.set_child(box)
+        row.set_tooltip_text(_combo_tooltip(item))
+        return row
+
+    def _iter_combo_rows(self):
+        row = self.combo_listbox.get_first_child()
+        while row is not None:
+            yield row
+            row = row.get_next_sibling()
+
+    def _visible_combo_count(self) -> int:
+        query = self.search_entry.get_text()
+        return sum(
+            1
+            for row in self._iter_combo_rows()
+            if fuzzy_query_matches(query, getattr(row, "_search_text", ""))
+        )
+
+    def _update_combo_list_state(self, *, has_combos: bool | None = None) -> None:
+        has_combos = has_combos if has_combos is not None else any(self._iter_combo_rows())
+        visible_count = self._visible_combo_count() if has_combos else 0
+        has_visible_rows = visible_count > 0
+        self.combo_listbox.set_visible(has_visible_rows)
+        self.column_header.set_visible(has_visible_rows)
+        if has_visible_rows:
+            self.section_label.set_text("Active Combos")
+        elif has_combos and self.search_entry.get_text().strip():
+            self.section_label.set_text("No matching active combos.")
+        else:
+            self.section_label.set_text("No active combos.")
+
+    def _after_search_filter_changed(self) -> None:
+        self._update_combo_list_state()
+
+    def _show_search(self) -> None:
+        self.search_entry.set_visible(True)
+        self.search_entry.grab_focus()
+        self.search_entry.select_region(0, -1)
+
+    def _hide_search(self) -> None:
+        self.search_entry.set_text("")
+        self.search_entry.set_visible(False)
+
+    def _on_search_clicked(self, _button: Gtk.Button) -> None:
+        self._show_search()
+
+    def _on_search_stop(self, _entry: Gtk.SearchEntry) -> None:
+        self._hide_search()
+
+    def _on_key_pressed(
+        self,
+        _controller: Gtk.EventControllerKey,
+        keyval: int,
+        _keycode: int,
+        state: Gdk.ModifierType,
+    ) -> bool:
+        if keyval in (Gdk.KEY_f, Gdk.KEY_F) and state & Gdk.ModifierType.CONTROL_MASK:
+            self._show_search()
+            return True
+        if keyval == Gdk.KEY_Escape and self.search_entry.get_visible():
+            self._hide_search()
+            return True
+        return False
+
+    def _on_profiles_changed(self, _event: JsonDict) -> bool:
+        self._request_snapshot()
+        return False
+
+    def _on_runtime_reset(self, _event: JsonDict) -> bool:
+        self._request_snapshot()
+        return False
+
+    def _on_keymasqd_status(self, event: JsonDict) -> bool:
+        if bool(event.get("connected", False)):
+            self._request_snapshot()
+        else:
+            self._set_status_title("Active Combos - Daemon disconnected", "stopped")
+        return False
+
+    def _on_close_request(self, *_args: object) -> bool:
+        self._finalize()
+        return False
+
+    def _on_destroy(self, *_args: object) -> None:
+        self._finalize()
+
+    def _finalize(self) -> None:
+        if self._finalized:
+            return
+        self._finalized = True
+        self._closing = True
+        unregister_session_event_callback("profiles_changed", self._on_profiles_changed)
+        unregister_session_event_callback("runtime_reset", self._on_runtime_reset)
+        unregister_session_event_callback("keymasqd_status", self._on_keymasqd_status)
+
+
+def _snapshot_from_payload(snapshot: JsonDict) -> ComboInspectorSnapshot:
+    combos = snapshot.get("combos", [])
+    items = [
+        item
+        for item in (_combo_item_from_payload(raw) for raw in _list_of_dicts(combos))
+        if item is not None
+    ]
+    return ComboInspectorSnapshot(
+        signature=_snapshot_signature(snapshot),
+        seen_at=datetime.now().strftime("%H:%M:%S"),
+        active_profiles=_active_profiles_from_payload(snapshot),
+        items=items,
+    )
+
+
+def _snapshot_signature(snapshot: JsonDict) -> str:
+    combos: list[dict[str, object]] = []
+    for combo_payload in _list_of_dicts(snapshot.get("combos")):
+        steps: list[dict[str, object]] = []
+        for step_payload in _list_of_dicts(combo_payload.get("steps")):
+            events = [
+                {
+                    "evdev": _text(event_payload.get("evdev")),
+                    "hardware_id": _text(event_payload.get("hardware_id")),
+                    "source": _text(event_payload.get("source")),
+                    "device_name": _text(event_payload.get("device_name")),
+                }
+                for event_payload in _list_of_dicts(step_payload.get("events"))
+            ]
+            steps.append(
+                {
+                    "timeout_ms": _int_or_none(step_payload.get("timeout_ms")),
+                    "events": events,
+                }
+            )
+        combos.append(
+            {
+                "id": _text(combo_payload.get("id")),
+                "name": _text(combo_payload.get("name")),
+                "profile_name": _text(combo_payload.get("profile_name")),
+                "order": _int_value(combo_payload.get("order"), 0),
+                "steps": steps,
+                "action": _json_compatible(combo_payload.get("action")),
+                "recall_trigger_keys": bool(combo_payload.get("recall_trigger_keys", False)),
+                "restore_trigger_keys": [
+                    str(value)
+                    for value in cast(
+                        list[object],
+                        combo_payload.get("restore_trigger_keys") or [],
+                    )
+                    if str(value or "").strip()
+                ],
+            }
+        )
+    return json.dumps(
+        {
+            "active_profiles": _active_profiles_from_payload(snapshot),
+            "combos": combos,
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+
+
+def _json_compatible(value: object) -> object:
+    if isinstance(value, dict):
+        return {
+            str(key): _json_compatible(item)
+            for key, item in cast(dict[object, object], value).items()
+        }
+    if isinstance(value, list):
+        return [_json_compatible(item) for item in cast(list[object], value)]
+    if isinstance(value, str | int | float | bool) or value is None:
+        return value
+    return str(value)
+
+
+def _active_profiles_from_payload(snapshot: JsonDict) -> list[str]:
+    active_profiles = snapshot.get("active_profiles", [])
+    if not isinstance(active_profiles, list):
+        return []
+    return [str(name) for name in active_profiles if str(name or "").strip()]
+
+
+def _profile_summary(active_profiles: list[str]) -> str:
+    if not active_profiles:
+        return "No active profiles"
+    visible_names = active_profiles[:2]
+    summary = " -> ".join(visible_names)
+    if len(active_profiles) > len(visible_names):
+        summary += f" -> +{len(active_profiles) - len(visible_names)}"
+    return summary
+
+
+def _combo_item_from_payload(payload: JsonDict) -> ComboInspectorItem | None:
+    steps: list[ComboStep] = []
+    step_tooltips: list[str] = []
+    search_parts: list[str] = []
+    for step_payload in _list_of_dicts(payload.get("steps")):
+        events: list[ComboEvent] = []
+        scope_lines: list[str] = []
+        for event_payload in _list_of_dicts(step_payload.get("events")):
+            evdev = _text(event_payload.get("evdev"))
+            if not evdev:
+                continue
+            hardware_id = _text(event_payload.get("hardware_id"))
+            source = _text(event_payload.get("source"))
+            device_name = _text(event_payload.get("device_name"))
+            events.append(ComboEvent(evdev=evdev, hardware_id=hardware_id, source=source or None))
+            scope_lines.append(_event_scope_label(evdev, hardware_id, source, device_name))
+            search_parts.extend([evdev, hardware_id, source, device_name])
+        if not events:
+            continue
+        timeout_ms = _int_or_none(step_payload.get("timeout_ms"))
+        if timeout_ms is not None:
+            search_parts.append(f"{timeout_ms}ms")
+        steps.append(ComboStep(events=events, timeout_ms=timeout_ms))
+        step_tooltips.append("\n".join(scope_lines))
+    if not steps:
+        return None
+
+    action = _mapping_action_from_payload(payload.get("action"))
+    combo_id = _text(payload.get("id"))
+    profile_name = _text(payload.get("profile_name"))
+    name = _text(payload.get("name"))
+    if not name:
+        name = _default_name(steps, action)
+    restore_trigger_keys = [
+        str(value)
+        for value in cast(list[object], payload.get("restore_trigger_keys") or [])
+        if str(value or "").strip()
+    ]
+    recall_trigger_keys = bool(payload.get("recall_trigger_keys", False))
+    search_config = _search_combo_config(
+        combo_id,
+        name,
+        steps,
+        action,
+        recall_trigger_keys,
+        restore_trigger_keys,
+    )
+    return ComboInspectorItem(
+        combo_id=combo_id,
+        name=name,
+        profile_name=profile_name,
+        steps=steps,
+        action=action,
+        order=_int_value(payload.get("order"), 0),
+        recall_trigger_keys=recall_trigger_keys,
+        restore_trigger_keys=restore_trigger_keys,
+        step_tooltips=step_tooltips,
+        search_text=" ".join(
+            [
+                combo_search_text(search_config, profile_name=profile_name),
+                " ".join(search_parts),
+                f"order {_int_value(payload.get('order'), 0) + 1}",
+            ]
+        ),
+    )
+
+
+def _search_combo_config(
+    combo_id: str,
+    name: str,
+    steps: list[ComboStep],
+    action: MappingAction | None,
+    recall_trigger_keys: bool,
+    restore_trigger_keys: list[str],
+) -> ComboConfig:
+    return ComboConfig(
+        id=combo_id,
+        name=name,
+        steps=steps,
+        action=action,
+        recall_trigger_keys=recall_trigger_keys,
+        restore_trigger_keys=restore_trigger_keys,
+    )
+
+
+def _mapping_action_from_payload(value: object) -> MappingAction | None:
+    if not isinstance(value, dict):
+        return None
+    action_data = cast(dict[str, object], value)
+    try:
+        action_type = ActionType(_text(action_data.get("action"), ActionType.PASSTHROUGH.value))
+    except ValueError:
+        return None
+
+    macro_name = _text(action_data.get("macro_name"))
+    if action_type == ActionType.MACRO and not macro_name:
+        macro_name = _text(action_data.get("target"))
+    profile_name = _text(action_data.get("profile_name"))
+    if action_type in {
+        ActionType.PROFILE_ENABLE,
+        ActionType.PROFILE_DISABLE,
+        ActionType.PROFILE_TOGGLE,
+    } and not profile_name:
+        profile_name = _text(action_data.get("target"))
+    keys_value = action_data.get("keys")
+    keys = (
+        [str(key) for key in keys_value if str(key or "").strip()]
+        if isinstance(keys_value, list)
+        else None
+    )
+
+    return MappingAction(
+        action_type=action_type,
+        target=_optional_text(action_data.get("target")),
+        output_id=_optional_text(action_data.get("output_id")),
+        keys=keys,
+        cmd=_optional_text(action_data.get("cmd")),
+        superkey_name=_optional_text(action_data.get("superkey_name")),
+        analog_control_names=[
+            str(name)
+            for name in cast(list[object], action_data.get("analog_control_names") or [])
+            if str(name or "").strip()
+        ],
+        macro_name=macro_name or None,
+        macro_replay_mouse_movement=bool(action_data.get("replay_mouse_movement", True)),
+        macro_replay_mouse_clicks=bool(action_data.get("replay_mouse_clicks", True)),
+        macro_speed=_float_value(action_data.get("speed"), 1.0),
+        macro_loop_mode=_text(action_data.get("loop_mode"), "none") or "none",
+        macro_loop_count=_int_value(action_data.get("loop_count"), 1),
+        macro_loop_stop_behavior=(
+            _text(action_data.get("loop_stop_behavior"), DEFAULT_MACRO_LOOP_STOP_BEHAVIOR)
+            or DEFAULT_MACRO_LOOP_STOP_BEHAVIOR
+        ),
+        macro_move_to_start=bool(action_data.get("move_to_start", False)),
+        macro_start_x=_int_value(action_data.get("start_x"), 0),
+        macro_start_y=_int_value(action_data.get("start_y"), 0),
+        macro_block_mouse_movement=bool(action_data.get("block_mouse_movement", False)),
+        profile_name=profile_name or None,
+        compositor_id=_optional_text(action_data.get("compositor")),
+        compositor_dispatcher=_optional_text(action_data.get("dispatcher")),
+        compositor_args=_optional_text(action_data.get("args")),
+        move_x=_int_value(action_data.get("x"), 0),
+        move_y=_int_value(action_data.get("y"), 0),
+        axis_value=_int_value(action_data.get("value"), 0),
+        rapidfire_enabled=bool(action_data.get("rapidfire_enabled", False)),
+        rapidfire_hold_ms=_int_value(action_data.get("rapidfire_hold_ms"), 0),
+        rapidfire_wait_ms=_int_value(action_data.get("rapidfire_wait_ms"), 0),
+        tap_enabled=bool(action_data.get("tap_enabled", False)),
+        tap_hold_ms=_int_value(action_data.get("tap_hold_ms"), 10),
+        source_profile_name=_optional_text(action_data.get("source_profile_name")),
+        profile_deactivation=parse_profile_deactivation_policy(
+            action_data.get("deactivation")
+        ),
+    )
+
+
+def _combo_tooltip(item: ComboInspectorItem) -> str:
+    lines = [
+        f"Profile: {item.profile_name or '?'}",
+        f"Trigger: {combo_trigger_label(item.steps) or '?'}",
+        f"Action: {describe_mapping_action(item.action)}",
+        f"Runtime order: {item.order + 1}",
+    ]
+    if item.recall_trigger_keys:
+        lines.append("Recall trigger keys")
+    if item.restore_trigger_keys:
+        restore_keys = ", ".join(combo_key_label(key) for key in item.restore_trigger_keys)
+        lines.append(f"Restore: {restore_keys}")
+    if item.step_tooltips:
+        lines.append("")
+        lines.extend(item.step_tooltips)
+    return "\n".join(lines)
+
+
+def _event_scope_label(
+    evdev: str,
+    hardware_id: str,
+    source: str,
+    device_name: str,
+) -> str:
+    key = combo_key_label(evdev)
+    scope_parts: list[str] = []
+    if device_name:
+        scope_parts.append(device_name)
+    elif hardware_id:
+        scope_parts.append(hardware_id)
+    else:
+        scope_parts.append("Any device")
+    if source:
+        scope_parts.append(f"source {source}")
+    elif not hardware_id:
+        scope_parts.append("any source")
+    return f"{key}: {', '.join(scope_parts)}"
+
+
+def _default_name(steps: list[ComboStep], action: MappingAction | None) -> str:
+    return combo_default_name(
+        ComboConfig(
+            id="",
+            steps=steps,
+            action=action,
+            name="",
+        )
+    ) or combo_action_label(action)
+
+
+def _list_of_dicts(value: object) -> list[JsonDict]:
+    if not isinstance(value, list):
+        return []
+    return [cast(JsonDict, item) for item in value if isinstance(item, dict)]
+
+
+def _text(value: object, default: str = "") -> str:
+    if value is None:
+        return default
+    return str(value)
+
+
+def _optional_text(value: object) -> str | None:
+    text = _text(value).strip()
+    return text or None
+
+
+def _int_value(value: object, default: int = 0) -> int:
+    if value is None:
+        return default
+    try:
+        return int(cast(Any, value))
+    except (TypeError, ValueError):
+        return default
+
+
+def _int_or_none(value: object) -> int | None:
+    if value is None:
+        return None
+    try:
+        return int(cast(Any, value))
+    except (TypeError, ValueError):
+        return None
+
+
+def _float_value(value: object, default: float = 0.0) -> float:
+    if value is None:
+        return default
+    try:
+        return float(cast(Any, value))
+    except (TypeError, ValueError):
+        return default

--- a/keymasq/gui/widgets/combo_inspector_window.py
+++ b/keymasq/gui/widgets/combo_inspector_window.py
@@ -62,6 +62,14 @@ class ComboInspectorSnapshot:
 
 SNAPSHOT_HISTORY_LIMIT = 12
 
+_SORT_NONE = 0
+_SORT_NAME = 1
+_SORT_TRIGGER = 2
+_SORT_ACTION = 3
+
+_ARROW_UP = " \u25b4"
+_ARROW_DOWN = " \u25be"
+
 
 class ComboInspectorWindow(Adw.Window):
     def __init__(self, parent: Gtk.Window):
@@ -76,6 +84,8 @@ class ComboInspectorWindow(Adw.Window):
         self._selected_snapshot_signature = ""
         self._follow_latest_snapshot = True
         self._syncing_snapshot_selector = False
+        self._sort_column = _SORT_NONE
+        self._sort_ascending = True
 
         self.set_title("Inspect Active Combos")
         self.set_default_size(780, 520)
@@ -156,13 +166,12 @@ class ComboInspectorWindow(Adw.Window):
         self.search_entry.connect("stop-search", self._on_search_stop)
         content.append(self.search_entry)
 
-        toolbar_row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=8)
-        self.section_label = Gtk.Label(label="Active Combos")
+        self.section_label = Gtk.Label(label="")
         self.section_label.add_css_class("heading")
         self.section_label.set_hexpand(True)
         self.section_label.set_halign(Gtk.Align.START)
-        toolbar_row.append(self.section_label)
-        content.append(toolbar_row)
+        self.section_label.set_visible(False)
+        content.append(self.section_label)
 
         self.column_header = self._create_column_header()
         content.append(self.column_header)
@@ -189,22 +198,41 @@ class ComboInspectorWindow(Adw.Window):
         col_header = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=12)
         col_header.add_css_class("combo-column-header")
 
-        name_label = Gtk.Label(label="Name")
-        name_label.add_css_class("combo-col-btn")
-        name_label.set_hexpand(True)
-        name_label.set_halign(Gtk.Align.START)
-        col_header.append(name_label)
+        self._name_header_btn = Gtk.Button(label="Name")
+        self._name_header_btn.add_css_class("flat")
+        self._name_header_btn.add_css_class("combo-col-btn")
+        self._name_header_btn.set_hexpand(True)
+        self._name_header_btn.set_halign(Gtk.Align.START)
+        self._name_header_btn.connect(
+            "clicked",
+            self._on_column_header_clicked,
+            _SORT_NAME,
+        )
+        col_header.append(self._name_header_btn)
 
-        trigger_label = Gtk.Label(label="Trigger")
-        trigger_label.add_css_class("combo-col-btn")
-        trigger_label.set_halign(Gtk.Align.START)
-        col_header.append(trigger_label)
+        self._trigger_header_btn = Gtk.Button(label="Trigger")
+        self._trigger_header_btn.add_css_class("flat")
+        self._trigger_header_btn.add_css_class("combo-col-btn")
+        self._trigger_header_btn.set_halign(Gtk.Align.START)
+        self._trigger_header_btn.connect(
+            "clicked",
+            self._on_column_header_clicked,
+            _SORT_TRIGGER,
+        )
+        col_header.append(self._trigger_header_btn)
 
-        action_label = Gtk.Label(label="Action")
-        action_label.add_css_class("combo-col-btn")
-        action_label.set_size_request(180, -1)
-        action_label.set_halign(Gtk.Align.END)
-        col_header.append(action_label)
+        self._action_header_btn = Gtk.Button(label="Action")
+        self._action_header_btn.add_css_class("flat")
+        self._action_header_btn.add_css_class("combo-col-btn")
+        self._action_header_btn.set_size_request(180, -1)
+        self._action_header_btn.connect(
+            "clicked",
+            self._on_column_header_clicked,
+            _SORT_ACTION,
+        )
+        col_header.append(self._action_header_btn)
+
+        self._update_column_header_labels()
         return col_header
 
     def _request_snapshot(self) -> None:
@@ -355,9 +383,41 @@ class ComboInspectorWindow(Adw.Window):
         while row := self.combo_listbox.get_first_child():
             self.combo_listbox.remove(row)
 
-        for item in self._items:
+        for item in self._sorted_items():
             self.combo_listbox.append(self._create_combo_row(item))
         self._update_combo_list_state(has_combos=bool(self._items))
+
+    def _sorted_items(self) -> list[ComboInspectorItem]:
+        if self._sort_column == _SORT_NAME:
+            result = sorted(self._items, key=lambda item: item.name.casefold())
+        elif self._sort_column == _SORT_TRIGGER:
+            result = sorted(
+                self._items,
+                key=lambda item: combo_trigger_label(item.steps).casefold(),
+            )
+        elif self._sort_column == _SORT_ACTION:
+            result = sorted(
+                self._items,
+                key=lambda item: describe_mapping_action(item.action).casefold(),
+            )
+        else:
+            return list(self._items)
+        if not self._sort_ascending:
+            result.reverse()
+        return result
+
+    def _update_column_header_labels(self) -> None:
+        for col, btn in (
+            (_SORT_NAME, self._name_header_btn),
+            (_SORT_TRIGGER, self._trigger_header_btn),
+            (_SORT_ACTION, self._action_header_btn),
+        ):
+            base = {_SORT_NAME: "Name", _SORT_TRIGGER: "Trigger", _SORT_ACTION: "Action"}[col]
+            if self._sort_column == col:
+                arrow = _ARROW_UP if self._sort_ascending else _ARROW_DOWN
+                btn.set_label(f"{base}{arrow}")
+            else:
+                btn.set_label(base)
 
     def _create_combo_row(self, item: ComboInspectorItem) -> Gtk.ListBoxRow:
         row = Gtk.ListBoxRow()
@@ -438,11 +498,13 @@ class ComboInspectorWindow(Adw.Window):
         self.combo_listbox.set_visible(has_visible_rows)
         self.column_header.set_visible(has_visible_rows)
         if has_visible_rows:
-            self.section_label.set_text("Active Combos")
+            self.section_label.set_visible(False)
         elif has_combos and self.search_entry.get_text().strip():
             self.section_label.set_text("No matching active combos.")
+            self.section_label.set_visible(True)
         else:
             self.section_label.set_text("No active combos.")
+            self.section_label.set_visible(True)
 
     def _after_search_filter_changed(self) -> None:
         self._update_combo_list_state()
@@ -461,6 +523,15 @@ class ComboInspectorWindow(Adw.Window):
 
     def _on_search_stop(self, _entry: Gtk.SearchEntry) -> None:
         self._hide_search()
+
+    def _on_column_header_clicked(self, _button: Gtk.Button, column: int) -> None:
+        if self._sort_column == column:
+            self._sort_ascending = not self._sort_ascending
+        else:
+            self._sort_column = column
+            self._sort_ascending = True
+        self._update_column_header_labels()
+        self._render_combo_list()
 
     def _on_key_pressed(
         self,

--- a/keymasq/gui/widgets/combo_inspector_window.py
+++ b/keymasq/gui/widgets/combo_inspector_window.py
@@ -519,7 +519,8 @@ class ComboInspectorWindow(Adw.Window):
         self.search_entry.select_region(0, -1)
 
     def _hide_search(self) -> None:
-        self.search_entry.set_text("")
+        if self.search_entry.get_text():
+            self.search_entry.set_text("")
         self.search_entry.set_visible(False)
 
     def _on_search_clicked(self, _button: Gtk.Button) -> None:

--- a/keymasq/gui/widgets/combo_inspector_window.py
+++ b/keymasq/gui/widgets/combo_inspector_window.py
@@ -48,6 +48,7 @@ class ComboInspectorItem:
     order: int
     recall_trigger_keys: bool = False
     restore_trigger_keys: list[str] | None = None
+    match_across_devices: bool = False
     step_tooltips: list[str] | None = None
     search_text: str = ""
 
@@ -86,6 +87,7 @@ class ComboInspectorWindow(Adw.Window):
         self._syncing_snapshot_selector = False
         self._sort_column = _SORT_NONE
         self._sort_ascending = True
+        self._snapshot_request_counter = 0
 
         self.set_title("Inspect Active Combos")
         self.set_default_size(780, 520)
@@ -238,14 +240,16 @@ class ComboInspectorWindow(Adw.Window):
     def _request_snapshot(self) -> None:
         if self._closing:
             return
+        self._snapshot_request_counter += 1
+        request_id = self._snapshot_request_counter
         session_request_async(
             {"command": "get_combo_inspector_snapshot"},
-            self._on_snapshot_response,
+            lambda result: self._on_snapshot_response(result, request_id),
             timeout=3.0,
         )
 
-    def _on_snapshot_response(self, result: JsonDict | None) -> bool:
-        if self._closing:
+    def _on_snapshot_response(self, result: JsonDict | None, request_id: int) -> bool:
+        if self._closing or request_id != self._snapshot_request_counter:
             return False
         if not result or result.get("status") != "ok":
             message = _text((result or {}).get("message"), "Combo inspector unavailable")
@@ -632,6 +636,9 @@ def _snapshot_signature(snapshot: JsonDict) -> str:
                     )
                     if str(value or "").strip()
                 ],
+                "match_across_devices": bool(
+                    combo_payload.get("match_across_devices", False)
+                ),
             }
         )
     return json.dumps(
@@ -713,6 +720,7 @@ def _combo_item_from_payload(payload: JsonDict) -> ComboInspectorItem | None:
         if str(value or "").strip()
     ]
     recall_trigger_keys = bool(payload.get("recall_trigger_keys", False))
+    match_across_devices = bool(payload.get("match_across_devices", False))
     search_config = _search_combo_config(
         combo_id,
         name,
@@ -720,6 +728,7 @@ def _combo_item_from_payload(payload: JsonDict) -> ComboInspectorItem | None:
         action,
         recall_trigger_keys,
         restore_trigger_keys,
+        match_across_devices,
     )
     return ComboInspectorItem(
         combo_id=combo_id,
@@ -730,6 +739,7 @@ def _combo_item_from_payload(payload: JsonDict) -> ComboInspectorItem | None:
         order=_int_value(payload.get("order"), 0),
         recall_trigger_keys=recall_trigger_keys,
         restore_trigger_keys=restore_trigger_keys,
+        match_across_devices=match_across_devices,
         step_tooltips=step_tooltips,
         search_text=" ".join(
             [
@@ -748,6 +758,7 @@ def _search_combo_config(
     action: MappingAction | None,
     recall_trigger_keys: bool,
     restore_trigger_keys: list[str],
+    match_across_devices: bool,
 ) -> ComboConfig:
     return ComboConfig(
         id=combo_id,
@@ -756,6 +767,7 @@ def _search_combo_config(
         action=action,
         recall_trigger_keys=recall_trigger_keys,
         restore_trigger_keys=restore_trigger_keys,
+        match_across_devices=match_across_devices,
     )
 
 

--- a/keymasq/gui/widgets/combo_inspector_window.py
+++ b/keymasq/gui/widgets/combo_inspector_window.py
@@ -775,10 +775,11 @@ def _mapping_action_from_payload(value: object) -> MappingAction | None:
     if not isinstance(value, dict):
         return None
     action_data = cast(dict[str, object], value)
+    action_name = _text(action_data.get("action"), ActionType.PASSTHROUGH.value)
     try:
-        action_type = ActionType(_text(action_data.get("action"), ActionType.PASSTHROUGH.value))
+        action_type = ActionType(action_name)
     except ValueError:
-        return None
+        action_type = ActionType.PASSTHROUGH
 
     macro_name = _text(action_data.get("macro_name"))
     if action_type == ActionType.MACRO and not macro_name:

--- a/keymasq/gui/widgets/combo_tab.py
+++ b/keymasq/gui/widgets/combo_tab.py
@@ -76,6 +76,7 @@ class ComboTab(ProfileManagedTab):
         if not self.demo_mode:
             inspect_btn = Gtk.Button(
                 icon_name=resolve_icon_name(
+                    "view-reveal-symbolic",
                     "edit-find-symbolic",
                     "system-search-symbolic",
                     "zoom-in-symbolic",
@@ -104,11 +105,11 @@ class ComboTab(ProfileManagedTab):
         self.combo_frame.set_margin_top(12)
 
         toolbar = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=8)
-        self.section_label = Gtk.Label(label="Combos")
-        self.section_label.add_css_class("heading")
-        self.section_label.set_hexpand(True)
-        self.section_label.set_halign(Gtk.Align.START)
-        toolbar.append(self.section_label)
+
+        self.add_combo_button = Gtk.Button(label="Add Combo")
+        self.add_combo_button.add_css_class("suggested-action")
+        self.add_combo_button.connect("clicked", self._on_add_combo_clicked)
+        toolbar.append(self.add_combo_button)
 
         self.search_button = Gtk.Button()
         self.search_button.set_icon_name("system-search-symbolic")
@@ -116,10 +117,6 @@ class ComboTab(ProfileManagedTab):
         self.search_button.connect("clicked", self._on_search_clicked)
         toolbar.append(self.search_button)
 
-        self.add_combo_button = Gtk.Button(label="Add Combo")
-        self.add_combo_button.add_css_class("suggested-action")
-        self.add_combo_button.connect("clicked", self._on_add_combo_clicked)
-        toolbar.append(self.add_combo_button)
         self.combo_frame.append(toolbar)
 
         self.search_entry = Gtk.SearchEntry()
@@ -130,6 +127,13 @@ class ComboTab(ProfileManagedTab):
         self.search_entry.set_visible(False)
         self.search_entry.connect("stop-search", self._on_search_stop)
         self.combo_frame.append(self.search_entry)
+
+        self.section_label = Gtk.Label(label="")
+        self.section_label.add_css_class("heading")
+        self.section_label.set_hexpand(True)
+        self.section_label.set_halign(Gtk.Align.START)
+        self.section_label.set_visible(False)
+        self.combo_frame.append(self.section_label)
 
         col_header = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=12)
         col_header.add_css_class("combo-column-header")
@@ -235,7 +239,7 @@ class ComboTab(ProfileManagedTab):
         combos = self._sorted_combos()
 
         if self._selected_profile is None:
-            self.section_label.set_text("Combos")
+            self.section_label.set_visible(False)
             self.combo_listbox.set_visible(False)
             self.column_header.set_visible(False)
             return
@@ -311,7 +315,7 @@ class ComboTab(ProfileManagedTab):
 
     def _update_combo_list_state(self, *, has_combos: bool | None = None) -> None:
         if self._selected_profile is None:
-            self.section_label.set_text("Combos")
+            self.section_label.set_visible(False)
             self.combo_listbox.set_visible(False)
             self.column_header.set_visible(False)
             return
@@ -322,11 +326,13 @@ class ComboTab(ProfileManagedTab):
         self.combo_listbox.set_visible(has_visible_rows)
         self.column_header.set_visible(has_visible_rows)
         if has_visible_rows:
-            self.section_label.set_text("Combos")
+            self.section_label.set_visible(False)
         elif has_combos and self.search_entry.get_text().strip():
             self.section_label.set_text("No matching combos.")
+            self.section_label.set_visible(True)
         else:
             self.section_label.set_text("No combos in this profile.")
+            self.section_label.set_visible(True)
 
     def _after_search_filter_changed(self) -> None:
         self._update_combo_list_state()

--- a/keymasq/gui/widgets/combo_tab.py
+++ b/keymasq/gui/widgets/combo_tab.py
@@ -239,6 +239,7 @@ class ComboTab(ProfileManagedTab):
         combos = self._sorted_combos()
 
         if self._selected_profile is None:
+            self._hide_search()
             self.section_label.set_visible(False)
             self.combo_listbox.set_visible(False)
             self.column_header.set_visible(False)
@@ -315,6 +316,7 @@ class ComboTab(ProfileManagedTab):
 
     def _update_combo_list_state(self, *, has_combos: bool | None = None) -> None:
         if self._selected_profile is None:
+            self._hide_search()
             self.section_label.set_visible(False)
             self.combo_listbox.set_visible(False)
             self.column_header.set_visible(False)
@@ -338,12 +340,15 @@ class ComboTab(ProfileManagedTab):
         self._update_combo_list_state()
 
     def _show_search(self) -> None:
+        if self._selected_profile is None:
+            return
         self.search_entry.set_visible(True)
         self.search_entry.grab_focus()
         self.search_entry.select_region(0, -1)
 
     def _hide_search(self) -> None:
-        self.search_entry.set_text("")
+        if self.search_entry.get_text():
+            self.search_entry.set_text("")
         self.search_entry.set_visible(False)
 
     def _on_search_clicked(self, _button: Gtk.Button) -> None:

--- a/keymasq/gui/widgets/combo_tab.py
+++ b/keymasq/gui/widgets/combo_tab.py
@@ -5,10 +5,10 @@ import gi
 gi.require_version("Gtk", "4.0")
 gi.require_version("Adw", "1")
 
-from gi.repository import Gtk, Pango  # pyright: ignore[reportAttributeAccessIssue]
+from gi.repository import Gdk, Gtk, Pango  # pyright: ignore[reportAttributeAccessIssue]
 
 from keymasq.common.models import ComboConfig
-from keymasq.gui.icons import combo_icon_names, image_from_icon_names
+from keymasq.gui.icons import combo_icon_names, image_from_icon_names, resolve_icon_name
 from keymasq.gui.widgets.combo_editor_dialog import (
     ComboEditorDialog,
     combo_default_name,
@@ -16,6 +16,7 @@ from keymasq.gui.widgets.combo_editor_dialog import (
     combo_trigger_label,
     describe_mapping_action,
 )
+from keymasq.gui.widgets.fuzzy_search import fuzzy_query_matches, install_listbox_fuzzy_filter
 from keymasq.gui.widgets.profile_managed_tab import ProfileManagedTab
 from keymasq.session.profiles import ProfileManager
 
@@ -49,7 +50,14 @@ class ComboTab(ProfileManagedTab):
         self._setup_header()
         self._setup_profile_selector()
         self._setup_combo_list()
+        self._setup_key_controller()
         self.refresh_profiles()
+
+    def _setup_key_controller(self) -> None:
+        key_controller = Gtk.EventControllerKey()
+        key_controller.connect("key-pressed", self._on_key_pressed)
+        self.add_controller(key_controller)
+        self.set_focusable(True)
 
     def _setup_header(self) -> None:
         header = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=12)
@@ -59,10 +67,27 @@ class ComboTab(ProfileManagedTab):
         header.append(icon)
 
         info_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=4)
+        title_row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=8)
         title = Gtk.Label(label="Combos")
         title.add_css_class("title-2")
         title.set_halign(Gtk.Align.START)
-        info_box.append(title)
+        title_row.append(title)
+
+        if not self.demo_mode:
+            inspect_btn = Gtk.Button(
+                icon_name=resolve_icon_name(
+                    "edit-find-symbolic",
+                    "system-search-symbolic",
+                    "zoom-in-symbolic",
+                    "dialog-information-symbolic",
+                )
+            )
+            inspect_btn.set_tooltip_text("Inspect active combos")
+            inspect_btn.add_css_class("flat")
+            inspect_btn.set_valign(Gtk.Align.CENTER)
+            inspect_btn.connect("clicked", self._on_inspect_combos_clicked)
+            title_row.append(inspect_btn)
+        info_box.append(title_row)
 
         subtitle = Gtk.Label(label="Profile combo triggers and actions")
         subtitle.add_css_class("dim-label")
@@ -85,11 +110,26 @@ class ComboTab(ProfileManagedTab):
         self.section_label.set_halign(Gtk.Align.START)
         toolbar.append(self.section_label)
 
+        self.search_button = Gtk.Button()
+        self.search_button.set_icon_name("system-search-symbolic")
+        self.search_button.set_tooltip_text("Search combos")
+        self.search_button.connect("clicked", self._on_search_clicked)
+        toolbar.append(self.search_button)
+
         self.add_combo_button = Gtk.Button(label="Add Combo")
         self.add_combo_button.add_css_class("suggested-action")
         self.add_combo_button.connect("clicked", self._on_add_combo_clicked)
         toolbar.append(self.add_combo_button)
         self.combo_frame.append(toolbar)
+
+        self.search_entry = Gtk.SearchEntry()
+        self.search_entry.set_placeholder_text("Search combos")
+        self.search_entry.set_tooltip_text(
+            "Filter combos by name, trigger, action, profile, device, or source"
+        )
+        self.search_entry.set_visible(False)
+        self.search_entry.connect("stop-search", self._on_search_stop)
+        self.combo_frame.append(self.search_entry)
 
         col_header = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=12)
         col_header.add_css_class("combo-column-header")
@@ -127,6 +167,11 @@ class ComboTab(ProfileManagedTab):
         self.combo_listbox.set_selection_mode(Gtk.SelectionMode.NONE)
         self.combo_listbox.add_css_class("boxed-list")
         self.combo_listbox.connect("row-activated", self._on_row_activated)
+        install_listbox_fuzzy_filter(
+            self.combo_listbox,
+            self.search_entry,
+            after_filter_changed=self._after_search_filter_changed,
+        )
 
         scrolled = Gtk.ScrolledWindow()
         scrolled.set_vexpand(True)
@@ -143,6 +188,7 @@ class ComboTab(ProfileManagedTab):
     def _after_profile_selection_applied(self) -> None:
         selected = self._selected_profile is not None
         self.add_combo_button.set_sensitive(selected)
+        self.search_button.set_sensitive(selected)
         self.combo_frame.set_sensitive(selected)
         self._render_combo_list()
 
@@ -187,21 +233,24 @@ class ComboTab(ProfileManagedTab):
             self.combo_listbox.remove(row)
 
         combos = self._sorted_combos()
-        has_combos = bool(combos)
-        self.combo_listbox.set_visible(has_combos)
-        self.column_header.set_visible(has_combos)
 
         if self._selected_profile is None:
             self.section_label.set_text("Combos")
+            self.combo_listbox.set_visible(False)
+            self.column_header.set_visible(False)
             return
-        self.section_label.set_text("Combos" if has_combos else "No combos in this profile.")
 
         for combo in combos:
             self.combo_listbox.append(self._create_combo_row(combo))
+        self._update_combo_list_state(has_combos=bool(combos))
 
     def _create_combo_row(self, combo: ComboConfig) -> Gtk.ListBoxRow:
         row = Gtk.ListBoxRow()
         row._combo_id = combo.id  # type: ignore[attr-defined]
+        row._search_text = combo_search_text(  # type: ignore[attr-defined]
+            combo,
+            profile_name=self.selected_profile_name() or "",
+        )
 
         box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=12)
         box.add_css_class("combo-row")
@@ -245,6 +294,78 @@ class ComboTab(ProfileManagedTab):
 
         row.set_child(box)
         return row
+
+    def _iter_combo_rows(self):
+        row = self.combo_listbox.get_first_child()
+        while row is not None:
+            yield row
+            row = row.get_next_sibling()
+
+    def _visible_combo_count(self) -> int:
+        query = self.search_entry.get_text()
+        return sum(
+            1
+            for row in self._iter_combo_rows()
+            if fuzzy_query_matches(query, getattr(row, "_search_text", ""))
+        )
+
+    def _update_combo_list_state(self, *, has_combos: bool | None = None) -> None:
+        if self._selected_profile is None:
+            self.section_label.set_text("Combos")
+            self.combo_listbox.set_visible(False)
+            self.column_header.set_visible(False)
+            return
+
+        has_combos = has_combos if has_combos is not None else any(self._iter_combo_rows())
+        visible_count = self._visible_combo_count() if has_combos else 0
+        has_visible_rows = visible_count > 0
+        self.combo_listbox.set_visible(has_visible_rows)
+        self.column_header.set_visible(has_visible_rows)
+        if has_visible_rows:
+            self.section_label.set_text("Combos")
+        elif has_combos and self.search_entry.get_text().strip():
+            self.section_label.set_text("No matching combos.")
+        else:
+            self.section_label.set_text("No combos in this profile.")
+
+    def _after_search_filter_changed(self) -> None:
+        self._update_combo_list_state()
+
+    def _show_search(self) -> None:
+        self.search_entry.set_visible(True)
+        self.search_entry.grab_focus()
+        self.search_entry.select_region(0, -1)
+
+    def _hide_search(self) -> None:
+        self.search_entry.set_text("")
+        self.search_entry.set_visible(False)
+
+    def _on_search_clicked(self, _button: Gtk.Button) -> None:
+        self._show_search()
+
+    def _on_search_stop(self, _entry: Gtk.SearchEntry) -> None:
+        self._hide_search()
+
+    def _on_key_pressed(
+        self,
+        _controller: Gtk.EventControllerKey,
+        keyval: int,
+        _keycode: int,
+        state: Gdk.ModifierType,
+    ) -> bool:
+        if keyval in (Gdk.KEY_f, Gdk.KEY_F) and state & Gdk.ModifierType.CONTROL_MASK:
+            self._show_search()
+            return True
+        if keyval == Gdk.KEY_Escape and self.search_entry.get_visible():
+            self._hide_search()
+            return True
+        return False
+
+    def _on_inspect_combos_clicked(self, _button: Gtk.Button) -> None:
+        root = self.main_window or self.get_root()
+        opener = getattr(root, "open_combo_inspector", None)
+        if callable(opener):
+            opener()
 
     def _on_column_header_clicked(self, _button: Gtk.Button, column: int) -> None:
         if self._sort_column == column:
@@ -298,3 +419,24 @@ class ComboTab(ProfileManagedTab):
         combos[:] = [combo for combo in combos if combo.id != combo_id]
         self._save_profile()
         self._render_combo_list()
+
+
+def combo_search_text(combo: ComboConfig, *, profile_name: str = "") -> str:
+    parts = [
+        combo.name or combo_default_name(combo),
+        combo_trigger_label(combo.steps),
+        describe_mapping_action(combo.action),
+        profile_name,
+    ]
+    for step in combo.steps:
+        if step.timeout_ms is not None:
+            parts.append(f"{int(step.timeout_ms)}ms")
+        for event in step.events:
+            parts.extend([event.evdev, event.hardware_id, event.source or ""])
+    if combo.recall_trigger_keys:
+        parts.append("recall trigger keys")
+    if combo.restore_trigger_keys:
+        parts.extend(combo.restore_trigger_keys)
+    if combo.match_across_devices:
+        parts.append("any device across devices")
+    return " ".join(str(part) for part in parts if str(part or "").strip())

--- a/keymasq/gui/widgets/device_tab.py
+++ b/keymasq/gui/widgets/device_tab.py
@@ -407,6 +407,7 @@ class DeviceTab(ProfileManagedTab):
         if not self.demo_mode:
             inspect_btn = Gtk.Button(
                 icon_name=resolve_icon_name(
+                    "view-reveal-symbolic",
                     "edit-find-symbolic",
                     "system-search-symbolic",
                     "zoom-in-symbolic",

--- a/keymasq/gui/window.py
+++ b/keymasq/gui/window.py
@@ -130,6 +130,7 @@ class MainWindow(Adw.ApplicationWindow):
         self._suppress_tab_layout_save = False
         self.combo_tab: ComboTab | None = None
         self._device_inspector_windows: dict[str, Gtk.Window] = {}
+        self._combo_inspector_window: Gtk.Window | None = None
 
         self.set_title("Keymasq")
         self.set_default_size(760, 1000)
@@ -864,6 +865,9 @@ class MainWindow(Adw.ApplicationWindow):
         for inspector_window in list(self._device_inspector_windows.values()):
             inspector_window.close()
         self._device_inspector_windows.clear()
+        if self._combo_inspector_window is not None:
+            self._combo_inspector_window.close()
+            self._combo_inspector_window = None
 
         if self.demo_mode:
             return
@@ -1393,6 +1397,37 @@ class MainWindow(Adw.ApplicationWindow):
         def on_destroy(window: Gtk.Window) -> None:
             if self._device_inspector_windows.get(hardware_id) is window:
                 self._device_inspector_windows.pop(hardware_id, None)
+
+        inspector.connect("close-request", on_close_request)
+        inspector.connect("destroy", on_destroy)
+        inspector.present()
+
+    def open_combo_inspector(self) -> None:
+        existing = self._combo_inspector_window
+        if existing is not None:
+            if bool(getattr(existing, "_closing", False)):
+                self._combo_inspector_window = None
+            else:
+                existing.present()
+                return
+
+        if self.demo_mode:
+            self._show_demo_notification("Combo inspector is not available in demo mode")
+            return
+
+        from keymasq.gui.widgets.combo_inspector_window import ComboInspectorWindow
+
+        inspector = ComboInspectorWindow(self)
+        self._combo_inspector_window = inspector
+
+        def on_close_request(window: Gtk.Window) -> bool:
+            if self._combo_inspector_window is window:
+                self._combo_inspector_window = None
+            return False
+
+        def on_destroy(window: Gtk.Window) -> None:
+            if self._combo_inspector_window is window:
+                self._combo_inspector_window = None
 
         inspector.connect("close-request", on_close_request)
         inspector.connect("destroy", on_destroy)

--- a/keymasq/session/manager/combo_inspector.py
+++ b/keymasq/session/manager/combo_inspector.py
@@ -49,11 +49,12 @@ def _serialize_combo(
                 ],
             }
             for step in combo.steps
-            if step.events
+            if any(event.evdev for event in step.events)
         ],
         "action": serialize_mapping_action(combo.action),
         "recall_trigger_keys": bool(combo.recall_trigger_keys),
         "restore_trigger_keys": list(combo.restore_trigger_keys),
+        "match_across_devices": bool(combo.match_across_devices),
     }
 
 

--- a/keymasq/session/manager/combo_inspector.py
+++ b/keymasq/session/manager/combo_inspector.py
@@ -1,0 +1,64 @@
+from typing import TYPE_CHECKING
+
+from keymasq.session.profiles import ResolvedCombo
+
+from .common import JsonObject
+from .device_inspector import serialize_mapping_action
+
+if TYPE_CHECKING:
+    from .core import SessionManager
+
+
+def build_combo_inspector_snapshot(manager: "SessionManager") -> JsonObject:
+    return {
+        "status": "ok",
+        "active_profiles": list(manager.profile_state.active_profile_names),
+        "combos": [
+            _serialize_combo(manager, combo, index)
+            for index, combo in enumerate(manager.profile_state.resolved_combos)
+        ],
+    }
+
+
+def _serialize_combo(
+    manager: "SessionManager",
+    combo: ResolvedCombo,
+    index: int,
+) -> JsonObject:
+    return {
+        "id": combo.id,
+        "name": combo.name,
+        "profile_name": combo.profile_name,
+        "order": index,
+        "steps": [
+            {
+                **(
+                    {"timeout_ms": int(step.timeout_ms)}
+                    if step.timeout_ms is not None
+                    else {}
+                ),
+                "events": [
+                    {
+                        "evdev": event.evdev,
+                        "hardware_id": event.hardware_id or "",
+                        "source": event.source or "",
+                        "device_name": _device_name(manager, event.hardware_id),
+                    }
+                    for event in step.events
+                    if event.evdev
+                ],
+            }
+            for step in combo.steps
+            if step.events
+        ],
+        "action": serialize_mapping_action(combo.action),
+        "recall_trigger_keys": bool(combo.recall_trigger_keys),
+        "restore_trigger_keys": list(combo.restore_trigger_keys),
+    }
+
+
+def _device_name(manager: "SessionManager", hardware_id: str | None) -> str:
+    if not hardware_id:
+        return ""
+    hardware = manager.hardware.get_hardware(hardware_id)
+    return hardware.name if hardware is not None else hardware_id

--- a/keymasq/session/manager/commands.py
+++ b/keymasq/session/manager/commands.py
@@ -4,11 +4,12 @@ from typing import TYPE_CHECKING, cast
 
 from keymasq.common.ipc import Command, CommandType
 from keymasq.common.models import normalize_macro_loop_stop_behavior
-from keymasq.common.security import PeerCredentials, command_allowed
+from keymasq.common.security import PeerCredentials, SecurityPolicy, command_allowed
 from keymasq.common.settings import GlobalSettings
 from keymasq.common.virtual_devices import MAX_VIRTUAL_GAMEPADS, MIN_VIRTUAL_GAMEPADS
 from keymasq.session.settings import save_global_settings, save_virtual_gamepad_count
 
+from . import combo_inspector as runtime_combo_inspector
 from . import compositor as runtime_compositor
 from . import device_inspector as runtime_device_inspector
 from . import profiles as runtime_profiles
@@ -54,7 +55,7 @@ async def handle_session_request(
             "message": "Sensitive command denied: caller is not active GUI owner",
         }
 
-    result = await _handle_profile_commands(manager, command, request)
+    result = await _handle_profile_commands(manager, command, request, client_class, policy)
     if result is not None:
         return result
 
@@ -103,9 +104,26 @@ async def _handle_profile_commands(
     manager: "SessionManager",
     command: str,
     request: JsonObject,
+    client_class: str,
+    policy: SecurityPolicy,
 ) -> JsonObject | None:
     if command == "get_active_profiles":
         return runtime_profiles.build_active_profiles_payload(manager)
+
+    if command == "get_combo_inspector_snapshot":
+        if not command_allowed(
+            "get_active_profiles",
+            policy.session_command_acl,
+            client_class,
+        ):
+            return {
+                "status": "error",
+                "message": (
+                    f"{client_class} is not allowed to call "
+                    "'get_combo_inspector_snapshot' while 'get_active_profiles' is denied"
+                ),
+            }
+        return runtime_combo_inspector.build_combo_inspector_snapshot(manager)
 
     if command == "list_profiles":
         return runtime_profiles.build_profile_overview(manager)

--- a/keymasq/session/manager/core.py
+++ b/keymasq/session/manager/core.py
@@ -790,6 +790,7 @@ class SessionManager:
         self.profile_state.last_sent_combo_signature = ""
         self.profile_state.active_profile_names.clear()
         self.profile_state.resolved_devices.clear()
+        self.profile_state.resolved_combos.clear()
         self.profile_state.runtime_profile_activations.clear()
         self.device_inspector_state.active_hardware_ids.clear()
         self.device_inspector_state.suppressed_hardware_ids.clear()

--- a/keymasq/session/manager/device_inspector.py
+++ b/keymasq/session/manager/device_inspector.py
@@ -9,6 +9,7 @@ from keymasq.common.models import (
     AnalogInputDefinition,
     ButtonDefinition,
     MappingAction,
+    profile_deactivation_policy_to_dict,
 )
 from keymasq.common.security import PeerCredentials
 from keymasq.session.profiles import ResolvedDeviceProfile
@@ -460,6 +461,9 @@ def _serialize_action(action: MappingAction | None) -> JsonObject | None:
     ):
         action_data["profile_name"] = action.profile_name or ""
         action_data["target"] = action.profile_name or ""
+        deactivation = profile_deactivation_policy_to_dict(action.profile_deactivation)
+        if deactivation is not None and action.action_type != ActionType.PROFILE_DISABLE:
+            action_data["deactivation"] = deactivation
     if action.action_type == ActionType.COMPOSITOR_DISPATCH:
         _set_optional(action_data, "compositor", action.compositor_id)
         action_data["dispatcher"] = action.compositor_dispatcher or ""
@@ -472,6 +476,10 @@ def _serialize_action(action: MappingAction | None) -> JsonObject | None:
         action_data["tap_enabled"] = True
         action_data["tap_hold_ms"] = int(action.tap_hold_ms)
     return action_data
+
+
+def serialize_mapping_action(action: MappingAction | None) -> JsonObject | None:
+    return _serialize_action(action)
 
 
 def _set_optional(action_data: JsonObject, key: str, value: object) -> None:

--- a/keymasq/session/manager/payloads.py
+++ b/keymasq/session/manager/payloads.py
@@ -385,52 +385,59 @@ def resolved_combos_payload(
 ) -> list[JsonObject]:
     payload: list[JsonObject] = []
     for combo in combos:
-        if combo.action is None:
-            continue
-        action_data = combo_action_to_payload(
-            manager,
-            combo.action,
-            step_count=len(combo.steps),
-        )
-        if action_data is None:
-            continue
-        steps: list[dict[str, object]] = []
-        for step in combo.steps:
-            events: list[dict[str, str]] = []
-            for event in step.events:
-                if not event.evdev:
-                    continue
-                event_data = {
-                    "evdev": event.evdev,
-                }
-                if event.hardware_id:
-                    event_data["hardware_id"] = event.hardware_id
-                if event.source:
-                    event_data["source"] = event.source
-                events.append(event_data)
-            if events:
-                step_payload: dict[str, object] = {"events": events}
-                if step.timeout_ms is not None:
-                    step_payload["timeout_ms"] = int(step.timeout_ms)
-                steps.append(step_payload)
-        if not steps:
-            continue
-        payload.append(
-            {
-                "id": combo.id,
-                "name": combo.name,
-                "profile_name": combo.profile_name,
-                "steps": steps,
-                "action": action_data,
-                **({"recall_trigger_keys": True} if combo.recall_trigger_keys else {}),
-                **(
-                    {"restore_trigger_keys": list(combo.restore_trigger_keys)}
-                    if combo.restore_trigger_keys
-                    else {}
-                ),
-            }
-        )
+        combo_payload = resolved_combo_payload(manager, combo)
+        if combo_payload is not None:
+            payload.append(combo_payload)
     return payload
+
+
+def resolved_combo_payload(
+    manager: "SessionManager",
+    combo: ResolvedCombo,
+) -> JsonObject | None:
+    if combo.action is None:
+        return None
+    action_data = combo_action_to_payload(
+        manager,
+        combo.action,
+        step_count=len(combo.steps),
+    )
+    if action_data is None:
+        return None
+    steps: list[dict[str, object]] = []
+    for step in combo.steps:
+        events: list[dict[str, str]] = []
+        for event in step.events:
+            if not event.evdev:
+                continue
+            event_data = {
+                "evdev": event.evdev,
+            }
+            if event.hardware_id:
+                event_data["hardware_id"] = event.hardware_id
+            if event.source:
+                event_data["source"] = event.source
+            events.append(event_data)
+        if events:
+            step_payload: dict[str, object] = {"events": events}
+            if step.timeout_ms is not None:
+                step_payload["timeout_ms"] = int(step.timeout_ms)
+            steps.append(step_payload)
+    if not steps:
+        return None
+    return {
+        "id": combo.id,
+        "name": combo.name,
+        "profile_name": combo.profile_name,
+        "steps": steps,
+        "action": action_data,
+        **({"recall_trigger_keys": True} if combo.recall_trigger_keys else {}),
+        **(
+            {"restore_trigger_keys": list(combo.restore_trigger_keys)}
+            if combo.restore_trigger_keys
+            else {}
+        ),
+    }
 
 
 def combo_action_to_payload(

--- a/keymasq/session/manager/profiles.py
+++ b/keymasq/session/manager/profiles.py
@@ -221,6 +221,7 @@ def invalidate_grabbed_state(manager: "SessionManager") -> None:
     manager.profile_state.last_sent_grab_signatures.clear()
     manager.profile_state.last_sent_mapping_signatures.clear()
     manager.profile_state.last_sent_combo_signature = ""
+    manager.profile_state.resolved_combos.clear()
 
 
 def clear_hardware_runtime_state(manager: "SessionManager", hardware_id: str) -> None:
@@ -1058,7 +1059,14 @@ async def update_combos(
         log.debug("Skipping unchanged combo payload")
         return
     runtime_payloads.clear_combo_exec_refs(manager)
-    payload = runtime_payloads.resolved_combos_payload(manager, combos)
+    payload: list[JsonObject] = []
+    active_combos: list[ResolvedCombo] = []
+    for combo in combos:
+        combo_payload = runtime_payloads.resolved_combo_payload(manager, combo)
+        if combo_payload is None:
+            continue
+        payload.append(combo_payload)
+        active_combos.append(combo)
     try:
         raise_if_stale_profile_apply(manager, generation)
         result = await manager.client.send_command(
@@ -1072,6 +1080,7 @@ async def update_combos(
             log.error("Failed to update combos: %s", result.error)
             return
         manager.profile_state.last_sent_combo_signature = signature
+        manager.profile_state.resolved_combos = list(active_combos)
     except Exception as e:
         log.error("Exception updating combos: %s: %s", type(e).__name__, e)
 

--- a/keymasq/session/manager/state.py
+++ b/keymasq/session/manager/state.py
@@ -4,7 +4,7 @@ from typing import Any, Literal
 
 from keymasq.common.models import ProfileDeactivationPolicy
 from keymasq.session.listeners.base import WindowListener
-from keymasq.session.profiles import ResolvedDeviceProfile
+from keymasq.session.profiles import ResolvedCombo, ResolvedDeviceProfile
 
 from .common import JsonObject
 
@@ -77,6 +77,7 @@ class ProfileRuntimeState:
     last_sent_combo_signature: str = ""
     active_profile_names: list[str] = field(default_factory=list)
     resolved_devices: dict[str, ResolvedDeviceProfile] = field(default_factory=dict)
+    resolved_combos: list[ResolvedCombo] = field(default_factory=list)
     runtime_profile_activations: dict[str, "RuntimeProfileActivation"] = field(
         default_factory=dict
     )

--- a/keymasq/session/profiles.py
+++ b/keymasq/session/profiles.py
@@ -99,6 +99,7 @@ class ResolvedCombo:
     profile_name: str = ""
     recall_trigger_keys: bool = False
     restore_trigger_keys: list[str] = field(default_factory=list)
+    match_across_devices: bool = False
 
 
 @dataclass
@@ -907,6 +908,7 @@ class ProfileManager:
                     restore_trigger_keys=normalize_combo_restore_keys(
                         copy.deepcopy(combo.restore_trigger_keys)
                     ),
+                    match_across_devices=bool(combo.match_across_devices),
                 )
 
         return ResolvedProfiles(

--- a/tests/gui/test_combo_inspector_window.py
+++ b/tests/gui/test_combo_inspector_window.py
@@ -1,0 +1,173 @@
+# ruff: noqa: F403, F405
+from collections.abc import Callable
+
+from tests.gui.support import *
+
+gi.require_version("Gtk", "4.0")
+
+
+def test_combo_inspector_window_renders_snapshot_and_search(monkeypatch) -> None:
+    from gi.repository import Gtk
+
+    from keymasq.gui.widgets import combo_inspector_window as inspector_module
+    from keymasq.gui.widgets.combo_inspector_window import ComboInspectorWindow
+
+    snapshot = {
+        "status": "ok",
+        "active_profiles": ["Base", "Overlay"],
+        "combos": [
+            {
+                "id": "combo-1",
+                "name": "Quick Save",
+                "profile_name": "Overlay",
+                "order": 0,
+                "steps": [
+                    {
+                        "timeout_ms": 500,
+                        "events": [
+                            {
+                                "evdev": "key_s",
+                                "hardware_id": "1234:5678",
+                                "source": "kbd",
+                                "device_name": "Gaming Keyboard",
+                            }
+                        ],
+                    }
+                ],
+                "action": {"action": "keyboard", "target": "key_f5"},
+                "recall_trigger_keys": True,
+                "restore_trigger_keys": ["key_leftctrl"],
+            }
+        ],
+    }
+    app_snapshot = {
+        "status": "ok",
+        "active_profiles": ["Base", "Overlay", "Firefox"],
+        "combos": [
+            {
+                "id": "combo-2",
+                "name": "App Action",
+                "profile_name": "Firefox",
+                "order": 0,
+                "steps": [
+                    {
+                        "events": [
+                            {
+                                "evdev": "key_f",
+                                "hardware_id": "1234:5678",
+                                "source": "kbd",
+                                "device_name": "Gaming Keyboard",
+                            }
+                        ],
+                    }
+                ],
+                "action": {"action": "keyboard", "target": "key_f6"},
+            }
+        ],
+    }
+    current_snapshot = {"value": snapshot}
+    requests: list[dict[str, object]] = []
+    callbacks: dict[str, list[Callable[[dict[str, object]], object]]] = {}
+
+    def fake_register(event, callback):
+        callbacks.setdefault(event, []).append(callback)
+
+    def fake_unregister(event, callback):
+        callbacks[event].remove(callback)
+
+    def fake_request_async(payload, callback, timeout=5.0):
+        requests.append(payload)
+        callback(current_snapshot["value"])
+
+    monkeypatch.setattr(inspector_module, "register_session_event_callback", fake_register)
+    monkeypatch.setattr(inspector_module, "unregister_session_event_callback", fake_unregister)
+    monkeypatch.setattr(inspector_module, "session_request_async", fake_request_async)
+
+    window = ComboInspectorWindow(Gtk.Window())
+
+    assert requests == [{"command": "get_combo_inspector_snapshot"}]
+    assert window._status_label.get_text() == "Active Combos - 1 combo"
+    assert window.active_profiles_label.get_text() == "Base, Overlay"
+    assert window.section_label.get_text() == "Active Combos"
+    assert window.search_entry.get_visible() is False
+    assert len(window._snapshots) == 1
+    assert window.snapshot_dropdown.get_sensitive() is False
+
+    first_row = window.combo_listbox.get_first_child()
+    assert first_row is not None
+    row_box = first_row.get_child()
+    name_box = row_box.get_first_child()
+    assert name_box.get_first_child().get_label() == "Quick Save"
+
+    window.search_button.emit("clicked")
+    assert window.search_entry.get_visible() is True
+
+    window.search_entry.set_text("gaming kbd")
+    assert window._visible_combo_count() == 1
+
+    window.search_entry.set_text("missing")
+    assert window._visible_combo_count() == 0
+    assert window.section_label.get_text() == "No matching active combos."
+    assert window.combo_listbox.get_visible() is False
+
+    window.search_entry.set_text("")
+    current_snapshot["value"] = app_snapshot
+    callbacks["profiles_changed"][0]({"event": "profiles_changed"})
+    assert requests[-1] == {"command": "get_combo_inspector_snapshot"}
+    assert len(window._snapshots) == 2
+    assert window.snapshot_dropdown.get_sensitive() is True
+    assert window._status_label.get_text() == "Active Combos - 1 combo"
+    assert window.active_profiles_label.get_text() == "Base, Overlay, Firefox"
+
+    window.snapshot_dropdown.set_selected(1)
+    assert window._status_label.get_text() == "Active Combos Snapshot - 1 combo"
+    assert window.active_profiles_label.get_text() == "Base, Overlay"
+    assert window._visible_combo_count() == 1
+
+    current_snapshot["value"] = snapshot
+    callbacks["profiles_changed"][0]({"event": "profiles_changed"})
+    assert len(window._snapshots) == 2
+    assert window._status_label.get_text() == "Active Combos - 1 combo"
+    assert window.active_profiles_label.get_text() == "Base, Overlay"
+
+    callbacks["keymasqd_status"][0]({"event": "keymasqd_status", "connected": False})
+    assert window._status_label.get_text() == "Active Combos - Daemon disconnected"
+    assert window.section_label.get_text() == "Active Combos"
+
+    window._finalize()
+    assert callbacks["profiles_changed"] == []
+    assert callbacks["runtime_reset"] == []
+    assert callbacks["keymasqd_status"] == []
+
+
+def test_combo_inspector_mapping_action_payload_preserves_macro_loop_stop_behavior() -> None:
+    from keymasq.gui.widgets.combo_inspector_window import _mapping_action_from_payload
+
+    action = _mapping_action_from_payload(
+        {
+            "action": "macro",
+            "target": "Looped Macro",
+            "loop_stop_behavior": "cancel_run",
+            "keys": "not-a-list",
+        }
+    )
+
+    assert action is not None
+    assert action.macro_loop_stop_behavior == "cancel_run"
+    assert action.keys is None
+
+
+def test_combo_inspector_mapping_action_payload_preserves_profile_deactivation() -> None:
+    from keymasq.gui.widgets.combo_inspector_window import _mapping_action_from_payload
+
+    action = _mapping_action_from_payload(
+        {
+            "action": "profile_toggle",
+            "profile_name": "Layer",
+            "deactivation": {"on_trigger_end": True},
+        }
+    )
+
+    assert action is not None
+    assert action.profile_deactivation is not None
+    assert action.profile_deactivation.on_trigger_end is True

--- a/tests/gui/test_combo_inspector_window.py
+++ b/tests/gui/test_combo_inspector_window.py
@@ -224,7 +224,7 @@ def test_combo_inspector_window_sorts_like_combo_tab(monkeypatch) -> None:
                 "name": "Bravo",
                 "profile_name": "Base",
                 "order": 0,
-                "steps": [{"events": [{"evdev": "key_b"}]}],
+                "steps": [{"events": [{"evdev": "key_c"}]}],
                 "action": {"action": "keyboard", "target": "key_c"},
             },
             {
@@ -232,7 +232,7 @@ def test_combo_inspector_window_sorts_like_combo_tab(monkeypatch) -> None:
                 "name": "Alpha",
                 "profile_name": "Base",
                 "order": 1,
-                "steps": [{"events": [{"evdev": "key_c"}]}],
+                "steps": [{"events": [{"evdev": "key_a"}]}],
                 "action": {"action": "keyboard", "target": "key_b"},
             },
             {
@@ -240,7 +240,7 @@ def test_combo_inspector_window_sorts_like_combo_tab(monkeypatch) -> None:
                 "name": "Charlie",
                 "profile_name": "Base",
                 "order": 2,
-                "steps": [{"events": [{"evdev": "key_a"}]}],
+                "steps": [{"events": [{"evdev": "key_b"}]}],
                 "action": {"action": "keyboard", "target": "key_a"},
             },
         ],
@@ -267,7 +267,7 @@ def test_combo_inspector_window_sorts_like_combo_tab(monkeypatch) -> None:
     assert window._name_header_btn.get_label() == "Name \u25be"
 
     window._trigger_header_btn.emit("clicked")
-    assert _combo_inspector_row_names(window) == ["Charlie", "Bravo", "Alpha"]
+    assert _combo_inspector_row_names(window) == ["Alpha", "Charlie", "Bravo"]
     assert window._trigger_header_btn.get_label() == "Trigger \u25b4"
     assert window._name_header_btn.get_label() == "Name"
 
@@ -326,6 +326,22 @@ def test_combo_inspector_mapping_action_payload_preserves_macro_loop_stop_behavi
     assert action is not None
     assert action.macro_loop_stop_behavior == "cancel_run"
     assert action.keys is None
+
+
+def test_combo_inspector_mapping_action_payload_keeps_unknown_actions_visible() -> None:
+    from keymasq.common.models import ActionType
+    from keymasq.gui.widgets.combo_inspector_window import _mapping_action_from_payload
+
+    action = _mapping_action_from_payload(
+        {
+            "action": "future_action",
+            "target": "future-target",
+        }
+    )
+
+    assert action is not None
+    assert action.action_type == ActionType.PASSTHROUGH
+    assert action.target == "future-target"
 
 
 def test_combo_inspector_mapping_action_payload_preserves_profile_deactivation() -> None:

--- a/tests/gui/test_combo_inspector_window.py
+++ b/tests/gui/test_combo_inspector_window.py
@@ -37,6 +37,7 @@ def test_combo_inspector_window_renders_snapshot_and_search(monkeypatch) -> None
                 "action": {"action": "keyboard", "target": "key_f5"},
                 "recall_trigger_keys": True,
                 "restore_trigger_keys": ["key_leftctrl"],
+                "match_across_devices": True,
             }
         ],
     }
@@ -105,6 +106,9 @@ def test_combo_inspector_window_renders_snapshot_and_search(monkeypatch) -> None
     window.search_entry.set_text("gaming kbd")
     assert window._visible_combo_count() == 1
 
+    window.search_entry.set_text("across devices")
+    assert window._visible_combo_count() == 1
+
     window.search_entry.set_text("missing")
     assert window._visible_combo_count() == 0
     assert window.section_label.get_text() == "No matching active combos."
@@ -138,6 +142,71 @@ def test_combo_inspector_window_renders_snapshot_and_search(monkeypatch) -> None
     assert callbacks["profiles_changed"] == []
     assert callbacks["runtime_reset"] == []
     assert callbacks["keymasqd_status"] == []
+
+
+def test_combo_inspector_window_ignores_stale_snapshot_responses(monkeypatch) -> None:
+    from gi.repository import Gtk
+
+    from keymasq.gui.widgets import combo_inspector_window as inspector_module
+    from keymasq.gui.widgets.combo_inspector_window import ComboInspectorWindow
+
+    old_snapshot = {
+        "status": "ok",
+        "active_profiles": ["Old"],
+        "combos": [
+            {
+                "id": "combo-old",
+                "name": "Old Combo",
+                "profile_name": "Old",
+                "steps": [{"events": [{"evdev": "key_o"}]}],
+                "action": {"action": "keyboard", "target": "key_o"},
+            }
+        ],
+    }
+    new_snapshot = {
+        "status": "ok",
+        "active_profiles": ["New"],
+        "combos": [
+            {
+                "id": "combo-new",
+                "name": "New Combo",
+                "profile_name": "New",
+                "steps": [{"events": [{"evdev": "key_n"}]}],
+                "action": {"action": "keyboard", "target": "key_n"},
+            }
+        ],
+    }
+    event_callbacks: dict[str, list[Callable[[dict[str, object]], object]]] = {}
+    response_callbacks: list[Callable[[dict[str, object]], object]] = []
+
+    def fake_register(event, callback):
+        event_callbacks.setdefault(event, []).append(callback)
+
+    def fake_unregister(event, callback):
+        event_callbacks[event].remove(callback)
+
+    def fake_request_async(_payload, callback, timeout=5.0):
+        response_callbacks.append(callback)
+
+    monkeypatch.setattr(inspector_module, "register_session_event_callback", fake_register)
+    monkeypatch.setattr(inspector_module, "unregister_session_event_callback", fake_unregister)
+    monkeypatch.setattr(inspector_module, "session_request_async", fake_request_async)
+
+    window = ComboInspectorWindow(Gtk.Window())
+    event_callbacks["profiles_changed"][0]({"event": "profiles_changed"})
+
+    assert len(response_callbacks) == 2
+
+    response_callbacks[1](new_snapshot)
+    assert window.active_profiles_label.get_text() == "New"
+    assert _combo_inspector_row_names(window) == ["New Combo"]
+
+    response_callbacks[0](old_snapshot)
+    assert window.active_profiles_label.get_text() == "New"
+    assert _combo_inspector_row_names(window) == ["New Combo"]
+    assert len(window._snapshots) == 1
+
+    window._finalize()
 
 
 def test_combo_inspector_window_sorts_like_combo_tab(monkeypatch) -> None:
@@ -207,6 +276,27 @@ def test_combo_inspector_window_sorts_like_combo_tab(monkeypatch) -> None:
     assert window._action_header_btn.get_label() == "Action \u25b4"
 
     window._finalize()
+
+
+def test_combo_inspector_snapshot_signature_includes_match_across_devices() -> None:
+    from keymasq.gui.widgets.combo_inspector_window import _snapshot_signature
+
+    base_combo = {
+        "id": "combo-1",
+        "name": "Across Devices",
+        "profile_name": "Base",
+        "steps": [{"events": [{"evdev": "key_a"}]}],
+        "action": {"action": "keyboard", "target": "key_b"},
+    }
+
+    scoped = {"status": "ok", "active_profiles": ["Base"], "combos": [base_combo]}
+    across = {
+        "status": "ok",
+        "active_profiles": ["Base"],
+        "combos": [{**base_combo, "match_across_devices": True}],
+    }
+
+    assert _snapshot_signature(scoped) != _snapshot_signature(across)
 
 
 def _combo_inspector_row_names(window) -> list[str]:

--- a/tests/gui/test_combo_inspector_window.py
+++ b/tests/gui/test_combo_inspector_window.py
@@ -88,7 +88,7 @@ def test_combo_inspector_window_renders_snapshot_and_search(monkeypatch) -> None
     assert requests == [{"command": "get_combo_inspector_snapshot"}]
     assert window._status_label.get_text() == "Active Combos - 1 combo"
     assert window.active_profiles_label.get_text() == "Base, Overlay"
-    assert window.section_label.get_text() == "Active Combos"
+    assert window.section_label.get_visible() is False
     assert window.search_entry.get_visible() is False
     assert len(window._snapshots) == 1
     assert window.snapshot_dropdown.get_sensitive() is False
@@ -132,12 +132,93 @@ def test_combo_inspector_window_renders_snapshot_and_search(monkeypatch) -> None
 
     callbacks["keymasqd_status"][0]({"event": "keymasqd_status", "connected": False})
     assert window._status_label.get_text() == "Active Combos - Daemon disconnected"
-    assert window.section_label.get_text() == "Active Combos"
+    assert window.section_label.get_visible() is False
 
     window._finalize()
     assert callbacks["profiles_changed"] == []
     assert callbacks["runtime_reset"] == []
     assert callbacks["keymasqd_status"] == []
+
+
+def test_combo_inspector_window_sorts_like_combo_tab(monkeypatch) -> None:
+    from gi.repository import Gtk
+
+    from keymasq.gui.widgets import combo_inspector_window as inspector_module
+    from keymasq.gui.widgets.combo_inspector_window import ComboInspectorWindow
+
+    snapshot = {
+        "status": "ok",
+        "active_profiles": ["Base"],
+        "combos": [
+            {
+                "id": "combo-1",
+                "name": "Bravo",
+                "profile_name": "Base",
+                "order": 0,
+                "steps": [{"events": [{"evdev": "key_b"}]}],
+                "action": {"action": "keyboard", "target": "key_c"},
+            },
+            {
+                "id": "combo-2",
+                "name": "Alpha",
+                "profile_name": "Base",
+                "order": 1,
+                "steps": [{"events": [{"evdev": "key_c"}]}],
+                "action": {"action": "keyboard", "target": "key_b"},
+            },
+            {
+                "id": "combo-3",
+                "name": "Charlie",
+                "profile_name": "Base",
+                "order": 2,
+                "steps": [{"events": [{"evdev": "key_a"}]}],
+                "action": {"action": "keyboard", "target": "key_a"},
+            },
+        ],
+    }
+
+    def fake_request_async(_payload, callback, timeout=5.0):
+        callback(snapshot)
+
+    monkeypatch.setattr(inspector_module, "register_session_event_callback", lambda *_: None)
+    monkeypatch.setattr(inspector_module, "unregister_session_event_callback", lambda *_: None)
+    monkeypatch.setattr(inspector_module, "session_request_async", fake_request_async)
+
+    window = ComboInspectorWindow(Gtk.Window())
+
+    assert _combo_inspector_row_names(window) == ["Bravo", "Alpha", "Charlie"]
+    assert window._name_header_btn.get_label() == "Name"
+
+    window._name_header_btn.emit("clicked")
+    assert _combo_inspector_row_names(window) == ["Alpha", "Bravo", "Charlie"]
+    assert window._name_header_btn.get_label() == "Name \u25b4"
+
+    window._name_header_btn.emit("clicked")
+    assert _combo_inspector_row_names(window) == ["Charlie", "Bravo", "Alpha"]
+    assert window._name_header_btn.get_label() == "Name \u25be"
+
+    window._trigger_header_btn.emit("clicked")
+    assert _combo_inspector_row_names(window) == ["Charlie", "Bravo", "Alpha"]
+    assert window._trigger_header_btn.get_label() == "Trigger \u25b4"
+    assert window._name_header_btn.get_label() == "Name"
+
+    window._action_header_btn.emit("clicked")
+    assert _combo_inspector_row_names(window) == ["Charlie", "Alpha", "Bravo"]
+    assert window._action_header_btn.get_label() == "Action \u25b4"
+
+    window._finalize()
+
+
+def _combo_inspector_row_names(window) -> list[str]:
+    names: list[str] = []
+    row = window.combo_listbox.get_first_child()
+    while row is not None:
+        row_box = row.get_child()
+        name_box = row_box.get_first_child()
+        name_label = name_box.get_first_child()
+        names.append(name_label.get_label())
+        row = row.get_next_sibling()
+    return names
 
 
 def test_combo_inspector_mapping_action_payload_preserves_macro_loop_stop_behavior() -> None:

--- a/tests/gui/test_combo_tab_widget.py
+++ b/tests/gui/test_combo_tab_widget.py
@@ -355,6 +355,81 @@ class TestComboTabWidget:
         assert tab._name_header_btn.get_label() == "Name ▾"
         assert opened == ["combo-c"]
 
+    def test_combo_tab_search_filters_rows(self, temp_config_dir):
+        from keymasq.common.models import (
+            ActionType,
+            ComboConfig,
+            ComboEvent,
+            ComboStep,
+            MappingAction,
+            ProfileConfig,
+        )
+        from keymasq.gui.widgets.combo_tab import ComboTab
+        from keymasq.session.profiles import ProfileManager
+
+        profile_manager = ProfileManager()
+        profile_manager.save_profile(
+            ProfileConfig(
+                name="Desktop",
+                enabled=True,
+                is_permanent=True,
+                combos=[
+                    ComboConfig(
+                        id="combo-a",
+                        name="Alpha",
+                        steps=[
+                            ComboStep(
+                                events=[
+                                    ComboEvent(
+                                        evdev="key_a",
+                                        hardware_id="1234:5678",
+                                        source="kbd",
+                                    )
+                                ]
+                            )
+                        ],
+                        action=MappingAction(action_type=ActionType.KEYBOARD, target="key_1"),
+                    ),
+                    ComboConfig(
+                        id="combo-b",
+                        name="Bravo",
+                        steps=[
+                            ComboStep(
+                                events=[
+                                    ComboEvent(
+                                        evdev="btn_side",
+                                        hardware_id="abcd:ef01",
+                                        source="mouse",
+                                    )
+                                ]
+                            )
+                        ],
+                        action=MappingAction(action_type=ActionType.MOUSE, target="btn_left"),
+                    ),
+                ],
+            )
+        )
+
+        tab = ComboTab(profile_manager=profile_manager, demo_mode=True)
+        tab.refresh_profiles(preferred_profile_name="Desktop", publish_selection=False)
+
+        assert tab.search_entry.get_visible() is False
+        tab.search_button.emit("clicked")
+        assert tab.search_entry.get_visible() is True
+
+        tab.search_entry.set_text("mouse")
+        assert tab._visible_combo_count() == 1
+        assert tab.section_label.get_text() == "Combos"
+
+        tab.search_entry.set_text("missing")
+        assert tab._visible_combo_count() == 0
+        assert tab.section_label.get_text() == "No matching combos."
+        assert tab.combo_listbox.get_visible() is False
+
+        tab._hide_search()
+        assert tab.search_entry.get_visible() is False
+        assert tab.section_label.get_text() == "Combos"
+
     def test_combo_tab_add_combo_requires_selected_profile(self, temp_config_dir):
         from gi.repository import Gtk
 

--- a/tests/gui/test_combo_tab_widget.py
+++ b/tests/gui/test_combo_tab_widget.py
@@ -430,6 +430,22 @@ class TestComboTabWidget:
         assert tab.search_entry.get_visible() is False
         assert tab.section_label.get_visible() is False
 
+        tab.search_button.emit("clicked")
+        tab.search_entry.set_text("mouse")
+        tab._selected_profile = None
+        tab._render_combo_list()
+        assert tab.search_entry.get_visible() is False
+        assert tab.search_entry.get_text() == ""
+
+        tab._show_search()
+        assert tab.search_entry.get_visible() is False
+
+        tab.search_entry.set_visible(True)
+        tab.search_entry.set_text("stale")
+        tab._update_combo_list_state()
+        assert tab.search_entry.get_visible() is False
+        assert tab.search_entry.get_text() == ""
+
     def test_combo_tab_toolbar_keeps_add_combo_and_search_left_bound(self):
         from keymasq.gui.widgets.combo_tab import ComboTab
 

--- a/tests/gui/test_combo_tab_widget.py
+++ b/tests/gui/test_combo_tab_widget.py
@@ -419,7 +419,7 @@ class TestComboTabWidget:
 
         tab.search_entry.set_text("mouse")
         assert tab._visible_combo_count() == 1
-        assert tab.section_label.get_text() == "Combos"
+        assert tab.section_label.get_visible() is False
 
         tab.search_entry.set_text("missing")
         assert tab._visible_combo_count() == 0
@@ -428,7 +428,16 @@ class TestComboTabWidget:
 
         tab._hide_search()
         assert tab.search_entry.get_visible() is False
-        assert tab.section_label.get_text() == "Combos"
+        assert tab.section_label.get_visible() is False
+
+    def test_combo_tab_toolbar_keeps_add_combo_and_search_left_bound(self):
+        from keymasq.gui.widgets.combo_tab import ComboTab
+
+        tab = ComboTab(profile_manager=None, demo_mode=True)
+        toolbar = tab.add_combo_button.get_parent()
+
+        assert toolbar.get_first_child() is tab.add_combo_button
+        assert tab.add_combo_button.get_next_sibling() is tab.search_button
 
     def test_combo_tab_add_combo_requires_selected_profile(self, temp_config_dir):
         from gi.repository import Gtk
@@ -441,6 +450,6 @@ class TestComboTabWidget:
 
         tab._on_add_combo_clicked(Gtk.Button())
 
-        assert tab.section_label.get_text() == "Combos"
+        assert tab.section_label.get_visible() is False
         assert tab._selected_profile is None
         assert opened == []

--- a/tests/gui/test_main_window.py
+++ b/tests/gui/test_main_window.py
@@ -204,10 +204,12 @@ class TestMainWindow:
         window.demo_mode = False
         present_calls: list[str] = []
         close_callbacks = []
+        instances: list[object] = []
 
         class FakeInspector:
             def __init__(self, parent):
                 self.parent = parent
+                instances.append(self)
 
             def connect(self, signal, callback):
                 if signal == "close-request":
@@ -226,7 +228,8 @@ class TestMainWindow:
         window.open_combo_inspector()
 
         assert present_calls == ["present", "present"]
-        assert window._combo_inspector_window is not None
+        assert len(instances) == 1
+        assert window._combo_inspector_window is instances[0]
 
         inspector = window._combo_inspector_window
         assert close_callbacks[-1][1](inspector) is False
@@ -234,7 +237,8 @@ class TestMainWindow:
 
         window.open_combo_inspector()
 
-        assert window._combo_inspector_window is not None
+        assert len(instances) == 2
+        assert window._combo_inspector_window is instances[1]
         assert present_calls == ["present", "present", "present"]
 
     def test_main_window_menu_reflects_saved_appearance(self, temp_config_dir):

--- a/tests/gui/test_main_window.py
+++ b/tests/gui/test_main_window.py
@@ -192,6 +192,51 @@ class TestMainWindow:
             device.hardware_id,
         ]
 
+    def test_main_window_combo_inspector_reuses_open_window(
+        self,
+        temp_config_dir,
+        monkeypatch,
+    ):
+        from keymasq.gui.widgets import combo_inspector_window as inspector_module
+        from keymasq.gui.window import MainWindow
+
+        window = MainWindow(demo_mode=True)
+        window.demo_mode = False
+        present_calls: list[str] = []
+        close_callbacks = []
+
+        class FakeInspector:
+            def __init__(self, parent):
+                self.parent = parent
+
+            def connect(self, signal, callback):
+                if signal == "close-request":
+                    close_callbacks.append((self, callback))
+                return 1
+
+            def present(self):
+                present_calls.append("present")
+
+            def close(self):
+                pass
+
+        monkeypatch.setattr(inspector_module, "ComboInspectorWindow", FakeInspector)
+
+        window.open_combo_inspector()
+        window.open_combo_inspector()
+
+        assert present_calls == ["present", "present"]
+        assert window._combo_inspector_window is not None
+
+        inspector = window._combo_inspector_window
+        assert close_callbacks[-1][1](inspector) is False
+        assert window._combo_inspector_window is None
+
+        window.open_combo_inspector()
+
+        assert window._combo_inspector_window is not None
+        assert present_calls == ["present", "present", "present"]
+
     def test_main_window_menu_reflects_saved_appearance(self, temp_config_dir):
         from keymasq.gui.preferences import save_appearance_mode
         from keymasq.gui.window import MainWindow

--- a/tests/session/test_session_manager_command_acl.py
+++ b/tests/session/test_session_manager_command_acl.py
@@ -188,6 +188,50 @@ async def test_get_status_omits_acl_gated_profile_and_window_sections() -> None:
 
 
 @pytest.mark.asyncio
+async def test_combo_inspector_snapshot_requires_active_profile_permission() -> None:
+    from keymasq.common.models import ActionType, ComboEvent, ComboStep, MappingAction
+    from keymasq.session.profiles import ResolvedCombo
+
+    manager = SessionManager()
+    manager.security_policy = SecurityPolicy(
+        session_command_acl={"client": ["!get_active_profiles"]},
+        daemon_command_acl={"session": []},
+    )
+    manager.profile_state.active_profile_names = ["Base", "Overlay"]
+    manager.profile_state.resolved_combos = [
+        ResolvedCombo(
+            id="combo-1",
+            name="Quick Save",
+            profile_name="Overlay",
+            steps=[
+                ComboStep(
+                    events=[
+                        ComboEvent(
+                            evdev="key_s",
+                            hardware_id="1234:5678",
+                            source="kbd",
+                        )
+                    ],
+                )
+            ],
+            action=MappingAction(action_type=ActionType.KEYBOARD, target="key_f5"),
+        )
+    ]
+    peer = PeerCredentials(pid=1, uid=1000, gid=1000)
+
+    result = await manager._handle_session_request(
+        {"command": "get_combo_inspector_snapshot"},
+        "client",
+        peer,
+        object(),
+    )
+
+    assert result["status"] == "error"
+    assert "get_active_profiles" in str(result["message"])
+    assert "combos" not in result
+
+
+@pytest.mark.asyncio
 async def test_handle_session_request_get_compositor_reports_compositor_dispatch_availability(
 ) -> None:
     manager = SessionManager()

--- a/tests/session/test_session_manager_command_runtime.py
+++ b/tests/session/test_session_manager_command_runtime.py
@@ -231,6 +231,7 @@ async def test_get_combo_inspector_snapshot_returns_resolved_active_combos() -> 
             name="Quick Save",
             profile_name="Overlay",
             steps=[
+                ComboStep(events=[ComboEvent(evdev="")], timeout_ms=250),
                 ComboStep(
                     events=[
                         ComboEvent(
@@ -245,6 +246,7 @@ async def test_get_combo_inspector_snapshot_returns_resolved_active_combos() -> 
             action=MappingAction(action_type=ActionType.KEYBOARD, target="key_f5"),
             recall_trigger_keys=True,
             restore_trigger_keys=["key_leftctrl"],
+            match_across_devices=True,
         )
     ]
     manager.hardware.get_hardware = lambda _hardware_id: SimpleNamespace(  # type: ignore[assignment]
@@ -263,7 +265,9 @@ async def test_get_combo_inspector_snapshot_returns_resolved_active_combos() -> 
     assert result["active_profiles"] == ["Base", "Overlay"]
     combos = cast(list[dict[str, object]], result["combos"])
     assert combos[0]["profile_name"] == "Overlay"
+    assert combos[0]["match_across_devices"] is True
     steps = cast(list[dict[str, object]], combos[0]["steps"])
+    assert len(steps) == 1
     assert steps[0]["timeout_ms"] == 500
     events = cast(list[dict[str, object]], steps[0]["events"])
     assert events[0]["device_name"] == "Gaming Keyboard"

--- a/tests/session/test_session_manager_command_runtime.py
+++ b/tests/session/test_session_manager_command_runtime.py
@@ -219,6 +219,101 @@ async def test_get_active_profiles_does_not_include_window_state() -> None:
 
 
 @pytest.mark.asyncio
+async def test_get_combo_inspector_snapshot_returns_resolved_active_combos() -> None:
+    from keymasq.common.models import ActionType, ComboEvent, ComboStep, MappingAction
+    from keymasq.session.profiles import ResolvedCombo
+
+    manager = SessionManager()
+    manager.profile_state.active_profile_names = ["Base", "Overlay"]
+    manager.profile_state.resolved_combos = [
+        ResolvedCombo(
+            id="combo-1",
+            name="Quick Save",
+            profile_name="Overlay",
+            steps=[
+                ComboStep(
+                    events=[
+                        ComboEvent(
+                            evdev="key_s",
+                            hardware_id="1234:5678",
+                            source="kbd",
+                        )
+                    ],
+                    timeout_ms=500,
+                )
+            ],
+            action=MappingAction(action_type=ActionType.KEYBOARD, target="key_f5"),
+            recall_trigger_keys=True,
+            restore_trigger_keys=["key_leftctrl"],
+        )
+    ]
+    manager.hardware.get_hardware = lambda _hardware_id: SimpleNamespace(  # type: ignore[assignment]
+        name="Gaming Keyboard"
+    )
+    peer = PeerCredentials(pid=1, uid=1000, gid=1000)
+
+    result = await manager._handle_session_request(
+        {"command": "get_combo_inspector_snapshot"},
+        "client",
+        peer,
+        object(),
+    )
+
+    assert result["status"] == "ok"
+    assert result["active_profiles"] == ["Base", "Overlay"]
+    combos = cast(list[dict[str, object]], result["combos"])
+    assert combos[0]["profile_name"] == "Overlay"
+    steps = cast(list[dict[str, object]], combos[0]["steps"])
+    assert steps[0]["timeout_ms"] == 500
+    events = cast(list[dict[str, object]], steps[0]["events"])
+    assert events[0]["device_name"] == "Gaming Keyboard"
+    action = cast(dict[str, object], combos[0]["action"])
+    assert action["action"] == "keyboard"
+    assert action["target"] == "key_f5"
+
+
+@pytest.mark.asyncio
+async def test_get_combo_inspector_snapshot_preserves_profile_deactivation() -> None:
+    from keymasq.common.models import (
+        ActionType,
+        ComboEvent,
+        ComboStep,
+        MappingAction,
+        ProfileDeactivationPolicy,
+    )
+    from keymasq.session.profiles import ResolvedCombo
+
+    manager = SessionManager()
+    manager.profile_state.resolved_combos = [
+        ResolvedCombo(
+            id="combo-1",
+            name="Hold Layer",
+            profile_name="Base",
+            steps=[ComboStep(events=[ComboEvent(evdev="key_space")])],
+            action=MappingAction(
+                action_type=ActionType.PROFILE_TOGGLE,
+                profile_name="Layer",
+                profile_deactivation=ProfileDeactivationPolicy(on_trigger_end=True),
+            ),
+        )
+    ]
+    peer = PeerCredentials(pid=1, uid=1000, gid=1000)
+
+    result = await manager._handle_session_request(
+        {"command": "get_combo_inspector_snapshot"},
+        "client",
+        peer,
+        object(),
+    )
+
+    combos = cast(list[dict[str, object]], result["combos"])
+    action = cast(dict[str, object], combos[0]["action"])
+    assert action["action"] == "profile_toggle"
+    assert action["profile_name"] == "Layer"
+    assert action["deactivation"] == {"on_trigger_end": True}
+
+
+@pytest.mark.asyncio
 async def test_get_recording_settings_uses_unlock_and_owner_state_only() -> None:
     manager = SessionManager()
     manager.security_policy.recording_unlock_required = True

--- a/tests/session/test_session_manager_profile_apply.py
+++ b/tests/session/test_session_manager_profile_apply.py
@@ -75,6 +75,7 @@ async def test_reevaluate_profiles_skips_unchanged_mapping_and_combos() -> None:
         CommandType.SET_MAPPING,
         CommandType.SET_COMBOS,
     ]
+    assert [combo.id for combo in manager.profile_state.resolved_combos] == ["combo-1"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- New `ComboInspectorWindow` with read-only active combo viewer, snapshot history, search, and live updates
- Added inspect button to the Combo tab that opens the inspector window
- New session command `get_combo_inspector_snapshot` returning resolved active combos with source profiles
- Added combo inspector backend in `keymasq/session/manager/combo_inspector.py`
- Search support added to both the Combo tab and the inspector via fuzzy filtering
- Updated `docs/COMBOS.md` with inspector usage documentation
- Added ACL enforcement for the inspector snapshot command

## Testing

- `tests/gui/test_combo_inspector_window.py` — window open, snapshot apply, profile switch, history, search
- `tests/gui/test_combo_tab_widget.py` — search entry, inspect button visibility
- `tests/gui/test_main_window.py` — inspector lifecycle and window manager integration
- `tests/session/test_session_manager_command_acl.py` — ACL checks for inspector command
- `tests/session/test_session_manager_command_runtime.py` — snapshot resolution correctness
- Ran `ruff check .` — no new issues
- Ran `basedpyright` — no type errors