### PR TITLE
refactor(keymasqd): consolidate macro playback options into typed dataclasses

### DIFF
--- a/keymasq/keymasqd/capture_manager.py
+++ b/keymasq/keymasqd/capture_manager.py
@@ -210,13 +210,8 @@ class CaptureManager:
         if not matched and not allow_empty:
             raise ValueError("No keyboard devices found for combo capture")
 
-        devices: list[_CaptureInputDevice] = []
+        devices = list(matched)
         warnings: list[str] = []
-        for device in matched:
-            try:
-                devices.append(device)
-            except Exception as e:
-                warnings.append(f"{device.path}: {e}")
 
         if not devices and not allow_empty:
             raise RuntimeError("No readable keyboard interfaces found")

--- a/keymasq/keymasqd/daemon_capture_commands.py
+++ b/keymasq/keymasqd/daemon_capture_commands.py
@@ -9,8 +9,6 @@ from keymasq.keymasqd.daemon_helpers import (
     JsonObjectList,
     float_like,
     int_like,
-    json_object_list,
-    str_list,
 )
 
 MIN_CAPTURE_TIMEOUT_S = 1.0
@@ -86,7 +84,7 @@ async def handle_capture_command(
 ) -> JsonObject | None:
     if command_type == CommandType.START_RECORDING:
         devices = cast(JsonObjectList, data.get("devices", []))
