### PR TITLE
fix: close evdev devices that are not grabbed or not matched

### DIFF
--- a/keymasq/keymasqd/capture_manager.py
+++ b/keymasq/keymasqd/capture_manager.py
@@ -141,6 +141,7 @@ class CaptureManager:
                     warnings.append(f"{device.path}: permission denied")
                 else:
                     warnings.append(f"{device.path}: {e}")
+                _close_device(device)
 
         if not grabbed:
             raise RuntimeError("No readable/grabbable interfaces found")
@@ -430,6 +431,8 @@ class CaptureManager:
                 and f"{device.info.product:04x}" == product_id
             ):
                 devices.append(device)
+            else:
+                _close_device(device)
         return devices
 
     def _find_devices_by_paths(self, evdev_paths: list[str]) -> list[_CaptureInputDevice]:
@@ -509,39 +512,45 @@ class CaptureManager:
         for path in list_devices():
             if path in exclude_paths:
                 continue
+            keep_device = False
             try:
                 device = cast(_CaptureInputDevice, evdev.InputDevice(path))
             except Exception:
                 continue
 
-            if device.name.startswith("keymasq-"):
-                continue
-            if path_hardware_ids:
-                if not _hardware_id_for_path(device.path, path_hardware_ids):
-                    continue
-            elif hardware_ids:
-                device_hardware_id = (
-                    f"{device.info.vendor:04x}:{device.info.product:04x}"
-                ).lower()
-                if device_hardware_id not in hardware_ids:
-                    continue
-
             try:
-                key_codes = device.capabilities().get(evdev.ecodes.EV_KEY, [])
-            except Exception:
-                key_codes = []
-
-            has_supported_key = False
-            for code in cast(list[object], key_codes):
-                if not isinstance(code, int):
+                if device.name.startswith("keymasq-"):
                     continue
-                code_name = _event_code_name(evdev.ecodes.EV_KEY, int(code)).upper()
-                if code_name.startswith(("KEY_", "BTN_")):
-                    has_supported_key = True
-                    break
+                if path_hardware_ids:
+                    if not _hardware_id_for_path(device.path, path_hardware_ids):
+                        continue
+                elif hardware_ids:
+                    device_hardware_id = (
+                        f"{device.info.vendor:04x}:{device.info.product:04x}"
+                    ).lower()
+                    if device_hardware_id not in hardware_ids:
+                        continue
 
