### PR TITLE
fix: reject non-object events in macro JSON input

### DIFF
--- a/keymasq/cli/commands.py
+++ b/keymasq/cli/commands.py
@@ -267,7 +267,7 @@ def play_adhoc_cli(
             raw_events = macro_data.get("events", [])
             if not isinstance(raw_events, list):
                 raise ValueError("macro JSON events must be a list")
-            events = [cast(JsonObject, event) for event in raw_events if isinstance(event, dict)]
+            events = _macro_events_from_json(raw_events)
             payload = build_macro_payload(
                 events,
                 name=str(macro_data.get("name", "") or ""),
@@ -362,7 +362,7 @@ def _macro_definition_from_json_input(name: str, json_parts: list[str]) -> JsonO
     raw_events = macro_data.get("events", [])
     if not isinstance(raw_events, list):
         raise ValueError("macro JSON events must be a list")
-    events = [cast(JsonObject, event) for event in raw_events if isinstance(event, dict)]
+    events = _macro_events_from_json(raw_events)
     macro = macro_definition_from_events(
         events,
         name=name,
@@ -388,6 +388,15 @@ def _macro_device_types(macro_data: JsonObject) -> list[str] | None:
     if not isinstance(raw_device_types, list):
         return None
     return [str(device_type) for device_type in raw_device_types if str(device_type)]
+
+
+def _macro_events_from_json(raw_events: list[object]) -> list[JsonObject]:
+    events: list[JsonObject] = []
+    for index, event in enumerate(raw_events):
+        if not isinstance(event, dict):
+            raise ValueError(f"macro JSON events[{index}] must be an object")
+        events.append(cast(JsonObject, event))
+    return events
 
 
 def set_diagnostics_cli(

--- a/tests/test_cli_commands_helpers.py
+++ b/tests/test_cli_commands_helpers.py
@@ -67,6 +67,22 @@ def test_create_macro_cli_sends_create_payload(monkeypatch: pytest.MonkeyPatch) 
     assert macro["events"] == [{"device_type": "keyboard", "t_us": 0}]
 
 
+def test_create_macro_cli_rejects_non_object_event(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr(commands, "_session_request", lambda payload: pytest.fail("sent request"))
+
+    with pytest.raises(SystemExit) as excinfo:
+        commands.create_macro_cli(
+            "stored",
+            ['{"events":[{"device_type":"keyboard","t_us":0},"bad",{"t_us":1}]}'],
+        )
+
+    assert excinfo.value.code == 1
+    assert "Error: macro JSON events[1] must be an object" in capsys.readouterr().out
+
+
 def test_create_macro_cli_force_sends_update_payload(monkeypatch: pytest.MonkeyPatch) -> None:
     sent: list[dict[str, object]] = []
 
@@ -275,6 +291,22 @@ def test_play_adhoc_cli_reads_json_payload(monkeypatch: pytest.MonkeyPatch) -> N
     assert payload["macro_events"] == [
         {"device_type": "keyboard", "type": 1, "code": 30, "value": 1, "t_us": 0}
     ]
+
+
+def test_play_adhoc_cli_rejects_non_object_json_event(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr(commands, "_session_request", lambda payload: pytest.fail("sent request"))
+
+    with pytest.raises(SystemExit) as excinfo:
+        commands.play_adhoc_cli(
+            ['{"events":[{"device_type":"keyboard","t_us":0},false,{"t_us":1}]}'],
+            input_json=True,
+        )
+
+    assert excinfo.value.code == 1
+    assert "Error: macro JSON events[1] must be an object" in capsys.readouterr().out
 
 
 def test_play_adhoc_cli_print_json_does_not_send(


### PR DESCRIPTION
## Summary

*   Extracted event validation into a `_macro_events_from_json` helper.
*   `play_adhoc_cli` and `_macro_definition_from_json_input` now raise a `ValueError` with the offending index instead of silently dropping non-dict items.
*   Added tests covering string and boolean non-object events in the events list.

## Testing

*   `test_create_macro_cli_rejects_non_object_event` — verifies error message for string event at index 1
*   `test_play_adhoc_cli_rejects_non_object_json_event` — verifies error message for `false` event at index 1
*   All existing tests in `test_cli_commands_helpers.py` continue to pass