### PR TITLE
feat: add Repeat Last Action support

### DIFF
--- a/docs/ACTIONS.md
+++ b/docs/ACTIONS.md
@@ -39,6 +39,42 @@ profile does map the key, that lower-priority mapping still applies.
 Block the key entirely. Nothing is sent — the key press is silently consumed.
 Use this to disable a key you never want to fire.
 
+### Repeat Last Action
+
+Repeat the most recent repeatable action Keymasq handled. This can be a normal
+mapping action or original passthrough input. Choose **Repeat Last Action** in
+the Special tab, then use the category toggle buttons to choose what kinds of
+remembered actions it may replay:
+
+| Toggle | What Repeat can replay |
+|---|---|
+| **Keys** | Keyboard key actions and passthrough keyboard key presses. |
+| **Mouse** | Mouse button and wheel actions, including passthrough mouse clicks and wheel events. |
+| **Gamepad** | Gamepad button and axis actions, including passthrough gamepad buttons. |
+| **Macros** | Macro playback actions. |
+| **Other** | Configured mouse movement actions, command/compositor actions, macro control actions, and resolved Super Key paths. |
+
+All five toggles are enabled by default. If every toggle is off, the dialog
+will not let you map the Repeat action.
+
+Repeat never records itself, passthrough mapping actions, suppress actions,
+profile actions, or the emergency reset action. Original passthrough mouse
+movement is not recorded.
+Repeating a remembered action also refreshes Repeat's history, so pressing
+Repeat several times in a row keeps replaying the same resolved action until
+another repeatable action takes its place.
+
+Repeat has its own Rapidfire control, but rapidfire only applies when the
+remembered action is a keyboard key, mouse button, mouse wheel action, or
+gamepad button. Remembered configured mouse movement, macro, and other special
+actions run once.
+
+Super Key actions are remembered by the path they resolved to. For example, a
+pattern super key that fired its double-tap slot is remembered as that super key's
+double-tap path, and an overload super key is remembered as its overload path.
+Repeating it runs that saved path once instead of replaying only the last child
+action. Super Key paths that contain profile actions are not remembered.
+
 ### Execute Shell Command
 
 Run a shell command when the key is pressed. The command runs inside your
@@ -415,9 +451,11 @@ options area below the action chooser tabs.
 Rapidfire and tap are **mutually exclusive** — enabling one disables the
 other.
 
-They are available for: Keyboard, Mouse, Navigation, Media, Gamepad, and Mouse Move
-actions. They are not available for: Special, Super Keys, Macro, Profile, or
-Compositor actions.
+They are available in the shared options area for: Keyboard, Mouse, Navigation,
+Media, Gamepad, and Mouse Move actions. Repeat has its own Rapidfire control in
+the Special tab, limited to remembered keyboard keys, mouse buttons, mouse wheel
+actions, and gamepad buttons. They are not available for other Special actions,
+Super Keys, Macro, Profile, or Compositor actions.
 
 ### Rapidfire
 

--- a/docs/DAEMON_SESSION_INTEGRATION_TEST.md
+++ b/docs/DAEMON_SESSION_INTEGRATION_TEST.md
@@ -13,6 +13,7 @@ coverage. It verifies that the core runtime classes still work together:
 - simple keyboard remap
 - suppress
 - tap-enabled remap
+- repeat last action across direct mappings, passthrough input, combos, and superkeys
 - rapidfire
 - macro playback and cancellation
 - macro create/update/rename/delete plus loop count

--- a/docs/SUPERKEYS.md
+++ b/docs/SUPERKEYS.md
@@ -68,6 +68,8 @@ Overload actions use the same runtime rules as normal mappings:
 - Key and button outputs receive down, repeat, and up.
 - Exec, macro, profile, and compositor actions fire on press, just like
   ordinary mappings.
+- **Repeat Last Action** remembers the overload path as one Super Key target,
+  then runs that path once when repeated.
 - Nested superkeys are not allowed.
 
 ## Creating And Editing Super Keys
@@ -112,6 +114,10 @@ superkeys and mapping-only control actions are not available. Pattern slots can 
 | **Compositor Dispatch** | Send a compositor-specific command. |
 | **Macro Controls** | Toggle recording, stop recording, or cancel playback. |
 | **Profile Controls** | Enable, disable, or toggle a profile. |
+
+When a pattern slot fires, **Repeat Last Action** remembers the resolved Super
+Key path, such as `tap`, `double_tap`, `hold`, or `tap_hold`. Repeating it
+runs that slot path once instead of replaying only the last child action.
 
 ### Editing Overload Actions
 

--- a/docs/agents/profiles.txt
+++ b/docs/agents/profiles.txt
@@ -75,6 +75,11 @@ action = "passthrough"
 # block input
 action = "suppress"
 
+# repeat the last remembered action
+action = "repeat"
+# optional; defaults to all categories:
+repeat_categories = ["keyboard", "mouse", "gamepad", "macro", "special"]
+
 # output keyboard key
 action = "keyboard"
 target = "key_space"
@@ -141,7 +146,9 @@ action = "cancel_macro_playback"
 
 Rapidfire emits repeated output pulses while the physical source is held.
 Supported by `keyboard`, `mouse`, `gamepad`, `mouse_move_rel`, and
-`mouse_move_abs`.
+`mouse_move_abs`. Repeat actions also store rapidfire fields, but Repeat only
+applies them when the remembered action is a keyboard key, mouse button, mouse
+wheel action, or gamepad button.
 
 ```toml
 rapidfire_enabled = true
@@ -157,6 +164,25 @@ tap_hold_ms = 10
 ```
 
 Rapidfire and tap are mutually exclusive.
+
+## Repeat action
+
+`action = "repeat"` replays the newest remembered action whose category is
+enabled by `repeat_categories`. Valid categories are `keyboard`, `mouse`,
+`gamepad`, `macro`, and `special`. Legacy `mouse_button` and `mouse_wheel`
+values are normalized to `mouse`.
+
+`mouse` covers mouse buttons and wheel directions. Configured
+`mouse_move_rel` and `mouse_move_abs` actions are `special`; raw passthrough
+mouse movement is not recorded. Repeat does not remember Repeat, passthrough
+mapping actions, suppress actions, profile actions, emergency reset, or
+unresolved top-level superkey bindings. For superkeys, the top-level binding
+itself is not stored
+verbatim; Repeat stores the resolved slot/overload path (not the original
+top-level superkey binding), so repeated Repeat invocations replay the resolved
+action. Repeating an action refreshes the Repeat history with the resolved
+action, so repeated presses of Repeat continue replaying it.
+Superkey paths that contain profile actions are not stored.
 
 ## Common snippets
 

--- a/docs/agents/superkeys-combos.txt
+++ b/docs/agents/superkeys-combos.txt
@@ -80,7 +80,11 @@ superkey_name = "copy_or_paste"
 
 Nested superkeys are not allowed. Pattern superkeys can use normal action
 types such as keyboard, mouse, gamepad, macro, exec, profile, and compositor
-actions.
+actions. Pattern superkeys expose Repeat after a superkey binding resolves:
+Repeat remembers and replays the resolved superkey path as a single Repeat
+target. The unresolved top-level superkey binding itself is not remembered, and
+the resolved superkey path is captured and replayed as one action rather than
+only remembering individual overload children.
 
 ## Combos
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -64,6 +64,13 @@ Primary docs:
   how the user presses it.
 - Rapidfire: emit repeated output pulses while the physical source is held.
   Each pulse has a press/hold duration and a wait before the next pulse.
+- Repeat Last Action: replay the newest remembered action in selected
+  categories (`keyboard`, `mouse`, `gamepad`, `macro`, `special`). Mouse covers
+  buttons and wheel. Raw passthrough mouse movement is not remembered.
+  Unresolved top-level superkey bindings are not remembered; however, when a
+  superkey sequence resolves to a concrete action (a resolved superkey path),
+  that action is stored and can be replayed. This lets readers distinguish
+  top-level superkeys from resolved superkey paths.
 - Tap: send one short press/release pulse even if the physical source is held.
 
 ## Config locations

--- a/keymasq/common/models.py
+++ b/keymasq/common/models.py
@@ -1,3 +1,4 @@
+import logging
 from collections.abc import Callable
 from dataclasses import dataclass, field, replace
 from datetime import datetime
@@ -9,6 +10,7 @@ from keymasq.common.gamepad_axes import clamp_gamepad_axis_value, normalize_game
 if TYPE_CHECKING:
     from keymasq.keymasqd.superkey_state import SuperkeyConfig as RuntimeSuperkeyConfig
 
+log = logging.getLogger("keymasq.common.models")
 PROTECTED_BUTTONS = frozenset({"btn_left", "btn_right"})
 
 
@@ -33,6 +35,35 @@ class ActionType(Enum):
     PROFILE_ENABLE = "profile_enable"
     PROFILE_DISABLE = "profile_disable"
     PROFILE_TOGGLE = "profile_toggle"
+    REPEAT = "repeat"
+
+
+REPEAT_CATEGORY_KEYBOARD = "keyboard"
+REPEAT_CATEGORY_MOUSE = "mouse"
+REPEAT_CATEGORY_GAMEPAD = "gamepad"
+REPEAT_CATEGORY_MACRO = "macro"
+REPEAT_CATEGORY_SPECIAL = "special"
+
+REPEAT_CATEGORIES = frozenset(
+    {
+        REPEAT_CATEGORY_KEYBOARD,
+        REPEAT_CATEGORY_MOUSE,
+        REPEAT_CATEGORY_GAMEPAD,
+        REPEAT_CATEGORY_MACRO,
+        REPEAT_CATEGORY_SPECIAL,
+    }
+)
+DEFAULT_REPEAT_CATEGORIES = (
+    REPEAT_CATEGORY_KEYBOARD,
+    REPEAT_CATEGORY_MOUSE,
+    REPEAT_CATEGORY_GAMEPAD,
+    REPEAT_CATEGORY_MACRO,
+    REPEAT_CATEGORY_SPECIAL,
+)
+_LEGACY_REPEAT_CATEGORY_ALIASES = {
+    "mouse_button": REPEAT_CATEGORY_MOUSE,
+    "mouse_wheel": REPEAT_CATEGORY_MOUSE,
+}
 
 
 class SuperkeyMode(Enum):
@@ -69,6 +100,7 @@ RAPIDFIRE_ACTION_TYPES = frozenset(
         ActionType.GAMEPAD_AXIS,
         ActionType.MOUSE_MOVE_REL,
         ActionType.MOUSE_MOVE_ABS,
+        ActionType.REPEAT,
     }
 )
 
@@ -191,6 +223,40 @@ def normalize_output_id(output_id: object) -> str | None:
         return None
     normalized = str(output_id).strip()
     return normalized or None
+
+
+def normalize_repeat_categories(categories: object) -> list[str]:
+    if categories is None:
+        return list(DEFAULT_REPEAT_CATEGORIES)
+    if isinstance(categories, str):
+        raw_values: list[object] = [categories]
+    elif isinstance(categories, (list, tuple, set, frozenset)):
+        raw_values = list(categories)
+    else:
+        log.warning(
+            "Invalid repeat_categories %r; using default repeat categories",
+            categories,
+        )
+        return list(DEFAULT_REPEAT_CATEGORIES)
+    if not raw_values:
+        return []
+
+    normalized: list[str] = []
+    seen: set[str] = set()
+    for value in raw_values:
+        category = str(value or "").strip().lower()
+        category = _LEGACY_REPEAT_CATEGORY_ALIASES.get(category, category)
+        if category not in REPEAT_CATEGORIES or category in seen:
+            continue
+        normalized.append(category)
+        seen.add(category)
+    if not normalized:
+        log.warning(
+            "Invalid repeat_categories %r; using default repeat categories",
+            categories,
+        )
+        return list(DEFAULT_REPEAT_CATEGORIES)
+    return normalized
 
 
 @dataclass
@@ -377,6 +443,7 @@ class MappingAction:
     tap_hold_ms: int = 10
     profile_deactivation: ProfileDeactivationPolicy | None = None
     source_profile_name: str | None = None
+    repeat_categories: list[str] | None = None
 
     def __post_init__(self) -> None:
         self.source_profile_name = (
@@ -411,6 +478,10 @@ class MappingAction:
             self.action_type,
             self.profile_deactivation,
         )
+        if self.action_type == ActionType.REPEAT:
+            self.repeat_categories = normalize_repeat_categories(self.repeat_categories)
+        else:
+            self.repeat_categories = None
 
 
 ANALOG_THRESHOLD_ACTION_TYPES = frozenset(
@@ -806,6 +877,8 @@ class SuperkeyConfig:
         ):
             if action.action_type == ActionType.SUPERKEY:
                 raise ValueError("nested superkeys are not allowed inside superkeys")
+            if action.action_type == ActionType.REPEAT:
+                raise ValueError("repeat is not allowed inside overload superkeys")
 
     def has_overload_actions(self) -> bool:
         return bool(

--- a/keymasq/gui/widgets/action_labels.py
+++ b/keymasq/gui/widgets/action_labels.py
@@ -57,6 +57,8 @@ def describe_mapping_action_compact(
         parts.append(f"🕹️ {label}")
     elif action.action_type == ActionType.MACRO:
         parts.append(f"🎬 {action.macro_name or '?'}")
+    elif action.action_type == ActionType.REPEAT:
+        parts.append("↻ repeat")
     elif action.action_type == ActionType.START_MACRO_RECORDING:
         parts.append("⏺ toggle recording")
     elif action.action_type == ActionType.STOP_MACRO_RECORDING:
@@ -85,6 +87,7 @@ def describe_mapping_action_compact(
         ActionType.MOUSE_MOVE_ABS,
         ActionType.GAMEPAD,
         ActionType.GAMEPAD_AXIS,
+        ActionType.REPEAT,
     }:
         if action.rapidfire_enabled:
             parts.append("⚡")
@@ -130,6 +133,8 @@ def describe_mapping_action_verbose(
         return f"Macro → {action.macro_name or '?'}"
     if action.action_type == ActionType.EXEC:
         return f"Exec → {action.cmd or '?'}"
+    if action.action_type == ActionType.REPEAT:
+        return "Repeat Last Action"
 
     compositor_action = describe_compositor_action(action)
     if compositor_action is not None:

--- a/keymasq/gui/widgets/combo_editor_dialog.py
+++ b/keymasq/gui/widgets/combo_editor_dialog.py
@@ -209,6 +209,8 @@ def combo_action_label(action: MappingAction | None) -> str:
         return "Suppress"
     if action.action_type == ActionType.MACRO:
         return action.macro_name or "Macro"
+    if action.action_type == ActionType.REPEAT:
+        return "Repeat Last"
     if action.action_type == ActionType.PROFILE_ENABLE:
         return f"Enable {action.profile_name or '?'}{_profile_lifetime_suffix(action)}"
     if action.action_type == ActionType.PROFILE_DISABLE:

--- a/keymasq/gui/widgets/key_selector_dialog.py
+++ b/keymasq/gui/widgets/key_selector_dialog.py
@@ -24,8 +24,14 @@ from keymasq.common.gamepad_axes import (
     gamepad_axis_value_from_percent,
 )
 from keymasq.common.models import (
+    DEFAULT_REPEAT_CATEGORIES,
     MIN_RAPIDFIRE_HOLD_MS,
     MIN_RAPIDFIRE_WAIT_MS,
+    REPEAT_CATEGORY_GAMEPAD,
+    REPEAT_CATEGORY_KEYBOARD,
+    REPEAT_CATEGORY_MACRO,
+    REPEAT_CATEGORY_MOUSE,
+    REPEAT_CATEGORY_SPECIAL,
     ActionType,
     AnalogControlConfig,
     MappingAction,
@@ -395,6 +401,25 @@ ACTION_DOC_LINKS = {
     "exec": ("execute-shell-command", "Command"),
 }
 
+REPEAT_RAPIDFIRE_TOOLTIP = (
+    "Rapidfire repeats only remembered keyboard keys, mouse buttons, mouse wheel actions, "
+    "and gamepad buttons. Other remembered actions run once."
+)
+DEFAULT_RAPIDFIRE_TOOLTIP = "Repeatedly send the mapped action while the button is held"
+REPEAT_CATEGORY_OPTIONS = (
+    (REPEAT_CATEGORY_KEYBOARD, "Keys", "Repeat remembered keyboard actions"),
+    (REPEAT_CATEGORY_MOUSE, "Mouse", "Repeat remembered mouse button and wheel actions"),
+    (REPEAT_CATEGORY_GAMEPAD, "Gamepad", "Repeat remembered gamepad actions"),
+    (REPEAT_CATEGORY_MACRO, "Macros", "Repeat remembered macro actions"),
+    (
+        REPEAT_CATEGORY_SPECIAL,
+        "Other",
+        "Repeat remembered Keymasq special actions that do not fit the other groups, "
+        "including mouse movement, shell commands, profile changes, and recording "
+        "or playback controls.",
+    ),
+)
+
 EVDEV_TO_KEY = {v: k for k, v in KEY_TO_EVDEV.items()}
 EVDEV_TO_GAMEPAD = {v[0]: k for k, v in GAMEPAD_BUTTONS.items()}
 
@@ -567,6 +592,7 @@ class KeySelectorDialog(Adw.Dialog, _GamepadAxisControlsMixin):
         allow_clear_mapping: bool = True,
         allow_suppress: bool = True,
         allow_superkey: bool = True,
+        allow_repeat: bool = True,
         allow_rapidfire: bool = True,
         allow_tap: bool = True,
         allow_macro_options: bool = True,
@@ -581,6 +607,7 @@ class KeySelectorDialog(Adw.Dialog, _GamepadAxisControlsMixin):
         self._allow_clear_mapping = allow_clear_mapping
         self._allow_suppress = allow_suppress
         self._allow_superkey = allow_superkey
+        self._allow_repeat = allow_repeat
         self._allow_rapidfire = allow_rapidfire
         self._allow_tap = allow_tap
         self._allow_macro_options = allow_macro_options
@@ -598,6 +625,11 @@ class KeySelectorDialog(Adw.Dialog, _GamepadAxisControlsMixin):
         self._rapidfire_wait = 20
         self._tap_enabled = False
         self._tap_hold = 50
+        self._repeat_categories: list[str] = list(DEFAULT_REPEAT_CATEGORIES)
+        self._repeat_toggle_buttons: dict[str, Gtk.ToggleButton] = {}
+        self._repeat_button: Gtk.ToggleButton | None = None
+        self._repeat_map_btn: Gtk.Button | None = None
+        self._repeat_options_box: Gtk.Widget | None = None
         self._macro_list: list[dict] = []
         self._selected_macro: str | None = None
         self._superkey_list: list[SuperkeyConfig] = []
@@ -672,6 +704,12 @@ class KeySelectorDialog(Adw.Dialog, _GamepadAxisControlsMixin):
                 )
             elif current_action.action_type == ActionType.EXEC:
                 self._exec_cmd = current_action.cmd or ""
+            elif current_action.action_type == ActionType.REPEAT:
+                self._repeat_categories = list(
+                    current_action.repeat_categories
+                    if current_action.repeat_categories is not None
+                    else DEFAULT_REPEAT_CATEGORIES
+                )
             elif current_action.action_type in (
                 ActionType.PROFILE_ENABLE,
                 ActionType.PROFILE_DISABLE,
@@ -908,6 +946,23 @@ class KeySelectorDialog(Adw.Dialog, _GamepadAxisControlsMixin):
         if self._source_type == "analog":
             return box
 
+        if self._allow_repeat:
+            repeat_btn = Gtk.ToggleButton(label="Repeat Last Action")
+            repeat_btn.add_css_class("key-button")
+            repeat_btn.set_size_request(200, 50)
+            repeat_btn.set_active(
+                bool(
+                    self._current_action
+                    and self._current_action.action_type == ActionType.REPEAT
+                )
+            )
+            repeat_btn.connect("toggled", self._on_repeat_button_toggled)
+            repeat_btn.set_tooltip_text("Replay the last remembered mapped action")
+            self._repeat_button = repeat_btn
+            box.append(repeat_btn)
+            box.append(self._build_repeat_section())
+            special_buttons_added = True
+
         exec_label = Gtk.Label(label="Execute Shell Command")
         exec_label.add_css_class("dim-label")
         if special_buttons_added:
@@ -933,6 +988,106 @@ class KeySelectorDialog(Adw.Dialog, _GamepadAxisControlsMixin):
         box.append(exec_box)
 
         return box
+
+    def _build_repeat_section(self) -> Gtk.Widget:
+        section = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=8)
+        section.set_halign(Gtk.Align.CENTER)
+
+        self._repeat_options_box = section
+        section.set_visible(bool(self._repeat_button and self._repeat_button.get_active()))
+
+        section.append(self._build_repeat_rapidfire_row())
+
+        self._repeat_toggle_buttons = {}
+        categories_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL)
+        categories_box.add_css_class("linked")
+        categories_box.set_halign(Gtk.Align.CENTER)
+        categories_box.set_hexpand(True)
+        categories_box.set_homogeneous(True)
+        categories_box.set_size_request(355, -1)
+        categories_box.set_margin_top(4)
+        for category, label, tooltip in REPEAT_CATEGORY_OPTIONS:
+            toggle = Gtk.ToggleButton(label=label)
+            toggle.set_active(category in self._repeat_categories)
+            toggle.set_tooltip_text(tooltip)
+            toggle.set_hexpand(True)
+            toggle.connect("toggled", self._on_repeat_category_toggled, category)
+            categories_box.append(toggle)
+            self._repeat_toggle_buttons[category] = toggle
+
+        section.append(categories_box)
+
+        action_row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=8)
+        action_row.set_halign(Gtk.Align.CENTER)
+        action_row.set_margin_top(4)
+        repeat_map_btn = Gtk.Button(label="Map Repeat")
+        repeat_map_btn.add_css_class("suggested-action")
+        repeat_map_btn.connect("clicked", self._on_repeat_map_clicked)
+        self._repeat_map_btn = repeat_map_btn
+        action_row.append(repeat_map_btn)
+        section.append(action_row)
+        self._update_repeat_map_button()
+
+        return section
+
+    def _build_repeat_rapidfire_row(self) -> Gtk.Widget:
+        row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=8)
+        row.set_halign(Gtk.Align.CENTER)
+
+        self.repeat_rapidfire_check = Gtk.CheckButton(label="Rapidfire")
+        self.repeat_rapidfire_check.set_active(self._allow_rapidfire and self._rapidfire_enabled)
+        self.repeat_rapidfire_check.set_tooltip_text(REPEAT_RAPIDFIRE_TOOLTIP)
+        self.repeat_rapidfire_check.connect("toggled", self._on_repeat_rapidfire_toggled)
+        row.append(self.repeat_rapidfire_check)
+
+        self.repeat_hold_label = Gtk.Label(label="Hold:")
+        row.append(self.repeat_hold_label)
+        self.repeat_hold_spin = Gtk.SpinButton()
+        self.repeat_hold_spin.set_adjustment(
+            Gtk.Adjustment(
+                value=self._rapidfire_hold,
+                lower=MIN_RAPIDFIRE_HOLD_MS,
+                upper=1000,
+                step_increment=1,
+            )
+        )
+        row.append(self.repeat_hold_spin)
+        self.repeat_hold_ms_label = Gtk.Label(label="ms")
+        row.append(self.repeat_hold_ms_label)
+
+        self.repeat_wait_label = Gtk.Label(label="Wait:")
+        row.append(self.repeat_wait_label)
+        self.repeat_wait_spin = Gtk.SpinButton()
+        self.repeat_wait_spin.set_adjustment(
+            Gtk.Adjustment(
+                value=self._rapidfire_wait,
+                lower=MIN_RAPIDFIRE_WAIT_MS,
+                upper=1000,
+                step_increment=1,
+            )
+        )
+        row.append(self.repeat_wait_spin)
+        self.repeat_wait_ms_label = Gtk.Label(label="ms")
+        row.append(self.repeat_wait_ms_label)
+
+        self._update_repeat_rapidfire_visibility()
+        return row
+
+    def _update_repeat_rapidfire_visibility(self) -> None:
+        self.repeat_rapidfire_check.set_visible(self._allow_rapidfire)
+        rf_active = self._allow_rapidfire and self.repeat_rapidfire_check.get_active()
+        for widget in (
+            self.repeat_hold_label,
+            self.repeat_hold_spin,
+            self.repeat_hold_ms_label,
+            self.repeat_wait_label,
+            self.repeat_wait_spin,
+            self.repeat_wait_ms_label,
+        ):
+            widget.set_visible(rf_active)
+
+    def _on_repeat_rapidfire_toggled(self, _check: Gtk.CheckButton) -> None:
+        self._update_repeat_rapidfire_visibility()
 
     def _build_superkey_tab(self) -> Gtk.Widget:
         outer = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=0)
@@ -1339,9 +1494,7 @@ class KeySelectorDialog(Adw.Dialog, _GamepadAxisControlsMixin):
 
         self.rapidfire_check = Gtk.CheckButton(label="Rapidfire")
         self.rapidfire_check.set_active(self._rapidfire_enabled)
-        self.rapidfire_check.set_tooltip_text(
-            "Repeatedly send the mapped action while the button is held"
-        )
+        self.rapidfire_check.set_tooltip_text(DEFAULT_RAPIDFIRE_TOOLTIP)
         self.rapidfire_check.connect("toggled", self._on_rapidfire_toggled)
         row1.append(self.rapidfire_check)
 
@@ -1409,10 +1562,11 @@ class KeySelectorDialog(Adw.Dialog, _GamepadAxisControlsMixin):
 
     def _update_options_visibility(self):
         rf_active = self._allow_rapidfire and self.rapidfire_check.get_active()
-        tap_active = self._allow_tap and self.tap_check.get_active()
+        tap_visible = self._allow_tap
+        tap_active = tap_visible and self.tap_check.get_active()
 
         self.rapidfire_check.set_visible(self._allow_rapidfire)
-        self.tap_check.set_visible(self._allow_tap)
+        self.tap_check.set_visible(tap_visible)
 
         self.hold_label.set_visible(rf_active)
         self.hold_spin.set_visible(rf_active)
@@ -1456,25 +1610,20 @@ class KeySelectorDialog(Adw.Dialog, _GamepadAxisControlsMixin):
         is_gamepad = child_name == "gamepad"
         is_compositor_action = child_name in self._compositor_action_page_ids
         has_options = self._allow_rapidfire or self._allow_tap
-        options_enabled = (
-            not is_special
-            and not is_superkey
-            and not is_analog_control
-            and not is_macro
-            and not is_profile
-            and not is_exec
-            and not is_compositor_action
+        # Repeat carries its own rapidfire controls in the Special tab, so the
+        # shared footer options only apply to the concrete-input tabs.
+        show_options = has_options and not (
+            is_special
+            or is_superkey
+            or is_analog_control
+            or is_macro
+            or is_profile
+            or is_exec
+            or is_compositor_action
         )
-        self.options_box.set_sensitive(options_enabled and has_options)
-        self.options_box.set_visible(
-            has_options
-            and not is_superkey
-            and not is_analog_control
-            and not is_macro
-            and not is_profile
-            and not is_exec
-            and not is_compositor_action
-        )
+        self.options_box.set_sensitive(show_options)
+        self.options_box.set_visible(show_options)
+        self._update_options_visibility()
         self.map_btn.set_visible(is_superkey or is_analog_control or is_macro or is_profile)
         if is_superkey:
             self.map_btn.set_sensitive(self._selected_superkey is not None)
@@ -1572,6 +1721,44 @@ class KeySelectorDialog(Adw.Dialog, _GamepadAxisControlsMixin):
             self._warn_and_clear_unsupported_rapidfire(ActionType.CANCEL_MACRO_PLAYBACK)
             action = MappingAction(action_type=ActionType.CANCEL_MACRO_PLAYBACK)
             self.emit("key-selected", action)
+        self.close()
+
+    def _on_repeat_button_toggled(self, btn: Gtk.ToggleButton) -> None:
+        if self._repeat_options_box is not None:
+            self._repeat_options_box.set_visible(btn.get_active())
+
+    def _on_repeat_category_toggled(
+        self,
+        check: Gtk.ToggleButton,
+        category: str,
+    ) -> None:
+        if check.get_active():
+            if category not in self._repeat_categories:
+                self._repeat_categories.append(category)
+        else:
+            self._repeat_categories = [
+                existing for existing in self._repeat_categories if existing != category
+            ]
+        self._update_repeat_map_button()
+
+    def _update_repeat_map_button(self) -> None:
+        if self._repeat_map_btn is not None:
+            self._repeat_map_btn.set_sensitive(bool(self._repeat_categories))
+
+    def _on_repeat_map_clicked(self, _btn: Gtk.Button) -> None:
+        if not self._repeat_categories:
+            return
+        rapidfire_enabled = bool(
+            self._allow_rapidfire and self.repeat_rapidfire_check.get_active()
+        )
+        action = MappingAction(
+            action_type=ActionType.REPEAT,
+            repeat_categories=list(self._repeat_categories),
+            rapidfire_enabled=rapidfire_enabled,
+            rapidfire_hold_ms=int(self.repeat_hold_spin.get_value()),
+            rapidfire_wait_ms=int(self.repeat_wait_spin.get_value()),
+        )
+        self.emit("key-selected", action)
         self.close()
 
     def _on_exec_text_changed(self, entry: Gtk.Entry) -> None:
@@ -2818,6 +3005,7 @@ class KeySelectorDialog(Adw.Dialog, _GamepadAxisControlsMixin):
         tab_map = {
             ActionType.PASSTHROUGH: "special",
             ActionType.SUPPRESS: "special",
+            ActionType.REPEAT: "special",
             ActionType.SUPERKEY: "superkey",
             ActionType.ANALOG_CONTROL: "analog_control",
             ActionType.START_MACRO_RECORDING: "macro",

--- a/keymasq/gui/widgets/key_selector_dialog.py
+++ b/keymasq/gui/widgets/key_selector_dialog.py
@@ -415,8 +415,7 @@ REPEAT_CATEGORY_OPTIONS = (
         REPEAT_CATEGORY_SPECIAL,
         "Other",
         "Repeat remembered Keymasq special actions that do not fit the other groups, "
-        "including mouse movement, shell commands, profile changes, and recording "
-        "or playback controls.",
+        "including mouse movement, shell commands, and recording or playback controls.",
     ),
 )
 

--- a/keymasq/gui/widgets/macro_editor_dialog.py
+++ b/keymasq/gui/widgets/macro_editor_dialog.py
@@ -3577,7 +3577,12 @@ class MacroEditorDialog(Adw.Dialog):
                 output_id=ev.output_id,
             )
 
-        dialog = KeySelectorDialog(self._parent, _get_key_name(ev.code), current_action)
+        dialog = KeySelectorDialog(
+            self._parent,
+            _get_key_name(ev.code),
+            current_action,
+            allow_repeat=False,
+        )
         dialog.connect("key-selected", self._on_key_selected_for_edit)
         dialog.present(self._parent)
 