-            if has_supported_key:
-                devices.append(device)
+                try:
+                    key_codes = device.capabilities().get(evdev.ecodes.EV_KEY, [])
+                except Exception:
+                    key_codes = []
+
+                has_supported_key = False
+                for code in cast(list[object], key_codes):
+                    if not isinstance(code, int):
+                        continue
+                    code_name = _event_code_name(evdev.ecodes.EV_KEY, int(code)).upper()
+                    if code_name.startswith(("KEY_", "BTN_")):
+                        has_supported_key = True
+                        break
+
+                if has_supported_key:
+                    devices.append(device)
+                    keep_device = True
+            finally:
+                if not keep_device:
+                    _close_device(device)
         return devices
 
     def _parse_event(
@@ -714,6 +723,11 @@ def _capture_mode(mode: str) -> str:
     if normalized not in {"button", "analog"}:
         raise ValueError(f"unsupported capture mode: {mode}")
     return normalized
+
+
+def _close_device(device: _CaptureInputDevice) -> None:
+    with contextlib.suppress(Exception):
+        device.close()
 
 
 def _abs_info_payload(device: _CaptureInputDevice, code: int) -> JsonObject:

--- a/tests/test_capture_manager.py
+++ b/tests/test_capture_manager.py
@@ -25,6 +25,7 @@ class _FakeDevice:
         self._events = list(events)
         self.grabbed = False
         self.closed = False
+        self.close_count = 0
         self.fd = hash(path) & 0xFFFF
         self._absinfo = {
             evdev.ecodes.ABS_X: evdev.AbsInfo(0, -32768, 32767, 0, 0, 0),
@@ -39,6 +40,7 @@ class _FakeDevice:
 
     def close(self) -> None:
         self.closed = True
+        self.close_count += 1
 
     def capabilities(self):
         return {evdev.ecodes.EV_KEY: [evdev.ecodes.KEY_A, evdev.ecodes.KEY_LEFTCTRL]}
@@ -283,6 +285,59 @@ def test_capture_manager_begin_reports_grab_warnings(monkeypatch) -> None:
     with pytest.raises(RuntimeError, match="No readable/grabbable interfaces found"):
         manager.begin("1234:5678")
 
+    assert busy.closed is True
+    assert denied.closed is True
+    assert busy.close_count == 1
+    assert denied.close_count == 1
+
+
+def test_capture_manager_begin_closes_failed_grab_devices_with_partial_success(
+    monkeypatch,
+) -> None:
+    grabbed = _FakeDevice("/dev/input/event1", 0x1234, 0x5678, [])
+    busy = _FakeDevice("/dev/input/event2", 0x1234, 0x5678, [])
+
+    def _grab_busy() -> None:
+        raise OSError(16, "busy")
+
+    busy.grab = _grab_busy
+
+    devices = {
+        grabbed.path: grabbed,
+        busy.path: busy,
+    }
+    monkeypatch.setattr(evdev, "list_devices", lambda: list(devices))
+    monkeypatch.setattr(evdev, "InputDevice", lambda path: devices[path])
+
+    manager = CaptureManager()
+    begin = manager.begin("1234:5678")
+
+    assert begin["warnings"] == ["/dev/input/event2: busy"]
+    assert grabbed.closed is False
+    assert busy.closed is True
+    assert busy.close_count == 1
+
+    manager.end(str(begin["token"]))
+    assert grabbed.closed is True
+
+
+def test_capture_manager_find_devices_closes_nonmatching_devices(monkeypatch) -> None:
+    wanted = _FakeDevice("/dev/input/event1", 0x1234, 0x5678, [])
+    other = _FakeDevice("/dev/input/event2", 0x0001, 0x0002, [])
+    devices = {
+        wanted.path: wanted,
+        other.path: other,
+    }
+    monkeypatch.setattr(evdev, "list_devices", lambda: list(devices))
+    monkeypatch.setattr(evdev, "InputDevice", lambda path: devices[path])
+
+    matched = CaptureManager()._find_devices("1234", "5678")
+
+    assert matched == [wanted]
+    assert wanted.closed is False
+    assert other.closed is True
+    assert other.close_count == 1
+
 
 def test_capture_manager_begin_combo_allow_empty_and_read_nowait(monkeypatch) -> None:
     monkeypatch.setattr(evdev, "list_devices", lambda: [])
@@ -427,6 +482,14 @@ def test_capture_manager_find_combo_devices_filters_inputs(monkeypatch) -> None:
     )
 
     assert matched == [good]
+    assert excluded.closed is False
+    assert virtual.closed is True
+    assert wrong_hwid.closed is True
+    assert no_keys.closed is True
+    assert good.closed is False
+    assert virtual.close_count == 1
+    assert wrong_hwid.close_count == 1
+    assert no_keys.close_count == 1
 
     matched_by_path = manager._find_combo_devices(
         exclude_paths=set(),


### PR DESCRIPTION
## Summary

- Devices opened during device discovery that do not match hardware IDs or key criteria are now closed immediately rather than leaked.
- Devices whose grab attempt fails with an error are also closed before raising, so file descriptors are not left dangling on partial failures.
- Introduces a `_close_device()` helper that safely suppresses close errors.

## Testing

- `test_capture_manager_begin_closes_failed_grab_devices_with_partial_success` — verifies devices that fail grab are closed while successfully grabbed devices remain open.
- `test_capture_manager_find_devices_closes_nonmatching_devices` — verifies a non-matching device is closed and a matching device stays open.
- `test_capture_manager_begin_reports_grab_warnings` — updated to assert the busy/denied devices are closed.
- `test_capture_manager_find_combo_devices_filters_inputs` — updated to assert virtual, wrong-hwid, and no-key devices are closed.
- All existing tests pass without regression.