### PR TITLE
Fix capture unlock token validation and end-after-expiry

### DIFF
--- a/keymasq/keymasqd/capture_manager.py
+++ b/keymasq/keymasqd/capture_manager.py
@@ -223,6 +223,8 @@ class CaptureManager:
 
         token = token or str(uuid.uuid4())
         if token in self._sessions:
+            for device in devices:
+                _close_device(device)
             raise ValueError("Capture token already active")
 
         session = CaptureSession(

--- a/keymasq/keymasqd/capture_manager.py
+++ b/keymasq/keymasqd/capture_manager.py
@@ -222,6 +222,9 @@ class CaptureManager:
             raise RuntimeError("No readable keyboard interfaces found")
 
         token = token or str(uuid.uuid4())
+        if token in self._sessions:
+            raise ValueError("Capture token already active")
+
         session = CaptureSession(
             token=token,
             hardware_id="__combo__",

--- a/keymasq/keymasqd/daemon.py
+++ b/keymasq/keymasqd/daemon.py
@@ -463,7 +463,14 @@ class Daemon:
         if not requires_unlock:
             return
 
-        self._ensure_sensitive_owner(command_type, client)
+        self._ensure_sensitive_owner(
+            command_type,
+            client,
+            claim_if_missing=command_type != CommandType.CAPTURE_END,
+        )
+
+        if command_type == CommandType.CAPTURE_END:
+            return
 
         unlocked, expires_at, source = self._recording_unlocked_for_uid(client.uid)
         if unlocked:
@@ -519,7 +526,13 @@ class Daemon:
             str(reason),
         )
 
-    def _ensure_sensitive_owner(self, command_type: CommandType, client: ClientContext) -> None:
+    def _ensure_sensitive_owner(
+        self,
+        command_type: CommandType,
+        client: ClientContext,
+        *,
+        claim_if_missing: bool = True,
+    ) -> None:
         sensitive_commands = {
             CommandType.START_RECORDING,
             CommandType.CAPTURE_BEGIN,
@@ -537,6 +550,10 @@ class Daemon:
 
         owner = self._recording_refresh_owners.get(int(client.uid))
         if owner is None:
+            if not claim_if_missing:
+                raise PermissionError(
+                    "sensitive_command_denied: caller is not active session owner"
+                )
             self._recording_refresh_owners[int(client.uid)] = (
                 int(client.pid),
                 int(client.connection_id),

--- a/tests/keymasqd/test_daemon_runtime_unlock.py
+++ b/tests/keymasqd/test_daemon_runtime_unlock.py
@@ -82,6 +82,39 @@ async def test_device_inspector_start_requires_recording_unlock(daemon_testbed, 
 
 
 @pytest.mark.asyncio
+async def test_capture_end_allows_owner_after_recording_unlock_expires(
+    daemon_testbed,
+    monkeypatch,
+):
+    daemon, _device_manager, _recording_manager, _macro_store, capture_manager = daemon_testbed
+    daemon.security_policy = SecurityPolicy(recording_unlock_required=True)
+    client = _client(uid=2000, pid=111, connection_id=10)
+    unlocked = True
+
+    def fake_recording_unlocked_for_uid(_uid: int):
+        return (unlocked, 0, "runtime" if unlocked else "runtime")
+
+    monkeypatch.setattr(daemon, "_recording_unlocked_for_uid", fake_recording_unlocked_for_uid)
+
+    begin = await daemon._handle_command(
+        CommandType.CAPTURE_BEGIN,
+        {"hardware_id": "1234:5678"},
+        client=client,
+    )
+    assert begin == {"token": "cap-token"}
+
+    unlocked = False
+    end = await daemon._handle_command(
+        CommandType.CAPTURE_END,
+        {"token": "cap-token"},
+        client=client,
+    )
+
+    assert end == {"ended": True}
+    capture_manager.end.assert_called_once_with("cap-token")
+
+
+@pytest.mark.asyncio
 async def test_macro_exec_complete_forwards_wait_id_and_returncode(daemon_testbed):
     daemon, device_manager, _recording_manager, _macro_store, _capture_manager = daemon_testbed
 

--- a/tests/test_capture_manager.py
+++ b/tests/test_capture_manager.py
@@ -381,6 +381,36 @@ def test_capture_manager_begin_combo_rejects_duplicate_token(monkeypatch) -> Non
     assert manager.end("same") == {"status": "ok", "ended": True}
 
 
+def test_capture_manager_begin_combo_closes_devices_on_duplicate_token(monkeypatch) -> None:
+    opened: list[_FakeDevice] = []
+
+    def fake_input_device(path: str) -> _FakeDevice:
+        device = _FakeDevice(path, 0x1234, 0x5678, [])
+        opened.append(device)
+        return device
+
+    monkeypatch.setattr(evdev, "list_devices", lambda: ["/dev/input/event1"])
+    monkeypatch.setattr(evdev, "InputDevice", fake_input_device)
+
+    manager = CaptureManager()
+    manager.begin_combo(
+        token="same",
+        authorization=manager._authorize_combo_capture(),
+    )
+
+    with pytest.raises(ValueError, match="Capture token already active"):
+        manager.begin_combo(
+            token="same",
+            authorization=manager._authorize_combo_capture(),
+        )
+
+    assert len(opened) == 2
+    assert opened[0].closed is False
+    assert opened[1].closed is True
+    assert manager.end("same") == {"status": "ok", "ended": True}
+    assert opened[0].closed is True
+
+
 def test_capture_manager_register_notifier_invalid_token() -> None:
     manager = CaptureManager()
 

--- a/tests/test_capture_manager.py
+++ b/tests/test_capture_manager.py
@@ -361,6 +361,26 @@ def test_capture_manager_begin_combo_requires_authorization(monkeypatch) -> None
         manager.begin_combo(allow_empty=True)
 
 
+def test_capture_manager_begin_combo_rejects_duplicate_token(monkeypatch) -> None:
+    monkeypatch.setattr(evdev, "list_devices", lambda: [])
+
+    manager = CaptureManager()
+    manager.begin_combo(
+        token="same",
+        allow_empty=True,
+        authorization=manager._authorize_combo_capture(),
+    )
+
+    with pytest.raises(ValueError, match="Capture token already active"):
+        manager.begin_combo(
+            token="same",
+            allow_empty=True,
+            authorization=manager._authorize_combo_capture(),
+        )
+
+    assert manager.end("same") == {"status": "ok", "ended": True}
+
+
 def test_capture_manager_register_notifier_invalid_token() -> None:
     manager = CaptureManager()
 


### PR DESCRIPTION
## Summary

- Validate capture token uniqueness to prevent duplicate sessions.
- Allow `CAPTURE_END` after recording unlock expires for the same owner.
- Add `claim_if_missing` parameter to `_ensure_sensitive_owner` so `CAPTURE_END` can bypass owner claiming.
- Add tests for duplicate token rejection and expired-unlock capture end.

## Testing

- `test_capture_end_allows_owner_after_recording_unlock_expires` – verifies that a client which began capture can end it even after the recording unlock expires.
- `test_capture_manager_begin_combo_rejects_duplicate_token` – verifies that `begin_combo` raises `ValueError` for an already-active token.
- Existing test suite (`./scripts/check.sh`) passes.