### PR TITLE
Add auto check category and integration runner script

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,68 +1,57 @@
 # Keymasq - Agent Guide
 
-Use this file as a quick project map. Keep deeper behavior details in `docs/`, not here.
-
 ## Architecture
 
-Keymasq is a Linux input remapper built around three processes:
+Keymasq is a Linux input remapper for keyboards, mice, gamepads, and other evdev
+devices. It supports layered profiles, macros, superkeys, combos, analog controls, and
+compositor-aware behavior through three processes:
 
 - `keymasqd` - privileged daemon for device grabbing, remap runtime, macro storage/playback, recording, and combo capture/runtime
 - `keymasq-session` - per-user broker for profiles, compositor/window tracking, daemon IPC, and GUI-facing state
-- `keymasq` - GTK4 GUI and CLI for profiles, mappings, macros, superkeys, and combos
+- `keymasq` - GTK4 GUI and CLI
+
+## Work Rules
+
+- Anchor commands and file paths to the current `environment_context.cwd`.
+- Do not overwrite unrelated local changes.
+- Match the surrounding Python and GTK4 patterns.
+- Keep behavior docs in `docs/`; update them when user-visible semantics change.
+- Keep new code async-friendly. Do not add blocking I/O or long synchronous waits.
 
 ## Main Code Areas
 
-- `keymasq/common/` - shared models, IPC types, paths, security helpers
-- `keymasq/keymasqd/` - privileged daemon and input runtime
-- `keymasq/session/` - profile resolution, listeners, session socket
-- `keymasq/gui/` - GTK app and widgets
-- `keymasq/cli/` - CLI
-- `tests/` - pytest suite, split into `tests/keymasqd/`, `tests/session/`, `tests/gui/`, and `tests/common/`
-- `docs/` - behavioral docs
+- `keymasq/common/`: shared models, IPC, paths, settings, security helpers.
+- `keymasq/keymasqd/`: daemon, command handlers, macro storage, capture.
+- `keymasq/keymasqd/runtime/`: grabbed devices, actions, outputs, combos,
+  analog controls, topology, runtime profile tracking.
+- `keymasq/session/`: profile/config managers, session client.
+- `keymasq/session/listeners`: compositor integration
+- `keymasq/session/manager/`: session broker lifecycle, command/event dispatch,
+  profile application, recording, inspectors, diagnostics/output streams.
+- `keymasq/gui/`: GTK application, window, widgets, wizards, dialogs.
+- `tests/`: pytest suite, with focused subtrees for common, keymasqd, session, GUI.
+- `docs/`: Project documentation
+- `docs/agents/`: compact config references for profiles, hardware, macros,
+  superkeys, and combos.
 
-## High-Value Files
+## Terms and Gotchas
 
-- `keymasq/common/models.py` - `ActionType`, `MappingAction`, profile and combo models
-- `keymasq/common/ipc.py` - daemon/session protocol and command types
-- `keymasq/keymasqd/daemon.py` - daemon bootstrap, socket server, ACL/recording-unlock enforcement, and dispatch into `daemon_*_commands.py`
-- `keymasq/keymasqd/device_manager.py` - stateful facade over `keymasq/keymasqd/runtime/*` for grabs, mappings, combos, topology, and macro playback
-- `keymasq/session/manager/core.py` - session server lifecycle, keymasqd reconnect loop, and manager wiring
-- `keymasq/session/manager/commands.py` - GUI/session request dispatch and policy gating
-- `keymasq/session/manager/profiles.py` - runtime profile reevaluation, device grab/apply logic, and combo updates
-- `keymasq/session/manager/state.py` - session runtime state containers
-- `keymasq/session/profiles.py` - on-disk profile load/save and profile/combo resolution
-- `keymasq/gui/window.py` - main window, device/combo tab setup, and shared profile selection sync
+- Grab: exclusive daemon control of an input device/interface so Keymasq can suppress,
+  pass through, or remap events.
+- Hardware config: the physical device description and source button/key IDs.
+- Profile: a global remap layer. A profile can contain mappings for multiple devices.
+- Mapping: one source input in one profile device layer bound to one action.
+- Profile layering has priority order. Conditional profiles override permanent profiles.
+- Macro: a saved timed sequence of input events.
+- Superkey: a reusable multi-role key/button definition for tap, hold, double-tap,
+  tap-hold, or grouped press/release actions.
+- Combo: a chord or sequence trigger across one or more grabbed input devices.
+- Prefix-shadowing between combos is valid runtime behavior.
+- Analog control: reusable stick, trigger, wheel, or game controller axis behavior.
 
-## Gotchas
+## Checks
 
