### PR TITLE
test: harden timer, icon, and recording-settings tests against flakiness and gap coverage

### DIFF
--- a/tests/gui/test_icon_assets.py
+++ b/tests/gui/test_icon_assets.py
@@ -1,5 +1,34 @@
+import re
 from importlib import resources
 from xml.etree import ElementTree
+
+import pytest
+
+_STYLE_RULE_PATTERN = re.compile(r"\{([^{}]*)\}")
+
+
+def _style_declarations(style: str) -> dict[str, str]:
+    declarations = {}
+    for rule in _STYLE_RULE_PATTERN.findall(style) or [style]:
+        for declaration in rule.split(";"):
+            name, separator, value = declaration.partition(":")
+            if separator:
+                declarations[name.strip().lower()] = value.strip().lower()
+    return declarations
+
+
+def _assert_symbolic_icon_uses_filled_paths(
+    root: ElementTree.Element,
+    icon_name: str,
+) -> None:
+    for element in root.iter():
+        style = _style_declarations(element.get("style", ""))
+        if element.tag.rsplit("}", 1)[-1] == "style" and element.text:
+            style.update(_style_declarations(element.text))
+        assert element.get("stroke") is None, icon_name
+        assert "stroke" not in style, icon_name
+        assert element.get("fill") != "none", icon_name
+        assert style.get("fill") != "none", icon_name
 
 
 def test_custom_symbolic_icons_use_filled_paths() -> None:
@@ -11,6 +40,19 @@ def test_custom_symbolic_icons_use_filled_paths() -> None:
         "keymasq-mouse-symbolic.svg",
     ):
         root = ElementTree.parse(assets.joinpath(icon_name)).getroot()
-        for element in root.iter():
-            assert element.get("stroke") is None, icon_name
-            assert element.get("fill") != "none", icon_name
+        _assert_symbolic_icon_uses_filled_paths(root, icon_name)
+
+
+@pytest.mark.parametrize(
+    "svg",
+    (
+        '<svg><path d="M0 0h1v1z" style="fill:none; stroke: #000" /></svg>',
+        '<svg><style>.outline { fill: none; stroke: #000; }</style>'
+        '<path class="outline" d="M0 0h1v1z" /></svg>',
+    ),
+)
+def test_symbolic_icon_styles_reject_stroked_empty_paths(svg: str) -> None:
+    root = ElementTree.fromstring(svg)
+
+    with pytest.raises(AssertionError):
+        _assert_symbolic_icon_uses_filled_paths(root, "inline-style.svg")

--- a/tests/keymasqd/test_timer_precision.py
+++ b/tests/keymasqd/test_timer_precision.py
@@ -1,8 +1,35 @@
+import ctypes
 import logging
+from collections.abc import Iterator
 
 import pytest
 
 from keymasq.keymasqd import timer_precision
+
+_PR_GET_TIMERSLACK = 30
+
+
+def _get_timer_slack_ns() -> int:
+    libc = ctypes.CDLL("libc.so.6", use_errno=True)
+    libc.prctl.restype = ctypes.c_long
+    result = libc.prctl(
+        ctypes.c_int(_PR_GET_TIMERSLACK),
+        ctypes.c_ulong(0),
+        ctypes.c_ulong(0),
+        ctypes.c_ulong(0),
+        ctypes.c_ulong(0),
+    )
+    if result < 0:
+        err = ctypes.get_errno()
+        raise OSError(err, "prctl(PR_GET_TIMERSLACK) failed")
+    return int(result)
+
+
+@pytest.fixture(autouse=True)
+def restore_timer_slack() -> Iterator[None]:
+    original_slack_ns = _get_timer_slack_ns()
+    yield
+    assert timer_precision.set_timer_slack_ns(original_slack_ns) is True
 
 
 def test_set_timer_slack_ns_succeeds(caplog: pytest.LogCaptureFixture) -> None:

--- a/tests/session/test_session_manager_recording_settings.py
+++ b/tests/session/test_session_manager_recording_settings.py
@@ -1,5 +1,6 @@
 # ruff: noqa: F403, F405, I001
 import logging
+import threading
 import tomllib
 from typing import cast
 
@@ -15,41 +16,72 @@ async def test_recording_settings_persistence_applies_latest_snapshot_last() -> 
     }
     persisted: dict[str, bool] = {}
     writes: list[dict[str, bool]] = []