@@ -4130,6 +4135,7 @@ class MacroEditorDialog(Adw.Dialog):
             self._parent,
             "Add Keystroke",
             MappingAction(action_type=ActionType.KEYBOARD),
+            allow_repeat=False,
         )
         dialog.connect(
             "key-selected",

--- a/keymasq/gui/widgets/superkey_dialog.py
+++ b/keymasq/gui/widgets/superkey_dialog.py
@@ -352,6 +352,7 @@ class ActionListDialog(Adw.Dialog):
                 allow_clear_mapping=False,
                 allow_suppress=False,
                 allow_superkey=False,
+                allow_repeat=False,
                 allow_rapidfire=allow_rapidfire,
                 allow_tap=False,
                 allow_macro_options=True,
@@ -370,6 +371,7 @@ class ActionListDialog(Adw.Dialog):
             allow_clear_mapping=False,
             allow_suppress=False,
             allow_superkey=False,
+            allow_repeat=False,
         )
         dialog.connect("key-selected", self._on_mapping_action_selected, index)
         dialog.present(self._parent)

--- a/keymasq/keymasqd/device_manager.py
+++ b/keymasq/keymasqd/device_manager.py
@@ -52,6 +52,7 @@ from keymasq.keymasqd.runtime import grab_lifecycle as runtime_grab_lifecycle
 from keymasq.keymasqd.runtime import grabbed_device as runtime_grabbed_device
 from keymasq.keymasqd.runtime import macros as runtime_macros
 from keymasq.keymasqd.runtime import outputs as runtime_outputs
+from keymasq.keymasqd.runtime import repeat as runtime_repeat
 from keymasq.keymasqd.runtime import topology as runtime_topology
 from keymasq.keymasqd.runtime.profile_activation_tracker import ProfileActivationTracker
 from keymasq.keymasqd.superkey_state import SuperkeyActionData, SuperkeyConfig
@@ -458,6 +459,7 @@ class DeviceManager:
             held_release_retry_s=max(0.01, float(held_release_retry_s)),
         )
         self.combo_state = runtime_combos.ComboRuntimeState()
+        self.repeat_state = runtime_repeat.RepeatRuntimeState()
         self.profile_activation_tracker = ProfileActivationTracker(
             broadcast_deactivate_request=self._broadcast_profile_deactivate_requested,
         )
@@ -680,6 +682,7 @@ class DeviceManager:
 
     async def release_all_devices(self) -> None:
         self.profile_activation_tracker.reset()
+        self.repeat_state.history.clear()
         await runtime_grab_lifecycle.release_all_devices(
             self,
             fire_and_observe_fn=_fire_and_observe,
@@ -880,7 +883,7 @@ class DeviceManager:
         hardware_id: str,
         mapping: JsonObject,
     ) -> JsonObject:
-        return await runtime_grab_lifecycle.set_mapping(
+        result = await runtime_grab_lifecycle.set_mapping(
             self,
             hardware_id,
             mapping,
@@ -892,6 +895,12 @@ class DeviceManager:
             float_value_fn=_float_value,
             log=log,
         )
+        runtime_repeat.forget_exec_actions(
+            self.repeat_state,
+            source_device=hardware_id,
+            exclude_source_button_prefix="combo:",
+        )
+        return result
 
     async def set_combos(self, combos: Sequence[object]) -> JsonObject:
         async with self._op_lock:
@@ -977,6 +986,10 @@ class DeviceManager:
             new_active_combos = self._with_emergency_cancel_combos(parsed)
             unchanged_ids = unchanged_combo_ids(old_active_signatures, new_active_combos)
             preserve_combo_ids = unchanged_ids if unchanged_ids else None
+            runtime_repeat.forget_exec_actions(
+                self.repeat_state,
+                source_button_prefix="combo:",
+            )
             self._configured_combos = parsed
             active_combos = await self._refresh_combo_runtime_unlocked(
                 preserve_combo_ids=preserve_combo_ids,

--- a/keymasq/keymasqd/runtime/action_runner.py
+++ b/keymasq/keymasqd/runtime/action_runner.py
@@ -47,6 +47,13 @@ from keymasq.keymasqd.runtime.mouse_actions import (
     resolve_mouse_output_target,
     write_relative_pulse,
 )
+from keymasq.keymasqd.runtime.repeat import (
+    RepeatHistoryEntry,
+    RepeatRuntimeState,
+    refresh_repeated_exec_source,
+    remember_action,
+    select_repeated_entry,
+)
 
 type JsonObject = dict[str, object]
 type BroadcastCallback = Callable[[CommandType, JsonObject], Awaitable[None]]
@@ -67,6 +74,20 @@ class SuperkeyExecutor(Protocol):
         deps: ActionExecutionDeps,
         shared_output_tracker: OutputTracker | None = None,
         shared_abs_output_tracker: OutputTracker | None = None,
+        execution_handle: "ActionExecutionHandle | None" = None,
+        cancel_macro_playback: CancelMacroPlayback | None = None,
+        resolve_code_fn: ResolveCodeFn = resolve_output_code,
+    ) -> None: ...
+
+
+class RepeatSuperkeyExecutor(Protocol):
+    async def __call__(
+        self,
+        device_runtime: ActionRuntime,
+        repeated_entry: RepeatHistoryEntry,
+        event_name: str,
+        *,
+        deps: ActionExecutionDeps,
         execution_handle: "ActionExecutionHandle | None" = None,
         cancel_macro_playback: CancelMacroPlayback | None = None,
         resolve_code_fn: ResolveCodeFn = resolve_output_code,
@@ -111,6 +132,7 @@ class ActionRuntimeContext:
     cursor_position_setter: CursorPositionSetter | None = None
     macro_player: MacroPlayer | None = None
     emergency_resetter: EmergencyResetter | None = None
+    repeat_state: RepeatRuntimeState | None = None
     suppress_rel_getter: Callable[[], bool] | None = None
     gamepad_output_resolver: Callable[[str | None, str], object | None] | None = None
     running: bool = True
@@ -301,8 +323,22 @@ async def execute_action(
     execution_handle: ActionExecutionHandle | None = None,
     cancel_macro_playback: CancelMacroPlayback | None = None,
     superkey_executor: SuperkeyExecutor | None = None,
+    repeat_superkey_executor: RepeatSuperkeyExecutor | None = None,
     resolve_code_fn: ResolveCodeFn = resolve_output_code,
+    record_repeat: bool = True,
 ) -> None:
+    if (
+        record_repeat
+        and int(event.value) == 1
+        and action.action_type not in {ActionType.PASSTHROUGH, ActionType.SUPERKEY}
+    ):
+        remember_action(
+            getattr(device_runtime, "repeat_state", None),
+            action,
+            source_device=device_runtime.hardware_id,
+            source_button=event_name,
+        )
+
     if action.action_type == ActionType.PASSTHROUGH:
         passthrough(
             device_runtime,
@@ -316,6 +352,24 @@ async def execute_action(
 
     if action.action_type == ActionType.SUPPRESS:
         mark_action_started(execution_handle)
+        return
+
+    if action.action_type == ActionType.REPEAT:
+        await _execute_repeat_action(
+            device_runtime,
+            action,
+            event,
+            event_name,
+            deps=deps,
+            shared_output_tracker=shared_output_tracker,
+            shared_abs_output_tracker=shared_abs_output_tracker,
+            execution_handle=execution_handle,
+            cancel_macro_playback=cancel_macro_playback,
+            superkey_executor=superkey_executor,
+            repeat_superkey_executor=repeat_superkey_executor,
+            resolve_code_fn=resolve_code_fn,
+            record_repeat=record_repeat,
+        )
         return
 
     if action.action_type == ActionType.KEYBOARD:
@@ -443,11 +497,7 @@ async def execute_action(
             source_button=event_name,
             trigger_value=int(event.value),
         )
-        if (
-            int(event.value) in (0, 1)
-            and macro_request is not None
-            and device_runtime.macro_player
-        ):
+        if int(event.value) in (0, 1) and macro_request is not None and device_runtime.macro_player:
             task = deps.fire_and_observe_fn(
                 device_runtime.macro_player(**macro_request),
                 f"macro action {event_name}",
@@ -513,7 +563,9 @@ async def execute_action_pulse(
     execution_handle: ActionExecutionHandle | None = None,
     cancel_macro_playback: CancelMacroPlayback | None = None,
     superkey_executor: SuperkeyExecutor | None = None,
+    repeat_superkey_executor: RepeatSuperkeyExecutor | None = None,
     resolve_code_fn: ResolveCodeFn = resolve_output_code,
+    record_repeat: bool = True,
 ) -> None:
     await execute_action(
         device_runtime,
@@ -526,7 +578,9 @@ async def execute_action_pulse(
         execution_handle=execution_handle,
         cancel_macro_playback=cancel_macro_playback,
         superkey_executor=superkey_executor,
+        repeat_superkey_executor=repeat_superkey_executor,
         resolve_code_fn=resolve_code_fn,
+        record_repeat=record_repeat,
     )
     await execute_action(
         device_runtime,
@@ -539,7 +593,9 @@ async def execute_action_pulse(
         execution_handle=execution_handle,
         cancel_macro_playback=cancel_macro_playback,
         superkey_executor=superkey_executor,
+        repeat_superkey_executor=repeat_superkey_executor,
         resolve_code_fn=resolve_code_fn,
+        record_repeat=record_repeat,
     )
 
 
@@ -573,6 +629,94 @@ class _SyntheticInputEvent:
         self.type = int(event_type)
         self.code = int(code)
         self.value = int(value)
+
+
+async def _execute_repeat_action(
+    device_runtime: ActionRuntime,
+    action: MappingAction,
+    event: InputEventLike,
+    event_name: str,
+    *,
+    deps: ActionExecutionDeps,
+    shared_output_tracker: OutputTracker | None = None,
+    shared_abs_output_tracker: OutputTracker | None = None,
+    execution_handle: ActionExecutionHandle | None = None,
+    cancel_macro_playback: CancelMacroPlayback | None = None,
+    superkey_executor: SuperkeyExecutor | None = None,
+    repeat_superkey_executor: RepeatSuperkeyExecutor | None = None,
+    resolve_code_fn: ResolveCodeFn = resolve_output_code,
+    record_repeat: bool = True,
+) -> None:
+    repeat_event_name = f"{event_name}#repeat"
+    repeat_state = getattr(device_runtime, "repeat_state", None)
+    active_actions = device_runtime.state.repeat_active_actions
+
+    if int(event.value) == 1:
+        repeated_entry = select_repeated_entry(repeat_state, action)
+        if repeated_entry is None:
+            mark_action_started(execution_handle)
+            return
+        if repeated_entry.superkey_slot is not None:
+            if repeat_superkey_executor is not None:
+                await repeat_superkey_executor(
+                    device_runtime,
+                    repeated_entry,
+                    event_name,
+                    deps=deps,
+                    execution_handle=execution_handle,
+                    cancel_macro_playback=cancel_macro_playback,
+                    resolve_code_fn=resolve_code_fn,
+                )
+                refresh_repeated_exec_source(repeat_state, repeated_entry)
+            mark_action_started(execution_handle)
+            return
+        repeated_action = repeated_entry.action
+        active_actions[repeat_event_name] = repeated_action
+        await execute_action(
+            device_runtime,
+            repeated_action,
+            event,
+            repeat_event_name,
+            deps=deps,
+            shared_output_tracker=shared_output_tracker,
+            shared_abs_output_tracker=shared_abs_output_tracker,
+            execution_handle=execution_handle,
+            cancel_macro_playback=cancel_macro_playback,
+            superkey_executor=superkey_executor,
+            repeat_superkey_executor=repeat_superkey_executor,
+            resolve_code_fn=resolve_code_fn,
+            record_repeat=record_repeat,
+        )
+        refresh_repeated_exec_source(repeat_state, repeated_entry)
+        return
+
+    if int(event.value) not in {0, 2}:
+        mark_action_started(execution_handle)
+        return
+
+    repeated_action = (
+        active_actions.get(repeat_event_name)
+        if int(event.value) == 2
+        else active_actions.pop(repeat_event_name, None)
+    )
+    if repeated_action is None:
+        mark_action_started(execution_handle)
+        return
+    await execute_action(
+        device_runtime,
+        repeated_action,
+        event,
+        repeat_event_name,
+        deps=deps,
+        shared_output_tracker=shared_output_tracker,
+        shared_abs_output_tracker=shared_abs_output_tracker,
+        execution_handle=execution_handle,
+        cancel_macro_playback=cancel_macro_playback,
+        superkey_executor=superkey_executor,
+        repeat_superkey_executor=repeat_superkey_executor,
+        resolve_code_fn=resolve_code_fn,
+        record_repeat=record_repeat,
+    )
 
 
 async def _execute_gamepad_axis_action(

--- a/keymasq/keymasqd/runtime/actions.py
+++ b/keymasq/keymasqd/runtime/actions.py
@@ -171,6 +171,7 @@ def parse_action(
         rapidfire_wait_ms=rapidfire_wait_ms,
         tap_enabled=bool(action_data.get("tap_enabled", False)),
         tap_hold_ms=int_value(action_data.get("tap_hold_ms"), 10),
+        repeat_categories=cast(list[str] | None, action_data.get("repeat_categories")),
     )
 
 
@@ -502,8 +503,11 @@ def parse_overload_action_bundle(
         payload = json_object(item) if json_object is not None else cast(JsonObject | None, item)
         if payload is None:
             raise TypeError("overload action must be an object")
-        if str_value(payload.get("action"), "passthrough") == "superkey":
+        action_type = str_value(payload.get("action"), "passthrough")
+        if action_type == "superkey":
             raise ValueError("nested superkeys are not allowed inside superkeys")
+        if action_type == "repeat":
+            raise ValueError("repeat is not allowed inside overload superkeys")
         actions.append(
             parse_action(
                 manager,

--- a/keymasq/keymasqd/runtime/analog_controls.py
+++ b/keymasq/keymasqd/runtime/analog_controls.py
@@ -153,8 +153,7 @@ def _control_state_key(source_id: str, index: int, total: int) -> str:
 def analog_state_keys_for_action(source_id: str, action: MappingAction | None) -> set[str]:
     configs = _action_analog_control_configs(action)
     return {
-        _control_state_key(source_id, index, len(configs))
-        for index, _config in enumerate(configs)
+        _control_state_key(source_id, index, len(configs)) for index, _config in enumerate(configs)
     }
 
 
@@ -453,9 +452,7 @@ async def _activate_threshold_actions(
                 value,
             ),
         )
-    device_runtime.state.analog_active_threshold_actions[threshold_key] = tuple(
-        executable_actions
-    )
+    device_runtime.state.analog_active_threshold_actions[threshold_key] = tuple(executable_actions)
 
 
 async def _release_threshold_actions(
@@ -473,7 +470,9 @@ async def _release_threshold_actions(
     action_entries = (
         actions
         if actions is not None
-        else tuple(enumerate(threshold.actions)) if threshold is not None else ()
+        else tuple(enumerate(threshold.actions))
+        if threshold is not None
+        else ()
     )
     for action_index, action in action_entries:
         if action.action_type in {
@@ -541,11 +540,7 @@ def _record_threshold_profile_action(
 ) -> None:
     recorder = getattr(device_runtime, "profile_activation_recorder", None)
     if recorder is not None:
-        trigger_id = (
-            source_trigger_id(device_runtime.hardware_id, source_id)
-            if source_id
-            else None
-        )
+        trigger_id = source_trigger_id(device_runtime.hardware_id, source_id) if source_id else None
         recorder(source_profile_name, trigger_id)
 
 
@@ -1213,8 +1208,7 @@ def _reset_analog_gamepad_output(
                     axis_code,
                     config.gamepad_output.output_rest
                     if config.gamepad_output.output_rest is not None
-                    else _axis_int(axis, "rest")
-                    or DEFAULT_TRIGGER_MIN,
+                    else _axis_int(axis, "rest") or DEFAULT_TRIGGER_MIN,
                 )
             )
         else:
@@ -1506,19 +1500,9 @@ def _same_trigger_output_id(
         label_value = input_metadata.get("label")
         label = str(label_value or "")
     text = f"{source_id} {label}".lower().replace("-", "_").replace(" ", "_")
-    if (
-        "left_trigger" in text
-        or text.endswith("_lt")
-        or "_lt_" in text
-        or "l2" in text
-    ):
+    if "left_trigger" in text or text.endswith("_lt") or "_lt_" in text or "l2" in text:
         return "left_trigger"
-    if (
-        "right_trigger" in text
-        or text.endswith("_rt")
-        or "_rt_" in text
-        or "r2" in text
-    ):
+    if "right_trigger" in text or text.endswith("_rt") or "_rt_" in text or "r2" in text:
         return "right_trigger"
     return None
 

--- a/keymasq/keymasqd/runtime/combos.py
+++ b/keymasq/keymasqd/runtime/combos.py
@@ -49,6 +49,7 @@ from keymasq.keymasqd.runtime.mouse_actions import resolve_mouse_output_target
 from keymasq.keymasqd.runtime.repeat import (
     SUPERKEY_SLOT_OVERLOAD,
     RepeatHistoryEntry,
+    execute_repeated_superkey_path,
     remember_superkey_path,
 )
 from keymasq.keymasqd.superkey_state import SuperkeyConfig as RuntimeSuperkeyConfig
@@ -1138,66 +1139,48 @@ async def _start_combo_superkey_repeat_path(
     *,
     deps: ComboRuntimeDeps,
 ) -> None:
-    action = repeated_entry.action
-    slot = repeated_entry.superkey_slot
-    if slot is None or action.action_type != ActionType.SUPERKEY:
-        return
-    config = cast(RuntimeSuperkeyConfig | None, action.superkey_config)
-    if config is None:
-        return
-    if slot == SUPERKEY_SLOT_OVERLOAD:
-        trigger_name = f"combo:{combo_id}"
+    async def execute_overload_once(action: MappingAction, repeat_event_name: str) -> None:
+        config = cast(RuntimeSuperkeyConfig, action.superkey_config)
         await _start_combo_overload_superkey(
             manager,
             combo_id,
             action,
             config,
             trigger_binding,
-            trigger_name,
+            repeat_event_name,
             (),
             (),
             deps=deps,
             record_repeat=False,
         )
         await stop_combo_action(manager, combo_id, deps=deps)
-        return
-    await _repeat_combo_pattern_slot_once(
-        manager,
-        combo_id,
-        action,
-        config,
-        slot,
-        trigger_binding,
-        deps=deps,
-    )
 
+    async def execute_pattern_slot_once(
+        action: MappingAction,
+        slot: str,
+        _repeat_event_name: str,
+    ) -> None:
+        machine = await _combo_superkey_machine(
+            manager,
+            combo_id,
+            action,
+            trigger_binding,
+            [trigger_binding],
+            deps=deps,
+        )
+        if machine is None:
+            return
+        await machine.execute_repeat_slot(slot)
+        await machine.stop()
+        manager.combo_state.superkey_machines.pop(combo_id, None)
+        manager.combo_state.superkey_machine_bindings.pop(combo_id, None)
 
-async def _repeat_combo_pattern_slot_once(
-    manager: _ComboManager,
-    combo_id: str,
-    action: MappingAction,
-    config: RuntimeSuperkeyConfig,
-    slot: str,
-    trigger_binding: RuntimeComboBinding,
-    *,
-    deps: ComboRuntimeDeps,
-) -> None:
-    if config.mode == SuperkeyMode.OVERLOAD:
-        return
-    machine = await _combo_superkey_machine(
-        manager,
-        combo_id,
-        action,
-        trigger_binding,
-        [trigger_binding],
-        deps=deps,
+    await execute_repeated_superkey_path(
+        repeated_entry,
+        f"combo:{combo_id}",
+        execute_overload_once=execute_overload_once,
+        execute_pattern_slot_once=execute_pattern_slot_once,
     )
-    if machine is None:
-        return
-    await machine.execute_repeat_slot(slot)
-    await machine.stop()
-    manager.combo_state.superkey_machines.pop(combo_id, None)
-    manager.combo_state.superkey_machine_bindings.pop(combo_id, None)
 
 
 async def _start_combo_action_instance(

--- a/keymasq/keymasqd/runtime/combos.py
+++ b/keymasq/keymasqd/runtime/combos.py
@@ -35,12 +35,22 @@ from keymasq.keymasqd.runtime import adapters as runtime_adapters
 from keymasq.keymasqd.runtime.action_runner import (
     ActionExecutionHandle,
     ActionRuntimeContext,
+    CancelMacroPlayback,
     dispatch_action_trigger,
     is_hold_macro_action,
     source_trigger_id,
 )
-from keymasq.keymasqd.runtime.grabbed_device_types import ActionExecutionDeps, EvdevModule
+from keymasq.keymasqd.runtime.grabbed_device_types import (
+    ActionExecutionDeps,
+    ActionRuntime,
+    EvdevModule,
+)
 from keymasq.keymasqd.runtime.mouse_actions import resolve_mouse_output_target
+from keymasq.keymasqd.runtime.repeat import (
+    SUPERKEY_SLOT_OVERLOAD,
+    RepeatHistoryEntry,
+    remember_superkey_path,
+)
 from keymasq.keymasqd.superkey_state import SuperkeyConfig as RuntimeSuperkeyConfig
 from keymasq.keymasqd.superkey_state import SuperkeyMachine
 
@@ -161,6 +171,7 @@ def _combo_action_runtime(
             if callable(emergency_resetter)
             else None
         ),
+        repeat_state=manager.repeat_state,
         gamepad_output_resolver=lambda output_id, context: manager.resolve_gamepad_output(
             output_id,
             context=context,
@@ -745,6 +756,15 @@ async def _combo_superkey_machine(
     def combo_superkey_output_tracker(action_type: str, code: int, value: int) -> bool:
         return track_combo_superkey_output(manager, action_type, code, value)
 
+    def repeat_path_recorder(slot: str) -> None:
+        remember_superkey_path(
+            manager.repeat_state,
+            action,
+            slot,
+            source_device=trigger_binding.hardware_id,
+            source_button=trigger_name,
+        )
+
     machine = SuperkeyMachine(
         config=config,
         event_name=trigger_name,
@@ -764,6 +784,7 @@ async def _combo_superkey_machine(
         cancel_macro_playback=manager.cancel_macro_playback,
         action_deps=_action_execution_deps(deps),
         await_action_tasks=False,
+        repeat_path_recorder=repeat_path_recorder,
     )
     manager.combo_state.superkey_machines[combo_id] = machine
     manager.combo_state.superkey_machine_bindings[combo_id] = machine_bindings
@@ -855,6 +876,7 @@ def _combo_action_needs_release(action: MappingAction) -> bool:
         ActionType.KEYBOARD,
         ActionType.GAMEPAD,
         ActionType.GAMEPAD_AXIS,
+        ActionType.REPEAT,
     }:
         return True
     if action.action_type == ActionType.MOUSE:
@@ -899,6 +921,7 @@ async def start_combo_action(
     trigger_bindings: Sequence[RuntimeComboBinding],
     *,
     deps: ComboRuntimeDeps,
+    record_repeat: bool = True,
 ) -> None:
     if action is None:
         return
@@ -946,87 +969,17 @@ async def start_combo_action(
     if action.action_type == ActionType.SUPERKEY:
         config = cast(RuntimeSuperkeyConfig, superkey_config)
         if config.mode == SuperkeyMode.OVERLOAD:
-            if config.overload_down_actions or config.overload_up_actions:
-                split_child_combo_ids: list[str] = []
-                for index, child_action in enumerate(config.overload_actions):
-                    if child_action.action_type == ActionType.SUPERKEY:
-                        log.warning(
-                            "Skipping nested superkey child %s in combo overload %s (%s)",
-                            child_action.superkey_name or "<unnamed>",
-                            combo_id,
-                            config.name,
-                        )
-                        continue
-                    child_combo_id = f"{combo_id}#overload#{index}"
-                    await _start_combo_action_instance(
-                        manager,
-                        child_combo_id,
-                        child_action,
-                        trigger_binding,
-                        trigger_name=f"{trigger_name}#overload#{index}",
-                        deps=deps,
-                    )
-                    if child_combo_id in manager.combo_state.active_actions:
-                        split_child_combo_ids.append(child_combo_id)
-                for index, child_action in enumerate(config.overload_down_actions):
-                    if child_action.action_type == ActionType.SUPERKEY:
-                        log.warning(
-                            "Skipping nested superkey child %s in combo overload %s (%s)",
-                            child_action.superkey_name or "<unnamed>",
-                            combo_id,
-                            config.name,
-                        )
-                        continue
-                    child_combo_id = f"{combo_id}#overload_down#{index}"
-                    await _pulse_combo_action_instance(
-                        manager,
-                        child_combo_id,
-                        child_action,
-                        trigger_binding,
-                        trigger_name=f"{trigger_name}#overload_down#{index}",
-                        deps=deps,
-                    )
-                manager.combo_state.active_actions[combo_id] = ComboActionState(
-                    kind="superkey_overload_split",
-                    child_combo_ids=split_child_combo_ids,
-                    action=action,
-                    trigger_binding=trigger_binding,
-                    source_button=trigger_name,
-                    recalled_bindings=recalled_bindings,
-                    restore_bindings=restore_bindings,
-                )
-                return
-
-            child_combo_ids: list[str] = []
-            for index, child_action in enumerate(config.overload_actions):
-                if child_action.action_type == ActionType.SUPERKEY:
-                    # Combo-triggered overloads intentionally stop at one superkey layer
-                    # so a saved superkey cannot recursively expand into more superkeys.
-                    log.warning(
-                        "Skipping nested superkey child %s in combo overload %s (%s)",
-                        child_action.superkey_name or "<unnamed>",
-                        combo_id,
-                        config.name,
-                    )
-                    continue
-                child_combo_id = f"{combo_id}#overload#{index}"
-                await _start_combo_action_instance(
-                    manager,
-                    child_combo_id,
-                    child_action,
-                    trigger_binding,
-                    trigger_name=f"{trigger_name}#overload#{index}",
-                    deps=deps,
-                )
-                if child_combo_id in manager.combo_state.active_actions:
-                    child_combo_ids.append(child_combo_id)
-            manager.combo_state.active_actions[combo_id] = ComboActionState(
-                kind="superkey_overload",
-                child_combo_ids=child_combo_ids,
-                trigger_binding=trigger_binding,
-                source_button=trigger_name,
-                recalled_bindings=recalled_bindings,
-                restore_bindings=restore_bindings,
+            await _start_combo_overload_superkey(
+                manager,
+                combo_id,
+                action,
+                config,
+                trigger_binding,
+                trigger_name,
+                recalled_bindings,
+                restore_bindings,
+                deps=deps,
+                record_repeat=record_repeat,
             )
             return
 
@@ -1071,6 +1024,182 @@ async def start_combo_action(
         _restore_combo_trigger_bindings(manager, restore_bindings)
 
 
+async def _start_combo_overload_superkey(
+    manager: _ComboManager,
+    combo_id: str,
+    action: MappingAction,
+    config: RuntimeSuperkeyConfig,
+    trigger_binding: RuntimeComboBinding,
+    trigger_name: str,
+    recalled_bindings: Sequence[RuntimeComboBinding],
+    restore_bindings: Sequence[RuntimeComboBinding],
+    *,
+    deps: ComboRuntimeDeps,
+    record_repeat: bool,
+) -> None:
+    if record_repeat:
+        remember_superkey_path(
+            manager.repeat_state,
+            action,
+            SUPERKEY_SLOT_OVERLOAD,
+            source_device=trigger_binding.hardware_id,
+            source_button=trigger_name,
+        )
+    if config.overload_down_actions or config.overload_up_actions:
+        split_child_combo_ids: list[str] = []
+        for index, child_action in enumerate(config.overload_actions):
+            if child_action.action_type == ActionType.SUPERKEY:
+                log.warning(
+                    "Skipping nested superkey child %s in combo overload %s (%s)",
+                    child_action.superkey_name or "<unnamed>",
+                    combo_id,
+                    config.name,
+                )
+                continue
+            child_combo_id = f"{combo_id}#overload#{index}"
+            await _start_combo_action_instance(
+                manager,
+                child_combo_id,
+                child_action,
+                trigger_binding,
+                trigger_name=f"{trigger_name}#overload#{index}",
+                deps=deps,
+                record_repeat=False,
+            )
+            if child_combo_id in manager.combo_state.active_actions:
+                split_child_combo_ids.append(child_combo_id)
+        for index, child_action in enumerate(config.overload_down_actions):
+            if child_action.action_type == ActionType.SUPERKEY:
+                log.warning(
+                    "Skipping nested superkey child %s in combo overload %s (%s)",
+                    child_action.superkey_name or "<unnamed>",
+                    combo_id,
+                    config.name,
+                )
+                continue
+            child_combo_id = f"{combo_id}#overload_down#{index}"
+            await _pulse_combo_action_instance(
+                manager,
+                child_combo_id,
+                child_action,
+                trigger_binding,
+                trigger_name=f"{trigger_name}#overload_down#{index}",
+                deps=deps,
+                record_repeat=False,
+            )
+        manager.combo_state.active_actions[combo_id] = ComboActionState(
+            kind="superkey_overload_split",
+            child_combo_ids=split_child_combo_ids,
+            action=action,
+            trigger_binding=trigger_binding,
+            source_button=trigger_name,
+            recalled_bindings=list(recalled_bindings),
+            restore_bindings=list(restore_bindings),
+        )
+        return
+
+    child_combo_ids: list[str] = []
+    for index, child_action in enumerate(config.overload_actions):
+        if child_action.action_type == ActionType.SUPERKEY:
+            log.warning(
+                "Skipping nested superkey child %s in combo overload %s (%s)",
+                child_action.superkey_name or "<unnamed>",
+                combo_id,
+                config.name,
+            )
+            continue
+        child_combo_id = f"{combo_id}#overload#{index}"
+        await _start_combo_action_instance(
+            manager,
+            child_combo_id,
+            child_action,
+            trigger_binding,
+            trigger_name=f"{trigger_name}#overload#{index}",
+            deps=deps,
+            record_repeat=False,
+        )
+        if child_combo_id in manager.combo_state.active_actions:
+            child_combo_ids.append(child_combo_id)
+    manager.combo_state.active_actions[combo_id] = ComboActionState(
+        kind="superkey_overload",
+        child_combo_ids=child_combo_ids,
+        trigger_binding=trigger_binding,
+        source_button=trigger_name,
+        recalled_bindings=list(recalled_bindings),
+        restore_bindings=list(restore_bindings),
+    )
+
+
+async def _start_combo_superkey_repeat_path(
+    manager: _ComboManager,
+    combo_id: str,
+    repeated_entry: RepeatHistoryEntry,
+    trigger_binding: RuntimeComboBinding,
+    *,
+    deps: ComboRuntimeDeps,
+) -> None:
+    action = repeated_entry.action
+    slot = repeated_entry.superkey_slot
+    if slot is None or action.action_type != ActionType.SUPERKEY:
+        return
+    config = cast(RuntimeSuperkeyConfig | None, action.superkey_config)
+    if config is None:
+        return
+    if slot == SUPERKEY_SLOT_OVERLOAD:
+        trigger_name = f"combo:{combo_id}"
+        await _start_combo_overload_superkey(
+            manager,
+            combo_id,
+            action,
+            config,
+            trigger_binding,
+            trigger_name,
+            (),
+            (),
+            deps=deps,
+            record_repeat=False,
+        )
+        await stop_combo_action(manager, combo_id, deps=deps)
+        return
+    await _repeat_combo_pattern_slot_once(
+        manager,
+        combo_id,
+        action,
+        config,
+        slot,
+        trigger_binding,
+        deps=deps,
+    )
+
+
+async def _repeat_combo_pattern_slot_once(
+    manager: _ComboManager,
+    combo_id: str,
+    action: MappingAction,
+    config: RuntimeSuperkeyConfig,
+    slot: str,
+    trigger_binding: RuntimeComboBinding,
+    *,
+    deps: ComboRuntimeDeps,
+) -> None:
+    if config.mode == SuperkeyMode.OVERLOAD:
+        return
+    machine = await _combo_superkey_machine(
+        manager,
+        combo_id,
+        action,
+        trigger_binding,
+        [trigger_binding],
+        deps=deps,
+    )
+    if machine is None:
+        return
+    await machine.execute_repeat_slot(slot)
+    await machine.stop()
+    manager.combo_state.superkey_machines.pop(combo_id, None)
+    manager.combo_state.superkey_machine_bindings.pop(combo_id, None)
+
+
 async def _start_combo_action_instance(
     manager: _ComboManager,
     combo_id: str,
@@ -1079,6 +1208,7 @@ async def _start_combo_action_instance(
     *,
     trigger_name: str,
     deps: ComboRuntimeDeps,
+    record_repeat: bool = True,
 ) -> None:
     if action is None or action.action_type == ActionType.SUPERKEY:
         return
@@ -1102,6 +1232,28 @@ async def _start_combo_action_instance(
         )
     started = deps.asyncio_mod.create_event()
     handle = ActionExecutionHandle(started=started)
+    combo_deps = deps
+
+    async def repeat_superkey_executor(
+        device_runtime: ActionRuntime,
+        repeated_entry: RepeatHistoryEntry,
+        event_name: str,
+        *,
+        deps: ActionExecutionDeps,
+        execution_handle: ActionExecutionHandle | None = None,
+        cancel_macro_playback: CancelMacroPlayback | None = None,
+        resolve_code_fn: ResolveCodeFn | None = None,
+    ) -> None:
+        del device_runtime, deps, execution_handle, cancel_macro_playback, resolve_code_fn
+        repeat_combo_id = event_name.removeprefix("combo:")
+        await _start_combo_superkey_repeat_path(
+            manager,
+            repeat_combo_id,
+            repeated_entry,
+            trigger_binding,
+            deps=combo_deps,
+        )
+
     await shared_action_runner.execute_action(
         runtime,
         action,
@@ -1110,14 +1262,19 @@ async def _start_combo_action_instance(
         deps=_action_execution_deps(deps),
         execution_handle=handle,
         cancel_macro_playback=manager.cancel_macro_playback,
+        repeat_superkey_executor=repeat_superkey_executor,
         resolve_code_fn=deps.resolve_code_fn,
+        record_repeat=record_repeat,
     )
     await started.wait()
 
     if is_hold_macro_action(action):
         await shared_action_runner.drain_action_tasks(handle)
 
-    if _combo_action_needs_release(action):
+    needs_release = _combo_action_needs_release(action)
+    if action.action_type == ActionType.REPEAT and not runtime.state.repeat_active_actions:
+        needs_release = False
+    if needs_release:
         manager.combo_state.active_actions[combo_id] = ComboActionState(
             kind="executor",
             action=action,
@@ -1141,6 +1298,7 @@ async def _pulse_combo_action_instance(
     *,
     trigger_name: str,
     deps: ComboRuntimeDeps,
+    record_repeat: bool = True,
 ) -> None:
     await _start_combo_action_instance(
         manager,
@@ -1149,6 +1307,7 @@ async def _pulse_combo_action_instance(
         trigger_binding,
         trigger_name=trigger_name,
         deps=deps,
+        record_repeat=record_repeat,
     )
     await wait_combo_action_started(manager, combo_id)
     await stop_combo_action(manager, combo_id, deps=deps)
@@ -1188,7 +1347,7 @@ async def stop_combo_action(
         trigger_binding = state.trigger_binding
         config = cast(RuntimeSuperkeyConfig | None, action.superkey_config) if action else None
         if trigger_binding is not None and config is not None:
-            trigger_name = str(state.source_button or combo_id)
+            trigger_name = str(state.source_button or f"combo:{combo_id}")
             for index, child_action in enumerate(config.overload_up_actions):
                 if child_action.action_type == ActionType.SUPERKEY:
                     log.warning(
@@ -1205,6 +1364,7 @@ async def stop_combo_action(
                     trigger_binding,
                     trigger_name=f"{trigger_name}#overload_up#{index}",
                     deps=deps,
+                    record_repeat=False,
                 )
         for child_combo_id in reversed(state.child_combo_ids):
             await stop_combo_action(
@@ -1301,8 +1461,7 @@ async def clear_combo_runtime_except(
         await machine.stop()
 
     active_output_roots = {
-        combo_id.split("#", 1)[0]
-        for combo_id in manager.combo_state.active_actions
+        combo_id.split("#", 1)[0] for combo_id in manager.combo_state.active_actions
     }
     if not any(root in preserved for root in active_output_roots):
         for held in manager.combo_state.held_output_keys.values():

--- a/keymasq/keymasqd/runtime/grab_lifecycle.py
+++ b/keymasq/keymasqd/runtime/grab_lifecycle.py
@@ -308,6 +308,7 @@ async def grab_device_unlocked(
                     mouse_rel_suppression_start_callback=lambda: None,
                     diagnostics_recorder=diagnostics_recorder,
                     runtime_cleanup_callback=runtime_cleanup_callback,
+                    repeat_state=manager.repeat_state,
                     interface_id=interface_id,
                 )
                 await grab_with_retry(

--- a/keymasq/keymasqd/runtime/grabbed_device.py
+++ b/keymasq/keymasqd/runtime/grabbed_device.py
@@ -49,6 +49,7 @@ from keymasq.keymasqd.runtime.grabbed_device_types import (
     WritableUInput as _WritableUInput,
 )
 from keymasq.keymasqd.runtime.outputs import uinput_identity
+from keymasq.keymasqd.runtime.repeat import RepeatRuntimeState
 
 log = logging.getLogger("keymasqd.devices")
 ACTIVE_KEY_IDLE_LOG_INTERVAL_S = 1.0
@@ -204,6 +205,7 @@ class GrabbedDevice:
         mouse_rel_suppression_start_callback: Callable[[], None] | None = None,
         diagnostics_recorder: Callable[[str, float], None] | None = None,
         runtime_cleanup_callback: Callable[[str, str | None], Awaitable[None]] | None = None,
+        repeat_state: RepeatRuntimeState | None = None,
         button_codes: dict[str, int] | None = None,
         button_values: dict[str, int] | None = None,
         analog_inputs: dict[str, object] | None = None,
@@ -255,6 +257,13 @@ class GrabbedDevice:
         self.mouse_rel_suppression_start_callback = mouse_rel_suppression_start_callback
         self.diagnostics_recorder = diagnostics_recorder
         self.runtime_cleanup_callback = runtime_cleanup_callback
+        if repeat_state is None:
+            log.warning(
+                "GrabbedDevice %s created without shared RepeatRuntimeState; "
+                "using isolated test-only repeat state",
+                hardware_id,
+            )
+        self.repeat_state = repeat_state if repeat_state is not None else RepeatRuntimeState()
         self.task: asyncio.Task[None] | None = None
         self._running = False
         self.state = GrabbedDeviceState()

--- a/keymasq/keymasqd/runtime/grabbed_device_actions.py
+++ b/keymasq/keymasqd/runtime/grabbed_device_actions.py
@@ -23,10 +23,88 @@ from keymasq.keymasqd.runtime.grabbed_device_types import (
     InputEventLike,
     WritableUInput,
 )
+from keymasq.keymasqd.runtime.repeat import (
+    SUPERKEY_SLOT_OVERLOAD,
+    RepeatHistoryEntry,
+    remember_superkey_path,
+)
 from keymasq.keymasqd.superkey_state import SuperkeyConfig as RuntimeSuperkeyConfig
 from keymasq.keymasqd.superkey_state import SuperkeyMachine
 
 log = logging.getLogger("keymasqd.runtime.grabbed_device_actions")
+
+
+def _build_superkey_machine(
+    device_runtime: GrabbedDeviceRuntime,
+    action: MappingAction,
+    event_name: str,
+    *,
+    deps: ActionExecutionDeps,
+    execution_handle: ActionExecutionHandle | None = None,
+    cancel_macro_playback: CancelMacroPlayback | None = None,
+) -> SuperkeyMachine:
+    async def superkey_broadcast(data: dict[str, object]) -> None:
+        if device_runtime.broadcast_callback:
+            task = deps.fire_and_observe_fn(
+                device_runtime.broadcast_callback(
+                    CommandType.ACTION_TRIGGER,
+                    data,
+                ),
+                f"superkey action {event_name}",
+            )
+            shared_action_runner.register_action_task(execution_handle, task)
+
+    def superkey_key_event_tracker(
+        action_type: str,
+        code: int,
+        value: int,
+    ) -> bool:
+        return track_superkey_output(
+            device_runtime,
+            action_type,
+            code,
+            value,
+        )
+
+    def superkey_abs_event_tracker(
+        bucket: str,
+        axis_code: int,
+        value: int,
+    ) -> bool:
+        return track_superkey_abs_output(
+            device_runtime,
+            bucket,
+            axis_code,
+            value,
+        )
+
+    def repeat_path_recorder(slot: str) -> None:
+        remember_superkey_path(
+            getattr(device_runtime, "repeat_state", None),
+            action,
+            slot,
+            source_device=device_runtime.hardware_id,
+            source_button=event_name,
+        )
+
+    return SuperkeyMachine(
+        config=cast(RuntimeSuperkeyConfig, action.superkey_config),
+        event_name=event_name,
+        keyboard_uinput=cast(WritableUInput, device_runtime.keyboard_uinput),
+        mouse_uinput=cast(WritableUInput, device_runtime.mouse_uinput),
+        gamepad_uinput=cast(WritableUInput, device_runtime.gamepad_uinput),
+        source_device=device_runtime.hardware_id,
+        broadcast_callback=superkey_broadcast,
+        cursor_position_setter=device_runtime.cursor_position_setter,
+        key_event_tracker=superkey_key_event_tracker,
+        axis_event_tracker=superkey_abs_event_tracker,
+        gamepad_output_resolver=device_runtime.resolve_gamepad_output,
+        macro_player=device_runtime.macro_player,
+        emergency_resetter=device_runtime.emergency_resetter,
+        cancel_macro_playback=cancel_macro_playback,
+        action_deps=deps,
+        repeat_path_recorder=repeat_path_recorder,
+    )
 
 
 async def execute_action(
@@ -41,6 +119,7 @@ async def execute_action(
     execution_handle: ActionExecutionHandle | None = None,
     cancel_macro_playback: CancelMacroPlayback | None = None,
     resolve_code_fn: ResolveCodeFn = resolve_output_code,
+    record_repeat: bool = True,
 ) -> None:
     await shared_action_runner.execute_action(
         device_runtime,
@@ -53,7 +132,9 @@ async def execute_action(
         execution_handle=execution_handle,
         cancel_macro_playback=cancel_macro_playback,
         superkey_executor=_execute_superkey_action,
+        repeat_superkey_executor=_execute_repeated_superkey_path,
         resolve_code_fn=resolve_code_fn,
+        record_repeat=record_repeat,
     )
 
 
@@ -67,6 +148,7 @@ async def execute_action_pulse(
     shared_output_tracker: Callable[[str, int, int], bool] | None = None,
     shared_abs_output_tracker: Callable[[str, int, int], bool] | None = None,
     explicit_bucket: str | None = None,
+    record_repeat: bool = True,
 ) -> None:
     del explicit_bucket
     await execute_action(
@@ -77,6 +159,7 @@ async def execute_action_pulse(
         deps=deps,
         shared_output_tracker=shared_output_tracker,
         shared_abs_output_tracker=shared_abs_output_tracker,
+        record_repeat=record_repeat,
     )
     await execute_action(
         device_runtime,
@@ -86,6 +169,7 @@ async def execute_action_pulse(
         deps=deps,
         shared_output_tracker=shared_output_tracker,
         shared_abs_output_tracker=shared_abs_output_tracker,
+        record_repeat=False,
     )
 
 
@@ -143,58 +227,13 @@ async def _execute_superkey_action(
 
     machine = device_runtime.state.superkey_machines.get(event_name)
     if int(event.value) == 1 and not machine:
-
-        async def superkey_broadcast(data: dict[str, object]) -> None:
-            if device_runtime.broadcast_callback:
-                task = deps.fire_and_observe_fn(
-                    device_runtime.broadcast_callback(
-                        CommandType.ACTION_TRIGGER,
-                        data,
-                    ),
-                    f"superkey action {event_name}",
-                )
-                shared_action_runner.register_action_task(execution_handle, task)
-
-        def superkey_key_event_tracker(
-            action_type: str,
-            code: int,
-            value: int,
-        ) -> bool:
-            return track_superkey_output(
-                device_runtime,
-                action_type,
-                code,
-                value,
-            )
-
-        def superkey_abs_event_tracker(
-            bucket: str,
-            axis_code: int,
-            value: int,
-        ) -> bool:
-            return track_superkey_abs_output(
-                device_runtime,
-                bucket,
-                axis_code,
-                value,
-            )
-
-        machine = SuperkeyMachine(
-            config=cast(RuntimeSuperkeyConfig, action.superkey_config),
-            event_name=event_name,
-            keyboard_uinput=cast(WritableUInput, device_runtime.keyboard_uinput),
-            mouse_uinput=cast(WritableUInput, device_runtime.mouse_uinput),
-            gamepad_uinput=cast(WritableUInput, device_runtime.gamepad_uinput),
-            source_device=device_runtime.hardware_id,
-            broadcast_callback=superkey_broadcast,
-            cursor_position_setter=device_runtime.cursor_position_setter,
-            key_event_tracker=superkey_key_event_tracker,
-            axis_event_tracker=superkey_abs_event_tracker,
-            gamepad_output_resolver=device_runtime.resolve_gamepad_output,
-            macro_player=device_runtime.macro_player,
-            emergency_resetter=device_runtime.emergency_resetter,
+        machine = _build_superkey_machine(
+            device_runtime,
+            action,
+            event_name,
+            deps=deps,
+            execution_handle=execution_handle,
             cancel_macro_playback=cancel_macro_playback,
-            action_deps=deps,
         )
         device_runtime.state.superkey_machines[event_name] = machine
 
@@ -216,6 +255,14 @@ async def _execute_overload_superkey(
     config = action.superkey_config
     if config is None:
         return
+    if int(event.value) == 1:
+        remember_superkey_path(
+            getattr(device_runtime, "repeat_state", None),
+            action,
+            SUPERKEY_SLOT_OVERLOAD,
+            source_device=device_runtime.hardware_id,
+            source_button=event_name,
+        )
 
     def overload_output_tracker(action_type: str, code: int, value: int) -> bool:
         return track_superkey_output(
@@ -251,6 +298,7 @@ async def _execute_overload_superkey(
                 deps=deps,
                 shared_output_tracker=overload_output_tracker,
                 shared_abs_output_tracker=overload_abs_output_tracker,
+                record_repeat=False,
             )
 
     for index, child_action in enumerate(config.overload_actions):
@@ -277,6 +325,7 @@ async def _execute_overload_superkey(
             deps=deps,
             shared_output_tracker=overload_output_tracker,
             shared_abs_output_tracker=overload_abs_output_tracker,
+            record_repeat=False,
         )
         if int(event.value) == 0:
             device_runtime.state.held_profile_trigger_events.discard(child_event_name)
@@ -304,4 +353,61 @@ async def _execute_overload_superkey(
                 deps=deps,
                 shared_output_tracker=overload_output_tracker,
                 shared_abs_output_tracker=overload_abs_output_tracker,
+                record_repeat=False,
             )
+
+
+async def _execute_repeated_superkey_path(
+    device_runtime: ActionRuntime,
+    repeated_entry: RepeatHistoryEntry,
+    event_name: str,
+    *,
+    deps: ActionExecutionDeps,
+    execution_handle: ActionExecutionHandle | None = None,
+    cancel_macro_playback: CancelMacroPlayback | None = None,
+    resolve_code_fn: ResolveCodeFn = resolve_output_code,
+) -> None:
+    del execution_handle, cancel_macro_playback, resolve_code_fn
+    device_runtime = cast(GrabbedDeviceRuntime, device_runtime)
+    action = repeated_entry.action
+    slot = repeated_entry.superkey_slot
+    if slot is None or action.action_type != ActionType.SUPERKEY or action.superkey_config is None:
+        return
+    if slot == SUPERKEY_SLOT_OVERLOAD:
+        await _execute_overload_slot_once(
+            device_runtime,
+            action,
+            event_name,
+            deps=deps,
+        )
+        return
+    if action.superkey_config.mode == SuperkeyMode.OVERLOAD:
+        return
+    machine = _build_superkey_machine(
+        device_runtime,
+        action,
+        event_name,
+        deps=deps,
+    )
+    await machine.execute_repeat_slot(slot)
+    await machine.stop()
+
+
+async def _execute_overload_slot_once(
+    device_runtime: GrabbedDeviceRuntime,
+    action: MappingAction,
+    event_name: str,
+    *,
+    deps: ActionExecutionDeps,
+) -> None:
+    config = action.superkey_config
+    if config is None:
+        return
+    for value in (1, 0):
+        await _execute_overload_superkey(
+            device_runtime,
+            action,
+            _SyntheticInputEvent(0, 0, value),
+            event_name,
+            deps=deps,
+        )

--- a/keymasq/keymasqd/runtime/grabbed_device_actions.py
+++ b/keymasq/keymasqd/runtime/grabbed_device_actions.py
@@ -26,6 +26,7 @@ from keymasq.keymasqd.runtime.grabbed_device_types import (
 from keymasq.keymasqd.runtime.repeat import (
     SUPERKEY_SLOT_OVERLOAD,
     RepeatHistoryEntry,
+    execute_repeated_superkey_path,
     remember_superkey_path,
 )
 from keymasq.keymasqd.superkey_state import SuperkeyConfig as RuntimeSuperkeyConfig
@@ -369,28 +370,35 @@ async def _execute_repeated_superkey_path(
 ) -> None:
     del execution_handle, cancel_macro_playback, resolve_code_fn
     device_runtime = cast(GrabbedDeviceRuntime, device_runtime)
-    action = repeated_entry.action
-    slot = repeated_entry.superkey_slot
-    if slot is None or action.action_type != ActionType.SUPERKEY or action.superkey_config is None:
-        return
-    if slot == SUPERKEY_SLOT_OVERLOAD:
+
+    async def execute_overload_once(action: MappingAction, repeat_event_name: str) -> None:
         await _execute_overload_slot_once(
             device_runtime,
             action,
-            event_name,
+            repeat_event_name,
             deps=deps,
         )
-        return
-    if action.superkey_config.mode == SuperkeyMode.OVERLOAD:
-        return
-    machine = _build_superkey_machine(
-        device_runtime,
-        action,
+
+    async def execute_pattern_slot_once(
+        action: MappingAction,
+        slot: str,
+        repeat_event_name: str,
+    ) -> None:
+        machine = _build_superkey_machine(
+            device_runtime,
+            action,
+            repeat_event_name,
+            deps=deps,
+        )
+        await machine.execute_repeat_slot(slot)
+        await machine.stop()
+
+    await execute_repeated_superkey_path(
+        repeated_entry,
         event_name,
-        deps=deps,
+        execute_overload_once=execute_overload_once,
+        execute_pattern_slot_once=execute_pattern_slot_once,
     )
-    await machine.execute_repeat_slot(slot)
-    await machine.stop()
 
 
 async def _execute_overload_slot_once(

--- a/keymasq/keymasqd/runtime/grabbed_device_events.py
+++ b/keymasq/keymasqd/runtime/grabbed_device_events.py
@@ -22,6 +22,7 @@ from keymasq.keymasqd.combo_engine import ComboDecision
 from keymasq.keymasqd.runtime import analog_controls as runtime_analog_controls
 from keymasq.keymasqd.runtime import grabbed_device_actions as runtime_actions
 from keymasq.keymasqd.runtime import grabbed_device_outputs as runtime_outputs
+from keymasq.keymasqd.runtime import repeat as runtime_repeat
 from keymasq.keymasqd.runtime.action_runner import source_trigger_id
 from keymasq.keymasqd.runtime.grabbed_device_types import (
     ActionExecutionDeps,
@@ -674,6 +675,13 @@ async def process_event(
             uinput_writer=identity_uinput_writer,
             sync=False,
         )
+        runtime_repeat.remember_passthrough_event(
+            device_runtime.repeat_state,
+            device_runtime,
+            event,
+            event_name,
+            evdev_mod=evdev_mod,
+        )
         if int(event.value) == 0:
             device_runtime.state.combo_passthrough_held.discard(event_name)
             _clear_released_source_action(
@@ -699,6 +707,30 @@ async def process_event(
             mapping,
             evdev_mod=evdev_mod,
         )
+        if (
+            high_res_wheel_action is not None
+            and high_res_wheel_action.action_type == ActionType.PASSTHROUGH
+        ):
+            _record_grabbed_event_if_allowed(
+                device_runtime,
+                event,
+                recording_manager=recording_manager,
+                deps=deps,
+            )
+            runtime_outputs.passthrough(
+                device_runtime,
+                event,
+                evdev_mod=evdev_mod,
+                uinput_writer=identity_uinput_writer,
+                sync=False,
+            )
+            _record_diagnostics(
+                device_runtime,
+                "wheel_passthrough",
+                started_ns,
+                time_mod=time_mod,
+            )
+            return
         if (
             high_res_wheel_action is not None
             and high_res_wheel_action.action_type != ActionType.PASSTHROUGH
@@ -740,6 +772,13 @@ async def process_event(
             and int(event.value) == 1
         ):
             device_runtime.state.combo_passthrough_held.add(event_name)
+        runtime_repeat.remember_passthrough_event(
+            device_runtime.repeat_state,
+            device_runtime,
+            event,
+            event_name,
+            evdev_mod=evdev_mod,
+        )
         runtime_outputs.passthrough(
             device_runtime,
             event,
@@ -809,6 +848,13 @@ async def process_event(
             and int(event.value) == 1
         ):
             device_runtime.state.combo_passthrough_held.add(event_name)
+        runtime_repeat.remember_passthrough_event(
+            device_runtime.repeat_state,
+            device_runtime,
+            event,
+            event_name,
+            evdev_mod=evdev_mod,
+        )
         runtime_outputs.passthrough(
             device_runtime,
             event,

--- a/keymasq/keymasqd/runtime/grabbed_device_types.py
+++ b/keymasq/keymasqd/runtime/grabbed_device_types.py
@@ -18,6 +18,7 @@ from keymasq.common.ipc import CommandType
 from keymasq.common.models import MappingAction
 from keymasq.keymasqd.combo_engine import ComboDecision
 from keymasq.keymasqd.recording import RecordingManager
+from keymasq.keymasqd.runtime.repeat import RepeatRuntimeState
 
 if TYPE_CHECKING:
     from keymasq.keymasqd.superkey_state import SuperkeyMachine
@@ -204,6 +205,7 @@ class GrabbedDeviceState:
     rapidfire_outputs: dict[str, RapidfireOutputState] = field(default_factory=dict)
     tap_active: dict[str, bool] = field(default_factory=dict)
     superkey_machines: dict[str, "SuperkeyMachine"] = field(default_factory=dict)
+    repeat_active_actions: dict[str, MappingAction] = field(default_factory=dict)
     held_source_keys: set[str] = field(default_factory=set)
     combo_passthrough_held: set[str] = field(default_factory=set)
     combo_recalled_bindings: set[str] = field(default_factory=set)
@@ -240,9 +242,7 @@ class GrabbedDeviceState:
         str,
         tuple[tuple[int, MappingAction], ...],
     ] = field(default_factory=dict)
-    analog_threshold_output_refcounts: dict[str, dict[int, int]] = field(
-        default_factory=dict
-    )
+    analog_threshold_output_refcounts: dict[str, dict[int, int]] = field(default_factory=dict)
     analog_threshold_abs_refcounts: dict[str, dict[int, int]] = field(default_factory=dict)
     analog_mouse_tasks: dict[str, asyncio.Task[None]] = field(default_factory=dict)
     analog_mouse_accumulators: dict[str, tuple[float, float]] = field(default_factory=dict)
@@ -287,6 +287,9 @@ class ActionRuntime(Protocol):
 
     @property
     def state(self) -> GrabbedDeviceState: ...
+
+    @property
+    def repeat_state(self) -> RepeatRuntimeState | None: ...
 
     @property
     def _running(self) -> bool: ...

--- a/keymasq/keymasqd/runtime/repeat.py
+++ b/keymasq/keymasqd/runtime/repeat.py
@@ -363,12 +363,6 @@ def forget_exec_actions(
     normalized_source_device = str(source_device or "").strip()
     normalized_source_button_prefix = str(source_button_prefix or "").strip()
     normalized_exclude_source_button_prefix = str(exclude_source_button_prefix or "").strip()
-    if not (
-        normalized_source_device
-        or normalized_source_button_prefix
-        or normalized_exclude_source_button_prefix
-    ):
-        return
     retained: list[RepeatHistoryEntry] = []
     for entry in repeat_state.history:
         if normalized_exclude_source_button_prefix and entry.source_button.startswith(

--- a/keymasq/keymasqd/runtime/repeat.py
+++ b/keymasq/keymasqd/runtime/repeat.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections import deque
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field, replace
 from typing import Any
 
@@ -35,6 +36,12 @@ SUPERKEY_REPEAT_SLOTS = frozenset(
         SUPERKEY_SLOT_OVERLOAD,
     }
 )
+
+type RepeatedSuperkeyOverloadExecutor = Callable[[MappingAction, str], Awaitable[None]]
+type RepeatedSuperkeyPatternSlotExecutor = Callable[
+    [MappingAction, str, str],
+    Awaitable[None],
+]
 
 _SPECIAL_REPEAT_ACTION_TYPES = frozenset(
     {
@@ -207,6 +214,30 @@ def select_repeated_entry(
         if entry.category in allowed:
             return replace(entry, action=repeat_execution_action(repeat_action, entry.action))
     return None
+
+
+async def execute_repeated_superkey_path(
+    repeated_entry: RepeatHistoryEntry,
+    event_name: str,
+    *,
+    execute_overload_once: RepeatedSuperkeyOverloadExecutor,
+    execute_pattern_slot_once: RepeatedSuperkeyPatternSlotExecutor,
+) -> bool:
+    action = repeated_entry.action
+    slot = repeated_entry.superkey_slot
+    if slot is None or action.action_type != ActionType.SUPERKEY:
+        return False
+    if action.superkey_config is None or slot not in SUPERKEY_REPEAT_SLOTS:
+        return False
+    if slot == SUPERKEY_SLOT_OVERLOAD:
+        if action.superkey_config.mode != SuperkeyMode.OVERLOAD:
+            return False
+        await execute_overload_once(action, event_name)
+        return True
+    if action.superkey_config.mode == SuperkeyMode.OVERLOAD:
+        return False
+    await execute_pattern_slot_once(action, slot, event_name)
+    return True
 
 
 def refresh_repeated_exec_source(

--- a/keymasq/keymasqd/runtime/repeat.py
+++ b/keymasq/keymasqd/runtime/repeat.py
@@ -1,0 +1,428 @@
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass, field, replace
+from typing import Any
+
+import evdev
+
+from keymasq.common.devices import high_res_wheel_low_res_code, normalize_wheel_value
+from keymasq.common.models import (
+    REPEAT_CATEGORY_GAMEPAD,
+    REPEAT_CATEGORY_KEYBOARD,
+    REPEAT_CATEGORY_MACRO,
+    REPEAT_CATEGORY_MOUSE,
+    REPEAT_CATEGORY_SPECIAL,
+    ActionType,
+    MappingAction,
+    SuperkeyMode,
+    normalize_repeat_categories,
+)
+from keymasq.keymasqd.runtime.mouse_actions import resolve_mouse_output_target
+
+REPEAT_HISTORY_LIMIT = 32
+SUPERKEY_SLOT_TAP = "tap"
+SUPERKEY_SLOT_DOUBLE_TAP = "double_tap"
+SUPERKEY_SLOT_HOLD = "hold"
+SUPERKEY_SLOT_TAP_HOLD = "tap_hold"
+SUPERKEY_SLOT_OVERLOAD = "overload"
+SUPERKEY_REPEAT_SLOTS = frozenset(
+    {
+        SUPERKEY_SLOT_TAP,
+        SUPERKEY_SLOT_DOUBLE_TAP,
+        SUPERKEY_SLOT_HOLD,
+        SUPERKEY_SLOT_TAP_HOLD,
+        SUPERKEY_SLOT_OVERLOAD,
+    }
+)
+
+_SPECIAL_REPEAT_ACTION_TYPES = frozenset(
+    {
+        ActionType.EXEC,
+        ActionType.COMPOSITOR_DISPATCH,
+        ActionType.START_MACRO_RECORDING,
+        ActionType.STOP_MACRO_RECORDING,
+        ActionType.CANCEL_MACRO_PLAYBACK,
+    }
+)
+
+_PROFILE_ACTION_TYPES = frozenset(
+    {
+        ActionType.PROFILE_ENABLE,
+        ActionType.PROFILE_DISABLE,
+        ActionType.PROFILE_TOGGLE,
+    }
+)
+
+
+@dataclass(frozen=True)
+class RepeatHistoryEntry:
+    category: str
+    action: MappingAction
+    source_device: str = ""
+    source_button: str = ""
+    superkey_slot: str | None = None
+
+
+@dataclass
+class RepeatRuntimeState:
+    history: deque[RepeatHistoryEntry] = field(
+        default_factory=lambda: deque(maxlen=REPEAT_HISTORY_LIMIT)
+    )
+
+
+def repeat_category_for_action(action: MappingAction) -> str | None:
+    action_type = action.action_type
+    if action_type in {ActionType.REPEAT, ActionType.SUPPRESS, ActionType.PASSTHROUGH}:
+        return None
+    if action_type == ActionType.KEYBOARD:
+        return REPEAT_CATEGORY_KEYBOARD
+    if action_type == ActionType.MOUSE:
+        return REPEAT_CATEGORY_MOUSE
+    if action_type in {ActionType.MOUSE_MOVE_REL, ActionType.MOUSE_MOVE_ABS}:
+        return REPEAT_CATEGORY_SPECIAL
+    if action_type in {ActionType.GAMEPAD, ActionType.GAMEPAD_AXIS}:
+        return REPEAT_CATEGORY_GAMEPAD
+    if action_type == ActionType.MACRO:
+        return REPEAT_CATEGORY_MACRO
+    if action_type in _SPECIAL_REPEAT_ACTION_TYPES:
+        return REPEAT_CATEGORY_SPECIAL
+    return None
+
+
+def action_supports_repeat_rapidfire(action: MappingAction) -> bool:
+    if action.action_type in {ActionType.KEYBOARD, ActionType.GAMEPAD}:
+        return True
+    if action.action_type != ActionType.MOUSE:
+        return False
+    target = resolve_mouse_output_target(action.target)
+    if target is None:
+        return False
+    if not target.is_relative:
+        return True
+    return int(target.code) in {int(evdev.ecodes.REL_WHEEL), int(evdev.ecodes.REL_HWHEEL)}
+
+
+def repeat_execution_action(
+    repeat_action: MappingAction,
+    action: MappingAction,
+) -> MappingAction:
+    rapidfire_enabled = bool(
+        repeat_action.rapidfire_enabled and action_supports_repeat_rapidfire(action)
+    )
+    return replace(
+        action,
+        rapidfire_enabled=rapidfire_enabled,
+        rapidfire_hold_ms=int(repeat_action.rapidfire_hold_ms),
+        rapidfire_wait_ms=int(repeat_action.rapidfire_wait_ms),
+        tap_enabled=False,
+    )
+
+
+def remember_action(
+    repeat_state: RepeatRuntimeState | None,
+    action: MappingAction,
+    *,
+    source_device: str = "",
+    source_button: str = "",
+) -> None:
+    if repeat_state is None:
+        return
+    category = repeat_category_for_action(action)
+    if category is None:
+        return
+    repeat_state.history.append(
+        RepeatHistoryEntry(
+            category=category,
+            action=replace(
+                action,
+                rapidfire_enabled=False,
+                tap_enabled=False,
+            ),
+            source_device=str(source_device or ""),
+            source_button=str(source_button or ""),
+        )
+    )
+
+
+def remember_superkey_path(
+    repeat_state: RepeatRuntimeState | None,
+    action: MappingAction,
+    slot: str,
+    *,
+    source_device: str = "",
+    source_button: str = "",
+) -> None:
+    if repeat_state is None:
+        return
+    if action.action_type != ActionType.SUPERKEY or action.superkey_config is None:
+        return
+    normalized_slot = str(slot or "").strip()
+    if normalized_slot not in SUPERKEY_REPEAT_SLOTS:
+        return
+    if normalized_slot == SUPERKEY_SLOT_OVERLOAD:
+        if action.superkey_config.mode != SuperkeyMode.OVERLOAD:
+            return
+    elif action.superkey_config.mode == SuperkeyMode.OVERLOAD:
+        return
+    if _superkey_slot_contains_profile_action(action, normalized_slot):
+        return
+    repeat_state.history.append(
+        RepeatHistoryEntry(
+            category=REPEAT_CATEGORY_SPECIAL,
+            action=replace(
+                action,
+                rapidfire_enabled=False,
+                tap_enabled=False,
+            ),
+            source_device=str(source_device or ""),
+            source_button=str(source_button or ""),
+            superkey_slot=normalized_slot,
+        )
+    )
+
+
+def select_repeated_action(
+    repeat_state: RepeatRuntimeState | None,
+    repeat_action: MappingAction,
+) -> MappingAction | None:
+    entry = select_repeated_entry(repeat_state, repeat_action)
+    return entry.action if entry is not None else None
+
+
+def select_repeated_entry(
+    repeat_state: RepeatRuntimeState | None,
+    repeat_action: MappingAction,
+) -> RepeatHistoryEntry | None:
+    if repeat_state is None:
+        return None
+    allowed = set(normalize_repeat_categories(repeat_action.repeat_categories))
+    if not allowed:
+        return None
+    for entry in reversed(repeat_state.history):
+        if entry.action.action_type == ActionType.REPEAT:
+            continue
+        if _repeat_entry_contains_profile_action(entry):
+            continue
+        if entry.category in allowed:
+            return replace(entry, action=repeat_execution_action(repeat_action, entry.action))
+    return None
+
+
+def refresh_repeated_exec_source(
+    repeat_state: RepeatRuntimeState | None,
+    repeated_entry: RepeatHistoryEntry,
+) -> None:
+    if repeat_state is None or not _repeat_entry_contains_exec_action(repeated_entry):
+        return
+    if not repeat_state.history:
+        return
+    latest = repeat_state.history[-1]
+    if not _same_repeated_exec_action(latest, repeated_entry):
+        return
+    repeat_state.history[-1] = replace(
+        latest,
+        source_device=repeated_entry.source_device,
+        source_button=repeated_entry.source_button,
+    )
+
+
+def _superkey_action_contains_exec(action: MappingAction) -> bool:
+    config = action.superkey_config
+    if action.action_type != ActionType.SUPERKEY or config is None:
+        return False
+    pattern_slots = (
+        config.tap_actions,
+        config.double_tap_actions,
+        config.hold_actions,
+        config.tap_hold_actions,
+    )
+    if any(
+        _is_exec_action_type(child.action_type) for actions in pattern_slots for child in actions
+    ):
+        return True
+    overload_slots = (
+        config.overload_actions,
+        config.overload_down_actions,
+        config.overload_up_actions,
+    )
+    return any(
+        _is_exec_action_type(child.action_type) for actions in overload_slots for child in actions
+    )
+
+
+def _superkey_slot_contains_profile_action(action: MappingAction, slot: str | None) -> bool:
+    config = action.superkey_config
+    if action.action_type != ActionType.SUPERKEY or config is None:
+        return False
+    if slot == SUPERKEY_SLOT_OVERLOAD:
+        return any(
+            _is_profile_action_type(child.action_type)
+            for actions in (
+                config.overload_actions,
+                config.overload_down_actions,
+                config.overload_up_actions,
+            )
+            for child in actions
+        )
+    pattern_slots = {
+        SUPERKEY_SLOT_TAP: config.tap_actions,
+        SUPERKEY_SLOT_DOUBLE_TAP: config.double_tap_actions,
+        SUPERKEY_SLOT_HOLD: config.hold_actions,
+        SUPERKEY_SLOT_TAP_HOLD: config.tap_hold_actions,
+    }
+    return any(
+        _is_profile_action_type(child.action_type)
+        for child in pattern_slots.get(str(slot or ""), [])
+    )
+
+
+def _repeat_entry_contains_profile_action(entry: RepeatHistoryEntry) -> bool:
+    return (
+        entry.action.action_type in _PROFILE_ACTION_TYPES
+        or _superkey_slot_contains_profile_action(entry.action, entry.superkey_slot)
+    )
+
+
+def _is_exec_action_type(action_type: object) -> bool:
+    if isinstance(action_type, ActionType):
+        return action_type == ActionType.EXEC
+    return str(action_type) == ActionType.EXEC.value
+
+
+def _is_profile_action_type(action_type: object) -> bool:
+    if isinstance(action_type, ActionType):
+        return action_type in _PROFILE_ACTION_TYPES
+    return str(action_type) in {profile_type.value for profile_type in _PROFILE_ACTION_TYPES}
+
+
+def _repeat_entry_contains_exec_action(entry: RepeatHistoryEntry) -> bool:
+    return entry.action.action_type == ActionType.EXEC or _superkey_action_contains_exec(
+        entry.action
+    )
+
+
+def _same_repeated_exec_action(
+    latest: RepeatHistoryEntry,
+    repeated_entry: RepeatHistoryEntry,
+) -> bool:
+    if repeated_entry.action.action_type == ActionType.EXEC:
+        return (
+            latest.action.action_type == ActionType.EXEC
+            and latest.action.exec_ref == repeated_entry.action.exec_ref
+        )
+    if repeated_entry.action.action_type == ActionType.SUPERKEY:
+        return (
+            latest.action.action_type == ActionType.SUPERKEY
+            and latest.superkey_slot == repeated_entry.superkey_slot
+            and latest.action.superkey_config is repeated_entry.action.superkey_config
+        )
+    return False
+
+
+def forget_exec_actions(
+    repeat_state: RepeatRuntimeState | None,
+    *,
+    source_device: str | None = None,
+    source_button_prefix: str | None = None,
+    exclude_source_button_prefix: str | None = None,
+) -> None:
+    if repeat_state is None:
+        return
+    normalized_source_device = str(source_device or "").strip()
+    normalized_source_button_prefix = str(source_button_prefix or "").strip()
+    normalized_exclude_source_button_prefix = str(exclude_source_button_prefix or "").strip()
+    if not (
+        normalized_source_device
+        or normalized_source_button_prefix
+        or normalized_exclude_source_button_prefix
+    ):
+        return
+    retained: list[RepeatHistoryEntry] = []
+    for entry in repeat_state.history:
+        if normalized_exclude_source_button_prefix and entry.source_button.startswith(
+            normalized_exclude_source_button_prefix
+        ):
+            retained.append(entry)
+            continue
+        if normalized_source_device and entry.source_device != normalized_source_device:
+            retained.append(entry)
+            continue
+        if normalized_source_button_prefix and not entry.source_button.startswith(
+            normalized_source_button_prefix
+        ):
+            retained.append(entry)
+            continue
+        if not _repeat_entry_contains_exec_action(entry):
+            retained.append(entry)
+    repeat_state.history.clear()
+    repeat_state.history.extend(retained)
+
+
+def remember_passthrough_event(
+    repeat_state: RepeatRuntimeState | None,
+    device_runtime: Any,
+    event: Any,
+    event_name: str,
+    *,
+    evdev_mod: Any,
+) -> None:
+    if repeat_state is None:
+        return
+    event_type = int(event.type)
+    event_code = int(event.code)
+    event_value = int(event.value)
+    normalized_name = str(event_name or "").lower()
+
+    if event_type == int(evdev_mod.ecodes.EV_KEY):
+        if event_value != 1:
+            return
+        if normalized_name.startswith("key_"):
+            action = MappingAction(action_type=ActionType.KEYBOARD, target=normalized_name)
+        elif normalized_name.startswith("btn_"):
+            if _device_is_gamepad(device_runtime):
+                output_id = str(getattr(device_runtime, "hardware_id", "") or "") or None
+                action = MappingAction(
+                    action_type=ActionType.GAMEPAD,
+                    target=normalized_name,
+                    output_id=output_id,
+                )
+            else:
+                action = MappingAction(action_type=ActionType.MOUSE, target=normalized_name)
+        else:
+            return
+        remember_action(
+            repeat_state,
+            action,
+            source_device=getattr(device_runtime, "hardware_id", ""),
+            source_button=normalized_name,
+        )
+        return
+
+    if event_type != int(evdev_mod.ecodes.EV_REL):
+        return
+
+    low_res_event_code = high_res_wheel_low_res_code(event_code) or event_code
+    if low_res_event_code == int(evdev_mod.ecodes.REL_WHEEL):
+        wheel_name = "rel_wheel"
+    elif low_res_event_code == int(evdev_mod.ecodes.REL_HWHEEL):
+        wheel_name = "rel_hwheel"
+    elif event_code in {int(evdev_mod.ecodes.REL_X), int(evdev_mod.ecodes.REL_Y)}:
+        return
+    else:
+        return
+
+    normalized_value = normalize_wheel_value(event_value)
+    if normalized_value is None:
+        return
+    remember_action(
+        repeat_state,
+        MappingAction(action_type=ActionType.MOUSE, target=f"{wheel_name}:{normalized_value}"),
+        source_device=getattr(device_runtime, "hardware_id", ""),
+        source_button=f"{wheel_name}:{normalized_value}",
+    )
+
+
+def _device_is_gamepad(device_runtime: Any) -> bool:
+    device_types = getattr(device_runtime, "device_types", []) or []
+    return "gamepad" in {str(device_kind or "").strip().lower() for device_kind in device_types}

--- a/keymasq/keymasqd/superkey_state.py
+++ b/keymasq/keymasqd/superkey_state.py
@@ -25,6 +25,12 @@ from keymasq.keymasqd.runtime.mouse_actions import (
     rapidfire_relative_pulses,
     resolve_mouse_output_target,
 )
+from keymasq.keymasqd.runtime.repeat import (
+    SUPERKEY_SLOT_DOUBLE_TAP,
+    SUPERKEY_SLOT_HOLD,
+    SUPERKEY_SLOT_TAP,
+    SUPERKEY_SLOT_TAP_HOLD,
+)
 
 if TYPE_CHECKING:
     from keymasq.keymasqd.runtime.grabbed_device_types import ActionExecutionDeps
@@ -172,6 +178,7 @@ class SuperkeyMachine:
         cancel_macro_playback: CancelMacroPlayback | None = None,
         action_deps: "ActionExecutionDeps | None" = None,
         await_action_tasks: bool = True,
+        repeat_path_recorder: Callable[[str], None] | None = None,
     ) -> None:
         self.config = config
         self.event_name = event_name
@@ -189,6 +196,7 @@ class SuperkeyMachine:
         self.cancel_macro_playback = cancel_macro_playback
         self.action_deps = action_deps or _default_action_deps()
         self.await_action_tasks = await_action_tasks
+        self.repeat_path_recorder = repeat_path_recorder
 
         self.state = SuperkeyState.IDLE
         self._hold_task: asyncio.Task[None] | None = None
@@ -343,14 +351,17 @@ class SuperkeyMachine:
 
     async def _emit_tap(self) -> None:
         if self.config.tap_actions:
+            self._record_repeat_path(SUPERKEY_SLOT_TAP)
             await self._execute_actions_tap(self.config.tap_actions)
 
     async def _emit_double_tap(self) -> None:
         if self.config.double_tap_actions:
+            self._record_repeat_path(SUPERKEY_SLOT_DOUBLE_TAP)
             await self._execute_actions_tap(self.config.double_tap_actions)
 
     async def _emit_hold_down(self) -> None:
         if self.config.hold_actions:
+            self._record_repeat_path(SUPERKEY_SLOT_HOLD)
             await self._execute_actions_down(self.config.hold_actions)
 
     async def _emit_hold_up(self) -> None:
@@ -359,11 +370,33 @@ class SuperkeyMachine:
 
     async def _emit_tap_hold_down(self) -> None:
         if self.config.tap_hold_actions:
+            self._record_repeat_path(SUPERKEY_SLOT_TAP_HOLD)
             await self._execute_actions_down(self.config.tap_hold_actions)
 
     async def _emit_tap_hold_up(self) -> None:
         if self.config.tap_hold_actions:
             await self._execute_actions_up(self.config.tap_hold_actions)
+
+    async def execute_repeat_slot(self, slot: str) -> None:
+        if slot == SUPERKEY_SLOT_TAP:
+            await self._emit_tap()
+            return
+        if slot == SUPERKEY_SLOT_DOUBLE_TAP:
+            await self._emit_double_tap()
+            return
+        if slot == SUPERKEY_SLOT_HOLD:
+            if self.config.hold_actions:
+                self._record_repeat_path(SUPERKEY_SLOT_HOLD)
+                await self._execute_actions_tap(self.config.hold_actions)
+            return
+        if slot == SUPERKEY_SLOT_TAP_HOLD:
+            if self.config.tap_hold_actions:
+                self._record_repeat_path(SUPERKEY_SLOT_TAP_HOLD)
+                await self._execute_actions_tap(self.config.tap_hold_actions)
+
+    def _record_repeat_path(self, slot: str) -> None:
+        if self.repeat_path_recorder is not None:
+            self.repeat_path_recorder(slot)
 
     async def _rapidfire_loop(self, action: SuperkeyActionData) -> None:
         hold = clamp_rapidfire_hold_ms(action.rapidfire_hold_ms) / 1000.0

--- a/keymasq/session/analog_controls.py
+++ b/keymasq/session/analog_controls.py
@@ -246,6 +246,15 @@ class AnalogControlManager:
                 compositor_args=str(action_data.get("args", "") or ""),
             )
 
+        if action_type == ActionType.REPEAT:
+            return MappingAction(
+                action_type=action_type,
+                repeat_categories=cast(list[str] | None, action_data.get("repeat_categories")),
+                rapidfire_enabled=rapidfire_enabled,
+                rapidfire_hold_ms=rapidfire_hold_ms,
+                rapidfire_wait_ms=rapidfire_wait_ms,
+            )
+
         if action_type in (ActionType.MOUSE_MOVE_REL, ActionType.MOUSE_MOVE_ABS):
             return MappingAction(
                 action_type=action_type,
@@ -440,6 +449,8 @@ class AnalogControlManager:
                 action_data["compositor"] = action.compositor_id
             action_data["dispatcher"] = action.compositor_dispatcher or ""
             action_data["args"] = action.compositor_args or ""
+        if action.action_type == ActionType.REPEAT:
+            action_data["repeat_categories"] = list(action.repeat_categories or [])
         if action.rapidfire_enabled:
             action_data["rapidfire_enabled"] = True
             action_data["rapidfire_hold_ms"] = int(action.rapidfire_hold_ms)

--- a/keymasq/session/manager/payloads.py
+++ b/keymasq/session/manager/payloads.py
@@ -27,6 +27,14 @@ if TYPE_CHECKING:
 log = logging.getLogger(__name__)
 
 
+def _add_repeat_action_fields(data: dict[str, object], action: MappingAction) -> None:
+    data["repeat_categories"] = list(action.repeat_categories or [])
+    if action.rapidfire_enabled:
+        data["rapidfire_enabled"] = True
+        data["rapidfire_hold_ms"] = int(action.rapidfire_hold_ms)
+        data["rapidfire_wait_ms"] = int(action.rapidfire_wait_ms)
+
+
 def clear_exec_refs(manager: "SessionManager", hardware_id: str) -> None:
     refs = manager.exec_state.device_exec_refs.pop(hardware_id, set())
     for ref in refs:
@@ -163,6 +171,10 @@ def action_signature_payload(
         if action.tap_enabled:
             data["tap_enabled"] = True
             data["tap_hold_ms"] = int(action.tap_hold_ms)
+        return data
+
+    if action_type == "repeat":
+        _add_repeat_action_fields(data, action)
         return data
 
     if action_type == "exec":
@@ -322,6 +334,8 @@ def profile_to_mapping(
                 action_data["compositor"] = action.compositor_id
             action_data["dispatcher"] = action.compositor_dispatcher or ""
             action_data["args"] = action.compositor_args or ""
+        elif action.action_type.value == "repeat":
+            _add_repeat_action_fields(action_data, action)
         elif action.action_type.value in (
             "start_macro_recording",
             "stop_macro_recording",
@@ -474,6 +488,10 @@ def combo_action_to_payload(
         if action.tap_enabled:
             action_data["tap_enabled"] = True
             action_data["tap_hold_ms"] = action.tap_hold_ms
+        return action_data
+
+    if action_type == "repeat":
+        _add_repeat_action_fields(action_data, action)
         return action_data
 
     if action_type == "exec":
@@ -646,7 +664,7 @@ def serialize_superkey(
             ]
     elif config.overload_actions:
         data["overload_actions"] = [
-            serialize_overload_action(
+            serialize_superkey_overload_action(
                 manager,
                 action,
                 hardware_id,
@@ -657,7 +675,7 @@ def serialize_superkey(
     if config.mode == SuperkeyMode.OVERLOAD:
         if config.overload_down_actions:
             data["overload_down_actions"] = [
-                serialize_overload_action(
+                serialize_superkey_overload_action(
                     manager,
                     action,
                     hardware_id,
@@ -667,7 +685,7 @@ def serialize_superkey(
             ]
         if config.overload_up_actions:
             data["overload_up_actions"] = [
-                serialize_overload_action(
+                serialize_superkey_overload_action(
                     manager,
                     action,
                     hardware_id,
@@ -894,6 +912,23 @@ def serialize_superkey_action(
     )
 
 
+def serialize_superkey_overload_action(
+    manager: "SessionManager",
+    action: MappingAction,
+    hardware_id: str,
+    *,
+    track_combo_refs: bool = False,
+) -> JsonObject:
+    if action.action_type == ActionType.REPEAT:
+        raise ValueError("repeat is not allowed inside overload superkeys")
+    return serialize_overload_action(
+        manager,
+        action,
+        hardware_id,
+        track_combo_refs=track_combo_refs,
+    )
+
+
 def serialize_superkey_action_signature(
     manager: "SessionManager",
     action: SuperkeyAction,
@@ -945,6 +980,10 @@ def serialize_overload_action(
         if action.tap_enabled:
             action_data["tap_enabled"] = True
             action_data["tap_hold_ms"] = action.tap_hold_ms
+        return action_data
+
+    if action_type == "repeat":
+        _add_repeat_action_fields(action_data, action)
         return action_data
 
     if action_type == "exec":

--- a/keymasq/session/profiles.py
+++ b/keymasq/session/profiles.py
@@ -466,6 +466,15 @@ class ProfileManager:
                 action_type.value,
             )
 
+        if action_type == ActionType.REPEAT:
+            return MappingAction(
+                action_type=action_type,
+                repeat_categories=cast(list[str] | None, action_data.get("repeat_categories")),
+                rapidfire_enabled=rapidfire_enabled,
+                rapidfire_hold_ms=rapidfire_hold_ms,
+                rapidfire_wait_ms=rapidfire_wait_ms,
+            )
+
         if action_type in (ActionType.MOUSE_MOVE_REL, ActionType.MOUSE_MOVE_ABS):
             return MappingAction(
                 action_type=action_type,
@@ -553,6 +562,8 @@ class ProfileManager:
                 action_data["compositor"] = action.compositor_id
             action_data["dispatcher"] = action.compositor_dispatcher or ""
             action_data["args"] = action.compositor_args or ""
+        if action.action_type == ActionType.REPEAT:
+            action_data["repeat_categories"] = list(action.repeat_categories or [])
         (
             rapidfire_enabled,
             rapidfire_hold_ms,

--- a/keymasq/session/superkeys.py
+++ b/keymasq/session/superkeys.py
@@ -261,6 +261,15 @@ class SuperkeyManager:
                 compositor_args=str(action_data.get("args", "") or ""),
             )
 
+        if action_type == ActionType.REPEAT:
+            return MappingAction(
+                action_type=action_type,
+                repeat_categories=cast(list[str] | None, action_data.get("repeat_categories")),
+                rapidfire_enabled=rapidfire_enabled,
+                rapidfire_hold_ms=rapidfire_hold_ms,
+                rapidfire_wait_ms=rapidfire_wait_ms,
+            )
+
         if action_type in (ActionType.MOUSE_MOVE_REL, ActionType.MOUSE_MOVE_ABS):
             return MappingAction(
                 action_type=action_type,
@@ -300,6 +309,8 @@ class SuperkeyManager:
             raise ValueError("nested superkeys are not allowed inside superkeys")
         if action.action_type == ActionType.PASSTHROUGH:
             raise ValueError("passthrough is not allowed inside overload superkeys")
+        if action.action_type == ActionType.REPEAT:
+            raise ValueError("repeat is not allowed inside overload superkeys")
 
     def get_superkey(self, name: str) -> SuperkeyConfig | None:
         return self._superkeys.get(name)
@@ -457,6 +468,8 @@ class SuperkeyManager:
                 action_data["compositor"] = action.compositor_id
             action_data["dispatcher"] = action.compositor_dispatcher or ""
             action_data["args"] = action.compositor_args or ""
+        if action.action_type == ActionType.REPEAT:
+            action_data["repeat_categories"] = list(action.repeat_categories or [])
         (
             rapidfire_enabled,
             rapidfire_hold_ms,

--- a/nix/daemon-session-integration-test/fixtures/profiles/repeat.toml
+++ b/nix/daemon-session-integration-test/fixtures/profiles/repeat.toml
@@ -1,0 +1,74 @@
+[profile]
+name = "$REPEAT_PROFILE_NAME"
+enabled = false
+is_permanent = true
+priority = 400
+notify_on_activation = false
+created_at = "2026-05-12T00:00:04"
+
+[devices."$HARDWARE_ID"]
+always_grab_all = true
+
+[devices."$HARDWARE_ID".mapping.key_f13]
+action = "repeat"
+
+[devices."$HARDWARE_ID".mapping.key_f14]
+action = "repeat"
+repeat_categories = ["keyboard"]
+
+[devices."$HARDWARE_ID".mapping.key_f15]
+action = "repeat"
+repeat_categories = ["mouse"]
+
+[devices."$HARDWARE_ID".mapping.key_f16]
+action = "repeat"
+repeat_categories = ["gamepad"]
+
+[devices."$HARDWARE_ID".mapping.key_f17]
+action = "repeat"
+repeat_categories = ["macro"]
+
+[devices."$HARDWARE_ID".mapping.key_f18]
+action = "repeat"
+repeat_categories = ["special"]
+
+[devices."$HARDWARE_ID".mapping.key_f19]
+action = "keyboard"
+target = "key_a"
+
+[devices."$HARDWARE_ID".mapping.key_f20]
+action = "mouse"
+target = "btn_middle"
+
+[devices."$HARDWARE_ID".mapping.key_f21]
+action = "gamepad"
+target = "btn_north"
+
+[devices."$HARDWARE_ID".mapping.key_f22]
+action = "macro"
+target = "$MACRO_NAME"
+
+[devices."$HARDWARE_ID".mapping.key_f23]
+action = "mouse_move_rel"
+x = 9
+y = -4
+
+[devices."$SECOND_HARDWARE_ID"]
+always_grab_all = false
+
+[devices."$SECOND_HARDWARE_ID".mapping.key_f13]
+action = "suppress"
+
+[devices."$SECOND_HARDWARE_ID".mapping.key_f14]
+action = "suppress"
+
+[[combos]]
+id = "integration-repeat-combo"
+name = "Integration repeat combo"
+steps = [
+  { events = [
+    { evdev = "key_f13", hardware_id = "$SECOND_HARDWARE_ID" },
+    { evdev = "key_f14", hardware_id = "$SECOND_HARDWARE_ID" },
+  ] },
+]
+action = { action = "repeat" }

--- a/nix/daemon-session-integration-test/scenarios/__init__.py
+++ b/nix/daemon-session-integration-test/scenarios/__init__.py
@@ -35,6 +35,9 @@ from .profile_lifetime_toggle import run as profile_lifetime_toggle
 from .profile_toggle import run as profile_toggle
 from .rapidfire_keyboard import run as rapidfire_keyboard
 from .recording_capture import run as recording_capture
+from .repeat_combo_superkey import run as repeat_combo_superkey
+from .repeat_direct_actions import run as repeat_direct_actions
+from .repeat_passthrough import run as repeat_passthrough
 from .restart_recovery import run as restart_recovery
 from .simple_remap import run as simple_remap
 from .superkey_overload_multi_action import run as superkey_overload_multi_action
@@ -43,6 +46,9 @@ from .suppress import run as suppress
 from .tap_enabled import run as tap_enabled
 
 SCENARIOS = [
+    ScenarioCase("repeat direct mapped actions", repeat_direct_actions),
+    ScenarioCase("repeat original passthrough input", repeat_passthrough),
+    ScenarioCase("repeat combos and superkeys", repeat_combo_superkey),
     ScenarioCase("simple 1->1 remap", simple_remap),
     ScenarioCase("suppress", suppress),
     ScenarioCase("tap-enabled keyboard action", tap_enabled),

--- a/nix/daemon-session-integration-test/scenarios/repeat_combo_superkey.py
+++ b/nix/daemon-session-integration-test/scenarios/repeat_combo_superkey.py
@@ -1,0 +1,165 @@
+import time
+
+import evdev
+from support import REPEAT_PROFILE_NAME, ScenarioContext
+
+
+def run(ctx: ScenarioContext) -> None:
+    try:
+        ctx.set_profile_enabled(REPEAT_PROFILE_NAME, enabled=True)
+        ctx.subtest(
+            "repeat replays combo output from a mapped repeat key",
+            lambda: _mapped_repeat_replays_combo_action(ctx),
+        )
+        ctx.subtest(
+            "combo repeat action replays mapped keyboard output",
+            lambda: _combo_repeat_replays_keyboard_action(ctx),
+        )
+        ctx.subtest(
+            "repeat replays pattern superkey path",
+            lambda: _repeat_replays_pattern_superkey(ctx),
+        )
+        ctx.subtest(
+            "combo repeat action replays pattern superkey path",
+            lambda: _combo_repeat_replays_pattern_superkey(ctx),
+        )
+        ctx.subtest(
+            "repeat replays overload superkey path",
+            lambda: _repeat_replays_overload_superkey(ctx),
+        )
+        ctx.subtest(
+            "combo repeat action replays overload superkey path",
+            lambda: _combo_repeat_replays_overload_superkey(ctx),
+        )
+    finally:
+        ctx.set_profile_enabled(REPEAT_PROFILE_NAME, enabled=False)
+
+
+def _mapped_repeat_replays_combo_action(ctx: ScenarioContext) -> None:
+    _trigger_primary_combo(ctx, evdev.ecodes.KEY_C, evdev.ecodes.KEY_D)
+    ctx.expect_keys([(evdev.ecodes.KEY_E, 1), (evdev.ecodes.KEY_E, 0)])
+
+    ctx.tap_source(evdev.ecodes.KEY_F13)
+    ctx.expect_keys([(evdev.ecodes.KEY_E, 1), (evdev.ecodes.KEY_E, 0)])
+
+
+def _combo_repeat_replays_keyboard_action(ctx: ScenarioContext) -> None:
+    ctx.tap_source(evdev.ecodes.KEY_F19)
+    ctx.expect_keys([(evdev.ecodes.KEY_A, 1), (evdev.ecodes.KEY_A, 0)])
+
+    _trigger_repeat_combo(ctx)
+    ctx.expect_keys([(evdev.ecodes.KEY_A, 1), (evdev.ecodes.KEY_A, 0)])
+
+
+def _repeat_replays_pattern_superkey(ctx: ScenarioContext) -> None:
+    ctx.tap_source(evdev.ecodes.KEY_B)
+    ctx.expect_keys([(evdev.ecodes.KEY_W, 1), (evdev.ecodes.KEY_W, 0)])
+
+    ctx.tap_source(evdev.ecodes.KEY_F13)
+    ctx.expect_keys([(evdev.ecodes.KEY_W, 1), (evdev.ecodes.KEY_W, 0)])
+
+
+def _combo_repeat_replays_pattern_superkey(ctx: ScenarioContext) -> None:
+    ctx.tap_source(evdev.ecodes.KEY_B)
+    ctx.expect_keys([(evdev.ecodes.KEY_W, 1), (evdev.ecodes.KEY_W, 0)])
+
+    _trigger_repeat_combo(ctx)
+    ctx.expect_keys([(evdev.ecodes.KEY_W, 1), (evdev.ecodes.KEY_W, 0)])
+
+
+def _repeat_replays_overload_superkey(ctx: ScenarioContext) -> None:
+    _press_overload_superkey(ctx)
+    _release_overload_superkey(ctx)
+
+    ctx.tap_source(evdev.ecodes.KEY_F13)
+    _expect_overload_full_cycle(ctx)
+
+
+def _combo_repeat_replays_overload_superkey(ctx: ScenarioContext) -> None:
+    _press_overload_superkey(ctx)
+    _release_overload_superkey(ctx)
+
+    _trigger_repeat_combo(ctx)
+    _expect_combo_overload_full_cycle(ctx)
+
+
+def _press_overload_superkey(ctx: ScenarioContext) -> None:
+    ctx.source_key(evdev.ecodes.KEY_E, 1)
+    ctx.expect_keys(
+        [
+            (evdev.ecodes.KEY_LEFTCTRL, 1),
+            (evdev.ecodes.KEY_LEFTSHIFT, 1),
+            (evdev.ecodes.KEY_1, 1),
+            (evdev.ecodes.KEY_1, 0),
+            (evdev.ecodes.KEY_2, 1),
+            (evdev.ecodes.KEY_2, 0),
+        ]
+    )
+
+
+def _release_overload_superkey(ctx: ScenarioContext) -> None:
+    ctx.source_key(evdev.ecodes.KEY_E, 0)
+    ctx.expect_keys(
+        [
+            (evdev.ecodes.KEY_3, 1),
+            (evdev.ecodes.KEY_3, 0),
+            (evdev.ecodes.KEY_4, 1),
+            (evdev.ecodes.KEY_4, 0),
+            (evdev.ecodes.KEY_LEFTCTRL, 0),
+            (evdev.ecodes.KEY_LEFTSHIFT, 0),
+        ]
+    )
+
+
+def _expect_overload_full_cycle(ctx: ScenarioContext) -> None:
+    ctx.expect_keys(
+        [
+            (evdev.ecodes.KEY_LEFTCTRL, 1),
+            (evdev.ecodes.KEY_LEFTSHIFT, 1),
+            (evdev.ecodes.KEY_1, 1),
+            (evdev.ecodes.KEY_1, 0),
+            (evdev.ecodes.KEY_2, 1),
+            (evdev.ecodes.KEY_2, 0),
+            (evdev.ecodes.KEY_3, 1),
+            (evdev.ecodes.KEY_3, 0),
+            (evdev.ecodes.KEY_4, 1),
+            (evdev.ecodes.KEY_4, 0),
+            (evdev.ecodes.KEY_LEFTCTRL, 0),
+            (evdev.ecodes.KEY_LEFTSHIFT, 0),
+        ]
+    )
+
+
+def _expect_combo_overload_full_cycle(ctx: ScenarioContext) -> None:
+    ctx.expect_keys(
+        [
+            (evdev.ecodes.KEY_LEFTCTRL, 1),
+            (evdev.ecodes.KEY_LEFTSHIFT, 1),
+            (evdev.ecodes.KEY_1, 1),
+            (evdev.ecodes.KEY_1, 0),
+            (evdev.ecodes.KEY_2, 1),
+            (evdev.ecodes.KEY_2, 0),
+            (evdev.ecodes.KEY_3, 1),
+            (evdev.ecodes.KEY_3, 0),
+            (evdev.ecodes.KEY_4, 1),
+            (evdev.ecodes.KEY_4, 0),
+            (evdev.ecodes.KEY_LEFTSHIFT, 0),
+            (evdev.ecodes.KEY_LEFTCTRL, 0),
+        ]
+    )
+
+
+def _trigger_primary_combo(ctx: ScenarioContext, first_code: int, second_code: int) -> None:
+    ctx.source_key(first_code, 1)
+    ctx.source_key(second_code, 1)
+    time.sleep(0.08)
+    ctx.source_key(second_code, 0)
+    ctx.source_key(first_code, 0)
+
+
+def _trigger_repeat_combo(ctx: ScenarioContext) -> None:
+    ctx.secondary_key(evdev.ecodes.KEY_F13, 1)
+    ctx.secondary_key(evdev.ecodes.KEY_F14, 1)
+    time.sleep(0.08)
+    ctx.secondary_key(evdev.ecodes.KEY_F14, 0)
+    ctx.secondary_key(evdev.ecodes.KEY_F13, 0)

--- a/nix/daemon-session-integration-test/scenarios/repeat_direct_actions.py
+++ b/nix/daemon-session-integration-test/scenarios/repeat_direct_actions.py
@@ -1,0 +1,128 @@
+import evdev
+from support import REPEAT_PROFILE_NAME, SECOND_PROFILE_NAME, ScenarioContext
+
+
+def run(ctx: ScenarioContext) -> None:
+    try:
+        ctx.set_profile_enabled(REPEAT_PROFILE_NAME, enabled=True)
+        ctx.subtest("repeat has no output before history", lambda: _repeat_without_history(ctx))
+        ctx.subtest(
+            "repeat follows keyboard press/repeat/release",
+            lambda: _keyboard_lifecycle(ctx),
+        )
+        ctx.subtest(
+            "repeat category filters select matching remembered actions",
+            lambda: _category_filters(ctx),
+        )
+        ctx.subtest(
+            "repeat ignores suppress and profile actions",
+            lambda: _ignored_actions_do_not_replace_history(ctx),
+        )
+    finally:
+        ctx.set_profile_enabled(SECOND_PROFILE_NAME, enabled=False)
+        ctx.set_profile_enabled(REPEAT_PROFILE_NAME, enabled=False)
+
+
+def _repeat_without_history(ctx: ScenarioContext) -> None:
+    ctx.tap_source(evdev.ecodes.KEY_F13)
+    ctx.expect_no_keyboard_events()
+    ctx.expect_no_mouse_events()
+    ctx.expect_no_gamepad_events()
+
+
+def _keyboard_lifecycle(ctx: ScenarioContext) -> None:
+    ctx.tap_source(evdev.ecodes.KEY_F19)
+    ctx.expect_keys([(evdev.ecodes.KEY_A, 1), (evdev.ecodes.KEY_A, 0)])
+
+    ctx.source_key(evdev.ecodes.KEY_F13, 1)
+    ctx.source_key(evdev.ecodes.KEY_F13, 2)
+    ctx.source_key(evdev.ecodes.KEY_F13, 0)
+    ctx.expect_keys(
+        [
+            (evdev.ecodes.KEY_A, 1),
+            (evdev.ecodes.KEY_A, 2),
+            (evdev.ecodes.KEY_A, 0),
+        ]
+    )
+
+    ctx.tap_source(evdev.ecodes.KEY_F13)
+    ctx.expect_keys([(evdev.ecodes.KEY_A, 1), (evdev.ecodes.KEY_A, 0)])
+
+
+def _category_filters(ctx: ScenarioContext) -> None:
+    ctx.tap_source(evdev.ecodes.KEY_F19)
+    ctx.expect_keys([(evdev.ecodes.KEY_A, 1), (evdev.ecodes.KEY_A, 0)])
+
+    ctx.tap_source(evdev.ecodes.KEY_F20)
+    ctx.expect_mouse_events(
+        [
+            (evdev.ecodes.EV_KEY, evdev.ecodes.BTN_MIDDLE, 1),
+            (evdev.ecodes.EV_KEY, evdev.ecodes.BTN_MIDDLE, 0),
+        ]
+    )
+
+    ctx.tap_source(evdev.ecodes.KEY_F21)
+    ctx.expect_gamepad_events(
+        [
+            (evdev.ecodes.EV_KEY, evdev.ecodes.BTN_NORTH, 1),
+            (evdev.ecodes.EV_KEY, evdev.ecodes.BTN_NORTH, 0),
+        ]
+    )
+
+    ctx.tap_source(evdev.ecodes.KEY_F22)
+    ctx.expect_keys([(evdev.ecodes.KEY_Y, 1), (evdev.ecodes.KEY_Y, 0)])
+
+    ctx.tap_source(evdev.ecodes.KEY_F23)
+    ctx.expect_mouse_events(
+        [
+            (evdev.ecodes.EV_REL, evdev.ecodes.REL_X, 9),
+            (evdev.ecodes.EV_REL, evdev.ecodes.REL_Y, -4),
+        ]
+    )
+
+    ctx.tap_source(evdev.ecodes.KEY_F14)
+    ctx.expect_keys([(evdev.ecodes.KEY_A, 1), (evdev.ecodes.KEY_A, 0)])
+
+    ctx.tap_source(evdev.ecodes.KEY_F15)
+    ctx.expect_mouse_events(
+        [
+            (evdev.ecodes.EV_KEY, evdev.ecodes.BTN_MIDDLE, 1),
+            (evdev.ecodes.EV_KEY, evdev.ecodes.BTN_MIDDLE, 0),
+        ]
+    )
+
+    ctx.tap_source(evdev.ecodes.KEY_F16)
+    ctx.expect_gamepad_events(
+        [
+            (evdev.ecodes.EV_KEY, evdev.ecodes.BTN_NORTH, 1),
+            (evdev.ecodes.EV_KEY, evdev.ecodes.BTN_NORTH, 0),
+        ]
+    )
+
+    ctx.tap_source(evdev.ecodes.KEY_F17)
+    ctx.expect_keys([(evdev.ecodes.KEY_Y, 1), (evdev.ecodes.KEY_Y, 0)])
+
+    ctx.tap_source(evdev.ecodes.KEY_F18)
+    ctx.expect_mouse_events(
+        [
+            (evdev.ecodes.EV_REL, evdev.ecodes.REL_X, 9),
+            (evdev.ecodes.EV_REL, evdev.ecodes.REL_Y, -4),
+        ]
+    )
+
+
+def _ignored_actions_do_not_replace_history(ctx: ScenarioContext) -> None:
+    ctx.tap_source(evdev.ecodes.KEY_F19)
+    ctx.expect_keys([(evdev.ecodes.KEY_A, 1), (evdev.ecodes.KEY_A, 0)])
+
+    ctx.tap_source(evdev.ecodes.KEY_L)
+    ctx.expect_no_keyboard_events()
+
+    ctx.tap_source(evdev.ecodes.KEY_F13)
+    ctx.expect_keys([(evdev.ecodes.KEY_A, 1), (evdev.ecodes.KEY_A, 0)])
+
+    ctx.tap_source(evdev.ecodes.KEY_N)
+    ctx.wait_for_active_profile(SECOND_PROFILE_NAME, enabled=True)
+
+    ctx.tap_source(evdev.ecodes.KEY_F13)
+    ctx.expect_keys([(evdev.ecodes.KEY_A, 1), (evdev.ecodes.KEY_A, 0)])

--- a/nix/daemon-session-integration-test/scenarios/repeat_passthrough.py
+++ b/nix/daemon-session-integration-test/scenarios/repeat_passthrough.py
@@ -1,0 +1,24 @@
+import evdev
+from support import HARDWARE_ID, REPEAT_PROFILE_NAME, ScenarioContext
+
+
+def run(ctx: ScenarioContext) -> None:
+    passthrough = ctx.open_passthrough_output(HARDWARE_ID)
+    try:
+        ctx.set_profile_enabled(REPEAT_PROFILE_NAME, enabled=True)
+
+        ctx.tap_source(evdev.ecodes.KEY_SPACE)
+        ctx.expect_events(
+            passthrough,
+            [
+                (evdev.ecodes.EV_KEY, evdev.ecodes.KEY_SPACE, 1),
+                (evdev.ecodes.EV_KEY, evdev.ecodes.KEY_SPACE, 0),
+            ],
+            label="primary passthrough",
+        )
+
+        ctx.tap_source(evdev.ecodes.KEY_F13)
+        ctx.expect_keys([(evdev.ecodes.KEY_SPACE, 1), (evdev.ecodes.KEY_SPACE, 0)])
+    finally:
+        passthrough.close()
+        ctx.set_profile_enabled(REPEAT_PROFILE_NAME, enabled=False)

--- a/nix/daemon-session-integration-test/support.py
+++ b/nix/daemon-session-integration-test/support.py
@@ -24,6 +24,7 @@ SECOND_PROFILE_NAME = "Integration Priority Override"
 LOWER_PROFILE_NAME = "Integration Lower Fallback"
 PASSTHROUGH_PROFILE_NAME = "Integration Passthrough Override"
 TEMP_PROFILE_NAME = "Integration Temporary Layer"
+REPEAT_PROFILE_NAME = "Integration Repeat"
 MACRO_NAME = "integration-macro"
 LONG_MACRO_NAME = "integration-hold-macro"
 SUPERKEY_NAME = "integration-tap-superkey"
@@ -77,6 +78,7 @@ class ScenarioContext:
                 "Integration Analog Signed Axis Threshold",
                 "Integration Analog Signed Axis Mouse",
                 "Integration Analog Gamepad",
+                REPEAT_PROFILE_NAME,
             ):
                 self.request({"command": "disable_profile", "profile_name": profile_name}, ok=False)
             self.request(
@@ -167,10 +169,8 @@ class ScenarioContext:
         source_keys = [
             getattr(evdev.ecodes, f"KEY_{letter}") for letter in "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
         ]
-        if product == 0x0001:
-            source_keys.extend(
-                getattr(evdev.ecodes, f"KEY_F{index}") for index in range(1, 13)
-            )
+        source_keys.append(evdev.ecodes.KEY_SPACE)
+        source_keys.extend(getattr(evdev.ecodes, f"KEY_F{index}") for index in range(1, 25))
         device = evdev.UInput(
             events={
                 evdev.ecodes.EV_KEY: source_keys,
@@ -252,6 +252,11 @@ class ScenarioContext:
             "profiles/temporary-layer.toml",
             values,
         )
+        self.write_fixture(
+            profiles_dir / "integration-repeat.toml",
+            "profiles/repeat.toml",
+            values,
+        )
         for fixture_name in (
             "analog-stick-gamepad.toml",
             "analog-trigger-deadzone.toml",
@@ -302,21 +307,22 @@ class ScenarioContext:
         primary_source_path: str,
         secondary_source_path: str,
     ) -> dict[str, str]:
-        primary_buttons = list("abcdefghijklmnopqrstuvwxyz") + [
-            f"f{index}" for index in range(1, 13)
+        primary_buttons = list("abcdefghijklmnopqrstuvwxyz") + ["space"] + [
+            f"f{index}" for index in range(1, 25)
         ]
+        secondary_buttons = list("abcdefghijklmnopqrstuvwxyz") + ["f13", "f14"]
         return {
             "HARDWARE_ID": HARDWARE_ID,
             "SECOND_HARDWARE_ID": SECOND_HARDWARE_ID,
             "PRIMARY_SOURCE_PATH": primary_source_path,
             "SECONDARY_SOURCE_PATH": secondary_source_path,
             "PRIMARY_BUTTONS": self.button_blocks(primary_buttons),
-            "SECONDARY_BUTTONS": self.button_blocks("abcdefghijklmnopqrstuvwxyz"),
             "PROFILE_NAME": PROFILE_NAME,
             "SECOND_PROFILE_NAME": SECOND_PROFILE_NAME,
             "LOWER_PROFILE_NAME": LOWER_PROFILE_NAME,
             "PASSTHROUGH_PROFILE_NAME": PASSTHROUGH_PROFILE_NAME,
             "TEMP_PROFILE_NAME": TEMP_PROFILE_NAME,
+            "REPEAT_PROFILE_NAME": REPEAT_PROFILE_NAME,
             "MACRO_NAME": MACRO_NAME,
             "LONG_MACRO_NAME": LONG_MACRO_NAME,
             "SUPERKEY_NAME": SUPERKEY_NAME,
@@ -328,6 +334,7 @@ class ScenarioContext:
             "PROFILE_LIFETIME_OVERLOAD_SUPERKEY_NAME": (
                 PROFILE_LIFETIME_OVERLOAD_SUPERKEY_NAME
             ),
+            "SECONDARY_BUTTONS": self.button_blocks(secondary_buttons),
         }
 
     def button_blocks(self, keys: list[str] | str) -> str:

--- a/tests/common/test_mapping_and_profile_state.py
+++ b/tests/common/test_mapping_and_profile_state.py
@@ -75,6 +75,73 @@ class TestMappingAction:
         assert roundtrip.axis_value == 12345
         assert roundtrip.output_id == "virtual-gamepad-2"
 
+    def test_repeat_action_normalizes_categories_and_supports_rapidfire(
+        self,
+        caplog: pytest.LogCaptureFixture,
+    ):
+        action = MappingAction(
+            action_type=ActionType.REPEAT,
+            repeat_categories=[
+                "keyboard",
+                "invalid",
+                "mouse_button",
+                "mouse_wheel",
+                "mouse",
+                "keyboard",
+            ],
+            rapidfire_enabled=True,
+            rapidfire_hold_ms=-1,
+            rapidfire_wait_ms=0,
+        )
+        default_action = MappingAction(action_type=ActionType.REPEAT)
+        with caplog.at_level("WARNING", logger="keymasq.common.models"):
+            invalid_action = MappingAction(
+                action_type=ActionType.REPEAT,
+                repeat_categories=["invalid"],
+            )
+        empty_action = MappingAction(
+            action_type=ActionType.REPEAT,
+            repeat_categories=[],
+        )
+        malformed_action = MappingAction(
+            action_type=ActionType.REPEAT,
+            repeat_categories=42,  # pyright: ignore[reportArgumentType]
+        )
+        unrelated = MappingAction(
+            action_type=ActionType.KEYBOARD,
+            target="key_a",
+            repeat_categories=["keyboard"],
+        )
+
+        assert action.repeat_categories == ["keyboard", "mouse"]
+        assert action.rapidfire_enabled is True
+        assert action.rapidfire_hold_ms == 0
+        assert action.rapidfire_wait_ms == 1
+        assert default_action.repeat_categories == [
+            "keyboard",
+            "mouse",
+            "gamepad",
+            "macro",
+            "special",
+        ]
+        assert invalid_action.repeat_categories == [
+            "keyboard",
+            "mouse",
+            "gamepad",
+            "macro",
+            "special",
+        ]
+        assert "Invalid repeat_categories" in caplog.text
+        assert empty_action.repeat_categories == []
+        assert malformed_action.repeat_categories == [
+            "keyboard",
+            "mouse",
+            "gamepad",
+            "macro",
+            "special",
+        ]
+        assert unrelated.repeat_categories is None
+
 
 class TestProfileState:
     def test_disabled_state(self):

--- a/tests/gui/test_gui_demo_and_dialogs.py
+++ b/tests/gui/test_gui_demo_and_dialogs.py
@@ -1013,9 +1013,59 @@ class TestDialogConstruction:
             "allow_clear_mapping": False,
             "allow_suppress": False,
             "allow_superkey": False,
+            "allow_repeat": False,
             "allow_rapidfire": True,
             "allow_tap": False,
             "allow_macro_options": True,
+        }
+
+    def test_overload_superkey_actions_disable_repeat_selector(self, monkeypatch):
+        gi.require_version("Gtk", "4.0")
+        from gi.repository import Gtk
+
+        from keymasq.common.models import ActionType, MappingAction
+        import keymasq.gui.widgets.key_selector_dialog as key_selector_dialog_module
+        from keymasq.gui.widgets.superkey_dialog import ActionListDialog
+
+        captured: dict[str, object] = {}
+        parent = Gtk.Window()
+
+        class DummyDialog:
+            def __init__(self, _parent, _label, current_action=None, **kwargs):
+                captured["parent"] = _parent
+                captured["current_action"] = current_action
+                captured["kwargs"] = kwargs
+
+            def connect(self, signal_name, callback, index):
+                captured["signal_name"] = signal_name
+                captured["callback"] = callback
+                captured["index"] = index
+
+            def present(self, parent):
+                captured["presented"] = True
+                captured["present_parent"] = parent
+
+        monkeypatch.setattr(key_selector_dialog_module, "KeySelectorDialog", DummyDialog)
+
+        dialog = ActionListDialog(parent, "Overload Actions", "overload")
+        dialog._open_child_editor(
+            MappingAction(action_type=ActionType.KEYBOARD, target="key_a"),
+            1,
+        )
+
+        assert captured["signal_name"] == "key-selected"
+        assert captured["presented"] is True
+        assert captured["parent"] is parent
+        assert captured["present_parent"] is parent
+        current_action = captured["current_action"]
+        assert isinstance(current_action, MappingAction)
+        assert current_action.action_type == ActionType.KEYBOARD
+        assert captured["kwargs"] == {
+            "allow_passthrough": False,
+            "allow_clear_mapping": False,
+            "allow_suppress": False,
+            "allow_superkey": False,
+            "allow_repeat": False,
         }
 
     def test_overload_pulse_action_editors_describe_down_and_up_timing(self, temp_config_dir):

--- a/tests/gui/test_gui_device_tab_misc.py
+++ b/tests/gui/test_gui_device_tab_misc.py
@@ -1059,6 +1059,106 @@ def test_analog_key_selector_opens_controls_first_and_special_has_no_passthrough
     assert "Passthrough" not in button_labels
 
 
+def test_key_selector_dialog_repeat_uses_special_toggle_buttons_and_inline_rapidfire():
+    from gi.repository import Gtk
+
+    from keymasq.common.models import (
+        REPEAT_CATEGORY_MOUSE,
+        REPEAT_CATEGORY_SPECIAL,
+        ActionType,
+        MappingAction,
+    )
+    from keymasq.gui.widgets.key_selector_dialog import KeySelectorDialog
+
+    def collect_buttons(widget):
+        buttons = []
+        child = widget.get_first_child()
+        while child is not None:
+            if isinstance(child, Gtk.Button):
+                buttons.append(child)
+            buttons.extend(collect_buttons(child))
+            child = child.get_next_sibling()
+        return buttons
+
+    results: list[MappingAction] = []
+    dialog = KeySelectorDialog(Gtk.Box(), "Back")
+    dialog.connect("key-selected", lambda _dialog, action: results.append(action))
+
+    dialog.stack.set_visible_child_name("special")
+    # Repeat carries its own rapidfire controls, so the shared footer stays hidden.
+    assert dialog.options_box.get_visible() is False
+    assert "keyboard keys, mouse buttons, mouse wheel actions" in (
+        dialog.repeat_rapidfire_check.get_tooltip_text() or ""
+    )
+
+    special_tab = dialog._build_special_tab()
+    buttons_by_label = {button.get_label(): button for button in collect_buttons(special_tab)}
+    assert "Repeat Last Action" in buttons_by_label
+    assert "Map Repeat" in buttons_by_label
+    assert dialog._repeat_options_box is not None
+    assert dialog._repeat_options_box.get_visible() is False
+    assert dialog._repeat_button is not None
+    assert dialog._repeat_button.get_active() is False
+
+    dialog._repeat_button.emit("clicked")
+    assert dialog._repeat_options_box.get_visible() is True
+    assert dialog._repeat_button.get_active() is True
+
+    dialog._repeat_button.emit("clicked")
+    assert dialog._repeat_options_box.get_visible() is False
+    assert dialog._repeat_button.get_active() is False
+
+    dialog._repeat_button.emit("clicked")
+    assert dialog._repeat_options_box.get_visible() is True
+
+    toggles = dialog._repeat_toggle_buttons
+    toggle_labels = {toggle.get_label() for toggle in toggles.values()}
+    assert toggle_labels == {"Keys", "Mouse", "Gamepad", "Macros", "Other"}
+    assert all(toggle.get_hexpand() for toggle in toggles.values())
+
+    mouse_toggle = toggles[REPEAT_CATEGORY_MOUSE]
+    other_toggle = toggles[REPEAT_CATEGORY_SPECIAL]
+    assert isinstance(mouse_toggle, Gtk.ToggleButton)
+    assert isinstance(other_toggle, Gtk.ToggleButton)
+    assert "Keymasq special actions" in (other_toggle.get_tooltip_text() or "")
+
+    dialog.repeat_rapidfire_check.set_active(True)
+    dialog.repeat_hold_spin.set_value(35)
+    dialog.repeat_wait_spin.set_value(45)
+    other_toggle.set_active(False)
+    buttons_by_label["Map Repeat"].emit("clicked")
+
+    assert len(results) == 1
+    action = results[0]
+    assert action.action_type == ActionType.REPEAT
+    assert "mouse" in (action.repeat_categories or [])
+    assert "mouse_move" not in (action.repeat_categories or [])
+    assert "special" not in (action.repeat_categories or [])
+    assert action.rapidfire_enabled is True
+    assert action.rapidfire_hold_ms == 35
+    assert action.rapidfire_wait_ms == 45
+
+
+def test_key_selector_dialog_repeat_preserves_empty_categories():
+    from gi.repository import Gtk
+
+    from keymasq.common.models import ActionType, MappingAction
+    from keymasq.gui.widgets.key_selector_dialog import KeySelectorDialog
+
+    dialog = KeySelectorDialog(
+        Gtk.Box(),
+        "Back",
+        MappingAction(action_type=ActionType.REPEAT, repeat_categories=[]),
+    )
+
+    assert dialog.stack.get_visible_child_name() == "special"
+    assert dialog._repeat_button is not None
+    assert dialog._repeat_button.get_active() is True
+    assert dialog._repeat_map_btn is not None
+    assert dialog._repeat_map_btn.get_sensitive() is False
+    assert all(not toggle.get_active() for toggle in dialog._repeat_toggle_buttons.values())
+
+
 def test_key_selector_dialog_uses_dedicated_superkey_tab(temp_config_dir, monkeypatch):
     from gi.repository import Gtk
 

--- a/tests/gui/test_profile_dialogs_and_actions.py
+++ b/tests/gui/test_profile_dialogs_and_actions.py
@@ -84,3 +84,4 @@ class TestProfileActions:
         assert ActionType.EXEC.value == "exec"
         assert ActionType.COMPOSITOR_DISPATCH.value == "compositor_dispatch"
         assert ActionType.SUPPRESS.value == "suppress"
+        assert ActionType.REPEAT.value == "repeat"

--- a/tests/keymasqd/test_analog_controls_runtime.py
+++ b/tests/keymasqd/test_analog_controls_runtime.py
@@ -182,9 +182,7 @@ async def test_threshold_profile_trigger_end_lifetime_follows_threshold_lifecycl
                             MappingAction(
                                 action_type=ActionType.PROFILE_ENABLE,
                                 profile_name="Nav",
-                                profile_deactivation=ProfileDeactivationPolicy(
-                                    on_trigger_end=True
-                                ),
+                                profile_deactivation=ProfileDeactivationPolicy(on_trigger_end=True),
                             )
                         ],
                     )
@@ -194,9 +192,7 @@ async def test_threshold_profile_trigger_end_lifetime_follows_threshold_lifecycl
     }
     runtime = _runtime(mapping, keyboard)
     runtime.broadcast_callback = broadcast
-    runtime.profile_activation_trigger_start_observer = (
-        manager.observe_profile_trigger_start
-    )
+    runtime.profile_activation_trigger_start_observer = manager.observe_profile_trigger_start
     runtime.profile_activation_trigger_end_observer = manager.observe_profile_trigger_end
 
     assert await process_analog_event(runtime, FakeEvent(32767), "abs_x", mapping, deps=_deps())
@@ -214,9 +210,7 @@ async def test_threshold_profile_trigger_end_lifetime_follows_threshold_lifecycl
             },
         }
     ]
-    assert [
-        event for event in events if event[0] == CommandType.PROFILE_DEACTIVATE_REQUESTED
-    ] == []
+    assert [event for event in events if event[0] == CommandType.PROFILE_DEACTIVATE_REQUESTED] == []
 
     assert await process_analog_event(runtime, FakeEvent(0), "abs_x", mapping, deps=_deps())
     await asyncio.wait_for(deactivate_event.wait(), timeout=1.0)
@@ -486,9 +480,7 @@ async def test_axis_mouse_motion_uses_direction_and_response_curve() -> None:
 
     mouse_events = runtime.mouse_uinput.events
     assert any(
-        event_type == evdev.ecodes.EV_REL
-        and code == evdev.ecodes.REL_Y
-        and value < 0
+        event_type == evdev.ecodes.EV_REL and code == evdev.ecodes.REL_Y and value < 0
         for event_type, code, value in mouse_events
     )
     assert not any(code == evdev.ecodes.REL_X for _event_type, code, _value in mouse_events)
@@ -687,9 +679,7 @@ async def test_stick_mouse_area_can_jump_to_start_on_activation() -> None:
     assert await process_analog_event(runtime, FakeEvent(32767), "abs_x", mapping, deps=_deps())
 
     assert starts == [(300, 400)]
-    assert runtime.mouse_uinput.events == [
-        (evdev.ecodes.EV_REL, evdev.ecodes.REL_X, 100)
-    ]
+    assert runtime.mouse_uinput.events == [(evdev.ecodes.EV_REL, evdev.ecodes.REL_X, 100)]
 
 
 @pytest.mark.asyncio
@@ -1016,9 +1006,7 @@ async def test_axis_gamepad_output_both_directions_routes_signed_range() -> None
         )
     }
     runtime = _runtime(mapping, keyboard)
-    runtime.analog_axis_bindings = {
-        (evdev.ecodes.EV_ABS, evdev.ecodes.ABS_X): ("wheel_axis", "x")
-    }
+    runtime.analog_axis_bindings = {(evdev.ecodes.EV_ABS, evdev.ecodes.ABS_X): ("wheel_axis", "x")}
     runtime.analog_axis_ranges = {("wheel_axis", "x"): (-32768, 32767)}
     runtime.resolve_gamepad_output = lambda _output_id, _context: SimpleNamespace(  # noqa: E731
         uinput=gamepad,
@@ -1144,9 +1132,7 @@ async def test_trigger_gamepad_output_same_uses_learned_logical_trigger_label() 
     }
     runtime = _runtime(mapping, keyboard)
     runtime.analog_inputs = {"axis_1": {"label": "Left Trigger", "type": "axis"}}
-    runtime.analog_axis_bindings = {
-        (evdev.ecodes.EV_ABS, evdev.ecodes.ABS_GAS): ("axis_1", "x")
-    }
+    runtime.analog_axis_bindings = {(evdev.ecodes.EV_ABS, evdev.ecodes.ABS_GAS): ("axis_1", "x")}
     runtime.analog_axis_output_codes = {("axis_1", "x"): evdev.ecodes.ABS_GAS}
     runtime.analog_axis_ranges = {("axis_1", "x"): (0, 255)}
     runtime.resolve_gamepad_output = lambda _output_id, _context: SimpleNamespace(  # noqa: E731
@@ -1177,9 +1163,7 @@ async def test_trigger_gamepad_output_same_uses_standard_source_axis_code() -> N
     }
     runtime = _runtime(mapping, keyboard)
     runtime.analog_inputs = {"axis_1": {"label": "Axis 1", "type": "axis"}}
-    runtime.analog_axis_bindings = {
-        (evdev.ecodes.EV_ABS, evdev.ecodes.ABS_RZ): ("axis_1", "x")
-    }
+    runtime.analog_axis_bindings = {(evdev.ecodes.EV_ABS, evdev.ecodes.ABS_RZ): ("axis_1", "x")}
     runtime.analog_axis_output_codes = {("axis_1", "x"): evdev.ecodes.ABS_RZ}
     runtime.analog_axis_ranges = {("axis_1", "x"): (0, 255)}
     runtime.resolve_gamepad_output = lambda _output_id, _context: SimpleNamespace(  # noqa: E731
@@ -1210,9 +1194,7 @@ async def test_generic_axis_gamepad_output_same_uses_learned_axis_code() -> None
     }
     runtime = _runtime(mapping, keyboard)
     runtime.analog_inputs = {"axis_1": {"label": "Axis 1", "type": "axis"}}
-    runtime.analog_axis_bindings = {
-        (evdev.ecodes.EV_ABS, evdev.ecodes.ABS_GAS): ("axis_1", "x")
-    }
+    runtime.analog_axis_bindings = {(evdev.ecodes.EV_ABS, evdev.ecodes.ABS_GAS): ("axis_1", "x")}
     runtime.analog_axis_output_codes = {("axis_1", "x"): evdev.ecodes.ABS_GAS}
     runtime.analog_axis_ranges = {("axis_1", "x"): (0, 255)}
     runtime.resolve_gamepad_output = lambda _output_id, _context: SimpleNamespace(  # noqa: E731
@@ -1702,9 +1684,7 @@ async def test_reset_analog_controls_releases_threshold_after_mapping_removed() 
                         trigger_max=1.0,
                         release_min=0.55,
                         release_max=1.0,
-                        actions=[
-                            MappingAction(action_type=ActionType.KEYBOARD, target="key_a")
-                        ],
+                        actions=[MappingAction(action_type=ActionType.KEYBOARD, target="key_a")],
                     )
                 ],
             ),

--- a/tests/keymasqd/test_combo_action_dispatch.py
+++ b/tests/keymasqd/test_combo_action_dispatch.py
@@ -1,6 +1,7 @@
 # ruff: noqa: F403, F405, I001
 from tests.keymasqd.device_manager_support import *
 
+
 class TestComboActionDispatch:
     @pytest.mark.asyncio
     async def test_profile_activation_trigger_end_follows_combo_lifecycle(self) -> None:
@@ -75,6 +76,187 @@ class TestComboActionDispatch:
         ]
 
     @pytest.mark.asyncio
+    async def test_combo_repeat_replays_last_combo_action_and_releases_child(self) -> None:
+        manager = DeviceManager()
+        manager.output_state.keyboard_uinput = _FakeUInput()
+        binding = dm.RuntimeComboBinding(hardware_id="1234:5678", source="kbd", evdev="key_f13")
+
+        await _runtime_start_combo_action(
+            manager,
+            "source",
+            dm.MappingAction(action_type=ActionType.KEYBOARD, target="key_a"),
+            binding,
+        )
+        await _runtime_stop_combo_action(manager, "source")
+        await _runtime_start_combo_action(
+            manager,
+            "repeat",
+            dm.MappingAction(action_type=ActionType.REPEAT),
+            binding,
+        )
+
+        assert manager.output_state.keyboard_uinput.writes == [
+            (evdev.ecodes.EV_KEY, evdev.ecodes.KEY_A, 1),
+            (evdev.ecodes.EV_KEY, evdev.ecodes.KEY_A, 0),
+            (evdev.ecodes.EV_KEY, evdev.ecodes.KEY_A, 1),
+        ]
+        assert "repeat" in manager.combo_state.active_actions
+        state = manager.combo_state.active_actions["repeat"]
+        assert state.action_runtime is not None
+        assert "combo:repeat#repeat" in state.action_runtime.state.repeat_active_actions
+
+        await _runtime_stop_combo_action(manager, "repeat")
+        await _runtime_start_combo_action(
+            manager,
+            "repeat-again",
+            dm.MappingAction(action_type=ActionType.REPEAT),
+            binding,
+        )
+        await _runtime_stop_combo_action(manager, "repeat-again")
+
+        assert manager.output_state.keyboard_uinput.writes == [
+            (evdev.ecodes.EV_KEY, evdev.ecodes.KEY_A, 1),
+            (evdev.ecodes.EV_KEY, evdev.ecodes.KEY_A, 0),
+            (evdev.ecodes.EV_KEY, evdev.ecodes.KEY_A, 1),
+            (evdev.ecodes.EV_KEY, evdev.ecodes.KEY_A, 0),
+            (evdev.ecodes.EV_KEY, evdev.ecodes.KEY_A, 1),
+            (evdev.ecodes.EV_KEY, evdev.ecodes.KEY_A, 0),
+        ]
+        assert len(manager.repeat_state.history) == 3
+
+    @pytest.mark.asyncio
+    async def test_combo_repeat_skips_profile_actions(self) -> None:
+        action_triggers: list[dict[str, object]] = []
+
+        async def broadcast(event_type: CommandType, data: dict[str, object]) -> None:
+            if event_type == CommandType.ACTION_TRIGGER:
+                action_triggers.append(data)
+
+        manager = DeviceManager(broadcast_callback=broadcast)
+        binding = dm.RuntimeComboBinding(hardware_id="1234:5678", source="kbd", evdev="key_f13")
+        profile_action = dm.MappingAction(
+            action_type=ActionType.PROFILE_ENABLE,
+            profile_name="Nav",
+            profile_deactivation=ProfileDeactivationPolicy(on_trigger_end=True),
+        )
+
+        await _runtime_start_combo_action(manager, "source-profile", profile_action, binding)
+        await asyncio.sleep(0)
+        await _runtime_stop_combo_action(manager, "source-profile")
+
+        assert len(action_triggers) == 1
+        assert list(manager.repeat_state.history) == []
+
+        await _runtime_start_combo_action(
+            manager,
+            "repeat-profile",
+            dm.MappingAction(action_type=ActionType.REPEAT),
+            binding,
+        )
+        await asyncio.sleep(0)
+
+        assert len(action_triggers) == 1
+        assert "repeat-profile" not in manager.combo_state.active_actions
+
+    @pytest.mark.asyncio
+    async def test_combo_repeat_replays_overload_superkey_path(self) -> None:
+        from keymasq.keymasqd.runtime.repeat import SUPERKEY_SLOT_OVERLOAD
+
+        manager = DeviceManager()
+        manager.output_state.keyboard_uinput = _FakeUInput()
+        binding = dm.RuntimeComboBinding(hardware_id="1234:5678", source="kbd", evdev="key_f13")
+        action = dm.MappingAction(
+            action_type=ActionType.SUPERKEY,
+            superkey_config=SuperkeyConfig(
+                name="combo-overload-repeat",
+                mode=SuperkeyMode.OVERLOAD,
+                overload_actions=[
+                    dm.MappingAction(action_type=ActionType.KEYBOARD, target="key_a"),
+                    dm.MappingAction(action_type=ActionType.KEYBOARD, target="key_b"),
+                ],
+            ),
+        )
+
+        await _runtime_start_combo_action(manager, "source", action, binding)
+        await _runtime_stop_combo_action(manager, "source")
+
+        latest = manager.repeat_state.history[-1]
+        assert latest.action.action_type == ActionType.SUPERKEY
+        assert latest.action.superkey_config is action.superkey_config
+        assert latest.superkey_slot == SUPERKEY_SLOT_OVERLOAD
+
+        await _runtime_start_combo_action(
+            manager,
+            "repeat",
+            dm.MappingAction(action_type=ActionType.REPEAT),
+            binding,
+        )
+        assert "repeat" not in manager.combo_state.active_actions
+        assert "repeat#repeat" not in manager.combo_state.active_actions
+
+        assert manager.output_state.keyboard_uinput.writes == [
+            (evdev.ecodes.EV_KEY, evdev.ecodes.KEY_A, 1),
+            (evdev.ecodes.EV_KEY, evdev.ecodes.KEY_B, 1),
+            (evdev.ecodes.EV_KEY, evdev.ecodes.KEY_B, 0),
+            (evdev.ecodes.EV_KEY, evdev.ecodes.KEY_A, 0),
+            (evdev.ecodes.EV_KEY, evdev.ecodes.KEY_A, 1),
+            (evdev.ecodes.EV_KEY, evdev.ecodes.KEY_B, 1),
+            (evdev.ecodes.EV_KEY, evdev.ecodes.KEY_B, 0),
+            (evdev.ecodes.EV_KEY, evdev.ecodes.KEY_A, 0),
+        ]
+        assert manager.repeat_state.history[-1].superkey_slot == SUPERKEY_SLOT_OVERLOAD
+
+    @pytest.mark.asyncio
+    async def test_combo_repeat_replays_split_overload_superkey_path(self) -> None:
+        from keymasq.keymasqd.runtime.repeat import SUPERKEY_SLOT_OVERLOAD
+
+        manager = DeviceManager()
+        manager.output_state.keyboard_uinput = _FakeUInput()
+        binding = dm.RuntimeComboBinding(hardware_id="1234:5678", source="kbd", evdev="key_f13")
+        action = dm.MappingAction(
+            action_type=ActionType.SUPERKEY,
+            superkey_config=SuperkeyConfig(
+                name="combo-split-overload-repeat",
+                mode=SuperkeyMode.OVERLOAD,
+                overload_actions=[
+                    dm.MappingAction(action_type=ActionType.KEYBOARD, target="key_leftctrl"),
+                ],
+                overload_down_actions=[
+                    dm.MappingAction(action_type=ActionType.KEYBOARD, target="key_a"),
+                ],
+                overload_up_actions=[
+                    dm.MappingAction(action_type=ActionType.KEYBOARD, target="key_b"),
+                ],
+            ),
+        )
+
+        await _runtime_start_combo_action(manager, "source", action, binding)
+        await _runtime_stop_combo_action(manager, "source")
+        await _runtime_start_combo_action(
+            manager,
+            "repeat",
+            dm.MappingAction(action_type=ActionType.REPEAT),
+            binding,
+        )
+
+        assert manager.output_state.keyboard_uinput.writes == [
+            (evdev.ecodes.EV_KEY, evdev.ecodes.KEY_LEFTCTRL, 1),
+            (evdev.ecodes.EV_KEY, evdev.ecodes.KEY_A, 1),
+            (evdev.ecodes.EV_KEY, evdev.ecodes.KEY_A, 0),
+            (evdev.ecodes.EV_KEY, evdev.ecodes.KEY_B, 1),
+            (evdev.ecodes.EV_KEY, evdev.ecodes.KEY_B, 0),
+            (evdev.ecodes.EV_KEY, evdev.ecodes.KEY_LEFTCTRL, 0),
+            (evdev.ecodes.EV_KEY, evdev.ecodes.KEY_LEFTCTRL, 1),
+            (evdev.ecodes.EV_KEY, evdev.ecodes.KEY_A, 1),
+            (evdev.ecodes.EV_KEY, evdev.ecodes.KEY_A, 0),
+            (evdev.ecodes.EV_KEY, evdev.ecodes.KEY_B, 1),
+            (evdev.ecodes.EV_KEY, evdev.ecodes.KEY_B, 0),
+            (evdev.ecodes.EV_KEY, evdev.ecodes.KEY_LEFTCTRL, 0),
+        ]
+        assert "repeat" not in manager.combo_state.active_actions
+        assert manager.repeat_state.history[-1].superkey_slot == SUPERKEY_SLOT_OVERLOAD
+
+    @pytest.mark.asyncio
     async def test_combo_overload_superkey_profile_lifetime_follows_child_trigger(
         self,
     ) -> None:
@@ -118,9 +300,7 @@ class TestComboActionDispatch:
                     dm.MappingAction(
                         action_type=ActionType.PROFILE_ENABLE,
                         profile_name="Nav",
-                        profile_deactivation=ProfileDeactivationPolicy(
-                            on_trigger_end=True
-                        ),
+                        profile_deactivation=ProfileDeactivationPolicy(on_trigger_end=True),
                     ),
                 ],
             ),
@@ -352,6 +532,7 @@ class TestComboActionDispatch:
         assert fake_device.presses == ["key_leftmeta"]
         assert fake_device.active == {"key_leftmeta"}
         assert fake_device.recalled == {"key_c"}
+
     @pytest.mark.asyncio
     async def test_combo_recall_trigger_keys_restores_selected_keys_on_immediate_action_completion(
         self,
@@ -426,6 +607,7 @@ class TestComboActionDispatch:
         assert fake_device.presses == ["key_leftmeta"]
         assert fake_device.active == {"key_leftmeta"}
         assert fake_device.recalled == {"key_c"}
+
     @pytest.mark.asyncio
     async def test_combo_recall_trigger_keys_restores_selected_keys_after_action_stop(
         self,
@@ -513,6 +695,7 @@ class TestComboActionDispatch:
             (evdev.ecodes.EV_KEY, evdev.ecodes.KEY_F5, 1),
             (evdev.ecodes.EV_KEY, evdev.ecodes.KEY_F5, 0),
         ]
+
     @pytest.mark.asyncio
     async def test_combo_pattern_superkey_single_step_supports_double_tap(self) -> None:
         manager = DeviceManager()
@@ -546,6 +729,7 @@ class TestComboActionDispatch:
             (evdev.ecodes.EV_KEY, evdev.ecodes.KEY_B, 1),
             (evdev.ecodes.EV_KEY, evdev.ecodes.KEY_B, 0),
         ]
+
     @pytest.mark.asyncio
     async def test_combo_pattern_superkey_single_step_supports_tap_hold(self) -> None:
         manager = DeviceManager()
@@ -583,6 +767,7 @@ class TestComboActionDispatch:
             (evdev.ecodes.EV_KEY, evdev.ecodes.KEY_B, 1),
             (evdev.ecodes.EV_KEY, evdev.ecodes.KEY_B, 0),
         ]
+
     @pytest.mark.asyncio
     async def test_combo_pattern_superkey_multistep_ignores_double_tap_slots(self) -> None:
         manager = DeviceManager()
@@ -618,6 +803,7 @@ class TestComboActionDispatch:
             (evdev.ecodes.EV_KEY, evdev.ecodes.KEY_C, 1),
             (evdev.ecodes.EV_KEY, evdev.ecodes.KEY_C, 0),
         ]
+
     @pytest.mark.asyncio
     async def test_combo_pattern_superkey_multistep_supports_hold_only(self) -> None:
         manager = DeviceManager()
@@ -656,6 +842,7 @@ class TestComboActionDispatch:
             (evdev.ecodes.EV_KEY, evdev.ecodes.KEY_E, 1),
             (evdev.ecodes.EV_KEY, evdev.ecodes.KEY_E, 0),
         ]
+
     @pytest.mark.asyncio
     async def test_clear_combo_runtime_releases_active_pattern_superkey_hold(self) -> None:
         manager = DeviceManager()
@@ -689,6 +876,7 @@ class TestComboActionDispatch:
             (evdev.ecodes.EV_KEY, evdev.ecodes.KEY_A, 1),
             (evdev.ecodes.EV_KEY, evdev.ecodes.KEY_A, 0),
         ]
+
     @pytest.mark.asyncio
     async def test_clear_combo_scope_stops_pending_pattern_superkey_machine(self) -> None:
         manager = DeviceManager()
@@ -816,9 +1004,7 @@ class TestComboActionDispatch:
             trigger_a,
         )
         await _runtime_stop_combo_action(manager, "combo-pattern-wildcard-reuse")
-        first_machine = manager.combo_state.superkey_machines[
-            "combo-pattern-wildcard-reuse"
-        ]
+        first_machine = manager.combo_state.superkey_machines["combo-pattern-wildcard-reuse"]
 
         await _runtime_start_combo_action(
             manager,
@@ -826,15 +1012,12 @@ class TestComboActionDispatch:
             action,
             trigger_b,
         )
-        second_machine = manager.combo_state.superkey_machines[
-            "combo-pattern-wildcard-reuse"
-        ]
+        second_machine = manager.combo_state.superkey_machines["combo-pattern-wildcard-reuse"]
 
         assert second_machine is not first_machine
         assert second_machine.source_device == "9999:0001"
-        assert (
-            manager.combo_state.superkey_machine_bindings["combo-pattern-wildcard-reuse"]
-            == (trigger_b,)
+        assert manager.combo_state.superkey_machine_bindings["combo-pattern-wildcard-reuse"] == (
+            trigger_b,
         )
 
     @pytest.mark.asyncio
@@ -882,9 +1065,9 @@ class TestComboActionDispatch:
         )
         await _runtime_stop_combo_action(manager, "combo-pattern-multi-scope")
 
-        assert (
-            manager.combo_state.superkey_machine_bindings["combo-pattern-multi-scope"]
-            == (trigger_a, trigger_b)
+        assert manager.combo_state.superkey_machine_bindings["combo-pattern-multi-scope"] == (
+            trigger_a,
+            trigger_b,
         )
 
         await _runtime_clear_combo_scope(manager, "1234:5678", "kbd")
@@ -945,6 +1128,7 @@ class TestComboActionDispatch:
         old_machine.stop.assert_awaited_once()
         assert len(created) == 1
         assert manager.combo_state.superkey_machines["combo-pattern-stale"] is created[0]
+
     @pytest.mark.asyncio
     async def test_start_and_stop_combo_action_cover_additional_synthetic_paths(self) -> None:
         manager = DeviceManager()

--- a/tests/keymasqd/test_device_manager_runtime_recovery.py
+++ b/tests/keymasqd/test_device_manager_runtime_recovery.py
@@ -296,6 +296,16 @@ class TestDeviceManagerHelpers:
                 "args": "2",
             },
         )
+        repeat_action = _runtime_parse_action(
+            manager,
+            {
+                "action": "repeat",
+                "repeat_categories": ["keyboard", "mouse_button", "mouse_wheel"],
+                "rapidfire_enabled": True,
+                "rapidfire_hold_ms": 30,
+                "rapidfire_wait_ms": 40,
+            },
+        )
 
         assert string_action.action_type == ActionType.KEYBOARD
         assert string_action.target == "key_a"
@@ -303,6 +313,185 @@ class TestDeviceManagerHelpers:
         assert dispatch_action.compositor_id == "hyprland"
         assert dispatch_action.compositor_dispatcher == "workspace"
         assert dispatch_action.compositor_args == "2"
+        assert repeat_action.action_type == ActionType.REPEAT
+        assert repeat_action.repeat_categories == ["keyboard", "mouse"]
+        assert repeat_action.rapidfire_enabled is True
+        assert repeat_action.rapidfire_hold_ms == 30
+        assert repeat_action.rapidfire_wait_ms == 40
+
+    @pytest.mark.asyncio
+    async def test_mapping_and_combo_updates_prune_stale_exec_repeat_history(self) -> None:
+        from keymasq.keymasqd.runtime.repeat import RepeatHistoryEntry
+
+        manager = DeviceManager()
+        manager.grabbed_devices["kbd"] = []
+        manager.repeat_state.history.extend(
+            [
+                RepeatHistoryEntry(
+                    category="special",
+                    action=dm.MappingAction(action_type=ActionType.EXEC, exec_ref=1),
+                    source_device="kbd",
+                    source_button="key_f13",
+                ),
+                RepeatHistoryEntry(
+                    category="special",
+                    action=dm.MappingAction(action_type=ActionType.EXEC, exec_ref=2),
+                    source_device="mouse",
+                    source_button="btn_side",
+                ),
+                RepeatHistoryEntry(
+                    category="special",
+                    action=dm.MappingAction(action_type=ActionType.EXEC, exec_ref=3),
+                    source_device="mouse",
+                    source_button="combo:launch",
+                ),
+                RepeatHistoryEntry(
+                    category="special",
+                    action=dm.MappingAction(action_type=ActionType.EXEC, exec_ref=4),
+                    source_device="kbd",
+                    source_button="combo:kbd-launch",
+                ),
+                RepeatHistoryEntry(
+                    category="keyboard",
+                    action=dm.MappingAction(action_type=ActionType.KEYBOARD, target="key_a"),
+                    source_device="kbd",
+                    source_button="key_a",
+                ),
+            ]
+        )
+
+        await manager.set_mapping("kbd", {})
+
+        assert [entry.action.exec_ref for entry in manager.repeat_state.history] == [
+            2,
+            3,
+            4,
+            None,
+        ]
+
+        await manager.set_combos([])
+
+        assert [entry.action.exec_ref for entry in manager.repeat_state.history] == [
+            2,
+            None,
+        ]
+
+    def test_forget_exec_actions_without_filters_keeps_history(self) -> None:
+        from keymasq.keymasqd.runtime.repeat import RepeatHistoryEntry, forget_exec_actions
+
+        manager = DeviceManager()
+        manager.repeat_state.history.extend(
+            [
+                RepeatHistoryEntry(
+                    category="special",
+                    action=dm.MappingAction(action_type=ActionType.EXEC, exec_ref=1),
+                    source_device="kbd",
+                    source_button="key_f13",
+                ),
+                RepeatHistoryEntry(
+                    category="keyboard",
+                    action=dm.MappingAction(action_type=ActionType.KEYBOARD, target="key_a"),
+                    source_device="kbd",
+                    source_button="key_a",
+                ),
+            ]
+        )
+
+        forget_exec_actions(manager.repeat_state)
+
+        assert [entry.action.action_type for entry in manager.repeat_state.history] == [
+            ActionType.EXEC,
+            ActionType.KEYBOARD,
+        ]
+
+    def test_forget_exec_actions_prunes_superkey_history_with_nested_exec_refs(
+        self,
+    ) -> None:
+        from keymasq.keymasqd.runtime.repeat import RepeatHistoryEntry, forget_exec_actions
+
+        manager = DeviceManager()
+        manager.repeat_state.history.extend(
+            [
+                RepeatHistoryEntry(
+                    category="special",
+                    action=dm.MappingAction(
+                        action_type=ActionType.SUPERKEY,
+                        superkey_config=SuperkeyConfig(
+                            name="pattern-exec",
+                            tap_actions=[
+                                SuperkeyActionData(action_type="exec", exec_ref=10),
+                            ],
+                        ),
+                    ),
+                    source_device="kbd",
+                    source_button="key_f13",
+                ),
+                RepeatHistoryEntry(
+                    category="special",
+                    action=dm.MappingAction(
+                        action_type=ActionType.SUPERKEY,
+                        superkey_config=SuperkeyConfig(
+                            name="other-device-pattern-exec",
+                            tap_actions=[
+                                SuperkeyActionData(action_type="exec", exec_ref=11),
+                            ],
+                        ),
+                    ),
+                    source_device="mouse",
+                    source_button="btn_side",
+                ),
+                RepeatHistoryEntry(
+                    category="special",
+                    action=dm.MappingAction(
+                        action_type=ActionType.SUPERKEY,
+                        superkey_config=SuperkeyConfig(
+                            name="combo-overload-exec",
+                            mode=SuperkeyMode.OVERLOAD,
+                            overload_actions=[
+                                dm.MappingAction(action_type=ActionType.EXEC, exec_ref=12),
+                            ],
+                        ),
+                    ),
+                    source_device="kbd",
+                    source_button="combo:launch",
+                ),
+                RepeatHistoryEntry(
+                    category="special",
+                    action=dm.MappingAction(
+                        action_type=ActionType.SUPERKEY,
+                        superkey_config=SuperkeyConfig(
+                            name="pattern-key",
+                            tap_actions=[
+                                SuperkeyActionData(
+                                    action_type="keyboard",
+                                    target="key_a",
+                                ),
+                            ],
+                        ),
+                    ),
+                    source_device="kbd",
+                    source_button="key_f14",
+                ),
+                RepeatHistoryEntry(
+                    category="special",
+                    action=dm.MappingAction(action_type=ActionType.EXEC, exec_ref=13),
+                    source_device="kbd",
+                    source_button="key_f15",
+                ),
+            ]
+        )
+
+        forget_exec_actions(
+            manager.repeat_state,
+            source_device="kbd",
+            exclude_source_button_prefix="combo:",
+        )
+
+        assert [entry.source_button for entry in manager.repeat_state.history] == [
+            "btn_side",
+            "combo:launch",
+            "key_f14",
+        ]
 
     def test_parse_action_warns_and_strips_unsupported_rapidfire(
         self,

--- a/tests/keymasqd/test_device_manager_runtime_recovery.py
+++ b/tests/keymasqd/test_device_manager_runtime_recovery.py
@@ -376,7 +376,7 @@ class TestDeviceManagerHelpers:
             None,
         ]
 
-    def test_forget_exec_actions_without_filters_keeps_history(self) -> None:
+    def test_forget_exec_actions_without_filters_prunes_global_exec_history(self) -> None:
         from keymasq.keymasqd.runtime.repeat import RepeatHistoryEntry, forget_exec_actions
 
         manager = DeviceManager()
@@ -400,7 +400,6 @@ class TestDeviceManagerHelpers:
         forget_exec_actions(manager.repeat_state)
 
         assert [entry.action.action_type for entry in manager.repeat_state.history] == [
-            ActionType.EXEC,
             ActionType.KEYBOARD,
         ]
 

--- a/tests/keymasqd/test_device_manager_superkeys.py
+++ b/tests/keymasqd/test_device_manager_superkeys.py
@@ -1,6 +1,7 @@
 # ruff: noqa: F403, F405, I001
 from tests.keymasqd.device_manager_support import *
 
+
 class TestSuperkeys:
     @pytest.mark.asyncio
     async def test_mapping_reset_clears_combo_passthrough_hold_but_preserves_passthrough_release(
@@ -66,6 +67,7 @@ class TestSuperkeys:
         ]
         assert mapped_uinput.writes == []
         assert "key_1" not in device.state.held_source_actions
+
     @pytest.mark.asyncio
     async def test_mapping_reset_clears_combo_recalled_suppression_state(
         self,
@@ -79,6 +81,7 @@ class TestSuperkeys:
 
         assert device.state.combo_passthrough_held == set()
         assert device.state.combo_recalled_bindings == set()
+
     @pytest.mark.asyncio
     async def test_combo_recalled_repeat_is_suppressed_until_restore_or_new_press(
         self,
@@ -109,6 +112,7 @@ class TestSuperkeys:
         assert passthrough.writes == [
             (evdev.ecodes.EV_KEY, evdev.ecodes.KEY_X, 2),
         ]
+
     @pytest.mark.asyncio
     async def test_combo_recalled_modifier_uses_normalized_name_for_suppression(
         self,
@@ -138,6 +142,7 @@ class TestSuperkeys:
         assert passthrough.writes == []
         assert device.state.combo_recalled_bindings == set()
         assert device.state.combo_passthrough_held == set()
+
     @pytest.mark.asyncio
     async def test_combo_recalled_release_clears_suppression_without_passthrough(
         self,
@@ -166,6 +171,7 @@ class TestSuperkeys:
         assert device.state.combo_passthrough_held == set()
         assert device.state.combo_recalled_bindings == set()
         assert "key_x" not in device.state.held_source_actions
+
     @pytest.mark.asyncio
     async def test_combo_recalled_press_becomes_fresh_press_again(
         self,
@@ -201,6 +207,7 @@ class TestSuperkeys:
         ]
         assert device.state.combo_recalled_bindings == set()
         assert device.state.combo_passthrough_held == {"key_x"}
+
     @pytest.mark.asyncio
     async def test_vvv_logs_raw_hardware_events_but_skips_mouse_motion(
         self,
@@ -231,6 +238,7 @@ class TestSuperkeys:
         assert "[hw 1234:5678 kbd] type=1 code=45 name=key_x value=2" in caplog.text
         assert "REL_X" not in caplog.text
         assert "type=2 code=0" not in caplog.text
+
     @pytest.mark.asyncio
     async def test_superkey_release_after_reset_does_not_recreate_stale_machine(
         self,
@@ -368,6 +376,7 @@ class TestSuperkeys:
             (evdev.ecodes.EV_KEY, evdev.ecodes.KEY_A, 0),
         ]
         assert device.state.held_output_keys["keyboard"] == set()
+
     @pytest.mark.asyncio
     async def test_overload_superkey_fans_out_press_repeat_and_release(
         self,
@@ -426,6 +435,295 @@ class TestSuperkeys:
         ]
 
     @pytest.mark.asyncio
+    async def test_repeat_replays_overload_superkey_path(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from keymasq.keymasqd.runtime.repeat import SUPERKEY_SLOT_OVERLOAD
+
+        monkeypatch.setattr(gdm, "resolve_stable_path", lambda path: path)
+        monkeypatch.setattr(gdm, "get_interface_id", lambda _path: "kbd")
+
+        mapping_state = {
+            "key_f13": dm.MappingAction(
+                action_type=ActionType.SUPERKEY,
+                superkey_config=SuperkeyConfig(
+                    name="bigA",
+                    mode=SuperkeyMode.OVERLOAD,
+                    overload_actions=[
+                        dm.MappingAction(action_type=ActionType.KEYBOARD, target="key_leftshift"),
+                        dm.MappingAction(action_type=ActionType.KEYBOARD, target="key_a"),
+                    ],
+                ),
+            ),
+            "key_f14": dm.MappingAction(action_type=ActionType.REPEAT),
+        }
+
+        keyboard_uinput = _FakeUInput()
+        device = GrabbedDevice(
+            path="/dev/input/event-test",
+            hardware_id="1234:5678",
+            button_map={"key_f13": "key_f13", "key_f14": "key_f14"},
+            mapping_getter=lambda: mapping_state,
+            event_callback=AsyncMock(return_value=None),
+            device_type=DeviceType.KEYBOARD,
+            keyboard_uinput=keyboard_uinput,  # type: ignore[arg-type]
+        )
+        device._running = True
+
+        await _runtime_process_grabbed_event(
+            device,
+            SimpleNamespace(type=evdev.ecodes.EV_KEY, code=evdev.ecodes.KEY_F13, value=1),
+        )
+        await _runtime_process_grabbed_event(
+            device,
+            SimpleNamespace(type=evdev.ecodes.EV_KEY, code=evdev.ecodes.KEY_F13, value=0),
+        )
+
+        latest = device.repeat_state.history[-1]
+        assert latest.action.action_type == ActionType.SUPERKEY
+        assert latest.action.superkey_config is mapping_state["key_f13"].superkey_config
+        assert latest.superkey_slot == SUPERKEY_SLOT_OVERLOAD
+
+        await _runtime_process_grabbed_event(
+            device,
+            SimpleNamespace(type=evdev.ecodes.EV_KEY, code=evdev.ecodes.KEY_F14, value=1),
+        )
+        await _runtime_process_grabbed_event(
+            device,
+            SimpleNamespace(type=evdev.ecodes.EV_KEY, code=evdev.ecodes.KEY_F14, value=0),
+        )
+
+        assert keyboard_uinput.writes == [
+            (evdev.ecodes.EV_KEY, evdev.ecodes.KEY_LEFTSHIFT, 1),
+            (evdev.ecodes.EV_KEY, evdev.ecodes.KEY_A, 1),
+            (evdev.ecodes.EV_KEY, evdev.ecodes.KEY_LEFTSHIFT, 0),
+            (evdev.ecodes.EV_KEY, evdev.ecodes.KEY_A, 0),
+            (evdev.ecodes.EV_KEY, evdev.ecodes.KEY_LEFTSHIFT, 1),
+            (evdev.ecodes.EV_KEY, evdev.ecodes.KEY_A, 1),
+            (evdev.ecodes.EV_KEY, evdev.ecodes.KEY_LEFTSHIFT, 0),
+            (evdev.ecodes.EV_KEY, evdev.ecodes.KEY_A, 0),
+        ]
+        assert device.repeat_state.history[-1].superkey_slot == SUPERKEY_SLOT_OVERLOAD
+
+    @pytest.mark.asyncio
+    async def test_repeat_replays_split_overload_superkey_path(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr(gdm, "resolve_stable_path", lambda path: path)
+        monkeypatch.setattr(gdm, "get_interface_id", lambda _path: "kbd")
+
+        mapping_state = {
+            "key_f13": dm.MappingAction(
+                action_type=ActionType.SUPERKEY,
+                superkey_config=SuperkeyConfig(
+                    name="repeat-split-overload",
+                    mode=SuperkeyMode.OVERLOAD,
+                    overload_actions=[
+                        dm.MappingAction(action_type=ActionType.KEYBOARD, target="key_leftctrl"),
+                    ],
+                    overload_down_actions=[
+                        dm.MappingAction(action_type=ActionType.KEYBOARD, target="key_a"),
+                    ],
+                    overload_up_actions=[
+                        dm.MappingAction(action_type=ActionType.KEYBOARD, target="key_b"),
+                    ],
+                ),
+            ),
+            "key_f14": dm.MappingAction(action_type=ActionType.REPEAT),
+        }
+
+        keyboard_uinput = _FakeUInput()
+        device = GrabbedDevice(
+            path="/dev/input/event-test",
+            hardware_id="1234:5678",
+            button_map={"key_f13": "key_f13", "key_f14": "key_f14"},
+            mapping_getter=lambda: mapping_state,
+            event_callback=AsyncMock(return_value=None),
+            device_type=DeviceType.KEYBOARD,
+            keyboard_uinput=keyboard_uinput,  # type: ignore[arg-type]
+        )
+        device._running = True
+
+        for code, value in (
+            (evdev.ecodes.KEY_F13, 1),
+            (evdev.ecodes.KEY_F13, 0),
+            (evdev.ecodes.KEY_F14, 1),
+            (evdev.ecodes.KEY_F14, 0),
+        ):
+            await _runtime_process_grabbed_event(
+                device,
+                SimpleNamespace(type=evdev.ecodes.EV_KEY, code=code, value=value),
+            )
+
+        assert keyboard_uinput.writes == [
+            (evdev.ecodes.EV_KEY, evdev.ecodes.KEY_LEFTCTRL, 1),
+            (evdev.ecodes.EV_KEY, evdev.ecodes.KEY_A, 1),
+            (evdev.ecodes.EV_KEY, evdev.ecodes.KEY_A, 0),
+            (evdev.ecodes.EV_KEY, evdev.ecodes.KEY_B, 1),
+            (evdev.ecodes.EV_KEY, evdev.ecodes.KEY_B, 0),
+            (evdev.ecodes.EV_KEY, evdev.ecodes.KEY_LEFTCTRL, 0),
+            (evdev.ecodes.EV_KEY, evdev.ecodes.KEY_LEFTCTRL, 1),
+            (evdev.ecodes.EV_KEY, evdev.ecodes.KEY_A, 1),
+            (evdev.ecodes.EV_KEY, evdev.ecodes.KEY_A, 0),
+            (evdev.ecodes.EV_KEY, evdev.ecodes.KEY_B, 1),
+            (evdev.ecodes.EV_KEY, evdev.ecodes.KEY_B, 0),
+            (evdev.ecodes.EV_KEY, evdev.ecodes.KEY_LEFTCTRL, 0),
+        ]
+
+    @pytest.mark.asyncio
+    async def test_repeat_replays_pattern_superkey_resolved_slot(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from keymasq.keymasqd.runtime.repeat import SUPERKEY_SLOT_DOUBLE_TAP
+
+        monkeypatch.setattr(gdm, "resolve_stable_path", lambda path: path)
+        monkeypatch.setattr(gdm, "get_interface_id", lambda _path: "kbd")
+
+        mapping_state = {
+            "key_f13": dm.MappingAction(
+                action_type=ActionType.SUPERKEY,
+                superkey_config=SuperkeyConfig(
+                    name="wpctl_volume_rocker",
+                    mode=SuperkeyMode.PATTERN,
+                    double_tap_window_ms=250,
+                    hold_threshold_ms=250,
+                    double_tap_actions=[
+                        SuperkeyActionData(action_type="keyboard", target="key_b"),
+                    ],
+                ),
+            ),
+            "key_f14": dm.MappingAction(action_type=ActionType.REPEAT),
+        }
+
+        keyboard_uinput = _FakeUInput()
+        device = GrabbedDevice(
+            path="/dev/input/event-test",
+            hardware_id="1234:5678",
+            button_map={"key_f13": "key_f13", "key_f14": "key_f14"},
+            mapping_getter=lambda: mapping_state,
+            event_callback=AsyncMock(return_value=None),
+            device_type=DeviceType.KEYBOARD,
+            keyboard_uinput=keyboard_uinput,  # type: ignore[arg-type]
+        )
+        device._running = True
+
+        for value in (1, 0, 1, 0):
+            await _runtime_process_grabbed_event(
+                device,
+                SimpleNamespace(type=evdev.ecodes.EV_KEY, code=evdev.ecodes.KEY_F13, value=value),
+            )
+
+        latest = device.repeat_state.history[-1]
+        assert latest.action.action_type == ActionType.SUPERKEY
+        assert latest.action.superkey_config is mapping_state["key_f13"].superkey_config
+        assert latest.superkey_slot == SUPERKEY_SLOT_DOUBLE_TAP
+
+        await _runtime_process_grabbed_event(
+            device,
+            SimpleNamespace(type=evdev.ecodes.EV_KEY, code=evdev.ecodes.KEY_F14, value=1),
+        )
+        await _runtime_process_grabbed_event(
+            device,
+            SimpleNamespace(type=evdev.ecodes.EV_KEY, code=evdev.ecodes.KEY_F14, value=0),
+        )
+
+        assert keyboard_uinput.writes == [
+            (evdev.ecodes.EV_KEY, evdev.ecodes.KEY_B, 1),
+            (evdev.ecodes.EV_KEY, evdev.ecodes.KEY_B, 0),
+            (evdev.ecodes.EV_KEY, evdev.ecodes.KEY_B, 1),
+            (evdev.ecodes.EV_KEY, evdev.ecodes.KEY_B, 0),
+        ]
+        assert device.repeat_state.history[-1].superkey_slot == SUPERKEY_SLOT_DOUBLE_TAP
+
+    @pytest.mark.asyncio
+    async def test_repeat_skips_superkey_profile_paths(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr(gdm, "resolve_stable_path", lambda path: path)
+        monkeypatch.setattr(gdm, "get_interface_id", lambda _path: "kbd")
+
+        action_triggers: list[dict[str, object]] = []
+
+        async def broadcast(event_type: CommandType, data: dict[str, object]) -> None:
+            if event_type == CommandType.ACTION_TRIGGER:
+                action_triggers.append(data)
+                await manager.track_profile_activation(
+                    str(data["profile_name"]),
+                    f"activation-{len(action_triggers)}",
+                    str(data["trigger_id"]),
+                    data["deactivation"],
+                )
+                return
+
+        manager = DeviceManager(broadcast_callback=broadcast)
+        mapping_state = {
+            "key_f13": dm.MappingAction(
+                action_type=ActionType.SUPERKEY,
+                superkey_config=SuperkeyConfig(
+                    name="repeat-hold-profile",
+                    mode=SuperkeyMode.PATTERN,
+                    hold_threshold_ms=1,
+                    hold_actions=[
+                        SuperkeyActionData(
+                            action_type="profile_enable",
+                            profile_name="Nav",
+                            profile_deactivation=ProfileDeactivationPolicy(on_trigger_end=True),
+                        ),
+                    ],
+                ),
+            ),
+            "key_f14": dm.MappingAction(action_type=ActionType.REPEAT),
+        }
+
+        device = GrabbedDevice(
+            path="/dev/input/event-test",
+            hardware_id="1234:5678",
+            button_map={"key_f13": "key_f13", "key_f14": "key_f14"},
+            mapping_getter=lambda: mapping_state,
+            event_callback=AsyncMock(return_value=None),
+            device_type=DeviceType.KEYBOARD,
+            keyboard_uinput=_FakeUInput(),  # type: ignore[arg-type]
+            broadcast_callback=broadcast,
+            profile_activation_trigger_start_observer=manager.observe_profile_trigger_start,
+            profile_activation_trigger_end_observer=manager.observe_profile_trigger_end,
+        )
+        device._running = True
+
+        await _runtime_process_grabbed_event(
+            device,
+            SimpleNamespace(type=evdev.ecodes.EV_KEY, code=evdev.ecodes.KEY_F13, value=1),
+        )
+        await asyncio.sleep(0.01)
+        await _runtime_process_grabbed_event(
+            device,
+            SimpleNamespace(type=evdev.ecodes.EV_KEY, code=evdev.ecodes.KEY_F13, value=0),
+        )
+        await asyncio.sleep(0.01)
+
+        assert len(action_triggers) == 1
+        assert list(device.repeat_state.history) == []
+
+        await _runtime_process_grabbed_event(
+            device,
+            SimpleNamespace(type=evdev.ecodes.EV_KEY, code=evdev.ecodes.KEY_F14, value=1),
+        )
+        await asyncio.sleep(0.01)
+
+        assert len(action_triggers) == 1
+
+        await _runtime_process_grabbed_event(
+            device,
+            SimpleNamespace(type=evdev.ecodes.EV_KEY, code=evdev.ecodes.KEY_F14, value=0),
+        )
+        await asyncio.sleep(0.01)
+
+        assert len(action_triggers) == 1
+
+    @pytest.mark.asyncio
     async def test_overload_superkey_profile_lifetime_follows_child_trigger(
         self,
         monkeypatch: pytest.MonkeyPatch,
@@ -459,9 +757,7 @@ class TestSuperkeys:
                         dm.MappingAction(
                             action_type=ActionType.PROFILE_ENABLE,
                             profile_name="Nav",
-                            profile_deactivation=ProfileDeactivationPolicy(
-                                on_trigger_end=True
-                            ),
+                            profile_deactivation=ProfileDeactivationPolicy(on_trigger_end=True),
                         ),
                     ],
                 ),
@@ -810,6 +1106,7 @@ class TestSuperkeys:
         assert device.keyboard_uinput.writes == [
             (evdev.ecodes.EV_KEY, evdev.ecodes.KEY_A, 0),
         ]
+
     @pytest.mark.asyncio
     async def test_superkey_broadcast_does_not_block_hot_path(
         self,
@@ -857,9 +1154,7 @@ class TestSuperkeys:
         )
 
         await asyncio.wait_for(_runtime_process_grabbed_event(device, press_event), timeout=0.05)
-        await asyncio.wait_for(
-            _runtime_process_grabbed_event(device, release_event), timeout=0.05
-        )
+        await asyncio.wait_for(_runtime_process_grabbed_event(device, release_event), timeout=0.05)
 
         blocker.set()
         await asyncio.sleep(0)

--- a/tests/keymasqd/test_grabbed_device_runtime_helpers.py
+++ b/tests/keymasqd/test_grabbed_device_runtime_helpers.py
@@ -462,9 +462,7 @@ class TestGrabbedDeviceHelpers:
             deps=gde.build_action_execution_deps(),
         )
 
-        assert target_uinput.writes == [
-            (evdev.ecodes.EV_ABS, evdev.ecodes.ABS_X, 32767)
-        ]
+        assert target_uinput.writes == [(evdev.ecodes.EV_ABS, evdev.ecodes.ABS_X, 32767)]
         assert target_uinput.syn_count == 0
 
         gdo.flush_passthrough_frame(
@@ -474,6 +472,7 @@ class TestGrabbedDeviceHelpers:
 
         assert target_uinput.syn_count == 1
         assert not gdo.passthrough_frame_open(target_uinput)
+
     def test_device_has_mapped_buttons_matches_by_code_when_names_differ(self) -> None:
         caps = {
             evdev.ecodes.EV_KEY: [evdev.ecodes.BTN_SOUTH],
@@ -484,6 +483,7 @@ class TestGrabbedDeviceHelpers:
             {"btn_south"},
             {(evdev.ecodes.EV_KEY, evdev.ecodes.BTN_SOUTH)},
         )
+
     def test_device_has_mapped_buttons_ignores_cross_type_code_collision(self) -> None:
         caps = {
             evdev.ecodes.EV_REL: [evdev.ecodes.REL_WHEEL],
@@ -621,6 +621,7 @@ class TestGrabbedDeviceHelpers:
         )
 
         assert _runtime_find_grabbed_action_for_event(device, event, mapping) is None
+
     def test_find_grabbed_action_for_event_distinguishes_wheel_direction(self, monkeypatch) -> None:
         device = _make_grabbed_device(
             monkeypatch,
@@ -652,11 +653,14 @@ class TestGrabbedDeviceHelpers:
             1,
         )
 
-        assert _runtime_find_grabbed_action_for_event(
-            device,
-            down_event,
-            mapping,
-        ) == mapping["wheel_down"]
+        assert (
+            _runtime_find_grabbed_action_for_event(
+                device,
+                down_event,
+                mapping,
+            )
+            == mapping["wheel_down"]
+        )
         assert _runtime_find_grabbed_action_for_event(device, up_event, mapping) is None
 
     @pytest.mark.asyncio
@@ -859,8 +863,7 @@ class TestGrabbedDeviceHelpers:
         await _runtime_process_grabbed_event(device, down_event)
 
         recorded_events = [
-            (device_type, event.code, event.value)
-            for device_type, event in recorder.calls
+            (device_type, event.code, event.value) for device_type, event in recorder.calls
         ]
         assert recorded_events == [
             ("mouse", evdev.ecodes.REL_WHEEL, 1),
@@ -903,8 +906,7 @@ class TestGrabbedDeviceHelpers:
         )
 
         assert [
-            (device_type, event.code, event.value)
-            for device_type, event in recorder.calls
+            (device_type, event.code, event.value) for device_type, event in recorder.calls
         ] == [
             ("mouse", evdev.ecodes.REL_WHEEL_HI_RES, -120),
         ]
@@ -942,13 +944,42 @@ class TestGrabbedDeviceHelpers:
         )
 
         recorded_events = [
-            (device_type, event.code, event.value)
-            for device_type, event in recorder.calls
+            (device_type, event.code, event.value) for device_type, event in recorder.calls
         ]
         assert recorded_events == [
             ("mouse", evdev.ecodes.REL_WHEEL, 1),
         ]
+        assert list(device.repeat_state.history) == []
         assert passthrough.writes == [(evdev.ecodes.EV_REL, evdev.ecodes.REL_WHEEL, 1)]
+
+    @pytest.mark.asyncio
+    async def test_explicit_passthrough_mapping_does_not_update_repeat_history(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        passthrough = _FakeUInput()
+        device = _make_grabbed_device(
+            monkeypatch,
+            button_map={"key_a": "key_a"},
+        )
+        device.uinput = passthrough  # type: ignore[assignment]
+        device.mapping_getter = lambda: {  # type: ignore[method-assign]
+            "key_a": MappingAction(action_type=ActionType.PASSTHROUGH),
+        }
+
+        await _runtime_process_grabbed_event(
+            device,
+            evdev.InputEvent(
+                0,
+                0,
+                evdev.ecodes.EV_KEY,
+                evdev.ecodes.KEY_A,
+                1,
+            ),
+        )
+
+        assert passthrough.writes == [(evdev.ecodes.EV_KEY, evdev.ecodes.KEY_A, 1)]
+        assert list(device.repeat_state.history) == []
 
     @pytest.mark.asyncio
     async def test_process_grabbed_high_res_wheel_passthrough_when_unmapped_or_explicit(
@@ -974,6 +1005,9 @@ class TestGrabbedDeviceHelpers:
                 -120,
             ),
         )
+        assert len(device.repeat_state.history) == 1
+        device.repeat_state.history.clear()
+
         device.mapping_getter = lambda: {  # type: ignore[method-assign]
             "wheel_down": MappingAction(action_type=ActionType.PASSTHROUGH),
         }
@@ -992,6 +1026,8 @@ class TestGrabbedDeviceHelpers:
             (evdev.ecodes.EV_REL, evdev.ecodes.REL_WHEEL_HI_RES, -120),
             (evdev.ecodes.EV_REL, evdev.ecodes.REL_WHEEL_HI_RES, -120),
         ]
+        assert list(device.repeat_state.history) == []
+
     def test_bucket_tracking_and_release_all_keys(self, monkeypatch: pytest.MonkeyPatch) -> None:
         device = _make_grabbed_device(monkeypatch)
         passthrough = _FakeUInput()
@@ -1006,6 +1042,7 @@ class TestGrabbedDeviceHelpers:
         device.keyboard_uinput = keyboard  # type: ignore[assignment]
         device.mouse_uinput = mouse  # type: ignore[assignment]
         device.gamepad_uinput = gamepad  # type: ignore[assignment]
+
         def resolve_gamepad_output(output_id, context):
             output = second_gamepad if output_id == "virtual-gamepad-2" else gamepad
             return SimpleNamespace(
@@ -1068,6 +1105,7 @@ class TestGrabbedDeviceHelpers:
         assert device.state.tap_active == {}
         assert device.state.combo_recalled_bindings == set()
         assert device.state.held_source_actions == {}
+
     def test_release_helpers_log_failed_uinput_releases(
         self,
         monkeypatch: pytest.MonkeyPatch,
@@ -1090,6 +1128,7 @@ class TestGrabbedDeviceHelpers:
 
         assert "Failed to release output key" in caplog.text
         assert "Failed to release gamepad ABS axis" in caplog.text
+
     def test_release_all_keys_keeps_tracking_after_failed_release(
         self,
         monkeypatch: pytest.MonkeyPatch,
@@ -1109,10 +1148,9 @@ class TestGrabbedDeviceHelpers:
             )
 
         assert device.state.held_output_keys["keyboard"] == {evdev.ecodes.KEY_A}
-        assert device.state.superkey_output_refcounts["keyboard"] == {
-            evdev.ecodes.KEY_A: 1
-        }
+        assert device.state.superkey_output_refcounts["keyboard"] == {evdev.ecodes.KEY_A: 1}
         assert "Failed to release held output keys" in caplog.text
+
     @pytest.mark.asyncio
     async def test_wait_for_active_key_activity_handles_timeouts_and_drain_errors(
         self,
@@ -1165,6 +1203,7 @@ class TestGrabbedDeviceHelpers:
             assert await _runtime_wait_for_grabbed_active_key_activity(device, 0.1) is True
 
         assert "failed to drain pending events before grab" in caplog.text
+
     @pytest.mark.asyncio
     async def test_broadcast_grab_status_and_startup_held_actions(
         self,
@@ -1212,6 +1251,7 @@ class TestGrabbedDeviceHelpers:
         assert device.state.held_source_actions["key_b"] == mapping_state["right"]
         assert keyboard.writes == [(evdev.ecodes.EV_KEY, evdev.ecodes.KEY_Z, 0)]
         assert mouse.writes == [(evdev.ecodes.EV_KEY, evdev.ecodes.BTN_LEFT, 0)]
+
     def test_seed_startup_held_actions_matches_gamepad_alias_by_code(
         self,
         monkeypatch: pytest.MonkeyPatch,
@@ -1235,6 +1275,7 @@ class TestGrabbedDeviceHelpers:
         gdg.seed_startup_held_actions(device)
 
         assert device.state.held_source_actions["btn_a"] == mapping_state["south"]
+
     def test_reconcile_startup_held_action_releases_gamepad_output(
         self,
         monkeypatch: pytest.MonkeyPatch,
@@ -1249,19 +1290,18 @@ class TestGrabbedDeviceHelpers:
                 action_type=ActionType.GAMEPAD_AXIS,
                 target="abs_z",
                 axis_value=255,
-            )
-            ,
+            ),
         )
         gdg.reconcile_startup_held_action(
             device,
-            dm.MappingAction(action_type=ActionType.GAMEPAD, target="btn_south")
-            ,
+            dm.MappingAction(action_type=ActionType.GAMEPAD, target="btn_south"),
         )
 
         assert gamepad.writes == [
             (evdev.ecodes.EV_ABS, evdev.ecodes.ABS_Z, 0),
             (evdev.ecodes.EV_KEY, evdev.ecodes.BTN_SOUTH, 0),
         ]
+
     @pytest.mark.asyncio
     async def test_tap_helpers_and_emit_combo_release_cover_cleanup_paths(
         self,
@@ -1304,6 +1344,7 @@ class TestGrabbedDeviceHelpers:
         ]
         assert passthrough.writes == [(evdev.ecodes.EV_KEY, evdev.ecodes.KEY_B, 0)]
         assert device.state.tap_active == {}
+
     def test_emit_combo_press_reestablishes_passthrough_hold_tracking(
         self,
         monkeypatch: pytest.MonkeyPatch,
@@ -1317,6 +1358,7 @@ class TestGrabbedDeviceHelpers:
         assert passthrough.writes == [(evdev.ecodes.EV_KEY, evdev.ecodes.KEY_B, 1)]
         assert device.state.combo_passthrough_held == {"key_b"}
         assert device.state.held_output_keys["passthrough"] == {evdev.ecodes.KEY_B}
+
     @pytest.mark.asyncio
     async def test_execute_action_covers_synthetic_non_keyboard_branches(
         self,
@@ -1543,6 +1585,684 @@ class TestGrabbedDeviceHelpers:
         callback.assert_not_awaited()
 
     @pytest.mark.asyncio
+    async def test_repeat_action_replays_last_keyboard_action(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        keyboard = _FakeUInput()
+        device = _make_grabbed_device(monkeypatch, keyboard_uinput=keyboard)
+        source_press = evdev.InputEvent(0, 0, evdev.ecodes.EV_KEY, evdev.ecodes.KEY_F13, 1)
+        source_release = evdev.InputEvent(0, 0, evdev.ecodes.EV_KEY, evdev.ecodes.KEY_F13, 0)
+        repeat_press = evdev.InputEvent(0, 0, evdev.ecodes.EV_KEY, evdev.ecodes.KEY_F14, 1)
+        repeat_hold = evdev.InputEvent(0, 0, evdev.ecodes.EV_KEY, evdev.ecodes.KEY_F14, 2)
+        repeat_release = evdev.InputEvent(0, 0, evdev.ecodes.EV_KEY, evdev.ecodes.KEY_F14, 0)
+
+        await _runtime_execute_grabbed_action(
+            device,
+            dm.MappingAction(action_type=ActionType.KEYBOARD, target="key_a"),
+            source_press,
+            "source",
+        )
+        await _runtime_execute_grabbed_action(
+            device,
+            dm.MappingAction(action_type=ActionType.KEYBOARD, target="key_a"),
+            source_release,
+            "source",
+        )
+        await _runtime_execute_grabbed_action(
+            device,
+            dm.MappingAction(action_type=ActionType.REPEAT),
+            repeat_press,
+            "repeat_btn",
+        )
+        await _runtime_execute_grabbed_action(
+            device,
+            dm.MappingAction(action_type=ActionType.REPEAT),
+            repeat_hold,
+            "repeat_btn",
+        )
+        await _runtime_execute_grabbed_action(
+            device,
+            dm.MappingAction(action_type=ActionType.REPEAT),
+            repeat_release,
+            "repeat_btn",
+        )
+        await _runtime_execute_grabbed_action(
+            device,
+            dm.MappingAction(action_type=ActionType.REPEAT),
+            repeat_press,
+            "repeat_btn",
+        )
+        await _runtime_execute_grabbed_action(
+            device,
+            dm.MappingAction(action_type=ActionType.REPEAT),
+            repeat_release,
+            "repeat_btn",
+        )
+
+        assert keyboard.writes == [
+            (evdev.ecodes.EV_KEY, evdev.ecodes.KEY_A, 1),
+            (evdev.ecodes.EV_KEY, evdev.ecodes.KEY_A, 0),
+            (evdev.ecodes.EV_KEY, evdev.ecodes.KEY_A, 1),
+            (evdev.ecodes.EV_KEY, evdev.ecodes.KEY_A, 2),
+            (evdev.ecodes.EV_KEY, evdev.ecodes.KEY_A, 0),
+            (evdev.ecodes.EV_KEY, evdev.ecodes.KEY_A, 1),
+            (evdev.ecodes.EV_KEY, evdev.ecodes.KEY_A, 0),
+        ]
+        assert len(device.repeat_state.history) == 3
+
+    @pytest.mark.asyncio
+    async def test_repeat_action_replays_mapped_gamepad_axis_action(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        gamepad = _FakeUInput()
+        device = _make_grabbed_device(monkeypatch, gamepad_uinput=gamepad)
+        source_press = evdev.InputEvent(0, 0, evdev.ecodes.EV_KEY, evdev.ecodes.KEY_F13, 1)
+        source_release = evdev.InputEvent(0, 0, evdev.ecodes.EV_KEY, evdev.ecodes.KEY_F13, 0)
+        repeat_press = evdev.InputEvent(0, 0, evdev.ecodes.EV_KEY, evdev.ecodes.KEY_F14, 1)
+        repeat_release = evdev.InputEvent(0, 0, evdev.ecodes.EV_KEY, evdev.ecodes.KEY_F14, 0)
+        axis_action = dm.MappingAction(
+            action_type=ActionType.GAMEPAD_AXIS,
+            target="abs_z",
+            axis_value=255,
+        )
+
+        await _runtime_execute_grabbed_action(device, axis_action, source_press, "source")
+        await _runtime_execute_grabbed_action(device, axis_action, source_release, "source")
+        await _runtime_execute_grabbed_action(
+            device,
+            dm.MappingAction(action_type=ActionType.REPEAT),
+            repeat_press,
+            "repeat_btn",
+        )
+        await _runtime_execute_grabbed_action(
+            device,
+            dm.MappingAction(action_type=ActionType.REPEAT),
+            repeat_release,
+            "repeat_btn",
+        )
+
+        assert gamepad.writes == [
+            (evdev.ecodes.EV_ABS, evdev.ecodes.ABS_Z, 255),
+            (evdev.ecodes.EV_ABS, evdev.ecodes.ABS_Z, 0),
+            (evdev.ecodes.EV_ABS, evdev.ecodes.ABS_Z, 255),
+            (evdev.ecodes.EV_ABS, evdev.ecodes.ABS_Z, 0),
+        ]
+
+    @pytest.mark.asyncio
+    async def test_repeat_exec_refresh_preserves_original_history_source(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from keymasq.keymasqd.runtime.repeat import RepeatHistoryEntry
+
+        device = _make_grabbed_device(monkeypatch)
+        device.repeat_state.history.append(
+            RepeatHistoryEntry(
+                category="special",
+                action=dm.MappingAction(action_type=ActionType.EXEC, exec_ref=7),
+                source_device="original-device",
+                source_button="original-button",
+            )
+        )
+
+        await _runtime_execute_grabbed_action(
+            device,
+            dm.MappingAction(action_type=ActionType.REPEAT),
+            evdev.InputEvent(0, 0, evdev.ecodes.EV_KEY, evdev.ecodes.KEY_F14, 1),
+            "repeat_btn",
+        )
+
+        latest = device.repeat_state.history[-1]
+        assert latest.action.action_type == ActionType.EXEC
+        assert latest.action.exec_ref == 7
+        assert latest.source_device == "original-device"
+        assert latest.source_button == "original-button"
+
+    @pytest.mark.asyncio
+    async def test_repeat_exec_refresh_checks_exec_ref_identity(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from keymasq.keymasqd.runtime.repeat import (
+            RepeatHistoryEntry,
+            refresh_repeated_exec_source,
+        )
+
+        device = _make_grabbed_device(monkeypatch)
+        selected_entry = RepeatHistoryEntry(
+            category="special",
+            action=dm.MappingAction(action_type=ActionType.EXEC, exec_ref=7),
+            source_device="original-device",
+            source_button="original-button",
+        )
+        device.repeat_state.history.append(
+            RepeatHistoryEntry(
+                category="special",
+                action=dm.MappingAction(action_type=ActionType.EXEC, exec_ref=8),
+                source_device="other-device",
+                source_button="other-button",
+            )
+        )
+
+        refresh_repeated_exec_source(device.repeat_state, selected_entry)
+
+        latest = device.repeat_state.history[-1]
+        assert latest.action.exec_ref == 8
+        assert latest.source_device == "other-device"
+        assert latest.source_button == "other-button"
+
+    @pytest.mark.asyncio
+    async def test_repeat_superkey_exec_refresh_preserves_original_history_source(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from keymasq.keymasqd.runtime.repeat import (
+            SUPERKEY_SLOT_TAP,
+            RepeatHistoryEntry,
+        )
+
+        device = _make_grabbed_device(monkeypatch)
+        superkey_config = SuperkeyConfig(
+            name="exec-superkey",
+            tap_actions=[SuperkeyActionData(action_type="exec", exec_ref=7)],
+        )
+        device.repeat_state.history.append(
+            RepeatHistoryEntry(
+                category="special",
+                action=dm.MappingAction(
+                    action_type=ActionType.SUPERKEY,
+                    superkey_config=superkey_config,
+                ),
+                source_device="original-device",
+                source_button="original-button",
+                superkey_slot=SUPERKEY_SLOT_TAP,
+            )
+        )
+
+        await _runtime_execute_grabbed_action(
+            device,
+            dm.MappingAction(action_type=ActionType.REPEAT),
+            evdev.InputEvent(0, 0, evdev.ecodes.EV_KEY, evdev.ecodes.KEY_F14, 1),
+            "repeat_btn",
+        )
+
+        latest = device.repeat_state.history[-1]
+        assert latest.action.action_type == ActionType.SUPERKEY
+        assert latest.action.superkey_config is superkey_config
+        assert latest.superkey_slot == SUPERKEY_SLOT_TAP
+        assert latest.source_device == "original-device"
+        assert latest.source_button == "original-button"
+
+    @pytest.mark.asyncio
+    async def test_repeat_profile_action_is_ignored(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from keymasq.keymasqd.runtime.repeat import RepeatHistoryEntry
+
+        events: list[tuple[CommandType, dict[str, object]]] = []
+
+        async def broadcast(event_type: CommandType, data: dict[str, object]) -> None:
+            events.append((event_type, data))
+            if event_type == CommandType.ACTION_TRIGGER:
+                await manager.track_profile_activation(
+                    str(data["profile_name"]),
+                    "activation-1",
+                    str(data["trigger_id"]),
+                    data.get("deactivation"),
+                )
+
+        manager = DeviceManager(broadcast_callback=broadcast)
+        device = _make_grabbed_device(
+            monkeypatch,
+            button_map={"repeat": "key_f13"},
+            broadcast_callback=broadcast,
+            profile_activation_trigger_start_observer=manager.observe_profile_trigger_start,
+            profile_activation_trigger_end_observer=manager.observe_profile_trigger_end,
+            repeat_state=manager.repeat_state,
+        )
+        device.mapping_getter = lambda: {  # type: ignore[method-assign]
+            "repeat": dm.MappingAction(action_type=ActionType.REPEAT),
+        }
+        manager.repeat_state.history.append(
+            RepeatHistoryEntry(
+                category="special",
+                action=dm.MappingAction(
+                    action_type=ActionType.PROFILE_ENABLE,
+                    profile_name="Nav",
+                    profile_deactivation=ProfileDeactivationPolicy(on_trigger_end=True),
+                ),
+            )
+        )
+        repeat_press = evdev.InputEvent(0, 0, evdev.ecodes.EV_KEY, evdev.ecodes.KEY_F13, 1)
+        repeat_release = evdev.InputEvent(0, 0, evdev.ecodes.EV_KEY, evdev.ecodes.KEY_F13, 0)
+
+        await _runtime_process_grabbed_event(device, repeat_press)
+        await asyncio.sleep(0)
+
+        assert events == []
+
+        await _runtime_process_grabbed_event(device, repeat_release)
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+
+        assert events == []
+
+    @pytest.mark.asyncio
+    async def test_repeat_action_filters_history_categories(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        keyboard = _FakeUInput()
+        mouse = _FakeUInput()
+        device = _make_grabbed_device(
+            monkeypatch,
+            keyboard_uinput=keyboard,
+            mouse_uinput=mouse,
+        )
+        press = evdev.InputEvent(0, 0, evdev.ecodes.EV_KEY, evdev.ecodes.KEY_F13, 1)
+        release = evdev.InputEvent(0, 0, evdev.ecodes.EV_KEY, evdev.ecodes.KEY_F13, 0)
+
+        await _runtime_execute_grabbed_action(
+            device,
+            dm.MappingAction(action_type=ActionType.MOUSE, target="btn_left"),
+            press,
+            "mouse",
+        )
+        await _runtime_execute_grabbed_action(
+            device,
+            dm.MappingAction(action_type=ActionType.MOUSE, target="btn_left"),
+            release,
+            "mouse",
+        )
+        await _runtime_execute_grabbed_action(
+            device,
+            dm.MappingAction(action_type=ActionType.KEYBOARD, target="key_a"),
+            press,
+            "keyboard",
+        )
+        await _runtime_execute_grabbed_action(
+            device,
+            dm.MappingAction(action_type=ActionType.KEYBOARD, target="key_a"),
+            release,
+            "keyboard",
+        )
+        await _runtime_execute_grabbed_action(
+            device,
+            dm.MappingAction(
+                action_type=ActionType.REPEAT,
+                repeat_categories=["mouse"],
+            ),
+            press,
+            "repeat_btn",
+        )
+        await _runtime_execute_grabbed_action(
+            device,
+            dm.MappingAction(
+                action_type=ActionType.REPEAT,
+                repeat_categories=["mouse"],
+            ),
+            release,
+            "repeat_btn",
+        )
+
+        assert keyboard.writes == [
+            (evdev.ecodes.EV_KEY, evdev.ecodes.KEY_A, 1),
+            (evdev.ecodes.EV_KEY, evdev.ecodes.KEY_A, 0),
+        ]
+        assert mouse.writes == [
+            (evdev.ecodes.EV_KEY, evdev.ecodes.BTN_LEFT, 1),
+            (evdev.ecodes.EV_KEY, evdev.ecodes.BTN_LEFT, 0),
+            (evdev.ecodes.EV_KEY, evdev.ecodes.BTN_LEFT, 1),
+            (evdev.ecodes.EV_KEY, evdev.ecodes.BTN_LEFT, 0),
+        ]
+
+    @pytest.mark.asyncio
+    async def test_repeat_action_can_replay_passthrough_input(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        keyboard = _FakeUInput()
+        passthrough = _FakeUInput()
+        device = _make_grabbed_device(monkeypatch, keyboard_uinput=keyboard)
+        device.uinput = passthrough  # type: ignore[assignment]
+        source_press = evdev.InputEvent(0, 0, evdev.ecodes.EV_KEY, evdev.ecodes.KEY_B, 1)
+        source_release = evdev.InputEvent(0, 0, evdev.ecodes.EV_KEY, evdev.ecodes.KEY_B, 0)
+        repeat_press = evdev.InputEvent(0, 0, evdev.ecodes.EV_KEY, evdev.ecodes.KEY_F14, 1)
+        repeat_release = evdev.InputEvent(0, 0, evdev.ecodes.EV_KEY, evdev.ecodes.KEY_F14, 0)
+
+        await _runtime_process_grabbed_event(device, source_press)
+        await _runtime_process_grabbed_event(device, source_release)
+        await _runtime_execute_grabbed_action(
+            device,
+            dm.MappingAction(action_type=ActionType.REPEAT),
+            repeat_press,
+            "repeat_btn",
+        )
+        await _runtime_execute_grabbed_action(
+            device,
+            dm.MappingAction(action_type=ActionType.REPEAT),
+            repeat_release,
+            "repeat_btn",
+        )
+
+        assert passthrough.writes == [
+            (evdev.ecodes.EV_KEY, evdev.ecodes.KEY_B, 1),
+            (evdev.ecodes.EV_KEY, evdev.ecodes.KEY_B, 0),
+        ]
+        assert keyboard.writes == [
+            (evdev.ecodes.EV_KEY, evdev.ecodes.KEY_B, 1),
+            (evdev.ecodes.EV_KEY, evdev.ecodes.KEY_B, 0),
+        ]
+
+    @pytest.mark.asyncio
+    async def test_repeat_action_replays_passthrough_mouse_click_more_than_once(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        mouse = _FakeUInput()
+        passthrough = _FakeUInput()
+        device = _make_grabbed_device(
+            monkeypatch,
+            button_map={"left": "btn_left", "repeat": "key_f13"},
+            mouse_uinput=mouse,
+        )
+        device.uinput = passthrough  # type: ignore[assignment]
+        device.mapping_getter = lambda: {"repeat": dm.MappingAction(action_type=ActionType.REPEAT)}
+        left_press = evdev.InputEvent(0, 0, evdev.ecodes.EV_KEY, evdev.ecodes.BTN_LEFT, 1)
+        left_release = evdev.InputEvent(0, 0, evdev.ecodes.EV_KEY, evdev.ecodes.BTN_LEFT, 0)
+        repeat_press = evdev.InputEvent(0, 0, evdev.ecodes.EV_KEY, evdev.ecodes.KEY_F13, 1)
+        repeat_release = evdev.InputEvent(0, 0, evdev.ecodes.EV_KEY, evdev.ecodes.KEY_F13, 0)
+
+        await _runtime_process_grabbed_event(device, left_press)
+        await _runtime_process_grabbed_event(device, left_release)
+        await _runtime_process_grabbed_event(device, repeat_press)
+        await _runtime_process_grabbed_event(device, repeat_release)
+        await _runtime_process_grabbed_event(device, repeat_press)
+        await _runtime_process_grabbed_event(device, repeat_release)
+
+        assert passthrough.writes == [
+            (evdev.ecodes.EV_KEY, evdev.ecodes.BTN_LEFT, 1),
+            (evdev.ecodes.EV_KEY, evdev.ecodes.BTN_LEFT, 0),
+        ]
+        assert mouse.writes == [
+            (evdev.ecodes.EV_KEY, evdev.ecodes.BTN_LEFT, 1),
+            (evdev.ecodes.EV_KEY, evdev.ecodes.BTN_LEFT, 0),
+            (evdev.ecodes.EV_KEY, evdev.ecodes.BTN_LEFT, 1),
+            (evdev.ecodes.EV_KEY, evdev.ecodes.BTN_LEFT, 0),
+        ]
+
+    @pytest.mark.asyncio
+    async def test_repeat_passthrough_gamepad_button_reuses_source_hardware_output(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from keymasq.keymasqd.runtime.repeat import remember_passthrough_event
+
+        source_gamepad = _FakeUInput()
+        default_gamepad = _FakeUInput()
+        resolved_output_ids: list[str | None] = []
+        device = _make_grabbed_device(
+            monkeypatch,
+            device_type=DeviceType.GAMEPAD,
+            device_types=[DeviceType.GAMEPAD.value],
+            gamepad_uinput=default_gamepad,
+        )
+
+        def resolve_gamepad_output(output_id: str | None, _context: str) -> SimpleNamespace:
+            resolved_output_ids.append(output_id)
+            return SimpleNamespace(
+                output_id=output_id,
+                uinput=source_gamepad if output_id == "1234:5678" else default_gamepad,
+                bucket=f"gamepad:{output_id or 'virtual-gamepad-1'}",
+            )
+
+        device._gamepad_output_resolver = resolve_gamepad_output  # type: ignore[method-assign, reportPrivateUsage]
+        remember_passthrough_event(
+            device.repeat_state,
+            device,
+            evdev.InputEvent(0, 0, evdev.ecodes.EV_KEY, evdev.ecodes.BTN_SOUTH, 1),
+            "btn_south",
+            evdev_mod=evdev,
+        )
+
+        remembered = device.repeat_state.history[-1].action
+        assert remembered.action_type == ActionType.GAMEPAD
+        assert remembered.output_id == "1234:5678"
+
+        await _runtime_execute_grabbed_action(
+            device,
+            dm.MappingAction(action_type=ActionType.REPEAT),
+            evdev.InputEvent(0, 0, evdev.ecodes.EV_KEY, evdev.ecodes.KEY_F14, 1),
+            "repeat_btn",
+        )
+        await _runtime_execute_grabbed_action(
+            device,
+            dm.MappingAction(action_type=ActionType.REPEAT),
+            evdev.InputEvent(0, 0, evdev.ecodes.EV_KEY, evdev.ecodes.KEY_F14, 0),
+            "repeat_btn",
+        )
+
+        assert resolved_output_ids == ["1234:5678", "1234:5678"]
+        assert source_gamepad.writes == [
+            (evdev.ecodes.EV_KEY, evdev.ecodes.BTN_SOUTH, 1),
+            (evdev.ecodes.EV_KEY, evdev.ecodes.BTN_SOUTH, 0),
+        ]
+        assert default_gamepad.writes == []
+
+    @pytest.mark.asyncio
+    async def test_repeat_passthrough_gamepad_trigger_button_remains_digital(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from keymasq.keymasqd.runtime.repeat import remember_passthrough_event
+
+        source_gamepad = _FakeUInput()
+        default_gamepad = _FakeUInput()
+        resolved_output_ids: list[str | None] = []
+        device = _make_grabbed_device(
+            monkeypatch,
+            device_type=DeviceType.GAMEPAD,
+            device_types=[DeviceType.GAMEPAD.value],
+            gamepad_uinput=default_gamepad,
+        )
+
+        def resolve_gamepad_output(output_id: str | None, _context: str) -> SimpleNamespace:
+            resolved_output_ids.append(output_id)
+            return SimpleNamespace(
+                output_id=output_id,
+                uinput=source_gamepad if output_id == "1234:5678" else default_gamepad,
+                bucket=f"gamepad:{output_id or 'virtual-gamepad-1'}",
+            )
+
+        device._gamepad_output_resolver = resolve_gamepad_output  # type: ignore[method-assign, reportPrivateUsage]
+        remember_passthrough_event(
+            device.repeat_state,
+            device,
+            evdev.InputEvent(0, 0, evdev.ecodes.EV_KEY, evdev.ecodes.BTN_TL2, 1),
+            "btn_tl2",
+            evdev_mod=evdev,
+        )
+
+        remembered = device.repeat_state.history[-1].action
+        assert remembered.action_type == ActionType.GAMEPAD
+        assert remembered.target == "btn_tl2"
+        assert remembered.output_id == "1234:5678"
+
+        await _runtime_execute_grabbed_action(
+            device,
+            dm.MappingAction(action_type=ActionType.REPEAT),
+            evdev.InputEvent(0, 0, evdev.ecodes.EV_KEY, evdev.ecodes.KEY_F14, 1),
+            "repeat_btn",
+        )
+        await _runtime_execute_grabbed_action(
+            device,
+            dm.MappingAction(action_type=ActionType.REPEAT),
+            evdev.InputEvent(0, 0, evdev.ecodes.EV_KEY, evdev.ecodes.KEY_F14, 0),
+            "repeat_btn",
+        )
+
+        assert resolved_output_ids == ["1234:5678", "1234:5678"]
+        assert source_gamepad.writes == [
+            (evdev.ecodes.EV_KEY, evdev.ecodes.BTN_TL2, 1),
+            (evdev.ecodes.EV_KEY, evdev.ecodes.BTN_TL2, 0),
+        ]
+        assert default_gamepad.writes == []
+
+    @pytest.mark.asyncio
+    async def test_repeat_replays_passthrough_high_res_wheel_event(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        rel_wheel_hi_res = getattr(evdev.ecodes, "REL_WHEEL_HI_RES", None)
+        if rel_wheel_hi_res is None:
+            pytest.skip("kernel headers do not expose REL_WHEEL_HI_RES")
+        mouse = _FakeUInput()
+        passthrough = _FakeUInput()
+        device = _make_grabbed_device(
+            monkeypatch,
+            button_map={"repeat": "key_f13"},
+            mouse_uinput=mouse,
+        )
+        device.uinput = passthrough  # type: ignore[assignment]
+        device.mapping_getter = lambda: {"repeat": dm.MappingAction(action_type=ActionType.REPEAT)}
+
+        await _runtime_process_grabbed_event(
+            device,
+            evdev.InputEvent(0, 0, evdev.ecodes.EV_REL, int(rel_wheel_hi_res), -120),
+        )
+        await _runtime_process_grabbed_event(
+            device,
+            evdev.InputEvent(0, 0, evdev.ecodes.EV_KEY, evdev.ecodes.KEY_F13, 1),
+        )
+        await _runtime_process_grabbed_event(
+            device,
+            evdev.InputEvent(0, 0, evdev.ecodes.EV_KEY, evdev.ecodes.KEY_F13, 0),
+        )
+
+        assert passthrough.writes == [(evdev.ecodes.EV_REL, int(rel_wheel_hi_res), -120)]
+        assert mouse.writes == [
+            (evdev.ecodes.EV_REL, evdev.ecodes.REL_WHEEL, -1),
+            (evdev.ecodes.EV_REL, int(rel_wheel_hi_res), -120),
+        ]
+
+    @pytest.mark.asyncio
+    async def test_repeat_mouse_wheel_rapidfire_emits_relative_events(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        mouse = _FakeUInput()
+        device = _make_grabbed_device(
+            monkeypatch,
+            mouse_uinput=mouse,
+        )
+        device._running = True
+        wheel_source = evdev.InputEvent(0, 0, evdev.ecodes.EV_KEY, evdev.ecodes.KEY_F13, 1)
+
+        await _runtime_execute_grabbed_action(
+            device,
+            dm.MappingAction(action_type=ActionType.MOUSE, target="rel_wheel:1"),
+            wheel_source,
+            "wheel",
+        )
+        await _runtime_execute_grabbed_action(
+            device,
+            dm.MappingAction(
+                action_type=ActionType.REPEAT,
+                rapidfire_enabled=True,
+                rapidfire_hold_ms=1,
+                rapidfire_wait_ms=1,
+            ),
+            evdev.InputEvent(0, 0, evdev.ecodes.EV_KEY, evdev.ecodes.KEY_F14, 1),
+            "repeat_btn",
+        )
+        await asyncio.sleep(0.01)
+        await _runtime_execute_grabbed_action(
+            device,
+            dm.MappingAction(
+                action_type=ActionType.REPEAT,
+                rapidfire_enabled=True,
+                rapidfire_hold_ms=1,
+                rapidfire_wait_ms=1,
+            ),
+            evdev.InputEvent(0, 0, evdev.ecodes.EV_KEY, evdev.ecodes.KEY_F14, 0),
+            "repeat_btn",
+        )
+
+        wheel_writes = [
+            write
+            for write in mouse.writes
+            if write[0:2] == (evdev.ecodes.EV_REL, evdev.ecodes.REL_WHEEL)
+        ]
+        assert len(wheel_writes) > 1
+
+    def test_repeat_rapidfire_is_limited_to_key_button_and_wheel_actions(self) -> None:
+        from keymasq.keymasqd.runtime.repeat import (
+            RepeatHistoryEntry,
+            RepeatRuntimeState,
+            remember_passthrough_event,
+            repeat_category_for_action,
+            repeat_execution_action,
+            select_repeated_action,
+        )
+
+        repeat_action = dm.MappingAction(
+            action_type=ActionType.REPEAT,
+            rapidfire_enabled=True,
+            rapidfire_hold_ms=5,
+            rapidfire_wait_ms=7,
+        )
+        key_action = repeat_execution_action(
+            repeat_action,
+            dm.MappingAction(action_type=ActionType.KEYBOARD, target="key_a"),
+        )
+        wheel_action = repeat_execution_action(
+            repeat_action,
+            dm.MappingAction(action_type=ActionType.MOUSE, target="rel_wheel:1"),
+        )
+        macro_action = repeat_execution_action(
+            repeat_action,
+            dm.MappingAction(action_type=ActionType.MACRO, macro_name="demo"),
+        )
+        repeat_state = RepeatRuntimeState()
+        remember_passthrough_event(
+            repeat_state,
+            SimpleNamespace(hardware_id="mouse", device_types=["mouse"]),
+            evdev.InputEvent(0, 0, evdev.ecodes.EV_REL, evdev.ecodes.REL_X, 10),
+            "rel_x",
+            evdev_mod=evdev,
+        )
+        repeat_state.history.append(
+            RepeatHistoryEntry(
+                category="keyboard",
+                action=dm.MappingAction(action_type=ActionType.KEYBOARD, target="key_b"),
+            )
+        )
+        repeat_state.history.append(
+            RepeatHistoryEntry(
+                category="special",
+                action=dm.MappingAction(action_type=ActionType.REPEAT),
+            )
+        )
+
+        assert key_action.rapidfire_enabled is True
+        assert key_action.rapidfire_hold_ms == 5
+        assert key_action.rapidfire_wait_ms == 7
+        assert wheel_action.rapidfire_enabled is True
+        assert macro_action.rapidfire_enabled is False
+        assert (
+            repeat_category_for_action(
+                dm.MappingAction(action_type=ActionType.MOUSE_MOVE_REL, move_x=5)
+            )
+            == "special"
+        )
+        selected_action = select_repeated_action(repeat_state, repeat_action)
+        assert selected_action is not None
+        assert selected_action.target == "key_b"
+
+    @pytest.mark.asyncio
     async def test_routed_gamepad_axis_release_all_keys_zeros_target_output(
         self,
         monkeypatch: pytest.MonkeyPatch,
@@ -1572,9 +2292,7 @@ class TestGrabbedDeviceHelpers:
         )
 
         assert second_gamepad.writes == [(evdev.ecodes.EV_ABS, evdev.ecodes.ABS_Z, 255)]
-        assert device.state.held_output_abs["gamepad:virtual-gamepad-2"] == {
-            evdev.ecodes.ABS_Z
-        }
+        assert device.state.held_output_abs["gamepad:virtual-gamepad-2"] == {evdev.ecodes.ABS_Z}
 
         gdo.release_all_keys(
             device,
@@ -1612,7 +2330,7 @@ class TestGrabbedDeviceHelpers:
     async def test_gamepad_axis_tap_uses_configured_value(
         self,
         monkeypatch: pytest.MonkeyPatch,
-        ) -> None:
+    ) -> None:
         gamepad = _FakeUInput()
         device = _make_grabbed_device(monkeypatch, gamepad_uinput=gamepad)
         press = evdev.InputEvent(0, 0, evdev.ecodes.EV_KEY, evdev.ecodes.BTN_SOUTH, 1)
@@ -1655,18 +2373,14 @@ class TestGrabbedDeviceHelpers:
             target="btn_south",
             output_id="virtual-gamepad-2",
         )
-        device.state.held_output_keys["gamepad:virtual-gamepad-2"] = {
-            evdev.ecodes.BTN_SOUTH
-        }
+        device.state.held_output_keys["gamepad:virtual-gamepad-2"] = {evdev.ecodes.BTN_SOUTH}
 
         assert device.combo_passthrough_binding_active("key_x") is True
 
         device.emit_combo_release("key_x")
 
         assert default_gamepad.writes == []
-        assert second_gamepad.writes == [
-            (evdev.ecodes.EV_KEY, evdev.ecodes.BTN_SOUTH, 0)
-        ]
+        assert second_gamepad.writes == [(evdev.ecodes.EV_KEY, evdev.ecodes.BTN_SOUTH, 0)]
         assert device.state.held_output_keys["gamepad:virtual-gamepad-2"] == set()
 
         device.emit_combo_press("key_x")
@@ -1686,9 +2400,7 @@ class TestGrabbedDeviceHelpers:
     ) -> None:
         device = _make_grabbed_device(monkeypatch)
         device._gamepad_output_resolver = lambda output_id, context: None  # type: ignore[method-assign, reportPrivateUsage]
-        device.state.held_output_abs["gamepad:virtual-gamepad-2"] = {
-            evdev.ecodes.ABS_Z
-        }
+        device.state.held_output_abs["gamepad:virtual-gamepad-2"] = {evdev.ecodes.ABS_Z}
         device.state.held_output_keys.pop("gamepad:virtual-gamepad-2", None)
 
         gdo.release_all_keys(
@@ -1903,8 +2615,7 @@ class TestGrabbedDeviceHelpers:
         )
 
         assert any(
-            write == (evdev.ecodes.EV_REL, evdev.ecodes.REL_HWHEEL, -1)
-            for write in mouse.writes
+            write == (evdev.ecodes.EV_REL, evdev.ecodes.REL_HWHEEL, -1) for write in mouse.writes
         )
 
     @pytest.mark.asyncio

--- a/tests/session/test_session_manager_payloads_extra.py
+++ b/tests/session/test_session_manager_payloads_extra.py
@@ -76,6 +76,13 @@ def test_profile_to_mapping_serializes_high_value_action_payloads() -> None:
                 action_type=ActionType.PROFILE_TOGGLE,
                 profile_name="Gaming",
             ),
+            "repeat": MappingAction(
+                action_type=ActionType.REPEAT,
+                repeat_categories=["keyboard", "mouse"],
+                rapidfire_enabled=True,
+                rapidfire_hold_ms=11,
+                rapidfire_wait_ms=13,
+            ),
             "super": MappingAction(
                 action_type=ActionType.SUPERKEY,
                 superkey_name="launcher",
@@ -116,6 +123,13 @@ def test_profile_to_mapping_serializes_high_value_action_payloads() -> None:
     assert macro_mapping["macro_loop_count"] == 3
     assert macro_mapping["macro_block_mouse_movement"] is True
     assert mapping["profile"] == {"action": "profile_toggle", "profile_name": "Gaming"}
+    assert mapping["repeat"] == {
+        "action": "repeat",
+        "repeat_categories": ["keyboard", "mouse"],
+        "rapidfire_enabled": True,
+        "rapidfire_hold_ms": 11,
+        "rapidfire_wait_ms": 13,
+    }
     super_mapping = cast(dict[str, object], mapping["super"])
     superkey_payload = cast(dict[str, object], super_mapping["superkey"])
     overload_actions = cast(list[dict[str, object]], superkey_payload["overload_actions"])
@@ -169,6 +183,39 @@ def test_gamepad_payloads_include_output_id_and_signature_changes() -> None:
     )
     routed_sig = payloads.resolved_mapping_signature(manager, resolved, "pad")
     assert default_sig != routed_sig
+
+
+def test_repeat_combo_payload_includes_categories_and_rapidfire() -> None:
+    from keymasq.common.models import ActionType, ComboEvent, ComboStep, MappingAction
+    from keymasq.session.manager import payloads
+    from keymasq.session.profiles import ResolvedCombo
+
+    manager = _manager_with_superkeys()
+    combo_payload = payloads.resolved_combos_payload(
+        manager,
+        [
+            ResolvedCombo(
+                id="repeat-combo",
+                name="Repeat Combo",
+                steps=[ComboStep(events=[ComboEvent(hardware_id="kbd", evdev="key_f13")])],
+                action=MappingAction(
+                    action_type=ActionType.REPEAT,
+                    repeat_categories=["keyboard", "gamepad"],
+                    rapidfire_enabled=True,
+                    rapidfire_hold_ms=15,
+                    rapidfire_wait_ms=25,
+                ),
+            )
+        ],
+    )
+
+    assert combo_payload[0]["action"] == {
+        "action": "repeat",
+        "repeat_categories": ["keyboard", "gamepad"],
+        "rapidfire_enabled": True,
+        "rapidfire_hold_ms": 15,
+        "rapidfire_wait_ms": 25,
+    }
 
 
 def test_profile_to_mapping_serializes_multiple_analog_controls() -> None:

--- a/tests/test_superkeys.py
+++ b/tests/test_superkeys.py
@@ -688,6 +688,25 @@ def test_superkey_runtime_payload_rejects_nested_overload_superkey() -> None:
         )
 
 
+def test_superkey_runtime_payload_rejects_repeat_overload_superkey() -> None:
+    with pytest.raises(ValueError, match="repeat is not allowed inside overload superkeys"):
+        parse_superkey_config(
+            _parse_manager(),
+            {
+                "name": "bad_overload_repeat",
+                "mode": "overload",
+                "overload_actions": [{"action": "repeat"}],
+            },
+            json_object=lambda value: value if isinstance(value, dict) else None,
+            str_value=lambda value, default="": default if value is None else str(value),
+            optional_str=lambda value: None if value is None else str(value),
+            int_value=lambda value, default=0: default if value is None else int(value),
+            int_or_none=lambda value: None if value is None else int(value),
+            float_value=lambda value, default=0.0: default if value is None else float(value),
+            parse_superkey_action=lambda *_args, **_kwargs: None,
+        )
+
+
 def test_superkey_manager_rejects_nested_overload_superkeys(
     temp_config_dir,
     monkeypatch: pytest.MonkeyPatch,
@@ -706,6 +725,24 @@ def test_superkey_manager_rejects_nested_overload_superkeys(
         )
 
 
+def test_superkey_manager_rejects_repeat_overload_superkeys(
+    temp_config_dir,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    superkeys_dir = temp_config_dir / "superkeys"
+    superkeys_dir.mkdir()
+    monkeypatch.setattr(paths, "SUPERKEYS_DIR", superkeys_dir)
+
+    with pytest.raises(ValueError, match="repeat is not allowed inside overload superkeys"):
+        SuperkeyConfig(
+            name="bad_overload",
+            mode=SuperkeyMode.OVERLOAD,
+            overload_actions=[
+                MappingAction(action_type=ActionType.REPEAT),
+            ],
+        )
+
+
 def test_superkey_payload_serializer_rejects_nested_overload_superkeys() -> None:
     manager = SimpleNamespace(
         exec_state=ExecRuntimeState(),
@@ -717,6 +754,20 @@ def test_superkey_payload_serializer_rejects_nested_overload_superkeys() -> None
     ]
 
     with pytest.raises(ValueError, match="nested superkeys are not allowed"):
+        serialize_superkey(manager, config, "1234:5678")
+
+
+def test_superkey_payload_serializer_rejects_repeat_overload_superkeys() -> None:
+    manager = SimpleNamespace(
+        exec_state=ExecRuntimeState(),
+        superkeys=SimpleNamespace(get_superkey=lambda _name: None),
+    )
+    config = SuperkeyConfig(name="bad_payload_repeat", mode=SuperkeyMode.OVERLOAD)
+    config.overload_actions = [
+        MappingAction(action_type=ActionType.REPEAT),
+    ]
+
+    with pytest.raises(ValueError, match="repeat is not allowed inside overload superkeys"):
         serialize_superkey(manager, config, "1234:5678")
 
 

--- a/tests/test_toml.py
+++ b/tests/test_toml.py
@@ -89,6 +89,13 @@ class TestProfileTOML:
                             action_type=ActionType.ANALOG_CONTROL,
                             analog_control_name="FPS Mouse",
                         ),
+                        "btn_repeat": MappingAction(
+                            action_type=ActionType.REPEAT,
+                            repeat_categories=["keyboard", "mouse"],
+                            rapidfire_enabled=True,
+                            rapidfire_hold_ms=40,
+                            rapidfire_wait_ms=60,
+                        ),
                     },
                 )
             },
@@ -113,6 +120,11 @@ class TestProfileTOML:
         assert layer.mappings["btn_forward"].rapidfire_hold_ms == 50
         assert layer.mappings["left_stick"].action_type == ActionType.ANALOG_CONTROL
         assert layer.mappings["left_stick"].analog_control_name == "FPS Mouse"
+        assert layer.mappings["btn_repeat"].action_type == ActionType.REPEAT
+        assert layer.mappings["btn_repeat"].repeat_categories == ["keyboard", "mouse"]
+        assert layer.mappings["btn_repeat"].rapidfire_enabled is True
+        assert layer.mappings["btn_repeat"].rapidfire_hold_ms == 40
+        assert layer.mappings["btn_repeat"].rapidfire_wait_ms == 60
 
     def test_profile_analog_control_names_roundtrip(self, temp_config_dir):
         original = ProfileConfig(


### PR DESCRIPTION
## Summary

- Introduces a new `repeat` action that replays the most recent repeatable action (keyboard, mouse, gamepad, macro, or special).
- Adds a `repeat_categories` field to let users filter which action types Repeat may replay.
- Includes a dedicated UI in the Special tab with category toggle buttons (Keys, Mouse, Gamepad, Macros, Other) and its own Rapidfire controls.
- Remembers resolved Super Key paths (tap, double_tap, hold, tap_hold, overload) rather than raw superkey bindings; repeating runs the saved path once.
- Does not record Repeat itself, passthrough mapping actions, suppress, profile actions, emergency reset, or raw passthrough mouse movement.
- Repeating a remembered action refreshes the history so repeated presses keep replaying the same resolved action.
- Super Key paths containing profile actions are excluded from recording.
- Updates docs (`ACTIONS.md`, `SUPERKEYS.md`, `agents/profiles.txt`, `agents/superkeys-combos.txt`, `llms.txt`) to document the new feature, its behavior, and limitations.
- Adds comprehensive test coverage across `test_device_manager_superkeys`, `test_grabbed_device_runtime_helpers`, `test_combo_action_dispatch`, `test_device_manager_runtime_recovery`, `test_session_manager_payloads_extra`, `test_gui_device_tab_misc`, `test_gui_demo_and_dialogs`, `test_superkeys`, `test_toml`, and `test_mapping_and_profile_state`.

## Testing

- [x] Unit tests pass in all modified test modules.
- [x] New repeat state machine tests cover `select_repeated_entry`, `remember_action`, `forget_exec_actions`, and category filtering.
- [x] GUI dialog tests verify the Repeat button, category toggle buttons, Map Repeat, and Rapidfire visibility.
- [x] Super Key integration tests confirm Repeat resolves and replays the correct slot/overload path.
- [x] Combo action dispatch tests verify Repeat works within combo sequences.
- [x] Device manager runtime recovery tests confirm Repeat state is cleared on device release and set_mapping.
- [x] Profile and mapping state model tests validate `normalize_repeat_categories` and validation of repeat inside overload superkeys.
- [x] Run: Full manual smoke test with physical hardware.