-- Profiles are global, not per-device. Per-device mappings live in profile device layers keyed by `hardware_id`.
-- Active profile ordering matters. Later profiles win.
-- Prefix-shadowing between combos is valid runtime behavior. The GUI only rejects exact duplicates within one profile.
-- `COMPOSITOR_DISPATCH` is generic backend behavior. Compositor-specific UI belongs under `gui/widgets/compositor_actions/`.
-- `MainWindow` owns profile selection. Device tabs and `ComboTab` must stay in sync with the window-level selection.
-- `KeySelectorDialog` is shared by device mappings and combo actions. Do not hardcode compositor-specific UI into it.
-- In GTK code, create dependent attributes before connecting signals that may fire immediately.
-- Xbox triggers are analog output (`ABS_Z`, `ABS_RZ`), not normal digital buttons.
+Before handing off Python code changes, run `./scripts/check.sh`. It includes
+`ruff`, `basedpyright`, and the relevant pytest suite in the pinned Nix environment.
 
-## Coding Style
-
-- Keep new code async-friendly. Do not add blocking I/O or long synchronous waits.
-- Match the surrounding Python and GTK4 patterns.
-- When adding behavior, update the relevant `docs/*.md` if the change affects user-visible semantics or security.
-
-## Worktree
-
-Always anchor work to the current `environment_context.cwd`.
-
-## Commands
-
-All tool commands (`ruff`, `basedpyright`, `pytest`) must run inside `nix develop -c <cmd>`. Example: `nix develop -c ruff check .`
-
-Run `./scripts/check.sh <category>` after Python code changes:
-
-- `keymasqd` for `keymasq/keymasqd/` changes and keymasqd-only tests
-- `session` for `keymasq/session/` changes and session/compositor tests
-- `gui` for `keymasq/gui/` changes and GTK tests
-- `full` for multi-category edits, shared-code edits (`keymasq/common/`, CLI, packaging-affecting changes), or before handing off a broad refactor
-
-`./scripts/check.sh` without an argument defaults to `full`. Skip checks for doc-only, config-only, or non-code changes.
+Run Python commands and tooling through `nix develop -c`.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -58,24 +58,28 @@ wrapper behavior, not as the fastest GUI iteration loop.
 
 ## Running Checks
 
-Run the full standard validation with:
+Run the standard validation with:
 
 ```bash
-./scripts/check.sh full
+./scripts/check.sh
 ```
 
-For fast local validation, run the narrowest category that matches the code you
-changed:
+By default, `check.sh` runs in `auto` mode and selects the narrowest safe
+category from pending and untracked changes under `keymasq/` and `tests/`.
+It falls back to `full` for shared, mixed, or broad changes.
+
+You can also run a category explicitly:
 
 ```bash
 ./scripts/check.sh keymasqd
 ./scripts/check.sh session
 ./scripts/check.sh gui
+./scripts/check.sh full
 ```
 
 `./scripts/check.sh` runs `ruff`, `basedpyright`, and the selected pytest
-subset from the dev shell. Use `full` for multi-area changes, shared code, or
-before handing off a broad refactor.
+subset from the dev shell when `auto` finds relevant code changes. Use `full`
+for multi-area changes, shared code, or before handing off a broad refactor.
 
 If the host does not have usable `uinput` access, or if you want the selected
 pytest category to run in the VM backend instead of the host backend, add
@@ -92,6 +96,35 @@ Run individual tools from the dev shell when needed:
 nix develop -c ruff check keymasq tests
 nix develop -c basedpyright
 ```
+
+## Running Integration Tests
+
+Keymasq has two NixOS VM integration suites:
+
+- listener VM tests for compositor/window tracking under GNOME, KDE, Hyprland,
+  Niri, XFCE/X11, COSMIC, and Sway
+- the daemon/session runtime suite, which starts `keymasqd` and
+  `keymasq-session`, drives virtual input devices, and checks remapped output
+
+Use the integration helper from the repository root:
+
+```bash
+./scripts/integration.sh cosmic
+./scripts/integration.sh daemon-session
+```
+
+List the available shortcuts with:
+
+```bash
+./scripts/integration.sh --help
+```
+
+The helper runs `nix build` against `path:.#checks.x86_64-linux...` targets so
+new or uncommitted VM files are included during local development. These tests
+are VM-heavy; a Linux host with KVM acceleration is strongly recommended.
+
+For detailed behavior and debugging notes, see `docs/LISTENER_VM_TESTS.md` and
+`docs/DAEMON_SESSION_INTEGRATION_TEST.md`.
 
 ## Local Test Input Suppression
 