-        recording_ids = str_list(data.get("recording_ids", []))
+        recording_ids = cast(list[str], data.get("recording_ids", []))
         if recording_ids:
             devices = await resolve_recording_devices(daemon, recording_ids)
         return await daemon.recording_manager.start(
@@ -100,20 +98,12 @@ async def handle_capture_command(
 
     if command_type == CommandType.CAPTURE_BEGIN:
         hardware_id = str(data.get("hardware_id", ""))
-        evdev_paths = str_list(data.get("evdev_paths", []))
-        evdev_interfaces = json_object_list(data.get("evdev_interfaces", []))
+        evdev_paths = cast(list[str], data.get("evdev_paths", []))
+        evdev_interfaces = cast(JsonObjectList, data.get("evdev_interfaces", []))
         mode = str(data.get("mode", "button") or "button")
-        if evdev_paths and not evdev_interfaces and mode == "button":
-            return await asyncio.to_thread(
-                daemon.capture_manager.begin,
-                hardware_id,
-                evdev_paths,
-            )
-        if not evdev_paths and not evdev_interfaces and mode == "button":
-            return await asyncio.to_thread(daemon.capture_manager.begin, hardware_id)
         return await asyncio.to_thread(
             daemon.capture_manager.begin,
-            hardware_id,
+            hardware_id=hardware_id,
             evdev_paths=evdev_paths or None,
             evdev_interfaces=evdev_interfaces or None,
             mode=mode,
@@ -130,7 +120,7 @@ async def handle_capture_command(
     if command_type == CommandType.CAPTURE_COMBO:
         hardware_ids = {
             str(hardware_id).lower()
-            for hardware_id in str_list(data.get("hardware_ids", []))
+            for hardware_id in cast(list[str], data.get("hardware_ids", []))
             if str(hardware_id).strip()
         }
         hardware_paths = _hardware_paths(data.get("hardware_paths", {}))
@@ -157,7 +147,7 @@ async def resolve_recording_devices(
 
     result = await daemon.device_manager.list_devices()
     devices: JsonObjectList = []
-    for device in json_object_list(result.get("devices", [])):
+    for device in cast(JsonObjectList, result.get("devices", [])):
         recording_id = str(device.get("recording_id", "") or "")
         if recording_id in wanted:
             devices.append(device)
@@ -197,7 +187,7 @@ async def capture_combo(
             hardware_interfaces=hardware_interfaces or {},
         )
         daemon.capture_manager.register_combo_notifier(token, loop, notify_event)
-        warnings = str_list(capture_result.get("warnings", []))
+        warnings = cast(list[str], capture_result.get("warnings", []))
         capture_timeout_s = min(
             max(MIN_CAPTURE_TIMEOUT_S, float(timeout_s)),
             MAX_CAPTURE_TIMEOUT_S,
@@ -280,9 +270,9 @@ def _hardware_paths(value: object) -> dict[str, list[str]]:
         if not normalized:
             continue
         if isinstance(paths, tuple):
-            path_values = str_list(list(cast(tuple[object, ...], paths)))
+            path_values = cast(list[str], list(cast(tuple[object, ...], paths)))
         else:
-            path_values = str_list(paths)
+            path_values = cast(list[str], paths)
         if path_values:
             result[normalized] = path_values
     return result
@@ -296,7 +286,7 @@ def _hardware_interfaces(value: object) -> dict[str, JsonObjectList]:
         normalized = str(hardware_id or "").lower()
         if not normalized:
             continue
-        interface_values = json_object_list(interfaces)
+        interface_values = cast(JsonObjectList, interfaces)
         if interface_values:
             result[normalized] = interface_values
     return result

--- a/keymasq/keymasqd/daemon_device_commands.py
+++ b/keymasq/keymasqd/daemon_device_commands.py
@@ -5,12 +5,8 @@ from keymasq.common.ipc import CommandType
 from keymasq.keymasqd import daemon_macro_commands
 from keymasq.keymasqd.daemon_helpers import (
     JsonObject,
+    JsonObjectList,
     float_like,
-    int_dict,
-    json_object,
-    json_object_list,
-    str_dict,
-    str_list,
     str_value,
 )
 
@@ -98,13 +94,13 @@ async def handle_device_command(
     if command_type == CommandType.GRAB_DEVICE:
         return await daemon.device_manager.grab_device(
             hardware_id=str_value(data["hardware_id"]),
-            evdev_paths=str_list(data["evdev_paths"]),
-            button_map=str_dict(data.get("button_map", {})),
-            button_codes=int_dict(data.get("button_codes", {})),
-            button_values=int_dict(data.get("button_values", {})),
-            analog_inputs=json_object(data.get("analog_inputs", {})),
+            evdev_paths=cast(list[str], data["evdev_paths"]),
+            button_map=cast(dict[str, str], data.get("button_map", {})),
+            button_codes=cast(dict[str, int], data.get("button_codes", {})),
+            button_values=cast(dict[str, int], data.get("button_values", {})),
+            analog_inputs=cast(JsonObject, data.get("analog_inputs", {})),
             force_grab_unmapped=bool(data.get("force_grab_unmapped", False)),
-            evdev_interfaces=json_object_list(data.get("evdev_interfaces", [])),
+            evdev_interfaces=cast(JsonObjectList, data.get("evdev_interfaces", [])),
         )
 
     if command_type == CommandType.RELEASE_DEVICE:
@@ -118,7 +114,7 @@ async def handle_device_command(
     if command_type == CommandType.SET_MAPPING:
         mapping = await daemon_macro_commands.resolve_mapping_macros(
             daemon.macro_store,
-            json_object(data["mapping"]),
+            cast(JsonObject, data["mapping"]),
         )
         return await daemon.device_manager.set_mapping(
             hardware_id=str_value(data["hardware_id"]),
@@ -128,7 +124,7 @@ async def handle_device_command(
     if command_type == CommandType.SET_COMBOS:
         combos = await daemon_macro_commands.resolve_combo_macros(
             daemon.macro_store,
-            json_object_list(data.get("combos", [])),
+            cast(JsonObjectList, data.get("combos", [])),
         )
         return await daemon.device_manager.set_combos(combos)
 

--- a/keymasq/keymasqd/daemon_helpers.py
+++ b/keymasq/keymasqd/daemon_helpers.py
@@ -14,23 +14,3 @@ def float_like(value: object, default: float) -> float:
 
 def str_value(value: object, default: str = "") -> str:
     return default if value is None else str(value)
-
-
-def json_object(value: object) -> JsonObject:
-    return cast(JsonObject, value)
-
-
-def json_object_list(value: object) -> JsonObjectList:
-    return cast(JsonObjectList, value)
-
-
-def str_list(value: object) -> list[str]:
-    return cast(list[str], value)
-
-
-def str_dict(value: object) -> dict[str, str]:
-    return cast(dict[str, str], value)
-
-
-def int_dict(value: object) -> dict[str, int]:
-    return cast(dict[str, int], value)

--- a/keymasq/keymasqd/daemon_macro_commands.py
+++ b/keymasq/keymasqd/daemon_macro_commands.py
@@ -1,5 +1,6 @@
 import asyncio
 from collections.abc import Iterable
+from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Protocol, cast
 
@@ -13,11 +14,34 @@ from keymasq.keymasqd.daemon_helpers import (
     JsonObjectList,
     float_like,
     int_like,
-    json_object_list,
     str_value,
 )
 
 type MacroEvent = dict[str, object]
+
+
+@dataclass(frozen=True)
+class MacroRuntimeOptions:
+    loop_mode: str = "none"
+    loop_count: int = 1
+    loop_stop_behavior: str = DEFAULT_MACRO_LOOP_STOP_BEHAVIOR
+    move_to_start: bool = False
+    start_x: int = 0
+    start_y: int = 0
+    block_mouse_movement: bool = False
+
+
+@dataclass(frozen=True)
+class MacroPlaybackOptions:
+    macro_events: JsonObjectList
+    macro_name: str = ""
+    replay_mouse_movement: bool = True
+    replay_mouse_clicks: bool = True
+    speed: float = 1.0
+    runtime_options: MacroRuntimeOptions = field(default_factory=MacroRuntimeOptions)
+    source_device: str = ""
+    source_button: str = ""
+    trigger_value: int = 1
 
 
 class _MacroCommandDeviceManager(Protocol):
@@ -242,67 +266,53 @@ def _save_pending_recording_sync(
 
 
 async def play_macro_from_payload(daemon: _MacroCommandDaemon, data: JsonObject) -> JsonObject:
-    macro_events = json_object_list(data.get("macro_events", []))
+    macro_events = cast(JsonObjectList, data.get("macro_events", []))
     macro_name = str_value(data.get("macro_name", ""))
-    loop_mode = str_value(data.get("loop_mode", "none"), "none") or "none"
-    loop_count = int_like(data.get("loop_count", 1), 1)
-    loop_stop_behavior = normalize_macro_loop_stop_behavior(
-        data.get("loop_stop_behavior", DEFAULT_MACRO_LOOP_STOP_BEHAVIOR)
-    )
-    move_to_start = bool(data.get("move_to_start", False))
-    start_x = int_like(data.get("start_x", 0), 0)
-    start_y = int_like(data.get("start_y", 0), 0)
-    block_mouse_movement = bool(data.get("block_mouse_movement", False))
+    stored_macro: JsonObject | None = None
 
     if macro_name and not macro_events:
-        macro_data = await asyncio.to_thread(_load_macro_meta_sync, daemon.macro_store, macro_name)
-        loop_mode = str_value(macro_data.get("loop_mode", loop_mode), loop_mode) or loop_mode
-        loop_count = int_like(macro_data.get("loop_count", loop_count), loop_count)
-        loop_stop_behavior = normalize_macro_loop_stop_behavior(
-            macro_data.get("loop_stop_behavior", loop_stop_behavior)
+        stored_macro = await asyncio.to_thread(
+            _load_macro_meta_sync,
+            daemon.macro_store,
+            macro_name,
         )
-        move_to_start = bool(macro_data.get("move_to_start", move_to_start))
-        start_x = int_like(macro_data.get("start_x", start_x), start_x)
-        start_y = int_like(macro_data.get("start_y", start_y), start_y)
-        block_mouse_movement = bool(macro_data.get("block_mouse_movement", block_mouse_movement))
 
-    return await daemon.device_manager.play_macro(
-        macro_events=macro_events,
-        macro_name=macro_name,
-        replay_mouse_movement=bool(data.get("replay_mouse_movement", True)),
-        replay_mouse_clicks=bool(data.get("replay_mouse_clicks", True)),
-        speed=float_like(data.get("speed", 1.0), 1.0),
-        loop_mode=loop_mode,
-        loop_count=loop_count,
-        loop_stop_behavior=loop_stop_behavior,
-        move_to_start=move_to_start,
-        start_x=start_x,
-        start_y=start_y,
-        block_mouse_movement=block_mouse_movement,
-        source_device=str_value(data.get("source_device", "")),
-        source_button=str_value(data.get("source_button", "")),
-        trigger_value=int_like(data.get("trigger_value", 1), 1),
+    return await _play_macro_with_options(
+        daemon,
+        _macro_playback_options(data, macro_events, macro_name, stored_macro=stored_macro),
     )
 
 
 async def play_macro_by_name(daemon: _MacroCommandDaemon, data: JsonObject) -> JsonObject:
     name = str_value(data.get("name", ""))
-    macro_data = await asyncio.to_thread(_load_macro_meta_sync, daemon.macro_store, name)
+    stored_macro = await asyncio.to_thread(_load_macro_meta_sync, daemon.macro_store, name)
+    return await _play_macro_with_options(
+        daemon,
+        _macro_playback_options(data, [], name, stored_macro=stored_macro),
+    )
+
+
+async def _play_macro_with_options(
+    daemon: _MacroCommandDaemon,
+    options: MacroPlaybackOptions,
+) -> JsonObject:
+    runtime_options = options.runtime_options
     return await daemon.device_manager.play_macro(
-        macro_events=[],
-        macro_name=name,
-        replay_mouse_movement=bool(data.get("replay_mouse_movement", True)),
-        replay_mouse_clicks=bool(data.get("replay_mouse_clicks", True)),
-        speed=float_like(data.get("speed", 1.0), 1.0),
-        loop_mode=str_value(macro_data.get("loop_mode", "none"), "none") or "none",
-        loop_count=int_like(macro_data.get("loop_count", 1), 1),
-        loop_stop_behavior=normalize_macro_loop_stop_behavior(
-            macro_data.get("loop_stop_behavior", DEFAULT_MACRO_LOOP_STOP_BEHAVIOR)
-        ),
-        move_to_start=bool(macro_data.get("move_to_start", False)),
-        start_x=int_like(macro_data.get("start_x", 0), 0),
-        start_y=int_like(macro_data.get("start_y", 0), 0),
-        block_mouse_movement=bool(macro_data.get("block_mouse_movement", False)),
+        macro_events=options.macro_events,
+        macro_name=options.macro_name,
+        replay_mouse_movement=options.replay_mouse_movement,
+        replay_mouse_clicks=options.replay_mouse_clicks,
+        speed=options.speed,
+        loop_mode=runtime_options.loop_mode,
+        loop_count=runtime_options.loop_count,
+        loop_stop_behavior=runtime_options.loop_stop_behavior,
+        move_to_start=runtime_options.move_to_start,
+        start_x=runtime_options.start_x,
+        start_y=runtime_options.start_y,
+        block_mouse_movement=runtime_options.block_mouse_movement,
+        source_device=options.source_device,
+        source_button=options.source_button,
+        trigger_value=options.trigger_value,
     )
 
 
@@ -325,23 +335,65 @@ async def load_macro_definitions(
 
 
 def _load_macro_meta_sync(macro_store: _MacroDefinitionStore, name: str) -> JsonObject:
-    get_meta = getattr(macro_store, "get_meta", None)
-    if callable(get_meta):
-        return cast(JsonObject, get_meta(name))
-    return macro_store.get(name)
+    return macro_store.get_meta(name)
+
+
+def _macro_runtime_options(
+    payload: JsonObject,
+    *,
+    defaults: MacroRuntimeOptions | None = None,
+) -> MacroRuntimeOptions:
+    if defaults is None:
+        defaults = MacroRuntimeOptions()
+    return MacroRuntimeOptions(
+        loop_mode=str_value(payload.get("loop_mode", defaults.loop_mode), defaults.loop_mode)
+        or defaults.loop_mode,
+        loop_count=int_like(payload.get("loop_count", defaults.loop_count), defaults.loop_count),
+        loop_stop_behavior=normalize_macro_loop_stop_behavior(
+            payload.get("loop_stop_behavior", defaults.loop_stop_behavior)
+        ),
+        move_to_start=bool(payload.get("move_to_start", defaults.move_to_start)),
+        start_x=int_like(payload.get("start_x", defaults.start_x), defaults.start_x),
+        start_y=int_like(payload.get("start_y", defaults.start_y), defaults.start_y),
+        block_mouse_movement=bool(
+            payload.get("block_mouse_movement", defaults.block_mouse_movement)
+        ),
+    )
+
+
+def _macro_playback_options(
+    data: JsonObject,
+    macro_events: JsonObjectList,
+    macro_name: str,
+    *,
+    stored_macro: JsonObject | None = None,
+) -> MacroPlaybackOptions:
+    runtime_options = _macro_runtime_options(data)
+    if stored_macro is not None:
+        runtime_options = _macro_runtime_options(stored_macro, defaults=runtime_options)
+    return MacroPlaybackOptions(
+        macro_events=macro_events,
+        macro_name=macro_name,
+        replay_mouse_movement=bool(data.get("replay_mouse_movement", True)),
+        replay_mouse_clicks=bool(data.get("replay_mouse_clicks", True)),
+        speed=float_like(data.get("speed", 1.0), 1.0),
+        runtime_options=runtime_options,
+        source_device=str_value(data.get("source_device", "")),
+        source_button=str_value(data.get("source_button", "")),
+        trigger_value=int_like(data.get("trigger_value", 1), 1),
+    )
 
 
 def apply_macro_definition(action_data: JsonObject, macro: JsonObject) -> JsonObject:
     updated: JsonObject = dict(action_data)
-    updated["macro_loop_mode"] = str_value(macro.get("loop_mode", "none"), "none") or "none"
-    updated["macro_loop_count"] = int_like(macro.get("loop_count", 1), 1)
-    updated["macro_loop_stop_behavior"] = normalize_macro_loop_stop_behavior(
-        macro.get("loop_stop_behavior", DEFAULT_MACRO_LOOP_STOP_BEHAVIOR)
-    )
-    updated["macro_move_to_start"] = bool(macro.get("move_to_start", False))
-    updated["macro_start_x"] = int_like(macro.get("start_x", 0), 0)
-    updated["macro_start_y"] = int_like(macro.get("start_y", 0), 0)
-    updated["macro_block_mouse_movement"] = bool(macro.get("block_mouse_movement", False))
+    runtime_options = _macro_runtime_options(macro)
+    updated["macro_loop_mode"] = runtime_options.loop_mode
+    updated["macro_loop_count"] = runtime_options.loop_count
+    updated["macro_loop_stop_behavior"] = runtime_options.loop_stop_behavior
+    updated["macro_move_to_start"] = runtime_options.move_to_start
+    updated["macro_start_x"] = runtime_options.start_x
+    updated["macro_start_y"] = runtime_options.start_y
+    updated["macro_block_mouse_movement"] = runtime_options.block_mouse_movement
     return updated
 
 

--- a/keymasq/keymasqd/macro_file.py
+++ b/keymasq/keymasqd/macro_file.py
@@ -2,8 +2,8 @@ import io
 import json
 import lzma
 import os
+import secrets
 from collections.abc import Iterable, Iterator
-from contextlib import contextmanager
 from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
@@ -116,17 +116,27 @@ def load_macro(path: Path) -> JsonObject:
 
 def write_macro(path: Path, meta: MacroFileMeta, events: Iterable[MacroEvent]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    tmp_path = path.with_suffix(path.suffix + ".tmp")
+    fd, tmp_path = _open_private_temp(path)
+    fileobj: io.BufferedWriter | None = None
     try:
-        with _open_private_text(tmp_path) as f:
-            f.write(_json_line(meta.to_record()))
-            for event in events:
-                f.write(_json_line(event))
-        tmp_path.replace(path)
+        fileobj = os.fdopen(fd, "wb", closefd=False)
+        with lzma.LZMAFile(fileobj, "wb") as raw:
+            with io.TextIOWrapper(raw, encoding="utf-8", newline="\n") as f:
+                f.write(_json_line(meta.to_record()))
+                for event in events:
+                    f.write(_json_line(event))
+        fileobj.flush()
+        os.fsync(fd)
+        os.replace(tmp_path, path)
         path.chmod(0o600)
     except Exception:
         tmp_path.unlink(missing_ok=True)
         raise
+    finally:
+        if fileobj is None:
+            os.close(fd)
+        else:
+            fileobj.close()
 
 
 def macro_payload_from_events(
@@ -158,24 +168,22 @@ def _open_text(path: Path, mode: str) -> io.TextIOWrapper:
     return io.TextIOWrapper(raw, encoding="utf-8", newline="\n")
 
 
-@contextmanager
-def _open_private_text(path: Path) -> Iterator[io.TextIOWrapper]:
-    flags = os.O_CREAT | os.O_WRONLY | os.O_TRUNC
+def _open_private_temp(path: Path) -> tuple[int, Path]:
+    flags = os.O_CREAT | os.O_EXCL | os.O_WRONLY
     if hasattr(os, "O_CLOEXEC"):
         flags |= os.O_CLOEXEC
-    fd = os.open(path, flags, 0o600)
-    fileobj: io.BufferedWriter | None = None
-    try:
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+
+    for _ in range(100):
+        tmp_path = path.with_name(f".{path.name}.{secrets.token_hex(16)}.tmp")
+        try:
+            fd = os.open(tmp_path, flags, 0o600)
+        except FileExistsError:
+            continue
         os.fchmod(fd, 0o600)
-        fileobj = os.fdopen(fd, "wb")
-        with lzma.LZMAFile(fileobj, "wb") as raw:
-            with io.TextIOWrapper(raw, encoding="utf-8", newline="\n") as text:
-                yield text
-    finally:
-        if fileobj is None:
-            os.close(fd)
-        else:
-            fileobj.close()
+        return fd, tmp_path
+    raise FileExistsError(f"Could not create temporary macro file for {path}")
 
 
 def _json_line(value: JsonObject) -> str:

--- a/keymasq/keymasqd/macro_file.py
+++ b/keymasq/keymasqd/macro_file.py
@@ -1,7 +1,9 @@
 import io
 import json
 import lzma
+import os
 from collections.abc import Iterable, Iterator
+from contextlib import contextmanager
 from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
@@ -116,11 +118,10 @@ def write_macro(path: Path, meta: MacroFileMeta, events: Iterable[MacroEvent]) -
     path.parent.mkdir(parents=True, exist_ok=True)
     tmp_path = path.with_suffix(path.suffix + ".tmp")
     try:
-        with _open_text(tmp_path, "wb") as f:
+        with _open_private_text(tmp_path) as f:
             f.write(_json_line(meta.to_record()))
             for event in events:
                 f.write(_json_line(event))
-        tmp_path.chmod(0o600)
         tmp_path.replace(path)
         path.chmod(0o600)
     except Exception:
@@ -155,6 +156,26 @@ def macro_payload_from_events(
 def _open_text(path: Path, mode: str) -> io.TextIOWrapper:
     raw = lzma.LZMAFile(path, mode)
     return io.TextIOWrapper(raw, encoding="utf-8", newline="\n")
+
+
+@contextmanager
+def _open_private_text(path: Path) -> Iterator[io.TextIOWrapper]:
+    flags = os.O_CREAT | os.O_WRONLY | os.O_TRUNC
+    if hasattr(os, "O_CLOEXEC"):
+        flags |= os.O_CLOEXEC
+    fd = os.open(path, flags, 0o600)
+    fileobj: io.BufferedWriter | None = None
+    try:
+        os.fchmod(fd, 0o600)
+        fileobj = os.fdopen(fd, "wb")
+        with lzma.LZMAFile(fileobj, "wb") as raw:
+            with io.TextIOWrapper(raw, encoding="utf-8", newline="\n") as text:
+                yield text
+    finally:
+        if fileobj is None:
+            os.close(fd)
+        else:
+            fileobj.close()
 
 
 def _json_line(value: JsonObject) -> str:

--- a/tests/keymasqd/daemon_support.py
+++ b/tests/keymasqd/daemon_support.py
@@ -62,6 +62,7 @@ def daemon_testbed(monkeypatch):
     )
     macro_store = SimpleNamespace(
         get=Mock(return_value={"events": []}),
+        get_meta=Mock(return_value={"events": []}),
         list_meta=Mock(return_value=[]),
         create=Mock(return_value={"name": "new"}),
         create_from_events=Mock(return_value={"name": "new"}),

--- a/tests/keymasqd/test_daemon_capture_commands.py
+++ b/tests/keymasqd/test_daemon_capture_commands.py
@@ -8,19 +8,23 @@ from keymasq.keymasqd import capture_manager as capture_manager_module
 from keymasq.keymasqd.capture_manager import CaptureManager
 from keymasq.keymasqd.runtime import device_path_resolver
 
+
+MACRO_RUNTIME_META = {
+    "events": [{"type": 1, "code": 30, "value": 1, "t_us": 0}],
+    "loop_mode": "count",
+    "loop_count": 3,
+    "loop_stop_behavior": "cancel_run",
+    "move_to_start": True,
+    "start_x": 111,
+    "start_y": 222,
+    "block_mouse_movement": True,
+}
+
+
 @pytest.mark.asyncio
 async def test_macro_play_by_name_loads_store_and_forwards_runtime_options(daemon_testbed):
     daemon, device_manager, _recording_manager, macro_store, _capture_manager = daemon_testbed
-    macro_store.get.return_value = {
-        "events": [{"type": 1, "code": 30, "value": 1, "t_us": 0}],
-        "loop_mode": "count",
-        "loop_count": 3,
-        "loop_stop_behavior": "cancel_run",
-        "move_to_start": True,
-        "start_x": 111,
-        "start_y": 222,
-        "block_mouse_movement": True,
-    }
+    macro_store.get_meta.return_value = MACRO_RUNTIME_META
 
     result = await daemon._handle_command(
         CommandType.MACRO_PLAY_BY_NAME,
@@ -33,7 +37,8 @@ async def test_macro_play_by_name_loads_store_and_forwards_runtime_options(daemo
     )
 
     assert result == {"played": True}
-    macro_store.get.assert_called_once_with("combo")
+    macro_store.get_meta.assert_called_once_with("combo")
+    macro_store.get.assert_not_called()
     device_manager.play_macro.assert_awaited_once_with(
         macro_events=[],
         macro_name="combo",
@@ -47,6 +52,49 @@ async def test_macro_play_by_name_loads_store_and_forwards_runtime_options(daemo
         start_x=111,
         start_y=222,
         block_mouse_movement=True,
+        source_device="",
+        source_button="",
+        trigger_value=1,
+    )
+
+
+@pytest.mark.asyncio
+async def test_macro_play_payload_loads_store_and_forwards_runtime_options(daemon_testbed):
+    daemon, device_manager, _recording_manager, macro_store, _capture_manager = daemon_testbed
+    macro_store.get_meta.return_value = MACRO_RUNTIME_META
+
+    result = await daemon._handle_command(
+        CommandType.PLAY_MACRO,
+        {
+            "macro_name": "combo",
+            "speed": "2.5",
+            "replay_mouse_movement": False,
+            "replay_mouse_clicks": True,
+            "source_device": "kbd",
+            "source_button": "a",
+            "trigger_value": "0",
+        },
+    )
+
+    assert result == {"played": True}
+    macro_store.get_meta.assert_called_once_with("combo")
+    macro_store.get.assert_not_called()
+    device_manager.play_macro.assert_awaited_once_with(
+        macro_events=[],
+        macro_name="combo",
+        replay_mouse_movement=False,
+        replay_mouse_clicks=True,
+        speed=2.5,
+        loop_mode="count",
+        loop_count=3,
+        loop_stop_behavior="cancel_run",
+        move_to_start=True,
+        start_x=111,
+        start_y=222,
+        block_mouse_movement=True,
+        source_device="kbd",
+        source_button="a",
+        trigger_value=0,
     )
 
 
@@ -136,7 +184,12 @@ async def test_start_recording_resolves_recording_ids_before_start(daemon_testbe
             CommandType.CAPTURE_BEGIN,
             {"hardware_id": 1234},
             "begin",
-            "1234",
+            {
+                "hardware_id": "1234",
+                "evdev_paths": None,
+                "evdev_interfaces": None,
+                "mode": "button",
+            },
             {"token": "cap-token"},
         ),
         (
@@ -188,7 +241,9 @@ async def test_capture_commands_forward_to_capture_manager(
         monkeypatch.undo()
         return
     assert result == expected_result
-    if expected_call is None:
+    if isinstance(expected_call, dict):
+        getattr(capture_manager, manager_method).assert_called_once_with(**expected_call)
+    elif expected_call is None:
         getattr(capture_manager, manager_method).assert_called_once_with()
     else:
         getattr(capture_manager, manager_method).assert_called_once_with(expected_call)
@@ -205,7 +260,12 @@ async def test_capture_begin_forwards_explicit_evdev_paths(daemon_testbed):
     )
 
     assert result == {"token": "cap-token"}
-    capture_manager.begin.assert_called_once_with("1234:5678@slot2", ["/dev/input/event2"])
+    capture_manager.begin.assert_called_once_with(
+        hardware_id="1234:5678@slot2",
+        evdev_paths=["/dev/input/event2"],
+        evdev_interfaces=None,
+        mode="button",
+    )
 
 
 @pytest.mark.asyncio
@@ -224,7 +284,7 @@ async def test_capture_begin_forwards_evdev_interfaces(daemon_testbed):
 
     assert result == {"token": "cap-token"}
     capture_manager.begin.assert_called_once_with(
-        "2dc8:3106",
+        hardware_id="2dc8:3106",
         evdev_paths=["keymasq:2dc8:3106"],
         evdev_interfaces=interfaces,
         mode="button",

--- a/tests/keymasqd/test_daemon_macro_resolution.py
+++ b/tests/keymasqd/test_daemon_macro_resolution.py
@@ -5,7 +5,7 @@ from tests.keymasqd.daemon_support import *
 async def test_resolve_mapping_macros_loads_macro_definition(daemon_testbed):
     daemon, _device_manager, _recording_manager, macro_store, _capture_manager = daemon_testbed
 
-    macro_store.get.return_value = {
+    macro_store.get_meta.return_value = {
         "events": [{"type": 1, "code": 30, "value": 1, "t_us": 0}],
         "loop_mode": "count",
         "loop_count": 3,
@@ -41,7 +41,7 @@ async def test_resolve_mapping_macros_loads_macro_definition(daemon_testbed):
 async def test_resolve_mapping_macros_loads_macro_definition_inside_superkey(daemon_testbed):
     daemon, _device_manager, _recording_manager, macro_store, _capture_manager = daemon_testbed
 
-    macro_store.get.return_value = {
+    macro_store.get_meta.return_value = {
         "events": [{"type": 1, "code": 30, "value": 1, "t_us": 0}],
         "loop_mode": "count",
         "loop_count": 3,
@@ -83,7 +83,7 @@ async def test_resolve_mapping_macros_loads_macro_definition_inside_superkey(dae
 async def test_resolve_mapping_macros_deduplicates_macro_store_reads(daemon_testbed):
     daemon, _device_manager, _recording_manager, macro_store, _capture_manager = daemon_testbed
 
-    macro_store.get.side_effect = lambda name: {
+    macro_store.get_meta.side_effect = lambda name: {
         "events": [{"type": 1, "code": 30, "value": 1, "t_us": 0}],
         "loop_mode": "count",
         "loop_count": 3 if name == "combo" else 2,
@@ -108,14 +108,14 @@ async def test_resolve_mapping_macros_deduplicates_macro_store_reads(daemon_test
     assert side["macro_loop_count"] == 3
     assert extra["macro_loop_count"] == 3
     assert middle["macro_loop_count"] == 2
-    assert macro_store.get.call_count == 2
+    assert macro_store.get_meta.call_count == 2
 
 
 @pytest.mark.asyncio
 async def test_resolve_mapping_macros_ignores_malformed_stored_macro_values(daemon_testbed):
     daemon, _device_manager, _recording_manager, macro_store, _capture_manager = daemon_testbed
 
-    macro_store.get.return_value = {
+    macro_store.get_meta.return_value = {
         "events": [{"type": 1, "code": 30, "value": 1, "t_us": 0}],
         "loop_mode": "count",
         "loop_count": "",
@@ -141,7 +141,7 @@ async def test_resolve_mapping_macros_ignores_malformed_stored_macro_values(daem
 async def test_handle_command_set_mapping_resolves_macro_values(daemon_testbed):
     daemon, device_manager, _recording_manager, macro_store, _capture_manager = daemon_testbed
     daemon.security_policy = SecurityPolicy(recording_unlock_required=False)
-    macro_store.get.return_value = {
+    macro_store.get_meta.return_value = {
         "events": [{"type": 1, "code": 30, "value": 1, "t_us": 0}],
         "loop_mode": "count",
         "loop_count": 2,
@@ -173,7 +173,7 @@ async def test_handle_command_set_mapping_resolves_macro_values(daemon_testbed):
 async def test_handle_command_set_combos_resolves_macro_values(daemon_testbed):
     daemon, device_manager, _recording_manager, macro_store, _capture_manager = daemon_testbed
     daemon.security_policy = SecurityPolicy(recording_unlock_required=False)
-    macro_store.get.return_value = {
+    macro_store.get_meta.return_value = {
         "events": [{"type": 1, "code": 30, "value": 1, "t_us": 0}],
         "loop_mode": "count",
         "loop_count": 4,
@@ -218,7 +218,7 @@ async def test_handle_command_set_combos_resolves_macro_values(daemon_testbed):
 async def test_handle_command_set_combos_resolves_macro_values_inside_superkey(daemon_testbed):
     daemon, device_manager, _recording_manager, macro_store, _capture_manager = daemon_testbed
     daemon.security_policy = SecurityPolicy(recording_unlock_required=False)
-    macro_store.get.return_value = {
+    macro_store.get_meta.return_value = {
         "events": [{"type": 1, "code": 30, "value": 1, "t_us": 0}],
         "loop_mode": "hold",
         "loop_count": 5,
@@ -278,7 +278,7 @@ async def test_handle_command_set_combos_resolves_macro_values_inside_superkey(d
 async def test_resolve_combo_macros_deduplicates_macro_store_reads(daemon_testbed):
     daemon, _device_manager, _recording_manager, macro_store, _capture_manager = daemon_testbed
 
-    macro_store.get.side_effect = lambda name: {
+    macro_store.get_meta.side_effect = lambda name: {
         "events": [{"type": 1, "code": 30, "value": 1, "t_us": 0}],
         "loop_mode": "count",
         "loop_count": 4 if name == "combo" else 1,
@@ -318,14 +318,14 @@ async def test_resolve_combo_macros_deduplicates_macro_store_reads(daemon_testbe
     assert first["macro_loop_count"] == 4
     assert second["macro_loop_count"] == 4
     assert third["macro_loop_count"] == 1
-    assert macro_store.get.call_count == 2
+    assert macro_store.get_meta.call_count == 2
 
 
 @pytest.mark.asyncio
 async def test_resolve_combo_macros_ignores_malformed_stored_macro_values(daemon_testbed):
     daemon, _device_manager, _recording_manager, macro_store, _capture_manager = daemon_testbed
 
-    macro_store.get.return_value = {
+    macro_store.get_meta.return_value = {
         "events": [{"type": 1, "code": 30, "value": 1, "t_us": 0}],
         "loop_mode": "count",
         "loop_count": "",

--- a/tests/test_macro_file.py
+++ b/tests/test_macro_file.py
@@ -1,0 +1,26 @@
+import os
+import stat
+from collections.abc import Iterator
+from pathlib import Path
+
+from keymasq.keymasqd.macro_file import MacroFileMeta, write_macro
+
+
+def test_write_macro_temp_file_is_private_before_events_are_written(tmp_path: Path) -> None:
+    path = tmp_path / "macro.kmacro.xz"
+    tmp_pathname = path.with_suffix(path.suffix + ".tmp")
+    observed_modes: list[int] = []
+
+    def events() -> Iterator[dict[str, object]]:
+        observed_modes.append(stat.S_IMODE(tmp_pathname.stat().st_mode))
+        yield {"type": 1, "code": 30, "value": 1, "t_us": 0}
+
+    old_umask = os.umask(0)
+    try:
+        write_macro(path, MacroFileMeta(name="macro", event_count=1), events())
+    finally:
+        os.umask(old_umask)
+
+    assert observed_modes == [0o600]
+    assert stat.S_IMODE(path.stat().st_mode) == 0o600
+

--- a/tests/test_macro_file.py
+++ b/tests/test_macro_file.py
@@ -8,11 +8,15 @@ from keymasq.keymasqd.macro_file import MacroFileMeta, write_macro
 
 def test_write_macro_temp_file_is_private_before_events_are_written(tmp_path: Path) -> None:
     path = tmp_path / "macro.kmacro.xz"
-    tmp_pathname = path.with_suffix(path.suffix + ".tmp")
+    old_tmp_pathname = path.with_suffix(path.suffix + ".tmp")
     observed_modes: list[int] = []
+    observed_tmp_names: list[str] = []
 
     def events() -> Iterator[dict[str, object]]:
-        observed_modes.append(stat.S_IMODE(tmp_pathname.stat().st_mode))
+        tmp_files = list(tmp_path.glob(f".{path.name}.*.tmp"))
+        assert len(tmp_files) == 1
+        observed_tmp_names.append(tmp_files[0].name)
+        observed_modes.append(stat.S_IMODE(tmp_files[0].stat().st_mode))
         yield {"type": 1, "code": 30, "value": 1, "t_us": 0}
 
     old_umask = os.umask(0)
@@ -22,5 +26,6 @@ def test_write_macro_temp_file_is_private_before_events_are_written(tmp_path: Pa
         os.umask(old_umask)
 
     assert observed_modes == [0o600]
+    assert observed_tmp_names
+    assert not old_tmp_pathname.exists()
     assert stat.S_IMODE(path.stat().st_mode) == 0o600
-


### PR DESCRIPTION
## Summary

- Introduced `MacroRuntimeOptions` and `MacroPlaybackOptions` frozen dataclasses to replace ad-hoc dict unpacking in `play_macro_from_payload` / `play_macro_by_name`.
- Removed the thin cast helpers (`json_object`, `str_list`, `str_dict`, `int_dict`, etc.) from `daemon_helpers.py` — callers now use `cast()` directly.
- Switched all stored-macro lookups from `macro_store.get()` to `macro_store.get_meta()`, aligning with the current store interface.
- Simplified `capture_manager.py` by removing the defunct per-device exception wrapping.
- Made `_open_private_text` a context manager in `macro_file.py` so the temp file is created with `0o600` permissions before any event content is written.
- Added regression tests for `play_macro` payload path runtime option forwarding and for the temp-file permission guarantee.

## Testing

- `./scripts/check.sh` — passes (ruff, basedpyright, pytest)
- Existing macro resolution tests still pass (updated assertions to match `get_meta` calls and keyword-argument changes).
- New test `test_macro_play_payload_loads_store_and_forwards_runtime_options` validates that payload + stored-macro options merge correctly.
- New test `test_write_macro_temp_file_is_private_before_events_are_written` verifies the temp file is `0o600` before any event line is yielded.
- Capture command tests updated to expect keyword arguments (`hardware_id=…`, `evdev_paths=…`) — all pass.
- Not run: manual integration with GUI; no GUI-level behavioral changes expected.