### PR TITLE
fix: use sendall and context manager in _session_request to prevent partial writes

### DIFF
--- a/keymasq/cli/commands.py
+++ b/keymasq/cli/commands.py
@@ -19,21 +19,20 @@ def _session_request(payload: JsonObject, timeout: float = 5.0) -> JsonObject | 
         return None
 
     try:
-        sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-        sock.settimeout(timeout)
-        sock.connect(str(SESSION_SOCKET_PATH))
-        sock.send((json.dumps(payload) + "\n").encode())
+        with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as sock:
+            sock.settimeout(timeout)
+            sock.connect(str(SESSION_SOCKET_PATH))
+            sock.sendall((json.dumps(payload) + "\n").encode())
 
-        buffer = b""
-        while True:
-            chunk = sock.recv(4096)
-            if not chunk:
-                break
-            buffer += chunk
-            if b"\n" in buffer:
-                break
+            buffer = b""
+            while True:
+                chunk = sock.recv(4096)
+                if not chunk:
+                    break
+                buffer += chunk
+                if b"\n" in buffer:
+                    break
 
-        sock.close()
         if not buffer:
             return None
         line = buffer.split(b"\n", 1)[0]

--- a/tests/test_cli_commands_helpers.py
+++ b/tests/test_cli_commands_helpers.py
@@ -1,4 +1,7 @@
 import json
+import socket
+from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -10,6 +13,61 @@ def test_profile_kind_variants() -> None:
     assert commands._profile_kind({"is_permanent": True, "window_rule_count": 0}) == "permanent"
     assert commands._profile_kind({"window_rule_count": 2}) == "conditional"
     assert commands._profile_kind({}) == "standard"
+
+
+def test_session_request_sends_complete_json_line(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    class FakeSocket:
+        def __init__(self, *_args: Any) -> None:
+            self.timeout: float | None = None
+            self.connected_to = ""
+            self.sent = b""
+            self.closed = False
+            self.recv_chunks = [b'{"status":"ok"}\n']
+
+        def __enter__(self) -> "FakeSocket":
+            return self
+
+        def __exit__(self, *_args: Any) -> None:
+            self.close()
+
+        def settimeout(self, timeout: float) -> None:
+            self.timeout = timeout
+
+        def connect(self, path: str) -> None:
+            self.connected_to = path
+
+        def sendall(self, data: bytes) -> None:
+            self.sent += data
+
+        def send(self, _data: bytes) -> int:
+            raise AssertionError("partial-write-prone send() must not be used")
+
+        def recv(self, _size: int) -> bytes:
+            if not self.recv_chunks:
+                return b""
+            return self.recv_chunks.pop(0)
+
+        def close(self) -> None:
+            self.closed = True
+
+    fake_socket = FakeSocket()
+    socket_path = tmp_path / "session.sock"
+    socket_path.touch()
+    monkeypatch.setattr(commands, "SESSION_SOCKET_PATH", socket_path)
+    monkeypatch.setattr(socket, "socket", lambda *_args: fake_socket)
+
+    result = commands._session_request({"command": "create_macro", "events": ["x" * 8192]})
+
+    assert result == {"status": "ok"}
+    assert fake_socket.connected_to == str(socket_path)
+    assert fake_socket.closed is True
+    assert fake_socket.sent.endswith(b"\n")
+    assert json.loads(fake_socket.sent.decode()) == {
+        "command": "create_macro",
+        "events": ["x" * 8192],
+    }
 
 
 def test_list_macros_cli_prints_macros(


### PR DESCRIPTION
## Summary

- Replaced `sock.send()` with `sock.sendall()` in `_session_request` to avoid partial writes on large payloads
- Wrapped socket usage in a context manager (`with` statement) to guarantee proper cleanup
- Added a comprehensive unit test (`test_session_request_sends_complete_json_line`) that verifies full payload delivery and that `send()` is never called

## Testing

- `test_session_request_sends_complete_json_line` passes — validates JSON line is sent in full, socket is closed, and `send()` raises `AssertionError` if accidentally used
- Existing `test_list_macros_cli_prints_macros` continues to pass
- Not run: manual end-to-end session request with a large macro payload