--- a/docs/DAEMON_SESSION_INTEGRATION_TEST.md
+++ b/docs/DAEMON_SESSION_INTEGRATION_TEST.md
@@ -59,6 +59,12 @@ Fixtures are rendered through `support.py` by loading template files from
 Run the VM check from the repository root:
 
 ```bash
+./scripts/integration.sh daemon-session
+```
+
+This is equivalent to running the Nix check directly:
+
+```bash
 nix build 'path:.#checks.x86_64-linux.daemon-session-integration-test'
 ```
 

--- a/docs/LISTENER_VM_TESTS.md
+++ b/docs/LISTENER_VM_TESTS.md
@@ -71,6 +71,23 @@ The shared desktop harness includes the cursor-position check for GNOME, KDE, Hy
 
 ## Running A Desktop VM Test
 
+Use the integration helper from the repository root:
+
+```bash
+./scripts/integration.sh cosmic
+./scripts/integration.sh gnome
+./scripts/integration.sh listeners
+```
+
+List every shortcut with:
+
+```bash
+./scripts/integration.sh --help
+```
+
+The shortcuts map to the same Nix check targets shown below. `listeners` runs
+the full listener VM matrix.
+
 ```bash
 nix build 'path:.#checks.x86_64-linux.listener-vm-gnome-bridge'
 nix build 'path:.#checks.x86_64-linux.listener-vm-gnome'

--- a/docs/PACKAGING.md
+++ b/docs/PACKAGING.md
@@ -525,9 +525,11 @@ Run the standard source checks first:
 ```
 
 This wrapper runs `ruff`, `basedpyright`, and the selected pytest scope in the
-Nix dev shell. Use `./scripts/check.sh keymasqd`, `./scripts/check.sh session`,
-or `./scripts/check.sh gui` for focused local validation, and keep `full` for
-packaging work, shared-code changes, and broad refactors.
+Nix dev shell. `./scripts/check.sh` defaults to auto-selection from pending and
+untracked source changes. Use `./scripts/check.sh keymasqd`,
+`./scripts/check.sh session`, or `./scripts/check.sh gui` for focused local
+validation, and keep `full` for packaging work, shared-code changes, and broad
+refactors.
 
 When the host does not have usable `uinput` access, the same entrypoint can use
 the VM backend:

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -3,10 +3,11 @@ set -euo pipefail
 
 usage() {
   cat <<'EOF'
-Usage: ./scripts/check.sh [--vm] [keymasqd|session|gui|full]
+Usage: ./scripts/check.sh [--vm] [auto|keymasqd|session|gui|full]
 
 Runs ruff, basedpyright, stylelint for GUI CSS, and the selected pytest category.
-Defaults to full.
+Defaults to auto, which selects the category from pending and untracked changes
+under keymasq/ and tests/.
 EOF
 }
 
@@ -14,14 +15,14 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT_DIR"
 
 BACKEND="host"
-CATEGORY="full"
+CATEGORY="auto"
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --vm)
       BACKEND="vm"
       ;;
-    keymasqd|session|keymasq-session|gui|full)
+    auto|keymasqd|session|keymasq-session|gui|full)
       CATEGORY="$1"
       ;;
     -h|--help)