+    writes_lock = threading.Lock()
+    stale_started = threading.Event()
+    stale_finished = threading.Event()
+    latest_finished = threading.Event()
+    release_stale = threading.Event()
 
     def fake_save(_manager, settings: dict | None = None) -> None:
         state = dict(settings or {})
         if state.get("include_mouse_movement", False):
-            time.sleep(0.05)
+            stale_started.set()
+            if not release_stale.wait(timeout=1.0):
+                return
+        with writes_lock:
+            persisted.clear()
+            persisted.update(state)
+            writes.append(state)
+        if state.get("include_mouse_movement", False):
+            stale_finished.set()
         else:
-            time.sleep(0.005)
-        persisted.clear()
-        persisted.update(state)
-        writes.append(state)
+            latest_finished.set()
+
+    async def wait_for_event(event: threading.Event, message: str) -> None:
+        if not await asyncio.to_thread(event.wait, 1.0):
+            pytest.fail(message)
 
     monkeypatch = pytest.MonkeyPatch()
     monkeypatch.setattr(session_recording_module, "save_recording_settings_to_disk", fake_save)
 
-    session_recording_module.update_recording_settings(manager, {"include_mouse_movement": True})
-    session_recording_module.update_recording_settings(
-        manager,
-        {"include_mouse_movement": False, "include_mouse_clicks": True},
-    )
+    try:
+        session_recording_module.update_recording_settings(
+            manager,
+            {"include_mouse_movement": True},
+        )
+        first_save_task = cast(
+            asyncio.Task[None] | None,
+            manager.recording_state.settings_save_task,
+        )
+        assert first_save_task is not None
+        await wait_for_event(stale_started, "stale settings save did not start")
 
-    for _ in range(100):
-        save_task = manager.recording_state.settings_save_task
-        if save_task is None or save_task.done():
-            break
-        await asyncio.sleep(0.01)
-    else:
-        pytest.fail("recording settings save task did not complete")
+        session_recording_module.update_recording_settings(
+            manager,
+            {"include_mouse_movement": False, "include_mouse_clicks": True},
+        )
 
-    assert writes
-    assert persisted == {
-        "include_mouse_movement": False,
-        "include_mouse_clicks": True,
-        "record_start_position": False,
-    }
-    monkeypatch.undo()
+        current_save_task = cast(
+            asyncio.Task[None] | None,
+            manager.recording_state.settings_save_task,
+        )
+        if current_save_task is not first_save_task:
+            await wait_for_event(latest_finished, "latest settings save did not finish")
+        release_stale.set()
+        await wait_for_event(stale_finished, "stale settings save did not finish")
+
+        if current_save_task is not None:
+            await asyncio.wait_for(current_save_task, timeout=1.0)
+        await wait_for_event(latest_finished, "latest settings save did not finish")
+
+        assert writes
+        assert persisted == {
+            "include_mouse_movement": False,
+            "include_mouse_clicks": True,
+            "record_start_position": False,
+        }
+    finally:
+        monkeypatch.undo()
 
 
 def test_recording_settings_save_load_toml_uses_recording_ids(tmp_path) -> None:


### PR DESCRIPTION
## Summary

- Add `restore_timer_slack` autouse fixture that restores the process timer slack after every `test_timer_precision` test, preventing cross-test pollution
- Extract `_assert_symbolic_icon_uses_filled_paths` helper that also parses `<style>` element content, and add parametrised tests verifying inline-style and `<style>`-element stroked/fill=none paths are rejected
- Refactor the recording-settings persistence test to use `threading.Event`-based synchronisation, removing fragile `sleep`-based polling and ensuring stale/latest save ordering is deterministic

## Testing

- `test_timer_precision.py` – `restore_timer_slack` fixture runs before/after each test; existing `test_set_timer_slack_ns_succeeds` passes without side effects
- `test_icon_assets.py` – `test_custom_symbolic_icons_use_filled_paths` continues to pass for all seven SVGs; new `test_symbolic_icon_styles_reject_stroked_empty_paths` correctly asserts on both inline-style and `<style>`-element inputs
- `test_session_manager_recording_settings.py` – `test_recording_settings_persistence_applies_latest_snapshot_last` no longer depends on `asyncio.sleep` polling; stale/latest write ordering is verified via `Event` synchronisation
- Not run: integration tests in CI that depend on real hardware or compositor state