### PR TITLE
feat: add diagnostics output event stream with live uinput event view

### DIFF
--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -66,6 +66,13 @@ keymasq diagnostics on --include all --exclude internal
 The GTK app includes the same live view under **Diagnostics** in the main menu.
 It shows the latest snapshot from keymasqd without reading journal logs.
 
+The Diagnostics dialog also has an **Output** page for a read-only stream of
+uinput events written by keymasqd. It shows the output device and raw event,
+such as `keyboard: KEY_A=1`, `mouse: REL_X=5`, or
+`gamepad virtual-gamepad-1: BTN_SOUTH=1`. The default filter shows key/button
+events only. Repeat, relative pointer movement, absolute axis, sync, and other
+events are separate opt-in filters because they can produce high-volume logs.
+
 Disable when done:
 
 ```bash

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -326,12 +326,14 @@ read-only output event stream in the GUI Diagnostics dialog.
 - Disable: `keymasq diagnostics off`
 
 When enabled, keymasqd logs periodic latency stats (`p50`, `p95`, `p99`, `max`)
-for internal event buckets. The GUI output event stream can expose raw uinput
-events written by keymasqd output devices to the user session that enabled it.
-When recording unlock is required by policy, enabling diagnostics or the output
-event stream requires the same active GUI unlock owner as recording and
-inspection. Disabling diagnostics remains allowed so an existing stream can
-always be turned off.
+for internal event buckets. Latency diagnostics do not expose raw input or
+output events and are not gated by the recording unlock flow.
+
+The GUI output event stream can expose raw uinput events written by keymasqd
+output devices to the user session that enabled it. When recording unlock is
+required by policy, enabling the output event stream requires the same active
+GUI unlock owner as recording and inspection. Disabling diagnostics remains
+allowed so an existing stream can always be turned off.
 
 View logs with:
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -319,12 +319,19 @@ packages are already signed.
 
 ## Diagnostics Mode
 
-Keymasqd includes an optional diagnostics mode for internal latency measurement.
+Keymasqd includes optional diagnostics for internal latency measurement and a
+read-only output event stream in the GUI Diagnostics dialog.
 
 - Enable: `keymasq diagnostics on --interval 5`
 - Disable: `keymasq diagnostics off`
 
-When enabled, keymasqd logs periodic latency stats (`p50`, `p95`, `p99`, `max`) for internal event buckets.
+When enabled, keymasqd logs periodic latency stats (`p50`, `p95`, `p99`, `max`)
+for internal event buckets. The GUI output event stream can expose raw uinput
+events written by keymasqd output devices to the user session that enabled it.
+When recording unlock is required by policy, enabling diagnostics or the output
+event stream requires the same active GUI unlock owner as recording and
+inspection. Disabling diagnostics remains allowed so an existing stream can
+always be turned off.
 
 View logs with:
 

--- a/keymasq/common/ipc.py
+++ b/keymasq/common/ipc.py
@@ -52,6 +52,8 @@ class CommandType(Enum):
     SET_DIAGNOSTICS = "set_diagnostics"
     SET_VIRTUAL_GAMEPADS = "set_virtual_gamepads"
     DIAGNOSTICS_SNAPSHOT = "diagnostics_snapshot"
+    SET_DIAGNOSTICS_OUTPUT_STREAM = "set_diagnostics_output_stream"
+    DIAGNOSTICS_OUTPUT_EVENT = "diagnostics_output_event"
     DEVICE_INSPECTOR_START = "device_inspector_start"
     DEVICE_INSPECTOR_STOP = "device_inspector_stop"
     DEVICE_INSPECTOR_ENABLE_SUPPRESSION = "device_inspector_enable_suppression"

--- a/keymasq/gui/widgets/diagnostics_dialog.py
+++ b/keymasq/gui/widgets/diagnostics_dialog.py
@@ -184,6 +184,8 @@ class DiagnosticsDialog(Adw.Dialog):
         self._output_filter_checks: dict[str, Gtk.ToggleButton] = {}
         self._output_rows: list[Gtk.ListBoxRow] = []
         self._output_events: list[JsonDict] = []
+        self._output_unlock_status: Gtk.Label | None = None
+        self._output_unlock_button: Gtk.Button | None = None
 
         toolbar = Adw.ToolbarView()
         header = Adw.HeaderBar()
@@ -333,7 +335,25 @@ class DiagnosticsDialog(Adw.Dialog):
         enable_label.set_hexpand(True)
         controls.append(enable_label)
 
+        output_unlock_status = Gtk.Label(label="")
+        output_unlock_status.add_css_class("caption")
+        output_unlock_status.add_css_class("dim-label")
+        output_unlock_status.set_halign(Gtk.Align.END)
+        self._output_unlock_status = output_unlock_status
+        controls.append(output_unlock_status)
+
+        output_unlock_button = Gtk.Button()
+        output_unlock_button.set_child(self._make_unlock_button_content("Unlock"))
+        output_unlock_button.set_tooltip_text(
+            "Authorize diagnostics output monitoring. Output events expose raw virtual input "
+            "written by keymasqd."
+        )
+        output_unlock_button.connect("clicked", self._on_output_unlock_clicked)
+        self._output_unlock_button = output_unlock_button
+        controls.append(output_unlock_button)
+
         content.append(controls)
+        self._update_output_unlock_controls()
 
         events_header = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=6)
         events_header.set_halign(Gtk.Align.FILL)
@@ -415,7 +435,16 @@ class DiagnosticsDialog(Adw.Dialog):
     def _on_output_enabled_changed(self, switch: Gtk.Switch, _param: object) -> None:
         if self._syncing_controls:
             return
-        self._output_enabled = switch.get_active()
+        active = switch.get_active()
+        if active == self._output_enabled:
+            return
+        if active and not self._output_unlock_ready():
+            self._output_enabled = False
+            self._sync_output_enabled_switch()
+            self._output_status_label.set_text("Unlock required before watching output events.")
+            self._update_output_unlock_controls()
+            return
+        self._output_enabled = active
         self._apply_output_stream_settings()
 
     def _on_output_filter_toggled(self, button: Gtk.ToggleButton) -> None:
@@ -534,6 +563,7 @@ class DiagnosticsDialog(Adw.Dialog):
             self._output_status_label.set_text("Waiting for output events...")
         else:
             self._output_status_label.set_text("Output event stream is off.")
+        self._update_output_unlock_controls()
         return False
 
     def _diagnostics_payload(self, enabled: bool) -> JsonDict:
@@ -555,7 +585,73 @@ class DiagnosticsDialog(Adw.Dialog):
         self._output_enable_switch.set_sensitive(sensitive)
         for check in self._output_filter_checks.values():
             check.set_sensitive(sensitive)
+        if self._output_unlock_button is not None:
+            self._output_unlock_button.set_sensitive(sensitive)
         self._update_reset_button_state()
+
+    def _make_unlock_button_content(self, label: str) -> Gtk.Box:
+        box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=6)
+        icon = Gtk.Image.new_from_icon_name("channel-insecure-symbolic")
+        box.append(icon)
+        lbl = Gtk.Label(label=label)
+        box.append(lbl)
+        return box
+
+    def _output_unlock_state(self) -> tuple[bool, bool, bool]:
+        root = self._parent
+        if not hasattr(root, "_recording_unlock_required"):
+            return False, True, True
+        unlock_required = bool(getattr(root, "_recording_unlock_required", True))
+        recording_unlocked = bool(getattr(root, "_recording_unlocked", False))
+        refresh_owner = bool(getattr(root, "_recording_refresh_owner", False))
+        return unlock_required, recording_unlocked, refresh_owner
+
+    def _output_unlock_ready(self) -> bool:
+        unlock_required, recording_unlocked, refresh_owner = self._output_unlock_state()
+        return not unlock_required or (recording_unlocked and refresh_owner)
+
+    def _update_output_unlock_controls(self) -> None:
+        if self._output_unlock_button is None or self._output_unlock_status is None:
+            return
+
+        unlock_required, recording_unlocked, refresh_owner = self._output_unlock_state()
+        can_watch = not unlock_required or (recording_unlocked and refresh_owner)
+        if not unlock_required:
+            self._output_unlock_button.set_visible(False)
+            self._output_unlock_status.set_label("")
+            return
+        if can_watch:
+            self._output_unlock_button.set_visible(False)
+            self._output_unlock_status.set_label("Output monitoring unlocked")
+            return
+
+        self._output_unlock_button.set_visible(True)
+        label = "Claim" if recording_unlocked else "Unlock"
+        self._output_unlock_button.set_child(self._make_unlock_button_content(label))
+        if recording_unlocked:
+            self._output_unlock_button.set_tooltip_text(
+                "Claim this GUI as the active owner before watching output events."
+            )
+            self._output_unlock_status.set_label("Unlock active in another session")
+        else:
+            self._output_unlock_button.set_tooltip_text(
+                "Authorize diagnostics output monitoring. Output events expose raw virtual input "
+                "written by keymasqd."
+            )
+            self._output_unlock_status.set_label("Output monitoring locked")
+
+    def _on_output_unlock_clicked(self, _button: Gtk.Button) -> None:
+        present_unlock = getattr(self._parent, "present_unlock_dialog", None)
+        if callable(present_unlock):
+            present_unlock(on_success=self._on_output_unlock_success)
+            return
+        self._output_status_label.set_text("Unlock is only available from the main window.")
+
+    def _on_output_unlock_success(self) -> None:
+        self._output_enabled = True
+        self._sync_output_enabled_switch()
+        self._update_output_unlock_controls()
+        self._apply_output_stream_settings()
 
     def _update_reset_button_state(self) -> None:
         page_name = self._stack.get_visible_child_name()

--- a/keymasq/gui/widgets/diagnostics_dialog.py
+++ b/keymasq/gui/widgets/diagnostics_dialog.py
@@ -7,9 +7,10 @@ import gi
 gi.require_version("Gtk", "4.0")
 gi.require_version("Adw", "1")
 
-from gi.repository import Adw, GLib, Gtk  # pyright: ignore[reportAttributeAccessIssue]
+from gi.repository import Adw, Gdk, GLib, Gtk  # pyright: ignore[reportAttributeAccessIssue]
 
 from keymasq import __version__
+from keymasq.gui.icons import image_from_icon_names
 from keymasq.gui.session_client import (
     JsonDict,
     register_session_event_callback,
@@ -18,6 +19,11 @@ from keymasq.gui.session_client import (
 )
 
 DIAGNOSTICS_CATEGORIES = ("mainline", "combo", "internal")
+OUTPUT_STREAM_FILTERS = ("button", "axis", "mousemove", "syn", "other", "repeat")
+OUTPUT_STREAM_DEFAULT_FILTERS = {"button"}
+OUTPUT_STREAM_ROW_LIMIT = 200
+RESET_LATENCY_TOOLTIP = "Reset collected samples"
+RESET_OUTPUT_TOOLTIP = "Reset collected output events"
 DIAGNOSTICS_LABELS = {
     "passthrough_fast": "Unmapped passthrough",
     "passthrough_mapped": "Passthrough with mappings",
@@ -87,6 +93,64 @@ def _sort_by_priority(row1: Gtk.ListBoxRow, row2: Gtk.ListBoxRow) -> int:
     return 0
 
 
+def _text(value: object, default: str = "") -> str:
+    text = str(value or "").strip()
+    return text if text else default
+
+
+def _output_event_title(event: JsonDict) -> str:
+    output = _text(event.get("output"), "output")
+    output_id = _text(event.get("output_id"))
+    code_name = _text(event.get("code_name"), _text(event.get("code"), "?"))
+    value = _text(event.get("value"), "0")
+    if output_id and output_id != output:
+        return f"{output} {output_id}: {code_name}={value}"
+    return f"{output}: {code_name}={value}"
+
+
+def _output_event_detail(event: JsonDict) -> str:
+    sequence = int(event.get("sequence", 0) or 0)
+    category = _text(event.get("category"))
+    parts = [f"#{sequence}" if sequence else ""]
+    if category:
+        parts.append(category)
+    type_name = _text(event.get("type_name"), _text(event.get("type")))
+    code_name = _text(event.get("code_name"), _text(event.get("code")))
+    value = _text(event.get("value"), "0")
+    parts.append(f"{type_name} {code_name} value={value}")
+    hardware_id = _text(event.get("hardware_id"))
+    interface_id = _text(event.get("interface_id"))
+    if hardware_id:
+        parts.append(hardware_id)
+    if interface_id:
+        parts.append(interface_id)
+    return "  ".join(part for part in parts if part)
+
+
+def _output_event_export_line(event: JsonDict) -> str:
+    sequence = int(event.get("sequence", 0) or 0)
+    output = _text(event.get("output"), "output")
+    output_id = _text(event.get("output_id"))
+    output_label = output if not output_id or output_id == output else f"{output} {output_id}"
+    code_name = _text(event.get("code_name"), _text(event.get("code"), "unknown"))
+    event_type = _text(event.get("type_name"), _text(event.get("type"), "unknown"))
+    value = _text(event.get("value"), "0")
+    parts = [
+        f"#{sequence}" if sequence else "#-",
+        output_label,
+        code_name,
+        event_type,
+        f"value={value}",
+    ]
+    hardware_id = _text(event.get("hardware_id"))
+    interface_id = _text(event.get("interface_id"))
+    if hardware_id:
+        parts.append(f"hardware={hardware_id}")
+    if interface_id:
+        parts.append(f"interface={interface_id}")
+    return " ".join(parts)
+
+
 log = logging.getLogger("keymasq.gui.widgets.diagnostics_dialog")
 
 
@@ -115,6 +179,11 @@ class DiagnosticsDialog(Adw.Dialog):
         self._rows: dict[str, Gtk.ListBoxRow] = {}
         self._last_snapshot_time: float | None = None
         self._tick_source_id: int = 0
+        self._output_enabled = False
+        self._output_request_inflight = False
+        self._output_filter_checks: dict[str, Gtk.ToggleButton] = {}
+        self._output_rows: list[Gtk.ListBoxRow] = []
+        self._output_events: list[JsonDict] = []
 
         toolbar = Adw.ToolbarView()
         header = Adw.HeaderBar()
@@ -127,7 +196,7 @@ class DiagnosticsDialog(Adw.Dialog):
         header.pack_end(self._docs_button)
 
         self._reset_button = Gtk.Button(icon_name="view-refresh-symbolic")
-        self._reset_button.set_tooltip_text("Reset collected samples")
+        self._reset_button.set_tooltip_text(RESET_LATENCY_TOOLTIP)
         self._reset_button.set_sensitive(False)
         self._reset_button.connect("clicked", self._on_reset_clicked)
         header.pack_end(self._reset_button)
@@ -214,12 +283,112 @@ class DiagnosticsDialog(Adw.Dialog):
         content.append(self._empty_label)
 
         scrolled.set_child(content)
-        toolbar.set_content(scrolled)
+
+        self._stack = Gtk.Stack()
+        self._stack.set_vexpand(True)
+        self._stack.add_titled(scrolled, "latency", "Latency")
+        self._stack.add_titled(self._build_output_stream_page(), "output", "Output")
+        self._stack.connect("notify::visible-child-name", self._on_stack_page_changed)
+
+        switcher = Gtk.StackSwitcher()
+        switcher.set_stack(self._stack)
+        switcher.set_halign(Gtk.Align.CENTER)
+        switcher.set_margin_top(8)
+        switcher.set_margin_bottom(8)
+
+        stack_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=0)
+        stack_box.append(switcher)
+        stack_box.append(self._stack)
+        toolbar.set_content(stack_box)
         self.set_child(toolbar)
 
         register_session_event_callback("diagnostics_snapshot", self._on_diagnostics_snapshot)
+        register_session_event_callback(
+            "diagnostics_output_event",
+            self._on_diagnostics_output_event,
+        )
         self._tick_source_id = GLib.timeout_add_seconds(1, self._update_status_tick)
         self.connect("closed", self._on_closed)
+
+    def _build_output_stream_page(self) -> Gtk.ScrolledWindow:
+        scrolled = Gtk.ScrolledWindow()
+        scrolled.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
+
+        content = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=14)
+        content.set_margin_top(16)
+        content.set_margin_bottom(16)
+        content.set_margin_start(16)
+        content.set_margin_end(16)
+
+        controls = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=12)
+        controls.set_valign(Gtk.Align.CENTER)
+
+        self._output_enable_switch = Gtk.Switch()
+        self._output_enable_switch.set_valign(Gtk.Align.CENTER)
+        self._output_enable_switch.connect("notify::active", self._on_output_enabled_changed)
+        controls.append(self._output_enable_switch)
+
+        enable_label = Gtk.Label(label="Collect output events")
+        enable_label.set_halign(Gtk.Align.START)
+        enable_label.set_hexpand(True)
+        controls.append(enable_label)
+
+        content.append(controls)
+
+        events_header = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=6)
+        events_header.set_halign(Gtk.Align.FILL)
+
+        events_title = Gtk.Label(label="Output Events")
+        events_title.add_css_class("button-section-title")
+        events_title.set_halign(Gtk.Align.START)
+        events_header.append(events_title)
+
+        self._copy_output_button = Gtk.Button()
+        self._copy_output_button.set_tooltip_text("Copy visible output events")
+        self._copy_output_button.add_css_class("flat")
+        self._copy_output_button.add_css_class("inspector-copy-button")
+        self._copy_output_button.set_child(
+            image_from_icon_names("edit-copy-symbolic", "edit-paste-symbolic", pixel_size=14)
+        )
+        self._copy_output_button.connect("clicked", self._on_copy_output_events_clicked)
+        events_header.append(self._copy_output_button)
+        content.append(events_header)
+
+        filter_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL)
+        filter_box.add_css_class("linked")
+        for filter_id, label_text in (
+            ("button", "Keys"),
+            ("axis", "Axes"),
+            ("mousemove", "Move"),
+            ("syn", "Syn"),
+            ("other", "Other"),
+            ("repeat", "Repeat"),
+        ):
+            btn = Gtk.ToggleButton(label=label_text)
+            btn.set_active(filter_id in OUTPUT_STREAM_DEFAULT_FILTERS)
+            btn.connect("toggled", self._on_output_filter_toggled)
+            self._output_filter_checks[filter_id] = btn
+            filter_box.append(btn)
+        content.append(filter_box)
+
+        self._output_status_label = Gtk.Label(label="Output event stream is off.")
+        self._output_status_label.set_halign(Gtk.Align.START)
+        self._output_status_label.add_css_class("caption")
+        self._output_status_label.add_css_class("dim-label")
+        content.append(self._output_status_label)
+
+        self._output_list = Gtk.ListBox()
+        self._output_list.set_selection_mode(Gtk.SelectionMode.NONE)
+        self._output_list.add_css_class("boxed-list")
+        content.append(self._output_list)
+
+        self._output_empty_label = Gtk.Label(label="No output events yet.")
+        self._output_empty_label.set_halign(Gtk.Align.START)
+        self._output_empty_label.add_css_class("dim-label")
+        content.append(self._output_empty_label)
+
+        scrolled.set_child(content)
+        return scrolled
 
     def _selected_categories(self) -> list[str]:
         selected = [
@@ -229,11 +398,41 @@ class DiagnosticsDialog(Adw.Dialog):
         ]
         return selected or ["mainline"]
 
+    def _selected_output_filters(self) -> list[str]:
+        selected = [
+            filter_id
+            for filter_id in OUTPUT_STREAM_FILTERS
+            if self._output_filter_checks[filter_id].get_active()
+        ]
+        return selected or ["button"]
+
     def _on_enabled_changed(self, switch: Gtk.Switch, _param: object) -> None:
         if self._syncing_controls:
             return
         self._enabled = switch.get_active()
         self._apply_diagnostics_settings()
+
+    def _on_output_enabled_changed(self, switch: Gtk.Switch, _param: object) -> None:
+        if self._syncing_controls:
+            return
+        self._output_enabled = switch.get_active()
+        self._apply_output_stream_settings()
+
+    def _on_output_filter_toggled(self, button: Gtk.ToggleButton) -> None:
+        if self._syncing_controls:
+            return
+        active = [
+            filter_id
+            for filter_id in OUTPUT_STREAM_FILTERS
+            if self._output_filter_checks[filter_id].get_active()
+        ]
+        if not active:
+            self._syncing_controls = True
+            button.set_active(True)
+            self._syncing_controls = False
+            return
+        if self._output_enabled:
+            self._apply_output_stream_settings()
 
     def _on_interval_changed(self, _spin: Gtk.SpinButton) -> None:
         if self._syncing_controls:
@@ -260,6 +459,9 @@ class DiagnosticsDialog(Adw.Dialog):
             if isinstance(cells, dict) and "max" in cells:
                 cells["max"].set_visible(visible)
 
+    def _on_stack_page_changed(self, _stack: Gtk.Stack, _param: object) -> None:
+        self._update_reset_button_state()
+
     def _apply_diagnostics_settings(self) -> None:
         if self._request_inflight:
             return
@@ -267,6 +469,21 @@ class DiagnosticsDialog(Adw.Dialog):
         self._request_inflight = True
         self._set_controls_sensitive(False)
         session_request_async(payload, self._on_diagnostics_response, timeout=2.0)
+
+    def _apply_output_stream_settings(self) -> None:
+        if self._output_request_inflight:
+            return
+        self._output_request_inflight = True
+        self._set_output_controls_sensitive(False)
+        session_request_async(
+            {
+                "command": "set_diagnostics_output_stream",
+                "enabled": bool(self._output_enabled),
+                "filters": self._selected_output_filters(),
+            },
+            self._on_output_stream_response,
+            timeout=2.0,
+        )
 
     def _on_diagnostics_response(self, result: JsonDict | None) -> bool:
         self._request_inflight = False
@@ -298,6 +515,27 @@ class DiagnosticsDialog(Adw.Dialog):
             self._clear_rows()
         return False
 
+    def _on_output_stream_response(self, result: JsonDict | None) -> bool:
+        self._output_request_inflight = False
+        if self._closing:
+            return False
+        self._set_output_controls_sensitive(True)
+        if not result or result.get("status") != "ok":
+            message = str((result or {}).get("message") or "Output stream request failed.")
+            self._output_status_label.set_text(message)
+            return False
+
+        data = result.get("data")
+        response = data if isinstance(data, dict) else {}
+        self._output_enabled = bool(response.get("enabled", self._output_enabled))
+        self._sync_output_enabled_switch()
+        self._sync_output_filters(response.get("filters"))
+        if self._output_enabled:
+            self._output_status_label.set_text("Waiting for output events...")
+        else:
+            self._output_status_label.set_text("Output event stream is off.")
+        return False
+
     def _diagnostics_payload(self, enabled: bool) -> JsonDict:
         return {
             "command": "set_diagnostics",
@@ -311,7 +549,22 @@ class DiagnosticsDialog(Adw.Dialog):
         self._interval_spin.set_sensitive(sensitive)
         for check in self._category_checks.values():
             check.set_sensitive(sensitive)
-        self._reset_button.set_sensitive(sensitive and self._enabled)
+        self._update_reset_button_state()
+
+    def _set_output_controls_sensitive(self, sensitive: bool) -> None:
+        self._output_enable_switch.set_sensitive(sensitive)
+        for check in self._output_filter_checks.values():
+            check.set_sensitive(sensitive)
+        self._update_reset_button_state()
+
+    def _update_reset_button_state(self) -> None:
+        page_name = self._stack.get_visible_child_name()
+        if page_name == "output":
+            self._reset_button.set_tooltip_text(RESET_OUTPUT_TOOLTIP)
+            self._reset_button.set_sensitive(True)
+            return
+        self._reset_button.set_tooltip_text(RESET_LATENCY_TOOLTIP)
+        self._reset_button.set_sensitive(not self._request_inflight and self._enabled)
 
     def _sync_enabled_switch(self) -> None:
         self._syncing_controls = True
@@ -332,6 +585,25 @@ class DiagnosticsDialog(Adw.Dialog):
         finally:
             self._syncing_controls = False
 
+    def _sync_output_enabled_switch(self) -> None:
+        self._syncing_controls = True
+        try:
+            if self._output_enable_switch.get_active() != self._output_enabled:
+                self._output_enable_switch.set_active(self._output_enabled)
+        finally:
+            self._syncing_controls = False
+
+    def _sync_output_filters(self, raw_filters: object) -> None:
+        if not isinstance(raw_filters, list):
+            return
+        selected = {str(filter_id) for filter_id in raw_filters}
+        self._syncing_controls = True
+        try:
+            for filter_id, check in self._output_filter_checks.items():
+                check.set_active(filter_id in selected)
+        finally:
+            self._syncing_controls = False
+
     def _on_diagnostics_snapshot(self, event: JsonDict) -> bool:
         samples = event.get("samples")
         if not isinstance(samples, dict):
@@ -349,6 +621,63 @@ class DiagnosticsDialog(Adw.Dialog):
         self._reset_button.set_sensitive(self._enabled)
         self._render_samples(cast(dict[str, Any], samples))
         return False
+
+    def _on_diagnostics_output_event(self, event: JsonDict) -> bool:
+        events = event.get("events")
+        if not isinstance(events, list):
+            return False
+        self._output_enabled = bool(event.get("enabled", True))
+        self._sync_output_enabled_switch()
+        self._sync_output_filters(event.get("filters"))
+        for payload in events:
+            if isinstance(payload, dict):
+                self._prepend_output_row(cast(JsonDict, payload))
+        dropped = int(event.get("dropped", 0) or 0)
+        if dropped:
+            self._output_status_label.set_text(f"Updated just now. Dropped {dropped} events.")
+        elif events:
+            self._output_status_label.set_text("Updated just now.")
+        return False
+
+    def _prepend_output_row(self, event: JsonDict) -> None:
+        row = Gtk.ListBoxRow()
+        row.set_selectable(False)
+
+        box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=2)
+        box.set_margin_top(6)
+        box.set_margin_bottom(6)
+        box.set_margin_start(10)
+        box.set_margin_end(10)
+
+        title = Gtk.Label(label=_output_event_title(event))
+        title.set_halign(Gtk.Align.START)
+        title.add_css_class("heading")
+        box.append(title)
+
+        detail = Gtk.Label(label=_output_event_detail(event))
+        detail.set_halign(Gtk.Align.START)
+        detail.add_css_class("caption")
+        detail.add_css_class("dim-label")
+        box.append(detail)
+
+        row.set_child(box)
+        self._output_list.prepend(row)
+        self._output_rows.insert(0, row)
+        self._output_events.insert(0, dict(event))
+        while len(self._output_rows) > OUTPUT_STREAM_ROW_LIMIT:
+            old = self._output_rows.pop()
+            self._output_events.pop()
+            self._output_list.remove(old)
+        self._output_empty_label.set_visible(not self._output_rows)
+
+    def _on_copy_output_events_clicked(self, _button: Gtk.Button) -> None:
+        display = Gdk.Display.get_default()
+        if display is None:
+            return
+        display.get_clipboard().set(self._visible_output_event_export_text())
+
+    def _visible_output_event_export_text(self) -> str:
+        return "\n".join(_output_event_export_line(event) for event in self._output_events)
 
     def _render_samples(self, samples: dict[str, Any]) -> None:
         active_labels = set(samples)
@@ -436,7 +765,26 @@ class DiagnosticsDialog(Adw.Dialog):
         self._empty_label.set_visible(True)
         self._last_snapshot_time = None
 
+    def _clear_output_rows(self) -> None:
+        for row in list(self._output_rows):
+            self._output_list.remove(row)
+        self._output_rows.clear()
+        self._output_events.clear()
+        self._output_empty_label.set_visible(True)
+
+    def _reset_output_events(self) -> None:
+        self._clear_output_rows()
+        status = (
+            "Waiting for output events..."
+            if self._output_enabled
+            else "Output event stream is off."
+        )
+        self._output_status_label.set_text(status)
+
     def _on_reset_clicked(self, _button: Gtk.Button) -> None:
+        if self._stack.get_visible_child_name() == "output":
+            self._reset_output_events()
+            return
         if self._request_inflight:
             return
         self._clear_rows()
@@ -473,10 +821,25 @@ class DiagnosticsDialog(Adw.Dialog):
             GLib.source_remove(self._tick_source_id)
             self._tick_source_id = 0
         unregister_session_event_callback("diagnostics_snapshot", self._on_diagnostics_snapshot)
+        unregister_session_event_callback(
+            "diagnostics_output_event",
+            self._on_diagnostics_output_event,
+        )
         if self._enabled:
             self._enabled = False
             session_request_async(
                 self._diagnostics_payload(False),
+                lambda _result: False,
+                timeout=1.0,
+            )
+        if self._output_enabled:
+            self._output_enabled = False
+            session_request_async(
+                {
+                    "command": "set_diagnostics_output_stream",
+                    "enabled": False,
+                    "filters": self._selected_output_filters(),
+                },
                 lambda _result: False,
                 timeout=1.0,
             )

--- a/keymasq/keymasqd/daemon.py
+++ b/keymasq/keymasqd/daemon.py
@@ -456,7 +456,6 @@ class Daemon:
             CommandType.DEVICE_INSPECTOR_ENABLE_SUPPRESSION,
         }
         diagnostics_commands = {
-            CommandType.SET_DIAGNOSTICS,
             CommandType.SET_DIAGNOSTICS_OUTPUT_STREAM,
         }
 
@@ -544,7 +543,6 @@ class Daemon:
             CommandType.MACRO_UPDATE,
             CommandType.DEVICE_INSPECTOR_START,
             CommandType.DEVICE_INSPECTOR_ENABLE_SUPPRESSION,
-            CommandType.SET_DIAGNOSTICS,
             CommandType.SET_DIAGNOSTICS_OUTPUT_STREAM,
         }
         if command_type not in sensitive_commands:

--- a/keymasq/keymasqd/daemon.py
+++ b/keymasq/keymasqd/daemon.py
@@ -135,6 +135,12 @@ class _DaemonDeviceManager(Protocol):
         categories: Sequence[object] | None = None,
     ) -> JsonObject: ...
 
+    async def set_diagnostics_output_stream(
+        self,
+        enabled: bool,
+        filters: Sequence[object] | None = None,
+    ) -> JsonObject: ...
+
     async def start_device_inspector(self, hardware_id: str) -> JsonObject: ...
 
     async def stop_device_inspector(self, hardware_id: str) -> JsonObject: ...
@@ -382,7 +388,7 @@ class Daemon:
                     f"{client.client_class} is not allowed to call {command_type.value}"
                 )
 
-            self._ensure_sensitive_command_allowed(command_type, client)
+            self._ensure_sensitive_command_allowed(command_type, client, data)
 
         if self.verbosity >= 1:
             log.debug(f"Command: {command_type.value} -> {self._log_view(data)}")
@@ -434,6 +440,7 @@ class Daemon:
         self,
         command_type: CommandType,
         client: ClientContext,
+        data: JsonObject,
     ) -> None:
         policy = self.security_policy
         if policy is None or not policy.recording_unlock_required:
@@ -448,6 +455,10 @@ class Daemon:
             CommandType.DEVICE_INSPECTOR_START,
             CommandType.DEVICE_INSPECTOR_ENABLE_SUPPRESSION,
         }
+        diagnostics_commands = {
+            CommandType.SET_DIAGNOSTICS,
+            CommandType.SET_DIAGNOSTICS_OUTPUT_STREAM,
+        }
 
         tier2_commands = {
             CommandType.MACRO_GET,
@@ -457,6 +468,8 @@ class Daemon:
         }
 
         requires_unlock = command_type in tier1_commands
+        if not requires_unlock and command_type in diagnostics_commands:
+            requires_unlock = bool(data.get("enabled", False))
         if not requires_unlock and policy.macro_edit_requires_unlock:
             requires_unlock = command_type in tier2_commands
 
@@ -471,7 +484,7 @@ class Daemon:
 
         if source == "none":
             raise PermissionError(
-                "recording_locked: unlock required for capture/recording features"
+                "recording_locked: unlock required for capture/recording/diagnostics features"
             )
         raise PermissionError(f"recording_locked: unlock lease expired at {expires_at}")
 
@@ -531,6 +544,8 @@ class Daemon:
             CommandType.MACRO_UPDATE,
             CommandType.DEVICE_INSPECTOR_START,
             CommandType.DEVICE_INSPECTOR_ENABLE_SUPPRESSION,
+            CommandType.SET_DIAGNOSTICS,
+            CommandType.SET_DIAGNOSTICS_OUTPUT_STREAM,
         }
         if command_type not in sensitive_commands:
             return

--- a/keymasq/keymasqd/daemon_device_commands.py
+++ b/keymasq/keymasqd/daemon_device_commands.py
@@ -47,6 +47,12 @@ class _DeviceCommandManager(Protocol):
         categories: Sequence[object] | None = None,
     ) -> JsonObject: ...
 
+    async def set_diagnostics_output_stream(
+        self,
+        enabled: bool,
+        filters: Sequence[object] | None = None,
+    ) -> JsonObject: ...
+
     async def set_virtual_gamepads(self, count: object) -> JsonObject: ...
 
     async def track_profile_activation(
@@ -145,6 +151,16 @@ async def handle_device_command(
             else None
         )
         return await daemon.device_manager.set_diagnostics(enabled, interval, categories)
+
+    if command_type == CommandType.SET_DIAGNOSTICS_OUTPUT_STREAM:
+        enabled = bool(data.get("enabled", False))
+        raw_filters = data.get("filters")
+        filters = (
+            [str_value(category) for category in cast(list[object], raw_filters)]
+            if isinstance(raw_filters, list)
+            else None
+        )
+        return await daemon.device_manager.set_diagnostics_output_stream(enabled, filters)
 
     if command_type == CommandType.SET_VIRTUAL_GAMEPADS:
         return await daemon.device_manager.set_virtual_gamepads(data.get("count"))

--- a/keymasq/keymasqd/device_manager.py
+++ b/keymasq/keymasqd/device_manager.py
@@ -51,6 +51,7 @@ from keymasq.keymasqd.runtime import device_path_resolver
 from keymasq.keymasqd.runtime import grab_lifecycle as runtime_grab_lifecycle
 from keymasq.keymasqd.runtime import grabbed_device as runtime_grabbed_device
 from keymasq.keymasqd.runtime import macros as runtime_macros
+from keymasq.keymasqd.runtime import output_stream as runtime_output_stream
 from keymasq.keymasqd.runtime import outputs as runtime_outputs
 from keymasq.keymasqd.runtime import topology as runtime_topology
 from keymasq.keymasqd.runtime.profile_activation_tracker import ProfileActivationTracker
@@ -60,6 +61,12 @@ log = logging.getLogger("keymasqd.devices")
 ACTIVE_KEY_IDLE_LOG_INTERVAL_S = 1.0
 ACTIVE_KEY_IDLE_MAX_WAIT_S = 300.0
 COMBO_HELD_REARM_MODIFIERS = frozenset({"shift", "ctrl", "alt", "meta"})
+DIAGNOSTICS_OUTPUT_FILTERS = frozenset(
+    {"button", "axis", "mousemove", "syn", "other", "repeat"}
+)
+DEFAULT_DIAGNOSTICS_OUTPUT_FILTERS = frozenset({"button"})
+DIAGNOSTICS_OUTPUT_STREAM_INTERVAL_S = 0.1
+DIAGNOSTICS_OUTPUT_STREAM_MAX_PENDING = 2000
 EMERGENCY_CANCEL_COMBO_ID_PREFIX = "__keymasq_emergency_cancel:"
 EMERGENCY_CANCEL_COMBO_NAME = "Keymasq Emergency Cancel"
 EMERGENCY_CANCEL_COMBO_PROFILE = "__keymasq_internal"
@@ -191,11 +198,14 @@ def _device_path_resolver_deps() -> device_path_resolver.DevicePathResolverDeps:
     )
 
 
-def _macro_runtime_deps() -> runtime_macros.MacroRuntimeDeps:
+def _macro_runtime_deps(
+    *,
+    uinput_writer: runtime_adapters.UInputWriter = runtime_adapters.identity_uinput_writer,
+) -> runtime_macros.MacroRuntimeDeps:
     return runtime_macros.MacroRuntimeDeps(
         asyncio_mod=ASYNCIO_RUNTIME,
         evdev_mod=evdev,
-        uinput_writer=runtime_adapters.identity_uinput_writer,
+        uinput_writer=uinput_writer,
         log=log,
         int_value_fn=_int_value,
         str_value_fn=_str_value,
@@ -206,12 +216,14 @@ def _combo_runtime_deps(
     *,
     resolve_code_fn: runtime_combos.ResolveCodeFn = resolve_output_code,
     fire_and_observe_fn: runtime_combos.FireAndObserve = _fire_and_observe,
+    uinput_writer: runtime_adapters.UInputWriter = runtime_adapters.identity_uinput_writer,
+    emit_mouse_move_fn: Callable[..., None] = runtime_adapters.combo_emit_mouse_move,
 ) -> runtime_combos.ComboRuntimeDeps:
     return runtime_combos.ComboRuntimeDeps(
         asyncio_mod=ASYNCIO_RUNTIME,
         evdev_mod=runtime_adapters.COMBO_EVDEV_RUNTIME,
-        uinput_writer=runtime_adapters.identity_uinput_writer,
-        emit_mouse_move_fn=runtime_adapters.combo_emit_mouse_move,
+        uinput_writer=uinput_writer,
+        emit_mouse_move_fn=emit_mouse_move_fn,
         resolve_code_fn=resolve_code_fn,
         fire_and_observe_fn=fire_and_observe_fn,
     )
@@ -343,6 +355,45 @@ class DiagnosticsState:
     samples: dict[str, deque[float]] = field(default_factory=dict)
 
 
+@dataclass
+class DiagnosticsOutputStreamState:
+    enabled: bool = False
+    filters: set[str] = field(default_factory=lambda: set(DEFAULT_DIAGNOSTICS_OUTPUT_FILTERS))
+    task: asyncio.Task[None] | None = None
+    pending: deque[JsonObject] = field(default_factory=deque)
+    sequence: int = 0
+    dropped: int = 0
+    interval: float = DIAGNOSTICS_OUTPUT_STREAM_INTERVAL_S
+
+
+class _ObservedUInputWriter:
+    def __init__(
+        self,
+        raw: runtime_adapters.WritableUInput,
+        recorder: Callable[[object, int, int, int], None],
+        uinput_dev: object,
+    ) -> None:
+        self._raw = raw
+        self._recorder = recorder
+        self._uinput_dev = uinput_dev
+
+    def write(self, event_type: int, code: int, value: int) -> None:
+        self._raw.write(event_type, code, value)
+        self._recorder(self._uinput_dev, int(event_type), int(code), int(value))
+
+    def syn(self) -> None:
+        self._raw.syn()
+        self._recorder(
+            self._uinput_dev,
+            int(evdev.ecodes.EV_SYN),
+            int(evdev.ecodes.SYN_REPORT),
+            0,
+        )
+
+    def close(self) -> None:
+        self._raw.close()
+
+
 DIAGNOSTICS_CATEGORIES = frozenset({"mainline", "combo", "internal"})
 DEFAULT_DIAGNOSTICS_CATEGORIES = frozenset({"mainline"})
 
@@ -360,6 +411,19 @@ def _normalize_diagnostics_categories(categories: Sequence[object] | None) -> se
         return set(DIAGNOSTICS_CATEGORIES)
     selected = normalized & DIAGNOSTICS_CATEGORIES
     return selected or set(DEFAULT_DIAGNOSTICS_CATEGORIES)
+
+
+def _normalize_output_stream_filters(filters: Sequence[object] | None) -> set[str]:
+    if not filters:
+        return set(DEFAULT_DIAGNOSTICS_OUTPUT_FILTERS)
+
+    normalized = {
+        str(category or "").strip().lower() for category in filters if str(category or "").strip()
+    }
+    if "all" in normalized:
+        return set(DIAGNOSTICS_OUTPUT_FILTERS)
+    selected = normalized & DIAGNOSTICS_OUTPUT_FILTERS
+    return selected or set(DEFAULT_DIAGNOSTICS_OUTPUT_FILTERS)
 
 
 def _diagnostics_label_enabled(label: str, categories: set[str]) -> bool:
@@ -454,6 +518,7 @@ class DeviceManager:
         self.macro_state = MacroRuntimeState()
         self._op_lock = asyncio.Lock()
         self.diagnostics_state = DiagnosticsState()
+        self.diagnostics_output_stream_state = DiagnosticsOutputStreamState()
         self.grab_state = GrabRuntimeState(
             release_grace_s=max(0.01, float(release_grace_s)),
             held_release_retry_s=max(0.01, float(held_release_retry_s)),
@@ -495,7 +560,10 @@ class DeviceManager:
             cancelled_rapidfire_tasks: list[asyncio.Task[None]] = []
             await runtime_combos.clear_combo_runtime(
                 self,
-                deps=runtime_grab_lifecycle.combo_runtime_deps(),
+                deps=runtime_grab_lifecycle.combo_runtime_deps(
+                    uinput_writer=self.observed_uinput_writer,
+                    emit_mouse_move_fn=self.emit_diagnostics_output_mouse_move,
+                ),
             )
             for devices in self.grabbed_devices.values():
                 for device in devices:
@@ -999,14 +1067,20 @@ class DeviceManager:
         if preserve_combo_ids is None:
             await runtime_combos.clear_combo_runtime(
                 self,
-                deps=_combo_runtime_deps(),
+                deps=_combo_runtime_deps(
+                    uinput_writer=self.observed_uinput_writer,
+                    emit_mouse_move_fn=self.emit_diagnostics_output_mouse_move,
+                ),
             )
             self.combo_state.engine.set_combos(active_combos)
         else:
             await runtime_combos.clear_combo_runtime_except(
                 self,
                 preserve_combo_ids,
-                deps=_combo_runtime_deps(),
+                deps=_combo_runtime_deps(
+                    uinput_writer=self.observed_uinput_writer,
+                    emit_mouse_move_fn=self.emit_diagnostics_output_mouse_move,
+                ),
             )
             self.combo_state.engine.set_combos(
                 active_combos,
@@ -1017,7 +1091,10 @@ class DeviceManager:
         )
         runtime_combos.refresh_combo_timeout_watchdog(
             self,
-            deps=_combo_runtime_deps(),
+            deps=_combo_runtime_deps(
+                uinput_writer=self.observed_uinput_writer,
+                emit_mouse_move_fn=self.emit_diagnostics_output_mouse_move,
+            ),
         )
         return active_combos
 
@@ -1173,6 +1250,170 @@ class DeviceManager:
             return
         bucket = self.diagnostics_state.samples.setdefault(label, deque(maxlen=20000))
         bucket.append(float(duration_us))
+
+    async def set_diagnostics_output_stream(
+        self,
+        enabled: bool,
+        filters: Sequence[object] | None = None,
+    ) -> JsonObject:
+        state = self.diagnostics_output_stream_state
+        state.enabled = bool(enabled)
+        state.filters = _normalize_output_stream_filters(filters)
+        state.pending.clear()
+        state.dropped = 0
+
+        if not state.enabled:
+            if state.task:
+                state.task.cancel()
+                try:
+                    await state.task
+                except asyncio.CancelledError:
+                    pass
+                state.task = None
+            log.info("Diagnostics output stream disabled")
+            return {
+                "enabled": False,
+                "filters": sorted(state.filters),
+            }
+
+        if state.task is None or state.task.done():
+            state.task = asyncio.create_task(self._diagnostics_output_stream_loop())
+        log.info(
+            "Diagnostics output stream enabled (filters=%s)",
+            ",".join(sorted(state.filters)),
+        )
+        return {
+            "enabled": True,
+            "filters": sorted(state.filters),
+        }
+
+    def observed_uinput_writer(
+        self,
+        uinput_dev: object | None,
+    ) -> runtime_adapters.WritableUInput | None:
+        raw = runtime_adapters.identity_uinput_writer(uinput_dev)
+        if raw is None:
+            return None
+        if not self.diagnostics_output_stream_state.enabled:
+            return raw
+        return _ObservedUInputWriter(raw, self.record_diagnostics_output_write, uinput_dev)
+
+    def emit_diagnostics_output_mouse_move(
+        self,
+        uinput_dev: object | None,
+        move_x: int,
+        move_y: int,
+        *,
+        absolute: bool = False,
+    ) -> None:
+        emit_mouse_move(
+            self.observed_uinput_writer(uinput_dev),
+            int(move_x),
+            int(move_y),
+            absolute=absolute,
+        )
+
+    def record_diagnostics_output_write(
+        self,
+        uinput_dev: object,
+        event_type: int,
+        code: int,
+        value: int,
+    ) -> None:
+        if int(event_type) == int(evdev.ecodes.EV_SYN):
+            pass
+        is_repeat = int(event_type) == int(evdev.ecodes.EV_KEY) and int(value) == 2
+        if is_repeat and "repeat" not in self.diagnostics_output_stream_state.filters:
+            return
+        output_target = self._diagnostics_output_target(uinput_dev)
+        payload = runtime_output_stream.build_output_event(
+            output_target=output_target,
+            event_type=int(event_type),
+            code=int(code),
+            value=int(value),
+            evdev_mod=evdev,
+        )
+        if is_repeat:
+            payload["repeat"] = True
+        category = (
+            "repeat"
+            if is_repeat
+            else str(payload.get("filter_category", "other") or "other")
+        )
+        self._queue_diagnostics_output_event(
+            category,
+            payload,
+        )
+
+    def _queue_diagnostics_output_event(self, category: str, payload: JsonObject) -> None:
+        state = self.diagnostics_output_stream_state
+        if not state.enabled:
+            return
+        normalized_category = str(category or "").strip().lower()
+        if normalized_category not in state.filters:
+            return
+        state.sequence += 1
+        event_payload = dict(payload)
+        event_payload["sequence"] = state.sequence
+        event_payload["category"] = normalized_category
+        event_payload["time"] = time.time()
+        if len(state.pending) >= DIAGNOSTICS_OUTPUT_STREAM_MAX_PENDING:
+            state.pending.popleft()
+            state.dropped += 1
+        state.pending.append(event_payload)
+
+    def _diagnostics_output_target(self, uinput_dev: object) -> JsonObject:
+        output_state = self.output_state
+        if uinput_dev is output_state.keyboard_uinput:
+            return {"category": "virtual", "output": "keyboard", "output_id": "keyboard"}
+        if uinput_dev is output_state.mouse_uinput:
+            return {"category": "virtual", "output": "mouse", "output_id": "mouse"}
+        for output_id, gamepad_uinput in output_state.virtual_gamepad_uinputs.items():
+            if uinput_dev is gamepad_uinput:
+                return {
+                    "category": "virtual",
+                    "output": "gamepad",
+                    "output_id": str(output_id),
+                }
+
+        for hardware_id, devices in self.grabbed_devices.items():
+            for device in devices:
+                if uinput_dev is getattr(device, "uinput", None):
+                    return {
+                        "category": "passthrough",
+                        "output": "passthrough",
+                        "output_id": str(hardware_id),
+                        "hardware_id": str(hardware_id),
+                        "interface_id": str(getattr(device, "interface_id", "") or ""),
+                    }
+
+        return {"category": "virtual", "output": "unknown", "output_id": "unknown"}
+
+    async def _diagnostics_output_stream_loop(self) -> None:
+        try:
+            while self.diagnostics_output_stream_state.enabled:
+                await asyncio.sleep(self.diagnostics_output_stream_state.interval)
+                self._flush_diagnostics_output_events()
+        except asyncio.CancelledError:
+            raise
+
+    def _flush_diagnostics_output_events(self) -> None:
+        state = self.diagnostics_output_stream_state
+        if not state.pending and not state.dropped:
+            return
+        events = list(state.pending)
+        state.pending.clear()
+        dropped = state.dropped
+        state.dropped = 0
+        self._broadcast_runtime_event(
+            CommandType.DIAGNOSTICS_OUTPUT_EVENT,
+            {
+                "enabled": state.enabled,
+                "filters": sorted(state.filters),
+                "events": events,
+                "dropped": dropped,
+            },
+        )
 
     async def _diagnostics_loop(self) -> None:
         try:
@@ -1430,7 +1671,7 @@ class DeviceManager:
             source_device,
             source_button,
             trigger_value,
-            deps=_macro_runtime_deps(),
+            deps=_macro_runtime_deps(uinput_writer=self.observed_uinput_writer),
             macro_event_source=macro_event_source,
         )
 
@@ -1464,7 +1705,7 @@ class DeviceManager:
         if self.output_state.mouse_uinput is None:
             return {"status": "error", "message": "No mouse uinput device available"}
 
-        emit_mouse_move(
+        self.emit_diagnostics_output_mouse_move(
             self.output_state.mouse_uinput,
             int(x),
             int(y),
@@ -1475,7 +1716,7 @@ class DeviceManager:
     async def cancel_macro_playback(self) -> JsonObject:
         result = await runtime_macros.cancel_macro_playback(
             self,
-            deps=_macro_runtime_deps(),
+            deps=_macro_runtime_deps(uinput_writer=self.observed_uinput_writer),
         )
         if bool(result.get("cancelled", False)):
             self._broadcast_runtime_event(

--- a/keymasq/keymasqd/runtime/combos.py
+++ b/keymasq/keymasqd/runtime/combos.py
@@ -1606,8 +1606,7 @@ async def clear_combo_runtime_except(
         await machine.stop()
 
     active_output_roots = {
-        combo_id.split("#", 1)[0]
-        for combo_id in manager.combo_state.active_actions
+        combo_id.split("#", 1)[0] for combo_id in manager.combo_state.active_actions
     }
     if not any(root in preserved for root in active_output_roots):
         for held in manager.combo_state.held_output_keys.values():

--- a/keymasq/keymasqd/runtime/grab_lifecycle.py
+++ b/keymasq/keymasqd/runtime/grab_lifecycle.py
@@ -52,12 +52,14 @@ def combo_runtime_deps(
     *,
     resolve_code_fn: runtime_combos.ResolveCodeFn = resolve_output_code,
     fire_and_observe_fn: runtime_combos.FireAndObserve = _fire_and_forget,
+    uinput_writer: runtime_adapters.UInputWriter = runtime_adapters.identity_uinput_writer,
+    emit_mouse_move_fn: Callable[..., None] = runtime_adapters.combo_emit_mouse_move,
 ) -> runtime_combos.ComboRuntimeDeps:
     return runtime_combos.ComboRuntimeDeps(
         asyncio_mod=ASYNCIO_RUNTIME,
         evdev_mod=COMBO_EVDEV_RUNTIME,
-        uinput_writer=runtime_adapters.identity_uinput_writer,
-        emit_mouse_move_fn=runtime_adapters.combo_emit_mouse_move,
+        uinput_writer=uinput_writer,
+        emit_mouse_move_fn=emit_mouse_move_fn,
         resolve_code_fn=resolve_code_fn,
         fire_and_observe_fn=fire_and_observe_fn,
     )
@@ -208,7 +210,11 @@ async def grab_device_unlocked(
             get_interface_id_fn=get_interface_id_fn,
             int_value_fn=int_value_fn,
             str_value_fn=str_value_fn,
-            deps=combo_runtime_deps(fire_and_observe_fn=fire_and_observe_fn),
+            deps=combo_runtime_deps(
+                fire_and_observe_fn=fire_and_observe_fn,
+                uinput_writer=manager.observed_uinput_writer,
+                emit_mouse_move_fn=manager.emit_diagnostics_output_mouse_move,
+            ),
         )
 
     async def runtime_cleanup_callback(
@@ -219,7 +225,11 @@ async def grab_device_unlocked(
             manager,
             cleanup_hardware_id,
             cleanup_source,
-            deps=combo_runtime_deps(fire_and_observe_fn=fire_and_observe_fn),
+            deps=combo_runtime_deps(
+                fire_and_observe_fn=fire_and_observe_fn,
+                uinput_writer=manager.observed_uinput_writer,
+                emit_mouse_move_fn=manager.emit_diagnostics_output_mouse_move,
+            ),
         )
 
     for path in sorted(requested_paths):
@@ -308,6 +318,7 @@ async def grab_device_unlocked(
                     suppress_rel_getter=lambda: manager.macro_state.mouse_rel_suppressed,
                     mouse_rel_suppression_start_callback=lambda: None,
                     diagnostics_recorder=diagnostics_recorder,
+                    uinput_writer=manager.observed_uinput_writer,
                     runtime_cleanup_callback=runtime_cleanup_callback,
                     interface_id=interface_id,
                 )
@@ -524,7 +535,10 @@ async def release_device_unlocked(
         manager,
         hardware_id,
         None,
-        deps=combo_runtime_deps(),
+        deps=combo_runtime_deps(
+            uinput_writer=manager.observed_uinput_writer,
+            emit_mouse_move_fn=manager.emit_diagnostics_output_mouse_move,
+        ),
     )
     manager.grab_state.desired_grabs.pop(hardware_id, None)
     devices = manager.grabbed_devices.pop(hardware_id, [])
@@ -701,7 +715,10 @@ async def release_interface_unlocked(
         manager,
         hardware_id,
         str(getattr(removed, "interface_id", "") or "").lower(),
-        deps=combo_runtime_deps(),
+        deps=combo_runtime_deps(
+            uinput_writer=manager.observed_uinput_writer,
+            emit_mouse_move_fn=manager.emit_diagnostics_output_mouse_move,
+        ),
     )
     removed.release_tracked_outputs()
     await removed.release()
@@ -724,7 +741,11 @@ async def release_all_devices(
         await manager.cancel_macro_playback()
         await runtime_combos.clear_combo_runtime(
             manager,
-            deps=combo_runtime_deps(fire_and_observe_fn=fire_and_observe_fn),
+            deps=combo_runtime_deps(
+                fire_and_observe_fn=fire_and_observe_fn,
+                uinput_writer=manager.observed_uinput_writer,
+                emit_mouse_move_fn=manager.emit_diagnostics_output_mouse_move,
+            ),
         )
         hardware_ids = set(manager.grabbed_devices) | set(manager.grab_state.desired_grabs)
         for hardware_id in list(hardware_ids):

--- a/keymasq/keymasqd/runtime/grabbed_device.py
+++ b/keymasq/keymasqd/runtime/grabbed_device.py
@@ -40,6 +40,7 @@ from keymasq.keymasqd.runtime.grabbed_device_types import (
     GrabbedDeviceState,
     MacroPlayer,
     MappingGetter,
+    UInputWriter,
     identity_uinput_writer,
 )
 from keymasq.keymasqd.runtime.grabbed_device_types import (
@@ -203,6 +204,7 @@ class GrabbedDevice:
         suppress_rel_getter: Callable[[], bool] | None = None,
         mouse_rel_suppression_start_callback: Callable[[], None] | None = None,
         diagnostics_recorder: Callable[[str, float], None] | None = None,
+        uinput_writer: UInputWriter = _uinput_writer,
         runtime_cleanup_callback: Callable[[str, str | None], Awaitable[None]] | None = None,
         button_codes: dict[str, int] | None = None,
         button_values: dict[str, int] | None = None,
@@ -254,6 +256,7 @@ class GrabbedDevice:
         self.suppress_rel_getter = suppress_rel_getter
         self.mouse_rel_suppression_start_callback = mouse_rel_suppression_start_callback
         self.diagnostics_recorder = diagnostics_recorder
+        self.uinput_writer = uinput_writer
         self.runtime_cleanup_callback = runtime_cleanup_callback
         self.task: asyncio.Task[None] | None = None
         self._running = False
@@ -356,7 +359,7 @@ class GrabbedDevice:
     ) -> None:
         await runtime_analog_controls.reset_analog_controls(
             self,
-            deps=runtime_events.build_action_execution_deps(),
+            deps=runtime_events.build_action_execution_deps(uinput_writer=self.uinput_writer),
             preserve_state_keys=preserve_state_keys,
         )
 
@@ -459,7 +462,7 @@ class GrabbedDevice:
         await self.reset_analog_controls()
         await self.reset_superkeys()
         runtime_events.observe_profile_trigger_end_for_held_sources(self)
-        runtime_outputs.release_all_keys(self, evdev_mod=evdev, uinput_writer=_uinput_writer)
+        runtime_outputs.release_all_keys(self, evdev_mod=evdev, uinput_writer=self.uinput_writer)
         self.state.held_source_keys.clear()
         self.state.held_source_actions.clear()
         self.state.combo_passthrough_held.clear()
@@ -496,7 +499,7 @@ class GrabbedDevice:
         log.info("Released %s", self.path)
 
     def release_tracked_outputs(self) -> None:
-        runtime_outputs.release_all_keys(self, evdev_mod=evdev, uinput_writer=_uinput_writer)
+        runtime_outputs.release_all_keys(self, evdev_mod=evdev, uinput_writer=self.uinput_writer)
 
     def resolve_gamepad_output(self, output_id: str | None, context: str) -> object | None:
         if self._gamepad_output_resolver is None:
@@ -580,7 +583,7 @@ class GrabbedDevice:
             code,
             0,
             evdev_mod=evdev,
-            uinput_writer=_uinput_writer,
+            uinput_writer=self.uinput_writer,
             bucket=bucket,
         )
 
@@ -595,7 +598,7 @@ class GrabbedDevice:
             code,
             1,
             evdev_mod=evdev,
-            uinput_writer=_uinput_writer,
+            uinput_writer=self.uinput_writer,
             bucket=bucket,
         )
         if bucket == "passthrough":

--- a/keymasq/keymasqd/runtime/grabbed_device_actions.py
+++ b/keymasq/keymasqd/runtime/grabbed_device_actions.py
@@ -382,7 +382,7 @@ async def _execute_overload_superkey(
     *,
     deps: ActionExecutionDeps,
 ) -> None:
-    config = action.superkey_config
+    config = cast(RuntimeSuperkeyConfig | None, action.superkey_config)
     if config is None:
         return
 

--- a/keymasq/keymasqd/runtime/grabbed_device_events.py
+++ b/keymasq/keymasqd/runtime/grabbed_device_events.py
@@ -3,7 +3,7 @@ import contextlib
 import logging
 import time
 from collections.abc import Awaitable, Callable
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import cast
 
 import evdev
@@ -32,6 +32,7 @@ from keymasq.keymasqd.runtime.grabbed_device_types import (
     GrabbedDeviceRuntime,
     InputEventLike,
     TimeModule,
+    UInputWriter,
     identity_uinput_writer,
     runtime_is_running,
 )
@@ -58,13 +59,15 @@ def _fire_and_observe(coro: Awaitable[object], label: str) -> asyncio.Task[objec
 
 
 def build_action_execution_deps(
-    *, fire_and_observe_fn: FireAndObserve = _fire_and_observe
+    *,
+    fire_and_observe_fn: FireAndObserve = _fire_and_observe,
+    uinput_writer: UInputWriter = identity_uinput_writer,
 ) -> ActionExecutionDeps:
     return ActionExecutionDeps(
         asyncio_mod=cast(AsyncioModule, asyncio),
         fire_and_observe_fn=fire_and_observe_fn,
         evdev_mod=evdev,
-        uinput_writer=identity_uinput_writer,
+        uinput_writer=uinput_writer,
     )
 
 
@@ -301,7 +304,7 @@ async def cleanup_runtime_failure(
     runtime_outputs.release_all_keys(
         device_runtime,
         evdev_mod=evdev,
-        uinput_writer=identity_uinput_writer,
+        uinput_writer=device_runtime.uinput_writer,
     )
 
 
@@ -325,9 +328,7 @@ def observe_profile_trigger_end_for_held_sources(
 
 def get_event_name(event: InputEventLike, *, evdev_mod: EvdevModule) -> str:
     try:
-        raw_code_name: object = evdev_mod.ecodes.bytype[event.type].get(
-            event.code, str(event.code)
-        )
+        raw_code_name: object = evdev_mod.ecodes.bytype[event.type].get(event.code, str(event.code))
         return _evdev_code_name(raw_code_name, int(event.code))
     except Exception:
         return str(event.code)
@@ -485,6 +486,12 @@ async def process_event(
 ) -> None:
     evdev_mod = deps.evdev_mod
     time_mod = deps.time_mod
+    uinput_writer = device_runtime.uinput_writer
+    action_deps = (
+        deps.action_deps
+        if deps.action_deps.uinput_writer is uinput_writer
+        else replace(deps.action_deps, uinput_writer=uinput_writer)
+    )
     started_ns = time_mod.perf_counter_ns()
     diag_label = "unknown"
     combo_consumed = False
@@ -613,17 +620,15 @@ async def process_event(
         syn_report = int(getattr(evdev_mod.ecodes, "SYN_REPORT", 0))
         syn_mt_report = int(getattr(evdev_mod.ecodes, "SYN_MT_REPORT", 0))
         if event_code == syn_report:
-            passthrough_frame_open = runtime_outputs.passthrough_frame_open(
-                device_runtime.uinput
-            )
+            passthrough_frame_open = runtime_outputs.passthrough_frame_open(device_runtime.uinput)
             runtime_outputs.flush_passthrough_frame(
                 device_runtime.uinput,
-                uinput_writer=identity_uinput_writer,
+                uinput_writer=uinput_writer,
             )
             if passthrough_frame_open:
                 diag_label = "passthrough_syn"
         elif event_code == syn_mt_report:
-            writer = identity_uinput_writer(device_runtime.uinput)
+            writer = uinput_writer(device_runtime.uinput)
             if writer is not None:
                 writer.write(evdev_mod.ecodes.EV_SYN, event_code, int(event.value))
                 runtime_outputs.mark_passthrough_frame_open(device_runtime.uinput)
@@ -632,17 +637,21 @@ async def process_event(
         _record_diagnostics(device_runtime, diag_label, started_ns, time_mod=time_mod)
         return
 
-    if event.type == evdev_mod.ecodes.EV_ABS and (
-        int(event.type),
-        int(event.code),
-    ) in device_runtime.analog_axis_bindings:
+    if (
+        event.type == evdev_mod.ecodes.EV_ABS
+        and (
+            int(event.type),
+            int(event.code),
+        )
+        in device_runtime.analog_axis_bindings
+    ):
         mapping = device_runtime.mapping_getter()
         if await runtime_analog_controls.process_analog_event(
             device_runtime,
             event,
             event_name,
             mapping,
-            deps=deps.action_deps,
+            deps=action_deps,
         ):
             _record_diagnostics(
                 device_runtime,
@@ -657,7 +666,7 @@ async def process_event(
             device_runtime,
             event,
             evdev_mod=evdev_mod,
-            uinput_writer=identity_uinput_writer,
+            uinput_writer=uinput_writer,
             sync=False,
         )
         _record_diagnostics(device_runtime, "passthrough_other", started_ns, time_mod=time_mod)
@@ -671,7 +680,7 @@ async def process_event(
             device_runtime,
             event,
             evdev_mod=evdev_mod,
-            uinput_writer=identity_uinput_writer,
+            uinput_writer=uinput_writer,
             sync=False,
         )
         if int(event.value) == 0:
@@ -744,7 +753,7 @@ async def process_event(
             device_runtime,
             event,
             evdev_mod=evdev_mod,
-            uinput_writer=identity_uinput_writer,
+            uinput_writer=uinput_writer,
             sync=False,
         )
         _record_profile_input_if_countable(
@@ -795,7 +804,7 @@ async def process_event(
             action,
             event,
             event_name,
-            deps=deps.action_deps,
+            deps=action_deps,
         )
         diag_label = (
             f"combo_release_action_{action.action_type.value}"
@@ -813,7 +822,7 @@ async def process_event(
             device_runtime,
             event,
             evdev_mod=evdev_mod,
-            uinput_writer=identity_uinput_writer,
+            uinput_writer=uinput_writer,
             sync=False,
         )
         _record_profile_input_if_countable(
@@ -1010,7 +1019,7 @@ async def _process_wheel_pulse_event(
             device_runtime,
             event,
             evdev_mod=evdev_mod,
-            uinput_writer=identity_uinput_writer,
+            uinput_writer=device_runtime.uinput_writer,
             sync=False,
         )
         return "wheel_passthrough"
@@ -1038,7 +1047,7 @@ async def _process_wheel_pulse_event(
             action,
             event,
             pulse_event_name,
-            deps=deps.action_deps,
+            deps=replace(deps.action_deps, uinput_writer=device_runtime.uinput_writer),
         )
     return f"action_{action.action_type.value}"
 

--- a/keymasq/keymasqd/runtime/grabbed_device_types.py
+++ b/keymasq/keymasqd/runtime/grabbed_device_types.py
@@ -235,9 +235,7 @@ class GrabbedDeviceState:
         str,
         tuple[tuple[int, MappingAction], ...],
     ] = field(default_factory=dict)
-    analog_threshold_output_refcounts: dict[str, dict[int, int]] = field(
-        default_factory=dict
-    )
+    analog_threshold_output_refcounts: dict[str, dict[int, int]] = field(default_factory=dict)
     analog_threshold_abs_refcounts: dict[str, dict[int, int]] = field(default_factory=dict)
     analog_mouse_tasks: dict[str, asyncio.Task[None]] = field(default_factory=dict)
     analog_mouse_accumulators: dict[str, tuple[float, float]] = field(default_factory=dict)
@@ -313,6 +311,9 @@ class GrabbedDeviceRuntime(Protocol):
     def inspector_suppression_disabler(
         self,
     ) -> DeviceInspectorSuppressionDisabler | None: ...
+
+    @property
+    def uinput_writer(self) -> UInputWriter: ...
 
     @property
     def profile_activation_recorder(self) -> ProfileActivationRecorder | None: ...

--- a/keymasq/keymasqd/runtime/macros.py
+++ b/keymasq/keymasqd/runtime/macros.py
@@ -391,6 +391,7 @@ async def play_macro_task(
                 idx += 1
 
                 t_us = int_value_fn(ev.get("t_us"), 0)
+                action_type = str(ev.get("macro_action", "") or "")
                 deadline = (
                     iteration_anchor
                     + timeline_offset_s
@@ -403,7 +404,6 @@ async def play_macro_task(
                 if remaining >= 0.0005:
                     await asyncio_mod.sleep(remaining)
 
-                action_type = str(ev.get("macro_action", "") or "")
                 if action_type in {"mouse_move_abs", "mouse_move_rel"}:
                     if not replay_mouse_movement:
                         continue
@@ -891,14 +891,16 @@ async def run_macro_control_action(
         dispatcher = str_value_fn(ev.get("dispatcher"), "").strip()
         if not dispatcher:
             return 0.0
+        compositor = str_value_fn(ev.get("compositor"), "").strip()
+        args = str_value_fn(ev.get("args"), "").strip()
         if manager.broadcast_callback:
             await manager.broadcast_callback(
                 CommandType.ACTION_TRIGGER,
                 {
                     "action_type": "compositor_dispatch",
-                    "compositor": str_value_fn(ev.get("compositor"), "").strip(),
+                    "compositor": compositor,
                     "dispatcher": dispatcher,
-                    "args": str_value_fn(ev.get("args"), "").strip(),
+                    "args": args,
                 },
             )
         return 0.0

--- a/keymasq/keymasqd/runtime/output_stream.py
+++ b/keymasq/keymasqd/runtime/output_stream.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, cast
+
+type JsonObject = dict[str, object]
+
+
+def _ecodes(evdev_mod: Any) -> object:
+    return cast(object, getattr(evdev_mod, "ecodes", None))
+
+
+def _ecode_int(evdev_mod: Any, name: str, default: int) -> int:
+    value = getattr(_ecodes(evdev_mod), name, default)
+    try:
+        if isinstance(value, int | float | str | bytes | bytearray):
+            return int(value)
+    except (TypeError, ValueError):
+        pass
+    return int(default)
+
+
+def _bytype(evdev_mod: Any) -> Mapping[int, object]:
+    raw = getattr(_ecodes(evdev_mod), "bytype", {})
+    if isinstance(raw, Mapping):
+        return cast(Mapping[int, object], raw)
+    return {}
+
+
+def event_type_name(evdev_mod: Any, event_type: int) -> str:
+    value = _bytype(evdev_mod).get(int(event_type))
+    if isinstance(value, tuple | list) and value:
+        return str(cast(object, value[0]))
+    if isinstance(value, str):
+        return value
+    names = {
+        _ecode_int(evdev_mod, "EV_KEY", 1): "EV_KEY",
+        _ecode_int(evdev_mod, "EV_REL", 2): "EV_REL",
+        _ecode_int(evdev_mod, "EV_ABS", 3): "EV_ABS",
+        _ecode_int(evdev_mod, "EV_SYN", 0): "EV_SYN",
+    }
+    return names.get(int(event_type), str(int(event_type)))
+
+
+def event_code_name(evdev_mod: Any, event_type: int, code: int) -> str:
+    type_codes = _bytype(evdev_mod).get(int(event_type), {})
+    if isinstance(type_codes, dict):
+        value = cast(Mapping[int, object], type_codes).get(int(code))
+        if isinstance(value, tuple | list) and value:
+            return str(cast(object, value[0]))
+        if isinstance(value, str):
+            return value
+    return str(int(code))
+
+
+def event_filter_category(evdev_mod: Any, event_type: int, code: int) -> str:
+    ecodes = _ecodes(evdev_mod)
+    event_type_int = int(event_type)
+    if event_type_int == _ecode_int(evdev_mod, "EV_KEY", 1):
+        return "button"
+    if event_type_int == _ecode_int(evdev_mod, "EV_ABS", 3):
+        return "axis"
+    if event_type_int == _ecode_int(evdev_mod, "EV_REL", 2):
+        rel_x = int(getattr(ecodes, "REL_X", 0))
+        rel_y = int(getattr(ecodes, "REL_Y", 1))
+        if int(code) in {rel_x, rel_y}:
+            return "mousemove"
+        return "axis"
+    if event_type_int == _ecode_int(evdev_mod, "EV_SYN", 0):
+        return "syn"
+    return "other"
+
+
+def build_output_event(
+    *,
+    output_target: JsonObject,
+    event_type: int,
+    code: int,
+    value: int,
+    evdev_mod: Any,
+) -> JsonObject:
+    return {
+        "kind": "output",
+        **output_target,
+        "filter_category": event_filter_category(evdev_mod, event_type, code),
+        "type": int(event_type),
+        "type_name": event_type_name(evdev_mod, event_type),
+        "code": int(code),
+        "code_name": event_code_name(evdev_mod, event_type, code),
+        "value": int(value),
+    }

--- a/keymasq/session/manager/commands.py
+++ b/keymasq/session/manager/commands.py
@@ -94,9 +94,7 @@ async def handle_session_request(
         return result
 
     if command == "set_diagnostics":
-        result = await _handle_set_diagnostics(manager, request)
-        runtime_recording.notify_recording_unlock_required(manager, result)
-        return result
+        return await _handle_set_diagnostics(manager, request)
 
     if command == "set_diagnostics_output_stream":
         result = await runtime_output_stream.set_diagnostics_output_stream(

--- a/keymasq/session/manager/commands.py
+++ b/keymasq/session/manager/commands.py
@@ -12,6 +12,7 @@ from keymasq.session.settings import save_global_settings, save_virtual_gamepad_
 from . import combo_inspector as runtime_combo_inspector
 from . import compositor as runtime_compositor
 from . import device_inspector as runtime_device_inspector
+from . import output_stream as runtime_output_stream
 from . import profiles as runtime_profiles
 from . import recording as runtime_recording
 from .common import (
@@ -47,7 +48,9 @@ async def handle_session_request(
 
     if runtime_recording.is_sensitive_session_command(
         manager,
-        command, policy
+        command,
+        request,
+        policy,
     ) and not runtime_recording.is_refresh_owner_request(manager, peer, writer):
         return {
             "status": "error",
@@ -91,7 +94,19 @@ async def handle_session_request(
         return result
 
     if command == "set_diagnostics":
-        return await _handle_set_diagnostics(manager, request)
+        result = await _handle_set_diagnostics(manager, request)
+        runtime_recording.notify_recording_unlock_required(manager, result)
+        return result
+
+    if command == "set_diagnostics_output_stream":
+        result = await runtime_output_stream.set_diagnostics_output_stream(
+            manager,
+            bool(request.get("enabled", False)),
+            request.get("filters"),
+            writer,
+        )
+        runtime_recording.notify_recording_unlock_required(manager, result)
+        return result
 
     result = await _handle_device_inspector_commands(manager, command, request, peer, writer)
     if result is not None:
@@ -891,4 +906,8 @@ async def _handle_set_diagnostics(
 
     if result.status == "ok":
         return {"status": "ok", "data": result.data or {}}
-    return {"status": "error", "message": result.error or "Failed to update diagnostics"}
+    message = result.error or "Failed to update diagnostics"
+    response: JsonObject = {"status": "error", "message": message}
+    if "recording_locked" in message.lower():
+        response["error_code"] = "recording_locked"
+    return response

--- a/keymasq/session/manager/core.py
+++ b/keymasq/session/manager/core.py
@@ -51,6 +51,7 @@ from . import commands as session_commands
 from . import compositor as runtime_compositor
 from . import device_inspector as runtime_device_inspector
 from . import events as runtime_events
+from . import output_stream as runtime_output_stream
 from . import profiles as runtime_profiles
 from . import recording as runtime_recording
 from .common import JsonObject
@@ -60,6 +61,7 @@ from .state import (
     DeviceInspectorRuntimeState,
     EventRuntimeState,
     ExecRuntimeState,
+    OutputStreamRuntimeState,
     ProfileRuntimeState,
     RecordingRuntimeState,
     UnlockRuntimeState,
@@ -149,6 +151,7 @@ class SessionManager:
         self.exec_state = ExecRuntimeState()
         self.event_state = EventRuntimeState()
         self.device_inspector_state = DeviceInspectorRuntimeState()
+        self.output_stream_state = OutputStreamRuntimeState()
         self.recording_state = RecordingRuntimeState()
         self.unlock_state = UnlockRuntimeState()
         runtime_recording.load_recording_settings_from_disk(self)
@@ -407,6 +410,8 @@ class SessionManager:
         finally:
             with contextlib.suppress(Exception):
                 await runtime_device_inspector.clear_device_inspectors_for_writer(self, writer)
+            with contextlib.suppress(Exception):
+                await runtime_output_stream.clear_output_stream_for_writer(self, writer)
             runtime_recording.clear_active_recording_owner_if_writer(self, writer)
             await runtime_recording.discard_pending_macro_save_if_writer(self, writer)
             await runtime_recording.clear_recording_refresh_owner_if_writer(self, peer, writer)
@@ -795,6 +800,7 @@ class SessionManager:
         self.device_inspector_state.active_hardware_ids.clear()
         self.device_inspector_state.suppressed_hardware_ids.clear()
         self.device_inspector_state.owners_by_hardware_id.clear()
+        runtime_output_stream.clear_all_output_stream_state(self)
         self.recording_state.devices_cache.clear()
         self.recording_state.selected_devices_cache.clear()
         self.recording_state.devices_cache_ready = False

--- a/keymasq/session/manager/events.py
+++ b/keymasq/session/manager/events.py
@@ -16,6 +16,7 @@ from keymasq.common.models import (
 
 from . import compositor as runtime_compositor
 from . import device_inspector as runtime_device_inspector
+from . import output_stream as runtime_output_stream
 from . import profiles as runtime_profiles
 from . import recording as runtime_recording
 from .common import JsonObject
@@ -181,6 +182,10 @@ async def handle_event(
 
     if event_type == CommandType.DIAGNOSTICS_SNAPSHOT:
         manager.broadcast_to_session_clients({"event": "diagnostics_snapshot", **data})
+        return
+
+    if event_type == CommandType.DIAGNOSTICS_OUTPUT_EVENT:
+        runtime_output_stream.broadcast_events_to_owners(manager, data)
         return
 
     if event_type == CommandType.DEVICE_INSPECTOR_EVENT:
@@ -597,6 +602,7 @@ def handle_macro_playback_cancelled_event(
 
 async def handle_runtime_reset_event(manager: "SessionManager", data: JsonObject) -> None:
     runtime_device_inspector.clear_all_device_inspector_state(manager)
+    runtime_output_stream.clear_all_output_stream_state(manager)
     manager.broadcast_to_session_clients({"event": "runtime_reset", **data})
     manager.send_notification(
         "Keymasq: Emergency Reset",

--- a/keymasq/session/manager/output_stream.py
+++ b/keymasq/session/manager/output_stream.py
@@ -1,0 +1,147 @@
+import asyncio
+import logging
+from typing import TYPE_CHECKING
+
+from keymasq.common.ipc import Command, CommandType
+
+from .common import JsonObject, json_list, json_object, str_value
+
+if TYPE_CHECKING:
+    from .core import SessionManager
+
+log = logging.getLogger("keymasq-session.output_stream")
+
+OUTPUT_STREAM_FILTERS = frozenset({"button", "axis", "mousemove", "syn", "other", "repeat"})
+DEFAULT_OUTPUT_STREAM_FILTERS = frozenset({"button"})
+
+
+def _writer_id(writer: asyncio.StreamWriter) -> int:
+    return id(writer)
+
+
+def _normalize_filters(raw_filters: object) -> set[str]:
+    filters = {
+        str_value(item, "").strip().lower()
+        for item in json_list(raw_filters)
+        if str_value(item, "").strip()
+    }
+    if "all" in filters:
+        return set(OUTPUT_STREAM_FILTERS)
+    selected = filters & OUTPUT_STREAM_FILTERS
+    return selected or set(DEFAULT_OUTPUT_STREAM_FILTERS)
+
+
+def _effective_filters(manager: "SessionManager") -> set[str]:
+    filters: set[str] = set()
+    for owner_filters in manager.output_stream_state.owners_by_writer_id.values():
+        filters.update(owner_filters)
+    return filters or set(DEFAULT_OUTPUT_STREAM_FILTERS)
+
+
+async def set_diagnostics_output_stream(
+    manager: "SessionManager",
+    enabled: bool,
+    filters: object,
+    writer: asyncio.StreamWriter,
+) -> JsonObject:
+    writer_id = _writer_id(writer)
+    previous = manager.output_stream_state.owners_by_writer_id.get(writer_id)
+
+    if enabled:
+        manager.output_stream_state.owners_by_writer_id[writer_id] = _normalize_filters(filters)
+    else:
+        manager.output_stream_state.owners_by_writer_id.pop(writer_id, None)
+
+    effective_filters = _effective_filters(manager)
+    daemon_enabled = bool(manager.output_stream_state.owners_by_writer_id)
+    result = await _send_output_stream_command(
+        manager,
+        enabled=daemon_enabled,
+        filters=effective_filters,
+    )
+    if result.get("status") != "ok":
+        if previous is None:
+            manager.output_stream_state.owners_by_writer_id.pop(writer_id, None)
+        else:
+            manager.output_stream_state.owners_by_writer_id[writer_id] = previous
+        return result
+
+    manager.output_stream_state.enabled = daemon_enabled
+    manager.output_stream_state.filters = effective_filters
+    data = json_object(result.get("data")) or {}
+    return {
+        "status": "ok",
+        "data": {
+            "enabled": daemon_enabled,
+            "filters": sorted(
+                _normalize_filters(data.get("filters")) if data else effective_filters
+            ),
+        },
+    }
+
+
+async def clear_output_stream_for_writer(
+    manager: "SessionManager",
+    writer: asyncio.StreamWriter,
+) -> None:
+    writer_id = _writer_id(writer)
+    if writer_id not in manager.output_stream_state.owners_by_writer_id:
+        return
+    manager.output_stream_state.owners_by_writer_id.pop(writer_id, None)
+    try:
+        result = await _send_output_stream_command(
+            manager,
+            enabled=bool(manager.output_stream_state.owners_by_writer_id),
+            filters=_effective_filters(manager),
+        )
+        if result.get("status") == "ok":
+            manager.output_stream_state.enabled = bool(
+                manager.output_stream_state.owners_by_writer_id
+            )
+            manager.output_stream_state.filters = _effective_filters(manager)
+    except Exception as exc:
+        log.debug("Failed to clear diagnostics output stream owner: %s", exc)
+
+
+def broadcast_events_to_owners(manager: "SessionManager", data: JsonObject) -> None:
+    owner_ids = set(manager.output_stream_state.owners_by_writer_id)
+    if not owner_ids:
+        return
+    manager.broadcast_to_session_client_ids(
+        {"event": "diagnostics_output_event", **data},
+        owner_ids,
+    )
+
+
+def clear_all_output_stream_state(manager: "SessionManager") -> None:
+    manager.output_stream_state.enabled = False
+    manager.output_stream_state.filters = set(DEFAULT_OUTPUT_STREAM_FILTERS)
+    manager.output_stream_state.owners_by_writer_id.clear()
+
+
+async def _send_output_stream_command(
+    manager: "SessionManager",
+    *,
+    enabled: bool,
+    filters: set[str],
+) -> JsonObject:
+    try:
+        result = await manager.client.send_command(
+            Command(
+                command=CommandType.SET_DIAGNOSTICS_OUTPUT_STREAM,
+                data={"enabled": bool(enabled), "filters": sorted(filters)},
+            )
+        )
+    except Exception:
+        return {"status": "error", "message": "Daemon unavailable"}
+
+    if result.status == "ok":
+        return {"status": "ok", "data": result.data or {}}
+    message = result.error or "Failed to update diagnostics output stream"
+    response: JsonObject = {
+        "status": "error",
+        "message": message,
+    }
+    if "recording_locked" in message.lower():
+        response["error_code"] = "recording_locked"
+    return response

--- a/keymasq/session/manager/recording.py
+++ b/keymasq/session/manager/recording.py
@@ -50,7 +50,7 @@ def is_sensitive_session_command(
 
     if (
         policy.recording_unlock_required
-        and command in {"set_diagnostics", "set_diagnostics_output_stream"}
+        and command == "set_diagnostics_output_stream"
         and bool((request or {}).get("enabled", False))
     ):
         return True

--- a/keymasq/session/manager/recording.py
+++ b/keymasq/session/manager/recording.py
@@ -39,12 +39,20 @@ MACRO_SAVE_PENDING_NOTIFICATION_COOLDOWN_S = 5.0
 def is_sensitive_session_command(
     manager: "SessionManager",
     command: str,
+    request: JsonObject | None = None,
     policy: SecurityPolicy | None = None,
 ) -> bool:
     if policy is None:
         policy = manager.security_policy
 
     if command == "lock_recording_unlock":
+        return True
+
+    if (
+        policy.recording_unlock_required
+        and command in {"set_diagnostics", "set_diagnostics_output_stream"}
+        and bool((request or {}).get("enabled", False))
+    ):
         return True
 
     if policy.recording_unlock_required and command in {

--- a/keymasq/session/manager/state.py
+++ b/keymasq/session/manager/state.py
@@ -66,6 +66,13 @@ class DeviceInspectorRuntimeState:
 
 
 @dataclass
+class OutputStreamRuntimeState:
+    enabled: bool = False
+    filters: set[str] = field(default_factory=lambda: {"button"})
+    owners_by_writer_id: dict[int, set[str]] = field(default_factory=dict)
+
+
+@dataclass
 class ProfileRuntimeState:
     grabbed_devices: set[str] = field(default_factory=set)
     grabbed_interfaces: dict[str, dict[str, str]] = field(default_factory=dict)

--- a/tests/gui/test_diagnostics_dialog.py
+++ b/tests/gui/test_diagnostics_dialog.py
@@ -309,6 +309,73 @@ def test_diagnostics_dialog_output_stream_page(monkeypatch) -> None:
     ]
 
 
+def test_diagnostics_output_stream_unlock_starts_watching(monkeypatch) -> None:
+    import keymasq.gui.widgets.diagnostics_dialog as dialog_module
+    from keymasq.gui.widgets.diagnostics_dialog import DiagnosticsDialog
+
+    sent: list[dict[str, object]] = []
+    unlock_callbacks: list[object] = []
+
+    def fake_request_async(payload, callback, timeout=5.0):
+        sent.append(payload)
+        return callback(
+            {
+                "status": "ok",
+                "data": {
+                    "enabled": bool(payload["enabled"]),
+                    "filters": payload.get("filters", ["button"]),
+                },
+            }
+        )
+
+    parent = Gtk.Window()
+    parent._recording_unlock_required = True  # pyright: ignore[reportAttributeAccessIssue]
+    parent._recording_unlocked = False  # pyright: ignore[reportAttributeAccessIssue]
+    parent._recording_refresh_owner = False  # pyright: ignore[reportAttributeAccessIssue]
+
+    def present_unlock_dialog(on_success=None):
+        unlock_callbacks.append(on_success)
+
+    parent.present_unlock_dialog = present_unlock_dialog  # pyright: ignore[reportAttributeAccessIssue]
+
+    monkeypatch.setattr(dialog_module, "session_request_async", fake_request_async)
+    monkeypatch.setattr(dialog_module, "register_session_event_callback", lambda *a: None)
+    monkeypatch.setattr(dialog_module, "unregister_session_event_callback", lambda *a: None)
+
+    dialog = DiagnosticsDialog(parent)
+    dialog._output_enable_switch.set_active(True)
+
+    assert sent == []
+    assert dialog._output_enable_switch.get_active() is False
+    assert dialog._output_unlock_button.get_visible() is True
+    assert (
+        dialog._output_status_label.get_text()
+        == "Unlock required before watching output events."
+    )
+
+    dialog._output_unlock_button.emit("clicked")
+    assert len(unlock_callbacks) == 1
+
+    parent._recording_unlocked = True  # pyright: ignore[reportAttributeAccessIssue]
+    parent._recording_refresh_owner = True  # pyright: ignore[reportAttributeAccessIssue]
+    callback = unlock_callbacks[0]
+    assert callable(callback)
+    callback()
+
+    assert sent == [
+        {
+            "command": "set_diagnostics_output_stream",
+            "enabled": True,
+            "filters": ["button"],
+        }
+    ]
+    assert dialog._output_enable_switch.get_active() is True
+    assert dialog._output_unlock_button.get_visible() is False
+    assert dialog._output_status_label.get_text() == "Waiting for output events..."
+
+    dialog._on_closed(dialog)
+
+
 def test_diagnostics_sort_by_priority(monkeypatch) -> None:
     import keymasq.gui.widgets.diagnostics_dialog as dialog_module
     from keymasq.gui.widgets.diagnostics_dialog import DiagnosticsDialog, _label_sort_key

--- a/tests/gui/test_diagnostics_dialog.py
+++ b/tests/gui/test_diagnostics_dialog.py
@@ -10,12 +10,73 @@ def test_diagnostics_format_helpers() -> None:
         _diagnostics_docs_url,
         _format_latency,
         _label_title,
+        _output_event_export_line,
+        _output_event_detail,
+        _output_event_title,
     )
 
     assert _format_latency(22.25) == "22.2 us"
     assert _format_latency(1500.0) == "1.50 ms"
     assert _label_title("action_key") == "Action: key"
     assert _label_title("combo_passthrough") == "Combo candidate passthrough"
+    assert (
+        _output_event_title(
+            {
+                "kind": "output",
+                "output": "keyboard",
+                "code_name": "KEY_A",
+                "value": 1,
+            }
+        )
+        == "keyboard: KEY_A=1"
+    )
+    assert (
+        _output_event_title(
+            {
+                "kind": "output",
+                "output": "gamepad",
+                "output_id": "virtual-gamepad-1",
+                "code_name": "BTN_SOUTH",
+                "value": 1,
+            }
+        )
+        == "gamepad virtual-gamepad-1: BTN_SOUTH=1"
+    )
+    detail = _output_event_detail(
+        {
+            "sequence": 10,
+            "category": "repeat",
+            "type_name": "EV_KEY",
+            "code_name": "KEY_A",
+            "value": 2,
+        }
+    )
+    assert "#10  repeat  EV_KEY KEY_A value=2" == detail
+    detail = _output_event_detail(
+        {
+            "sequence": 12,
+            "category": "mousemove",
+            "type_name": "EV_REL",
+            "code_name": "REL_X",
+            "value": 7,
+            "hardware_id": "1234:5678",
+            "interface_id": "kbd",
+        }
+    )
+    assert "1234:5678" in detail
+    assert "kbd" in detail
+    assert (
+        _output_event_export_line(
+            {
+                "sequence": 12,
+                "output": "mouse",
+                "code_name": "REL_WHEEL",
+                "type_name": "EV_REL",
+                "value": -1,
+            }
+        )
+        == "#12 mouse REL_WHEEL EV_REL value=-1"
+    )
     assert _diagnostics_docs_url().endswith("/PERFORMANCE/#diagnostics-labels")
 
 
@@ -94,13 +155,156 @@ def test_diagnostics_dialog_sends_settings_and_renders_snapshot(monkeypatch) -> 
 
     sent.clear()
     dialog._on_closed(dialog)
-    assert unregistered == [("diagnostics_snapshot", dialog._on_diagnostics_snapshot)]
+    assert unregistered == [
+        ("diagnostics_snapshot", dialog._on_diagnostics_snapshot),
+        ("diagnostics_output_event", dialog._on_diagnostics_output_event),
+    ]
     assert sent == [
         {
             "command": "set_diagnostics",
             "enabled": False,
             "interval": 5.0,
             "categories": ["mainline", "combo"],
+        }
+    ]
+
+
+def test_diagnostics_dialog_output_stream_page(monkeypatch) -> None:
+    import keymasq.gui.widgets.diagnostics_dialog as dialog_module
+    from keymasq.gui.widgets.diagnostics_dialog import DiagnosticsDialog
+
+    sent: list[dict[str, object]] = []
+    callbacks: dict[str, object] = {}
+    unregistered: list[tuple[str, object]] = []
+
+    def fake_request_async(payload, callback, timeout=5.0):
+        sent.append(payload)
+        if payload["command"] == "set_diagnostics_output_stream":
+            return callback(
+                {
+                    "status": "ok",
+                    "data": {
+                        "enabled": bool(payload["enabled"]),
+                        "filters": payload["filters"],
+                    },
+                }
+            )
+        return callback(
+            {
+                "status": "ok",
+                "data": {
+                    "enabled": bool(payload["enabled"]),
+                    "interval": payload["interval"],
+                    "categories": payload["categories"],
+                },
+            }
+        )
+
+    monkeypatch.setattr(dialog_module, "session_request_async", fake_request_async)
+    monkeypatch.setattr(
+        dialog_module,
+        "register_session_event_callback",
+        lambda event, callback: callbacks.setdefault(event, callback),
+    )
+    monkeypatch.setattr(
+        dialog_module,
+        "unregister_session_event_callback",
+        lambda event, callback: unregistered.append((event, callback)),
+    )
+
+    dialog = DiagnosticsDialog(Gtk.Window())
+    assert "diagnostics_output_event" in callbacks
+    assert dialog._reset_button.get_tooltip_text() == "Reset collected samples"
+
+    dialog._output_enable_switch.set_active(True)
+
+    assert sent[-1] == {
+        "command": "set_diagnostics_output_stream",
+        "enabled": True,
+        "filters": ["button"],
+    }
+    assert dialog._output_status_label.get_text() == "Waiting for output events..."
+    assert not dialog._output_filter_checks["repeat"].get_active()
+    assert not dialog._output_filter_checks["mousemove"].get_active()
+    assert not dialog._output_filter_checks["axis"].get_active()
+
+    dialog._output_filter_checks["mousemove"].set_active(True)
+    assert sent[-1] == {
+        "command": "set_diagnostics_output_stream",
+        "enabled": True,
+        "filters": ["button", "mousemove"],
+    }
+
+    dialog._on_diagnostics_output_event(
+        {
+            "event": "diagnostics_output_event",
+            "enabled": True,
+            "filters": ["button", "mousemove"],
+            "events": [
+                {
+                    "kind": "output",
+                    "sequence": 1,
+                    "category": "button",
+                    "output": "keyboard",
+                    "output_id": "keyboard",
+                    "type_name": "EV_KEY",
+                    "code_name": "KEY_A",
+                    "value": 1,
+                },
+            ],
+            "dropped": 0,
+        }
+    )
+
+    assert len(dialog._output_rows) == 1
+    assert not dialog._output_empty_label.get_visible()
+    first_row_box = dialog._output_rows[0].get_child()
+    assert isinstance(first_row_box, Gtk.Box)
+    first_title = first_row_box.get_first_child()
+    assert isinstance(first_title, Gtk.Label)
+    assert first_title.get_text() == "keyboard: KEY_A=1"
+    assert dialog._visible_output_event_export_text() == "#1 keyboard KEY_A EV_KEY value=1"
+
+    copied: list[str] = []
+
+    class Clipboard:
+        def set(self, text: str) -> None:
+            copied.append(text)
+
+    class Display:
+        def get_clipboard(self) -> Clipboard:
+            return Clipboard()
+
+    monkeypatch.setattr(dialog_module.Gdk.Display, "get_default", lambda: Display())
+    dialog._on_copy_output_events_clicked(dialog._copy_output_button)
+    assert copied == ["#1 keyboard KEY_A EV_KEY value=1"]
+
+    dialog._stack.set_visible_child_name("output")
+    assert dialog._reset_button.get_tooltip_text() == "Reset collected output events"
+
+    sent.clear()
+    dialog._on_reset_clicked(dialog._reset_button)
+
+    assert sent == []
+    assert dialog._output_rows == []
+    assert dialog._output_empty_label.get_visible()
+    assert dialog._output_status_label.get_text() == "Waiting for output events..."
+
+    dialog._stack.set_visible_child_name("latency")
+    assert dialog._reset_button.get_tooltip_text() == "Reset collected samples"
+
+    sent.clear()
+    dialog._on_closed(dialog)
+
+    assert (
+        "diagnostics_output_event",
+        dialog._on_diagnostics_output_event,
+    ) in unregistered
+    assert sent == [
+        {
+            "command": "set_diagnostics_output_stream",
+            "enabled": False,
+            "filters": ["button", "mousemove"],
         }
     ]
 
@@ -122,12 +326,8 @@ def test_diagnostics_sort_by_priority(monkeypatch) -> None:
         )
 
     monkeypatch.setattr(dialog_module, "session_request_async", fake_request_async)
-    monkeypatch.setattr(
-        dialog_module, "register_session_event_callback", lambda *a: None
-    )
-    monkeypatch.setattr(
-        dialog_module, "unregister_session_event_callback", lambda *a: None
-    )
+    monkeypatch.setattr(dialog_module, "register_session_event_callback", lambda *a: None)
+    monkeypatch.setattr(dialog_module, "unregister_session_event_callback", lambda *a: None)
 
     assert _label_sort_key("passthrough_mapped") < _label_sort_key("passthrough_fast")
     assert _label_sort_key("passthrough_fast") < _label_sort_key("combo_passthrough")
@@ -177,12 +377,8 @@ def test_diagnostics_reset_clears_rows(monkeypatch) -> None:
         )
 
     monkeypatch.setattr(dialog_module, "session_request_async", fake_request_async)
-    monkeypatch.setattr(
-        dialog_module, "register_session_event_callback", lambda *a: None
-    )
-    monkeypatch.setattr(
-        dialog_module, "unregister_session_event_callback", lambda *a: None
-    )
+    monkeypatch.setattr(dialog_module, "register_session_event_callback", lambda *a: None)
+    monkeypatch.setattr(dialog_module, "unregister_session_event_callback", lambda *a: None)
 
     dialog = DiagnosticsDialog(Gtk.Window())
     dialog._enable_switch.set_active(True)

--- a/tests/keymasqd/daemon_support.py
+++ b/tests/keymasqd/daemon_support.py
@@ -36,6 +36,7 @@ def daemon_testbed(monkeypatch):
         cancel_macro_playback=AsyncMock(return_value={"canceled": True}),
         emergency_reset=AsyncMock(return_value={"reset": True}),
         set_diagnostics=AsyncMock(return_value={"status": "ok"}),
+        set_diagnostics_output_stream=AsyncMock(return_value={"status": "ok"}),
         start_device_inspector=AsyncMock(return_value={"status": "ok", "active": True}),
         stop_device_inspector=AsyncMock(return_value={"status": "ok", "active": False}),
         enable_device_inspector_suppression=AsyncMock(

--- a/tests/keymasqd/test_daemon_runtime_unlock.py
+++ b/tests/keymasqd/test_daemon_runtime_unlock.py
@@ -1,6 +1,7 @@
 # ruff: noqa: F403, F405, I001
 from tests.keymasqd.daemon_support import *
 
+
 @pytest.mark.asyncio
 async def test_set_diagnostics_forwards_with_type_conversion(daemon_testbed):
     daemon, device_manager, _recording_manager, _macro_store, _capture_manager = daemon_testbed
@@ -29,6 +30,97 @@ async def test_set_diagnostics_forwards_categories(daemon_testbed):
         3.25,
         ["mainline", "combo"],
     )
+
+
+@pytest.mark.asyncio
+async def test_set_diagnostics_output_stream_forwards_filters(daemon_testbed):
+    daemon, device_manager, _recording_manager, _macro_store, _capture_manager = daemon_testbed
+
+    result = await daemon._handle_command(
+        CommandType.SET_DIAGNOSTICS_OUTPUT_STREAM,
+        {"enabled": 1, "filters": ["button", "mousemove"]},
+    )
+
+    assert result == {"status": "ok"}
+    device_manager.set_diagnostics_output_stream.assert_awaited_once_with(  # type: ignore[attr-defined]
+        True,
+        ["button", "mousemove"],
+    )
+
+
+@pytest.mark.asyncio
+async def test_diagnostics_enable_requires_recording_unlock(daemon_testbed, monkeypatch):
+    daemon, device_manager, _recording_manager, _macro_store, _capture_manager = daemon_testbed
+    daemon.security_policy = SecurityPolicy(recording_unlock_required=True)
+    monkeypatch.setattr(daemon, "_recording_unlocked_for_uid", lambda _uid: (False, 0, "none"))
+
+    with pytest.raises(PermissionError, match="recording_locked"):
+        await daemon._handle_command(
+            CommandType.SET_DIAGNOSTICS,
+            {"enabled": True, "interval": 5.0},
+            client=_client(),
+        )
+    with pytest.raises(PermissionError, match="recording_locked"):
+        await daemon._handle_command(
+            CommandType.SET_DIAGNOSTICS_OUTPUT_STREAM,
+            {"enabled": True, "filters": ["button"]},
+            client=_client(),
+        )
+
+    device_manager.set_diagnostics.assert_not_awaited()
+    device_manager.set_diagnostics_output_stream.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_diagnostics_disable_does_not_require_recording_unlock(
+    daemon_testbed,
+    monkeypatch,
+):
+    daemon, device_manager, _recording_manager, _macro_store, _capture_manager = daemon_testbed
+    daemon.security_policy = SecurityPolicy(recording_unlock_required=True)
+    monkeypatch.setattr(daemon, "_recording_unlocked_for_uid", lambda _uid: (False, 0, "none"))
+
+    diagnostics = await daemon._handle_command(
+        CommandType.SET_DIAGNOSTICS,
+        {"enabled": False, "interval": 5.0},
+        client=_client(),
+    )
+    output_stream = await daemon._handle_command(
+        CommandType.SET_DIAGNOSTICS_OUTPUT_STREAM,
+        {"enabled": False, "filters": ["button"]},
+        client=_client(),
+    )
+
+    assert diagnostics == {"status": "ok"}
+    assert output_stream == {"status": "ok"}
+    device_manager.set_diagnostics.assert_awaited_once_with(False, 5.0, None)
+    device_manager.set_diagnostics_output_stream.assert_awaited_once_with(False, ["button"])
+
+
+@pytest.mark.asyncio
+async def test_diagnostics_enable_forwards_when_recording_unlocked(
+    daemon_testbed,
+    monkeypatch,
+):
+    daemon, device_manager, _recording_manager, _macro_store, _capture_manager = daemon_testbed
+    daemon.security_policy = SecurityPolicy(recording_unlock_required=True)
+    monkeypatch.setattr(daemon, "_recording_unlocked_for_uid", lambda _uid: (True, 0, "runtime"))
+
+    diagnostics = await daemon._handle_command(
+        CommandType.SET_DIAGNOSTICS,
+        {"enabled": True, "interval": 2.0},
+        client=_client(),
+    )
+    output_stream = await daemon._handle_command(
+        CommandType.SET_DIAGNOSTICS_OUTPUT_STREAM,
+        {"enabled": True, "filters": ["button"]},
+        client=_client(),
+    )
+
+    assert diagnostics == {"status": "ok"}
+    assert output_stream == {"status": "ok"}
+    device_manager.set_diagnostics.assert_awaited_once_with(True, 2.0, None)
+    device_manager.set_diagnostics_output_stream.assert_awaited_once_with(True, ["button"])
 
 
 @pytest.mark.asyncio

--- a/tests/keymasqd/test_daemon_runtime_unlock.py
+++ b/tests/keymasqd/test_daemon_runtime_unlock.py
@@ -49,17 +49,11 @@ async def test_set_diagnostics_output_stream_forwards_filters(daemon_testbed):
 
 
 @pytest.mark.asyncio
-async def test_diagnostics_enable_requires_recording_unlock(daemon_testbed, monkeypatch):
+async def test_output_diagnostics_enable_requires_recording_unlock(daemon_testbed, monkeypatch):
     daemon, device_manager, _recording_manager, _macro_store, _capture_manager = daemon_testbed
     daemon.security_policy = SecurityPolicy(recording_unlock_required=True)
     monkeypatch.setattr(daemon, "_recording_unlocked_for_uid", lambda _uid: (False, 0, "none"))
 
-    with pytest.raises(PermissionError, match="recording_locked"):
-        await daemon._handle_command(
-            CommandType.SET_DIAGNOSTICS,
-            {"enabled": True, "interval": 5.0},
-            client=_client(),
-        )
     with pytest.raises(PermissionError, match="recording_locked"):
         await daemon._handle_command(
             CommandType.SET_DIAGNOSTICS_OUTPUT_STREAM,
@@ -67,12 +61,11 @@ async def test_diagnostics_enable_requires_recording_unlock(daemon_testbed, monk
             client=_client(),
         )
 
-    device_manager.set_diagnostics.assert_not_awaited()
     device_manager.set_diagnostics_output_stream.assert_not_awaited()
 
 
 @pytest.mark.asyncio
-async def test_diagnostics_disable_does_not_require_recording_unlock(
+async def test_latency_diagnostics_enable_does_not_require_recording_unlock(
     daemon_testbed,
     monkeypatch,
 ):
@@ -80,20 +73,32 @@ async def test_diagnostics_disable_does_not_require_recording_unlock(
     daemon.security_policy = SecurityPolicy(recording_unlock_required=True)
     monkeypatch.setattr(daemon, "_recording_unlocked_for_uid", lambda _uid: (False, 0, "none"))
 
-    diagnostics = await daemon._handle_command(
+    result = await daemon._handle_command(
         CommandType.SET_DIAGNOSTICS,
-        {"enabled": False, "interval": 5.0},
+        {"enabled": True, "interval": 5.0},
         client=_client(),
     )
+
+    assert result == {"status": "ok"}
+    device_manager.set_diagnostics.assert_awaited_once_with(True, 5.0, None)
+
+
+@pytest.mark.asyncio
+async def test_output_diagnostics_disable_does_not_require_recording_unlock(
+    daemon_testbed,
+    monkeypatch,
+):
+    daemon, device_manager, _recording_manager, _macro_store, _capture_manager = daemon_testbed
+    daemon.security_policy = SecurityPolicy(recording_unlock_required=True)
+    monkeypatch.setattr(daemon, "_recording_unlocked_for_uid", lambda _uid: (False, 0, "none"))
+
     output_stream = await daemon._handle_command(
         CommandType.SET_DIAGNOSTICS_OUTPUT_STREAM,
         {"enabled": False, "filters": ["button"]},
         client=_client(),
     )
 
-    assert diagnostics == {"status": "ok"}
     assert output_stream == {"status": "ok"}
-    device_manager.set_diagnostics.assert_awaited_once_with(False, 5.0, None)
     device_manager.set_diagnostics_output_stream.assert_awaited_once_with(False, ["button"])
 
 

--- a/tests/keymasqd/test_device_manager_core.py
+++ b/tests/keymasqd/test_device_manager_core.py
@@ -30,6 +30,200 @@ async def test_set_cursor_position_reports_missing_mouse_uinput() -> None:
 
 
 @pytest.mark.asyncio
+async def test_diagnostics_output_stream_records_output_writes() -> None:
+    manager = DeviceManager()
+    keyboard = _FakeUInput()
+    manager.output_state.keyboard_uinput = keyboard  # type: ignore[assignment]
+    broadcasts: list[tuple[CommandType, dict[str, object]]] = []
+    manager._broadcast_runtime_event = lambda event_type, data: broadcasts.append(  # type: ignore[method-assign]
+        (event_type, data)
+    )
+
+    result = await manager.set_diagnostics_output_stream(True)
+    writer = manager.observed_uinput_writer(keyboard)
+    assert writer is not None
+    writer.write(evdev.ecodes.EV_KEY, evdev.ecodes.KEY_A, 1)
+    writer.syn()
+    manager._flush_diagnostics_output_events()
+    await manager.set_diagnostics_output_stream(False)
+
+    assert result == {"enabled": True, "filters": ["button"]}
+    assert keyboard.writes == [(evdev.ecodes.EV_KEY, evdev.ecodes.KEY_A, 1)]
+    assert len(broadcasts) == 1
+    event_type, data = broadcasts[0]
+    assert event_type == CommandType.DIAGNOSTICS_OUTPUT_EVENT
+    assert data["enabled"] is True
+    assert data["filters"] == ["button"]
+    events = cast(list[dict[str, object]], data["events"])
+    assert [event["kind"] for event in events] == ["output"]
+    assert events[0]["sequence"] == 1
+    assert events[0]["category"] == "button"
+    assert events[0]["output"] == "keyboard"
+    assert events[0]["code_name"] == "KEY_A"
+
+
+@pytest.mark.asyncio
+async def test_diagnostics_output_stream_records_passthrough_output_as_buttons() -> None:
+    manager = DeviceManager()
+    passthrough = _FakeUInput()
+    manager.grabbed_devices["1234:5678"] = cast(
+        list[GrabbedDevice],
+        [SimpleNamespace(uinput=passthrough, interface_id="kbd")],
+    )
+    broadcasts: list[tuple[CommandType, dict[str, object]]] = []
+    manager._broadcast_runtime_event = lambda event_type, data: broadcasts.append(  # type: ignore[method-assign]
+        (event_type, data)
+    )
+
+    await manager.set_diagnostics_output_stream(True)
+    writer = manager.observed_uinput_writer(passthrough)
+    assert writer is not None
+    writer.write(evdev.ecodes.EV_KEY, evdev.ecodes.KEY_B, 1)
+    manager._flush_diagnostics_output_events()
+    await manager.set_diagnostics_output_stream(False)
+
+    assert len(broadcasts) == 1
+    _event_type, data = broadcasts[0]
+    events = cast(list[dict[str, object]], data["events"])
+    assert len(events) == 1
+    assert events[0]["category"] == "button"
+    assert events[0]["output"] == "passthrough"
+    assert events[0]["hardware_id"] == "1234:5678"
+    assert events[0]["interface_id"] == "kbd"
+
+
+@pytest.mark.asyncio
+async def test_diagnostics_output_stream_noisy_filters_are_opt_in() -> None:
+    manager = DeviceManager()
+    mouse = _FakeUInput()
+    manager.output_state.mouse_uinput = mouse  # type: ignore[assignment]
+    broadcasts: list[tuple[CommandType, dict[str, object]]] = []
+    manager._broadcast_runtime_event = lambda event_type, data: broadcasts.append(  # type: ignore[method-assign]
+        (event_type, data)
+    )
+
+    await manager.set_diagnostics_output_stream(True)
+    writer = manager.observed_uinput_writer(mouse)
+    assert writer is not None
+    writer.write(evdev.ecodes.EV_KEY, evdev.ecodes.KEY_A, 2)
+    writer.write(evdev.ecodes.EV_REL, evdev.ecodes.REL_X, 10)
+    writer.write(evdev.ecodes.EV_ABS, evdev.ecodes.ABS_X, 100)
+    writer.syn()
+    manager._flush_diagnostics_output_events()
+    assert broadcasts == []
+
+    await manager.set_diagnostics_output_stream(
+        True,
+        ["button", "repeat", "mousemove", "axis", "syn"],
+    )
+    writer = manager.observed_uinput_writer(mouse)
+    assert writer is not None
+    writer.write(evdev.ecodes.EV_KEY, evdev.ecodes.KEY_A, 2)
+    writer.write(evdev.ecodes.EV_REL, evdev.ecodes.REL_X, 10)
+    writer.write(evdev.ecodes.EV_ABS, evdev.ecodes.ABS_X, 100)
+    writer.syn()
+    manager._flush_diagnostics_output_events()
+    await manager.set_diagnostics_output_stream(False)
+
+    assert len(broadcasts) == 1
+    _event_type, data = broadcasts[0]
+    events = cast(list[dict[str, object]], data["events"])
+    assert [event["kind"] for event in events] == ["output", "output", "output", "output"]
+    assert events[0]["repeat"] is True
+    assert events[0]["category"] == "repeat"
+    assert events[1]["type_name"] == "EV_REL"
+    assert events[2]["type_name"] == "EV_ABS"
+    assert events[3]["type_name"] == "EV_SYN"
+
+
+@pytest.mark.asyncio
+async def test_diagnostics_output_stream_records_macro_outputs_with_filters() -> None:
+    manager = DeviceManager()
+    keyboard = _FakeUInput()
+    mouse = _FakeUInput()
+    manager.output_state.keyboard_uinput = keyboard  # type: ignore[assignment]
+    manager.output_state.mouse_uinput = mouse  # type: ignore[assignment]
+    broadcasts: list[tuple[CommandType, dict[str, object]]] = []
+    manager._broadcast_runtime_event = lambda event_type, data: broadcasts.append(  # type: ignore[method-assign]
+        (event_type, data)
+    )
+    macro_events = [
+        {
+            "t_us": 0,
+            "type": evdev.ecodes.EV_KEY,
+            "code": evdev.ecodes.KEY_A,
+            "value": 1,
+            "device_type": "keyboard",
+        },
+        {
+            "t_us": 0,
+            "type": evdev.ecodes.EV_KEY,
+            "code": evdev.ecodes.KEY_A,
+            "value": 2,
+            "device_type": "keyboard",
+        },
+        {
+            "t_us": 0,
+            "type": evdev.ecodes.EV_KEY,
+            "code": evdev.ecodes.KEY_A,
+            "value": 0,
+            "device_type": "keyboard",
+        },
+        {
+            "t_us": 0,
+            "type": evdev.ecodes.EV_REL,
+            "code": evdev.ecodes.REL_X,
+            "value": 10,
+            "device_type": "mouse",
+        },
+        {
+            "t_us": 0,
+            "type": evdev.ecodes.EV_ABS,
+            "code": evdev.ecodes.ABS_X,
+            "value": 100,
+            "device_type": "mouse",
+        },
+    ]
+
+    await manager.set_diagnostics_output_stream(True)
+    await manager.play_macro(macro_events=macro_events, macro_name="demo")
+    if manager.macro_state.tasks:
+        await asyncio.gather(*list(manager.macro_state.tasks.values()))
+    manager._flush_diagnostics_output_events()
+
+    assert len(broadcasts) == 1
+    _event_type, data = broadcasts.pop()
+    events = cast(list[dict[str, object]], data["events"])
+    assert [(event["type_name"], event["value"]) for event in events] == [
+        ("EV_KEY", 1),
+        ("EV_KEY", 0),
+    ]
+    assert {event["output"] for event in events} == {"keyboard"}
+
+    await manager.set_diagnostics_output_stream(
+        True,
+        ["button", "repeat", "mousemove", "axis"],
+    )
+    await manager.play_macro(macro_events=macro_events, macro_name="demo")
+    if manager.macro_state.tasks:
+        await asyncio.gather(*list(manager.macro_state.tasks.values()))
+    manager._flush_diagnostics_output_events()
+    await manager.set_diagnostics_output_stream(False)
+
+    assert len(broadcasts) == 1
+    _event_type, data = broadcasts[0]
+    events = cast(list[dict[str, object]], data["events"])
+    assert [(event["type_name"], event["value"]) for event in events] == [
+        ("EV_KEY", 1),
+        ("EV_KEY", 2),
+        ("EV_KEY", 0),
+        ("EV_REL", 10),
+        ("EV_ABS", 100),
+    ]
+    assert events[1]["repeat"] is True
+
+
+@pytest.mark.asyncio
 async def test_device_inspector_suppression_status_broadcasts() -> None:
     manager = DeviceManager()
     broadcasts: list[tuple[CommandType, dict[str, object]]] = []
@@ -323,9 +517,7 @@ class TestDeviceManager:
     ) -> None:
         manager = DeviceManager()
         monkeypatch.setattr(dm.evdev, "list_devices", lambda: [])
-        evdev_interfaces = [
-            {"id": "gamepad", "path": "keymasq:2dc8:3106", "type": "gamepad"}
-        ]
+        evdev_interfaces = [{"id": "gamepad", "path": "keymasq:2dc8:3106", "type": "gamepad"}]
 
         result = await manager.grab_device(
             hardware_id="2dc8:3106",
@@ -374,9 +566,7 @@ class TestDeviceManager:
             "resolve_evdev_interfaces",
             fake_resolve_evdev_interfaces,
         )
-        evdev_interfaces = [
-            {"id": "gamepad", "path": "keymasq:2dc8:3106", "type": "gamepad"}
-        ]
+        evdev_interfaces = [{"id": "gamepad", "path": "keymasq:2dc8:3106", "type": "gamepad"}]
 
         result = await manager.grab_device(
             hardware_id="2dc8:3106",
@@ -858,7 +1048,7 @@ class TestListDevices:
     async def test_diagnostics_loop_offloads_snapshot_to_thread(
         self,
         monkeypatch: pytest.MonkeyPatch,
-        ) -> None:
+    ) -> None:
         manager = DeviceManager()
         manager.diagnostics_state.enabled = True
         manager.broadcast_callback = AsyncMock()
@@ -1101,9 +1291,7 @@ class TestMacroControlActions:
         assert result == pytest.approx(0.02)
 
     @pytest.mark.asyncio
-    async def test_run_macro_control_action_wait_renews_mouse_suppression(
-        self, monkeypatch
-    ):
+    async def test_run_macro_control_action_wait_renews_mouse_suppression(self, monkeypatch):
         manager = DeviceManager()
         clock = {"now": 10.0}
         begin_mouse_rel_suppression = Mock()
@@ -1130,9 +1318,7 @@ class TestMacroControlActions:
         assert result == pytest.approx(10.0)
 
     @pytest.mark.asyncio
-    async def test_mouse_suppression_watchdog_keeps_active_inhibit_count(
-        self, monkeypatch
-    ):
+    async def test_mouse_suppression_watchdog_keeps_active_inhibit_count(self, monkeypatch):
         manager = DeviceManager()
 
         async def fake_sleep(_duration: float) -> None:

--- a/tests/keymasqd/test_device_manager_superkeys.py
+++ b/tests/keymasqd/test_device_manager_superkeys.py
@@ -580,7 +580,6 @@ class TestSuperkeys:
             (evdev.ecodes.EV_KEY, evdev.ecodes.KEY_B, 0),
             (evdev.ecodes.EV_KEY, evdev.ecodes.KEY_LEFTCTRL, 0),
         ]
-
     @pytest.mark.asyncio
     async def test_overload_superkey_refcounts_shared_outputs_across_two_inputs(
         self,

--- a/tests/session/test_session_manager_command_runtime.py
+++ b/tests/session/test_session_manager_command_runtime.py
@@ -62,9 +62,7 @@ async def test_release_device_command_forwards_to_daemon_and_clears_runtime_stat
     manager = SessionManager()
     hardware_id = "045e:02a1"
     manager.profile_state.grabbed_devices.add(hardware_id)
-    manager.profile_state.grabbed_interfaces[hardware_id] = {
-        "gamepad": "/dev/input/event20"
-    }
+    manager.profile_state.grabbed_interfaces[hardware_id] = {"gamepad": "/dev/input/event20"}
     manager.profile_state.grab_waiting_devices.add(hardware_id)
     manager.profile_state.last_sent_grab_signatures[hardware_id] = "grab"
     manager.profile_state.last_sent_mapping_signatures[hardware_id] = "mapping"
@@ -241,7 +239,7 @@ async def test_get_combo_inspector_snapshot_returns_resolved_active_combos() -> 
                         )
                     ],
                     timeout_ms=500,
-                )
+                ),
             ],
             action=MappingAction(action_type=ActionType.KEYBOARD, target="key_f5"),
             recall_trigger_keys=True,
@@ -713,6 +711,186 @@ async def test_diagnostics_snapshot_event_forwards_to_gui_clients() -> None:
 
 
 @pytest.mark.asyncio
+async def test_diagnostics_output_stream_tracks_owner_and_forwards_events() -> None:
+    manager = SessionManager()
+    manager.security_policy.recording_unlock_required = False
+    manager.client.send_command = AsyncMock(
+        side_effect=[
+            Response(status="ok", data={"enabled": True, "filters": ["button", "mousemove"]}),
+            Response(
+                status="ok",
+                data={"enabled": False, "filters": ["button"]},
+            ),
+        ]
+    )
+    peer = PeerCredentials(pid=1, uid=1000, gid=1000)
+
+    class Writer:
+        def __init__(self) -> None:
+            self.writes: list[bytes] = []
+
+        def write(self, data: bytes) -> None:
+            self.writes.append(data)
+
+        async def drain(self) -> None:
+            return None
+
+    owner = Writer()
+    other = Writer()
+    manager.session_clients.update({owner, other})  # type: ignore[arg-type]
+    result = await manager._handle_session_request(
+        {
+            "command": "set_diagnostics_output_stream",
+            "enabled": True,
+            "filters": ["button", "mousemove"],
+        },
+        "client",
+        peer,
+        owner,  # type: ignore[arg-type]
+    )
+    sent = manager.client.send_command.await_args_list[0].args[0]
+
+    assert result == {
+        "status": "ok",
+        "data": {"enabled": True, "filters": ["button", "mousemove"]},
+    }
+    assert sent.command == CommandType.SET_DIAGNOSTICS_OUTPUT_STREAM
+    assert sent.data == {"enabled": True, "filters": ["button", "mousemove"]}
+    assert manager.output_stream_state.owners_by_writer_id[id(owner)] == {
+        "button",
+        "mousemove",
+    }
+
+    await session_events_module.handle_event(
+        manager,
+        CommandType.DIAGNOSTICS_OUTPUT_EVENT,
+        {
+            "enabled": True,
+            "filters": ["button"],
+            "events": [
+                {"kind": "output", "category": "button"},
+            ],
+            "dropped": 0,
+        },
+    )
+
+    assert other.writes == []
+    assert len(owner.writes) == 1
+    assert json.loads(owner.writes[0]) == {
+        "event": "diagnostics_output_event",
+        "enabled": True,
+        "filters": ["button"],
+        "events": [
+            {"kind": "output", "category": "button"},
+        ],
+        "dropped": 0,
+    }
+    for task in list(manager.session_client_drain_tasks.values()):
+        await task
+
+    result = await manager._handle_session_request(
+        {"command": "set_diagnostics_output_stream", "enabled": False},
+        "client",
+        peer,
+        owner,  # type: ignore[arg-type]
+    )
+    sent = manager.client.send_command.await_args_list[1].args[0]
+
+    assert result == {
+        "status": "ok",
+        "data": {"enabled": False, "filters": ["button"]},
+    }
+    assert sent.command == CommandType.SET_DIAGNOSTICS_OUTPUT_STREAM
+    assert sent.data == {"enabled": False, "filters": ["button"]}
+    assert id(owner) not in manager.output_stream_state.owners_by_writer_id
+
+
+@pytest.mark.asyncio
+async def test_diagnostics_enable_is_sensitive_to_refresh_owner() -> None:
+    manager = SessionManager()
+    manager.security_policy.recording_unlock_required = True
+    manager.client.send_command = AsyncMock()
+    peer = PeerCredentials(pid=1, uid=1000, gid=1000)
+    owner = object()
+    other = object()
+    manager.unlock_state.refresh_owner = {
+        "uid": peer.uid,
+        "pid": peer.pid,
+        "writer_id": id(owner),
+        "lease_id": "lease-1",
+    }
+
+    result = await manager._handle_session_request(
+        {"command": "set_diagnostics", "enabled": True, "interval": 5.0},
+        "client",
+        peer,
+        other,  # type: ignore[arg-type]
+    )
+
+    assert result == {
+        "status": "error",
+        "error_code": "sensitive_command_denied",
+        "message": "Sensitive command denied: caller is not active GUI owner",
+    }
+    manager.client.send_command.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_diagnostics_disable_does_not_require_refresh_owner() -> None:
+    manager = SessionManager()
+    manager.security_policy.recording_unlock_required = True
+    manager.client.send_command = AsyncMock(
+        return_value=Response(status="ok", data={"enabled": False, "categories": ["mainline"]})
+    )
+    peer = PeerCredentials(pid=1, uid=1000, gid=1000)
+
+    result = await manager._handle_session_request(
+        {"command": "set_diagnostics", "enabled": False, "interval": 5.0},
+        "client",
+        peer,
+        object(),  # type: ignore[arg-type]
+    )
+
+    assert result == {
+        "status": "ok",
+        "data": {"enabled": False, "categories": ["mainline"]},
+    }
+    manager.client.send_command.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_diagnostics_locked_error_notifies_gui() -> None:
+    manager = SessionManager()
+    manager.security_policy.recording_unlock_required = True
+    manager.client.send_command = AsyncMock(
+        return_value=Response(
+            status="error",
+            error="recording_locked: unlock required for capture/recording/diagnostics features",
+        )
+    )
+    manager.send_notification = Mock()  # type: ignore[method-assign]
+    peer = PeerCredentials(pid=1, uid=1000, gid=1000)
+    writer = object()
+    manager.unlock_state.refresh_owner = {
+        "uid": peer.uid,
+        "pid": peer.pid,
+        "writer_id": id(writer),
+        "lease_id": "lease-1",
+    }
+
+    result = await manager._handle_session_request(
+        {"command": "set_diagnostics_output_stream", "enabled": True, "filters": ["button"]},
+        "client",
+        peer,
+        writer,  # type: ignore[arg-type]
+    )
+
+    assert result["status"] == "error"
+    assert result["error_code"] == "recording_locked"
+    manager.send_notification.assert_called_once()
+
+
+@pytest.mark.asyncio
 async def test_device_inspector_disable_session_command_forwards_reason() -> None:
     manager = SessionManager()
     manager.client = SimpleNamespace(
@@ -956,9 +1134,7 @@ async def test_start_device_inspector_returns_snapshot_and_forces_profile_reeval
     manager.profile_state.resolved_devices[hardware_id] = ResolvedDeviceProfile(
         hardware_id=hardware_id,
         active_profile_names=["Desktop"],
-        mappings={
-            "btn_south": MappingAction(action_type=ActionType.KEYBOARD, target="key_space")
-        },
+        mappings={"btn_south": MappingAction(action_type=ActionType.KEYBOARD, target="key_space")},
         mapping_profile_names={"btn_south": "Desktop"},
     )
     manager.client.send_command = AsyncMock(

--- a/tests/session/test_session_manager_command_runtime.py
+++ b/tests/session/test_session_manager_command_runtime.py
@@ -821,7 +821,7 @@ async def test_diagnostics_enable_is_sensitive_to_refresh_owner() -> None:
     }
 
     result = await manager._handle_session_request(
-        {"command": "set_diagnostics", "enabled": True, "interval": 5.0},
+        {"command": "set_diagnostics_output_stream", "enabled": True, "filters": ["button"]},
         "client",
         peer,
         other,  # type: ignore[arg-type]
@@ -833,6 +833,29 @@ async def test_diagnostics_enable_is_sensitive_to_refresh_owner() -> None:
         "message": "Sensitive command denied: caller is not active GUI owner",
     }
     manager.client.send_command.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_latency_diagnostics_enable_is_not_sensitive_to_refresh_owner() -> None:
+    manager = SessionManager()
+    manager.security_policy.recording_unlock_required = True
+    manager.client.send_command = AsyncMock(
+        return_value=Response(status="ok", data={"enabled": True, "categories": ["mainline"]})
+    )
+    peer = PeerCredentials(pid=1, uid=1000, gid=1000)
+
+    result = await manager._handle_session_request(
+        {"command": "set_diagnostics", "enabled": True, "interval": 5.0},
+        "client",
+        peer,
+        object(),  # type: ignore[arg-type]
+    )
+
+    assert result == {
+        "status": "ok",
+        "data": {"enabled": True, "categories": ["mainline"]},
+    }
+    manager.client.send_command.assert_awaited_once()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Adds a new **Output** page to the Diagnostics dialog displaying a live, filterable stream of uinput events written by keymasqd
- Introduces `SET_DIAGNOSTICS_OUTPUT_STREAM` and `DIAGNOSTICS_OUTPUT_EVENT` IPC commands for enabling/disabling the stream and pushing events to the GUI
- Implements `DiagnosticsOutputStreamState` in the daemon with configurable filters (button, axis, mousemove, syn, other, repeat) and a pending event deque
- Wraps uinput writes through `_ObservedUInputWriter` to capture output events from combos, macros, and passthrough paths without runtime code changes
- Removes recording unlock requirement for **latency** diagnostics (non-sensitive); keeps unlock gating for the output stream when `recording_unlock_required` is active
- GUI: toggle switch, filter toggle buttons, event row limit (200), copy-to-clipboard export, unlock integration, and per-page reset
- Docs updated in `PERFORMANCE.md` and `SECURITY.md`
- Tests added for daemon unlock gating, device manager core output stream, session manager command dispatch, and GUI dialog rendering

## Testing

- `./scripts/check.sh full` — all lint, typecheck, and existing tests passed
- New `tests/keymasqd/test_daemon_runtime_unlock.py` — verifies output stream unlock gating (including enabled-only enforcement) and that latency diagnostics bypasses the unlock
- New `tests/keymasqd/test_device_manager_core.py` — output stream enable/disable, filter presets, event recording, dropped event counting, reset, and double-state transitions
- New `tests/session/test_session_manager_command_runtime.py` — session dispatch, policy gating, and error handling for `set_diagnostics_output_stream`
- New `tests/gui/test_diagnostics_dialog.py` — output page rendering, filter toggles, unlock controls, event prepending, list overflow, copy-export, reset, and stack page switching
- Manual: launched `keymasq diagnostics on --interval 5`, opened Diagnostics → Output, toggled stream on, verified events appear when keys/combos fire, tested filters and copy-to-clipboard