@@ -36,6 +37,66 @@ while [[ $# -gt 0 ]]; do
   esac
   shift
 done
+
+resolve_auto_category() {
+  local path
+  local selected=""
+  local -a changed_paths=()
+  local -a untracked_paths=()
+
+  mapfile -t changed_paths < <(git diff --name-only HEAD -- keymasq tests)
+  mapfile -t untracked_paths < <(git ls-files --others --exclude-standard -- keymasq tests)
+
+  for path in "${changed_paths[@]}" "${untracked_paths[@]}"; do
+    [[ -n "$path" ]] || continue
+
+    case "$path" in
+      keymasq/keymasqd/*|tests/keymasqd/*)
+        if [[ -z "$selected" ]]; then
+          selected="keymasqd"
+        elif [[ "$selected" != "keymasqd" ]]; then
+          selected="full"
+        fi
+        ;;
+      keymasq/session/*|tests/session/*)
+        if [[ -z "$selected" ]]; then
+          selected="session"
+        elif [[ "$selected" != "session" ]]; then
+          selected="full"
+        fi
+        ;;
+      keymasq/gui/*|tests/gui/*)
+        if [[ -z "$selected" ]]; then
+          selected="gui"
+        elif [[ "$selected" != "gui" ]]; then
+          selected="full"
+        fi
+        ;;
+      keymasq/*|tests/*)
+        selected="full"
+        ;;
+    esac
+
+    if [[ "$selected" == "full" ]]; then
+      break
+    fi
+  done
+
+  if [[ -z "$selected" ]]; then
+    return 1
+  fi
+
+  printf '%s\n' "$selected"
+}
+
+if [[ "$CATEGORY" == "auto" ]]; then
+  if CATEGORY="$(resolve_auto_category)"; then
+    echo "auto: selected ${CATEGORY}"
+  else
+    echo "auto: no pending or untracked changes under keymasq/ or tests/; nothing to run"
+    exit 0
+  fi
+fi
 
 case "$CATEGORY" in
   keymasqd)

--- a/scripts/integration.sh
+++ b/scripts/integration.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+SYSTEM="x86_64-linux"
+
+usage() {
+  cat <<'EOF'
+Usage: ./scripts/integration.sh [test ...]
+
+Runs Keymasq NixOS VM integration checks through nix build.
+
+Tests:
+  daemon-session  daemon/session runtime integration suite
+  gnome-bridge    GNOME Shell bridge listener preflight
+  gnome           GNOME listener
+  kde             KDE Plasma listener
+  hyprland        Hyprland listener
+  niri            Niri listener
+  xfce            X11/XFCE listener
+  cosmic          COSMIC listener
+  sway            wlroots/Sway listener
+  listeners       all listener VM tests
+  all             daemon-session plus all listener VM tests
+
+Examples:
+  ./scripts/integration.sh cosmic
+  ./scripts/integration.sh daemon-session
+  ./scripts/integration.sh listeners
+
+Use path: flake references so newly added or uncommitted VM files are included.
+EOF
+}
+
+check_name_for_test() {
+  case "$1" in
+    daemon-session|daemon-session-integration|daemon-session-integration-test)
+      printf '%s\n' "daemon-session-integration-test"
+      ;;
+    gnome-bridge|listener-vm-gnome-bridge)
+      printf '%s\n' "listener-vm-gnome-bridge"
+      ;;
+    gnome|listener-vm-gnome)
+      printf '%s\n' "listener-vm-gnome"
+      ;;
+    kde|plasma|listener-vm-kde)
+      printf '%s\n' "listener-vm-kde"
+      ;;
+    hyprland|listener-vm-hyprland)
+      printf '%s\n' "listener-vm-hyprland"
+      ;;
+    niri|listener-vm-niri)
+      printf '%s\n' "listener-vm-niri"
+      ;;
+    xfce|x11|listener-vm-xfce)
+      printf '%s\n' "listener-vm-xfce"
+      ;;
+    cosmic|listener-vm-cosmic)
+      printf '%s\n' "listener-vm-cosmic"
+      ;;
+    sway|wayland|wlroots|listener-vm-sway)
+      printf '%s\n' "listener-vm-sway"
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+expand_group() {
+  case "$1" in
+    listeners)
+      printf '%s\n' \
+        gnome-bridge \
+        gnome \
+        kde \
+        hyprland \
+        niri \
+        xfce \
+        cosmic \
+        sway
+      ;;
+    all)
+      printf '%s\n' \
+        daemon-session \
+        gnome-bridge \
+        gnome \
+        kde \
+        hyprland \
+        niri \
+        xfce \
+        cosmic \
+        sway
+      ;;
+    *)
+      printf '%s\n' "$1"
+      ;;
+  esac
+}
+
+if [[ $# -eq 0 ]]; then
+  usage
+  exit 0
+fi
+
+case "$1" in
+  -h|--help|help|list|--list)
+    usage
+    exit 0
+    ;;
+esac
+
+tests=()
+for arg in "$@"; do
+  case "$arg" in
+    -h|--help|help|list|--list)
+      usage
+      exit 0
+      ;;
+  esac
+
+  while IFS= read -r expanded; do
+    [[ -n "$expanded" ]] || continue
+    tests+=("$expanded")
+  done < <(expand_group "$arg")
+done
+
+for test in "${tests[@]}"; do
+  if ! check_name="$(check_name_for_test "$test")"; then
+    echo "Unknown integration test: $test" >&2
+    echo >&2
+    usage >&2
+    exit 1
+  fi
+
+  target="path:.#checks.${SYSTEM}.${check_name}"
+  echo "integration: ${test} -> ${target}"
+  nix build "$target"
+done


### PR DESCRIPTION
## Summary

- Add `scripts/integration.sh` runner for NixOS VM integration tests (daemon/session and listener suites)
- Add auto-category resolution to `scripts/check.sh` that selects the narrowest safe pytest scope based on pending/untracked changes
- Update `DEVELOPMENT.md`, `docs/LISTENER_VM_TESTS.md`, `docs/DAEMON_SESSION_INTEGRATION_TEST.md`, and `docs/PACKAGING.md` with new runner usage
- Restructure `AGENTS.md` to focus on agent work rules, code areas, and gotchas instead of duplicating docs