### PR TITLE
refactor(keymasqd): unify action execution paths for devices and combos

### DIFF
--- a/keymasq/keymasqd/device_manager.py
+++ b/keymasq/keymasqd/device_manager.py
@@ -211,7 +211,6 @@ def _combo_runtime_deps(
         asyncio_mod=ASYNCIO_RUNTIME,
         evdev_mod=runtime_adapters.COMBO_EVDEV_RUNTIME,
         uinput_writer=runtime_adapters.identity_uinput_writer,
-        emit_mouse_move_fn=runtime_adapters.combo_emit_mouse_move,
         resolve_code_fn=resolve_code_fn,
         fire_and_observe_fn=fire_and_observe_fn,
     )

--- a/keymasq/keymasqd/runtime/action_runner.py
+++ b/keymasq/keymasqd/runtime/action_runner.py
@@ -1,6 +1,7 @@
 import asyncio
 from collections.abc import Awaitable, Callable
-from typing import TypedDict
+from dataclasses import dataclass, field
+from typing import Protocol, TypedDict
 
 from keymasq.common.ipc import CommandType
 from keymasq.common.models import (
@@ -9,10 +10,67 @@ from keymasq.common.models import (
     normalize_macro_loop_stop_behavior,
     profile_deactivation_policy_to_dict,
 )
+from keymasq.keymasqd.output_helpers import (
+    resolve_gamepad_axis_code,
+    resolve_output_code,
+)
+from keymasq.keymasqd.runtime.grabbed_device_outputs import (
+    bucket_for_uinput,
+    passthrough,
+    write_abs_axis,
+    write_key,
+)
+from keymasq.keymasqd.runtime.grabbed_device_repeat import (
+    emit_move_action,
+    rapidfire_abs_axis,
+    rapidfire_key,
+    rapidfire_move,
+    rapidfire_relative,
+    start_rapidfire_task,
+    stop_rapidfire_async,
+    tap_abs_axis,
+    tap_key,
+    tap_move,
+    tap_relative,
+)
+from keymasq.keymasqd.runtime.grabbed_device_types import (
+    ActionExecutionDeps,
+    ActionRuntime,
+    AsyncioEvent,
+    CursorPositionSetter,
+    EmergencyResetter,
+    GrabbedDeviceState,
+    InputEventLike,
+    MacroPlayer,
+)
+from keymasq.keymasqd.runtime.mouse_actions import (
+    resolve_mouse_output_target,
+    write_relative_pulse,
+)
 
 type JsonObject = dict[str, object]
 type BroadcastCallback = Callable[[CommandType, JsonObject], Awaitable[None]]
 type FireAndObserve = Callable[[Awaitable[object], str], asyncio.Task[object]]
+type OutputTracker = Callable[[str, int, int], bool]
+type ResolveCodeFn = Callable[[str], int | None]
+type CancelMacroPlayback = Callable[[], Awaitable[JsonObject]]
+
+
+class SuperkeyExecutor(Protocol):
+    async def __call__(
+        self,
+        device_runtime: ActionRuntime,
+        action: MappingAction,
+        event: InputEventLike,
+        event_name: str,
+        *,
+        deps: ActionExecutionDeps,
+        shared_output_tracker: OutputTracker | None = None,
+        shared_abs_output_tracker: OutputTracker | None = None,
+        execution_handle: "ActionExecutionHandle | None" = None,
+        cancel_macro_playback: CancelMacroPlayback | None = None,
+        resolve_code_fn: ResolveCodeFn = resolve_output_code,
+    ) -> None: ...
 
 
 class MacroPlaybackRequest(TypedDict):
@@ -31,6 +89,87 @@ class MacroPlaybackRequest(TypedDict):
     source_device: str
     source_button: str
     trigger_value: int
+
+
+@dataclass
+class ActionOutputTarget:
+    output_id: str
+    uinput: object | None
+    bucket: str
+
+
+@dataclass
+class ActionRuntimeContext:
+    path: str
+    hardware_id: str
+    state: GrabbedDeviceState = field(default_factory=GrabbedDeviceState)
+    uinput: object | None = None
+    keyboard_uinput: object | None = None
+    mouse_uinput: object | None = None
+    gamepad_uinput: object | None = None
+    broadcast_callback: BroadcastCallback | None = None
+    cursor_position_setter: CursorPositionSetter | None = None
+    macro_player: MacroPlayer | None = None
+    emergency_resetter: EmergencyResetter | None = None
+    suppress_rel_getter: Callable[[], bool] | None = None
+    gamepad_output_resolver: Callable[[str | None, str], object | None] | None = None
+    running: bool = True
+
+    @property
+    def _running(self) -> bool:
+        return self.running
+
+    def stop(self) -> None:
+        self.running = False
+
+    def resolve_gamepad_output(self, output_id: str | None, context: str) -> object | None:
+        if self.gamepad_output_resolver is not None:
+            return self.gamepad_output_resolver(output_id, context)
+        return ActionOutputTarget(
+            output_id=output_id or "virtual-gamepad-1",
+            uinput=self.gamepad_uinput,
+            bucket="gamepad",
+        )
+
+
+@dataclass
+class ActionExecutionHandle:
+    started: AsyncioEvent | None = None
+    tasks: list[asyncio.Task[object]] = field(default_factory=list)
+
+
+def mark_action_started(handle: ActionExecutionHandle | None) -> None:
+    if handle is not None and handle.started is not None:
+        handle.started.set()
+
+
+def register_action_task(
+    handle: ActionExecutionHandle | None,
+    task: asyncio.Task[object],
+) -> None:
+    if handle is not None:
+        handle.tasks.append(task)
+
+
+async def drain_action_tasks(handle: ActionExecutionHandle | None) -> None:
+    if handle is None or not handle.tasks:
+        return
+    tasks = list(dict.fromkeys(handle.tasks))
+    handle.tasks.clear()
+    if tasks:
+        await asyncio.gather(*tasks, return_exceptions=True)
+
+
+async def cancel_action_tasks(handle: ActionExecutionHandle | None) -> None:
+    if handle is None or not handle.tasks:
+        return
+    tasks = list(dict.fromkeys(handle.tasks))
+    handle.tasks.clear()
+    for task in tasks:
+        if not task.done():
+            task.cancel()
+    if tasks:
+        await asyncio.gather(*tasks, return_exceptions=True)
 
 
 def build_action_trigger_payload(
@@ -148,3 +287,704 @@ def dispatch_action_trigger(
         label,
     )
     return True
+
+
+async def execute_action(
+    device_runtime: ActionRuntime,
+    action: MappingAction,
+    event: InputEventLike,
+    event_name: str,
+    *,
+    deps: ActionExecutionDeps,
+    shared_output_tracker: OutputTracker | None = None,
+    shared_abs_output_tracker: OutputTracker | None = None,
+    execution_handle: ActionExecutionHandle | None = None,
+    cancel_macro_playback: CancelMacroPlayback | None = None,
+    superkey_executor: SuperkeyExecutor | None = None,
+    resolve_code_fn: ResolveCodeFn = resolve_output_code,
+) -> None:
+    if action.action_type == ActionType.PASSTHROUGH:
+        passthrough(
+            device_runtime,
+            event,
+            evdev_mod=deps.evdev_mod,
+            uinput_writer=deps.uinput_writer,
+            sync=False,
+        )
+        mark_action_started(execution_handle)
+        return
+
+    if action.action_type == ActionType.SUPPRESS:
+        mark_action_started(execution_handle)
+        return
+
+    if action.action_type == ActionType.KEYBOARD:
+        await _execute_key_action(
+            device_runtime,
+            action,
+            event,
+            event_name,
+            deps=deps,
+            uinput_dev=device_runtime.keyboard_uinput,
+            trigger_kind="key",
+            shared_output_tracker=shared_output_tracker,
+            execution_handle=execution_handle,
+            resolve_code_fn=resolve_code_fn,
+        )
+        return
+
+    if action.action_type == ActionType.MOUSE:
+        await _execute_mouse_action(
+            device_runtime,
+            action,
+            event,
+            event_name,
+            deps=deps,
+            shared_output_tracker=shared_output_tracker,
+            execution_handle=execution_handle,
+            resolve_code_fn=resolve_code_fn,
+        )
+        return
+
+    if action.action_type == ActionType.GAMEPAD_AXIS:
+        await _execute_gamepad_axis_action(
+            device_runtime,
+            action,
+            event,
+            event_name,
+            deps=deps,
+            shared_abs_output_tracker=shared_abs_output_tracker,
+            execution_handle=execution_handle,
+        )
+        return
+
+    if action.action_type == ActionType.GAMEPAD:
+        if action.target:
+            target = device_runtime.resolve_gamepad_output(
+                action.output_id,
+                f"{event_name} -> {action.target}",
+            )
+            if target is None:
+                mark_action_started(execution_handle)
+                return
+            await _execute_key_action(
+                device_runtime,
+                action,
+                event,
+                event_name,
+                deps=deps,
+                uinput_dev=getattr(target, "uinput", None),
+                explicit_bucket=str(getattr(target, "bucket", "gamepad")),
+                trigger_kind="key",
+                shared_output_tracker=shared_output_tracker,
+                execution_handle=execution_handle,
+                resolve_code_fn=resolve_code_fn,
+            )
+        else:
+            mark_action_started(execution_handle)
+        return
+
+    if action.action_type == ActionType.CANCEL_MACRO_PLAYBACK:
+        if int(event.value) == 1:
+            if cancel_macro_playback is not None:
+                task = deps.fire_and_observe_fn(
+                    cancel_macro_playback(),
+                    f"cancel macro action {event_name}",
+                )
+                register_action_task(execution_handle, task)
+            else:
+                _dispatch_trigger_action(
+                    device_runtime,
+                    action,
+                    event_name,
+                    deps=deps,
+                    execution_handle=execution_handle,
+                    label=f"cancel macro action {event_name}",
+                )
+        mark_action_started(execution_handle)
+        return
+
+    if action.action_type == ActionType.EMERGENCY_RESET:
+        if int(event.value) == 1:
+            if device_runtime.emergency_resetter is not None:
+                task = deps.fire_and_observe_fn(
+                    device_runtime.emergency_resetter(),
+                    f"emergency reset action {event_name}",
+                )
+                register_action_task(execution_handle, task)
+        mark_action_started(execution_handle)
+        return
+
+    if action.action_type in {
+        ActionType.EXEC,
+        ActionType.COMPOSITOR_DISPATCH,
+        ActionType.START_MACRO_RECORDING,
+        ActionType.STOP_MACRO_RECORDING,
+        ActionType.PROFILE_ENABLE,
+        ActionType.PROFILE_DISABLE,
+        ActionType.PROFILE_TOGGLE,
+    }:
+        if int(event.value) == 1:
+            _dispatch_trigger_action(
+                device_runtime,
+                action,
+                event_name,
+                deps=deps,
+                execution_handle=execution_handle,
+                label=f"{action.action_type.value} action {event_name}",
+            )
+        mark_action_started(execution_handle)
+        return
+
+    if action.action_type == ActionType.MACRO:
+        macro_request = build_macro_playback_request(
+            action,
+            source_device=device_runtime.hardware_id,
+            source_button=event_name,
+            trigger_value=int(event.value),
+        )
+        if (
+            int(event.value) in (0, 1)
+            and macro_request is not None
+            and device_runtime.macro_player
+        ):
+            task = deps.fire_and_observe_fn(
+                device_runtime.macro_player(**macro_request),
+                f"macro action {event_name}",
+            )
+            register_action_task(execution_handle, task)
+        elif (
+            int(event.value) in (0, 1)
+            and macro_request is not None
+            and device_runtime.broadcast_callback is not None
+        ):
+            task = deps.fire_and_observe_fn(
+                device_runtime.broadcast_callback(
+                    CommandType.ACTION_TRIGGER,
+                    {
+                        "action_type": "macro",
+                        **macro_request,
+                    },
+                ),
+                f"macro action {event_name}",
+            )
+            register_action_task(execution_handle, task)
+        mark_action_started(execution_handle)
+        return
+
+    if action.action_type in (ActionType.MOUSE_MOVE_REL, ActionType.MOUSE_MOVE_ABS):
+        await _execute_move_action(
+            device_runtime,
+            action,
+            event,
+            event_name,
+            deps=deps,
+            execution_handle=execution_handle,
+        )
+        return
+
+    if action.action_type == ActionType.SUPERKEY and superkey_executor is not None:
+        await superkey_executor(
+            device_runtime,
+            action,
+            event,
+            event_name,
+            deps=deps,
+            shared_output_tracker=shared_output_tracker,
+            shared_abs_output_tracker=shared_abs_output_tracker,
+            execution_handle=execution_handle,
+            cancel_macro_playback=cancel_macro_playback,
+            resolve_code_fn=resolve_code_fn,
+        )
+        return
+
+    mark_action_started(execution_handle)
+
+
+async def execute_action_pulse(
+    device_runtime: ActionRuntime,
+    action: MappingAction,
+    event: InputEventLike,
+    event_name: str,
+    *,
+    deps: ActionExecutionDeps,
+    shared_output_tracker: OutputTracker | None = None,
+    shared_abs_output_tracker: OutputTracker | None = None,
+    execution_handle: ActionExecutionHandle | None = None,
+    cancel_macro_playback: CancelMacroPlayback | None = None,
+    superkey_executor: SuperkeyExecutor | None = None,
+    resolve_code_fn: ResolveCodeFn = resolve_output_code,
+) -> None:
+    await execute_action(
+        device_runtime,
+        action,
+        _SyntheticInputEvent(int(event.type), int(event.code), 1),
+        event_name,
+        deps=deps,
+        shared_output_tracker=shared_output_tracker,
+        shared_abs_output_tracker=shared_abs_output_tracker,
+        execution_handle=execution_handle,
+        cancel_macro_playback=cancel_macro_playback,
+        superkey_executor=superkey_executor,
+        resolve_code_fn=resolve_code_fn,
+    )
+    await execute_action(
+        device_runtime,
+        action,
+        _SyntheticInputEvent(int(event.type), int(event.code), 0),
+        event_name,
+        deps=deps,
+        shared_output_tracker=shared_output_tracker,
+        shared_abs_output_tracker=shared_abs_output_tracker,
+        execution_handle=execution_handle,
+        cancel_macro_playback=cancel_macro_playback,
+        superkey_executor=superkey_executor,
+        resolve_code_fn=resolve_code_fn,
+    )
+
+
+def _dispatch_trigger_action(
+    device_runtime: ActionRuntime,
+    action: MappingAction,
+    event_name: str,
+    *,
+    deps: ActionExecutionDeps,
+    execution_handle: ActionExecutionHandle | None,
+    label: str,
+) -> bool:
+    payload = build_action_trigger_payload(
+        action,
+        source_device=device_runtime.hardware_id,
+        source_button=event_name,
+        trigger_id=source_trigger_id(device_runtime.hardware_id, event_name),
+    )
+    if device_runtime.broadcast_callback is None or payload is None:
+        return False
+    task = deps.fire_and_observe_fn(
+        device_runtime.broadcast_callback(CommandType.ACTION_TRIGGER, payload),
+        label,
+    )
+    register_action_task(execution_handle, task)
+    return True
+
+
+class _SyntheticInputEvent:
+    def __init__(self, event_type: int, code: int, value: int) -> None:
+        self.type = int(event_type)
+        self.code = int(code)
+        self.value = int(value)
+
+
+async def _execute_gamepad_axis_action(
+    device_runtime: ActionRuntime,
+    action: MappingAction,
+    event: InputEventLike,
+    event_name: str,
+    *,
+    deps: ActionExecutionDeps,
+    shared_abs_output_tracker: OutputTracker | None = None,
+    execution_handle: ActionExecutionHandle | None = None,
+) -> None:
+    if not action.target:
+        mark_action_started(execution_handle)
+        return
+    target = device_runtime.resolve_gamepad_output(
+        action.output_id,
+        f"{event_name} -> {action.target}",
+    )
+    if target is None:
+        mark_action_started(execution_handle)
+        return
+    axis_code = resolve_gamepad_axis_code(action.target)
+    if axis_code is None:
+        mark_action_started(execution_handle)
+        return
+    await _execute_abs_axis_output(
+        device_runtime,
+        action,
+        event,
+        event_name,
+        deps=deps,
+        axis_code=axis_code,
+        active_value=int(action.axis_value),
+        release_value=0,
+        target_uinput=getattr(target, "uinput", None),
+        target_bucket=str(getattr(target, "bucket", "gamepad")),
+        rapidfire_kind="axis",
+        tap_label=f"tap axis action {event_name}",
+        shared_abs_output_tracker=shared_abs_output_tracker,
+        execution_handle=execution_handle,
+    )
+
+
+async def _execute_abs_axis_output(
+    device_runtime: ActionRuntime,
+    action: MappingAction,
+    event: InputEventLike,
+    event_name: str,
+    *,
+    deps: ActionExecutionDeps,
+    axis_code: int,
+    active_value: int,
+    release_value: int,
+    target_uinput: object | None,
+    target_bucket: str,
+    rapidfire_kind: str,
+    tap_label: str,
+    shared_abs_output_tracker: OutputTracker | None = None,
+    execution_handle: ActionExecutionHandle | None = None,
+) -> None:
+    if action.rapidfire_enabled:
+        if int(event.value) == 1:
+            start_rapidfire_task(
+                device_runtime,
+                event_name,
+                rapidfire_kind,
+                lambda: deps.asyncio_mod.create_task(
+                    rapidfire_abs_axis(
+                        device_runtime,
+                        axis_code,
+                        active_value,
+                        release_value,
+                        action.rapidfire_hold_ms,
+                        action.rapidfire_wait_ms,
+                        event_name,
+                        target_uinput,
+                        asyncio_mod=deps.asyncio_mod,
+                        evdev_mod=deps.evdev_mod,
+                        uinput_writer=deps.uinput_writer,
+                        bucket=target_bucket,
+                        started=execution_handle.started if execution_handle else None,
+                        output_tracker=shared_abs_output_tracker,
+                    )
+                ),
+                code=None,
+                uinput=target_uinput,
+                axis_code=axis_code,
+                bucket=target_bucket,
+                axis_release_value=release_value,
+                output_tracker=shared_abs_output_tracker,
+            )
+        elif int(event.value) == 0:
+            await stop_rapidfire_async(
+                device_runtime,
+                event_name,
+                asyncio_mod=deps.asyncio_mod,
+            )
+            mark_action_started(execution_handle)
+        return
+
+    if action.tap_enabled:
+        if int(event.value) == 1 and not device_runtime.state.tap_active.get(event_name, False):
+            device_runtime.state.tap_active[event_name] = True
+            task = deps.fire_and_observe_fn(
+                tap_abs_axis(
+                    device_runtime,
+                    axis_code,
+                    active_value,
+                    release_value,
+                    action.tap_hold_ms,
+                    event_name,
+                    target_uinput,
+                    asyncio_mod=deps.asyncio_mod,
+                    evdev_mod=deps.evdev_mod,
+                    uinput_writer=deps.uinput_writer,
+                    bucket=target_bucket,
+                    started=execution_handle.started if execution_handle else None,
+                ),
+                tap_label,
+            )
+            register_action_task(execution_handle, task)
+        elif int(event.value) == 0:
+            mark_action_started(execution_handle)
+        return
+
+    output_value = active_value if int(event.value) else release_value
+    should_emit = True
+    if shared_abs_output_tracker is not None:
+        should_emit = shared_abs_output_tracker(target_bucket, int(axis_code), int(output_value))
+    if should_emit:
+        write_abs_axis(
+            device_runtime,
+            target_uinput,
+            axis_code,
+            output_value,
+            evdev_mod=deps.evdev_mod,
+            uinput_writer=deps.uinput_writer,
+            bucket=target_bucket,
+        )
+    mark_action_started(execution_handle)
+
+
+async def _execute_key_action(
+    device_runtime: ActionRuntime,
+    action: MappingAction,
+    event: InputEventLike,
+    event_name: str,
+    *,
+    deps: ActionExecutionDeps,
+    uinput_dev: object | None,
+    trigger_kind: str,
+    shared_output_tracker: OutputTracker | None = None,
+    explicit_bucket: str | None = None,
+    execution_handle: ActionExecutionHandle | None = None,
+    resolve_code_fn: ResolveCodeFn = resolve_output_code,
+) -> None:
+    if not action.target:
+        mark_action_started(execution_handle)
+        return
+    code = resolve_code_fn(action.target)
+    if code is None:
+        mark_action_started(execution_handle)
+        return
+    if action.rapidfire_enabled:
+        if int(event.value) == 1:
+            tracker_bucket = explicit_bucket or bucket_for_uinput(device_runtime, uinput_dev)
+            output_tracker = shared_output_tracker if tracker_bucket is not None else None
+            start_rapidfire_task(
+                device_runtime,
+                event_name,
+                trigger_kind,
+                lambda: deps.asyncio_mod.create_task(
+                    rapidfire_key(
+                        device_runtime,
+                        code,
+                        action.rapidfire_hold_ms,
+                        action.rapidfire_wait_ms,
+                        event_name,
+                        uinput_dev,
+                        asyncio_mod=deps.asyncio_mod,
+                        bucket=tracker_bucket,
+                        started=execution_handle.started if execution_handle else None,
+                        output_tracker=output_tracker,
+                    )
+                ),
+                code=code,
+                uinput=uinput_dev,
+                axis_code=None,
+                bucket=tracker_bucket,
+                output_tracker=output_tracker,
+            )
+        elif int(event.value) == 0:
+            await stop_rapidfire_async(
+                device_runtime,
+                event_name,
+                asyncio_mod=deps.asyncio_mod,
+            )
+            mark_action_started(execution_handle)
+        return
+
+    if action.tap_enabled:
+        if int(event.value) == 1 and not device_runtime.state.tap_active.get(event_name, False):
+            device_runtime.state.tap_active[event_name] = True
+            task = deps.fire_and_observe_fn(
+                tap_key(
+                    device_runtime,
+                    code,
+                    action.tap_hold_ms,
+                    event_name,
+                    uinput_dev,
+                    asyncio_mod=deps.asyncio_mod,
+                    bucket=explicit_bucket,
+                    started=execution_handle.started if execution_handle else None,
+                ),
+                f"tap action {event_name}",
+            )
+            register_action_task(execution_handle, task)
+        elif int(event.value) == 0:
+            mark_action_started(execution_handle)
+        return
+
+    should_emit = True
+    if shared_output_tracker is not None:
+        bucket = explicit_bucket or bucket_for_uinput(device_runtime, uinput_dev)
+        if bucket is not None:
+            should_emit = shared_output_tracker(bucket, int(code), int(event.value))
+    if should_emit:
+        write_key(
+            device_runtime,
+            uinput_dev,
+            code,
+            int(event.value),
+            evdev_mod=deps.evdev_mod,
+            uinput_writer=deps.uinput_writer,
+            bucket=explicit_bucket,
+        )
+    mark_action_started(execution_handle)
+
+
+async def _execute_mouse_action(
+    device_runtime: ActionRuntime,
+    action: MappingAction,
+    event: InputEventLike,
+    event_name: str,
+    *,
+    deps: ActionExecutionDeps,
+    shared_output_tracker: OutputTracker | None = None,
+    execution_handle: ActionExecutionHandle | None = None,
+    resolve_code_fn: ResolveCodeFn = resolve_output_code,
+) -> None:
+    target = resolve_mouse_output_target(action.target)
+    if target is None:
+        mark_action_started(execution_handle)
+        return
+    if target.is_relative:
+        await _execute_relative_mouse_action(
+            device_runtime,
+            action,
+            event,
+            event_name,
+            code=target.code,
+            relative_value=target.relative_value,
+            deps=deps,
+            execution_handle=execution_handle,
+        )
+        return
+    await _execute_key_action(
+        device_runtime,
+        action,
+        event,
+        event_name,
+        deps=deps,
+        uinput_dev=device_runtime.mouse_uinput,
+        trigger_kind="key",
+        shared_output_tracker=shared_output_tracker,
+        execution_handle=execution_handle,
+        resolve_code_fn=resolve_code_fn,
+    )
+
+
+async def _execute_relative_mouse_action(
+    device_runtime: ActionRuntime,
+    action: MappingAction,
+    event: InputEventLike,
+    event_name: str,
+    *,
+    code: int,
+    relative_value: int,
+    deps: ActionExecutionDeps,
+    execution_handle: ActionExecutionHandle | None = None,
+) -> None:
+    if action.rapidfire_enabled:
+        if int(event.value) == 1:
+            start_rapidfire_task(
+                device_runtime,
+                event_name,
+                "relative",
+                lambda: deps.asyncio_mod.create_task(
+                    rapidfire_relative(
+                        device_runtime,
+                        code,
+                        relative_value,
+                        action.rapidfire_hold_ms,
+                        action.rapidfire_wait_ms,
+                        event_name,
+                        device_runtime.mouse_uinput,
+                        asyncio_mod=deps.asyncio_mod,
+                        started=execution_handle.started if execution_handle else None,
+                    )
+                ),
+                code=code,
+                uinput=device_runtime.mouse_uinput,
+                axis_code=None,
+            )
+        elif int(event.value) == 0:
+            await stop_rapidfire_async(
+                device_runtime,
+                event_name,
+                asyncio_mod=deps.asyncio_mod,
+            )
+            mark_action_started(execution_handle)
+        return
+
+    if action.tap_enabled:
+        if int(event.value) == 1 and not device_runtime.state.tap_active.get(event_name, False):
+            device_runtime.state.tap_active[event_name] = True
+            task = deps.fire_and_observe_fn(
+                tap_relative(
+                    device_runtime,
+                    code,
+                    relative_value,
+                    action.tap_hold_ms,
+                    event_name,
+                    device_runtime.mouse_uinput,
+                    asyncio_mod=deps.asyncio_mod,
+                    started=execution_handle.started if execution_handle else None,
+                ),
+                f"tap action {event_name}",
+            )
+            register_action_task(execution_handle, task)
+        elif int(event.value) == 0:
+            mark_action_started(execution_handle)
+        return
+
+    if int(event.value) == 1:
+        write_relative_pulse(
+            device_runtime.mouse_uinput,
+            code,
+            relative_value,
+            ev_rel_code=deps.evdev_mod.ecodes.EV_REL,
+            uinput_writer=deps.uinput_writer,
+        )
+    mark_action_started(execution_handle)
+
+
+async def _execute_move_action(
+    device_runtime: ActionRuntime,
+    action: MappingAction,
+    event: InputEventLike,
+    event_name: str,
+    *,
+    deps: ActionExecutionDeps,
+    execution_handle: ActionExecutionHandle | None = None,
+) -> None:
+    if action.rapidfire_enabled:
+        if int(event.value) == 1:
+            start_rapidfire_task(
+                device_runtime,
+                event_name,
+                "move",
+                lambda: deps.asyncio_mod.create_task(
+                    rapidfire_move(
+                        device_runtime,
+                        action,
+                        event_name,
+                        action.rapidfire_hold_ms,
+                        action.rapidfire_wait_ms,
+                        asyncio_mod=deps.asyncio_mod,
+                        started=execution_handle.started if execution_handle else None,
+                    )
+                ),
+                code=None,
+                uinput=None,
+                axis_code=None,
+            )
+        elif int(event.value) == 0:
+            await stop_rapidfire_async(
+                device_runtime,
+                event_name,
+                asyncio_mod=deps.asyncio_mod,
+            )
+            mark_action_started(execution_handle)
+    elif action.tap_enabled:
+        if int(event.value) == 1 and not device_runtime.state.tap_active.get(event_name, False):
+            device_runtime.state.tap_active[event_name] = True
+            task = deps.fire_and_observe_fn(
+                tap_move(
+                    device_runtime,
+                    action,
+                    event_name,
+                    action.tap_hold_ms,
+                    asyncio_mod=deps.asyncio_mod,
+                    started=execution_handle.started if execution_handle else None,
+                ),
+                f"tap move {event_name}",
+            )
+            register_action_task(execution_handle, task)
+        elif int(event.value) == 0:
+            mark_action_started(execution_handle)
+    elif int(event.value) == 1:
+        await emit_move_action(device_runtime, action)
+        mark_action_started(execution_handle)
+    else:
+        mark_action_started(execution_handle)

--- a/keymasq/keymasqd/runtime/adapters.py
+++ b/keymasq/keymasqd/runtime/adapters.py
@@ -1,10 +1,8 @@
 import asyncio
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Iterator, Mapping
 from typing import Final, Protocol, TypeVar, cast
 
 import evdev
-
-from keymasq.keymasqd.output_helpers import emit_mouse_move
 
 _T = TypeVar("_T")
 
@@ -79,20 +77,28 @@ def identity_uinput_writer(device: object | None) -> WritableUInput | None:
     return cast(WritableUInput | None, device)
 
 
-class _ComboEcodesByType:
-    def get(self, key: int, default: dict[int, object] | None = None) -> dict[int, object]:
-        value = evdev.ecodes.bytype.get(key)
-        if isinstance(value, dict):
-            return cast(dict[int, object], value)
-        return {} if default is None else default
+class _ComboEcodesByType(Mapping[int, Mapping[int, object]]):
+    def __getitem__(self, key: int) -> Mapping[int, object]:
+        return cast(Mapping[int, object], evdev.ecodes.bytype[int(key)])
+
+    def __iter__(self) -> Iterator[int]:
+        return iter(evdev.ecodes.bytype)
+
+    def __len__(self) -> int:
+        return len(evdev.ecodes.bytype)
 
 
 class _ComboEcodes:
     EV_KEY: Final[int] = evdev.ecodes.EV_KEY
     EV_REL: Final[int] = evdev.ecodes.EV_REL
+    EV_SYN: Final[int] = evdev.ecodes.EV_SYN
     EV_ABS: Final[int] = evdev.ecodes.EV_ABS
+    REL_X: Final[int] = evdev.ecodes.REL_X
+    REL_Y: Final[int] = evdev.ecodes.REL_Y
     REL_WHEEL: Final[int] = evdev.ecodes.REL_WHEEL
     REL_HWHEEL: Final[int] = evdev.ecodes.REL_HWHEEL
+    ABS_Z: Final[int] = evdev.ecodes.ABS_Z
+    ABS_RZ: Final[int] = evdev.ecodes.ABS_RZ
     bytype: Final[_ComboEcodesByType] = _ComboEcodesByType()
 
 
@@ -101,13 +107,3 @@ class ComboEvdevAdapter:
 
 
 COMBO_EVDEV_RUNTIME: Final[ComboEvdevAdapter] = ComboEvdevAdapter()
-
-
-def combo_emit_mouse_move(
-    uinput_dev: object | None,
-    move_x: int,
-    move_y: int,
-    *,
-    absolute: bool = False,
-) -> None:
-    emit_mouse_move(identity_uinput_writer(uinput_dev), move_x, move_y, absolute=absolute)

--- a/keymasq/keymasqd/runtime/combos.py
+++ b/keymasq/keymasqd/runtime/combos.py
@@ -5,20 +5,20 @@ import queue
 import time
 from collections.abc import Awaitable, Callable, Sequence
 from dataclasses import dataclass, field
-from typing import Any, Protocol, cast
+from typing import Any, cast
 
 from keymasq.common.combos import is_combo_pulse_evdev, normalize_combo_evdev
 from keymasq.common.devices import (
     high_res_wheel_low_res_code,
     normalize_wheel_value,
+    resolve_evdev_code,
+    resolve_evdev_event_type,
     wheel_button_id,
 )
 from keymasq.common.models import (
     ActionType,
     MappingAction,
     SuperkeyMode,
-    clamp_rapidfire_hold_ms,
-    clamp_rapidfire_wait_ms,
     combo_effective_superkey_config,
 )
 from keymasq.keymasqd.combo_engine import (
@@ -30,22 +30,17 @@ from keymasq.keymasqd.combo_engine import (
     RuntimeCombo,
     RuntimeComboBinding,
 )
-from keymasq.keymasqd.output_helpers import resolve_gamepad_axis_code
+from keymasq.keymasqd.runtime import action_runner as shared_action_runner
 from keymasq.keymasqd.runtime import adapters as runtime_adapters
 from keymasq.keymasqd.runtime.action_runner import (
-    build_action_trigger_payload,
-    build_macro_playback_request,
+    ActionExecutionHandle,
+    ActionRuntimeContext,
     dispatch_action_trigger,
     is_hold_macro_action,
     source_trigger_id,
 )
-from keymasq.keymasqd.runtime.grabbed_device_outputs import syn_if_passthrough_frame_closed
-from keymasq.keymasqd.runtime.mouse_actions import (
-    rapidfire_relative_pulses,
-    resolve_mouse_output_target,
-    tap_relative_pulse,
-    write_relative_pulse,
-)
+from keymasq.keymasqd.runtime.grabbed_device_types import ActionExecutionDeps, EvdevModule
+from keymasq.keymasqd.runtime.mouse_actions import resolve_mouse_output_target
 from keymasq.keymasqd.superkey_state import SuperkeyConfig as RuntimeSuperkeyConfig
 from keymasq.keymasqd.superkey_state import SuperkeyMachine
 
@@ -64,17 +59,6 @@ type ComboCaptureQueueState = tuple[
 ]
 
 
-class _EmitMouseMoveFn(Protocol):
-    def __call__(
-        self,
-        uinput_dev: object | None,
-        move_x: int,
-        move_y: int,
-        *,
-        absolute: bool = False,
-    ) -> None: ...
-
-
 type _GrabbedComboDevice = Any
 type _ComboManager = Any
 
@@ -82,15 +66,6 @@ type _ComboManager = Any
 @dataclass
 class ComboActionState:
     kind: str
-    code: int | None = None
-    axis_code: int | None = None
-    axis_value: int = 0
-    axis_release_value: int = 0
-    uinput: object | None = None
-    bucket: str | None = None
-    output_id: str | None = None
-    active: bool = False
-    task: asyncio.Task[None] | None = None
     started: runtime_adapters.AsyncioEvent | None = None
     action: MappingAction | None = None
     source_device: str | None = None
@@ -101,6 +76,8 @@ class ComboActionState:
     machine: SuperkeyMachine | None = None
     recalled_bindings: list[RuntimeComboBinding] = field(default_factory=list)
     restore_bindings: list[RuntimeComboBinding] = field(default_factory=list)
+    action_runtime: ActionRuntimeContext | None = None
+    execution_handle: ActionExecutionHandle | None = None
 
 
 @dataclass
@@ -135,9 +112,79 @@ class ComboRuntimeDeps:
     asyncio_mod: runtime_adapters.AsyncioRuntimeAdapter
     evdev_mod: runtime_adapters.ComboEvdevAdapter
     uinput_writer: runtime_adapters.UInputWriter
-    emit_mouse_move_fn: _EmitMouseMoveFn
     resolve_code_fn: ResolveCodeFn
     fire_and_observe_fn: FireAndObserve
+
+
+def _action_execution_deps(deps: ComboRuntimeDeps) -> ActionExecutionDeps:
+    return ActionExecutionDeps(
+        asyncio_mod=deps.asyncio_mod,
+        fire_and_observe_fn=deps.fire_and_observe_fn,
+        evdev_mod=cast(EvdevModule, deps.evdev_mod),
+        uinput_writer=deps.uinput_writer,
+    )
+
+
+def _combo_action_runtime(
+    manager: _ComboManager,
+    combo_id: str,
+    action: MappingAction,
+    trigger_binding: RuntimeComboBinding,
+    *,
+    trigger_name: str,
+) -> ActionRuntimeContext:
+    cursor_position_setter = getattr(manager, "set_cursor_position", None)
+    macro_player = getattr(manager, "play_macro", None)
+    emergency_resetter = getattr(manager, "emergency_reset", None)
+    return ActionRuntimeContext(
+        path=f"combo:{combo_id}:{trigger_name}",
+        hardware_id=(
+            "combo" if action.action_type == ActionType.MACRO else trigger_binding.hardware_id
+        ),
+        uinput=None,
+        keyboard_uinput=manager.output_state.keyboard_uinput,
+        mouse_uinput=manager.output_state.mouse_uinput,
+        gamepad_uinput=manager.output_state.gamepad_uinput,
+        broadcast_callback=manager.broadcast_callback,
+        cursor_position_setter=(
+            cast(Callable[[int, int], Awaitable[dict[str, object]]], cursor_position_setter)
+            if callable(cursor_position_setter)
+            else None
+        ),
+        macro_player=(
+            cast(Callable[..., Awaitable[dict[str, object]]], macro_player)
+            if callable(macro_player)
+            else None
+        ),
+        emergency_resetter=(
+            cast(Callable[[], Awaitable[dict[str, object]]], emergency_resetter)
+            if callable(emergency_resetter)
+            else None
+        ),
+        gamepad_output_resolver=lambda output_id, context: manager.resolve_gamepad_output(
+            output_id,
+            context=context,
+        ),
+    )
+
+
+class _ComboSyntheticEvent:
+    def __init__(self, event_type: int | None, code: int | None, value: int) -> None:
+        self.type = int(event_type or 0)
+        self.code = int(code or 0)
+        self.value = int(value)
+
+
+def _combo_synthetic_event(
+    trigger_binding: RuntimeComboBinding | None,
+    value: int,
+) -> _ComboSyntheticEvent:
+    evdev_name = trigger_binding.evdev if trigger_binding is not None else None
+    return _ComboSyntheticEvent(
+        resolve_evdev_event_type(evdev_name),
+        resolve_evdev_code(evdev_name),
+        value,
+    )
 
 
 def _evdev_code_name(raw_name: object, fallback: int) -> str:
@@ -540,16 +587,6 @@ def _observe_combo_profile_trigger(
         observer(source_trigger_id(trigger_binding.hardware_id, trigger_name))
 
 
-def prune_combo_action_task(
-    manager: _ComboManager, combo_id: str, task: asyncio.Task[None] | None
-) -> None:
-    if task is None:
-        return
-    state = manager.combo_state.active_actions.get(combo_id)
-    if state is not None and state.task is task:
-        manager.combo_state.active_actions.pop(combo_id, None)
-
-
 async def wait_combo_action_started(manager: _ComboManager, combo_id: str) -> None:
     state = manager.combo_state.active_actions.get(combo_id)
     if state is None:
@@ -561,11 +598,6 @@ async def wait_combo_action_started(manager: _ComboManager, combo_id: str) -> No
     if state.started is None:
         return
     await state.started.wait()
-
-
-def mark_combo_action_started(started: runtime_adapters.AsyncioEvent | None) -> None:
-    if started is not None:
-        started.set()
 
 
 def track_combo_superkey_output(
@@ -727,6 +759,11 @@ async def _combo_superkey_machine(
             output_id,
             context=context,
         ),
+        macro_player=manager.play_macro,
+        emergency_resetter=manager.emergency_reset,
+        cancel_macro_playback=manager.cancel_macro_playback,
+        action_deps=_action_execution_deps(deps),
+        await_action_tasks=False,
     )
     manager.combo_state.superkey_machines[combo_id] = machine
     manager.combo_state.superkey_machine_bindings[combo_id] = machine_bindings
@@ -813,76 +850,45 @@ def _attach_combo_trigger_recall_state(
     return True
 
 
-async def combo_tap_key(
-    manager: _ComboManager,
-    combo_id: str,
-    uinput_dev: object | None,
-    code: int,
-    hold_ms: int,
-    started: runtime_adapters.AsyncioEvent | None = None,
-    *,
-    deps: ComboRuntimeDeps,
-) -> None:
-    task = deps.asyncio_mod.current_task()
-    pressed = False
-    started_set = False
-
-    try:
-        write_combo_key(uinput_dev, code, 1, deps=deps)
-        mark_combo_action_started(started)
-        started_set = True
-        pressed = True
-        await deps.asyncio_mod.sleep(max(0.001, float(hold_ms) / 1000.0))
-    except deps.asyncio_mod.CancelledError:
-        raise
-    finally:
-        if pressed:
-            write_combo_key(uinput_dev, code, 0, deps=deps)
-        if not started_set:
-            mark_combo_action_started(started)
-        prune_combo_action_task(manager, combo_id, task)
-
-
-async def combo_tap_axis(
-    manager: _ComboManager,
-    combo_id: str,
-    axis_code: int,
-    hold_ms: int,
-    started: runtime_adapters.AsyncioEvent | None = None,
-    uinput_dev: object | None = None,
-    *,
-    deps: ComboRuntimeDeps,
-    active_value: int = 255,
-    release_value: int = 0,
-) -> None:
-    task = deps.asyncio_mod.current_task()
-    pressed = False
-    started_set = False
-
-    try:
-        write_combo_axis(
-            uinput_dev,
-            axis_code,
-            active_value,
-            deps=deps,
+def _combo_action_needs_release(action: MappingAction) -> bool:
+    if action.action_type in {
+        ActionType.KEYBOARD,
+        ActionType.GAMEPAD,
+        ActionType.GAMEPAD_AXIS,
+    }:
+        return True
+    if action.action_type == ActionType.MOUSE:
+        target = resolve_mouse_output_target(action.target)
+        return bool(
+            action.tap_enabled
+            or action.rapidfire_enabled
+            or (target is not None and not target.is_relative)
         )
-        mark_combo_action_started(started)
-        started_set = True
-        pressed = True
-        await deps.asyncio_mod.sleep(max(0.001, float(hold_ms) / 1000.0))
-    except deps.asyncio_mod.CancelledError:
-        raise
-    finally:
-        if pressed:
-            write_combo_axis(
-                uinput_dev,
-                axis_code,
-                release_value,
-                deps=deps,
-            )
-        if not started_set:
-            mark_combo_action_started(started)
-        prune_combo_action_task(manager, combo_id, task)
+    if action.action_type in {ActionType.MOUSE_MOVE_REL, ActionType.MOUSE_MOVE_ABS}:
+        return bool(action.tap_enabled or action.rapidfire_enabled)
+    if action.action_type == ActionType.MACRO:
+        return is_hold_macro_action(action)
+    return action.action_type in {
+        ActionType.EXEC,
+        ActionType.COMPOSITOR_DISPATCH,
+        ActionType.START_MACRO_RECORDING,
+        ActionType.STOP_MACRO_RECORDING,
+        ActionType.PROFILE_ENABLE,
+        ActionType.PROFILE_DISABLE,
+        ActionType.PROFILE_TOGGLE,
+    }
+
+
+def _combo_action_uses_tap_task(action: MappingAction | None) -> bool:
+    return bool(action and action.tap_enabled)
+
+
+def _combo_profile_action_tracks_trigger(action: MappingAction) -> bool:
+    return (
+        action.action_type in {ActionType.PROFILE_ENABLE, ActionType.PROFILE_TOGGLE}
+        and action.profile_deactivation is not None
+        and action.profile_deactivation.on_trigger_end
+    )
 
 
 async def start_combo_action(
@@ -1077,190 +1083,54 @@ async def _start_combo_action_instance(
     if action is None or action.action_type == ActionType.SUPERKEY:
         return
 
-    if action.action_type == ActionType.KEYBOARD and action.target:
-        await start_combo_key_action(
-            manager,
-            combo_id,
-            action,
-            manager.output_state.keyboard_uinput,
-            deps=deps,
-        )
+    if action.action_type in {ActionType.PASSTHROUGH, ActionType.SUPPRESS}:
         return
 
-    if action.action_type == ActionType.MOUSE and action.target:
-        await start_combo_mouse_action(
-            manager,
-            combo_id,
-            action,
-            manager.output_state.mouse_uinput,
-            deps=deps,
-        )
-        return
-
-    if action.action_type == ActionType.GAMEPAD and action.target:
-        target = manager.resolve_gamepad_output(
-            action.output_id,
-            context=f"combo:{combo_id} -> {action.target}",
-        )
-        if target is None:
-            return
-        target_uinput = getattr(target, "uinput", None)
-        target_bucket = str(getattr(target, "bucket", "gamepad"))
-        await start_combo_key_action(
-            manager,
-            combo_id,
-            action,
-            target_uinput,
-            deps=deps,
-            bucket=target_bucket,
-        )
-        return
-
-    if action.action_type == ActionType.GAMEPAD_AXIS and action.target:
-        target = manager.resolve_gamepad_output(
-            action.output_id,
-            context=f"combo:{combo_id} -> {action.target}",
-        )
-        if target is None:
-            return
-        axis_code = resolve_gamepad_axis_code(action.target)
-        if axis_code is None:
-            return
-        target_uinput = getattr(target, "uinput", None)
-        target_bucket = str(getattr(target, "bucket", "gamepad"))
-        target_output_id = str(getattr(target, "output_id", action.output_id or ""))
-        active_value = int(action.axis_value)
-        release_value = 0
-        if action.tap_enabled:
-            started = deps.asyncio_mod.create_event()
-            task = deps.asyncio_mod.create_task(
-                combo_tap_axis(
-                    manager,
-                    combo_id,
-                    axis_code,
-                    action.tap_hold_ms,
-                    started,
-                    target_uinput,
-                    deps=deps,
-                    active_value=active_value,
-                    release_value=release_value,
-                )
-            )
-            manager.combo_state.active_actions[combo_id] = ComboActionState(
-                kind="tap_axis",
-                axis_code=axis_code,
-                axis_value=active_value,
-                axis_release_value=release_value,
-                uinput=target_uinput,
-                bucket=target_bucket,
-                output_id=target_output_id,
-                task=task,
-                started=started,
-            )
-            return
-        if action.rapidfire_enabled:
-            started = deps.asyncio_mod.create_event()
-            task = deps.asyncio_mod.create_task(
-                combo_rapidfire_axis(
-                    manager,
-                    combo_id,
-                    axis_code,
-                    action.rapidfire_hold_ms,
-                    action.rapidfire_wait_ms,
-                    started,
-                    target_uinput,
-                    deps=deps,
-                    active_value=active_value,
-                    release_value=release_value,
-                )
-            )
-            manager.combo_state.active_actions[combo_id] = ComboActionState(
-                kind="rapidfire_axis",
-                axis_code=axis_code,
-                axis_value=active_value,
-                axis_release_value=release_value,
-                uinput=target_uinput,
-                bucket=target_bucket,
-                output_id=target_output_id,
-                active=True,
-                task=task,
-                started=started,
-            )
-            return
-        write_combo_axis(target_uinput, axis_code, active_value, deps=deps)
-        manager.combo_state.active_actions[combo_id] = ComboActionState(
-            kind="axis",
-            axis_code=axis_code,
-            axis_value=active_value,
-            axis_release_value=release_value,
-            uinput=target_uinput,
-            bucket=target_bucket,
-            output_id=target_output_id,
-        )
-        return
-
-    if action.action_type == ActionType.MOUSE_MOVE_ABS:
-        await manager.set_cursor_position(int(action.move_x), int(action.move_y))
-        return
-
-    if action.action_type == ActionType.MOUSE_MOVE_REL:
-        emit_combo_mouse_move(manager, action, deps=deps)
-        return
-
-    if action.action_type == ActionType.MACRO:
-        macro_request = build_macro_playback_request(
-            action,
-            source_device="combo",
-            source_button=trigger_name,
-            trigger_value=1,
-        )
-        if macro_request is not None:
-            await manager.play_macro(**macro_request)
-            if is_hold_macro_action(action):
-                manager.combo_state.active_actions[combo_id] = ComboActionState(
-                    kind="macro_hold",
-                    action=action,
-                    source_device="combo",
-                    source_button=trigger_name,
-                )
-        return
-
-    if action.action_type == ActionType.CANCEL_MACRO_PLAYBACK:
-        await manager.cancel_macro_playback()
-        return
-
-    if action.action_type == ActionType.EMERGENCY_RESET:
-        deps.fire_and_observe_fn(
-            manager.emergency_reset(),
-            "combo emergency runtime reset",
-        )
-        return
-
-    action_payload = build_action_trigger_payload(
+    runtime = _combo_action_runtime(
+        manager,
+        combo_id,
         action,
-        source_device=trigger_binding.hardware_id,
-        source_button=trigger_name,
-        trigger_id=source_trigger_id(trigger_binding.hardware_id, trigger_name),
+        trigger_binding,
+        trigger_name=trigger_name,
     )
-    if action_payload is not None:
+    if _combo_profile_action_tracks_trigger(action):
         _observe_combo_profile_trigger(
             manager,
             trigger_binding,
             trigger_name,
             active=True,
         )
-        await broadcast_combo_action(
-            manager,
-            action_payload,
-            deps=deps,
-        )
+    started = deps.asyncio_mod.create_event()
+    handle = ActionExecutionHandle(started=started)
+    await shared_action_runner.execute_action(
+        runtime,
+        action,
+        _combo_synthetic_event(trigger_binding, 1),
+        trigger_name,
+        deps=_action_execution_deps(deps),
+        execution_handle=handle,
+        cancel_macro_playback=manager.cancel_macro_playback,
+        resolve_code_fn=deps.resolve_code_fn,
+    )
+    await started.wait()
+
+    if is_hold_macro_action(action):
+        await shared_action_runner.drain_action_tasks(handle)
+
+    if _combo_action_needs_release(action):
         manager.combo_state.active_actions[combo_id] = ComboActionState(
-            kind="trigger_only",
+            kind="executor",
             action=action,
             trigger_binding=trigger_binding,
+            source_device=runtime.hardware_id,
             source_button=trigger_name,
+            started=handle.started,
+            action_runtime=runtime,
+            execution_handle=handle,
         )
         return
+
+    await shared_action_runner.drain_action_tasks(handle)
 
 
 async def _pulse_combo_action_instance(
@@ -1282,150 +1152,6 @@ async def _pulse_combo_action_instance(
     )
     await wait_combo_action_started(manager, combo_id)
     await stop_combo_action(manager, combo_id, deps=deps)
-
-
-async def start_combo_key_action(
-    manager: _ComboManager,
-    combo_id: str,
-    action: MappingAction,
-    uinput_dev: object | None,
-    *,
-    deps: ComboRuntimeDeps,
-    bucket: str | None = None,
-) -> None:
-    target = str(action.target or "")
-    if not target:
-        return
-    code = deps.resolve_code_fn(target)
-    if code is None:
-        return
-    if action.tap_enabled:
-        started = deps.asyncio_mod.create_event()
-        task = deps.asyncio_mod.create_task(
-            combo_tap_key(
-                manager,
-                combo_id,
-                uinput_dev,
-                code,
-                action.tap_hold_ms,
-                started,
-                deps=deps,
-            )
-        )
-        manager.combo_state.active_actions[combo_id] = ComboActionState(
-            kind="tap_key",
-            uinput=uinput_dev,
-            code=code,
-            task=task,
-            started=started,
-            bucket=bucket,
-        )
-        return
-    if action.rapidfire_enabled:
-        started = deps.asyncio_mod.create_event()
-        task = deps.asyncio_mod.create_task(
-            combo_rapidfire_key(
-                manager,
-                combo_id,
-                uinput_dev,
-                code,
-                action.rapidfire_hold_ms,
-                action.rapidfire_wait_ms,
-                started,
-                deps=deps,
-            )
-        )
-        manager.combo_state.active_actions[combo_id] = ComboActionState(
-            kind="rapidfire_key",
-            uinput=uinput_dev,
-            code=code,
-            active=True,
-            task=task,
-            started=started,
-            bucket=bucket,
-        )
-        return
-    write_combo_key(uinput_dev, code, 1, deps=deps)
-    manager.combo_state.active_actions[combo_id] = ComboActionState(
-        kind="key",
-        uinput=uinput_dev,
-        code=code,
-        bucket=bucket,
-    )
-
-
-async def start_combo_mouse_action(
-    manager: _ComboManager,
-    combo_id: str,
-    action: MappingAction,
-    uinput_dev: object | None,
-    *,
-    deps: ComboRuntimeDeps,
-) -> None:
-    target = resolve_mouse_output_target(action.target)
-    if target is None:
-        return
-    if not target.is_relative:
-        await start_combo_key_action(
-            manager,
-            combo_id,
-            action,
-            uinput_dev,
-            deps=deps,
-        )
-        return
-    if action.tap_enabled:
-        started = deps.asyncio_mod.create_event()
-        task = deps.asyncio_mod.create_task(
-            combo_tap_relative(
-                manager,
-                combo_id,
-                uinput_dev,
-                target.code,
-                target.relative_value,
-                action.tap_hold_ms,
-                started,
-                deps=deps,
-            )
-        )
-        manager.combo_state.active_actions[combo_id] = ComboActionState(
-            kind="tap_relative",
-            uinput=uinput_dev,
-            code=target.code,
-            task=task,
-            started=started,
-        )
-        return
-    if action.rapidfire_enabled:
-        started = deps.asyncio_mod.create_event()
-        task = deps.asyncio_mod.create_task(
-            combo_rapidfire_relative(
-                manager,
-                combo_id,
-                uinput_dev,
-                target.code,
-                target.relative_value,
-                action.rapidfire_hold_ms,
-                action.rapidfire_wait_ms,
-                started,
-                deps=deps,
-            )
-        )
-        manager.combo_state.active_actions[combo_id] = ComboActionState(
-            kind="rapidfire_relative",
-            uinput=uinput_dev,
-            code=target.code,
-            active=True,
-            task=task,
-            started=started,
-        )
-        return
-    write_combo_relative(
-        uinput_dev,
-        target.code,
-        target.relative_value,
-        deps=deps,
-    )
 
 
 async def stop_combo_action(
@@ -1494,57 +1220,26 @@ async def stop_combo_action(
             await machine.on_up()
         _restore_combo_trigger_bindings(manager, restore_bindings)
         return
-    if kind == "key":
-        uinput_dev = state.uinput
-        code = state.code
-        if code is not None:
-            write_combo_key(
-                uinput_dev,
-                code,
-                0,
-                deps=deps,
-            )
-        _restore_combo_trigger_bindings(manager, restore_bindings)
-        return
-    if kind == "axis":
-        axis_code = state.axis_code
-        if axis_code is not None:
-            write_combo_axis(
-                state.uinput,
-                axis_code,
-                state.axis_release_value,
-                deps=deps,
-            )
-        _restore_combo_trigger_bindings(manager, restore_bindings)
-        return
-    if kind in {
-        "tap_key",
-        "tap_axis",
-        "rapidfire_key",
-        "rapidfire_axis",
-        "tap_relative",
-        "rapidfire_relative",
-    }:
-        state.active = False
-        task = state.task
-        if task is not None and not task.done():
-            task.cancel()
-            with contextlib.suppress(deps.asyncio_mod.CancelledError):
-                await task
-        _restore_combo_trigger_bindings(manager, restore_bindings)
-        return
-    if kind == "macro_hold":
+    if kind == "executor":
+        runtime = state.action_runtime
         action = state.action
-        if action is not None:
-            macro_request = build_macro_playback_request(
+        handle = state.execution_handle
+        if runtime is not None and action is not None:
+            await shared_action_runner.execute_action(
+                runtime,
                 action,
-                source_device=str(state.source_device or ""),
-                source_button=str(state.source_button or ""),
-                trigger_value=0,
-                include_macro_events=False,
+                _combo_synthetic_event(trigger_binding, 0),
+                source_button,
+                deps=_action_execution_deps(deps),
+                execution_handle=handle,
+                cancel_macro_playback=manager.cancel_macro_playback,
+                resolve_code_fn=deps.resolve_code_fn,
             )
-            if macro_request is not None:
-                await manager.play_macro(**macro_request)
+            if _combo_action_uses_tap_task(action):
+                await shared_action_runner.cancel_action_tasks(handle)
+            else:
+                await shared_action_runner.drain_action_tasks(handle)
+            runtime.stop()
         _restore_combo_trigger_bindings(manager, restore_bindings)
         return
     _restore_combo_trigger_bindings(manager, restore_bindings)
@@ -1705,223 +1400,6 @@ async def combo_timeout_watchdog(
             manager,
             deps=deps,
         )
-
-
-async def combo_rapidfire_key(
-    manager: _ComboManager,
-    combo_id: str,
-    uinput_dev: object | None,
-    code: int,
-    hold_ms: int,
-    wait_ms: int,
-    started: runtime_adapters.AsyncioEvent | None = None,
-    *,
-    deps: ComboRuntimeDeps,
-) -> None:
-    started_set = False
-
-    try:
-        while _combo_action_active(manager, combo_id):
-            write_combo_key(uinput_dev, code, 1, deps=deps)
-            if not started_set:
-                mark_combo_action_started(started)
-                started_set = True
-            await deps.asyncio_mod.sleep(clamp_rapidfire_hold_ms(hold_ms) / 1000.0)
-            if not _combo_action_active(manager, combo_id):
-                break
-            write_combo_key(uinput_dev, code, 0, deps=deps)
-            await deps.asyncio_mod.sleep(clamp_rapidfire_wait_ms(wait_ms) / 1000.0)
-    except deps.asyncio_mod.CancelledError:
-        raise
-    finally:
-        write_combo_key(uinput_dev, code, 0, deps=deps)
-        if not started_set:
-            mark_combo_action_started(started)
-
-
-async def combo_tap_relative(
-    manager: _ComboManager,
-    combo_id: str,
-    uinput_dev: object | None,
-    code: int,
-    value: int,
-    hold_ms: int,
-    started: runtime_adapters.AsyncioEvent | None = None,
-    *,
-    deps: ComboRuntimeDeps,
-) -> None:
-    task = deps.asyncio_mod.current_task()
-    started_set = False
-
-    def emit_started_pulse() -> None:
-        nonlocal started_set
-        write_combo_relative(
-            uinput_dev,
-            code,
-            value,
-            deps=deps,
-        )
-        if not started_set:
-            mark_combo_action_started(started)
-            started_set = True
-
-    try:
-        await tap_relative_pulse(
-            emit_pulse=emit_started_pulse,
-            hold_s=max(0.001, float(hold_ms) / 1000.0),
-            asyncio_mod=deps.asyncio_mod,
-        )
-    except deps.asyncio_mod.CancelledError:
-        raise
-    finally:
-        if not started_set:
-            mark_combo_action_started(started)
-        prune_combo_action_task(manager, combo_id, task)
-
-
-async def combo_rapidfire_relative(
-    manager: _ComboManager,
-    combo_id: str,
-    uinput_dev: object | None,
-    code: int,
-    value: int,
-    hold_ms: int,
-    wait_ms: int,
-    started: runtime_adapters.AsyncioEvent | None = None,
-    *,
-    deps: ComboRuntimeDeps,
-) -> None:
-    started_set = False
-
-    def emit_started_pulse() -> None:
-        nonlocal started_set
-        write_combo_relative(
-            uinput_dev,
-            code,
-            value,
-            deps=deps,
-        )
-        if not started_set:
-            mark_combo_action_started(started)
-            started_set = True
-
-    try:
-        await rapidfire_relative_pulses(
-            emit_pulse=emit_started_pulse,
-            is_active=lambda: _combo_action_active(manager, combo_id),
-            hold_s=clamp_rapidfire_hold_ms(hold_ms) / 1000.0,
-            wait_s=clamp_rapidfire_wait_ms(wait_ms) / 1000.0,
-            asyncio_mod=deps.asyncio_mod,
-        )
-    except deps.asyncio_mod.CancelledError:
-        raise
-    finally:
-        if not started_set:
-            mark_combo_action_started(started)
-
-
-async def combo_rapidfire_axis(
-    manager: _ComboManager,
-    combo_id: str,
-    axis_code: int,
-    hold_ms: int,
-    wait_ms: int,
-    started: runtime_adapters.AsyncioEvent | None = None,
-    uinput_dev: object | None = None,
-    *,
-    deps: ComboRuntimeDeps,
-    active_value: int = 255,
-    release_value: int = 0,
-) -> None:
-    started_set = False
-
-    try:
-        while _combo_action_active(manager, combo_id):
-            write_combo_axis(
-                uinput_dev,
-                axis_code,
-                active_value,
-                deps=deps,
-            )
-            if not started_set:
-                mark_combo_action_started(started)
-                started_set = True
-            await deps.asyncio_mod.sleep(clamp_rapidfire_hold_ms(hold_ms) / 1000.0)
-            if not _combo_action_active(manager, combo_id):
-                break
-            write_combo_axis(
-                uinput_dev,
-                axis_code,
-                release_value,
-                deps=deps,
-            )
-            await deps.asyncio_mod.sleep(clamp_rapidfire_wait_ms(wait_ms) / 1000.0)
-    except deps.asyncio_mod.CancelledError:
-        raise
-    finally:
-        write_combo_axis(uinput_dev, axis_code, release_value, deps=deps)
-        if not started_set:
-            mark_combo_action_started(started)
-
-
-def write_combo_key(
-    uinput_dev: object | None,
-    code: int,
-    value: int,
-    *,
-    deps: ComboRuntimeDeps,
-) -> None:
-    writer = deps.uinput_writer(uinput_dev)
-    if writer is None:
-        return
-    writer.write(deps.evdev_mod.ecodes.EV_KEY, int(code), int(value))
-    syn_if_passthrough_frame_closed(uinput_dev, writer)
-
-
-def write_combo_relative(
-    uinput_dev: object | None,
-    code: int,
-    value: int,
-    *,
-    deps: ComboRuntimeDeps,
-) -> None:
-    write_relative_pulse(
-        uinput_dev,
-        code,
-        value,
-        ev_rel_code=deps.evdev_mod.ecodes.EV_REL,
-        uinput_writer=deps.uinput_writer,
-    )
-
-
-def write_combo_axis(
-    uinput_dev: object | None,
-    axis_code: int,
-    value: int,
-    *,
-    deps: ComboRuntimeDeps,
-) -> None:
-    writer = deps.uinput_writer(uinput_dev)
-    if writer is None:
-        return
-    writer.write(deps.evdev_mod.ecodes.EV_ABS, int(axis_code), int(value))
-    syn_if_passthrough_frame_closed(uinput_dev, writer)
-
-
-def emit_combo_mouse_move(
-    manager: _ComboManager, action: MappingAction, *, deps: ComboRuntimeDeps
-) -> None:
-    deps.emit_mouse_move_fn(
-        manager.output_state.mouse_uinput,
-        int(action.move_x),
-        int(action.move_y),
-        absolute=bool(action.action_type.value == "mouse_move_abs"),
-    )
-
-
-def _combo_action_active(manager: _ComboManager, combo_id: str) -> bool:
-    state = manager.combo_state.active_actions.get(combo_id)
-    return state.active if state is not None else False
 
 
 def begin_combo_capture(

--- a/keymasq/keymasqd/runtime/grab_lifecycle.py
+++ b/keymasq/keymasqd/runtime/grab_lifecycle.py
@@ -57,7 +57,6 @@ def combo_runtime_deps(
         asyncio_mod=ASYNCIO_RUNTIME,
         evdev_mod=COMBO_EVDEV_RUNTIME,
         uinput_writer=runtime_adapters.identity_uinput_writer,
-        emit_mouse_move_fn=runtime_adapters.combo_emit_mouse_move,
         resolve_code_fn=resolve_code_fn,
         fire_and_observe_fn=fire_and_observe_fn,
     )

--- a/keymasq/keymasqd/runtime/grabbed_device_actions.py
+++ b/keymasq/keymasqd/runtime/grabbed_device_actions.py
@@ -4,46 +4,24 @@ from typing import cast
 
 from keymasq.common.ipc import CommandType
 from keymasq.common.models import ActionType, MappingAction, SuperkeyMode
-from keymasq.keymasqd.output_helpers import (
-    resolve_gamepad_axis_code,
-    resolve_output_code,
-)
+from keymasq.keymasqd.output_helpers import resolve_output_code
+from keymasq.keymasqd.runtime import action_runner as shared_action_runner
 from keymasq.keymasqd.runtime.action_runner import (
-    build_action_trigger_payload,
-    build_macro_playback_request,
-    dispatch_action_trigger,
+    ActionExecutionHandle,
+    CancelMacroPlayback,
+    ResolveCodeFn,
     source_trigger_id,
 )
 from keymasq.keymasqd.runtime.grabbed_device_outputs import (
-    bucket_for_uinput,
-    passthrough,
     track_superkey_abs_output,
     track_superkey_output,
-    write_abs_axis,
-    write_key,
-)
-from keymasq.keymasqd.runtime.grabbed_device_repeat import (
-    emit_move_action,
-    rapidfire_abs_axis,
-    rapidfire_key,
-    rapidfire_move,
-    rapidfire_relative,
-    start_rapidfire_task,
-    stop_rapidfire_async,
-    tap_abs_axis,
-    tap_key,
-    tap_move,
-    tap_relative,
 )
 from keymasq.keymasqd.runtime.grabbed_device_types import (
     ActionExecutionDeps,
+    ActionRuntime,
     GrabbedDeviceRuntime,
     InputEventLike,
     WritableUInput,
-)
-from keymasq.keymasqd.runtime.mouse_actions import (
-    resolve_mouse_output_target,
-    write_relative_pulse,
 )
 from keymasq.keymasqd.superkey_state import SuperkeyConfig as RuntimeSuperkeyConfig
 from keymasq.keymasqd.superkey_state import SuperkeyMachine
@@ -60,264 +38,23 @@ async def execute_action(
     deps: ActionExecutionDeps,
     shared_output_tracker: Callable[[str, int, int], bool] | None = None,
     shared_abs_output_tracker: Callable[[str, int, int], bool] | None = None,
+    execution_handle: ActionExecutionHandle | None = None,
+    cancel_macro_playback: CancelMacroPlayback | None = None,
+    resolve_code_fn: ResolveCodeFn = resolve_output_code,
 ) -> None:
-    evdev_mod = deps.evdev_mod
-    uinput_writer = deps.uinput_writer
-    fire_and_observe_fn = deps.fire_and_observe_fn
-    if action.action_type == ActionType.PASSTHROUGH:
-        passthrough(
-            device_runtime,
-            event,
-            evdev_mod=evdev_mod,
-            uinput_writer=uinput_writer,
-            sync=False,
-        )
-
-    elif action.action_type == ActionType.SUPPRESS:
-        pass
-
-    elif action.action_type == ActionType.KEYBOARD:
-        await _execute_key_action(
-            device_runtime,
-            action,
-            event,
-            event_name,
-            deps=deps,
-            uinput_dev=device_runtime.keyboard_uinput,
-            target_kind="key",
-            trigger_kind="key",
-            shared_output_tracker=shared_output_tracker,
-        )
-
-    elif action.action_type == ActionType.MOUSE:
-        await _execute_mouse_action(
-            device_runtime,
-            action,
-            event,
-            event_name,
-            deps=deps,
-            shared_output_tracker=shared_output_tracker,
-        )
-
-    elif action.action_type == ActionType.GAMEPAD_AXIS:
-        await _execute_gamepad_axis_action(
-            device_runtime,
-            action,
-            event,
-            event_name,
-            deps=deps,
-            shared_output_tracker=shared_output_tracker,
-            shared_abs_output_tracker=shared_abs_output_tracker,
-        )
-
-    elif action.action_type == ActionType.GAMEPAD:
-        if action.target:
-            target = device_runtime.resolve_gamepad_output(
-                action.output_id,
-                f"{event_name} -> {action.target}",
-            )
-            if target is None:
-                return
-            target_uinput = getattr(target, "uinput", None)
-            target_bucket = str(getattr(target, "bucket", "gamepad"))
-            await _execute_key_action(
-                device_runtime,
-                action,
-                event,
-                event_name,
-                deps=deps,
-                uinput_dev=target_uinput,
-                explicit_bucket=target_bucket,
-                target_kind="key",
-                trigger_kind="key",
-                shared_output_tracker=shared_output_tracker,
-            )
-
-    elif action.action_type == ActionType.EXEC:
-        if event.value == 1:
-            dispatch_action_trigger(
-                device_runtime.broadcast_callback,
-                build_action_trigger_payload(
-                    action,
-                    source_device=device_runtime.hardware_id,
-                    source_button=event_name,
-                    trigger_id=source_trigger_id(device_runtime.hardware_id, event_name),
-                ),
-                fire_and_observe_fn=fire_and_observe_fn,
-                label=f"exec action {event_name}",
-            )
-
-    elif action.action_type == ActionType.COMPOSITOR_DISPATCH:
-        if event.value == 1:
-            dispatch_action_trigger(
-                device_runtime.broadcast_callback,
-                build_action_trigger_payload(
-                    action,
-                    source_device=device_runtime.hardware_id,
-                    source_button=event_name,
-                    trigger_id=source_trigger_id(device_runtime.hardware_id, event_name),
-                ),
-                fire_and_observe_fn=fire_and_observe_fn,
-                label=f"compositor action {event_name}",
-            )
-
-    elif action.action_type == ActionType.START_MACRO_RECORDING:
-        if event.value == 1:
-            dispatch_action_trigger(
-                device_runtime.broadcast_callback,
-                build_action_trigger_payload(
-                    action,
-                    source_device=device_runtime.hardware_id,
-                    source_button=event_name,
-                    trigger_id=source_trigger_id(device_runtime.hardware_id, event_name),
-                ),
-                fire_and_observe_fn=fire_and_observe_fn,
-                label=f"start recording action {event_name}",
-            )
-
-    elif action.action_type == ActionType.STOP_MACRO_RECORDING:
-        if event.value == 1:
-            dispatch_action_trigger(
-                device_runtime.broadcast_callback,
-                build_action_trigger_payload(
-                    action,
-                    source_device=device_runtime.hardware_id,
-                    source_button=event_name,
-                    trigger_id=source_trigger_id(device_runtime.hardware_id, event_name),
-                ),
-                fire_and_observe_fn=fire_and_observe_fn,
-                label=f"stop recording action {event_name}",
-            )
-
-    elif action.action_type == ActionType.CANCEL_MACRO_PLAYBACK:
-        if event.value == 1:
-            dispatch_action_trigger(
-                device_runtime.broadcast_callback,
-                build_action_trigger_payload(
-                    action,
-                    source_device=device_runtime.hardware_id,
-                    source_button=event_name,
-                    trigger_id=source_trigger_id(device_runtime.hardware_id, event_name),
-                ),
-                fire_and_observe_fn=fire_and_observe_fn,
-                label=f"cancel macro action {event_name}",
-            )
-
-    elif action.action_type == ActionType.EMERGENCY_RESET:
-        if event.value == 1 and device_runtime.emergency_resetter is not None:
-            fire_and_observe_fn(
-                device_runtime.emergency_resetter(),
-                f"emergency reset action {event_name}",
-            )
-
-    elif action.action_type in (
-        ActionType.PROFILE_ENABLE,
-        ActionType.PROFILE_DISABLE,
-        ActionType.PROFILE_TOGGLE,
-    ):
-        if event.value == 1:
-            dispatch_action_trigger(
-                device_runtime.broadcast_callback,
-                build_action_trigger_payload(
-                    action,
-                    source_device=device_runtime.hardware_id,
-                    source_button=event_name,
-                    trigger_id=source_trigger_id(device_runtime.hardware_id, event_name),
-                ),
-                fire_and_observe_fn=fire_and_observe_fn,
-                label=f"profile action {event_name}",
-            )
-
-    elif action.action_type == ActionType.MACRO:
-        macro_request = build_macro_playback_request(
-            action,
-            source_device=device_runtime.hardware_id,
-            source_button=event_name,
-            trigger_value=int(event.value),
-        )
-        if event.value in (0, 1) and macro_request is not None and device_runtime.macro_player:
-            fire_and_observe_fn(
-                device_runtime.macro_player(**macro_request),
-                f"macro action {event_name}",
-            )
-
-    elif action.action_type in (ActionType.MOUSE_MOVE_REL, ActionType.MOUSE_MOVE_ABS):
-        await _execute_move_action(
-            device_runtime,
-            action,
-            event,
-            event_name,
-            deps=deps,
-        )
-
-    elif action.action_type == ActionType.SUPERKEY:
-        if action.superkey_config:
-            if action.superkey_config.mode == SuperkeyMode.OVERLOAD:
-                await _execute_overload_superkey(
-                    device_runtime,
-                    action,
-                    event,
-                    event_name,
-                    deps=deps,
-                )
-                return
-
-            machine = device_runtime.state.superkey_machines.get(event_name)
-            if event.value == 1 and not machine:
-
-                async def superkey_broadcast(data: dict[str, object]) -> None:
-                    if device_runtime.broadcast_callback:
-                        fire_and_observe_fn(
-                            device_runtime.broadcast_callback(
-                                CommandType.ACTION_TRIGGER,
-                                data,
-                            ),
-                            f"superkey action {event_name}",
-                        )
-
-                def superkey_key_event_tracker(
-                    action_type: str,
-                    code: int,
-                    value: int,
-                ) -> bool:
-                    return track_superkey_output(
-                        device_runtime,
-                        action_type,
-                        code,
-                        value,
-                    )
-
-                def superkey_abs_event_tracker(
-                    bucket: str,
-                    axis_code: int,
-                    value: int,
-                ) -> bool:
-                    return track_superkey_abs_output(
-                        device_runtime,
-                        bucket,
-                        axis_code,
-                        value,
-                    )
-
-                machine = SuperkeyMachine(
-                    config=cast(RuntimeSuperkeyConfig, action.superkey_config),
-                    event_name=event_name,
-                    keyboard_uinput=cast(WritableUInput, device_runtime.keyboard_uinput),
-                    mouse_uinput=cast(WritableUInput, device_runtime.mouse_uinput),
-                    gamepad_uinput=cast(WritableUInput, device_runtime.gamepad_uinput),
-                    source_device=device_runtime.hardware_id,
-                    broadcast_callback=superkey_broadcast,
-                    cursor_position_setter=device_runtime.cursor_position_setter,
-                    key_event_tracker=superkey_key_event_tracker,
-                    axis_event_tracker=superkey_abs_event_tracker,
-                    gamepad_output_resolver=device_runtime.resolve_gamepad_output,
-                )
-                device_runtime.state.superkey_machines[event_name] = machine
-
-            if event.value == 1 and machine is not None:
-                await machine.on_down()
-            elif event.value == 0 and machine is not None:
-                await machine.on_up()
+    await shared_action_runner.execute_action(
+        device_runtime,
+        action,
+        event,
+        event_name,
+        deps=deps,
+        shared_output_tracker=shared_output_tracker,
+        shared_abs_output_tracker=shared_abs_output_tracker,
+        execution_handle=execution_handle,
+        cancel_macro_playback=cancel_macro_playback,
+        superkey_executor=_execute_superkey_action,
+        resolve_code_fn=resolve_code_fn,
+    )
 
 
 async def execute_action_pulse(
@@ -372,6 +109,100 @@ def _observe_overload_profile_trigger(
     )
     if observer is not None:
         observer(source_trigger_id(device_runtime.hardware_id, child_event_name))
+
+
+async def _execute_superkey_action(
+    device_runtime: ActionRuntime,
+    action: MappingAction,
+    event: InputEventLike,
+    event_name: str,
+    *,
+    deps: ActionExecutionDeps,
+    shared_output_tracker: Callable[[str, int, int], bool] | None = None,
+    shared_abs_output_tracker: Callable[[str, int, int], bool] | None = None,
+    execution_handle: ActionExecutionHandle | None = None,
+    cancel_macro_playback: CancelMacroPlayback | None = None,
+    resolve_code_fn: ResolveCodeFn = resolve_output_code,
+) -> None:
+    device_runtime = cast(GrabbedDeviceRuntime, device_runtime)
+    del shared_output_tracker, shared_abs_output_tracker, resolve_code_fn
+    if action.superkey_config is None:
+        shared_action_runner.mark_action_started(execution_handle)
+        return
+
+    if action.superkey_config.mode == SuperkeyMode.OVERLOAD:
+        await _execute_overload_superkey(
+            device_runtime,
+            action,
+            event,
+            event_name,
+            deps=deps,
+        )
+        shared_action_runner.mark_action_started(execution_handle)
+        return
+
+    machine = device_runtime.state.superkey_machines.get(event_name)
+    if int(event.value) == 1 and not machine:
+
+        async def superkey_broadcast(data: dict[str, object]) -> None:
+            if device_runtime.broadcast_callback:
+                task = deps.fire_and_observe_fn(
+                    device_runtime.broadcast_callback(
+                        CommandType.ACTION_TRIGGER,
+                        data,
+                    ),
+                    f"superkey action {event_name}",
+                )
+                shared_action_runner.register_action_task(execution_handle, task)
+
+        def superkey_key_event_tracker(
+            action_type: str,
+            code: int,
+            value: int,
+        ) -> bool:
+            return track_superkey_output(
+                device_runtime,
+                action_type,
+                code,
+                value,
+            )
+
+        def superkey_abs_event_tracker(
+            bucket: str,
+            axis_code: int,
+            value: int,
+        ) -> bool:
+            return track_superkey_abs_output(
+                device_runtime,
+                bucket,
+                axis_code,
+                value,
+            )
+
+        machine = SuperkeyMachine(
+            config=cast(RuntimeSuperkeyConfig, action.superkey_config),
+            event_name=event_name,
+            keyboard_uinput=cast(WritableUInput, device_runtime.keyboard_uinput),
+            mouse_uinput=cast(WritableUInput, device_runtime.mouse_uinput),
+            gamepad_uinput=cast(WritableUInput, device_runtime.gamepad_uinput),
+            source_device=device_runtime.hardware_id,
+            broadcast_callback=superkey_broadcast,
+            cursor_position_setter=device_runtime.cursor_position_setter,
+            key_event_tracker=superkey_key_event_tracker,
+            axis_event_tracker=superkey_abs_event_tracker,
+            gamepad_output_resolver=device_runtime.resolve_gamepad_output,
+            macro_player=device_runtime.macro_player,
+            emergency_resetter=device_runtime.emergency_resetter,
+            cancel_macro_playback=cancel_macro_playback,
+            action_deps=deps,
+        )
+        device_runtime.state.superkey_machines[event_name] = machine
+
+    if int(event.value) == 1 and machine is not None:
+        await machine.on_down()
+    elif int(event.value) == 0 and machine is not None:
+        await machine.on_up()
+    shared_action_runner.mark_action_started(execution_handle)
 
 
 async def _execute_overload_superkey(
@@ -474,374 +305,3 @@ async def _execute_overload_superkey(
                 shared_output_tracker=overload_output_tracker,
                 shared_abs_output_tracker=overload_abs_output_tracker,
             )
-
-
-async def _execute_gamepad_axis_action(
-    device_runtime: GrabbedDeviceRuntime,
-    action: MappingAction,
-    event: InputEventLike,
-    event_name: str,
-    *,
-    deps: ActionExecutionDeps,
-    shared_output_tracker: Callable[[str, int, int], bool] | None = None,
-    shared_abs_output_tracker: Callable[[str, int, int], bool] | None = None,
-) -> None:
-    del shared_output_tracker
-    if not action.target:
-        return
-    target = device_runtime.resolve_gamepad_output(
-        action.output_id,
-        f"{event_name} -> {action.target}",
-    )
-    if target is None:
-        return
-    axis_code = resolve_gamepad_axis_code(action.target)
-    if axis_code is None:
-        return
-    await _execute_abs_axis_output(
-        device_runtime,
-        action,
-        event,
-        event_name,
-        deps=deps,
-        axis_code=axis_code,
-        active_value=int(action.axis_value),
-        release_value=0,
-        target_uinput=getattr(target, "uinput", None),
-        target_bucket=str(getattr(target, "bucket", "gamepad")),
-        rapidfire_kind="axis",
-        tap_label=f"tap axis action {event_name}",
-        shared_abs_output_tracker=shared_abs_output_tracker,
-    )
-
-
-async def _execute_abs_axis_output(
-    device_runtime: GrabbedDeviceRuntime,
-    action: MappingAction,
-    event: InputEventLike,
-    event_name: str,
-    *,
-    deps: ActionExecutionDeps,
-    axis_code: int,
-    active_value: int,
-    release_value: int,
-    target_uinput: object | None,
-    target_bucket: str,
-    rapidfire_kind: str,
-    tap_label: str,
-    shared_abs_output_tracker: Callable[[str, int, int], bool] | None = None,
-) -> None:
-    if action.rapidfire_enabled:
-        if event.value == 1:
-            start_rapidfire_task(
-                device_runtime,
-                event_name,
-                rapidfire_kind,
-                lambda: deps.asyncio_mod.create_task(
-                    rapidfire_abs_axis(
-                        device_runtime,
-                        axis_code,
-                        active_value,
-                        release_value,
-                        action.rapidfire_hold_ms,
-                        action.rapidfire_wait_ms,
-                        event_name,
-                        target_uinput,
-                        asyncio_mod=deps.asyncio_mod,
-                        evdev_mod=deps.evdev_mod,
-                        uinput_writer=deps.uinput_writer,
-                        bucket=target_bucket,
-                    )
-                ),
-                code=None,
-                uinput=target_uinput,
-                axis_code=axis_code,
-                bucket=target_bucket,
-                axis_release_value=release_value,
-            )
-        elif event.value == 0:
-            await stop_rapidfire_async(
-                device_runtime,
-                event_name,
-                asyncio_mod=deps.asyncio_mod,
-            )
-        return
-
-    if action.tap_enabled:
-        if event.value == 1 and not device_runtime.state.tap_active.get(event_name, False):
-            device_runtime.state.tap_active[event_name] = True
-            deps.fire_and_observe_fn(
-                tap_abs_axis(
-                    device_runtime,
-                    axis_code,
-                    active_value,
-                    release_value,
-                    action.tap_hold_ms,
-                    event_name,
-                    target_uinput,
-                    asyncio_mod=deps.asyncio_mod,
-                    evdev_mod=deps.evdev_mod,
-                    uinput_writer=deps.uinput_writer,
-                    bucket=target_bucket,
-                ),
-                tap_label,
-            )
-        return
-
-    output_value = active_value if int(event.value) else release_value
-    should_emit = True
-    if shared_abs_output_tracker is not None:
-        should_emit = shared_abs_output_tracker(target_bucket, int(axis_code), int(output_value))
-    if not should_emit:
-        return
-    write_abs_axis(
-        device_runtime,
-        target_uinput,
-        axis_code,
-        output_value,
-        evdev_mod=deps.evdev_mod,
-        uinput_writer=deps.uinput_writer,
-        bucket=target_bucket,
-    )
-
-
-async def _execute_key_action(
-    device_runtime: GrabbedDeviceRuntime,
-    action: MappingAction,
-    event: InputEventLike,
-    event_name: str,
-    *,
-    deps: ActionExecutionDeps,
-    uinput_dev: object | None,
-    target_kind: str,
-    trigger_kind: str,
-    shared_output_tracker: Callable[[str, int, int], bool] | None = None,
-    explicit_bucket: str | None = None,
-) -> None:
-    del target_kind
-    if not action.target:
-        return
-    code = resolve_output_code(action.target)
-    if not code:
-        return
-    if action.rapidfire_enabled:
-        if event.value == 1:
-            start_rapidfire_task(
-                device_runtime,
-                event_name,
-                trigger_kind,
-                lambda: deps.asyncio_mod.create_task(
-                    rapidfire_key(
-                        device_runtime,
-                        code,
-                        action.rapidfire_hold_ms,
-                        action.rapidfire_wait_ms,
-                        event_name,
-                        uinput_dev,
-                        asyncio_mod=deps.asyncio_mod,
-                        bucket=explicit_bucket,
-                    )
-                ),
-                code=code,
-                uinput=uinput_dev,
-                axis_code=None,
-                bucket=explicit_bucket,
-            )
-        elif event.value == 0:
-            await stop_rapidfire_async(
-                device_runtime,
-                event_name,
-                asyncio_mod=deps.asyncio_mod,
-            )
-    elif action.tap_enabled:
-        if event.value == 1 and not device_runtime.state.tap_active.get(event_name, False):
-            device_runtime.state.tap_active[event_name] = True
-            deps.fire_and_observe_fn(
-                tap_key(
-                    device_runtime,
-                    code,
-                    action.tap_hold_ms,
-                    event_name,
-                    uinput_dev,
-                    asyncio_mod=deps.asyncio_mod,
-                    bucket=explicit_bucket,
-                ),
-                f"tap action {event_name}",
-            )
-    else:
-        should_emit = True
-        if shared_output_tracker is not None:
-            bucket = explicit_bucket or bucket_for_uinput(device_runtime, uinput_dev)
-            if bucket is not None:
-                should_emit = shared_output_tracker(bucket, int(code), int(event.value))
-        if not should_emit:
-            return
-        write_key(
-            device_runtime,
-            uinput_dev,
-            code,
-            int(event.value),
-            evdev_mod=deps.evdev_mod,
-            uinput_writer=deps.uinput_writer,
-            bucket=explicit_bucket,
-        )
-
-
-async def _execute_mouse_action(
-    device_runtime: GrabbedDeviceRuntime,
-    action: MappingAction,
-    event: InputEventLike,
-    event_name: str,
-    *,
-    deps: ActionExecutionDeps,
-    shared_output_tracker: Callable[[str, int, int], bool] | None = None,
-) -> None:
-    target = resolve_mouse_output_target(action.target)
-    if target is None:
-        return
-    if target.is_relative:
-        await _execute_relative_mouse_action(
-            device_runtime,
-            action,
-            event,
-            event_name,
-            code=target.code,
-            relative_value=target.relative_value,
-            deps=deps,
-            shared_output_tracker=shared_output_tracker,
-        )
-        return
-    await _execute_key_action(
-        device_runtime,
-        action,
-        event,
-        event_name,
-        deps=deps,
-        uinput_dev=device_runtime.mouse_uinput,
-        target_kind="key",
-        trigger_kind="key",
-        shared_output_tracker=shared_output_tracker,
-    )
-
-
-async def _execute_relative_mouse_action(
-    device_runtime: GrabbedDeviceRuntime,
-    action: MappingAction,
-    event: InputEventLike,
-    event_name: str,
-    *,
-    code: int,
-    relative_value: int,
-    deps: ActionExecutionDeps,
-    shared_output_tracker: Callable[[str, int, int], bool] | None = None,
-) -> None:
-    del shared_output_tracker
-
-    if action.rapidfire_enabled:
-        if event.value == 1:
-            start_rapidfire_task(
-                device_runtime,
-                event_name,
-                "relative",
-                lambda: deps.asyncio_mod.create_task(
-                    rapidfire_relative(
-                        device_runtime,
-                        code,
-                        relative_value,
-                        action.rapidfire_hold_ms,
-                        action.rapidfire_wait_ms,
-                        event_name,
-                        device_runtime.mouse_uinput,
-                        asyncio_mod=deps.asyncio_mod,
-                    )
-                ),
-                code=code,
-                uinput=device_runtime.mouse_uinput,
-                axis_code=None,
-            )
-        elif event.value == 0:
-            await stop_rapidfire_async(
-                device_runtime,
-                event_name,
-                asyncio_mod=deps.asyncio_mod,
-            )
-        return
-
-    if action.tap_enabled:
-        if event.value == 1 and not device_runtime.state.tap_active.get(event_name, False):
-            device_runtime.state.tap_active[event_name] = True
-            deps.fire_and_observe_fn(
-                tap_relative(
-                    device_runtime,
-                    code,
-                    relative_value,
-                    action.tap_hold_ms,
-                    event_name,
-                    device_runtime.mouse_uinput,
-                    asyncio_mod=deps.asyncio_mod,
-                ),
-                f"tap action {event_name}",
-            )
-        return
-
-    if int(event.value) != 1:
-        return
-
-    write_relative_pulse(
-        device_runtime.mouse_uinput,
-        code,
-        relative_value,
-        ev_rel_code=deps.evdev_mod.ecodes.EV_REL,
-        uinput_writer=deps.uinput_writer,
-    )
-
-
-async def _execute_move_action(
-    device_runtime: GrabbedDeviceRuntime,
-    action: MappingAction,
-    event: InputEventLike,
-    event_name: str,
-    *,
-    deps: ActionExecutionDeps,
-) -> None:
-    if action.rapidfire_enabled:
-        if event.value == 1:
-            start_rapidfire_task(
-                device_runtime,
-                event_name,
-                "move",
-                lambda: deps.asyncio_mod.create_task(
-                    rapidfire_move(
-                        device_runtime,
-                        action,
-                        event_name,
-                        action.rapidfire_hold_ms,
-                        action.rapidfire_wait_ms,
-                        asyncio_mod=deps.asyncio_mod,
-                    )
-                ),
-                code=None,
-                uinput=None,
-                axis_code=None,
-            )
-        elif event.value == 0:
-            await stop_rapidfire_async(
-                device_runtime,
-                event_name,
-                asyncio_mod=deps.asyncio_mod,
-            )
-    elif action.tap_enabled:
-        if event.value == 1 and not device_runtime.state.tap_active.get(event_name, False):
-            device_runtime.state.tap_active[event_name] = True
-            deps.fire_and_observe_fn(
-                tap_move(
-                    device_runtime,
-                    action,
-                    event_name,
-                    action.tap_hold_ms,
-                    asyncio_mod=deps.asyncio_mod,
-                ),
-                f"tap move {event_name}",
-            )
-    elif event.value == 1:
-        await emit_move_action(device_runtime, action)

--- a/keymasq/keymasqd/runtime/grabbed_device_outputs.py
+++ b/keymasq/keymasqd/runtime/grabbed_device_outputs.py
@@ -6,8 +6,8 @@ import evdev
 from keymasq.common.models import ActionType, MappingAction
 from keymasq.keymasqd.output_helpers import emit_mouse_move
 from keymasq.keymasqd.runtime.grabbed_device_types import (
+    ActionRuntime,
     EvdevModule,
-    GrabbedDeviceRuntime,
     InputEventLike,
     UInputWriter,
     WritableUInput,
@@ -76,7 +76,7 @@ def flush_passthrough_frame(
 
 
 def bucket_for_uinput(
-    device_runtime: GrabbedDeviceRuntime, uinput_dev: object | None
+    device_runtime: ActionRuntime, uinput_dev: object | None
 ) -> str | None:
     if uinput_dev is None:
         return None
@@ -92,7 +92,7 @@ def bucket_for_uinput(
 
 
 def track_key_state(
-    device_runtime: GrabbedDeviceRuntime,
+    device_runtime: ActionRuntime,
     uinput_dev: object | None,
     code: int,
     value: int,
@@ -110,7 +110,7 @@ def track_key_state(
 
 
 def track_abs_state(
-    device_runtime: GrabbedDeviceRuntime,
+    device_runtime: ActionRuntime,
     axis_code: int,
     value: int,
     *,
@@ -126,7 +126,7 @@ def track_abs_state(
 
 
 def write_abs_axis(
-    device_runtime: GrabbedDeviceRuntime,
+    device_runtime: ActionRuntime,
     uinput_dev: object | None,
     axis_code: int,
     value: int,
@@ -148,7 +148,7 @@ def write_abs_axis(
 
 
 def write_key(
-    device_runtime: GrabbedDeviceRuntime,
+    device_runtime: ActionRuntime,
     uinput_dev: object | None,
     code: int,
     value: int,
@@ -172,7 +172,7 @@ def write_key(
 
 
 def track_superkey_output(
-    device_runtime: GrabbedDeviceRuntime, action_type: str, code: int, value: int
+    device_runtime: ActionRuntime, action_type: str, code: int, value: int
 ) -> bool:
     bucket = action_type
     if bucket not in device_runtime.state.superkey_output_refcounts:
@@ -200,7 +200,7 @@ def track_superkey_output(
 
 
 def track_superkey_abs_output(
-    device_runtime: GrabbedDeviceRuntime,
+    device_runtime: ActionRuntime,
     bucket: str,
     axis_code: int,
     value: int,
@@ -229,7 +229,7 @@ def track_superkey_abs_output(
 
 
 def passthrough(
-    device_runtime: GrabbedDeviceRuntime,
+    device_runtime: ActionRuntime,
     event: InputEventLike,
     *,
     evdev_mod: EvdevModule,
@@ -269,7 +269,7 @@ def passthrough(
 
 
 def ensure_abs_axis_released(
-    device_runtime: GrabbedDeviceRuntime,
+    device_runtime: ActionRuntime,
     axis_code: int,
     *,
     evdev_mod: EvdevModule,
@@ -299,7 +299,7 @@ def ensure_abs_axis_released(
 
 
 def ensure_key_released(
-    device_runtime: GrabbedDeviceRuntime,
+    device_runtime: ActionRuntime,
     code: int,
     uinput_dev: object | None,
     *,
@@ -328,7 +328,7 @@ def ensure_key_released(
 
 
 def emit_configured_mouse_move(
-    device_runtime: GrabbedDeviceRuntime, action: MappingAction
+    device_runtime: ActionRuntime, action: MappingAction
 ) -> None:
     emit_mouse_move(
         cast(WritableUInput | None, device_runtime.mouse_uinput),
@@ -339,7 +339,7 @@ def emit_configured_mouse_move(
 
 
 def release_all_keys(
-    device_runtime: GrabbedDeviceRuntime,
+    device_runtime: ActionRuntime,
     *,
     evdev_mod: EvdevModule,
     uinput_writer: UInputWriter,

--- a/keymasq/keymasqd/runtime/grabbed_device_repeat.py
+++ b/keymasq/keymasqd/runtime/grabbed_device_repeat.py
@@ -65,7 +65,6 @@ def start_rapidfire_task(
     task = task_factory()
     device_runtime.state.rapidfire_active[event_name] = True
     device_runtime.state.rapidfire_tasks[event_name] = task
-    from keymasq.keymasqd.runtime.grabbed_device_types import RapidfireOutputState
 
     state = RapidfireOutputState(kind=kind)
     if code is not None:

--- a/keymasq/keymasqd/runtime/grabbed_device_repeat.py
+++ b/keymasq/keymasqd/runtime/grabbed_device_repeat.py
@@ -18,9 +18,12 @@ from keymasq.keymasqd.runtime.grabbed_device_outputs import (
     write_key,
 )
 from keymasq.keymasqd.runtime.grabbed_device_types import (
+    ActionRuntime,
+    AsyncioEvent,
     AsyncioModule,
     EvdevModule,
-    GrabbedDeviceRuntime,
+    OutputTracker,
+    RapidfireOutputState,
     TaskFactory,
     UInputWriter,
     WritableUInput,
@@ -34,7 +37,7 @@ from keymasq.keymasqd.runtime.mouse_actions import (
 
 
 async def emit_move_action(
-    device_runtime: GrabbedDeviceRuntime,
+    device_runtime: ActionRuntime,
     action: MappingAction,
 ) -> None:
     if action.action_type == ActionType.MOUSE_MOVE_ABS:
@@ -46,7 +49,7 @@ async def emit_move_action(
 
 
 def start_rapidfire_task(
-    device_runtime: GrabbedDeviceRuntime,
+    device_runtime: ActionRuntime,
     event_name: str,
     kind: str,
     task_factory: TaskFactory,
@@ -56,6 +59,7 @@ def start_rapidfire_task(
     axis_code: int | None,
     bucket: str | None = None,
     axis_release_value: int = 0,
+    output_tracker: OutputTracker | None = None,
 ) -> None:
     stop_rapidfire(device_runtime, event_name)
     task = task_factory()
@@ -72,10 +76,11 @@ def start_rapidfire_task(
         state.axis_code = int(axis_code)
         state.axis_release_value = int(axis_release_value)
     state.bucket = bucket
+    state.output_tracker = output_tracker
     device_runtime.state.rapidfire_outputs[event_name] = state
 
 
-def stop_rapidfire(device_runtime: GrabbedDeviceRuntime, event_name: str) -> None:
+def stop_rapidfire(device_runtime: ActionRuntime, event_name: str) -> None:
     device_runtime.state.rapidfire_active[event_name] = False
     task = device_runtime.state.rapidfire_tasks.pop(event_name, None)
     if task is not None and not task.done():
@@ -87,15 +92,7 @@ def stop_rapidfire(device_runtime: GrabbedDeviceRuntime, event_name: str) -> Non
     if kind == "axis":
         axis_code = state.axis_code
         if axis_code is not None:
-            ensure_abs_axis_released(
-                device_runtime,
-                axis_code,
-                evdev_mod=evdev,
-                uinput_writer=_uinput_writer,
-                uinput_dev=state.uinput,
-                bucket=state.bucket,
-                release_value=state.axis_release_value,
-            )
+            _release_rapidfire_abs_axis(device_runtime, state, axis_code)
         return
     if kind == "relative":
         return
@@ -103,12 +100,12 @@ def stop_rapidfire(device_runtime: GrabbedDeviceRuntime, event_name: str) -> Non
         code = state.code
         uinput = state.uinput
         if code is not None:
-            ensure_key_released(device_runtime, code, uinput, bucket=state.bucket)
+            _release_rapidfire_key(device_runtime, state, code, uinput)
             return
 
 
 async def stop_rapidfire_async(
-    device_runtime: GrabbedDeviceRuntime,
+    device_runtime: ActionRuntime,
     event_name: str,
     *,
     asyncio_mod: AsyncioModule,
@@ -121,7 +118,7 @@ async def stop_rapidfire_async(
 
 
 def finish_rapidfire_task(
-    device_runtime: GrabbedDeviceRuntime, event_name: str, task: object
+    device_runtime: ActionRuntime, event_name: str, task: object
 ) -> None:
     active_task = device_runtime.state.rapidfire_tasks.get(event_name)
     if active_task is not task:
@@ -135,15 +132,7 @@ def finish_rapidfire_task(
     if kind == "axis":
         axis_code = state.axis_code
         if axis_code is not None:
-            ensure_abs_axis_released(
-                device_runtime,
-                axis_code,
-                evdev_mod=evdev,
-                uinput_writer=_uinput_writer,
-                uinput_dev=state.uinput,
-                bucket=state.bucket,
-                release_value=state.axis_release_value,
-            )
+            _release_rapidfire_abs_axis(device_runtime, state, axis_code)
         return
     if kind == "relative":
         return
@@ -151,11 +140,58 @@ def finish_rapidfire_task(
         code = state.code
         uinput = state.uinput
         if code is not None:
-            ensure_key_released(device_runtime, code, uinput, bucket=state.bucket)
+            _release_rapidfire_key(device_runtime, state, code, uinput)
+
+
+def _release_rapidfire_abs_axis(
+    device_runtime: ActionRuntime,
+    rapidfire_state: RapidfireOutputState,
+    axis_code: int,
+) -> None:
+    if rapidfire_state.output_tracker is not None:
+        if not rapidfire_state.pressed:
+            return
+        should_emit = rapidfire_state.output_tracker(
+            str(rapidfire_state.bucket or "gamepad"),
+            int(axis_code),
+            int(rapidfire_state.axis_release_value),
+        )
+        rapidfire_state.pressed = False
+        if not should_emit:
+            return
+    ensure_abs_axis_released(
+        device_runtime,
+        axis_code,
+        evdev_mod=evdev,
+        uinput_writer=_uinput_writer,
+        uinput_dev=rapidfire_state.uinput,
+        bucket=rapidfire_state.bucket,
+        release_value=rapidfire_state.axis_release_value,
+    )
+
+
+def _release_rapidfire_key(
+    device_runtime: ActionRuntime,
+    rapidfire_state: RapidfireOutputState,
+    code: int,
+    uinput: object | None,
+) -> None:
+    if rapidfire_state.output_tracker is not None:
+        if not rapidfire_state.pressed:
+            return
+        should_emit = rapidfire_state.output_tracker(
+            str(rapidfire_state.bucket or "keyboard"),
+            int(code),
+            0,
+        )
+        rapidfire_state.pressed = False
+        if not should_emit:
+            return
+    ensure_key_released(device_runtime, code, uinput, bucket=rapidfire_state.bucket)
 
 
 async def rapidfire_abs_axis(
-    device_runtime: GrabbedDeviceRuntime,
+    device_runtime: ActionRuntime,
     axis_code: int,
     active_value: int,
     release_value: int,
@@ -168,11 +204,14 @@ async def rapidfire_abs_axis(
     evdev_mod: EvdevModule,
     uinput_writer: UInputWriter,
     bucket: str | None = None,
+    started: AsyncioEvent | None = None,
+    output_tracker: OutputTracker | None = None,
 ) -> None:
     hold = clamp_rapidfire_hold_ms(hold_ms) / 1000.0
     wait = clamp_rapidfire_wait_ms(wait_ms) / 1000.0
     task = asyncio_mod.current_task()
     pressed = False
+    started_set = False
 
     try:
         while (
@@ -182,28 +221,53 @@ async def rapidfire_abs_axis(
             gamepad_uinput = uinput_writer(uinput_dev)
             if gamepad_uinput is None:
                 return
-            write_abs_axis(
-                device_runtime,
-                uinput_dev,
-                axis_code,
-                active_value,
-                evdev_mod=evdev_mod,
-                uinput_writer=uinput_writer,
-                bucket=bucket,
-            )
-            pressed = True
-            await asyncio_mod.sleep(hold)
-
-            if pressed:
+            should_emit = True
+            state = device_runtime.state.rapidfire_outputs.get(event_name)
+            if output_tracker is not None:
+                should_emit = output_tracker(
+                    str(bucket or "gamepad"),
+                    int(axis_code),
+                    int(active_value),
+                )
+                if state is not None:
+                    state.pressed = True
+            if should_emit:
                 write_abs_axis(
                     device_runtime,
                     uinput_dev,
                     axis_code,
-                    release_value,
+                    active_value,
                     evdev_mod=evdev_mod,
                     uinput_writer=uinput_writer,
                     bucket=bucket,
                 )
+            pressed = True
+            if not started_set:
+                _mark_started(started)
+                started_set = True
+            await asyncio_mod.sleep(hold)
+
+            if pressed:
+                should_emit = True
+                state = device_runtime.state.rapidfire_outputs.get(event_name)
+                if output_tracker is not None:
+                    should_emit = output_tracker(
+                        str(bucket or "gamepad"),
+                        int(axis_code),
+                        int(release_value),
+                    )
+                    if state is not None:
+                        state.pressed = False
+                if should_emit:
+                    write_abs_axis(
+                        device_runtime,
+                        uinput_dev,
+                        axis_code,
+                        release_value,
+                        evdev_mod=evdev_mod,
+                        uinput_writer=uinput_writer,
+                        bucket=bucket,
+                    )
                 pressed = False
             if not device_runtime.state.rapidfire_active.get(event_name, False):
                 break
@@ -212,22 +276,17 @@ async def rapidfire_abs_axis(
     except Exception:
         pass
     finally:
-        if pressed:
-            ensure_abs_axis_released(
-                device_runtime,
-                axis_code,
-                evdev_mod=evdev_mod,
-                uinput_writer=uinput_writer,
-                uinput_dev=uinput_dev,
-                bucket=bucket,
-                release_value=release_value,
-            )
+        if pressed and event_name in device_runtime.state.rapidfire_outputs:
+            state = device_runtime.state.rapidfire_outputs[event_name]
+            _release_rapidfire_abs_axis(device_runtime, state, axis_code)
         if task is not None:
             finish_rapidfire_task(device_runtime, event_name, task)
+        if not started_set:
+            _mark_started(started)
 
 
 async def tap_abs_axis(
-    device_runtime: GrabbedDeviceRuntime,
+    device_runtime: ActionRuntime,
     axis_code: int,
     active_value: int,
     release_value: int,
@@ -239,8 +298,11 @@ async def tap_abs_axis(
     evdev_mod: EvdevModule,
     uinput_writer: UInputWriter,
     bucket: str | None = None,
+    started: AsyncioEvent | None = None,
 ) -> None:
     hold = hold_ms / 1000.0
+    pressed = False
+    started_set = False
 
     try:
         gamepad_uinput = uinput_writer(uinput_dev)
@@ -255,6 +317,9 @@ async def tap_abs_axis(
             uinput_writer=uinput_writer,
             bucket=bucket,
         )
+        pressed = True
+        _mark_started(started)
+        started_set = True
         await asyncio_mod.sleep(hold)
         write_abs_axis(
             device_runtime,
@@ -265,14 +330,27 @@ async def tap_abs_axis(
             uinput_writer=uinput_writer,
             bucket=bucket,
         )
+        pressed = False
     except Exception:
         pass
     finally:
+        if pressed:
+            ensure_abs_axis_released(
+                device_runtime,
+                axis_code,
+                evdev_mod=evdev_mod,
+                uinput_writer=uinput_writer,
+                uinput_dev=uinput_dev,
+                bucket=bucket,
+                release_value=release_value,
+            )
         device_runtime.state.tap_active.pop(event_name, None)
+        if not started_set:
+            _mark_started(started)
 
 
 async def rapidfire_key(
-    device_runtime: GrabbedDeviceRuntime,
+    device_runtime: ActionRuntime,
     code: int,
     hold_ms: int,
     wait_ms: int,
@@ -281,39 +359,59 @@ async def rapidfire_key(
     *,
     asyncio_mod: AsyncioModule,
     bucket: str | None = None,
+    started: AsyncioEvent | None = None,
+    output_tracker: OutputTracker | None = None,
 ) -> None:
     hold = clamp_rapidfire_hold_ms(hold_ms) / 1000.0
     wait = clamp_rapidfire_wait_ms(wait_ms) / 1000.0
     task = asyncio_mod.current_task()
     pressed = False
+    started_set = False
 
     try:
         while (
             device_runtime.state.rapidfire_active.get(event_name, False)
             and runtime_is_running(device_runtime)
         ):
-            write_key(
-                device_runtime,
-                uinput_dev,
-                code,
-                1,
-                evdev_mod=evdev,
-                uinput_writer=_uinput_writer,
-                bucket=bucket,
-            )
-            pressed = True
-            await asyncio_mod.sleep(hold)
-
-            if pressed:
+            should_emit = True
+            state = device_runtime.state.rapidfire_outputs.get(event_name)
+            if output_tracker is not None:
+                should_emit = output_tracker(str(bucket or "keyboard"), int(code), 1)
+                if state is not None:
+                    state.pressed = True
+            if should_emit:
                 write_key(
                     device_runtime,
                     uinput_dev,
                     code,
-                    0,
+                    1,
                     evdev_mod=evdev,
                     uinput_writer=_uinput_writer,
                     bucket=bucket,
                 )
+            pressed = True
+            if not started_set:
+                _mark_started(started)
+                started_set = True
+            await asyncio_mod.sleep(hold)
+
+            if pressed:
+                should_emit = True
+                state = device_runtime.state.rapidfire_outputs.get(event_name)
+                if output_tracker is not None:
+                    should_emit = output_tracker(str(bucket or "keyboard"), int(code), 0)
+                    if state is not None:
+                        state.pressed = False
+                if should_emit:
+                    write_key(
+                        device_runtime,
+                        uinput_dev,
+                        code,
+                        0,
+                        evdev_mod=evdev,
+                        uinput_writer=_uinput_writer,
+                        bucket=bucket,
+                    )
                 pressed = False
             if not device_runtime.state.rapidfire_active.get(event_name, False):
                 break
@@ -322,14 +420,17 @@ async def rapidfire_key(
     except Exception:
         pass
     finally:
-        if pressed:
-            ensure_key_released(device_runtime, code, uinput_dev, bucket=bucket)
+        if pressed and event_name in device_runtime.state.rapidfire_outputs:
+            state = device_runtime.state.rapidfire_outputs[event_name]
+            _release_rapidfire_key(device_runtime, state, code, uinput_dev)
         if task is not None:
             finish_rapidfire_task(device_runtime, event_name, task)
+        if not started_set:
+            _mark_started(started)
 
 
 async def tap_key(
-    device_runtime: GrabbedDeviceRuntime,
+    device_runtime: ActionRuntime,
     code: int,
     hold_ms: int,
     event_name: str,
@@ -337,8 +438,11 @@ async def tap_key(
     *,
     asyncio_mod: AsyncioModule,
     bucket: str | None = None,
+    started: AsyncioEvent | None = None,
 ) -> None:
     hold = hold_ms / 1000.0
+    pressed = False
+    started_set = False
 
     try:
         write_key(
@@ -350,6 +454,9 @@ async def tap_key(
             uinput_writer=_uinput_writer,
             bucket=bucket,
         )
+        pressed = True
+        _mark_started(started)
+        started_set = True
         await asyncio_mod.sleep(hold)
         write_key(
             device_runtime,
@@ -360,14 +467,19 @@ async def tap_key(
             uinput_writer=_uinput_writer,
             bucket=bucket,
         )
+        pressed = False
     except Exception:
         pass
     finally:
+        if pressed:
+            ensure_key_released(device_runtime, code, uinput_dev, bucket=bucket)
         device_runtime.state.tap_active.pop(event_name, None)
+        if not started_set:
+            _mark_started(started)
 
 
 async def rapidfire_relative(
-    device_runtime: GrabbedDeviceRuntime,
+    device_runtime: ActionRuntime,
     code: int,
     value: int,
     hold_ms: int,
@@ -376,20 +488,29 @@ async def rapidfire_relative(
     uinput_dev: object | None,
     *,
     asyncio_mod: AsyncioModule,
+    started: AsyncioEvent | None = None,
 ) -> None:
     hold = clamp_rapidfire_hold_ms(hold_ms) / 1000.0
     wait = clamp_rapidfire_wait_ms(wait_ms) / 1000.0
     task = asyncio_mod.current_task()
+    started_set = False
+
+    def emit_started_pulse() -> None:
+        nonlocal started_set
+        write_relative_pulse(
+            uinput_dev,
+            code,
+            value,
+            ev_rel_code=evdev.ecodes.EV_REL,
+            uinput_writer=_uinput_writer,
+        )
+        if not started_set:
+            _mark_started(started)
+            started_set = True
 
     try:
         await rapidfire_relative_pulses(
-            emit_pulse=lambda: write_relative_pulse(
-                uinput_dev,
-                code,
-                value,
-                ev_rel_code=evdev.ecodes.EV_REL,
-                uinput_writer=_uinput_writer,
-            ),
+            emit_pulse=emit_started_pulse,
             is_active=lambda: (
                 device_runtime.state.rapidfire_active.get(event_name, False)
                 and runtime_is_running(device_runtime)
@@ -403,10 +524,12 @@ async def rapidfire_relative(
     finally:
         if task is not None:
             finish_rapidfire_task(device_runtime, event_name, task)
+        if not started_set:
+            _mark_started(started)
 
 
 async def tap_relative(
-    device_runtime: GrabbedDeviceRuntime,
+    device_runtime: ActionRuntime,
     code: int,
     value: int,
     hold_ms: int,
@@ -414,18 +537,27 @@ async def tap_relative(
     uinput_dev: object | None,
     *,
     asyncio_mod: AsyncioModule,
+    started: AsyncioEvent | None = None,
 ) -> None:
     hold = hold_ms / 1000.0
+    started_set = False
+
+    def emit_started_pulse() -> None:
+        nonlocal started_set
+        write_relative_pulse(
+            uinput_dev,
+            code,
+            value,
+            ev_rel_code=evdev.ecodes.EV_REL,
+            uinput_writer=_uinput_writer,
+        )
+        if not started_set:
+            _mark_started(started)
+            started_set = True
 
     try:
         await tap_relative_pulse(
-            emit_pulse=lambda: write_relative_pulse(
-                uinput_dev,
-                code,
-                value,
-                ev_rel_code=evdev.ecodes.EV_REL,
-                uinput_writer=_uinput_writer,
-            ),
+            emit_pulse=emit_started_pulse,
             hold_s=hold,
             asyncio_mod=asyncio_mod,
         )
@@ -433,20 +565,24 @@ async def tap_relative(
         pass
     finally:
         device_runtime.state.tap_active.pop(event_name, None)
+        if not started_set:
+            _mark_started(started)
 
 
 async def rapidfire_move(
-    device_runtime: GrabbedDeviceRuntime,
+    device_runtime: ActionRuntime,
     action: MappingAction,
     event_name: str,
     hold_ms: int,
     wait_ms: int,
     *,
     asyncio_mod: AsyncioModule,
+    started: AsyncioEvent | None = None,
 ) -> None:
     hold = clamp_rapidfire_hold_ms(hold_ms) / 1000.0
     wait = clamp_rapidfire_wait_ms(wait_ms) / 1000.0
     task = asyncio_mod.current_task()
+    started_set = False
 
     try:
         while (
@@ -454,6 +590,9 @@ async def rapidfire_move(
             and runtime_is_running(device_runtime)
         ):
             await emit_move_action(device_runtime, action)
+            if not started_set:
+                _mark_started(started)
+                started_set = True
             await asyncio_mod.sleep(hold)
 
             if not device_runtime.state.rapidfire_active.get(event_name, False):
@@ -465,26 +604,39 @@ async def rapidfire_move(
     finally:
         if task is not None:
             finish_rapidfire_task(device_runtime, event_name, task)
+        if not started_set:
+            _mark_started(started)
 
 
 async def tap_move(
-    device_runtime: GrabbedDeviceRuntime,
+    device_runtime: ActionRuntime,
     action: MappingAction,
     event_name: str,
     hold_ms: int,
     *,
     asyncio_mod: AsyncioModule,
+    started: AsyncioEvent | None = None,
 ) -> None:
     hold = hold_ms / 1000.0
+    started_set = False
 
     try:
         await emit_move_action(device_runtime, action)
+        _mark_started(started)
+        started_set = True
         await asyncio_mod.sleep(hold)
     except Exception:
         pass
     finally:
         device_runtime.state.tap_active.pop(event_name, None)
+        if not started_set:
+            _mark_started(started)
 
 
 def _uinput_writer(device: object | None) -> WritableUInput | None:
     return cast(WritableUInput | None, device)
+
+
+def _mark_started(started: AsyncioEvent | None) -> None:
+    if started is not None:
+        started.set()

--- a/keymasq/keymasqd/runtime/grabbed_device_types.py
+++ b/keymasq/keymasqd/runtime/grabbed_device_types.py
@@ -10,7 +10,7 @@ from collections.abc import (
     Sequence,
 )
 from dataclasses import dataclass, field
-from typing import Final, Protocol, TypeVar, cast
+from typing import TYPE_CHECKING, Final, Protocol, TypeVar, cast
 
 import evdev
 
@@ -18,7 +18,9 @@ from keymasq.common.ipc import CommandType
 from keymasq.common.models import MappingAction
 from keymasq.keymasqd.combo_engine import ComboDecision
 from keymasq.keymasqd.recording import RecordingManager
-from keymasq.keymasqd.superkey_state import SuperkeyMachine
+
+if TYPE_CHECKING:
+    from keymasq.keymasqd.superkey_state import SuperkeyMachine
 
 type BroadcastCallback = Callable[[CommandType, dict[str, object]], Awaitable[None]]
 type CursorPositionSetter = Callable[[int, int], Awaitable[dict[str, object]]]
@@ -35,6 +37,7 @@ type ProfileActivationRecorder = Callable[[str | None, str | None], None]
 type ProfileActivationTriggerObserver = Callable[[str | None], None]
 type FireAndObserve = Callable[[Awaitable[object], str], asyncio.Task[object]]
 type RuntimeCleanupCallback = Callable[[str, str | None], Awaitable[None]]
+type OutputTracker = Callable[[str, int, int], bool]
 _T = TypeVar("_T")
 
 
@@ -184,6 +187,8 @@ class RapidfireOutputState:
     axis_code: int | None = None
     axis_release_value: int = 0
     bucket: str | None = None
+    output_tracker: OutputTracker | None = None
+    pressed: bool = False
 
 
 @dataclass
@@ -198,7 +203,7 @@ class GrabbedDeviceState:
     rapidfire_tasks: dict[str, asyncio.Task[None]] = field(default_factory=dict)
     rapidfire_outputs: dict[str, RapidfireOutputState] = field(default_factory=dict)
     tap_active: dict[str, bool] = field(default_factory=dict)
-    superkey_machines: dict[str, SuperkeyMachine] = field(default_factory=dict)
+    superkey_machines: dict[str, "SuperkeyMachine"] = field(default_factory=dict)
     held_source_keys: set[str] = field(default_factory=set)
     combo_passthrough_held: set[str] = field(default_factory=set)
     combo_recalled_bindings: set[str] = field(default_factory=set)
@@ -246,27 +251,12 @@ class GrabbedDeviceState:
     analog_gamepad_outputs: dict[str, AnalogGamepadOutputState] = field(default_factory=dict)
 
 
-class GrabbedDeviceRuntime(Protocol):
+class ActionRuntime(Protocol):
     @property
     def path(self) -> str: ...
 
     @property
     def hardware_id(self) -> str: ...
-
-    @property
-    def stable_path(self) -> str: ...
-
-    @property
-    def interface_id(self) -> str: ...
-
-    @property
-    def device_types(self) -> list[str]: ...
-
-    @property
-    def verbosity(self) -> int: ...
-
-    @property
-    def device(self) -> ManagedInputDevice | None: ...
 
     @property
     def uinput(self) -> object | None: ...
@@ -287,13 +277,41 @@ class GrabbedDeviceRuntime(Protocol):
     def cursor_position_setter(self) -> CursorPositionSetter | None: ...
 
     @property
-    def recording_manager(self) -> RecordingManager | None: ...
-
-    @property
     def macro_player(self) -> MacroPlayer | None: ...
 
     @property
     def emergency_resetter(self) -> EmergencyResetter | None: ...
+
+    @property
+    def suppress_rel_getter(self) -> Callable[[], bool] | None: ...
+
+    @property
+    def state(self) -> GrabbedDeviceState: ...
+
+    @property
+    def _running(self) -> bool: ...
+
+    def resolve_gamepad_output(self, output_id: str | None, context: str) -> object | None: ...
+
+
+class GrabbedDeviceRuntime(ActionRuntime, Protocol):
+    @property
+    def stable_path(self) -> str: ...
+
+    @property
+    def interface_id(self) -> str: ...
+
+    @property
+    def device_types(self) -> list[str]: ...
+
+    @property
+    def verbosity(self) -> int: ...
+
+    @property
+    def device(self) -> ManagedInputDevice | None: ...
+
+    @property
+    def recording_manager(self) -> RecordingManager | None: ...
 
     @property
     def inspector_event_callback(self) -> DeviceInspectorEventCallback | None: ...
@@ -326,9 +344,6 @@ class GrabbedDeviceRuntime(Protocol):
     def profile_activation_trigger_end_observer(
         self,
     ) -> ProfileActivationTriggerObserver | None: ...
-
-    @property
-    def suppress_rel_getter(self) -> Callable[[], bool] | None: ...
 
     @property
     def diagnostics_recorder(self) -> Callable[[str, float], None] | None: ...
@@ -366,18 +381,10 @@ class GrabbedDeviceRuntime(Protocol):
     @property
     def analog_axis_calibrations(self) -> dict[tuple[str, str], dict[str, object]]: ...
 
-    @property
-    def state(self) -> GrabbedDeviceState: ...
-
-    @property
-    def _running(self) -> bool: ...
-
     async def reset_superkeys(self) -> None: ...
 
     async def reset_analog_controls(self) -> None: ...
 
-    def resolve_gamepad_output(self, output_id: str | None, context: str) -> object | None: ...
 
-
-def runtime_is_running(device_runtime: GrabbedDeviceRuntime) -> bool:
+def runtime_is_running(device_runtime: ActionRuntime) -> bool:
     return device_runtime._running  # pyright: ignore[reportPrivateUsage]

--- a/keymasq/keymasqd/superkey_state.py
+++ b/keymasq/keymasqd/superkey_state.py
@@ -4,11 +4,12 @@ import logging
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any, Protocol, cast
+from typing import TYPE_CHECKING, Any, Protocol, cast
 
 import evdev
 
 from keymasq.common.gamepad_axes import clamp_gamepad_axis_value, normalize_gamepad_axis_target
+from keymasq.common.ipc import CommandType
 from keymasq.common.models import (
     ActionType,
     MappingAction,
@@ -19,31 +20,16 @@ from keymasq.common.models import (
     normalize_profile_deactivation_policy,
     superkey_action_shared_kwargs,
 )
-from keymasq.keymasqd.output_helpers import (
-    emit_mouse_move,
-    resolve_gamepad_axis_code,
-    resolve_output_code,
-)
-from keymasq.keymasqd.runtime.action_runner import (
-    build_action_trigger_payload,
-    build_macro_playback_request,
-    source_trigger_id,
-)
 from keymasq.keymasqd.runtime.mouse_actions import (
     emit_relative_pulse,
     rapidfire_relative_pulses,
     resolve_mouse_output_target,
 )
 
+if TYPE_CHECKING:
+    from keymasq.keymasqd.runtime.grabbed_device_types import ActionExecutionDeps
+
 log = logging.getLogger("keymasqd.superkey")
-
-
-def _syn_if_passthrough_frame_closed(uinput: object) -> None:
-    from keymasq.keymasqd.runtime.grabbed_device_outputs import (
-        syn_if_passthrough_frame_closed,
-    )
-
-    syn_if_passthrough_frame_closed(uinput, cast(Any, uinput))
 
 
 class SuperkeyState(Enum):
@@ -143,7 +129,28 @@ class _WritableUInput(Protocol):
     def syn(self) -> None: ...
 
 
-type CursorPositionSetter = Callable[[int, int], Awaitable[object]]
+type CursorPositionSetter = Callable[[int, int], Awaitable[dict[str, object]]]
+type CancelMacroPlayback = Callable[[], Awaitable[dict[str, object]]]
+type MacroPlayer = Callable[..., Awaitable[dict[str, object]]]
+type EmergencyResetter = Callable[[], Awaitable[dict[str, object]]]
+
+
+def _fire_and_observe(coro: Awaitable[object], _label: str) -> asyncio.Task[object]:
+    return asyncio.ensure_future(coro)
+
+
+def _default_action_deps() -> "ActionExecutionDeps":
+    from keymasq.keymasqd.runtime.grabbed_device_types import (
+        ActionExecutionDeps,
+        identity_uinput_writer,
+    )
+
+    return ActionExecutionDeps(
+        asyncio_mod=cast(Any, asyncio),
+        fire_and_observe_fn=_fire_and_observe,
+        evdev_mod=cast(Any, evdev),
+        uinput_writer=identity_uinput_writer,
+    )
 
 
 class SuperkeyMachine:
@@ -160,6 +167,11 @@ class SuperkeyMachine:
         key_event_tracker: Callable[[str, int, int], bool] | None = None,
         axis_event_tracker: Callable[[str, int, int], bool] | None = None,
         gamepad_output_resolver: Callable[[str | None, str], object | None] | None = None,
+        macro_player: MacroPlayer | None = None,
+        emergency_resetter: EmergencyResetter | None = None,
+        cancel_macro_playback: CancelMacroPlayback | None = None,
+        action_deps: "ActionExecutionDeps | None" = None,
+        await_action_tasks: bool = True,
     ) -> None:
         self.config = config
         self.event_name = event_name
@@ -172,6 +184,11 @@ class SuperkeyMachine:
         self.key_event_tracker = key_event_tracker
         self.axis_event_tracker = axis_event_tracker
         self.gamepad_output_resolver = gamepad_output_resolver
+        self.macro_player = macro_player
+        self.emergency_resetter = emergency_resetter
+        self.cancel_macro_playback = cancel_macro_playback
+        self.action_deps = action_deps or _default_action_deps()
+        self.await_action_tasks = await_action_tasks
 
         self.state = SuperkeyState.IDLE
         self._hold_task: asyncio.Task[None] | None = None
@@ -179,9 +196,24 @@ class SuperkeyMachine:
         self._rapidfire_tasks: list[asyncio.Task[None]] = []
         self._rapidfire_active = False
         self._running = True
+        from keymasq.keymasqd.runtime.action_runner import ActionRuntimeContext
+
+        self._action_runtime = ActionRuntimeContext(
+            path=f"superkey:{event_name}",
+            hardware_id=source_device,
+            keyboard_uinput=keyboard_uinput,
+            mouse_uinput=mouse_uinput,
+            gamepad_uinput=gamepad_uinput,
+            broadcast_callback=self._broadcast_action_trigger,
+            cursor_position_setter=cursor_position_setter,
+            macro_player=macro_player,
+            emergency_resetter=emergency_resetter,
+            gamepad_output_resolver=gamepad_output_resolver,
+        )
 
     async def stop(self) -> None:
         self._running = False
+        self._action_runtime.stop()
         self._rapidfire_active = False
         if self._hold_task:
             self._hold_task.cancel()
@@ -388,176 +420,90 @@ class SuperkeyMachine:
                 await task
 
     async def _execute_actions_tap(self, actions: list[SuperkeyActionData]) -> None:
-        for action in actions:
-            await self._execute_action_down(action)
+        indexed_actions = list(enumerate(actions))
+        for index, action in indexed_actions:
+            await self._execute_action_down(
+                action,
+                action_event_name=self._child_event_name(action, index),
+            )
         await asyncio.sleep(0.01)
-        for action in reversed(actions):
-            await self._execute_action_up(action)
+        for index, action in reversed(indexed_actions):
+            await self._execute_action_up(
+                action,
+                action_event_name=self._child_event_name(action, index),
+            )
 
     async def _execute_actions_down(self, actions: list[SuperkeyActionData]) -> None:
-        self._rapidfire_active = any(action.rapidfire_enabled for action in actions)
-
-        for action in actions:
-            if action.rapidfire_enabled:
-                task = asyncio.create_task(self._rapidfire_loop(action))
-                self._rapidfire_tasks.append(task)
-            else:
-                await self._execute_action_down(action)
+        for index, action in enumerate(actions):
+            await self._execute_action_down(
+                action,
+                action_event_name=self._child_event_name(action, index),
+            )
 
     async def _execute_actions_up(self, actions: list[SuperkeyActionData]) -> None:
-        for action in reversed(actions):
-            if action.rapidfire_enabled:
-                continue
-            await self._execute_action_up(action)
-
-    async def _execute_action_down(self, action: SuperkeyActionData) -> None:
-        if action.action_type == "exec":
-            trigger_payload = build_action_trigger_payload(
-                self._mapping_action(action),
-                source_device=self.source_device,
-                source_button=self.event_name,
+        indexed_actions = list(enumerate(actions))
+        for index, action in reversed(indexed_actions):
+            await self._execute_action_up(
+                action,
+                action_event_name=self._child_event_name(action, index),
             )
-            if trigger_payload is not None and self.broadcast_callback:
-                await self.broadcast_callback(trigger_payload)
+
+    async def _execute_action_down(
+        self,
+        action: SuperkeyActionData,
+        *,
+        action_event_name: str | None = None,
+    ) -> None:
+        await self._execute_mapping_action(action, 1, action_event_name=action_event_name)
+
+    async def _execute_action_up(
+        self,
+        action: SuperkeyActionData,
+        *,
+        action_event_name: str | None = None,
+    ) -> None:
+        await self._execute_mapping_action(action, 0, action_event_name=action_event_name)
+
+    async def _execute_mapping_action(
+        self,
+        action: SuperkeyActionData,
+        value: int,
+        *,
+        action_event_name: str | None = None,
+    ) -> None:
+        from keymasq.keymasqd.runtime import action_runner
+
+        event_name = action_event_name or self.event_name
+        started = asyncio.Event()
+        handle = action_runner.ActionExecutionHandle(started=started)
+        await action_runner.execute_action(
+            self._action_runtime,
+            self._mapping_action(action),
+            _SyntheticInputEvent(evdev.ecodes.EV_KEY, 0, value),
+            event_name,
+            deps=self.action_deps,
+            shared_output_tracker=self.key_event_tracker,
+            shared_abs_output_tracker=self.axis_event_tracker,
+            execution_handle=handle,
+            cancel_macro_playback=self.cancel_macro_playback,
+        )
+        await started.wait()
+        if self.await_action_tasks:
+            await action_runner.drain_action_tasks(handle)
+
+    def _child_event_name(self, action: SuperkeyActionData, index: int) -> str:
+        if not action.rapidfire_enabled:
+            return self.event_name
+        return f"{self.event_name}#{index}"
+
+    async def _broadcast_action_trigger(
+        self,
+        event_type: CommandType,
+        data: dict[str, object],
+    ) -> None:
+        if event_type != CommandType.ACTION_TRIGGER or self.broadcast_callback is None:
             return
-
-        if action.action_type == "macro":
-            trigger_payload = self._macro_trigger_payload(action, trigger_value=1)
-            if trigger_payload is not None and self.broadcast_callback:
-                await self.broadcast_callback(trigger_payload)
-            return
-
-        if action.action_type == "mouse_move_abs":
-            if self.cursor_position_setter is not None:
-                await self.cursor_position_setter(int(action.move_x), int(action.move_y))
-                return
-            emit_mouse_move(
-                self.mouse_uinput,
-                int(action.move_x),
-                int(action.move_y),
-                absolute=True,
-            )
-            return
-
-        if action.action_type == "mouse_move_rel":
-            emit_mouse_move(
-                self.mouse_uinput,
-                int(action.move_x),
-                int(action.move_y),
-                absolute=False,
-            )
-            return
-
-        trigger_action = self._broadcast_action(action)
-        if trigger_action is not None and self.broadcast_callback:
-            await self.broadcast_callback(trigger_action)
-            return
-
-        if action.action_type == "gamepad_axis":
-            axis_code = resolve_gamepad_axis_code(action.target)
-            if axis_code is None:
-                return
-            uinput, bucket = self._get_action_output(action)
-            if uinput is None:
-                return
-            should_emit = True
-            if self.axis_event_tracker:
-                should_emit = self.axis_event_tracker(
-                    bucket,
-                    int(axis_code),
-                    int(action.axis_value),
-                )
-            if should_emit:
-                uinput.write(evdev.ecodes.EV_ABS, axis_code, int(action.axis_value))
-                _syn_if_passthrough_frame_closed(uinput)
-            return
-
-        if action.action_type in ("keyboard", "mouse", "gamepad"):
-            code = self._resolve_code(action.target)
-            if code is None:
-                return
-
-            uinput, bucket = self._get_action_output(action)
-            if uinput is None:
-                return
-
-            mouse_target = (
-                self._resolve_mouse_target(action.target) if action.action_type == "mouse" else None
-            )
-            if mouse_target is not None and mouse_target.is_relative:
-                emit_relative_pulse(
-                    uinput,
-                    mouse_target.code,
-                    mouse_target.relative_value,
-                    ev_rel_code=evdev.ecodes.EV_REL,
-                )
-                return
-
-            should_emit = True
-            if self.key_event_tracker:
-                should_emit = self.key_event_tracker(bucket, int(code), 1)
-            if should_emit:
-                uinput.write(evdev.ecodes.EV_KEY, code, 1)
-                _syn_if_passthrough_frame_closed(uinput)
-
-    async def _execute_action_up(self, action: SuperkeyActionData) -> None:
-        if action.action_type in (
-            "exec",
-            "mouse_move_rel",
-            "mouse_move_abs",
-            "compositor_dispatch",
-            "start_macro_recording",
-            "stop_macro_recording",
-            "cancel_macro_playback",
-            "emergency_reset",
-            "profile_enable",
-            "profile_disable",
-            "profile_toggle",
-        ):
-            return
-
-        if action.action_type == "macro":
-            trigger_payload = self._macro_trigger_payload(action, trigger_value=0)
-            if trigger_payload is not None and self.broadcast_callback:
-                await self.broadcast_callback(trigger_payload)
-            return
-
-        if action.action_type == "gamepad_axis":
-            axis_code = resolve_gamepad_axis_code(action.target)
-            if axis_code is None:
-                return
-            uinput, bucket = self._get_action_output(action)
-            if uinput is None:
-                return
-            should_emit = True
-            if self.axis_event_tracker:
-                should_emit = self.axis_event_tracker(bucket, int(axis_code), 0)
-            if should_emit:
-                uinput.write(evdev.ecodes.EV_ABS, axis_code, 0)
-                _syn_if_passthrough_frame_closed(uinput)
-            return
-
-        if action.action_type in ("keyboard", "mouse", "gamepad"):
-            code = self._resolve_code(action.target)
-            if code is None:
-                return
-
-            uinput, bucket = self._get_action_output(action)
-            if uinput is None:
-                return
-
-            mouse_target = (
-                self._resolve_mouse_target(action.target) if action.action_type == "mouse" else None
-            )
-            if mouse_target is not None and mouse_target.is_relative:
-                return
-
-            should_emit = True
-            if self.key_event_tracker:
-                should_emit = self.key_event_tracker(bucket, int(code), 0)
-            if should_emit:
-                uinput.write(evdev.ecodes.EV_KEY, code, 0)
-                _syn_if_passthrough_frame_closed(uinput)
+        await self.broadcast_callback(data)
 
     def _get_uinput(self, action_type: str) -> _WritableUInput | None:
         if action_type == "keyboard":
@@ -568,69 +514,22 @@ class SuperkeyMachine:
             return self.gamepad_uinput
         return None
 
-    def _get_action_output(self, action: SuperkeyActionData) -> tuple[_WritableUInput | None, str]:
-        if action.action_type not in ("gamepad", "gamepad_axis"):
-            return self._get_uinput(action.action_type), action.action_type
-        if self.gamepad_output_resolver is not None:
-            target = self.gamepad_output_resolver(
-                action.output_id,
-                f"{self.event_name} -> {action.target or ''}",
-            )
-            if target is None:
-                return None, "gamepad"
-            return cast(_WritableUInput | None, getattr(target, "uinput", None)), str(
-                getattr(target, "bucket", "gamepad")
-            )
-        return self.gamepad_uinput, "gamepad"
-
-    def _resolve_code(self, target: str | None) -> int | None:
-        return resolve_output_code(target)
-
     def _resolve_mouse_target(self, target: str | None):
         return resolve_mouse_output_target(target)
 
     def _mapping_action(self, action: SuperkeyActionData) -> MappingAction:
+        action_kwargs = superkey_action_shared_kwargs(action)
+        action_kwargs["rapidfire_enabled"] = action.rapidfire_enabled
+        action_kwargs["rapidfire_hold_ms"] = action.rapidfire_hold_ms
+        action_kwargs["rapidfire_wait_ms"] = action.rapidfire_wait_ms
         return MappingAction(
             action_type=ActionType(action.action_type),
-            **superkey_action_shared_kwargs(action),
+            **action_kwargs,
         )
 
-    def _broadcast_action(self, action: SuperkeyActionData) -> dict[str, object] | None:
-        action_type = action.action_type
-        if action_type not in {
-            "compositor_dispatch",
-            "start_macro_recording",
-            "stop_macro_recording",
-            "cancel_macro_playback",
-            "emergency_reset",
-            "profile_enable",
-            "profile_disable",
-            "profile_toggle",
-        }:
-            return None
-        return build_action_trigger_payload(
-            self._mapping_action(action),
-            source_device=self.source_device,
-            source_button=self.event_name,
-            trigger_id=source_trigger_id(self.source_device, self.event_name),
-        )
 
-    def _macro_trigger_payload(
-        self,
-        action: SuperkeyActionData,
-        *,
-        trigger_value: int,
-    ) -> dict[str, object] | None:
-        payload = build_macro_playback_request(
-            self._mapping_action(action),
-            source_device=self.source_device,
-            source_button=self.event_name,
-            trigger_value=trigger_value,
-            include_macro_events=False,
-        )
-        if payload is None:
-            return None
-        return {
-            "action_type": "macro",
-            **payload,
-        }
+class _SyntheticInputEvent:
+    def __init__(self, event_type: int, code: int, value: int) -> None:
+        self.type = int(event_type)
+        self.code = int(code)
+        self.value = int(value)

--- a/tests/keymasqd/device_manager_support.py
+++ b/tests/keymasqd/device_manager_support.py
@@ -93,7 +93,6 @@ def _combo_runtime_deps(
         asyncio_mod=dm.ASYNCIO_RUNTIME,
         evdev_mod=dm.runtime_adapters.COMBO_EVDEV_RUNTIME,
         uinput_writer=dm.runtime_adapters.identity_uinput_writer,
-        emit_mouse_move_fn=dm.runtime_adapters.combo_emit_mouse_move,
         resolve_code_fn=resolve_code_fn,
         fire_and_observe_fn=fire_and_observe_fn,
     )

--- a/tests/keymasqd/test_combo_action_dispatch.py
+++ b/tests/keymasqd/test_combo_action_dispatch.py
@@ -128,6 +128,7 @@ class TestComboActionDispatch:
 
         await _runtime_start_combo_action(manager, "combo-overload-profile", action, binding)
         await asyncio.wait_for(action_trigger_event.wait(), timeout=1.0)
+        await asyncio.sleep(0)
 
         assert action_triggers == [
             {
@@ -219,6 +220,46 @@ class TestComboActionDispatch:
         assert starts == []
         assert ends == []
         assert "combo-invalid-superkey" not in manager.combo_state.active_actions
+
+    @pytest.mark.asyncio
+    async def test_combo_hold_macro_waits_for_press_registration_before_active(
+        self,
+    ) -> None:
+        manager = DeviceManager()
+        binding = dm.RuntimeComboBinding(hardware_id="1234:5678", source="kbd", evdev="key_a")
+        press_started = asyncio.Event()
+        press_registered = asyncio.Event()
+        press_continue = asyncio.Event()
+
+        async def play_macro(**kwargs: object) -> dict[str, object]:
+            if kwargs["trigger_value"] == 1:
+                press_started.set()
+                await press_continue.wait()
+                press_registered.set()
+            else:
+                assert press_registered.is_set()
+            return {"status": "ok"}
+
+        manager.play_macro = play_macro  # type: ignore[method-assign]
+        action = dm.MappingAction(
+            action_type=ActionType.MACRO,
+            macro_name="hold",
+            macro_loop_mode="hold",
+        )
+
+        start_task = asyncio.create_task(
+            _runtime_start_combo_action(manager, "macro-hold", action, binding)
+        )
+        await asyncio.wait_for(press_started.wait(), timeout=1.0)
+        await asyncio.sleep(0)
+
+        assert not start_task.done()
+
+        press_continue.set()
+        await start_task
+        await _runtime_stop_combo_action(manager, "macro-hold")
+
+        assert press_registered.is_set()
 
     @pytest.mark.asyncio
     async def test_combo_overload_restore_runs_after_child_release_for_overlapping_key(
@@ -910,16 +951,7 @@ class TestComboActionDispatch:
         manager.output_state.mouse_uinput = _FakeUInput()
         manager.output_state.gamepad_uinput = _FakeUInput()
         manager.play_macro = AsyncMock(return_value={"status": "ok"})  # type: ignore[method-assign]
-        broadcast_combo_action = AsyncMock()
-        emit_combo_mouse_move = Mock()
         resolve_code = Mock(return_value=evdev.ecodes.BTN_SOUTH)
-        combo_tap_axis = AsyncMock()
-        combo_rapidfire_axis = AsyncMock()
-        monkeypatch = pytest.MonkeyPatch()
-        monkeypatch.setattr(cdm, "broadcast_combo_action", broadcast_combo_action)
-        monkeypatch.setattr(cdm, "emit_combo_mouse_move", emit_combo_mouse_move)
-        monkeypatch.setattr(cdm, "combo_tap_axis", combo_tap_axis)
-        monkeypatch.setattr(cdm, "combo_rapidfire_axis", combo_rapidfire_axis)
 
         binding = dm.RuntimeComboBinding(hardware_id="1234:5678", source="mouse", evdev="btn_side")
 
@@ -1042,16 +1074,24 @@ class TestComboActionDispatch:
         await _runtime_stop_combo_action(manager, "rapid-axis")
         await _runtime_stop_combo_action(manager, "macro")
 
-        emit_combo_mouse_move.assert_called_once()
         assert manager.play_macro.await_count == 2
         assert manager.play_macro.await_args_list[0].kwargs["trigger_value"] == 1
         assert manager.play_macro.await_args_list[1].kwargs["trigger_value"] == 0
-        assert broadcast_combo_action.await_count == 4
         assert manager.output_state.mouse_uinput.writes[0] == (
+            evdev.ecodes.EV_REL,
+            evdev.ecodes.REL_X,
+            3,
+        )
+        assert manager.output_state.mouse_uinput.writes[1] == (
+            evdev.ecodes.EV_REL,
+            evdev.ecodes.REL_Y,
+            -1,
+        )
+        assert (
             evdev.ecodes.EV_REL,
             evdev.ecodes.REL_WHEEL,
             1,
-        )
+        ) in manager.output_state.mouse_uinput.writes
         assert (
             evdev.ecodes.EV_REL,
             evdev.ecodes.REL_WHEEL,
@@ -1062,17 +1102,13 @@ class TestComboActionDispatch:
             evdev.ecodes.REL_HWHEEL,
             1,
         ) in manager.output_state.mouse_uinput.writes
-        monkeypatch.undo()
 
     @pytest.mark.asyncio
     async def test_start_combo_action_mouse_move_abs_uses_cursor_position_setter(self) -> None:
         manager = DeviceManager()
         manager.output_state.mouse_uinput = _FakeUInput()
         manager.set_cursor_position = AsyncMock(return_value={"status": "ok"})  # type: ignore[method-assign]
-        emit_combo_mouse_move = Mock()
         binding = dm.RuntimeComboBinding(hardware_id="1234:5678", source="mouse", evdev="btn_side")
-        monkeypatch = pytest.MonkeyPatch()
-        monkeypatch.setattr(cdm, "emit_combo_mouse_move", emit_combo_mouse_move)
 
         await _runtime_start_combo_action(
             manager,
@@ -1082,9 +1118,7 @@ class TestComboActionDispatch:
         )
 
         manager.set_cursor_position.assert_awaited_once_with(33, 44)
-        emit_combo_mouse_move.assert_not_called()
         assert manager.output_state.mouse_uinput.writes == []
-        monkeypatch.undo()
 
     @pytest.mark.asyncio
     async def test_combo_pattern_superkey_passes_cursor_position_setter(self, monkeypatch) -> None:

--- a/tests/keymasqd/test_grabbed_device_runtime_helpers.py
+++ b/tests/keymasqd/test_grabbed_device_runtime_helpers.py
@@ -1346,7 +1346,7 @@ class TestGrabbedDeviceHelpers:
             ),
         )
         monkeypatch.setattr(
-            gda,
+            gda.shared_action_runner,
             "passthrough",
             lambda _device, event, **_kwargs: passthrough_calls.append(
                 (event.type, event.code, event.value)
@@ -1520,6 +1520,27 @@ class TestGrabbedDeviceHelpers:
         emergency_resetter.assert_awaited_once_with()
         assert macro_player.await_args_list[0].kwargs["trigger_value"] == 1
         assert macro_player.await_args_list[1].kwargs["trigger_value"] == 0
+
+    @pytest.mark.asyncio
+    async def test_emergency_reset_action_without_resetter_does_not_broadcast(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        callback = AsyncMock()
+        device = _make_grabbed_device(
+            monkeypatch,
+            broadcast_callback=callback,
+        )
+
+        await _runtime_execute_grabbed_action(
+            device,
+            dm.MappingAction(action_type=ActionType.EMERGENCY_RESET),
+            SimpleNamespace(type=evdev.ecodes.EV_KEY, code=1, value=1),
+            "emergency_reset",
+        )
+        await asyncio.sleep(0)
+
+        callback.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_routed_gamepad_axis_release_all_keys_zeros_target_output(
@@ -1769,6 +1790,7 @@ class TestGrabbedDeviceHelpers:
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         cursor_position_setter = AsyncMock(return_value={"status": "ok"})
+        cancel_macro_playback = AsyncMock(return_value={"status": "ok"})
         device = _make_grabbed_device(
             monkeypatch,
             cursor_position_setter=cursor_position_setter,
@@ -1777,6 +1799,7 @@ class TestGrabbedDeviceHelpers:
         fake_machine = SimpleNamespace(on_down=AsyncMock(), on_up=AsyncMock())
         created_configs: list[SuperkeyConfig] = []
         created_setters: list[object] = []
+        created_cancelers: list[object] = []
 
         monkeypatch.setattr(
             gda,
@@ -1784,6 +1807,7 @@ class TestGrabbedDeviceHelpers:
             lambda **kwargs: (
                 created_configs.append(kwargs["config"]),
                 created_setters.append(kwargs.get("cursor_position_setter")),
+                created_cancelers.append(kwargs.get("cancel_macro_playback")),
                 fake_machine,
             )[-1],
         )
@@ -1793,7 +1817,7 @@ class TestGrabbedDeviceHelpers:
             lambda coro, _label: asyncio.create_task(coro),
         )
         monkeypatch.setattr(
-            gda,
+            gda.shared_action_runner,
             "tap_move",
             AsyncMock(
                 side_effect=lambda _device, action, event_name, hold_ms, **_kwargs: (
@@ -1817,8 +1841,13 @@ class TestGrabbedDeviceHelpers:
             tap_hold_ms=33,
         )
 
-        await _runtime_execute_grabbed_action(
-            device, superkey_action, SimpleNamespace(value=1), "super_btn"
+        await gda.execute_action(
+            device,
+            superkey_action,
+            SimpleNamespace(value=1),
+            "super_btn",
+            deps=gde.build_action_execution_deps(fire_and_observe_fn=gde._fire_and_observe),
+            cancel_macro_playback=cancel_macro_playback,
         )
         await _runtime_execute_grabbed_action(
             device, superkey_action, SimpleNamespace(value=0), "super_btn"
@@ -1830,6 +1859,7 @@ class TestGrabbedDeviceHelpers:
 
         assert created_configs and created_configs[0].name == "super"
         assert created_setters == [cursor_position_setter]
+        assert created_cancelers == [cancel_macro_playback]
         fake_machine.on_down.assert_awaited_once()
         fake_machine.on_up.assert_awaited_once()
         assert move_calls == [("move_btn", 33)]

--- a/tests/test_superkey_state.py
+++ b/tests/test_superkey_state.py
@@ -515,6 +515,169 @@ async def test_rapidfire_hold_release_emits_single_key_up() -> None:
 
 
 @pytest.mark.asyncio
+async def test_superkey_rapidfire_respects_shared_key_refcounts() -> None:
+    keyboard_uinput = MagicMock()
+    keyboard_uinput.write = MagicMock()
+    keyboard_uinput.syn = MagicMock()
+    refcounts: dict[tuple[str, int], int] = {}
+
+    def track_output(bucket: str, code: int, value: int) -> bool:
+        key = (bucket, code)
+        current = refcounts.get(key, 0)
+        if value == 1:
+            refcounts[key] = current + 1
+            return current == 0
+        if current <= 1:
+            refcounts.pop(key, None)
+            return current == 1
+        refcounts[key] = current - 1
+        return False
+
+    machine = SuperkeyMachine(
+        config=SuperkeyConfig(
+            name="rapidfire_refcount_test",
+            hold_actions=[
+                SuperkeyActionData(action_type="keyboard", target="key_e"),
+                SuperkeyActionData(
+                    action_type="keyboard",
+                    target="key_e",
+                    rapidfire_enabled=True,
+                    rapidfire_hold_ms=1,
+                    rapidfire_wait_ms=1,
+                ),
+            ],
+        ),
+        event_name="btn_side",
+        keyboard_uinput=keyboard_uinput,
+        mouse_uinput=MagicMock(),
+        gamepad_uinput=MagicMock(),
+        key_event_tracker=track_output,
+    )
+
+    await machine._start_holding()
+    await asyncio.sleep(0.01)
+
+    assert [tuple(call.args) for call in keyboard_uinput.write.call_args_list] == [
+        (evdev.ecodes.EV_KEY, evdev.ecodes.KEY_E, 1),
+    ]
+
+    await machine.on_up()
+
+    assert [tuple(call.args) for call in keyboard_uinput.write.call_args_list] == [
+        (evdev.ecodes.EV_KEY, evdev.ecodes.KEY_E, 1),
+        (evdev.ecodes.EV_KEY, evdev.ecodes.KEY_E, 0),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_superkey_rapidfire_respects_shared_axis_refcounts() -> None:
+    gamepad_uinput = MagicMock()
+    gamepad_uinput.write = MagicMock()
+    gamepad_uinput.syn = MagicMock()
+    refcounts: dict[tuple[str, int], int] = {}
+
+    def track_output(bucket: str, code: int, value: int) -> bool:
+        key = (bucket, code)
+        current = refcounts.get(key, 0)
+        if value != 0:
+            refcounts[key] = current + 1
+            return current == 0
+        if current <= 1:
+            refcounts.pop(key, None)
+            return current == 1
+        refcounts[key] = current - 1
+        return False
+
+    machine = SuperkeyMachine(
+        config=SuperkeyConfig(
+            name="rapidfire_axis_refcount_test",
+            hold_actions=[
+                SuperkeyActionData(
+                    action_type="gamepad_axis",
+                    target="abs_z",
+                    axis_value=255,
+                ),
+                SuperkeyActionData(
+                    action_type="gamepad_axis",
+                    target="abs_z",
+                    axis_value=255,
+                    rapidfire_enabled=True,
+                    rapidfire_hold_ms=1,
+                    rapidfire_wait_ms=1,
+                ),
+            ],
+        ),
+        event_name="btn_side",
+        keyboard_uinput=MagicMock(),
+        mouse_uinput=MagicMock(),
+        gamepad_uinput=gamepad_uinput,
+        axis_event_tracker=track_output,
+    )
+
+    await machine._start_holding()
+    await asyncio.sleep(0.01)
+
+    assert [tuple(call.args) for call in gamepad_uinput.write.call_args_list] == [
+        (evdev.ecodes.EV_ABS, evdev.ecodes.ABS_Z, 255),
+    ]
+
+    await machine.on_up()
+
+    assert [tuple(call.args) for call in gamepad_uinput.write.call_args_list] == [
+        (evdev.ecodes.EV_ABS, evdev.ecodes.ABS_Z, 255),
+        (evdev.ecodes.EV_ABS, evdev.ecodes.ABS_Z, 0),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_multiple_superkey_rapidfire_actions_run_independently() -> None:
+    keyboard_uinput = MagicMock()
+    keyboard_uinput.write = MagicMock()
+    keyboard_uinput.syn = MagicMock()
+
+    machine = SuperkeyMachine(
+        config=SuperkeyConfig(
+            name="multi_rapidfire_test",
+            hold_actions=[
+                SuperkeyActionData(
+                    action_type="keyboard",
+                    target="key_a",
+                    rapidfire_enabled=True,
+                    rapidfire_hold_ms=100,
+                    rapidfire_wait_ms=100,
+                ),
+                SuperkeyActionData(
+                    action_type="keyboard",
+                    target="key_b",
+                    rapidfire_enabled=True,
+                    rapidfire_hold_ms=100,
+                    rapidfire_wait_ms=100,
+                ),
+            ],
+        ),
+        event_name="btn_side",
+        keyboard_uinput=keyboard_uinput,
+        mouse_uinput=MagicMock(),
+        gamepad_uinput=MagicMock(),
+    )
+
+    await machine._start_holding()
+    await asyncio.sleep(0)
+
+    assert set(machine._action_runtime.state.rapidfire_tasks) == {"btn_side#0", "btn_side#1"}
+    assert (evdev.ecodes.EV_KEY, evdev.ecodes.KEY_A, 1) in [
+        tuple(call.args) for call in keyboard_uinput.write.call_args_list
+    ]
+    assert (evdev.ecodes.EV_KEY, evdev.ecodes.KEY_B, 1) in [
+        tuple(call.args) for call in keyboard_uinput.write.call_args_list
+    ]
+
+    await machine.on_up()
+
+    assert machine._action_runtime.state.rapidfire_tasks == {}
+
+
+@pytest.mark.asyncio
 async def test_mouse_wheel_rapidfire_repeats_without_key_up() -> None:
     mouse_uinput = MagicMock()
     mouse_uinput.write = MagicMock()


### PR DESCRIPTION
## Summary
- Consolidates action execution logic (keys, mouse moves, gamepad axes, macros, superkeys) into a shared `action_runner` module, eliminating duplicate code between `grabbed_device_actions.py` and `combos.py`.
- Introduces `ActionRuntimeContext` and `ActionExecutionHandle` to standardize runtime state and async task lifecycle across both device and combo paths.
- Refactors combo dispatch to call the shared `execute_action` function, removing ~800 lines of specialized combo-only rapidfire, tap, and output tracking code.
- Simplifies the evdev adapter layer and removes redundant protocols (`_EmitMouseMoveFn`, combo-specific ecodes helpers).
- Updates test fixtures in `test_combo_action_dispatch.py` and `test_grabbed_device_runtime_helpers.py` for the new `ComboRuntimeDeps` and shared dispatch signatures.
- Adds new `test_superkey_state.py` tests for superkey machine interaction with the shared executor.

## Testing
- [x] `pytest tests/keymasqd/test_combo_action_dispatch.py` — passes with updated fixtures.
- [x] `pytest tests/keymasqd/test_grabbed_device_runtime_helpers.py` — passes with refactored dispatch.
- [x] `pytest tests/test_superkey_state.py` — new test suite passes.
- [x] `ruff check keymasq/keymasqd/runtime/` — passes with no new violations.
- [x] `basedpyright keymasq/keymasqd/runtime/` — passes with no new type errors.
- [x] Manual integration test — Not run (structural refactor, no behavioral change intended).