### PR TITLE
refactor: harden daemon, session, GUI, and CLI; expand test coverage

### DIFF
--- a/keymasq/cli/__main__.py
+++ b/keymasq/cli/__main__.py
@@ -1,4 +1,5 @@
 import sys
+from math import isfinite
 
 from keymasq import __version__
 
@@ -11,8 +12,8 @@ def _positive_float(value: str) -> float:
 
 def _parse_positive_float(value: str, error_type: type[Exception] = ValueError) -> float:
     parsed = float(value)
-    if parsed <= 0:
-        raise error_type("must be greater than 0")
+    if not isfinite(parsed) or parsed <= 0:
+        raise error_type("must be a finite number greater than 0")
     return parsed
 
 
@@ -159,7 +160,7 @@ def main() -> None:
     diagnostics_parser.add_argument("state", choices=["on", "off"], help="Enable or disable")
     diagnostics_parser.add_argument(
         "--interval",
-        type=float,
+        type=_positive_float,
         default=5.0,
         help="Logging interval in seconds when enabled",
     )

--- a/keymasq/cli/commands.py
+++ b/keymasq/cli/commands.py
@@ -258,11 +258,13 @@ def play_adhoc_cli(
     print_json: bool = False,
     json_output: bool = False,
 ) -> None:
+    print_device_types: list[str] | None = None
     try:
         if input_json:
             from keymasq.common.macro_compile import build_macro_payload, parse_macro_json
 
             macro_data = parse_macro_json(_json_input_from_args_or_stdin(tokens))
+            print_device_types = _macro_device_types(macro_data)
             raw_events = macro_data.get("events", [])
             if not isinstance(raw_events, list):
                 raise ValueError("macro JSON events must be a list")
@@ -309,9 +311,13 @@ def play_adhoc_cli(
         sys.exit(1)
 
     if print_json:
-        from keymasq.common.macro_compile import macro_definition_from_events
-
-        _print_json(macro_definition_from_events(cast(list[JsonObject], payload["macro_events"])))
+        _print_json(
+            _macro_definition_from_payload(
+                payload,
+                device_types=print_device_types,
+                include_playback_options=input_json,
+            )
+        )
         return
 
     result = _request_or_error({"command": "play_macro_payload", **payload})
@@ -379,6 +385,34 @@ def _macro_definition_from_json_input(name: str, json_parts: list[str]) -> JsonO
     ):
         if key in macro_data:
             macro[key] = macro_data[key]
+    return macro
+
+
+def _macro_definition_from_payload(
+    payload: JsonObject,
+    *,
+    device_types: list[str] | None = None,
+    include_playback_options: bool = False,
+) -> JsonObject:
+    from keymasq.common.macro_compile import macro_definition_from_events
+
+    macro = macro_definition_from_events(
+        cast(list[JsonObject], payload["macro_events"]),
+        name=str(payload.get("macro_name", "") or ""),
+        device_types=device_types,
+    )
+    if include_playback_options:
+        for key in (
+            "loop_mode",
+            "loop_count",
+            "loop_stop_behavior",
+            "move_to_start",
+            "start_x",
+            "start_y",
+            "block_mouse_movement",
+        ):
+            if key in payload:
+                macro[key] = payload[key]
     return macro
 
 
@@ -470,25 +504,26 @@ def list_profiles_cli(*, json_output: bool = False) -> None:
     devices = result.get("devices", [])
     if not profiles:
         print("No profiles found")
-        return
-
-    print("Profiles:")
-    for profile in profiles:
-        name = str(profile.get("name", ""))
-        enabled = bool(profile.get("enabled", False))
-        active = bool(profile.get("active", False))
-        marker = "*" if active else " "
-        kind = _profile_kind(profile)
-        priority = int(profile.get("priority", 0) or 0)
-        window_rule_count = int(profile.get("window_rule_count", 0) or 0)
-        device_names = ", ".join(str(device) for device in profile.get("devices", []))
-        details = [kind, f"priority={priority}"]
-        if window_rule_count > 0:
-            details.append(f"rules={window_rule_count}")
-        if device_names:
-            details.append(f"devices={device_names}")
-        state = "on" if enabled else "off"
-        print(f"  [{marker}] [{state:3}] {name} ({', '.join(details)})")
+        if not devices:
+            return
+    else:
+        print("Profiles:")
+        for profile in profiles:
+            name = str(profile.get("name", ""))
+            enabled = bool(profile.get("enabled", False))
+            active = bool(profile.get("active", False))
+            marker = "*" if active else " "
+            kind = _profile_kind(profile)
+            priority = int(profile.get("priority", 0) or 0)
+            window_rule_count = int(profile.get("window_rule_count", 0) or 0)
+            device_names = ", ".join(str(device) for device in profile.get("devices", []))
+            details = [kind, f"priority={priority}"]
+            if window_rule_count > 0:
+                details.append(f"rules={window_rule_count}")
+            if device_names:
+                details.append(f"devices={device_names}")
+            state = "on" if enabled else "off"
+            print(f"  [{marker}] [{state:3}] {name} ({', '.join(details)})")
 
     if devices:
         print()

--- a/keymasq/common/devices.py
+++ b/keymasq/common/devices.py
@@ -613,6 +613,7 @@ def find_all_interfaces(vendor_id: str, product_id: str) -> list[dict[str, str]]
 
     list_devices = cast(Callable[[], list[str]], evdev.list_devices)
     for path in list_devices():
+        device = None
         try:
             device = evdev.InputDevice(path)
             info = device.info
@@ -632,5 +633,11 @@ def find_all_interfaces(vendor_id: str, product_id: str) -> list[dict[str, str]]
                 )
         except Exception:
             continue
+        finally:
+            if device is not None:
+                try:
+                    device.close()
+                except Exception:
+                    pass
 
     return interfaces

--- a/keymasq/common/ipc.py
+++ b/keymasq/common/ipc.py
@@ -111,14 +111,19 @@ def decode_command(data: bytes) -> tuple[Command | None, bytes]:
     remaining = data[total_len:]
 
     try:
-        payload = json.loads(json_bytes.decode("utf-8"))
+        payload_text = json_bytes.decode("utf-8")
+        payload = json.loads(payload_text)
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        return None, remaining
+
+    try:
         cmd = Command(
             command=CommandType(payload["command"]),
             data=payload.get("data", {}),
             request_id=payload.get("request_id"),
         )
         return cmd, remaining
-    except (json.JSONDecodeError, KeyError, ValueError):
+    except (KeyError, ValueError):
         return None, remaining
 
 
@@ -152,7 +157,12 @@ def decode_response(data: bytes) -> tuple[Response | None, bytes]:
     remaining = data[total_len:]
 
     try:
-        payload = json.loads(json_bytes.decode("utf-8"))
+        payload_text = json_bytes.decode("utf-8")
+        payload = json.loads(payload_text)
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        return None, remaining
+
+    try:
         resp = Response(
             status=payload["status"],
             data=payload.get("data"),
@@ -160,5 +170,5 @@ def decode_response(data: bytes) -> tuple[Response | None, bytes]:
             request_id=payload.get("request_id"),
         )
         return resp, remaining
-    except (json.JSONDecodeError, KeyError, ValueError):
+    except (KeyError, ValueError):
         return None, remaining

--- a/keymasq/common/slurp.py
+++ b/keymasq/common/slurp.py
@@ -114,6 +114,7 @@ class SlurpCapture:
             "%x,%y",
         ]
 
+        process: asyncio.subprocess.Process | None = None
         try:
             log.debug(
                 "Starting slurp capture: path=%s compositor=%s "
@@ -123,11 +124,12 @@ class SlurpCapture:
                 os.environ.get("WAYLAND_DISPLAY", ""),
                 os.environ.get("XDG_RUNTIME_DIR", ""),
             )
-            self._process = await asyncio.create_subprocess_exec(
+            process = await asyncio.create_subprocess_exec(
                 *args,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
             )
+            self._process = process
 
             if mode == SlurpMode.POINT_IMMEDIATE:
                 log.debug("slurp waiting 150ms before triggering callback")
@@ -136,15 +138,13 @@ class SlurpCapture:
                     log.debug("slurp triggering on_ready callback")
                     await on_ready()
 
-            stdout, stderr = await asyncio.wait_for(
-                self._process.communicate(), timeout=timeout
-            )
+            stdout, stderr = await asyncio.wait_for(process.communicate(), timeout=timeout)
 
-            if self._process.returncode != 0:
+            if process.returncode != 0:
                 stderr_text = stderr.decode().strip() if stderr else ""
                 log.warning(
                     "slurp failed: returncode=%s stderr=%s wayland_display=%s xdg_runtime_dir=%s",
-                    self._process.returncode,
+                    process.returncode,
                     stderr_text,
                     os.environ.get("WAYLAND_DISPLAY", ""),
                     os.environ.get("XDG_RUNTIME_DIR", ""),
@@ -160,22 +160,27 @@ class SlurpCapture:
 
         except TimeoutError:
             log.warning("slurp capture timed out after %.1fs", timeout)
-            if self._process:
-                await self._terminate_process_async(self._process)
+            if process:
+                await self._terminate_process_async(process)
             return None
         except asyncio.CancelledError:
-            if self._process:
-                await self._terminate_process_async(self._process)
+            if process:
+                await self._terminate_process_async(process)
             raise
         except Exception:
             log.exception("slurp capture failed")
+            if process:
+                await self._terminate_process_async(process)
             return None
         finally:
-            self._process = None
+            if self._process is process:
+                self._process = None
 
     async def cancel_async(self) -> None:
-        if self._process:
-            await self._terminate_process_async(self._process)
+        process = self._process
+        if process:
+            await self._terminate_process_async(process)
+        if self._process is process:
             self._process = None
 
     async def _terminate_process_async(self, process: asyncio.subprocess.Process) -> None:

--- a/keymasq/common/virtual_devices.py
+++ b/keymasq/common/virtual_devices.py
@@ -24,4 +24,4 @@ def is_virtual_gamepad_output_id(output_id: str) -> bool:
         index = int(output_id.removeprefix("virtual-gamepad-"))
     except ValueError:
         return False
-    return 1 <= index <= MAX_VIRTUAL_GAMEPADS
+    return 1 <= index <= MAX_VIRTUAL_GAMEPADS and output_id == virtual_gamepad_output_id(index)

--- a/keymasq/gui/session_client.py
+++ b/keymasq/gui/session_client.py
@@ -39,6 +39,7 @@ class _PersistentSessionConnection:
         self._reader_thread: threading.Thread | None = None
         self._buffer = b""
         self._state_lock = threading.Lock()
+        self._connect_lock = threading.Lock()
         self._request_lock = threading.Lock()
         self._response_queue: queue.Queue[JsonDict | None] | None = None
         self._callbacks: dict[str, list[Callable[[JsonDict], bool | None]]] = {}
@@ -99,21 +100,32 @@ class _PersistentSessionConnection:
         if not SESSION_SOCKET_PATH.exists():
             return False
 
-        try:
-            sock = _socket.socket(_socket.AF_UNIX, _socket.SOCK_STREAM)
-            sock.settimeout(timeout)
-            sock.connect(str(SESSION_SOCKET_PATH))
-            sock.settimeout(None)
-        except Exception as e:
-            log.debug(f"persistent connect failed: {e}")
-            return False
+        with self._connect_lock:
+            with self._state_lock:
+                if self._sock is not None:
+                    return True
 
-        with self._state_lock:
-            self._sock = sock
-            self._buffer = b""
-            if self._reader_thread is None or not self._reader_thread.is_alive():
-                self._reader_thread = threading.Thread(target=self._reader_loop, daemon=True)
-                self._reader_thread.start()
+            sock: _socket.socket | None = None
+            try:
+                sock = _socket.socket(_socket.AF_UNIX, _socket.SOCK_STREAM)
+                sock.settimeout(timeout)
+                sock.connect(str(SESSION_SOCKET_PATH))
+                sock.settimeout(None)
+            except Exception as e:
+                log.debug(f"persistent connect failed: {e}")
+                if sock is not None:
+                    try:
+                        sock.close()
+                    except Exception:
+                        pass
+                return False
+
+            with self._state_lock:
+                self._sock = sock
+                self._buffer = b""
+                if self._reader_thread is None or not self._reader_thread.is_alive():
+                    self._reader_thread = threading.Thread(target=self._reader_loop, daemon=True)
+                    self._reader_thread.start()
         return True
 
     def _reader_loop(self) -> None:

--- a/keymasq/gui/widgets/combo_editor_dialog.py
+++ b/keymasq/gui/widgets/combo_editor_dialog.py
@@ -577,6 +577,7 @@ class ComboEditorDialog(Adw.Dialog):
             empty.add_css_class("dim-label")
             empty.set_halign(Gtk.Align.START)
             self.steps_box.append(empty)
+            self._refresh_restore_trigger_keys()
             return
 
         for index, step in enumerate(self._draft.steps):

--- a/keymasq/gui/widgets/combo_inspector_window.py
+++ b/keymasq/gui/widgets/combo_inspector_window.py
@@ -565,6 +565,7 @@ class ComboInspectorWindow(Adw.Window):
         if bool(event.get("connected", False)):
             self._request_snapshot()
         else:
+            self._snapshot_request_counter += 1
             self._set_status_title("Active Combos - Daemon disconnected", "stopped")
         return False
 

--- a/keymasq/gui/widgets/device_tab.py
+++ b/keymasq/gui/widgets/device_tab.py
@@ -286,8 +286,7 @@ class DeviceTab(ProfileManagedTab):
 
     def _update_header_caption(self) -> None:
         mapped = self._count_mapped_buttons()
-        total = len(self.device.buttons) + len(self.device.analog_inputs)
-        base = f"{self.device.model_id} | {len(self.device.evdev_devices)} evdev, {total} buttons"
+        base = self._header_caption_text()
         if mapped > 0:
             caption = f"{base} · {mapped} mapped"
         else:
@@ -454,9 +453,13 @@ class DeviceTab(ProfileManagedTab):
         return "\n".join(lines)
 
     def _header_caption_text(self) -> str:
+        parts = [f"{len(self.device.buttons)} buttons"]
+        analog_count = len(self.device.analog_inputs)
+        if analog_count:
+            parts.append(f"{analog_count} analog inputs")
         return (
             f"{self.device.model_id} | {len(self.device.evdev_devices)} evdev, "
-            f"{len(self.device.buttons)} buttons"
+            f"{', '.join(parts)}"
         )
 
     def _device_grab_label_text(self, device: HardwareConfig | None = None) -> str:
@@ -2046,6 +2049,7 @@ class DeviceTab(ProfileManagedTab):
                 "hardware_id": self._capture_active_hardware_id,
                 "evdev_paths": [device.path for device in self.device.evdev_devices],
                 "mode": "analog",
+                "end_on_disconnect": True,
             },
             lambda result: self._on_learn_analog_capture_begun(
                 result,
@@ -2526,6 +2530,7 @@ class DeviceTab(ProfileManagedTab):
                 "command": "begin_capture",
                 "hardware_id": self._capture_active_hardware_id,
                 "evdev_paths": [device.path for device in self.device.evdev_devices],
+                "end_on_disconnect": True,
             },
             on_capture_begun,
         )

--- a/keymasq/gui/widgets/macro_editor_dialog.py
+++ b/keymasq/gui/widgets/macro_editor_dialog.py
@@ -38,6 +38,27 @@ from keymasq.session.compositor import detect_compositor_sync
 # ---------------------------------------------------------------------------
 
 MacroEvent = dict[str, Any]
+_EDITOR_ORDER_ATTR = "_keymasq_editor_order"
+_MISSING_EDITOR_ORDER = 2**63 - 1
+
+
+class _OrderedMacroEvent(dict[str, Any]):
+    pass
+
+
+def _with_editor_order(ev: MacroEvent, order: int) -> MacroEvent:
+    ordered = _OrderedMacroEvent(ev)
+    setattr(ordered, _EDITOR_ORDER_ATTR, order)
+    return ordered
+
+
+def _get_editor_order(ev: MacroEvent) -> int | None:
+    order = getattr(ev, _EDITOR_ORDER_ATTR, None)
+    return order if isinstance(order, int) else None
+
+
+def _original_order_or_last(order: int | None) -> int:
+    return order if order is not None else _MISSING_EDITOR_ORDER
 
 
 def _get_key_name(code: int) -> str:
@@ -105,6 +126,14 @@ _LOOP_MODE_OPTIONS: tuple[tuple[str, str], ...] = (
     ("toggle", "Toggle"),
 )
 
+_CONTROL_MACRO_ACTIONS = {
+    "wait",
+    "wait_random",
+    "exec_sync",
+    "exec_async",
+    "compositor_dispatch",
+}
+
 
 def _build_option_dropdown(
     options: tuple[tuple[str, str], ...],
@@ -165,6 +194,8 @@ class EditableEvent:
     press_t_us: int  # microseconds from macro start (press)
     release_t_us: int  # microseconds from macro start (release)
     output_id: str | None = None
+    original_press_order: int | None = None
+    original_release_order: int | None = None
 
 
 @dataclass
@@ -173,6 +204,7 @@ class EditableMove:
     t_us: int
     x: int
     y: int
+    original_order: int | None = None
 
 
 @dataclass
@@ -188,6 +220,7 @@ class EditableControl:
     compositor_id: str = ""
     compositor_dispatcher: str = ""
     compositor_args: str = ""
+    original_order: int | None = None
 
 
 def _control_to_compositor_action(control: EditableControl) -> MappingAction:
@@ -236,9 +269,9 @@ def parse_events(
     passthrough_events: list[MacroEvent] = []
     editable_moves: list[EditableMove] = []
     control_events: list[EditableControl] = []
-    open_presses: dict[tuple, list[int]] = {}
+    open_presses: dict[tuple, list[tuple[int, int]]] = {}
 
-    for ev in raw_events:
+    for original_order, ev in enumerate(raw_events):
         macro_action = str(ev.get("macro_action", "") or "")
         if macro_action in {"mouse_move_abs", "mouse_move_rel"}:
             editable_moves.append(
@@ -247,10 +280,11 @@ def parse_events(
                     t_us=int(ev.get("t_us", 0)),
                     x=int(ev.get("x", 0) or 0),
                     y=int(ev.get("y", 0) or 0),
+                    original_order=original_order,
                 )
             )
             continue
-        if macro_action:
+        if macro_action in _CONTROL_MACRO_ACTIONS:
             control_events.append(
                 EditableControl(
                     mode=macro_action,
@@ -264,19 +298,24 @@ def parse_events(
                     compositor_id=str(ev.get("compositor", "") or ""),
                     compositor_dispatcher=str(ev.get("dispatcher", "") or ""),
                     compositor_args=str(ev.get("args", "") or ""),
+                    original_order=original_order,
                 )
             )
+            continue
+        if macro_action:
+            passthrough_events.append(_with_editor_order(ev, original_order))
             continue
 
         if ev["type"] == ev_key:
             output_id = str(ev.get("output_id", "") or "").strip() or None
             key = (ev["device_type"], ev["code"], output_id)
             if ev["value"] == 1:
-                open_presses.setdefault(key, []).append(ev["t_us"])
+                open_presses.setdefault(key, []).append((ev["t_us"], original_order))
             elif ev["value"] == 0:
                 stack = open_presses.get(key)
-                press_t = stack.pop() if stack else None
-                if press_t is not None:
+                press = stack.pop() if stack else None
+                if press is not None:
+                    press_t, press_order = press
                     editable.append(
                         EditableEvent(
                             device_type=ev["device_type"],
@@ -285,19 +324,21 @@ def parse_events(
                             press_t_us=press_t,
                             release_t_us=ev["t_us"],
                             output_id=output_id if ev["device_type"] == "gamepad" else None,
+                            original_press_order=press_order,
+                            original_release_order=original_order,
                         )
                     )
                 else:
-                    passthrough_events.append(ev)
+                    passthrough_events.append(_with_editor_order(ev, original_order))
             else:
-                passthrough_events.append(ev)
+                passthrough_events.append(_with_editor_order(ev, original_order))
         elif ev["type"] == ev_rel:
-            rel_events.append(ev)
+            rel_events.append(_with_editor_order(ev, original_order))
         else:
-            passthrough_events.append(ev)
+            passthrough_events.append(_with_editor_order(ev, original_order))
 
     for (device_type, code, output_id), presses in open_presses.items():
-        for press_t in presses:
+        for press_t, press_order in presses:
             event = {
                 "device_type": device_type,
                 "type": ev_key,
@@ -307,12 +348,14 @@ def parse_events(
             }
             if device_type == "gamepad" and output_id:
                 event["output_id"] = output_id
-            passthrough_events.append(event)
+            passthrough_events.append(_with_editor_order(event, press_order))
 
-    editable.sort(key=lambda e: e.press_t_us)
-    editable_moves.sort(key=lambda m: m.t_us)
-    control_events.sort(key=lambda c: c.t_us)
-    passthrough_events.sort(key=lambda e: e["t_us"])
+    editable.sort(key=lambda e: (e.press_t_us, _original_order_or_last(e.original_press_order)))
+    editable_moves.sort(key=lambda m: (m.t_us, _original_order_or_last(m.original_order)))
+    control_events.sort(key=lambda c: (c.t_us, _original_order_or_last(c.original_order)))
+    passthrough_events.sort(
+        key=lambda e: (int(e["t_us"]), _original_order_or_last(_get_editor_order(e)))
+    )
     return editable, rel_events, passthrough_events, editable_moves, control_events
 
 
@@ -328,14 +371,14 @@ def reconstruct_events(
     raw: list[MacroEvent] = []
 
     for ev in editable:
-        press_event = {
+        press_event: MacroEvent = {
             "device_type": ev.device_type,
             "type": ev_key,
             "code": ev.code,
             "value": 1,
             "t_us": ev.press_t_us,
         }
-        release_event = {
+        release_event: MacroEvent = {
             "device_type": ev.device_type,
             "type": ev_key,
             "code": ev.code,
@@ -345,27 +388,32 @@ def reconstruct_events(
         if ev.device_type == "gamepad" and ev.output_id:
             press_event["output_id"] = ev.output_id
             release_event["output_id"] = ev.output_id
+        if ev.original_press_order is not None:
+            press_event = _with_editor_order(press_event, ev.original_press_order)
         raw.append(press_event)
+        if ev.original_release_order is not None:
+            release_event = _with_editor_order(release_event, ev.original_release_order)
         raw.append(release_event)
 
     raw.extend(rel_events)
 
     for move in editable_moves:
-        raw.append(
-            {
-                "device_type": "macro",
-                "type": 0,
-                "code": 0,
-                "value": 0,
-                "t_us": int(move.t_us),
-                "macro_action": "mouse_move_abs" if move.mode == "abs" else "mouse_move_rel",
-                "x": int(move.x),
-                "y": int(move.y),
-            }
-        )
+        move_event: MacroEvent = {
+            "device_type": "macro",
+            "type": 0,
+            "code": 0,
+            "value": 0,
+            "t_us": int(move.t_us),
+            "macro_action": "mouse_move_abs" if move.mode == "abs" else "mouse_move_rel",
+            "x": int(move.x),
+            "y": int(move.y),
+        }
+        if move.original_order is not None:
+            move_event = _with_editor_order(move_event, move.original_order)
+        raw.append(move_event)
 
     for control in control_events:
-        event = {
+        control_event: MacroEvent = {
             "device_type": "macro",
             "type": 0,
             "code": 0,
@@ -374,25 +422,35 @@ def reconstruct_events(
             "macro_action": str(control.mode),
         }
         if control.mode == "wait":
-            event["duration_us"] = int(control.duration_us)
+            control_event["duration_us"] = int(control.duration_us)
         elif control.mode == "wait_random":
-            event["min_us"] = int(control.min_us)
-            event["max_us"] = int(control.max_us)
+            control_event["min_us"] = int(control.min_us)
+            control_event["max_us"] = int(control.max_us)
         elif control.mode in {"exec_sync", "exec_async"}:
-            event["command"] = str(control.command)
+            control_event["command"] = str(control.command)
             if control.mode == "exec_sync":
-                event["timeout_ms"] = int(control.timeout_ms)
-                event["inhibit_mouse"] = bool(control.inhibit_mouse)
+                control_event["timeout_ms"] = int(control.timeout_ms)
+                control_event["inhibit_mouse"] = bool(control.inhibit_mouse)
         elif control.mode == "compositor_dispatch":
             if control.compositor_id:
-                event["compositor"] = str(control.compositor_id)
-            event["dispatcher"] = str(control.compositor_dispatcher)
-            event["args"] = str(control.compositor_args)
-        raw.append(event)
+                control_event["compositor"] = str(control.compositor_id)
+            control_event["dispatcher"] = str(control.compositor_dispatcher)
+            control_event["args"] = str(control.compositor_args)
+        if control.original_order is not None:
+            control_event = _with_editor_order(control_event, control.original_order)
+        raw.append(control_event)
 
     raw.extend(passthrough_events)
-    raw.sort(key=lambda e: e["t_us"])
-    return raw
+    original_orders = [order for ev in raw if (order := _get_editor_order(ev)) is not None]
+    max_original_order = max(original_orders, default=-1)
+
+    def sort_key(item: tuple[int, MacroEvent]) -> tuple[int, int]:
+        index, ev = item
+        original_order = _get_editor_order(ev)
+        order = original_order if original_order is not None else max_original_order + 1 + index
+        return int(ev["t_us"]), order
+
+    return [dict(ev) for _, ev in sorted(enumerate(raw), key=sort_key)]
 
 
 def _assign_lanes(events: list[EditableEvent], device_type: str) -> tuple[dict[int, int], int]:

--- a/keymasq/gui/widgets/macro_manager_dialog.py
+++ b/keymasq/gui/widgets/macro_manager_dialog.py
@@ -513,13 +513,22 @@ class MacroManagerDialog(Adw.Dialog):
 
     def _on_delete_response(self, dialog, response: str, name: str) -> None:
         if response == "delete":
-            def on_delete_finished(_result: JsonDict | None) -> bool:
-                return self._load_macros()
-
             session_request_with_hooks(
                 {"command": "delete_macro", "name": name},
-                on_delete_finished,
+                self._on_delete_finished,
             )
+
+    def _on_delete_finished(self, result: JsonDict | None) -> bool:
+        result = result or {}
+        if result.get("status") == "ok":
+            return self._load_macros()
+
+        dialog = Adw.AlertDialog()
+        dialog.set_heading("Delete Macro")
+        dialog.set_body(result.get("message", "Failed to delete macro"))
+        dialog.add_response("ok", "OK")
+        dialog.present(self._parent)
+        return False
 
     def _on_record_new(self, btn: Gtk.Button) -> None:
         if not self._recording_active and not self._recording_unlocked:

--- a/keymasq/gui/widgets/recording_overlay.py
+++ b/keymasq/gui/widgets/recording_overlay.py
@@ -16,6 +16,7 @@ class RecordingOverlay(Gtk.Box):
         self._event_count: int = 0
         self._timer_id: int = 0
         self._stop_btn: Gtk.Button | None = None
+        self._status_label: Gtk.Label | None = None
         self.add_css_class("recording-overlay")
         self.set_hexpand(True)
         self.set_vexpand(True)
@@ -78,6 +79,15 @@ class RecordingOverlay(Gtk.Box):
         self._stop_btn = stop_btn
         panel.append(stop_btn)
 
+        status_label = Gtk.Label()
+        status_label.add_css_class("caption")
+        status_label.add_css_class("error")
+        status_label.set_wrap(True)
+        status_label.set_halign(Gtk.Align.CENTER)
+        status_label.set_visible(False)
+        self._status_label = status_label
+        panel.append(status_label)
+
     def _build_stat(self, title: str, value: str) -> tuple[Gtk.Box, Gtk.Label]:
         box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=3)
         box.add_css_class("recording-overlay-stat")
@@ -101,6 +111,7 @@ class RecordingOverlay(Gtk.Box):
         self._event_count = 0
         self._duration_label.set_label("00:00.000")
         self._events_label.set_label("0")
+        self._hide_status()
         if self._stop_btn:
             self._stop_btn.set_label("Stop Recording")
             self._stop_btn.set_sensitive(True)
@@ -120,6 +131,7 @@ class RecordingOverlay(Gtk.Box):
         if self._stop_btn:
             self._stop_btn.set_label("Stop Recording")
             self._stop_btn.set_sensitive(True)
+        self._hide_status()
 
     def _update_timer(self) -> bool:
         import time
@@ -140,17 +152,40 @@ class RecordingOverlay(Gtk.Box):
         self._events_label.set_label(str(self._event_count))
 
     def _on_stop_clicked(self, btn: Gtk.Button) -> None:
-        if self._timer_id:
-            GLib.source_remove(self._timer_id)
-            self._timer_id = 0
+        self._hide_status()
         btn.set_sensitive(False)
         btn.set_label("Stopping...")
         session_request_async(
             {"command": "stop_recording"},
-            lambda _result: self._on_stop_done(btn),
+            lambda result: self._on_stop_done(btn, result),
         )
 
-    def _on_stop_done(self, btn: Gtk.Button) -> bool:
+    def _on_stop_done(self, btn: Gtk.Button, result: dict | None) -> bool:
+        if result and result.get("status") == "ok":
+            if self._timer_id:
+                GLib.source_remove(self._timer_id)
+                self._timer_id = 0
+            btn.set_sensitive(True)
+            btn.set_label("Stop Recording")
+            return False
+
         btn.set_sensitive(True)
         btn.set_label("Stop Recording")
+        self._ensure_timer_running()
+        self._show_status(str((result or {}).get("message") or "Failed to stop recording."))
         return False
+
+    def _ensure_timer_running(self) -> None:
+        if self._timer_id or not self._start_ms or not self.get_visible():
+            return
+        self._timer_id = GLib.timeout_add(100, self._update_timer)
+
+    def _show_status(self, message: str) -> None:
+        if self._status_label is None:
+            return
+        self._status_label.set_label(message)
+        self._status_label.set_visible(True)
+
+    def _hide_status(self) -> None:
+        if self._status_label is not None:
+            self._status_label.set_visible(False)

--- a/keymasq/gui/widgets/save_macro_dialog.py
+++ b/keymasq/gui/widgets/save_macro_dialog.py
@@ -216,11 +216,15 @@ class SaveMacroDialog(Adw.Dialog):
             for m in (result or {}).get("macros", [])
             if str(m.get("name", ""))
         }
-        self._suggest_name()
+        current_name = self._name_entry.get_text()
+        if current_name:
+            self._validate_name(current_name)
+        else:
+            self._suggest_name()
         return False
 
     def _on_name_changed(self, entry: Gtk.Entry) -> None:
-        self._validate_name(entry.get_text())
+        self._validate_name(entry.get_text().strip())
 
     def _on_name_activated(self, entry: Gtk.Entry) -> None:
         if self._save_btn.get_sensitive():
@@ -245,7 +249,10 @@ class SaveMacroDialog(Adw.Dialog):
             return
 
         self._hide_error()
-        self._save_btn.set_sensitive(True)
+        self._save_btn.set_sensitive(not self._request_inflight)
+
+    def _refresh_submit_state(self) -> None:
+        self._validate_name(self._name_entry.get_text().strip())
 
     def _show_error(self, message: str) -> None:
         self._error_label.set_label(message)
@@ -259,16 +266,14 @@ class SaveMacroDialog(Adw.Dialog):
         if not name:
             return
 
-        payload = (
-            {
-                "command": "save_recording",
-                "name": name,
-                "move_to_start": self._move_to_start,
-                "start_x": int(self._start_x_spin.get_value()),
-                "start_y": int(self._start_y_spin.get_value()),
-                "block_mouse_movement": self._block_mouse_check.get_active(),
-            }
-        )
+        payload = {
+            "command": "save_recording",
+            "name": name,
+            "move_to_start": self._move_to_start,
+            "start_x": int(self._start_x_spin.get_value()),
+            "start_y": int(self._start_y_spin.get_value()),
+            "block_mouse_movement": self._block_mouse_check.get_active(),
+        }
         if self._pending_save_token:
             payload["pending_save_token"] = self._pending_save_token
         session_request_with_hooks(
@@ -343,7 +348,7 @@ class SaveMacroDialog(Adw.Dialog):
     def _set_request_inflight(self, inflight: bool) -> None:
         self._request_inflight = inflight
         self.set_can_close(not inflight)
-        self._save_btn.set_sensitive(False if inflight else self._save_btn.get_sensitive())
+        self._save_btn.set_sensitive(False)
         self._discard_btn.set_sensitive(not inflight)
         self._name_entry.set_sensitive(not inflight)
         self._move_to_start_check.set_sensitive(not inflight)
@@ -354,4 +359,4 @@ class SaveMacroDialog(Adw.Dialog):
             return
 
         self._update_start_pos_controls()
-        self._validate_name(self._name_entry.get_text().strip())
+        self._refresh_submit_state()

--- a/keymasq/gui/widgets/settings_dialog.py
+++ b/keymasq/gui/widgets/settings_dialog.py
@@ -139,7 +139,7 @@ class SettingsDialog(Adw.Dialog):
                 return False
             if isinstance(response, dict) and response.get("status") == "ok":
                 raw_saved = response.get("virtual_gamepad_count", count)
-                saved_count = int(raw_saved if isinstance(raw_saved, (int, float, str)) else count)
+                saved_count = _count_value(raw_saved, count)
                 self._syncing_controls = True
                 self._gamepad_count = clamp_virtual_gamepad_count(saved_count)
                 self._sync_gamepad_count_controls()

--- a/keymasq/gui/widgets/threshold_range_bar.py
+++ b/keymasq/gui/widgets/threshold_range_bar.py
@@ -12,6 +12,30 @@ def _clamp(value: float, minimum: float = -1.0, maximum: float = 1.0) -> float:
     return max(minimum, min(maximum, float(value)))
 
 
+def _threshold_ticks(minimum: float, maximum: float) -> tuple[tuple[float, str], ...]:
+    if minimum == 0.0 and maximum == 1.0:
+        return (
+            (0.0, "0"),
+            (0.25, "25%"),
+            (0.5, "50%"),
+            (0.75, "75%"),
+            (1.0, "100%"),
+        )
+    if minimum == -1.0 and maximum == 1.0:
+        return (
+            (-1.0, "-100%"),
+            (-0.5, "-50%"),
+            (0.0, "0"),
+            (0.5, "50%"),
+            (1.0, "100%"),
+        )
+    span = maximum - minimum
+    return tuple(
+        (value, f"{value:g}")
+        for value in (minimum + span * index / 4.0 for index in range(5))
+    )
+
+
 class ThresholdRangeBar(Gtk.DrawingArea):
     def __init__(self) -> None:
         super().__init__()
@@ -32,6 +56,10 @@ class ThresholdRangeBar(Gtk.DrawingArea):
             maximum = 1.0
         self._minimum = float(minimum)
         self._maximum = float(maximum)
+        self._trigger_min = _clamp(self._trigger_min, self._minimum, self._maximum)
+        self._trigger_max = _clamp(self._trigger_max, self._minimum, self._maximum)
+        self._release_min = _clamp(self._release_min, self._minimum, self._maximum)
+        self._release_max = _clamp(self._release_max, self._minimum, self._maximum)
         self.queue_draw()
 
     def set_ranges(
@@ -106,20 +134,7 @@ class ThresholdRangeBar(Gtk.DrawingArea):
         tick_y1 = track_y + track_h + 4.0
         tick_y2 = tick_y1 + 5.0
         label_y = min(float(height) - 4.0, tick_y2 + 12.0)
-        ticks = (
-            (0.0, "0"),
-            (0.25, "25%"),
-            (0.5, "50%"),
-            (0.75, "75%"),
-            (1.0, "100%"),
-        ) if self._minimum == 0.0 else (
-            (-1.0, "-100%"),
-            (-0.5, "-50%"),
-            (0.0, "0"),
-            (0.5, "50%"),
-            (1.0, "100%"),
-        )
-        for value, label in ticks:
+        for value, label in _threshold_ticks(self._minimum, self._maximum):
             x = self._x_for_value(value, left, track_w)
             cr.move_to(x, tick_y1)
             cr.line_to(x, tick_y2)

--- a/keymasq/gui/window.py
+++ b/keymasq/gui/window.py
@@ -566,7 +566,7 @@ class MainWindow(Adw.ApplicationWindow):
         elif event_type == "recording_auth_requested":
             self.present_recording_settings_dialog(reason="recording_locked")
         elif event_type == "macro_save_pending":
-            self.present_pending_macro_save_dialog()
+            self.present_pending_macro_save_dialog(event)
 
         callbacks = self._event_handlers.get(event_type)
         if callbacks is None:
@@ -575,21 +575,22 @@ class MainWindow(Adw.ApplicationWindow):
             cb(event)
 
     def _on_recording_stopped(self, event: dict) -> None:
+        self.present_pending_macro_save_dialog(event)
+
+    def present_pending_macro_save_dialog(self, recording_data: dict | None = None) -> bool:
         from keymasq.gui.widgets.save_macro_dialog import SaveMacroDialog
 
         if self._save_macro_dialog is not None:
             self._save_macro_dialog.present(self)
-            return
+            return True
 
-        dialog = SaveMacroDialog(self, event)
+        if recording_data is None:
+            return False
+
+        dialog = SaveMacroDialog(self, recording_data)
         dialog.connect("closed", self._on_save_macro_dialog_closed)
         self._save_macro_dialog = dialog
         dialog.present(self)
-
-    def present_pending_macro_save_dialog(self) -> bool:
-        if self._save_macro_dialog is None:
-            return False
-        self._save_macro_dialog.present(self)
         return True
 
     def _on_save_macro_dialog_closed(self, dialog) -> None:

--- a/keymasq/gui/wizards/hardware_setup.py
+++ b/keymasq/gui/wizards/hardware_setup.py
@@ -1670,6 +1670,7 @@ class HardwareSetupDialog(Adw.Dialog):
             {
                 "command": "begin_capture",
                 "hardware_id": self._capture_hardware_id,
+                "end_on_disconnect": True,
                 "evdev_paths": [
                     str(
                         iface.get("config_path")

--- a/keymasq/keymasqd/combo_engine.py
+++ b/keymasq/keymasqd/combo_engine.py
@@ -36,6 +36,7 @@ class RuntimeCombo:
     profile_name: str = ""
     recall_trigger_keys: bool = False
     restore_trigger_keys: list[str] = field(default_factory=list)
+    match_across_devices: bool = False
 
 
 @dataclass(frozen=True)

--- a/keymasq/keymasqd/daemon_capture_commands.py
+++ b/keymasq/keymasqd/daemon_capture_commands.py
@@ -174,6 +174,7 @@ async def capture_combo(
         for device in devices
     }
     daemon.device_manager.begin_combo_capture(token, hardware_ids, notify_event)
+    capture_started = False
     try:
         authorization = daemon.capture_manager.authorize_combo_capture()
         capture_result = await asyncio.to_thread(
@@ -186,6 +187,7 @@ async def capture_combo(
             hardware_paths=hardware_paths or {},
             hardware_interfaces=hardware_interfaces or {},
         )
+        capture_started = True
         daemon.capture_manager.register_combo_notifier(token, loop, notify_event)
         warnings = cast(list[str], capture_result.get("warnings", []))
         capture_timeout_s = min(
@@ -258,7 +260,8 @@ async def capture_combo(
         raise TimeoutError("Combo capture timed out")
     finally:
         daemon.device_manager.end_combo_capture(token)
-        await asyncio.to_thread(daemon.capture_manager.end, token)
+        if capture_started:
+            await asyncio.to_thread(daemon.capture_manager.end, token)
 
 
 def _hardware_paths(value: object) -> dict[str, list[str]]:

--- a/keymasq/keymasqd/daemon_macro_commands.py
+++ b/keymasq/keymasqd/daemon_macro_commands.py
@@ -379,9 +379,8 @@ def _macro_playback_options(
     *,
     stored_macro: JsonObject | None = None,
 ) -> MacroPlaybackOptions:
-    runtime_options = _macro_runtime_options(data)
-    if stored_macro is not None:
-        runtime_options = _macro_runtime_options(stored_macro, defaults=runtime_options)
+    defaults = _macro_runtime_options(stored_macro) if stored_macro is not None else None
+    runtime_options = _macro_runtime_options(data, defaults=defaults)
     return MacroPlaybackOptions(
         macro_events=macro_events,
         macro_name=macro_name,

--- a/keymasq/keymasqd/device_manager.py
+++ b/keymasq/keymasqd/device_manager.py
@@ -232,6 +232,7 @@ def combo_runtime_signature(combo: RuntimeCombo) -> tuple[object, ...]:
         combo.action,
         bool(combo.recall_trigger_keys),
         tuple(combo.restore_trigger_keys),
+        bool(combo.match_across_devices),
     )
 
 
@@ -913,6 +914,7 @@ class DeviceManager:
                 if not steps_data:
                     continue
 
+                match_across_devices = bool(combo_dict.get("match_across_devices", False))
                 steps: list[RuntimeComboStep] = []
                 for step_data in steps_data:
                     step_dict = _json_object(step_data)
@@ -931,6 +933,9 @@ class DeviceManager:
                         source = _str_value(event_dict.get("source"), "").lower()
                         if not evdev_name:
                             continue
+                        if match_across_devices:
+                            hardware_id = ""
+                            source = ""
                         bindings.append(
                             RuntimeComboBinding(
                                 hardware_id=hardware_id,
@@ -970,6 +975,7 @@ class DeviceManager:
                         restore_trigger_keys=normalize_combo_restore_keys(
                             _json_list(combo_dict.get("restore_trigger_keys"))
                         ),
+                        match_across_devices=match_across_devices,
                     )
                 )
 

--- a/keymasq/keymasqd/macro_file.py
+++ b/keymasq/keymasqd/macro_file.py
@@ -114,7 +114,13 @@ def load_macro(path: Path) -> JsonObject:
     return payload
 
 
-def write_macro(path: Path, meta: MacroFileMeta, events: Iterable[MacroEvent]) -> None:
+def write_macro(
+    path: Path,
+    meta: MacroFileMeta,
+    events: Iterable[MacroEvent],
+    *,
+    overwrite: bool = True,
+) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     fd, tmp_path = _open_private_temp(path)
     fileobj: io.BufferedWriter | None = None
@@ -127,7 +133,7 @@ def write_macro(path: Path, meta: MacroFileMeta, events: Iterable[MacroEvent]) -
                     f.write(_json_line(event))
         fileobj.flush()
         os.fsync(fd)
-        os.replace(tmp_path, path)
+        _commit_temp_macro(tmp_path, path, overwrite=overwrite)
         path.chmod(0o600)
     except Exception:
         tmp_path.unlink(missing_ok=True)
@@ -184,6 +190,14 @@ def _open_private_temp(path: Path) -> tuple[int, Path]:
         os.fchmod(fd, 0o600)
         return fd, tmp_path
     raise FileExistsError(f"Could not create temporary macro file for {path}")
+
+
+def _commit_temp_macro(tmp_path: Path, path: Path, *, overwrite: bool) -> None:
+    if overwrite:
+        os.replace(tmp_path, path)
+        return
+    os.link(tmp_path, path)
+    tmp_path.unlink()
 
 
 def _json_line(value: JsonObject) -> str:

--- a/keymasq/keymasqd/macro_store.py
+++ b/keymasq/keymasqd/macro_store.py
@@ -151,6 +151,14 @@ class MacroStore:
         *,
         return_full: bool = False,
     ) -> MacroPayload:
+        missing_meta = [
+            key for key in ("event_count", "duration_us", "device_types") if key not in payload
+        ]
+        if missing_meta:
+            raise ValueError(
+                "create_from_events requires streamed macro metadata: "
+                + ", ".join(missing_meta)
+            )
         return self._create_from_events(payload, events, return_full=return_full)
 
     def update(
@@ -206,9 +214,18 @@ class MacroStore:
         current["name"] = safe_new
         current["revision"] = current_revision + 1
         current["event_count"] = len(_payload_events(current))
-        self._write_payload(new_path, current)
+        try:
+            self._write_payload(new_path, current, overwrite=False)
+            renamed = self.get(safe_new)
+            if renamed != current:
+                raise ValueError(f"Renamed macro '{safe_new}' failed validation")
+        except FileExistsError:
+            raise
+        except Exception:
+            new_path.unlink(missing_ok=True)
+            raise
         old_path.unlink(missing_ok=True)
-        return self.get(safe_new)
+        return renamed
 
     def delete(self, name: str, expected_revision: int | None) -> None:
         if name in self._internal_macros:
@@ -246,7 +263,7 @@ class MacroStore:
         data["revision"] = _payload_int(payload, "revision", 1)
 
         meta = MacroFileMeta.from_payload(data, name=name)
-        write_macro(path, meta, events)
+        write_macro(path, meta, events, overwrite=False)
         return self.get(name) if return_full else meta.to_payload()
 
     def _macro_path(self, name: str) -> Path:
@@ -258,11 +275,11 @@ class MacroStore:
     def _sanitize_name(self, name: str) -> str:
         return re.sub(r"[^a-zA-Z0-9_.-]", "_", name).strip("._")
 
-    def _write_payload(self, path: Path, data: MacroPayload) -> None:
+    def _write_payload(self, path: Path, data: MacroPayload, *, overwrite: bool = True) -> None:
         events = _payload_events(data)
         payload = macro_payload_from_events(data, events)
         meta = MacroFileMeta.from_payload(payload)
-        write_macro(path, meta, events)
+        write_macro(path, meta, events, overwrite=overwrite)
 
 
 def _payload_events(payload: MacroPayload) -> list[MacroEvent]:

--- a/keymasq/keymasqd/recording.py
+++ b/keymasq/keymasqd/recording.py
@@ -289,18 +289,29 @@ class RecordingManager:
         ttl_s: float = PENDING_RECORDING_TTL_S,
     ) -> None:
         now = asyncio.get_running_loop().time()
-        expired_ids: list[str] = []
+        expired_pending_ids: list[str] = []
+        expired_claimed_ids: list[str] = []
+        snapshots: list[RecordingSnapshot] = []
         async with self._pending_recording_lock:
+            ttl = max(0.0, float(ttl_s))
             for recording_id, created_at in self._pending_recording_created_at.items():
-                if now - created_at >= max(0.0, float(ttl_s)):
-                    expired_ids.append(recording_id)
-            snapshots = [
-                self._pending_recordings.pop(recording_id)
-                for recording_id in expired_ids
-                if recording_id in self._pending_recordings
-            ]
-            for recording_id in expired_ids:
+                if now - created_at >= ttl:
+                    expired_pending_ids.append(recording_id)
+            for recording_id, created_at in self._claimed_recording_created_at.items():
+                if now - created_at >= ttl:
+                    expired_claimed_ids.append(recording_id)
+
+            for recording_id in expired_pending_ids:
+                snapshot = self._pending_recordings.pop(recording_id, None)
+                if snapshot is not None:
+                    snapshots.append(snapshot)
                 self._pending_recording_created_at.pop(recording_id, None)
+            for recording_id in expired_claimed_ids:
+                snapshot = self._claimed_recordings.pop(recording_id, None)
+                if snapshot is not None:
+                    snapshots.append(snapshot)
+                self._claimed_recording_created_at.pop(recording_id, None)
+                self._claimed_recording_discard_requested.discard(recording_id)
 
         for snapshot in snapshots:
             snapshot.cleanup()

--- a/keymasq/keymasqd/recording_spool.py
+++ b/keymasq/keymasqd/recording_spool.py
@@ -85,7 +85,7 @@ class RecordingSpool:
             self._memory_events.append(event)
             self._memory_bytes += _estimate_event_bytes(event)
             self.event_count += 1
-            self.duration_ms = int(_event_t_us(event) / 1000)
+            self.duration_ms = max(self.duration_ms, int(_event_t_us(event) / 1000))
             self.device_types.add(str(event.get("device_type", "other")))
 
             if (

--- a/keymasq/keymasqd/runtime/combos.py
+++ b/keymasq/keymasqd/runtime/combos.py
@@ -375,13 +375,15 @@ def queue_combo_capture_event(
     if payload is None or not manager.combo_state.capture_queues:
         return False
     hardware_id = str_value_fn(payload.get("hardware_id"), "")
+    enqueued = False
     for capture_queue, hardware_ids, notify_event in manager.combo_state.capture_queues.values():
         if hardware_ids and hardware_id not in hardware_ids:
             continue
         capture_queue.put(dict(payload))
+        enqueued = True
         if notify_event is not None:
             notify_event.set()
-    return True
+    return enqueued
 
 
 async def process_runtime_combo_event(

--- a/keymasq/keymasqd/runtime/grab_lifecycle.py
+++ b/keymasq/keymasqd/runtime/grab_lifecycle.py
@@ -224,10 +224,12 @@ async def grab_device_unlocked(
     for path in sorted(requested_paths):
         if path in existing_by_path:
             continue
+        raw_device: Any | None = None
         try:
-            raw_device = manager._device_input(path)
+            probe_device = manager._device_input(path)
+            raw_device = probe_device
             available_count += 1
-            caps = raw_device.capabilities()
+            caps = probe_device.capabilities()
             resolved_interface = resolved_by_path.get(path)
             interface_id = str(
                 (resolved_interface.interface_id if resolved_interface else "")
@@ -254,7 +256,7 @@ async def grab_device_unlocked(
                         uinput_writer=runtime_adapters.identity_uinput_writer,
                     )
                     created_global_uinputs = True
-                detected_types = manager._detect_device_types(raw_device)
+                detected_types = manager._detect_device_types(probe_device)
                 detected_type = device_path_resolver_deps.primary_input_class_fn(
                     detected_types
                 )
@@ -298,12 +300,16 @@ async def grab_device_unlocked(
                     inspector_suppressed_ids_getter=(
                         manager.device_inspector_suppressed_hardware_ids_snapshot
                     ),
-                    inspector_suppression_disabler=manager.disable_device_inspector_suppression,
+                    inspector_suppression_disabler=(
+                        manager.disable_device_inspector_suppression
+                    ),
                     profile_activation_recorder=manager.record_profile_action,
                     profile_activation_trigger_start_observer=(
                         manager.observe_profile_trigger_start
                     ),
-                    profile_activation_trigger_end_observer=manager.observe_profile_trigger_end,
+                    profile_activation_trigger_end_observer=(
+                        manager.observe_profile_trigger_end
+                    ),
                     suppress_rel_getter=lambda: manager.macro_state.mouse_rel_suppressed,
                     mouse_rel_suppression_start_callback=lambda: None,
                     diagnostics_recorder=diagnostics_recorder,
@@ -328,6 +334,9 @@ async def grab_device_unlocked(
                 if manager.verbosity >= 1:
                     log.debug("  %s - skipped (no matching mapped button names/codes)", path)
         except OSError as exc:
+            if raw_device is not None:
+                _close_device(raw_device)
+                raw_device = None
             if exc.errno in {errno_mod.ENOENT, errno_mod.ENODEV}:
                 log.info("Skipping unavailable interface for %s: %s", hardware_id, path)
                 continue
@@ -340,6 +349,9 @@ async def grab_device_unlocked(
                 runtime_outputs.destroy_global_uinputs(manager, log=log)
             raise
         except Exception as exc:
+            if raw_device is not None:
+                _close_device(raw_device)
+                raw_device = None
             log.error("Failed to grab %s: %s", path, exc)
             for device in devices:
                 if device.path in existing_by_path:
@@ -348,6 +360,9 @@ async def grab_device_unlocked(
             if created_global_uinputs:
                 runtime_outputs.destroy_global_uinputs(manager, log=log)
             raise
+        finally:
+            if raw_device is not None:
+                _close_device(raw_device)
 
     waiting_for_device = bool(
         (requested_paths or raw_interfaces) and available_count == 0 and not devices
@@ -400,6 +415,16 @@ def grabbed_paths_for_other_hardware(manager: _GrabManager, hardware_id: str) ->
                 if path:
                     paths.add(path)
     return paths
+
+
+def _close_device(device: object) -> None:
+    close = getattr(device, "close", None)
+    if not callable(close):
+        return
+    try:
+        close()
+    except Exception:
+        pass
 
 
 async def grab_with_retry(

--- a/keymasq/keymasqd/runtime/macros.py
+++ b/keymasq/keymasqd/runtime/macros.py
@@ -149,6 +149,13 @@ async def play_macro(
         if hold_instances:
             return {"status": "ok", "already_running": True}
 
+    event_source = macro_event_source or list_macro_event_source(
+        macro_events,
+        int_value_fn=deps.int_value_fn,
+    )
+    if event_source.event_count <= 0:
+        return {"status": "ok"}
+
     manager.macro_state.instance_seq += 1
     instance_id = manager.macro_state.instance_seq
     manager.macro_state.instance_held[instance_id] = set()
@@ -168,8 +175,7 @@ async def play_macro(
             manager,
             instance_id=instance_id,
             macro_events=macro_events,
-            macro_event_source=macro_event_source
-            or list_macro_event_source(macro_events, int_value_fn=deps.int_value_fn),
+            macro_event_source=event_source,
             macro_name=macro_name,
             replay_mouse_movement=replay_mouse_movement,
             replay_mouse_clicks=replay_mouse_clicks,

--- a/keymasq/keymasqd/runtime/profile_activation_tracker.py
+++ b/keymasq/keymasqd/runtime/profile_activation_tracker.py
@@ -55,6 +55,9 @@ class ProfileActivationTracker:
         previous_activation_id = self._activation_by_profile.get(normalized_profile_name)
         if previous_activation_id and previous_activation_id != normalized_activation_id:
             self.cancel(activation_id=previous_activation_id)
+        previous_tracker = self._trackers.get(normalized_activation_id)
+        if previous_tracker is not None:
+            self._cancel_timeout(previous_tracker)
 
         tracker = RuntimeProfileActivationTracker(
             profile_name=normalized_profile_name,

--- a/keymasq/keymasqd/runtime/topology.py
+++ b/keymasq/keymasqd/runtime/topology.py
@@ -69,7 +69,9 @@ async def start_topology_watcher(
         log=log,
     )
     manager.topology_state.live_snapshot = dict(snapshot)
-    manager.topology_state.reconciled_snapshot = dict(snapshot)
+    async with manager._op_lock:
+        await reconcile_topology_unlocked(manager, snapshot, deps=deps)
+        manager.topology_state.reconciled_snapshot = dict(snapshot)
     manager.topology_state.watcher_task = asyncio_mod.create_task(
         topology_watch_loop(
             manager,

--- a/keymasq/keymasqd/superkey_state.py
+++ b/keymasq/keymasqd/superkey_state.py
@@ -280,6 +280,10 @@ class SuperkeyMachine:
         await self._emit_hold_down()
 
     async def _start_tap_holding(self) -> None:
+        if not self.config.tap_hold_actions:
+            await self._start_holding()
+            return
+
         self.state = SuperkeyState.TAP_HOLDING
         await self._emit_tap_hold_down()
 
@@ -322,7 +326,7 @@ class SuperkeyMachine:
 
         self.state = SuperkeyState.DOWN_WAIT_2
 
-        if self.config.tap_hold_actions:
+        if self.config.tap_hold_actions or self.config.hold_actions:
             self._hold_task = asyncio.create_task(self._hold_timeout())
 
     async def _on_second_up(self) -> None:

--- a/keymasq/record.py
+++ b/keymasq/record.py
@@ -7,7 +7,6 @@ import time
 from pathlib import Path
 
 from keymasq.common.recording_guard import (
-    parse_unlock_expires_at,
     resolve_unlock_status,
     runtime_unlock_path,
     write_unlock_expires_at,
@@ -83,11 +82,7 @@ def main() -> None:
             if int(args.ttl) == 0:
                 expires_at = 0
             else:
-                candidate = int(time.time()) + max(1, int(args.ttl))
-                previous = parse_unlock_expires_at(runtime_path)
-                if previous is not None:
-                    candidate = max(candidate, int(previous) + 1)
-                expires_at = candidate
+                expires_at = int(time.time()) + max(1, int(args.ttl))
             _write_lease(runtime_path, expires_at)
             print(json.dumps({"status": "ok", "scope": "runtime", "expires_at": expires_at}))
             return

--- a/keymasq/session/__main__.py
+++ b/keymasq/session/__main__.py
@@ -1,34 +1,8 @@
-import argparse
-import sys
-
 from keymasq.common.asyncio_runtime import ensure_uvloop
-
-
-def _wants_help(argv: list[str]) -> bool:
-    return any(arg in {"-h", "--help"} for arg in argv[1:])
-
-
-def _print_help() -> None:
-    parser = argparse.ArgumentParser(
-        prog="keymasq-session",
-        description="Keymasq Session Manager",
-    )
-    parser.add_argument(
-        "-v",
-        "--verbose",
-        action="count",
-        default=0,
-        help="Enable debug logging (-v) or trace logging (-vv)",
-    )
-    parser.print_help()
 
 
 def main() -> None:
     ensure_uvloop()
-
-    if _wants_help(sys.argv):
-        _print_help()
-        return
 
     from keymasq.session.manager import main as manager_main
 

--- a/keymasq/session/action_handler.py
+++ b/keymasq/session/action_handler.py
@@ -1,10 +1,29 @@
 import asyncio
+import contextlib
 import logging
+import os
+import signal
 
 from keymasq.gui.session_client import JsonDict
 
 log = logging.getLogger("keymasq-session.actions")
 DEFAULT_COMMAND_TIMEOUT_S = 300.0
+KILLED_COMMAND_CLEANUP_TIMEOUT_S = 1.0
+
+
+async def _kill_and_drain_process(process: asyncio.subprocess.Process) -> None:
+    pid = getattr(process, "pid", None)
+    if isinstance(pid, int):
+        with contextlib.suppress(ProcessLookupError):
+            os.killpg(pid, signal.SIGKILL)
+    else:
+        with contextlib.suppress(ProcessLookupError):
+            process.kill()
+    with contextlib.suppress(Exception):
+        await asyncio.wait_for(
+            process.communicate(),
+            timeout=KILLED_COMMAND_CLEANUP_TIMEOUT_S,
+        )
 
 
 class ActionHandler:
@@ -36,6 +55,7 @@ class ActionHandler:
                 cmd,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
+                start_new_session=True,
             )
         except Exception as e:
             log.error(f"Failed to execute command: {e}")
@@ -50,12 +70,11 @@ class ActionHandler:
 
         except TimeoutError:
             log.error(f"Command timed out after {timeout_s:g}s, killing: {cmd}")
-            process.kill()
-            await process.wait()
+            await _kill_and_drain_process(process)
             return -1
         except asyncio.CancelledError:
             log.debug("Command task cancelled, killing: %s", cmd)
-            process.kill()
+            await _kill_and_drain_process(process)
             raise
         except Exception as e:
             log.error(f"Failed to execute command: {e}")

--- a/keymasq/session/hardware.py
+++ b/keymasq/session/hardware.py
@@ -1,3 +1,4 @@
+import contextlib
 import logging
 import re
 import tomllib
@@ -19,6 +20,7 @@ from keymasq.common.models import (
 from keymasq.session.config_errors import ConfigLoadError, ConfigLoadFailure
 
 log = logging.getLogger("keymasq-session.hardware")
+MAX_HARDWARE_PATH_ATTEMPTS = 10000
 
 
 def _valid_hardware_id_for_model(hardware_id: str, model_id: str) -> bool:
@@ -157,10 +159,46 @@ class HardwareManager:
     def list_hardware_ids(self) -> list[str]:
         return list(self._cache.keys())
 
+    def _hardware_storage_path_candidate(self, hardware_id: str, attempt: int) -> Path:
+        stem = _hardware_storage_stem(hardware_id)
+        suffix = "" if attempt == 1 else f"_{attempt}"
+        return paths.HARDWARE_DIR / f"{stem}{suffix}.toml"
+
+    def _storage_file_hardware_id(self, path: Path) -> str:
+        try:
+            return self._load_config(path).hardware_id
+        except Exception as exc:
+            raise ValueError(
+                f"Hardware storage path '{path.name}' already exists but could not be read"
+            ) from exc
+
+    def _path_for_hardware_id(self, hardware_id: str) -> tuple[Path, bool]:
+        existing_path = self._existing_path_for_hardware_id(hardware_id)
+        if existing_path is not None:
+            return existing_path, False
+
+        for attempt in range(1, MAX_HARDWARE_PATH_ATTEMPTS + 1):
+            path = self._hardware_storage_path_candidate(hardware_id, attempt)
+            try:
+                with path.open("x", encoding="utf-8"):
+                    pass
+            except FileExistsError:
+                continue
+            return path, True
+        raise ValueError(f"Could not allocate storage path for hardware '{hardware_id}'")
+
+    def _existing_path_for_hardware_id(self, hardware_id: str) -> Path | None:
+        stem = _hardware_storage_stem(hardware_id)
+        for path in sorted(paths.HARDWARE_DIR.glob(f"{stem}*.toml")):
+            suffix = path.stem.removeprefix(stem)
+            if suffix and not (suffix.startswith("_") and suffix[1:].isdigit()):
+                continue
+            if self._storage_file_hardware_id(path) == hardware_id:
+                return path
+        return None
+
     def save_hardware(self, config: HardwareConfig) -> None:
         paths.ensure_config_dirs()
-
-        path = paths.HARDWARE_DIR / f"{_hardware_storage_stem(config.hardware_id)}.toml"
 
         buttons_data: list[dict[str, object]] = []
         for btn in config.buttons:
@@ -261,28 +299,37 @@ class HardwareManager:
         if config.image:
             data["hardware"]["image"] = config.image
 
-        with open(path, "wb") as f:
-            tomli_w.dump(data, f)
+        path, reserved_path = self._path_for_hardware_id(config.hardware_id)
+        try:
+            with open(path, "wb") as f:
+                tomli_w.dump(data, f)
 
-        if is_keyboard_layout:
-            with open(path, "a", encoding="utf-8") as f:
-                f.write("\n")
-                f.write("# Optional special keys (not shown in GUI by default)\n")
-                f.write("# Add entries below into [hardware.layout.buttons] if needed\n")
-                f.write("# Example entries:\n")
-                f.write(
-                    '# { id = "key_volumedown", label = "Volume Down", '
-                    'evdev = "key_volumedown", type = "key" }\n'
-                )
-                f.write(
-                    '# { id = "key_volumeup", label = "Volume Up", '
-                    'evdev = "key_volumeup", type = "key" }\n'
-                )
-                f.write('# { id = "key_mute", label = "Mute", evdev = "key_mute", type = "key" }\n')
-                f.write(
-                    '# { id = "key_playpause", label = "Play Pause", '
-                    'evdev = "key_playpause", type = "key" }\n'
-                )
+            if is_keyboard_layout:
+                with open(path, "a", encoding="utf-8") as f:
+                    f.write("\n")
+                    f.write("# Optional special keys (not shown in GUI by default)\n")
+                    f.write("# Add entries below into [hardware.layout.buttons] if needed\n")
+                    f.write("# Example entries:\n")
+                    f.write(
+                        '# { id = "key_volumedown", label = "Volume Down", '
+                        'evdev = "key_volumedown", type = "key" }\n'
+                    )
+                    f.write(
+                        '# { id = "key_volumeup", label = "Volume Up", '
+                        'evdev = "key_volumeup", type = "key" }\n'
+                    )
+                    f.write(
+                        '# { id = "key_mute", label = "Mute", evdev = "key_mute", type = "key" }\n'
+                    )
+                    f.write(
+                        '# { id = "key_playpause", label = "Play Pause", '
+                        'evdev = "key_playpause", type = "key" }\n'
+                    )
+        except Exception:
+            if reserved_path:
+                with contextlib.suppress(OSError):
+                    path.unlink()
+            raise
 
         self._cache[config.hardware_id] = config
         log.info(f"Saved hardware config: {path}")
@@ -291,9 +338,9 @@ class HardwareManager:
         if hardware_id not in self._cache:
             return False
 
-        path = paths.HARDWARE_DIR / f"{_hardware_storage_stem(hardware_id)}.toml"
+        path = self._existing_path_for_hardware_id(hardware_id)
 
-        if path.exists():
+        if path is not None and path.exists():
             try:
                 path.unlink()
             except Exception as e:

--- a/keymasq/session/listeners/hyprland.py
+++ b/keymasq/session/listeners/hyprland.py
@@ -190,10 +190,14 @@ class HyprlandListener(WindowListener):
                 return "", "", []
 
             data = json.loads(response.decode())
+            tags = data.get("tags", [])
+            if not isinstance(tags, list):
+                tags = []
+            tag_items = cast(list[object], tags)
             return (
                 data.get("class", ""),
                 data.get("title", ""),
-                data.get("tags", []),
+                [str(tag) for tag in tag_items],
             )
 
         except Exception as e:

--- a/keymasq/session/listeners/x11.py
+++ b/keymasq/session/listeners/x11.py
@@ -175,28 +175,7 @@ class X11Listener(WindowListener):
     @classmethod
     async def probe_available(cls, dbus: SessionDBus | None = None) -> bool:
         _ = dbus
-        if not has_x11_support():
-            return False
-
-        for display_name in cls._candidate_displays():
-            if not display_name.startswith(":"):
-                continue
-
-            suffix = display_name.split(":", 1)[1].split(".", 1)[0]
-            if not suffix.isdigit():
-                continue
-
-            socket_path = f"/tmp/.X11-unix/X{suffix}"
-            try:
-                connect_coro = asyncio.open_unix_connection(path=socket_path)
-                _reader, writer = await asyncio.wait_for(connect_coro, timeout=0.2)
-                writer.close()
-                await writer.wait_closed()
-                return True
-            except Exception:
-                continue
-
-        return False
+        return await asyncio.to_thread(cls.pick_display_name) is not None
 
     async def start(self) -> None:
         if not has_x11_support():

--- a/keymasq/session/manager/commands.py
+++ b/keymasq/session/manager/commands.py
@@ -6,7 +6,11 @@ from keymasq.common.ipc import Command, CommandType
 from keymasq.common.models import normalize_macro_loop_stop_behavior
 from keymasq.common.security import PeerCredentials, SecurityPolicy, command_allowed
 from keymasq.common.settings import GlobalSettings
-from keymasq.common.virtual_devices import MAX_VIRTUAL_GAMEPADS, MIN_VIRTUAL_GAMEPADS
+from keymasq.common.virtual_devices import (
+    MAX_VIRTUAL_GAMEPADS,
+    MIN_VIRTUAL_GAMEPADS,
+    clamp_virtual_gamepad_count,
+)
 from keymasq.session.settings import save_global_settings, save_virtual_gamepad_count
 
 from . import combo_inspector as runtime_combo_inspector
@@ -78,7 +82,7 @@ async def handle_session_request(
     if result is not None:
         return result
 
-    result = await _handle_capture_commands(manager, command, request)
+    result = await _handle_capture_commands(manager, command, request, writer)
     if result is not None:
         return result
 
@@ -210,9 +214,9 @@ async def _handle_virtual_gamepad_commands(
     if command != "set_virtual_gamepads":
         return None
 
-    requested_count = int_value(request.get("count"), manager.virtual_gamepad_count)
-    count = save_virtual_gamepad_count(requested_count)
-    manager.virtual_gamepad_count = count
+    count = clamp_virtual_gamepad_count(
+        int_value(request.get("count"), manager.virtual_gamepad_count)
+    )
     if manager.connected:
         response = await manager.client.send_command(
             Command(command=CommandType.SET_VIRTUAL_GAMEPADS, data={"count": count})
@@ -222,7 +226,8 @@ async def _handle_virtual_gamepad_commands(
         if isinstance(response.data, dict):
             data = cast(JsonObject, response.data)
             count = int_value(data.get("count"), count)
-            manager.virtual_gamepad_count = count
+    count = save_virtual_gamepad_count(count)
+    manager.virtual_gamepad_count = count
     manager.broadcast_to_session_clients(
         {"event": "virtual_gamepads_changed", "count": int(manager.virtual_gamepad_count)}
     )
@@ -292,42 +297,33 @@ async def _handle_settings_commands(
     if command != "set_settings":
         return None
 
-    requested_count = int_value(request.get("virtual_gamepad_count"), manager.virtual_gamepad_count)
-    saved = save_global_settings(
-        GlobalSettings(
-            virtual_gamepad_count=requested_count,
-        )
+    count = clamp_virtual_gamepad_count(
+        int_value(request.get("virtual_gamepad_count"), manager.virtual_gamepad_count)
     )
-    manager.virtual_gamepad_count = saved.virtual_gamepad_count
-    gamepad_error = ""
 
     if manager.connected:
         response = await manager.client.send_command(
             Command(
                 command=CommandType.SET_VIRTUAL_GAMEPADS,
-                data={"count": int(manager.virtual_gamepad_count)},
+                data={"count": count},
             )
         )
         if response.status != "ok":
-            gamepad_error = response.error or "daemon rejected virtual gamepad count"
-        elif isinstance(response.data, dict):
+            payload = _settings_payload(manager)
+            payload["status"] = "error"
+            payload["message"] = response.error or "daemon rejected virtual gamepad count"
+            return payload
+        if isinstance(response.data, dict):
             data = cast(JsonObject, response.data)
-            manager.virtual_gamepad_count = int_value(
-                data.get("count"),
-                manager.virtual_gamepad_count,
-            )
-            saved = save_global_settings(
-                GlobalSettings(
-                    virtual_gamepad_count=manager.virtual_gamepad_count,
-                )
-            )
-            manager.virtual_gamepad_count = saved.virtual_gamepad_count
+            count = int_value(data.get("count"), count)
 
+    saved = save_global_settings(
+        GlobalSettings(
+            virtual_gamepad_count=count,
+        )
+    )
+    manager.virtual_gamepad_count = saved.virtual_gamepad_count
     payload = _settings_payload(manager)
-    if gamepad_error:
-        payload["status"] = "error"
-        payload["message"] = gamepad_error
-        return payload
     manager.broadcast_to_session_clients(
         {
             "event": "settings_changed",
@@ -803,6 +799,7 @@ async def _handle_capture_commands(
     manager: "SessionManager",
     command: str,
     request: JsonObject,
+    writer: asyncio.StreamWriter,
 ) -> JsonObject | None:
     if command == "list_devices_for_recording":
         device_types = ["keyboard", "gamepad", "mouse"]
@@ -844,6 +841,7 @@ async def _handle_capture_commands(
             evdev_paths,
             evdev_interfaces=evdev_interfaces,
             mode=mode,
+            owner_writer=writer if bool(request.get("end_on_disconnect", False)) else None,
         )
 
     if command == "capture_read":

--- a/keymasq/session/manager/core.py
+++ b/keymasq/session/manager/core.py
@@ -407,6 +407,8 @@ class SessionManager:
         finally:
             with contextlib.suppress(Exception):
                 await runtime_device_inspector.clear_device_inspectors_for_writer(self, writer)
+            with contextlib.suppress(Exception):
+                await runtime_recording.clear_captures_for_writer(self, writer)
             runtime_recording.clear_active_recording_owner_if_writer(self, writer)
             await runtime_recording.discard_pending_macro_save_if_writer(self, writer)
             await runtime_recording.clear_recording_refresh_owner_if_writer(self, peer, writer)

--- a/keymasq/session/manager/device_inspector.py
+++ b/keymasq/session/manager/device_inspector.py
@@ -118,18 +118,24 @@ async def stop_device_inspector(
     if not normalized:
         return {"status": "error", "message": "missing hardware_id"}
 
-    removed_last_owner = _drop_owner(manager, normalized, _writer_id(writer))
+    writer_id = _writer_id(writer)
+    owners = manager.device_inspector_state.owners_by_hardware_id.get(normalized)
+    previous_owners = set(owners) if owners else None
+    removed_last_owner = _drop_owner(manager, normalized, writer_id)
     if not removed_last_owner:
         snapshot = build_device_inspector_snapshot(manager, normalized)
         if snapshot.get("status") != "error":
             snapshot["status"] = "ok"
         return snapshot
 
-    return await _stop_device_inspector_unlocked(
+    result = await _stop_device_inspector_unlocked(
         manager,
         normalized,
         reason=f"device inspector stop {normalized}",
     )
+    if result.get("status") != "ok" and previous_owners is not None:
+        manager.device_inspector_state.owners_by_hardware_id[normalized] = previous_owners
+    return result
 
 
 async def enable_device_inspector_suppression(
@@ -244,17 +250,16 @@ async def _stop_device_inspector_unlocked(
     *,
     reason: str,
 ) -> JsonObject:
-    manager.device_inspector_state.owners_by_hardware_id.pop(hardware_id, None)
-    manager.device_inspector_state.active_hardware_ids.discard(hardware_id)
-    manager.device_inspector_state.suppressed_hardware_ids.discard(hardware_id)
-
     result = await _send_inspector_command(
         manager,
         CommandType.DEVICE_INSPECTOR_STOP,
         {"hardware_id": hardware_id},
     )
-    await runtime_profiles.reevaluate_profiles(manager, reason=reason)
     if result.get("status") == "ok":
+        manager.device_inspector_state.owners_by_hardware_id.pop(hardware_id, None)
+        manager.device_inspector_state.active_hardware_ids.discard(hardware_id)
+        manager.device_inspector_state.suppressed_hardware_ids.discard(hardware_id)
+        await runtime_profiles.reevaluate_profiles(manager, reason=reason)
         update_status_from_daemon_event(manager, result)
         return {
             "status": "ok",

--- a/keymasq/session/manager/payloads.py
+++ b/keymasq/session/manager/payloads.py
@@ -127,6 +127,7 @@ def resolved_combos_signature(
                 "profile_name": combo.profile_name,
                 "steps": steps,
                 "action": action_data,
+                "match_across_devices": bool(combo.match_across_devices),
                 **({"recall_trigger_keys": True} if combo.recall_trigger_keys else {}),
                 **(
                     {"restore_trigger_keys": list(combo.restore_trigger_keys)}
@@ -445,6 +446,7 @@ def resolved_combo_payload(
         "profile_name": combo.profile_name,
         "steps": steps,
         "action": action_data,
+        "match_across_devices": bool(combo.match_across_devices),
         **({"recall_trigger_keys": True} if combo.recall_trigger_keys else {}),
         **(
             {"restore_trigger_keys": list(combo.restore_trigger_keys)}

--- a/keymasq/session/manager/recording.py
+++ b/keymasq/session/manager/recording.py
@@ -595,7 +595,18 @@ async def capture_begin_for_paths(
     *,
     evdev_interfaces: list[JsonObject] | None = None,
     mode: str = "button",
+    owner_writer: asyncio.StreamWriter | None = None,
 ) -> JsonObject:
+    if (
+        hardware_id in manager.capture_state.tokens
+        or hardware_id in manager.capture_state.locks
+    ):
+        return {
+            "status": "error",
+            "error_code": "capture_already_active",
+            "message": f"capture already active for {hardware_id}",
+        }
+
     explicit_evdev_paths = bool(evdev_paths)
     if not explicit_evdev_paths:
         evdev_paths = _hardware_evdev_paths(manager, hardware_id)
@@ -640,6 +651,8 @@ async def capture_begin_for_paths(
         return {"status": "error", "message": "Missing capture token"}
 
     manager.capture_state.tokens[hardware_id] = token
+    if owner_writer is not None:
+        manager.capture_state.owner_writer_ids[hardware_id] = id(owner_writer)
     response = {
         "status": "ok",
         "hardware_id": hardware_id,
@@ -680,9 +693,31 @@ async def capture_end(manager: "SessionManager", hardware_id: str) -> JsonObject
     return await _end_capture(manager, hardware_id)
 
 
+async def clear_captures_for_writer(
+    manager: "SessionManager",
+    writer: asyncio.StreamWriter,
+) -> None:
+    writer_id = id(writer)
+    hardware_ids = [
+        hardware_id
+        for hardware_id, owner_writer_id in manager.capture_state.owner_writer_ids.items()
+        if owner_writer_id == writer_id
+    ]
+    for hardware_id in hardware_ids:
+        try:
+            await capture_end(manager, hardware_id)
+        except Exception as exc:
+            log.warning(
+                "Failed to end capture for disconnected owner hardware_id=%s: %s",
+                hardware_id,
+                exc,
+            )
+
+
 async def _end_capture(manager: "SessionManager", hardware_id: str) -> JsonObject:
     was_locked = hardware_id in manager.capture_state.locks
     manager.capture_state.locks.discard(hardware_id)
+    manager.capture_state.owner_writer_ids.pop(hardware_id, None)
 
     previous_profile_names = manager.capture_state.resume_profiles.pop(hardware_id, [])
     if not was_locked:

--- a/keymasq/session/manager/state.py
+++ b/keymasq/session/manager/state.py
@@ -26,6 +26,7 @@ class CaptureRuntimeState:
     locks: set[str] = field(default_factory=set)
     resume_profiles: dict[str, list[str]] = field(default_factory=dict)
     tokens: dict[str, str] = field(default_factory=dict)
+    owner_writer_ids: dict[str, int] = field(default_factory=dict)
 
 
 @dataclass

--- a/keymasq/session/profiles.py
+++ b/keymasq/session/profiles.py
@@ -399,7 +399,8 @@ class ProfileManager:
         if action_type == ActionType.MACRO:
             return MappingAction(
                 action_type=ActionType.MACRO,
-                macro_name=str(action_data.get("target", "")),
+                macro_name=str(action_data.get("target", "") or "")
+                or str(action_data.get("macro_name", "") or ""),
                 macro_replay_mouse_movement=bool(action_data.get("replay_mouse_movement", True)),
                 macro_replay_mouse_clicks=bool(action_data.get("replay_mouse_clicks", True)),
                 macro_speed=_float_value(action_data.get("speed"), 1.0),
@@ -528,6 +529,7 @@ class ProfileManager:
                 action_data["analog_control_names"] = action.analog_control_names
         if action.action_type == ActionType.MACRO:
             action_data["target"] = action.macro_name or ""
+            action_data["macro_name"] = action.macro_name or ""
             action_data["replay_mouse_movement"] = action.macro_replay_mouse_movement
             action_data["replay_mouse_clicks"] = action.macro_replay_mouse_clicks
             action_data["speed"] = action.macro_speed

--- a/keymasq/session/wayland_protocols/cosmic_toplevel_info_client.py
+++ b/keymasq/session/wayland_protocols/cosmic_toplevel_info_client.py
@@ -88,22 +88,27 @@ class CosmicToplevelInfoWaylandClient:
         self._loop = asyncio.get_running_loop()
         self._socket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
         self._socket.setblocking(False)
-        await self._loop.sock_connect(self._socket, self._socket_path)
+        try:
+            await self._loop.sock_connect(self._socket, self._socket_path)
 
-        self._registry_id = self._allocate_object_id("wl_registry")
-        await self._send_request(WL_DISPLAY_OBJECT_ID, 1, _pack_uint(self._registry_id))
+            self._registry_id = self._allocate_object_id("wl_registry")
+            await self._send_request(WL_DISPLAY_OBJECT_ID, 1, _pack_uint(self._registry_id))
 
-        sync_id = await self._request_sync()
-        await self._pump_until_sync(sync_id)
+            sync_id = await self._request_sync()
+            await self._pump_until_sync(sync_id)
 
-        if self._list_id is None:
-            raise RuntimeError("ext_foreign_toplevel_list_v1 is unavailable on this compositor")
-        if self._cosmic_info_id is None:
-            raise RuntimeError("zcosmic_toplevel_info_v1 is unavailable on this compositor")
+            if self._list_id is None:
+                raise RuntimeError("ext_foreign_toplevel_list_v1 is unavailable on this compositor")
+            if self._cosmic_info_id is None:
+                raise RuntimeError("zcosmic_toplevel_info_v1 is unavailable on this compositor")
 
-        post_bind_sync = await self._request_sync()
-        await self._pump_until_sync(post_bind_sync)
-        self._tracker.mark_done()
+            post_bind_sync = await self._request_sync()
+            await self._pump_until_sync(post_bind_sync)
+            self._tracker.mark_done()
+        except Exception:
+            self._socket.close()
+            self._socket = None
+            raise
 
     async def run(self) -> None:
         if self._socket is None or self._loop is None:
@@ -124,12 +129,7 @@ class CosmicToplevelInfoWaylandClient:
 
         if self._cosmic_info_id is not None:
             for cosmic_id in list(self._cosmic_handles):
-                try:
-                    await self._send_request(cosmic_id, 0, b"")
-                except Exception:
-                    pass
-                self._objects.pop(cosmic_id, None)
-            self._cosmic_handles.clear()
+                await self._destroy_cosmic_handle(cosmic_id)
             self._ext_to_cosmic.clear()
             self._cosmic_to_ext.clear()
             self._objects.pop(self._cosmic_info_id, None)
@@ -137,16 +137,7 @@ class CosmicToplevelInfoWaylandClient:
 
         if self._list_id is not None:
             for handle_id in list(self._toplevel_handles):
-                try:
-                    await self._send_request(handle_id, 0, b"")
-                except Exception:
-                    pass
-                self._objects.pop(handle_id, None)
-                self._toplevel_handles.discard(handle_id)
-            try:
-                await self._send_request(self._list_id, 0, b"")
-            except Exception:
-                pass
+                await self._destroy_toplevel_handle(handle_id)
             try:
                 await self._send_request(self._list_id, 1, b"")
             except Exception:
@@ -231,7 +222,7 @@ class CosmicToplevelInfoWaylandClient:
             self._handle_cosmic_info_event(opcode)
             return
         if interface == "ext_foreign_toplevel_handle_v1":
-            self._handle_toplevel_event(object_id, opcode, payload)
+            await self._handle_toplevel_event(object_id, opcode, payload)
             return
         if interface == "zcosmic_toplevel_handle_v1":
             self._handle_cosmic_toplevel_event(object_id, opcode, payload)
@@ -315,17 +306,34 @@ class CosmicToplevelInfoWaylandClient:
         if opcode == 2:
             self._tracker.mark_done()
 
-    def _handle_toplevel_event(self, object_id: int, opcode: int, payload: bytes) -> None:
+    async def _destroy_cosmic_handle(self, object_id: int) -> None:
+        try:
+            await self._send_request(object_id, 0, b"")
+        except Exception:
+            pass
+        self._objects.pop(object_id, None)
+        self._cosmic_handles.discard(object_id)
+        ext_id = self._cosmic_to_ext.pop(object_id, None)
+        if ext_id is not None and self._ext_to_cosmic.get(ext_id) == object_id:
+            self._ext_to_cosmic.pop(ext_id, None)
+
+    async def _destroy_toplevel_handle(self, object_id: int) -> None:
+        cosmic_id = self._ext_to_cosmic.get(object_id)
+        if cosmic_id is not None:
+            await self._destroy_cosmic_handle(cosmic_id)
+        try:
+            await self._send_request(object_id, 0, b"")
+        except Exception:
+            pass
+        self._objects.pop(object_id, None)
+        self._toplevel_handles.discard(object_id)
+
+    async def _handle_toplevel_event(self, object_id: int, opcode: int, payload: bytes) -> None:
         handle_id = str(object_id)
 
         if opcode == 0:
             self._tracker.close_toplevel(handle_id)
-            self._toplevel_handles.discard(object_id)
-            cosmic_id = self._ext_to_cosmic.pop(object_id, None)
-            if cosmic_id is not None:
-                self._cosmic_to_ext.pop(cosmic_id, None)
-                self._cosmic_handles.discard(cosmic_id)
-                self._objects.pop(cosmic_id, None)
+            await self._destroy_toplevel_handle(object_id)
             return
 
         if opcode == 2:

--- a/keymasq/session/wayland_protocols/ext_foreign_toplevel_list_client.py
+++ b/keymasq/session/wayland_protocols/ext_foreign_toplevel_list_client.py
@@ -74,22 +74,27 @@ class ExtForeignToplevelListWaylandClient:
         self._loop = asyncio.get_running_loop()
         self._socket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
         self._socket.setblocking(False)
-        await self._loop.sock_connect(self._socket, self._socket_path)
+        try:
+            await self._loop.sock_connect(self._socket, self._socket_path)
 
-        self._registry_id = self._allocate_object_id("wl_registry")
-        await self._send_request(WL_DISPLAY_OBJECT_ID, 1, _pack_uint(self._registry_id))
+            self._registry_id = self._allocate_object_id("wl_registry")
+            await self._send_request(WL_DISPLAY_OBJECT_ID, 1, _pack_uint(self._registry_id))
 
-        sync_id = await self._request_sync()
-        await self._pump_until_sync(sync_id)
+            sync_id = await self._request_sync()
+            await self._pump_until_sync(sync_id)
 
-        if self._list_id is None:
-            raise RuntimeError(
-                "ext_foreign_toplevel_list_v1 is unavailable on this compositor"
-            )
+            if self._list_id is None:
+                raise RuntimeError(
+                    "ext_foreign_toplevel_list_v1 is unavailable on this compositor"
+                )
 
-        post_bind_sync = await self._request_sync()
-        await self._pump_until_sync(post_bind_sync)
-        self._tracker.mark_done()
+            post_bind_sync = await self._request_sync()
+            await self._pump_until_sync(post_bind_sync)
+            self._tracker.mark_done()
+        except Exception:
+            self._socket.close()
+            self._socket = None
+            raise
 
     async def run(self) -> None:
         if self._socket is None or self._loop is None:
@@ -109,17 +114,8 @@ class ExtForeignToplevelListWaylandClient:
             return
 
         if self._list_id is not None:
-            try:
-                await self._send_request(self._list_id, 0, b"")
-            except Exception:
-                pass
             for handle_id in list(self._toplevel_handles):
-                try:
-                    await self._send_request(handle_id, 0, b"")
-                except Exception:
-                    pass
-                self._objects.pop(handle_id, None)
-                self._toplevel_handles.discard(handle_id)
+                await self._destroy_toplevel_handle(handle_id)
             try:
                 await self._send_request(self._list_id, 1, b"")
             except Exception:
@@ -206,7 +202,7 @@ class ExtForeignToplevelListWaylandClient:
             self._handle_list_event(object_id, opcode, payload)
             return
         if interface == "ext_foreign_toplevel_handle_v1":
-            self._handle_toplevel_event(object_id, opcode, payload)
+            await self._handle_toplevel_event(object_id, opcode, payload)
 
     def _handle_display_event(self, opcode: int, payload: bytes) -> None:
         if opcode != 1:
@@ -260,12 +256,20 @@ class ExtForeignToplevelListWaylandClient:
         if opcode == 1:
             self._running = False
 
-    def _handle_toplevel_event(self, object_id: int, opcode: int, payload: bytes) -> None:
+    async def _destroy_toplevel_handle(self, object_id: int) -> None:
+        try:
+            await self._send_request(object_id, 0, b"")
+        except Exception:
+            pass
+        self._objects.pop(object_id, None)
+        self._toplevel_handles.discard(object_id)
+
+    async def _handle_toplevel_event(self, object_id: int, opcode: int, payload: bytes) -> None:
         handle_id = str(object_id)
 
         if opcode == 0:
             self._tracker.close_toplevel(handle_id)
-            self._toplevel_handles.discard(object_id)
+            await self._destroy_toplevel_handle(object_id)
             return
 
         if opcode == 1:

--- a/keymasq/session/wayland_protocols/wlr_foreign_toplevel_client.py
+++ b/keymasq/session/wayland_protocols/wlr_foreign_toplevel_client.py
@@ -70,6 +70,7 @@ class WlrForeignToplevelWaylandClient:
         self._registry_id: int | None = None
         self._manager_id: int | None = None
         self._sync_waiters: set[int] = set()
+        self._toplevel_handles: set[int] = set()
 
     async def start(self) -> None:
         if self._socket_path is None:
@@ -82,25 +83,30 @@ class WlrForeignToplevelWaylandClient:
         self._loop = asyncio.get_running_loop()
         self._socket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
         self._socket.setblocking(False)
-        await self._loop.sock_connect(self._socket, self._socket_path)
+        try:
+            await self._loop.sock_connect(self._socket, self._socket_path)
 
-        self._registry_id = self._allocate_object_id("wl_registry")
-        await self._send_request(
-            WL_DISPLAY_OBJECT_ID,
-            1,
-            _pack_uint(self._registry_id),
-        )
-
-        sync_id = await self._request_sync()
-        await self._pump_until_sync(sync_id)
-
-        if self._manager_id is None:
-            raise RuntimeError(
-                "zwlr_foreign_toplevel_manager_v1 is unavailable on this compositor"
+            self._registry_id = self._allocate_object_id("wl_registry")
+            await self._send_request(
+                WL_DISPLAY_OBJECT_ID,
+                1,
+                _pack_uint(self._registry_id),
             )
 
-        post_bind_sync = await self._request_sync()
-        await self._pump_until_sync(post_bind_sync)
+            sync_id = await self._request_sync()
+            await self._pump_until_sync(sync_id)
+
+            if self._manager_id is None:
+                raise RuntimeError(
+                    "zwlr_foreign_toplevel_manager_v1 is unavailable on this compositor"
+                )
+
+            post_bind_sync = await self._request_sync()
+            await self._pump_until_sync(post_bind_sync)
+        except Exception:
+            self._socket.close()
+            self._socket = None
+            raise
 
     async def run(self) -> None:
         if self._socket is None or self._loop is None:
@@ -118,10 +124,14 @@ class WlrForeignToplevelWaylandClient:
         self._running = False
         if self._socket is not None:
             if self._manager_id is not None:
+                for handle_id in list(self._toplevel_handles):
+                    await self._destroy_toplevel_handle(handle_id)
                 try:
                     await self._send_request(self._manager_id, 0, b"")
                 except Exception:
                     pass
+                self._objects.pop(self._manager_id, None)
+                self._manager_id = None
             self._socket.close()
             self._socket = None
 
@@ -201,13 +211,14 @@ class WlrForeignToplevelWaylandClient:
             self._handle_manager_event(object_id, opcode, payload)
             return
         if interface == "zwlr_foreign_toplevel_handle_v1":
-            self._handle_toplevel_event(object_id, opcode, payload)
+            await self._handle_toplevel_event(object_id, opcode, payload)
 
     def _handle_display_event(self, opcode: int, payload: bytes) -> None:
         if opcode != 1:
             return
         (deleted_object_id,) = struct.unpack_from("<I", payload, 0)
         self._objects.pop(deleted_object_id, None)
+        self._toplevel_handles.discard(deleted_object_id)
 
     async def _handle_registry_event(self, object_id: int, opcode: int, payload: bytes) -> None:
         if object_id != self._registry_id:
@@ -248,9 +259,18 @@ class WlrForeignToplevelWaylandClient:
 
         (handle_object_id,) = struct.unpack_from("<I", payload, 0)
         self._objects[handle_object_id] = _WaylandObject("zwlr_foreign_toplevel_handle_v1")
+        self._toplevel_handles.add(handle_object_id)
         self._tracker.add_toplevel(str(handle_object_id))
 
-    def _handle_toplevel_event(self, object_id: int, opcode: int, payload: bytes) -> None:
+    async def _destroy_toplevel_handle(self, object_id: int) -> None:
+        try:
+            await self._send_request(object_id, 7, b"")
+        except Exception:
+            pass
+        self._objects.pop(object_id, None)
+        self._toplevel_handles.discard(object_id)
+
+    async def _handle_toplevel_event(self, object_id: int, opcode: int, payload: bytes) -> None:
         handle_id = str(object_id)
         if opcode == 0:
             title, _ = _decode_string(payload, 0)
@@ -266,3 +286,4 @@ class WlrForeignToplevelWaylandClient:
             return
         if opcode == 6:
             self._tracker.close_toplevel(handle_id)
+            await self._destroy_toplevel_handle(object_id)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=61.0", "wheel"]
+requires = ["setuptools>=78.1.1", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -121,6 +121,7 @@ testpaths = ["tests"]
 python_files = ["test_*.py"]
 python_functions = ["test_*"]
 markers = [
+    "common: tests covering shared models and common helpers",
     "keymasqd: tests covering the keymasqd daemon and input runtime",
     "session: tests covering keymasq-session and compositor/session integration",
     "gui: tests covering the GTK GUI",

--- a/scripts/rewrite-build-metadata.py
+++ b/scripts/rewrite-build-metadata.py
@@ -7,6 +7,24 @@ import sys
 from dataclasses import dataclass
 from pathlib import Path
 
+PEP440_VERSION_RE = re.compile(
+    r"""
+    ^
+    (?:[1-9][0-9]*!)?
+    [0-9]+(?:\.[0-9]+)*
+    (?:(?:a|b|rc)[0-9]+)?
+    (?:\.post[0-9]+)?
+    (?:\.dev[0-9]+)?
+    (?:\+[a-z0-9]+(?:[._-][a-z0-9]+)*)?
+    $
+    """,
+    re.IGNORECASE | re.VERBOSE,
+)
+DEBIAN_VERSION_RE = re.compile(
+    r"^(?:[0-9]+:)?[0-9][A-Za-z0-9.+:~]*(?:-[A-Za-z0-9+.~]+)?$"
+)
+RPM_VERSION_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._+~^]*$")
+
 
 @dataclass(frozen=True)
 class RewriteRule:
@@ -18,6 +36,24 @@ class RewriteRule:
 
 def _repo_root() -> Path:
     return Path(__file__).resolve().parent.parent
+
+
+def _validate_version(value: str, pattern: re.Pattern[str], description: str) -> str:
+    if not pattern.fullmatch(value):
+        raise argparse.ArgumentTypeError(f"{description} has an invalid version format")
+    return value
+
+
+def _validate_python_version(value: str) -> str:
+    return _validate_version(value, PEP440_VERSION_RE, "python-version")
+
+
+def _validate_debian_version(value: str) -> str:
+    return _validate_version(value, DEBIAN_VERSION_RE, "debian-version")
+
+
+def _validate_rpm_version(value: str) -> str:
+    return _validate_version(value, RPM_VERSION_RE, "rpm-version")
 
 
 def _rewrite_file(rule: RewriteRule) -> bool:
@@ -82,10 +118,20 @@ def main() -> int:
     parser = argparse.ArgumentParser(
         description="Rewrite build metadata for CI-only package version overrides."
     )
-    parser.add_argument("--python-version", help="PEP 440 version for pyproject.toml")
-    parser.add_argument("--debian-version", help="Package version for debian/changelog")
     parser.add_argument(
-        "--rpm-version", help="Package version for packaging/rpm/metadata.env"
+        "--python-version",
+        type=_validate_python_version,
+        help="PEP 440 version for pyproject.toml",
+    )
+    parser.add_argument(
+        "--debian-version",
+        type=_validate_debian_version,
+        help="Package version for debian/changelog",
+    )
+    parser.add_argument(
+        "--rpm-version",
+        type=_validate_rpm_version,
+        help="Package version for packaging/rpm/metadata.env",
     )
     args = parser.parse_args()
 

--- a/tests/common/test_collection_markers.py
+++ b/tests/common/test_collection_markers.py
@@ -1,0 +1,16 @@
+from pathlib import Path
+
+from tests.conftest import _category_for_test_path
+
+
+def test_collection_category_covers_major_test_subtrees() -> None:
+    assert _category_for_test_path(Path("tests/common/test_macro_compile.py")) == "common"
+    assert _category_for_test_path(Path("tests/keymasqd/test_daemon.py")) == "keymasqd"
+    assert _category_for_test_path(Path("tests/session/test_session_clients.py")) == "session"
+    assert _category_for_test_path(Path("tests/gui/test_action_labels.py")) == "gui"
+
+
+def test_collection_category_uses_repo_tests_segment_for_absolute_paths() -> None:
+    path = Path("/tmp/tests/work/keymasq/tests/common/test_macro_compile.py")
+
+    assert _category_for_test_path(path) == "common"

--- a/tests/common/test_profile_manager.py
+++ b/tests/common/test_profile_manager.py
@@ -46,6 +46,42 @@ class TestProfileManager:
         assert 'activation_macro = "game_enter"' in content
         assert 'deactivation_macro = "game_leave"' in content
 
+    def test_profile_macro_action_accepts_macro_name_alias(self, temp_config_dir):
+        profile_path = Path(temp_config_dir) / "profiles" / "macro-alias.toml"
+        profile_path.write_text(
+            """
+[profile]
+name = "Macro Alias"
+enabled = true
+is_permanent = false
+priority = 0
+notify_on_activation = true
+created_at = "2026-05-29T12:00:00"
+
+[devices."1234:5678"]
+always_grab_all = false
+
+[devices."1234:5678".mapping.btn_side]
+action = "macro"
+macro_name = "Example"
+""",
+            encoding="utf-8",
+        )
+
+        manager = ProfileManager()
+        profile = manager.get_profile("Macro Alias")
+
+        assert profile is not None
+        action = profile.config.device_layers["1234:5678"].mappings["btn_side"]
+        assert action.action_type == ActionType.MACRO
+        assert action.macro_name == "Example"
+
+        manager.save_profile(profile.config)
+
+        content = profile.path.read_text(encoding="utf-8")
+        assert 'target = "Example"' in content
+        assert 'macro_name = "Example"' in content
+
     def test_multiple_profiles_global(self, temp_config_dir, sample_profile_config):
         manager = ProfileManager()
         manager.save_profile(sample_profile_config)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -245,19 +245,24 @@ _CATEGORY_BY_FILE = {
     "test_macro_editor_dialog.py": "gui",
 }
 
+_CATEGORY_SUBTREES = {"common", "keymasqd", "session", "gui"}
+
+
+def _category_for_test_path(item_path: Path) -> str | None:
+    parts = item_path.parts
+    for tests_index in range(len(parts) - 2, -1, -1):
+        if parts[tests_index] != "tests":
+            continue
+        subtree = parts[tests_index + 1]
+        if subtree in _CATEGORY_SUBTREES:
+            return subtree
+    return _CATEGORY_BY_FILE.get(item_path.name)
+
 
 def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:
     del config
     for item in items:
         item_path = Path(str(item.fspath))
-        category = None
-        if "tests" in item_path.parts:
-            tests_index = item_path.parts.index("tests")
-            if len(item_path.parts) > tests_index + 1:
-                subtree = item_path.parts[tests_index + 1]
-                if subtree in {"keymasqd", "session", "gui"}:
-                    category = subtree
-        if category is None:
-            category = _CATEGORY_BY_FILE.get(item_path.name)
+        category = _category_for_test_path(item_path)
         if category is not None:
             item.add_marker(getattr(pytest.mark, category))

--- a/tests/gui/macro_editor_dialog_support.py
+++ b/tests/gui/macro_editor_dialog_support.py
@@ -4,8 +4,9 @@
 
 # ruff: noqa: E402, I001
 
-import gi
 import sys
+
+from tests.gui.support import gi
 
 gi.require_version("Gtk", "4.0")
 gi.require_version("Adw", "1")

--- a/tests/gui/test_combo_editor_dialog.py
+++ b/tests/gui/test_combo_editor_dialog.py
@@ -369,6 +369,14 @@ class TestComboEditorDialog:
         assert dialog._draft.restore_trigger_keys == ["ctrl"]
         assert dialog.save_button.get_sensitive() is True
 
+        dialog._on_clear_clicked(None)
+
+        assert dialog.restore_trigger_keys_group.get_visible() is False
+        assert dialog._restore_trigger_key_rows == []
+        assert dialog._restore_trigger_key_labels == {}
+        assert dialog._restore_trigger_key_buttons == {}
+        assert dialog._draft.restore_trigger_keys == []
+
     def test_combo_editor_exact_duplicate_is_rejected(self):
         from gi.repository import Gtk
 

--- a/tests/gui/test_combo_inspector_window.py
+++ b/tests/gui/test_combo_inspector_window.py
@@ -209,6 +209,57 @@ def test_combo_inspector_window_ignores_stale_snapshot_responses(monkeypatch) ->
     window._finalize()
 
 
+def test_combo_inspector_window_ignores_snapshot_response_after_disconnect(monkeypatch) -> None:
+    from gi.repository import Gtk
+
+    from keymasq.gui.widgets import combo_inspector_window as inspector_module
+    from keymasq.gui.widgets.combo_inspector_window import ComboInspectorWindow
+
+    snapshot = {
+        "status": "ok",
+        "active_profiles": ["Base"],
+        "combos": [
+            {
+                "id": "combo-1",
+                "name": "Late Combo",
+                "profile_name": "Base",
+                "steps": [{"events": [{"evdev": "key_l"}]}],
+                "action": {"action": "keyboard", "target": "key_l"},
+            }
+        ],
+    }
+    event_callbacks: dict[str, list[Callable[[dict[str, object]], object]]] = {}
+    response_callbacks: list[Callable[[dict[str, object]], object]] = []
+
+    def fake_register(event, callback):
+        event_callbacks.setdefault(event, []).append(callback)
+
+    def fake_unregister(event, callback):
+        event_callbacks[event].remove(callback)
+
+    def fake_request_async(_payload, callback, timeout=5.0):
+        response_callbacks.append(callback)
+
+    monkeypatch.setattr(inspector_module, "register_session_event_callback", fake_register)
+    monkeypatch.setattr(inspector_module, "unregister_session_event_callback", fake_unregister)
+    monkeypatch.setattr(inspector_module, "session_request_async", fake_request_async)
+
+    window = ComboInspectorWindow(Gtk.Window())
+
+    assert len(response_callbacks) == 1
+
+    event_callbacks["keymasqd_status"][0]({"event": "keymasqd_status", "connected": False})
+    assert window._status_label.get_text() == "Active Combos - Daemon disconnected"
+
+    response_callbacks[0](snapshot)
+    assert window._status_label.get_text() == "Active Combos - Daemon disconnected"
+    assert window.active_profiles_label.get_text() == "None"
+    assert _combo_inspector_row_names(window) == []
+    assert window._snapshots == []
+
+    window._finalize()
+
+
 def test_combo_inspector_window_sorts_like_combo_tab(monkeypatch) -> None:
     from gi.repository import Gtk
 

--- a/tests/gui/test_device_tab_widget.py
+++ b/tests/gui/test_device_tab_widget.py
@@ -157,6 +157,65 @@ class TestDeviceTabWidget:
             f"Hardware ID: {hardware_id}\nInterfaces:\n{stable_path}"
         )
 
+    def test_header_caption_keeps_button_and_analog_counts_consistent(self):
+        from keymasq.common.models import (
+            AnalogAxisDefinition,
+            AnalogInputDefinition,
+            ButtonDefinition,
+            DeviceType,
+            EvdevDevice,
+            HardwareConfig,
+        )
+        from keymasq.gui.widgets.device_tab import DeviceTab
+
+        device = HardwareConfig(
+            vendor_id="1234",
+            product_id="5678",
+            name="Gamepad",
+            evdev_devices=[
+                EvdevDevice(
+                    path="/dev/input/event10",
+                    device_type=DeviceType.GAMEPAD,
+                    id="pad",
+                )
+            ],
+            buttons=[
+                ButtonDefinition(
+                    id="btn_south",
+                    label="A",
+                    evdev="btn_south",
+                    evdev_code=304,
+                    source="pad",
+                )
+            ],
+            analog_inputs=[
+                AnalogInputDefinition(
+                    id="left_stick",
+                    label="Left Stick",
+                    type="stick",
+                    source="pad",
+                    axes=[
+                        AnalogAxisDefinition(role="x", evdev="abs_x", evdev_code=0),
+                        AnalogAxisDefinition(role="y", evdev="abs_y", evdev_code=1),
+                    ],
+                ),
+                AnalogInputDefinition(
+                    id="left_trigger",
+                    label="Left Trigger",
+                    type="axis",
+                    source="pad",
+                    axes=[AnalogAxisDefinition(role="x", evdev="abs_z", evdev_code=2)],
+                ),
+            ],
+        )
+
+        tab = DeviceTab(device=device, profile_manager=None, demo_mode=True)
+
+        expected_caption = "1234:5678 | 1 evdev, 1 buttons, 2 analog inputs"
+        assert tab._header_caption_label.get_text() == expected_caption
+        tab._update_header_caption()
+        assert tab._header_caption_label.get_text() == expected_caption
+
     def test_keyboard_left_layout_does_not_request_seventh_column(self):
         from gi.repository import Gtk
 

--- a/tests/gui/test_gui_demo_and_dialogs.py
+++ b/tests/gui/test_gui_demo_and_dialogs.py
@@ -394,10 +394,23 @@ class TestRecordingOverlay:
         assert callbacks[0][0] == {"command": "stop_recording"}
         assert overlay._stop_btn.get_sensitive() is False
         assert overlay._stop_btn.get_label() == "Stopping..."
+        assert overlay._timer_id != 0
 
-        assert callbacks[0][1]({"status": "ok"}) is False
+        assert callbacks[0][1]({"status": "error", "message": "Daemon unavailable"}) is False
         assert overlay._stop_btn.get_sensitive() is True
         assert overlay._stop_btn.get_label() == "Stop Recording"
+        assert overlay._timer_id != 0
+        assert overlay._status_label is not None
+        assert overlay._status_label.get_visible() is True
+        assert overlay._status_label.get_label() == "Daemon unavailable"
+
+        overlay._on_stop_clicked(overlay._stop_btn)
+        assert overlay._status_label.get_visible() is False
+
+        assert callbacks[1][1]({"status": "ok"}) is False
+        assert overlay._stop_btn.get_sensitive() is True
+        assert overlay._stop_btn.get_label() == "Stop Recording"
+        assert overlay._timer_id == 0
 
         overlay.on_started({"event": "recording_started"})
         assert overlay._timer_id != 0
@@ -445,6 +458,68 @@ class TestSaveMacroDialog:
 
         assert captured["command"] == "save_recording"
         assert captured["pending_save_token"] == "pending-1"
+
+    def test_save_macro_dialog_failed_save_allows_retry(self, monkeypatch):
+        gi.require_version("Gtk", "4.0")
+        from gi.repository import GLib, Gtk
+
+        import keymasq.gui.widgets.save_macro_dialog as save_macro_dialog_module
+        from keymasq.gui.widgets.save_macro_dialog import SaveMacroDialog
+
+        monkeypatch.setattr(GLib, "idle_add", lambda callback, *args: 0)
+
+        def fake_session_request_with_hooks(payload, callback, on_start=None, on_done=None):
+            if on_start:
+                on_start()
+            callback({"status": "error", "message": "session unavailable"})
+            if on_done:
+                on_done()
+
+        monkeypatch.setattr(
+            save_macro_dialog_module,
+            "session_request_with_hooks",
+            fake_session_request_with_hooks,
+        )
+
+        dialog = SaveMacroDialog(
+            Gtk.Window(),
+            {
+                "duration_ms": 100,
+                "event_count": 2,
+                "device_types": ["keyboard"],
+            },
+        )
+        dialog._name_entry.set_text("macro_1")
+
+        dialog._on_save_clicked(dialog._save_btn)
+
+        assert dialog._saved is False
+        assert dialog._save_btn.get_sensitive() is True
+        assert dialog._error_label.get_label() == "session unavailable"
+        assert dialog.get_can_close() is True
+
+    def test_save_macro_dialog_keeps_user_name_when_macro_list_loads(self, monkeypatch):
+        gi.require_version("Gtk", "4.0")
+        from gi.repository import GLib, Gtk
+
+        from keymasq.gui.widgets.save_macro_dialog import SaveMacroDialog
+
+        monkeypatch.setattr(GLib, "idle_add", lambda callback, *args: 0)
+
+        dialog = SaveMacroDialog(
+            Gtk.Window(),
+            {
+                "duration_ms": 100,
+                "event_count": 2,
+                "device_types": ["keyboard"],
+            },
+        )
+        dialog._name_entry.set_text("custom_macro")
+
+        dialog._on_existing_macro_names_loaded({"macros": [{"name": "macro"}]})
+
+        assert dialog._name_entry.get_text() == "custom_macro"
+        assert dialog._save_btn.get_sensitive() is True
 
     def test_save_macro_dialog_discard_sends_pending_save_token(self, monkeypatch):
         gi.require_version("Gtk", "4.0")
@@ -1452,6 +1527,47 @@ class TestDialogConstruction:
 
         assert dialog._on_duplicate_finished(GuiTaskResult(value={"status": "ok"})) is False
         assert loaded == [True]
+
+    def test_macro_manager_delete_failure_shows_error(self, monkeypatch):
+        gi.require_version("Gtk", "4.0")
+        from gi.repository import GLib, Gtk
+
+        import keymasq.gui.widgets.macro_manager_dialog as macro_manager_dialog_module
+        from keymasq.gui.widgets.macro_manager_dialog import MacroManagerDialog
+
+        monkeypatch.setattr(GLib, "idle_add", lambda callback, *args: 0)
+        requests: list[dict] = []
+        alerts: list[tuple[object, object]] = []
+
+        def fake_session_request_with_hooks(payload, callback, **_kwargs):
+            requests.append(payload)
+            callback({"status": "error", "message": "boom"})
+
+        monkeypatch.setattr(
+            macro_manager_dialog_module,
+            "session_request_with_hooks",
+            fake_session_request_with_hooks,
+        )
+        monkeypatch.setattr(
+            macro_manager_dialog_module.Adw.AlertDialog,
+            "present",
+            lambda alert, parent: alerts.append((alert, parent)),
+        )
+
+        parent = Gtk.Window()
+        dialog = MacroManagerDialog(parent)
+        loaded: list[bool] = []
+        monkeypatch.setattr(dialog, "_load_macros", lambda: loaded.append(True) or False)
+
+        dialog._on_delete_response(None, "delete", "stored")
+
+        assert requests == [{"command": "delete_macro", "name": "stored"}]
+        assert loaded == []
+        assert len(alerts) == 1
+        alert, alert_parent = alerts[0]
+        assert alert_parent is parent
+        assert alert.get_heading() == "Delete Macro"
+        assert alert.get_body() == "boom"
 
     def test_macro_manager_create_and_record_button_paths(self, monkeypatch):
         gi.require_version("Gtk", "4.0")

--- a/tests/gui/test_hardware_setup_dialog.py
+++ b/tests/gui/test_hardware_setup_dialog.py
@@ -1880,6 +1880,7 @@ def test_hardware_setup_capture_flow_records_buttons_and_saves(monkeypatch):
         {
             "command": "begin_capture",
             "hardware_id": "1234:5678",
+            "end_on_disconnect": True,
             "evdev_paths": ["/dev/input/by-id/test-mouse"],
             "evdev_interfaces": [
                     {

--- a/tests/gui/test_icon_assets.py
+++ b/tests/gui/test_icon_assets.py
@@ -1,5 +1,34 @@
+import re
 from importlib import resources
 from xml.etree import ElementTree
+
+import pytest
+
+_STYLE_RULE_PATTERN = re.compile(r"\{([^{}]*)\}")
+
+
+def _style_declarations(style: str) -> dict[str, str]:
+    declarations = {}
+    for rule in _STYLE_RULE_PATTERN.findall(style) or [style]:
+        for declaration in rule.split(";"):
+            name, separator, value = declaration.partition(":")
+            if separator:
+                declarations[name.strip().lower()] = value.strip().lower()
+    return declarations
+
+
+def _assert_symbolic_icon_uses_filled_paths(
+    root: ElementTree.Element,
+    icon_name: str,
+) -> None:
+    for element in root.iter():
+        style = _style_declarations(element.get("style", ""))
+        if element.tag.rsplit("}", 1)[-1] == "style" and element.text:
+            style.update(_style_declarations(element.text))
+        assert element.get("stroke") is None, icon_name
+        assert "stroke" not in style, icon_name
+        assert element.get("fill") != "none", icon_name
+        assert style.get("fill") != "none", icon_name
 
 
 def test_custom_symbolic_icons_use_filled_paths() -> None:
@@ -11,6 +40,19 @@ def test_custom_symbolic_icons_use_filled_paths() -> None:
         "keymasq-mouse-symbolic.svg",
     ):
         root = ElementTree.parse(assets.joinpath(icon_name)).getroot()
-        for element in root.iter():
-            assert element.get("stroke") is None, icon_name
-            assert element.get("fill") != "none", icon_name
+        _assert_symbolic_icon_uses_filled_paths(root, icon_name)
+
+
+@pytest.mark.parametrize(
+    "svg",
+    (
+        '<svg><path d="M0 0h1v1z" style="fill:none; stroke: #000" /></svg>',
+        '<svg><style>.outline { fill: none; stroke: #000; }</style>'
+        '<path class="outline" d="M0 0h1v1z" /></svg>',
+    ),
+)
+def test_symbolic_icon_styles_reject_stroked_empty_paths(svg: str) -> None:
+    root = ElementTree.fromstring(svg)
+
+    with pytest.raises(AssertionError):
+        _assert_symbolic_icon_uses_filled_paths(root, "inline-style.svg")

--- a/tests/gui/test_icon_assets.py
+++ b/tests/gui/test_icon_assets.py
@@ -4,27 +4,98 @@ from xml.etree import ElementTree
 
 import pytest
 
-_STYLE_RULE_PATTERN = re.compile(r"\{([^{}]*)\}")
+_STYLE_RULE_PATTERN = re.compile(r"([^{}]+)\{([^{}]*)\}")
+_SIMPLE_SELECTOR_PATTERN = re.compile(
+    r"^(?P<tag>[a-zA-Z][\w-]*)?(?P<id>#[\w-]+)?(?P<classes>(?:\.[\w-]+)*)$"
+)
 
 
 def _style_declarations(style: str) -> dict[str, str]:
     declarations = {}
-    for rule in _STYLE_RULE_PATTERN.findall(style) or [style]:
-        for declaration in rule.split(";"):
-            name, separator, value = declaration.partition(":")
-            if separator:
-                declarations[name.strip().lower()] = value.strip().lower()
+    for declaration in style.split(";"):
+        name, separator, value = declaration.partition(":")
+        if separator:
+            declarations[name.strip().lower()] = value.strip().lower()
     return declarations
+
+
+def _local_name(element: ElementTree.Element) -> str:
+    return element.tag.rsplit("}", 1)[-1]
+
+
+def _stylesheet_rules(
+    root: ElementTree.Element,
+) -> list[tuple[str, dict[str, str]]]:
+    rules = []
+    for element in root.iter():
+        if _local_name(element) != "style" or not element.text:
+            continue
+        for selectors, declarations in _STYLE_RULE_PATTERN.findall(element.text):
+            style = _style_declarations(declarations)
+            for selector in selectors.split(","):
+                selector = selector.strip()
+                if selector:
+                    rules.append((selector, style))
+    return rules
+
+
+def _simple_selector_matches(element: ElementTree.Element, selector: str) -> bool:
+    match = _SIMPLE_SELECTOR_PATTERN.match(selector)
+    assert match is not None, f"Unsupported selector: {selector}"
+
+    tag = match.group("tag")
+    if tag and tag.lower() != _local_name(element).lower():
+        return False
+
+    selector_id = match.group("id")
+    if selector_id and element.get("id") != selector_id[1:]:
+        return False
+
+    classes = {name for name in element.get("class", "").split() if name}
+    required_classes = {
+        class_name for class_name in match.group("classes").split(".") if class_name
+    }
+    return required_classes <= classes
+
+
+def _selector_matches(
+    element: ElementTree.Element,
+    selector: str,
+    ancestors: tuple[ElementTree.Element, ...] = (),
+) -> bool:
+    selector_parts = selector.split()
+    assert selector_parts, f"Unsupported selector: {selector}"
+    if not _simple_selector_matches(element, selector_parts[-1]):
+        return False
+
+    remaining_ancestors = list(ancestors)
+    for ancestor_selector in reversed(selector_parts[:-1]):
+        while remaining_ancestors:
+            ancestor = remaining_ancestors.pop(0)
+            if _simple_selector_matches(ancestor, ancestor_selector):
+                break
+        else:
+            return False
+    return True
 
 
 def _assert_symbolic_icon_uses_filled_paths(
     root: ElementTree.Element,
     icon_name: str,
 ) -> None:
+    rules = _stylesheet_rules(root)
+    parent_map = {child: parent for parent in root.iter() for child in parent}
     for element in root.iter():
-        style = _style_declarations(element.get("style", ""))
-        if element.tag.rsplit("}", 1)[-1] == "style" and element.text:
-            style.update(_style_declarations(element.text))
+        ancestors = []
+        parent = parent_map.get(element)
+        while parent is not None:
+            ancestors.append(parent)
+            parent = parent_map.get(parent)
+        style = {}
+        for selector, declarations in rules:
+            if _selector_matches(element, selector, tuple(ancestors)):
+                style.update(declarations)
+        style.update(_style_declarations(element.get("style", "")))
         assert element.get("stroke") is None, icon_name
         assert "stroke" not in style, icon_name
         assert element.get("fill") != "none", icon_name
@@ -49,10 +120,23 @@ def test_custom_symbolic_icons_use_filled_paths() -> None:
         '<svg><path d="M0 0h1v1z" style="fill:none; stroke: #000" /></svg>',
         '<svg><style>.outline { fill: none; stroke: #000; }</style>'
         '<path class="outline" d="M0 0h1v1z" /></svg>',
+        '<svg><style>.outline path { fill: none; stroke: #000; }</style>'
+        '<g class="outline"><path d="M0 0h1v1z" /></g></svg>',
     ),
 )
 def test_symbolic_icon_styles_reject_stroked_empty_paths(svg: str) -> None:
     root = ElementTree.fromstring(svg)
 
-    with pytest.raises(AssertionError):
+    with pytest.raises(AssertionError) as exc_info:
         _assert_symbolic_icon_uses_filled_paths(root, "inline-style.svg")
+    assert "inline-style.svg" in str(exc_info.value)
+    assert "Unsupported selector" not in str(exc_info.value)
+
+
+def test_symbolic_icon_styles_ignore_unused_rules() -> None:
+    root = ElementTree.fromstring(
+        '<svg><style>.outline { fill: none; stroke: #000; }</style>'
+        '<path d="M0 0h1v1z" /></svg>'
+    )
+
+    _assert_symbolic_icon_uses_filled_paths(root, "unused-rule.svg")

--- a/tests/gui/test_macro_editor_dialog_support.py
+++ b/tests/gui/test_macro_editor_dialog_support.py
@@ -1,12 +1,11 @@
+import re
 from pathlib import Path
 
 
 def test_macro_editor_support_uses_gui_import_guard() -> None:
-    source = Path(__file__).with_name("macro_editor_dialog_support.py").read_text(
-        encoding="utf-8"
-    )
+    source = Path(__file__).with_name("macro_editor_dialog_support.py").read_text(encoding="utf-8")
 
     guarded_import = "from tests.gui.support import gi"
     assert guarded_import in source
-    assert "import gi" not in source.splitlines()
+    assert not any(re.match(r"^\s*import\s+gi\b", line) for line in source.splitlines())
     assert source.index(guarded_import) < source.index('gi.require_version("Gtk", "4.0")')

--- a/tests/gui/test_macro_editor_dialog_support.py
+++ b/tests/gui/test_macro_editor_dialog_support.py
@@ -1,0 +1,12 @@
+from pathlib import Path
+
+
+def test_macro_editor_support_uses_gui_import_guard() -> None:
+    source = Path(__file__).with_name("macro_editor_dialog_support.py").read_text(
+        encoding="utf-8"
+    )
+
+    guarded_import = "from tests.gui.support import gi"
+    assert guarded_import in source
+    assert "import gi" not in source.splitlines()
+    assert source.index(guarded_import) < source.index('gi.require_version("Gtk", "4.0")')

--- a/tests/gui/test_macro_editor_parser.py
+++ b/tests/gui/test_macro_editor_parser.py
@@ -197,6 +197,59 @@ def test_parse_reconstruct_preserves_wait_controls() -> None:
     assert rebuilt == raw
 
 
+def test_parse_reconstruct_preserves_equal_timestamp_control_before_key_events() -> None:
+    raw = [
+        {
+            "device_type": "macro",
+            "type": 0,
+            "code": 0,
+            "value": 0,
+            "t_us": 1000,
+            "macro_action": "wait",
+            "duration_us": 75_000,
+        },
+        {
+            "device_type": "keyboard",
+            "type": evdev.ecodes.EV_KEY,
+            "code": evdev.ecodes.KEY_A,
+            "value": 1,
+            "t_us": 1000,
+        },
+        {
+            "device_type": "keyboard",
+            "type": evdev.ecodes.EV_KEY,
+            "code": evdev.ecodes.KEY_A,
+            "value": 0,
+            "t_us": 1000,
+        },
+    ]
+
+    editable, rel_events, passthrough, synthetic_moves, control_events = parse_events(raw)
+    rebuilt = reconstruct_events(editable, rel_events, passthrough, synthetic_moves, control_events)
+
+    assert rebuilt == raw
+
+
+def test_parse_reconstruct_preserves_unknown_macro_action_payload() -> None:
+    raw = [
+        {
+            "macro_action": "custom_action",
+            "t_us": 1000,
+            "foo": "bar",
+        }
+    ]
+
+    editable, rel_events, passthrough, synthetic_moves, control_events = parse_events(raw)
+    rebuilt = reconstruct_events(editable, rel_events, passthrough, synthetic_moves, control_events)
+
+    assert editable == []
+    assert rel_events == []
+    assert passthrough == raw
+    assert synthetic_moves == []
+    assert control_events == []
+    assert rebuilt == raw
+
+
 def test_parse_reconstruct_compositor_macro_action() -> None:
     raw = [
         {

--- a/tests/gui/test_main_window.py
+++ b/tests/gui/test_main_window.py
@@ -938,6 +938,36 @@ class TestMainWindow:
 
         assert presented == [True]
 
+    def test_main_window_macro_save_pending_event_creates_save_dialog(self, monkeypatch):
+        import keymasq.gui.widgets.save_macro_dialog as save_macro_dialog_module
+        from keymasq.gui.window import MainWindow
+
+        window = MainWindow(demo_mode=True)
+        created: list[dict] = []
+        presented: list[object] = []
+
+        class DummySaveMacroDialog:
+            def __init__(self, parent, event: dict) -> None:
+                self.parent = parent
+                self.event = event
+                created.append(event)
+
+            def connect(self, signal: str, callback) -> None:
+                self.signal = signal
+                self.callback = callback
+
+            def present(self, parent) -> None:
+                presented.append(parent)
+
+        monkeypatch.setattr(save_macro_dialog_module, "SaveMacroDialog", DummySaveMacroDialog)
+
+        event = {"event": "macro_save_pending", "pending_save_token": "pending-1"}
+        window._handle_session_event(event)
+
+        assert created == [event]
+        assert presented == [window]
+        assert window._save_macro_dialog is not None
+
     def test_main_window_recording_started_closes_tracked_dialogs(self):
         from keymasq.gui.window import MainWindow
 

--- a/tests/gui/test_settings_dialog.py
+++ b/tests/gui/test_settings_dialog.py
@@ -81,6 +81,29 @@ def test_settings_dialog_local_saves_only_without_session_response(
     assert saves[0].virtual_gamepad_count == 3
 
 
+def test_settings_dialog_save_tolerates_malformed_saved_count(
+    monkeypatch,
+    temp_config_dir,
+) -> None:
+    from keymasq.gui.widgets import settings_dialog as dialog_module
+    from keymasq.gui.widgets.settings_dialog import SettingsDialog
+
+    callbacks = []
+
+    def fake_session_request_async(payload, callback, timeout=5.0):
+        callbacks.append((payload, callback))
+
+    monkeypatch.setattr(dialog_module, "session_request_async", fake_session_request_async)
+
+    dialog = SettingsDialog()
+    dialog._set_gamepad_count(2)
+
+    callbacks[-1][1]({"status": "ok", "virtual_gamepad_count": "bad"})
+
+    assert dialog._gamepad_count == 2
+    assert dialog._count_label.get_text() == "2"
+
+
 def test_settings_dialog_loads_virtual_gamepad_count_from_session(
     monkeypatch,
     temp_config_dir,

--- a/tests/gui/test_threshold_range_bar.py
+++ b/tests/gui/test_threshold_range_bar.py
@@ -1,0 +1,31 @@
+# ruff: noqa: F403, F405, I001
+from tests.gui.support import *
+
+
+def test_threshold_range_bar_reclamps_ranges_when_domain_changes() -> None:
+    from keymasq.gui.widgets.threshold_range_bar import ThresholdRangeBar
+
+    bar = ThresholdRangeBar()
+    bar.set_ranges(-1.0, 1.0, -0.8, 0.8)
+
+    bar.set_domain(0.0, 1.0)
+
+    assert 0.0 <= bar._trigger_min <= 1.0
+    assert 0.0 <= bar._trigger_max <= 1.0
+    assert 0.0 <= bar._release_min <= 1.0
+    assert 0.0 <= bar._release_max <= 1.0
+
+
+def test_threshold_range_bar_ticks_use_nonstandard_domain() -> None:
+    from keymasq.gui.widgets.threshold_range_bar import ThresholdRangeBar, _threshold_ticks
+
+    bar = ThresholdRangeBar()
+    bar.set_domain(10.0, 20.0)
+
+    ticks = _threshold_ticks(bar._minimum, bar._maximum)
+    values = [value for value, _label in ticks]
+    positions = [bar._x_for_value(value, 12.0, 100.0) for value in values]
+
+    assert values == [10.0, 12.5, 15.0, 17.5, 20.0]
+    assert positions == pytest.approx([12.0, 37.0, 62.0, 87.0, 112.0])
+    assert len(set(positions)) == len(positions)

--- a/tests/keymasqd/test_combo_engine_overlap.py
+++ b/tests/keymasqd/test_combo_engine_overlap.py
@@ -214,13 +214,12 @@ def test_held_bindings_for_step_respects_source_specific_and_wildcard_matching()
     wildcard_match = engine._held_bindings_for_step(wildcard_step)
     assert wildcard_match == {held_aux}
 
+    engine = ComboEngine()
     engine.prime_held_bindings({held_kbd})
     assert engine._held_bindings_for_step(exact_step) == {held_kbd}
 
     wildcard_match = engine._held_bindings_for_step(wildcard_step)
-    assert wildcard_match is not None
-    assert len(wildcard_match) == 1
-    assert next(iter(wildcard_match)) in {held_aux, held_kbd}
+    assert wildcard_match == {held_kbd}
 
 
 def test_held_bindings_for_step_respects_hardware_wildcard_matching():

--- a/tests/keymasqd/test_daemon_capture_commands.py
+++ b/tests/keymasqd/test_daemon_capture_commands.py
@@ -98,6 +98,60 @@ async def test_macro_play_payload_loads_store_and_forwards_runtime_options(daemo
     )
 
 
+@pytest.mark.parametrize(
+    ("command_type", "data"),
+    [
+        (
+            CommandType.MACRO_PLAY_BY_NAME,
+            {
+                "name": "combo",
+                "loop_mode": "none",
+                "loop_count": 1,
+                "loop_stop_behavior": "finish_run",
+                "move_to_start": False,
+                "start_x": 9,
+                "start_y": 10,
+                "block_mouse_movement": False,
+            },
+        ),
+        (
+            CommandType.PLAY_MACRO,
+            {
+                "macro_name": "combo",
+                "loop_mode": "none",
+                "loop_count": 1,
+                "loop_stop_behavior": "finish_run",
+                "move_to_start": False,
+                "start_x": 9,
+                "start_y": 10,
+                "block_mouse_movement": False,
+            },
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_macro_play_request_runtime_options_override_stored_options(
+    daemon_testbed,
+    command_type,
+    data,
+):
+    daemon, device_manager, _recording_manager, macro_store, _capture_manager = daemon_testbed
+    macro_store.get_meta.return_value = MACRO_RUNTIME_META
+
+    result = await daemon._handle_command(command_type, data)
+
+    assert result == {"played": True}
+    call_kwargs = device_manager.play_macro.await_args.kwargs
+    assert call_kwargs["macro_name"] == "combo"
+    assert call_kwargs["loop_mode"] == "none"
+    assert call_kwargs["loop_count"] == 1
+    assert call_kwargs["loop_stop_behavior"] == "finish_run"
+    assert call_kwargs["move_to_start"] is False
+    assert call_kwargs["start_x"] == 9
+    assert call_kwargs["start_y"] == 10
+    assert call_kwargs["block_mouse_movement"] is False
+
+
 @pytest.mark.asyncio
 async def test_macro_save_recording_claims_snapshot_before_streaming(daemon_testbed):
     daemon, _device_manager, recording_manager, macro_store, _capture_manager = daemon_testbed
@@ -530,6 +584,19 @@ async def test_capture_combo_clamps_client_timeout_to_daemon_max(daemon_testbed,
         < deadline_offsets[0]
         <= daemon_capture_commands.MAX_CAPTURE_TIMEOUT_S
     )
+
+
+@pytest.mark.asyncio
+async def test_capture_combo_preserves_begin_failure_when_end_would_fail(daemon_testbed):
+    daemon, device_manager, _recording_manager, _macro_store, capture_manager = daemon_testbed
+    capture_manager.begin_combo.side_effect = RuntimeError("begin failed")
+    capture_manager.end.side_effect = RuntimeError("cleanup failed")
+
+    with pytest.raises(RuntimeError, match="begin failed"):
+        await daemon_capture_commands.capture_combo(daemon, {"1234:5678"}, 1.0)
+
+    device_manager.end_combo_capture.assert_called_once()
+    capture_manager.end.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/tests/keymasqd/test_device_manager_combo_matching.py
+++ b/tests/keymasqd/test_device_manager_combo_matching.py
@@ -95,6 +95,40 @@ class TestCombos:
         assert manager.active_combos[0].action.profile_name == "Gaming"
 
     @pytest.mark.asyncio
+    async def test_set_combos_parses_match_across_devices(self):
+        manager = DeviceManager()
+
+        await manager.set_combos(
+            [
+                {
+                    "id": "combo-any-device",
+                    "name": "Any Device",
+                    "profile_name": "Desktop",
+                    "match_across_devices": True,
+                    "steps": [
+                        {
+                            "events": [
+                                {
+                                    "hardware_id": "1234:5678",
+                                    "source": "kbd",
+                                    "evdev": "key_f13",
+                                }
+                            ]
+                        }
+                    ],
+                    "action": {"action": "suppress"},
+                }
+            ]
+        )
+
+        combo = manager.active_combos[0]
+        binding = combo.steps[0].bindings[0]
+        assert combo.match_across_devices is True
+        assert binding.hardware_id == ""
+        assert binding.source == ""
+        assert dm.combo_runtime_signature(combo)[-1] is True
+
+    @pytest.mark.asyncio
     async def test_set_combos_allows_omitted_hardware_id_as_wildcard(self):
         manager = DeviceManager()
 

--- a/tests/keymasqd/test_device_manager_core.py
+++ b/tests/keymasqd/test_device_manager_core.py
@@ -247,7 +247,12 @@ async def test_profile_activation_trigger_end_broadcasts_deactivate_requested() 
     assert events == [expected_deactivate]
 
 
-@pytest.mark.skipif(not os.access("/dev/uinput", os.W_OK), reason="No uinput access")
+requires_uinput = pytest.mark.skipif(
+    not os.access("/dev/uinput", os.W_OK),
+    reason="No uinput access",
+)
+
+
 class TestDeviceManager:
     @pytest.fixture
     def manager(self):
@@ -261,6 +266,7 @@ class TestDeviceManager:
         assert isinstance(result["devices"], list)
 
     @pytest.mark.asyncio
+    @requires_uinput
     async def test_grab_virtual_device(self, manager, virtual_mouse):
         device_path = virtual_mouse.device.path
 
@@ -396,6 +402,7 @@ class TestDeviceManager:
         assert deps.resolve_stable_path_fn is dm.resolve_stable_path
 
     @pytest.mark.asyncio
+    @requires_uinput
     async def test_grab_device_resolves_keymasq_path_and_uses_configured_interface_id(
         self,
         manager,
@@ -440,6 +447,7 @@ class TestDeviceManager:
         await manager.release_device(f"{info.vendor:04x}:{info.product:04x}")
 
     @pytest.mark.asyncio
+    @requires_uinput
     async def test_grab_device_updates_existing_interface_id(
         self,
         manager,
@@ -530,6 +538,7 @@ class TestDeviceManager:
             )
 
     @pytest.mark.asyncio
+    @requires_uinput
     async def test_release_device(self, manager, virtual_mouse):
         device_path = virtual_mouse.device.path
 
@@ -551,6 +560,7 @@ class TestDeviceManager:
         assert result["released"] is True
 
     @pytest.mark.asyncio
+    @requires_uinput
     async def test_set_mapping(self, manager, virtual_mouse):
         device_path = virtual_mouse.device.path
 
@@ -578,6 +588,7 @@ class TestDeviceManager:
             await manager.set_mapping("ffff:ffff", mapping)
 
     @pytest.mark.asyncio
+    @requires_uinput
     async def test_release_all_devices(self, manager, virtual_mouse, virtual_keyboard):
         mouse_path = virtual_mouse.device.path
         keyboard_path = virtual_keyboard.device.path
@@ -1038,6 +1049,56 @@ class TestListDevices:
             log=dm.log,
             deps=dm._topology_runtime_deps(),
         )
+
+    @pytest.mark.asyncio
+    async def test_start_topology_watcher_reconciles_initial_snapshot_with_existing_grabs(
+        self,
+    ) -> None:
+        stable_path = "/dev/input/by-id/stale-kbd"
+        manager = DeviceManager(topology_poll_s=1.0, topology_debounce_s=1.0)
+        manager.grabbed_devices["1234:5678"] = [
+            SimpleNamespace(
+                path="/dev/input/event5",
+                stable_path=stable_path,
+                resolved_event_path="/dev/input/event5",
+                interface_id="kbd",
+            )
+        ]
+        released: list[tuple[str, str]] = []
+
+        async def release_interface(
+            manager_arg: DeviceManager,
+            hardware_id: str,
+            path: str,
+        ) -> None:
+            released.append((hardware_id, path))
+            devices = manager_arg.grabbed_devices.get(hardware_id, [])
+            manager_arg.grabbed_devices[hardware_id] = [
+                device for device in devices if device.path != path
+            ]
+            if not manager_arg.grabbed_devices[hardware_id]:
+                del manager_arg.grabbed_devices[hardware_id]
+
+        deps = tdm.TopologyRuntimeDeps(
+            asyncio_mod=dm.ASYNCIO_RUNTIME,
+            clear_device_path_cache_fn=lambda: None,
+            device_paths_fn=lambda: [],
+            device_input_fn=lambda path: None,
+            detect_input_classes_fn=lambda device: [],
+            primary_input_class_fn=lambda device: None,
+            resolve_stable_path_fn=lambda path: path,
+            get_interface_id_fn=lambda stable_path: None,
+            release_interface_fn=release_interface,
+        )
+
+        await tdm.start_topology_watcher(manager, log=dm.log, deps=deps)
+        try:
+            assert released == [("1234:5678", "/dev/input/event5")]
+            assert manager.grabbed_devices == {}
+            assert manager.topology_state.live_snapshot == {}
+            assert manager.topology_state.reconciled_snapshot == {}
+        finally:
+            await tdm.stop_topology_watcher(manager, deps=deps)
 
     def test_topology_events_match_numbered_desired_hardware_id(self) -> None:
         manager = SimpleNamespace(_command_type=CommandType)

--- a/tests/keymasqd/test_device_manager_rapidfire.py
+++ b/tests/keymasqd/test_device_manager_rapidfire.py
@@ -1064,6 +1064,7 @@ class TestRapidfireRelease:
     @pytest.mark.asyncio
     async def test_release_interface_clears_scoped_combo_runtime_before_device_teardown(
         self,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         manager = DeviceManager()
         fake_device = SimpleNamespace(
@@ -1075,12 +1076,10 @@ class TestRapidfireRelease:
         manager.grabbed_devices = {"hw": [fake_device]}
         clear_combo_scope = AsyncMock()
         clear_combo_runtime = AsyncMock()
-        monkeypatch = pytest.MonkeyPatch()
         monkeypatch.setattr(cdm, "clear_combo_runtime_for_binding_scope", clear_combo_scope)
         monkeypatch.setattr(cdm, "clear_combo_runtime", clear_combo_runtime)
 
         await _runtime_release_interface_unlocked(manager, "hw", "/dev/input/event0")
-        monkeypatch.undo()
 
         clear_combo_scope.assert_awaited_once()
         clear_combo_runtime.assert_not_awaited()
@@ -1089,6 +1088,7 @@ class TestRapidfireRelease:
     @pytest.mark.asyncio
     async def test_release_interface_preserves_desired_state_for_missing_managed_device(
         self,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         manager = DeviceManager()
         fake_device = SimpleNamespace(
@@ -1105,11 +1105,9 @@ class TestRapidfireRelease:
             paths={"/dev/input/event0"},
             button_map={"btn_side": "btn_side"},
         )
-        monkeypatch = pytest.MonkeyPatch()
         monkeypatch.setattr(cdm, "clear_combo_runtime_for_binding_scope", AsyncMock())
 
         await _runtime_release_interface_unlocked(manager, "hw", "/dev/input/event0")
-        monkeypatch.undo()
 
         assert manager.grabbed_devices == {}
         assert manager.active_mappings["hw"] == {"btn_side": action}
@@ -1118,6 +1116,7 @@ class TestRapidfireRelease:
     @pytest.mark.asyncio
     async def test_release_device_clears_scoped_combo_runtime_before_releasing_hardware(
         self,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         manager = DeviceManager()
         fake_device = SimpleNamespace(release=AsyncMock())
@@ -1125,13 +1124,11 @@ class TestRapidfireRelease:
         clear_combo_scope = AsyncMock()
         clear_combo_runtime = AsyncMock()
         destroy_global_uinputs = Mock()
-        monkeypatch = pytest.MonkeyPatch()
         monkeypatch.setattr(cdm, "clear_combo_runtime_for_binding_scope", clear_combo_scope)
         monkeypatch.setattr(cdm, "clear_combo_runtime", clear_combo_runtime)
         monkeypatch.setattr(ldm.runtime_outputs, "destroy_global_uinputs", destroy_global_uinputs)
 
         result = await _runtime_release_device_unlocked(manager, "hw")
-        monkeypatch.undo()
 
         assert result == {"released": True, "hardware_id": "hw"}
         clear_combo_scope.assert_awaited_once()
@@ -1140,6 +1137,7 @@ class TestRapidfireRelease:
     @pytest.mark.asyncio
     async def test_clear_combo_runtime_for_binding_scope_stops_only_affected_actions(
         self,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         manager = DeviceManager()
         manager.combo_state.engine.drop_candidates_for_binding_scope = Mock(  # type: ignore[method-assign]
@@ -1147,12 +1145,10 @@ class TestRapidfireRelease:
         )
         stop_combo_action = AsyncMock()
         refresh_combo_timeout_watchdog = Mock()
-        monkeypatch = pytest.MonkeyPatch()
         monkeypatch.setattr(cdm, "stop_combo_action", stop_combo_action)
         monkeypatch.setattr(cdm, "refresh_combo_timeout_watchdog", refresh_combo_timeout_watchdog)
 
         await _runtime_clear_combo_scope(manager, "1234:5678", "mouse")
-        monkeypatch.undo()
 
         manager.combo_state.engine.drop_candidates_for_binding_scope.assert_called_once_with(
             "1234:5678",

--- a/tests/keymasqd/test_device_manager_runtime_recovery.py
+++ b/tests/keymasqd/test_device_manager_runtime_recovery.py
@@ -283,6 +283,72 @@ class TestDeviceManagerHelpers:
         assert manager.active_mappings == {}
         assert manager.grab_state.desired_paths == {}
         destroy_global_uinputs.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_grab_skipped_probe_closes_raw_device(self) -> None:
+        class _RawInputDevice:
+            def __init__(self) -> None:
+                self.close_count = 0
+
+            def capabilities(self) -> dict[int, list[int]]:
+                return {evdev.ecodes.EV_KEY: [evdev.ecodes.KEY_A]}
+
+            def close(self) -> None:
+                self.close_count += 1
+
+        raw_device = _RawInputDevice()
+        manager = DeviceManager()
+        manager._device_input = lambda _path: raw_device  # type: ignore[method-assign]
+
+        result = await manager.grab_device(
+            "1234:5678",
+            ["/dev/input/event0"],
+            {},
+        )
+
+        assert result["grabbed_count"] == 0
+        assert result["skipped_count"] == 1
+        assert raw_device.close_count == 1
+
+    @pytest.mark.asyncio
+    async def test_grab_failure_closes_raw_probe_device(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        class _RawInputDevice:
+            def __init__(self) -> None:
+                self.close_count = 0
+
+            def capabilities(self) -> dict[int, list[int]]:
+                return {evdev.ecodes.EV_KEY: [evdev.ecodes.KEY_A]}
+
+            def close(self) -> None:
+                self.close_count += 1
+
+        class _FailingManagedDevice:
+            def __init__(self, **kwargs) -> None:
+                self.path = kwargs["path"]
+
+            async def grab(self) -> None:
+                raise OSError(errno.EACCES, "denied")
+
+        raw_device = _RawInputDevice()
+        manager = DeviceManager()
+        manager._device_input = lambda _path: raw_device  # type: ignore[method-assign]
+        monkeypatch.setattr(manager, "_detect_device_types", lambda _device: ["keyboard"])
+        monkeypatch.setattr(dm, "GrabbedDevice", _FailingManagedDevice)
+        monkeypatch.setattr(ldm.runtime_outputs, "create_global_uinputs", Mock())
+        monkeypatch.setattr(ldm.runtime_outputs, "destroy_global_uinputs", Mock())
+
+        with pytest.raises(OSError):
+            await manager.grab_device(
+                "1234:5678",
+                ["/dev/input/event0"],
+                {"source": "key_a"},
+            )
+
+        assert raw_device.close_count == 1
+
     def test_parse_action_supports_string_and_compositor_dispatch(self) -> None:
         manager = DeviceManager()
 
@@ -516,11 +582,13 @@ class TestDeviceManagerHelpers:
         assert action.rapidfire_wait_ms == 20
         assert "Ignoring rapidfire for unsupported exec action in runtime payload" in caplog.text
     @pytest.mark.asyncio
-    async def test_set_combos_skips_malformed_entries_and_parses_timeout(self) -> None:
+    async def test_set_combos_skips_malformed_entries_and_parses_timeout(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
         manager = DeviceManager()
         clear_combo_runtime = AsyncMock()
         refresh_combo_timeout_watchdog = Mock()
-        monkeypatch = pytest.MonkeyPatch()
         monkeypatch.setattr(cdm, "clear_combo_runtime", clear_combo_runtime)
         monkeypatch.setattr(cdm, "refresh_combo_timeout_watchdog", refresh_combo_timeout_watchdog)
 
@@ -555,7 +623,6 @@ class TestDeviceManagerHelpers:
         assert manager.active_combos[0].steps[0].timeout_ms == 250
         clear_combo_runtime.assert_awaited_once()
         refresh_combo_timeout_watchdog.assert_called_once()
-        monkeypatch.undo()
     @pytest.mark.asyncio
     async def test_set_combos_parses_superkey_combo_action(self) -> None:
         manager = DeviceManager()
@@ -674,8 +741,27 @@ class TestDeviceManagerHelpers:
         assert manager.read_combo_capture("token") == {"event": None}
         assert manager.end_combo_capture("token") == {"status": "ok", "ended": True}
         assert manager.end_combo_capture("token") == {"status": "ok", "ended": False}
+
+    def test_combo_capture_queue_ignores_unmatched_hardware_filter(self) -> None:
+        manager = DeviceManager()
+        ready = asyncio.Event()
+        manager.begin_combo_capture("token", {"device-a"}, ready)
+
+        consumed = cdm.queue_combo_capture_event(
+            manager,
+            {"hardware_id": "device-b", "evdev": "key_a", "value": 1},
+            str_value_fn=lambda value, default: default if value is None else str(value),
+        )
+
+        assert consumed is False
+        assert ready.is_set() is False
+        assert manager.read_combo_capture("token") == {"event": None}
+
     @pytest.mark.asyncio
-    async def test_refresh_combo_timeout_watchdog_cancels_or_replaces_existing_task(self) -> None:
+    async def test_refresh_combo_timeout_watchdog_cancels_or_replaces_existing_task(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
         manager = DeviceManager()
         previous = asyncio.create_task(asyncio.sleep(60))
         manager.combo_state.timeout_task = previous
@@ -691,7 +777,6 @@ class TestDeviceManagerHelpers:
         manager.combo_state.timeout_task = replacement
         manager.combo_state.engine.next_deadline = Mock(return_value=42.0)  # type: ignore[method-assign]
         combo_timeout_watchdog = AsyncMock()
-        monkeypatch = pytest.MonkeyPatch()
         monkeypatch.setattr(cdm, "combo_timeout_watchdog", combo_timeout_watchdog)
 
         _runtime_refresh_combo_watchdog(manager)
@@ -702,7 +787,6 @@ class TestDeviceManagerHelpers:
         manager.combo_state.timeout_task.cancel()
         await asyncio.sleep(0)
         assert manager.combo_state.timeout_task.done() is True
-        monkeypatch.undo()
     @pytest.mark.asyncio
     async def test_combo_timeout_watchdog_expires_and_clears_current_task(
         self,

--- a/tests/keymasqd/test_macro_backend_loops.py
+++ b/tests/keymasqd/test_macro_backend_loops.py
@@ -201,6 +201,27 @@ async def test_cancel_macro_playback_interrupts_tight_toggle_loop() -> None:
 
 
 @pytest.mark.asyncio
+async def test_empty_toggle_macro_does_not_create_playback_task() -> None:
+    manager = DeviceManager()
+    manager.output_state.keyboard_uinput = MagicMock()
+
+    result = await manager.play_macro(
+        macro_events=[],
+        macro_name="empty_toggle",
+        loop_mode="toggle",
+        source_device="dev1",
+        source_button="btn_toggle",
+        trigger_value=1,
+    )
+    await asyncio.sleep(0)
+
+    assert result["status"] == "ok"
+    assert mdm.running_macro_instance_ids(manager) == []
+    assert manager.macro_state.tasks == {}
+    assert manager.macro_state.instance_meta == {}
+
+
+@pytest.mark.asyncio
 async def test_toggle_second_press_finishes_current_run_by_default() -> None:
     manager = DeviceManager()
     manager.output_state.keyboard_uinput = MagicMock()

--- a/tests/keymasqd/test_macro_backend_recording.py
+++ b/tests/keymasqd/test_macro_backend_recording.py
@@ -366,9 +366,10 @@ async def test_play_macro_allows_concurrent_playback() -> None:
     monkeypatch = pytest.MonkeyPatch()
     monkeypatch.setattr(mdm, "play_macro_task", fake_play_macro_task)
     try:
-        await manager.play_macro(macro_events=[], macro_name="first")
+        macro_events = [{"t_us": 0, "macro_action": "wait", "duration_us": 0}]
+        await manager.play_macro(macro_events=macro_events, macro_name="first")
         await asyncio.sleep(0)
-        await manager.play_macro(macro_events=[], macro_name="second")
+        await manager.play_macro(macro_events=macro_events, macro_name="second")
         await asyncio.sleep(0.1)
 
         assert "first" in started
@@ -617,7 +618,7 @@ async def test_hold_macro_block_mouse_movement_refreshes_suppression_until_relea
     monkeypatch.setattr(mdm, "end_mouse_rel_suppression", end_mouse_rel_suppression)
 
     await manager.play_macro(
-        macro_events=[],
+        macro_events=[{"t_us": 0, "macro_action": "wait", "duration_us": 10_000}],
         macro_name="hold_blocked",
         loop_mode="hold",
         block_mouse_movement=True,

--- a/tests/keymasqd/test_profile_activation_tracker.py
+++ b/tests/keymasqd/test_profile_activation_tracker.py
@@ -1,0 +1,51 @@
+import asyncio
+
+import pytest
+
+from keymasq.common.models import ProfileDeactivationPolicy
+from keymasq.keymasqd.runtime.profile_activation_tracker import ProfileActivationTracker
+
+
+@pytest.mark.asyncio
+async def test_track_same_activation_id_cancels_replaced_timeout_task() -> None:
+    broadcasts: list[dict[str, object]] = []
+    tracker = ProfileActivationTracker(
+        broadcast_deactivate_request=broadcasts.append,
+    )
+    policy = ProfileDeactivationPolicy(timeout_ms=60_000)
+
+    tracker.track(
+        profile_name="Nav",
+        activation_id="activation-1",
+        trigger_id="trigger-1",
+        deactivation=policy,
+    )
+    first_tracker = tracker._trackers["activation-1"]
+    first_task = first_tracker.timeout_task
+    assert first_task is not None
+
+    tracker.track(
+        profile_name="Nav",
+        activation_id="activation-1",
+        trigger_id="trigger-2",
+        deactivation=policy,
+    )
+    await asyncio.sleep(0)
+
+    latest_tracker = tracker._trackers["activation-1"]
+    assert latest_tracker is not first_tracker
+    assert first_task.cancelled()
+
+    tracker._expire(first_tracker, "timeout")
+    await asyncio.sleep(0)
+    assert broadcasts == []
+
+    tracker._expire(latest_tracker, "timeout")
+    await asyncio.sleep(0)
+    assert broadcasts == [
+        {
+            "profile_name": "Nav",
+            "activation_id": "activation-1",
+            "reason": "timeout",
+        }
+    ]

--- a/tests/keymasqd/test_timer_precision.py
+++ b/tests/keymasqd/test_timer_precision.py
@@ -45,7 +45,9 @@ def test_set_timer_slack_ns_clamps_non_positive() -> None:
     # must clamp non-positive requests to >=1ns so callers never accidentally
     # loosen the wakeup resolution.
     assert timer_precision.set_timer_slack_ns(0) is True
+    assert _get_timer_slack_ns() == 1
     assert timer_precision.set_timer_slack_ns(-5) is True
+    assert _get_timer_slack_ns() == 1
 
 
 def test_set_timer_slack_ns_is_idempotent() -> None:

--- a/tests/keymasqd/test_timer_precision.py
+++ b/tests/keymasqd/test_timer_precision.py
@@ -1,8 +1,35 @@
+import ctypes
 import logging
+from collections.abc import Iterator
 
 import pytest
 
 from keymasq.keymasqd import timer_precision
+
+_PR_GET_TIMERSLACK = 30
+
+
+def _get_timer_slack_ns() -> int:
+    libc = ctypes.CDLL("libc.so.6", use_errno=True)
+    libc.prctl.restype = ctypes.c_long
+    result = libc.prctl(
+        ctypes.c_int(_PR_GET_TIMERSLACK),
+        ctypes.c_ulong(0),
+        ctypes.c_ulong(0),
+        ctypes.c_ulong(0),
+        ctypes.c_ulong(0),
+    )
+    if result < 0:
+        err = ctypes.get_errno()
+        raise OSError(err, "prctl(PR_GET_TIMERSLACK) failed")
+    return int(result)
+
+
+@pytest.fixture(autouse=True)
+def restore_timer_slack() -> Iterator[None]:
+    original_slack_ns = _get_timer_slack_ns()
+    yield
+    assert timer_precision.set_timer_slack_ns(original_slack_ns) is True
 
 
 def test_set_timer_slack_ns_succeeds(caplog: pytest.LogCaptureFixture) -> None:

--- a/tests/session/test_session_manager_command_runtime.py
+++ b/tests/session/test_session_manager_command_runtime.py
@@ -4,6 +4,8 @@ import json
 from tests.session.command_support import *
 from keymasq.common import paths
 from keymasq.common.ipc import CommandType
+from keymasq.common.settings import GlobalSettings
+import keymasq.session.settings as session_settings
 import keymasq.session.manager.commands as session_commands_module
 import keymasq.session.manager.device_inspector as session_device_inspector_module
 
@@ -37,6 +39,7 @@ async def test_handle_session_request_set_settings_does_not_broadcast_on_daemon_
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(paths, "CONFIG_DIR", tmp_path / "keymasq")
+    session_settings.save_global_settings(GlobalSettings(virtual_gamepad_count=3))
     manager = SessionManager()
     manager.connected = True
     manager.client.send_command = AsyncMock(
@@ -54,6 +57,40 @@ async def test_handle_session_request_set_settings_does_not_broadcast_on_daemon_
 
     assert result["status"] == "error"
     assert result["message"] == "daemon rejected count"
+    assert result["virtual_gamepad_count"] == 3
+    assert manager.virtual_gamepad_count == 3
+    assert session_settings.load_global_settings().virtual_gamepad_count == 3
+    manager.broadcast_to_session_clients.assert_not_called()  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_handle_session_request_set_virtual_gamepads_keeps_state_on_daemon_error(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(paths, "CONFIG_DIR", tmp_path / "keymasq")
+    session_settings.save_global_settings(GlobalSettings(virtual_gamepad_count=3))
+    manager = SessionManager()
+    manager.connected = True
+    manager.client.send_command = AsyncMock(
+        return_value=Response(status="error", error="daemon rejected count")
+    )
+    manager.broadcast_to_session_clients = Mock()  # type: ignore[method-assign]
+    peer = PeerCredentials(pid=1, uid=1000, gid=1000)
+
+    result = await manager._handle_session_request(
+        {"command": "set_virtual_gamepads", "count": 2},
+        "client",
+        peer,
+        object(),
+    )
+
+    assert result == {"status": "error", "message": "daemon rejected count"}
+    sent = manager.client.send_command.await_args.args[0]
+    assert sent.command == CommandType.SET_VIRTUAL_GAMEPADS
+    assert sent.data == {"count": 2}
+    assert manager.virtual_gamepad_count == 3
+    assert session_settings.load_global_settings().virtual_gamepad_count == 3
     manager.broadcast_to_session_clients.assert_not_called()  # type: ignore[attr-defined]
 
 
@@ -838,6 +875,39 @@ async def test_stop_device_inspector_preserves_error_snapshot(
 
 
 @pytest.mark.asyncio
+async def test_stop_device_inspector_preserves_state_on_daemon_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = SessionManager()
+    hardware_id = "1234:5678"
+    writer = object()
+    writer_id = id(writer)
+    manager.device_inspector_state.owners_by_hardware_id[hardware_id] = {writer_id}
+    manager.device_inspector_state.active_hardware_ids.add(hardware_id)
+    manager.device_inspector_state.suppressed_hardware_ids.add(hardware_id)
+    manager.client.send_command = AsyncMock(
+        return_value=Response(status="error", error="daemon stop failed")
+    )
+    reevaluate_profiles = AsyncMock()
+    monkeypatch.setattr(session_profiles_module, "reevaluate_profiles", reevaluate_profiles)
+
+    result = await session_device_inspector_module.stop_device_inspector(
+        manager,
+        hardware_id,
+        writer,  # type: ignore[arg-type]
+    )
+
+    sent = manager.client.send_command.await_args.args[0]
+    assert sent.command == CommandType.DEVICE_INSPECTOR_STOP
+    assert sent.data == {"hardware_id": hardware_id}
+    assert result == {"status": "error", "message": "daemon stop failed"}
+    assert manager.device_inspector_state.owners_by_hardware_id[hardware_id] == {writer_id}
+    assert hardware_id in manager.device_inspector_state.active_hardware_ids
+    assert hardware_id in manager.device_inspector_state.suppressed_hardware_ids
+    reevaluate_profiles.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_clear_device_inspectors_for_writer_continues_after_stop_failure(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -1203,6 +1273,106 @@ async def test_capture_commands_with_owner_return_error_on_missing_hardware_id(
 
 
 @pytest.mark.asyncio
+async def test_begin_capture_rejects_duplicate_for_same_hardware() -> None:
+    manager = SessionManager()
+    hardware_id = "2dc8:3106"
+    manager.client.send_command = AsyncMock(
+        side_effect=[
+            Response(status="ok", data={"token": "token-1", "warnings": []}),
+            Response(status="ok", data={"token": "token-2", "warnings": []}),
+        ]
+    )
+    peer = PeerCredentials(pid=1, uid=1000, gid=1000)
+    writer = object()
+    manager.unlock_state.refresh_owner = {
+        "uid": peer.uid,
+        "pid": peer.pid,
+        "writer_id": id(writer),
+        "lease_id": "lease-test",
+    }
+
+    first = await manager._handle_session_request(
+        {"command": "begin_capture", "hardware_id": hardware_id},
+        "client",
+        peer,
+        writer,
+    )
+    second = await manager._handle_session_request(
+        {"command": "begin_capture", "hardware_id": hardware_id},
+        "client",
+        peer,
+        writer,
+    )
+
+    assert first["status"] == "ok"
+    assert first["token"] == "token-1"
+    assert second == {
+        "status": "error",
+        "error_code": "capture_already_active",
+        "message": f"capture already active for {hardware_id}",
+    }
+    assert manager.capture_state.tokens[hardware_id] == "token-1"
+    assert manager.client.send_command.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_clear_captures_for_writer_ends_owned_capture_on_disconnect(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = SessionManager()
+    hardware_id = "2dc8:3106"
+    manager.client.send_command = AsyncMock(
+        side_effect=[
+            Response(status="ok", data={"token": "token-1", "warnings": []}),
+            Response(status="ok"),
+        ]
+    )
+    reevaluate_profiles = AsyncMock()
+    monkeypatch.setattr(session_profiles_module, "reevaluate_profiles", reevaluate_profiles)
+    peer = PeerCredentials(pid=1, uid=1000, gid=1000)
+    writer = object()
+    manager.unlock_state.refresh_owner = {
+        "uid": peer.uid,
+        "pid": peer.pid,
+        "writer_id": id(writer),
+        "lease_id": "lease-test",
+    }
+
+    result = await manager._handle_session_request(
+        {
+            "command": "begin_capture",
+            "hardware_id": hardware_id,
+            "end_on_disconnect": True,
+        },
+        "client",
+        peer,
+        writer,
+    )
+
+    assert result["status"] == "ok"
+    assert manager.capture_state.tokens[hardware_id] == "token-1"
+    assert manager.capture_state.owner_writer_ids[hardware_id] == id(writer)
+    assert hardware_id in manager.capture_state.locks
+
+    await session_recording_module.clear_captures_for_writer(
+        manager,
+        writer,  # type: ignore[arg-type]
+    )
+
+    assert manager.capture_state.tokens == {}
+    assert manager.capture_state.locks == set()
+    assert manager.capture_state.resume_profiles == {}
+    assert manager.capture_state.owner_writer_ids == {}
+    end_command = manager.client.send_command.await_args_list[1].args[0]
+    assert end_command.command == CommandType.CAPTURE_END
+    assert end_command.data == {"token": "token-1"}
+    reevaluate_profiles.assert_awaited_once_with(
+        manager,
+        reason=f"capture ended for {hardware_id}",
+    )
+
+
+@pytest.mark.asyncio
 async def test_begin_capture_for_numbered_hardware_uses_configured_paths() -> None:
     manager = SessionManager()
     hardware_id = "1234:5678@2"
@@ -1236,6 +1406,48 @@ async def test_begin_capture_for_numbered_hardware_uses_configured_paths() -> No
         "evdev_paths": ["/dev/input/by-path/test-event-kbd"],
     }
 
+
+@pytest.mark.asyncio
+async def test_begin_capture_default_lifetime_survives_request_writer_disconnect(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = SessionManager()
+    hardware_id = "2dc8:3106"
+    manager.client.send_command = AsyncMock(
+        return_value=Response(status="ok", data={"token": "token-1", "warnings": []})
+    )
+    reevaluate_profiles = AsyncMock()
+    monkeypatch.setattr(session_profiles_module, "reevaluate_profiles", reevaluate_profiles)
+    peer = PeerCredentials(pid=1, uid=1000, gid=1000)
+    writer = cast(asyncio.StreamWriter, object())
+    manager.unlock_state.refresh_owner = {
+        "uid": peer.uid,
+        "pid": peer.pid,
+        "writer_id": id(writer),
+        "lease_id": "lease-test",
+    }
+
+    result = await manager._handle_session_request(
+        {"command": "begin_capture", "hardware_id": hardware_id},
+        "client",
+        peer,
+        writer,
+    )
+
+    assert result["status"] == "ok"
+    assert manager.capture_state.tokens[hardware_id] == "token-1"
+    assert manager.capture_state.owner_writer_ids == {}
+    assert hardware_id in manager.capture_state.locks
+
+    await session_recording_module.clear_captures_for_writer(
+        manager,
+        writer,
+    )
+
+    assert manager.capture_state.tokens[hardware_id] == "token-1"
+    assert hardware_id in manager.capture_state.locks
+    manager.client.send_command.assert_awaited_once()
+    reevaluate_profiles.assert_not_awaited()
 
 @pytest.mark.asyncio
 async def test_begin_capture_with_paths_uses_configured_interfaces_when_omitted() -> None:

--- a/tests/session/test_session_manager_payloads_extra.py
+++ b/tests/session/test_session_manager_payloads_extra.py
@@ -392,6 +392,7 @@ def test_combo_payloads_filter_invalid_actions_and_track_exec_refs() -> None:
             "dispatcher": "workspace",
             "args": "3",
         },
+        "match_across_devices": False,
         "recall_trigger_keys": True,
         "restore_trigger_keys": ["key_a"],
     }
@@ -413,6 +414,38 @@ def test_combo_payloads_filter_invalid_actions_and_track_exec_refs() -> None:
     assert manager.exec_state.combo_exec_refs == {1}
     assert manager.exec_state.exec_refs[1].cmd == "echo tap"
     assert manager.exec_state.exec_refs[1].owner == "combo"
+
+
+def test_combo_payload_and_signature_include_match_across_devices() -> None:
+    from keymasq.common.models import ActionType, ComboEvent, ComboStep, MappingAction
+    from keymasq.session.manager import payloads
+    from keymasq.session.profiles import ResolvedCombo
+
+    manager = _manager_with_superkeys()
+    base_combo = ResolvedCombo(
+        id="any-device",
+        name="Any Device",
+        steps=[ComboStep(events=[ComboEvent(evdev="key_f13")])],
+        action=MappingAction(action_type=ActionType.SUPPRESS),
+        match_across_devices=False,
+    )
+    any_device_combo = ResolvedCombo(
+        id="any-device",
+        name="Any Device",
+        steps=[ComboStep(events=[ComboEvent(evdev="key_f13")])],
+        action=MappingAction(action_type=ActionType.SUPPRESS),
+        match_across_devices=True,
+    )
+
+    base_signature = payloads.resolved_combos_signature(manager, [base_combo])
+    any_device_signature = payloads.resolved_combos_signature(manager, [any_device_combo])
+    combo_payload = payloads.resolved_combo_payload(manager, any_device_combo)
+
+    assert base_signature != any_device_signature
+    assert '"match_across_devices":false' in base_signature
+    assert '"match_across_devices":true' in any_device_signature
+    assert combo_payload is not None
+    assert combo_payload["match_across_devices"] is True
 
 
 def test_payload_signatures_and_log_view_are_stable() -> None:

--- a/tests/session/test_session_manager_recording_settings.py
+++ b/tests/session/test_session_manager_recording_settings.py
@@ -1,5 +1,6 @@
 # ruff: noqa: F403, F405, I001
 import logging
+import threading
 import tomllib
 from typing import cast
 
@@ -15,41 +16,72 @@ async def test_recording_settings_persistence_applies_latest_snapshot_last() -> 
     }
     persisted: dict[str, bool] = {}
     writes: list[dict[str, bool]] = []
+    writes_lock = threading.Lock()
+    stale_started = threading.Event()
+    stale_finished = threading.Event()
+    latest_finished = threading.Event()
+    release_stale = threading.Event()
 
     def fake_save(_manager, settings: dict | None = None) -> None:
         state = dict(settings or {})
         if state.get("include_mouse_movement", False):
-            time.sleep(0.05)
+            stale_started.set()
+            if not release_stale.wait(timeout=1.0):
+                return
+        with writes_lock:
+            persisted.clear()
+            persisted.update(state)
+            writes.append(state)
+        if state.get("include_mouse_movement", False):
+            stale_finished.set()
         else:
-            time.sleep(0.005)
-        persisted.clear()
-        persisted.update(state)
-        writes.append(state)
+            latest_finished.set()
+
+    async def wait_for_event(event: threading.Event, message: str) -> None:
+        if not await asyncio.to_thread(event.wait, 1.0):
+            pytest.fail(message)
 
     monkeypatch = pytest.MonkeyPatch()
     monkeypatch.setattr(session_recording_module, "save_recording_settings_to_disk", fake_save)
 
-    session_recording_module.update_recording_settings(manager, {"include_mouse_movement": True})
-    session_recording_module.update_recording_settings(
-        manager,
-        {"include_mouse_movement": False, "include_mouse_clicks": True},
-    )
+    try:
+        session_recording_module.update_recording_settings(
+            manager,
+            {"include_mouse_movement": True},
+        )
+        first_save_task = cast(
+            asyncio.Task[None] | None,
+            manager.recording_state.settings_save_task,
+        )
+        assert first_save_task is not None
+        await wait_for_event(stale_started, "stale settings save did not start")
 
-    for _ in range(100):
-        save_task = manager.recording_state.settings_save_task
-        if save_task is None or save_task.done():
-            break
-        await asyncio.sleep(0.01)
-    else:
-        pytest.fail("recording settings save task did not complete")
+        session_recording_module.update_recording_settings(
+            manager,
+            {"include_mouse_movement": False, "include_mouse_clicks": True},
+        )
 
-    assert writes
-    assert persisted == {
-        "include_mouse_movement": False,
-        "include_mouse_clicks": True,
-        "record_start_position": False,
-    }
-    monkeypatch.undo()
+        current_save_task = cast(
+            asyncio.Task[None] | None,
+            manager.recording_state.settings_save_task,
+        )
+        if current_save_task is not first_save_task:
+            await wait_for_event(latest_finished, "latest settings save did not finish")
+        release_stale.set()
+        await wait_for_event(stale_finished, "stale settings save did not finish")
+
+        if current_save_task is not None:
+            await asyncio.wait_for(current_save_task, timeout=1.0)
+        await wait_for_event(latest_finished, "latest settings save did not finish")
+
+        assert writes
+        assert persisted == {
+            "include_mouse_movement": False,
+            "include_mouse_clicks": True,
+            "record_start_position": False,
+        }
+    finally:
+        monkeypatch.undo()
 
 
 def test_recording_settings_save_load_toml_uses_recording_ids(tmp_path) -> None:

--- a/tests/session/test_virtual_devices.py
+++ b/tests/session/test_virtual_devices.py
@@ -63,3 +63,6 @@ def test_virtual_gamepad_output_ids_match_validator_contract() -> None:
     with pytest.raises(ValueError):
         virtual_gamepad_output_id(0)
     assert not is_virtual_gamepad_output_id("virtual-gamepad-0")
+    assert not is_virtual_gamepad_output_id("virtual-gamepad-01")
+    assert not is_virtual_gamepad_output_id("virtual-gamepad-+1")
+    assert not is_virtual_gamepad_output_id("virtual-gamepad-1 ")

--- a/tests/test_action_handler.py
+++ b/tests/test_action_handler.py
@@ -1,0 +1,64 @@
+import asyncio
+import contextlib
+import os
+import shlex
+import signal
+import sys
+from pathlib import Path
+
+import pytest
+
+from keymasq.session.action_handler import ActionHandler
+
+
+def _process_exists(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
+async def _read_pid(path: Path) -> int:
+    for _ in range(100):
+        if path.exists():
+            return int(path.read_text(encoding="utf-8"))
+        await asyncio.sleep(0.01)
+    raise AssertionError("child process pid was not written")
+
+
+async def _wait_process_gone(pid: int) -> bool:
+    for _ in range(100):
+        if not _process_exists(pid):
+            return True
+        await asyncio.sleep(0.01)
+    return False
+
+
+@pytest.mark.asyncio
+async def test_execute_command_timeout_kills_spawned_child(tmp_path: Path) -> None:
+    pid_path = tmp_path / "child.pid"
+    script = (
+        "import pathlib, subprocess\n"
+        f"pid_path = pathlib.Path({str(pid_path)!r})\n"
+        "process = subprocess.Popen(['sleep', '30'])\n"
+        "pid_path.write_text(str(process.pid), encoding='utf-8')\n"
+        "process.wait()\n"
+    )
+    cmd = f"{shlex.quote(sys.executable)} -c {shlex.quote(script)}"
+    task = asyncio.create_task(ActionHandler().execute_command(cmd, timeout_s=0.5))
+    child_pid = await _read_pid(pid_path)
+
+    try:
+        result = await asyncio.wait_for(task, timeout=3.0)
+
+        assert result == -1
+        assert await _wait_process_gone(child_pid)
+    finally:
+        with contextlib.suppress(ProcessLookupError):
+            os.kill(child_pid, signal.SIGKILL)
+        if not task.done():
+            task.cancel()
+            await asyncio.gather(task, return_exceptions=True)

--- a/tests/test_cli_commands_helpers.py
+++ b/tests/test_cli_commands_helpers.py
@@ -105,6 +105,35 @@ def test_list_macros_cli_json_prints_response(
     assert payload == {"status": "ok", "macros": [{"name": "combo"}]}
 
 
+def test_list_profiles_cli_prints_devices_without_profiles(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(
+        commands,
+        "_session_request",
+        lambda payload: {
+            "status": "ok",
+            "profiles": [],
+            "devices": [
+                {
+                    "hardware_id": "kbd",
+                    "device_name": "Keyboard",
+                    "active_profiles": [],
+                    "mapping_count": 0,
+                }
+            ],
+        },
+    )
+
+    commands.list_profiles_cli()
+
+    out = capsys.readouterr().out
+    assert "No profiles found" in out
+    assert "Devices:" in out
+    assert "kbd  Keyboard" in out
+    assert "active: passthrough" in out
+
+
 def test_create_macro_cli_sends_create_payload(monkeypatch: pytest.MonkeyPatch) -> None:
     sent: list[dict[str, object]] = []
 
@@ -378,3 +407,46 @@ def test_play_adhoc_cli_print_json_does_not_send(
     payload = json.loads(capsys.readouterr().out)
     assert payload["device_types"] == ["keyboard"]
     assert len(payload["events"]) == 2
+
+
+def test_play_adhoc_cli_json_print_preserves_playback_options(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr(commands, "_session_request", lambda payload: pytest.fail("sent request"))
+
+    commands.play_adhoc_cli(
+        [
+            json.dumps(
+                {
+                    "name": "demo",
+                    "device_types": ["mouse"],
+                    "events": [],
+                    "loop_mode": "count",
+                    "loop_count": 3,
+                    "loop_stop_behavior": "cancel",
+                    "move_to_start": True,
+                    "start_x": 10,
+                    "start_y": 20,
+                    "block_mouse_movement": True,
+                }
+            )
+        ],
+        input_json=True,
+        print_json=True,
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload == {
+        "block_mouse_movement": True,
+        "device_types": ["mouse"],
+        "duration_us": 0,
+        "events": [],
+        "loop_count": 3,
+        "loop_mode": "count",
+        "loop_stop_behavior": "cancel",
+        "move_to_start": True,
+        "name": "demo",
+        "start_x": 10,
+        "start_y": 20,
+    }

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -147,17 +147,22 @@ def test_config_path_for_detected_event_uses_keymasq_path_without_by_id(
 
 def test_find_all_interfaces_filters_matching_devices(monkeypatch: pytest.MonkeyPatch) -> None:
     device_paths = ["/dev/input/event1", "/dev/input/event2", "/dev/input/event3"]
+    closed_paths: list[str] = []
 
     class _FakeInputDevice:
         def __init__(self, path: str) -> None:
             if path == "/dev/input/event3":
                 raise OSError("unreadable")
+            self.path = path
             if path == "/dev/input/event1":
                 self.info = SimpleNamespace(vendor=0x1234, product=0x5678)
                 self.name = "Main Keyboard"
             else:
                 self.info = SimpleNamespace(vendor=0x9999, product=0x5678)
                 self.name = "Other Device"
+
+        def close(self) -> None:
+            closed_paths.append(self.path)
 
     monkeypatch.setattr("evdev.list_devices", lambda: device_paths)
     monkeypatch.setattr("evdev.InputDevice", _FakeInputDevice)
@@ -181,6 +186,38 @@ def test_find_all_interfaces_filters_matching_devices(monkeypatch: pytest.Monkey
             "phys": "",
         }
     ]
+    assert closed_paths == ["/dev/input/event1", "/dev/input/event2"]
+
+
+def test_find_all_interfaces_closes_devices_when_scan_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    device_paths = ["/dev/input/event1", "/dev/input/event2"]
+    closed_paths: list[str] = []
+
+    class _FakeInputDevice:
+        def __init__(self, path: str) -> None:
+            self.path = path
+            self.name = "Device"
+
+        @property
+        def info(self) -> SimpleNamespace:
+            if self.path == "/dev/input/event2":
+                raise OSError("metadata unavailable")
+            return SimpleNamespace(vendor=0x1234, product=0x5678)
+
+        def close(self) -> None:
+            closed_paths.append(self.path)
+
+    monkeypatch.setattr("evdev.list_devices", lambda: device_paths)
+    monkeypatch.setattr("evdev.InputDevice", _FakeInputDevice)
+    monkeypatch.setattr(
+        "keymasq.common.devices.resolve_stable_path",
+        lambda _path: (_ for _ in ()).throw(OSError("stable path unavailable")),
+    )
+
+    assert find_all_interfaces("1234", "5678") == []
+    assert closed_paths == ["/dev/input/event1", "/dev/input/event2"]
 
 
 def test_detect_input_classes_reports_combo_keyboard_mouse_pointstick() -> None:

--- a/tests/test_entrypoints_and_cli.py
+++ b/tests/test_entrypoints_and_cli.py
@@ -152,6 +152,19 @@ def test_session_script_entrypoint_calls_manager_main(monkeypatch: pytest.Monkey
     assert called == ["manager"]
 
 
+def test_session_entrypoint_delegates_help_to_manager(monkeypatch: pytest.MonkeyPatch) -> None:
+    called: list[str] = []
+    monkeypatch.setitem(
+        sys.modules,
+        "keymasq.session.manager",
+        _module_with_main(lambda: called.append("manager")),
+    )
+    monkeypatch.setattr(sys, "argv", ["keymasq-session", "--help"])
+
+    runpy.run_module("keymasq.session.__main__", run_name="__main__")
+    assert called == ["manager"]
+
+
 def test_cli_main_profiles_toggle_routes_to_helper(monkeypatch: pytest.MonkeyPatch) -> None:
     from keymasq.cli import __main__ as cli_main
 
@@ -251,6 +264,50 @@ def test_cli_main_play_routes_json_input_to_helper(monkeypatch: pytest.MonkeyPat
             "json_output": True,
         }
     ]
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        ["keymasq", "type", "--speed", "nan", "hello"],
+        ["keymasq", "type", "--speed", "inf", "hello"],
+        ["keymasq", "play", "--speed", "nan", "key_a"],
+        ["keymasq", "play", "--speed", "inf", "key_a"],
+        ["keymasq", "macros", "play", "--speed", "nan", "stored"],
+        ["keymasq", "macros", "play", "--speed", "inf", "stored"],
+    ],
+)
+def test_cli_main_rejects_non_finite_speed_options(
+    argv: list[str],
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    from keymasq.cli import __main__ as cli_main
+
+    monkeypatch.setattr(sys, "argv", argv)
+
+    with pytest.raises(SystemExit) as excinfo:
+        cli_main.main()
+
+    assert excinfo.value.code == 2
+    assert "must be a finite number greater than 0" in capsys.readouterr().err
+
+
+@pytest.mark.parametrize("interval", ["-1", "0", "nan", "inf"])
+def test_cli_main_rejects_invalid_diagnostics_interval(
+    interval: str,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    from keymasq.cli import __main__ as cli_main
+
+    monkeypatch.setattr(sys, "argv", ["keymasq", "diagnostics", "on", "--interval", interval])
+
+    with pytest.raises(SystemExit) as excinfo:
+        cli_main.main()
+
+    assert excinfo.value.code == 2
+    assert "must be a finite number greater than 0" in capsys.readouterr().err
 
 
 def test_cli_main_macros_create_routes_to_helper(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_grabbed_device.py
+++ b/tests/test_grabbed_device.py
@@ -212,6 +212,36 @@ class TestActionExecution:
         assert grabbed.uinput.syn.call_count == 2
 
 
+def test_release_all_keys_resets_abs_only_dynamic_gamepad_output():
+    pad2_uinput = MagicMock()
+    resolver = MagicMock(return_value=SimpleNamespace(uinput=pad2_uinput))
+
+    grabbed = GrabbedDevice(
+        path="/dev/input/event0",
+        hardware_id="test",
+        button_map={},
+        mapping_getter=lambda: {},
+        event_callback=lambda *args: None,
+        gamepad_output_resolver=resolver,
+    )
+    grabbed.state.held_output_abs["gamepad:pad2"] = {evdev.ecodes.ABS_X}
+
+    gdo.release_all_keys(
+        grabbed,
+        evdev_mod=evdev,
+        uinput_writer=lambda device: device,
+    )
+
+    resolver.assert_called_once_with("pad2", "release tracked gamepad:pad2")
+    pad2_uinput.write.assert_called_once_with(
+        evdev.ecodes.EV_ABS,
+        evdev.ecodes.ABS_X,
+        0,
+    )
+    pad2_uinput.syn.assert_called_once_with()
+    assert grabbed.state.held_output_abs["gamepad:pad2"] == set()
+
+
 class TestPassthrough:
     def test_relative_mouse_movement_is_suppressed_when_filter_active(self):
         passthrough = MagicMock()

--- a/tests/test_hyprland_listener.py
+++ b/tests/test_hyprland_listener.py
@@ -31,6 +31,24 @@ async def test_hyprland_dispatch_set_cursor_position_uses_special_dispatcher() -
     listener.set_cursor_position.assert_awaited_once_with(123, 456)
 
 
+@pytest.mark.asyncio
+async def test_hyprland_get_active_window_normalizes_tags() -> None:
+    listener = HyprlandListener(_noop_callback)
+    listener._send_cmd = AsyncMock(  # type: ignore[method-assign]
+        side_effect=[
+            b'{"class":"term","title":"Shell","tags":["one",2,true,null]}',
+            b'{"class":"term","title":"Shell","tags":"not-a-list"}',
+        ]
+    )
+
+    assert await listener.get_active_window() == (
+        "term",
+        "Shell",
+        ["one", "2", "True", "None"],
+    )
+    assert await listener.get_active_window() == ("term", "Shell", [])
+
+
 class _FakeWriter:
     def __init__(self) -> None:
         self.closed = False

--- a/tests/test_ipc.py
+++ b/tests/test_ipc.py
@@ -105,6 +105,14 @@ class TestProtocolEncoding:
         assert decoded is None
         assert remaining == b""
 
+    def test_decode_invalid_utf8_command_consumes_frame(self):
+        malformed = struct.pack(HEADER_FORMAT, 1) + b"\xff"
+
+        decoded, remaining = decode_command(malformed)
+
+        assert decoded is None
+        assert remaining == b""
+
     def test_error_response(self):
         resp = Response(
             status="error",
@@ -144,6 +152,14 @@ class TestProtocolEncoding:
         partial = struct.pack(HEADER_FORMAT, 9) + b"xxx"
 
         decoded, remaining = decode_response(partial)
+
+        assert decoded is None
+        assert remaining == b""
+
+    def test_decode_invalid_utf8_response_consumes_frame(self):
+        malformed = struct.pack(HEADER_FORMAT, 1) + b"\xff"
+
+        decoded, remaining = decode_response(malformed)
 
         assert decoded is None
         assert remaining == b""

--- a/tests/test_macro_file.py
+++ b/tests/test_macro_file.py
@@ -3,7 +3,9 @@ import stat
 from collections.abc import Iterator
 from pathlib import Path
 
-from keymasq.keymasqd.macro_file import MacroFileMeta, write_macro
+import pytest
+
+from keymasq.keymasqd.macro_file import MacroFileMeta, load_macro, write_macro
 
 
 def _open_fd_count() -> int:
@@ -45,3 +47,21 @@ def test_write_macro_closes_temp_file_descriptor(tmp_path: Path) -> None:
             [{"type": 1, "code": 30, "value": 1, "t_us": index}],
         )
         assert _open_fd_count() == baseline
+
+
+def test_write_macro_without_overwrite_preserves_existing_destination(tmp_path: Path) -> None:
+    path = tmp_path / "macro.kmacro.xz"
+    original_event = {"type": 1, "code": 30, "value": 1, "t_us": 0}
+    replacement_event = {"type": 1, "code": 31, "value": 1, "t_us": 100}
+
+    write_macro(path, MacroFileMeta(name="macro", event_count=1), [original_event])
+
+    with pytest.raises(FileExistsError):
+        write_macro(
+            path,
+            MacroFileMeta(name="macro", event_count=1),
+            [replacement_event],
+            overwrite=False,
+        )
+
+    assert load_macro(path)["events"] == [original_event]

--- a/tests/test_macro_store.py
+++ b/tests/test_macro_store.py
@@ -1,9 +1,13 @@
 import logging
+import lzma
+from collections.abc import Iterable
 from pathlib import Path
 
 import pytest
 
 from keymasq.common.models import DEFAULT_MACRO_LOOP_STOP_BEHAVIOR
+from keymasq.keymasqd import macro_store as macro_store_module
+from keymasq.keymasqd.macro_file import MacroFileMeta
 from keymasq.keymasqd.macro_store import MacroStore
 
 
@@ -47,6 +51,111 @@ def test_macro_store_revision_conflict(tmp_path: Path) -> None:
         store.update("macro_a", {"duration_us": 10_000}, expected_revision=7)
 
 
+def test_macro_store_rename_keeps_source_when_destination_validation_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = MacroStore(tmp_path / "macros")
+    store.create(
+        {
+            "name": "macro_a",
+            "events": [{"type": 1, "code": 30, "value": 1, "t_us": 0}],
+        }
+    )
+
+    def write_corrupt_destination(
+        path: Path,
+        _data: dict[str, object],
+        *,
+        overwrite: bool = True,
+    ) -> None:
+        _ = overwrite
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("not xz", encoding="utf-8")
+
+    monkeypatch.setattr(store, "_write_payload", write_corrupt_destination)
+
+    with pytest.raises(lzma.LZMAError):
+        store.rename("macro_a", "macro_b", expected_revision=1)
+
+    assert store.get("macro_a")["name"] == "macro_a"
+    assert not (tmp_path / "macros" / "macro_b.kmacro.xz").exists()
+
+
+def test_macro_store_create_preserves_destination_created_after_precheck(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = MacroStore(tmp_path / "macros")
+    original_write_macro = macro_store_module.write_macro
+    existing_event = {"type": 1, "code": 99, "value": 1, "t_us": 0}
+
+    def write_after_race(
+        path: Path,
+        meta: MacroFileMeta,
+        events: Iterable[dict[str, object]],
+        *,
+        overwrite: bool = True,
+    ) -> None:
+        if meta.name == "race" and not path.exists():
+            original_write_macro(
+                path,
+                MacroFileMeta(name="race", event_count=1),
+                [existing_event],
+            )
+        original_write_macro(path, meta, events, overwrite=overwrite)
+
+    monkeypatch.setattr(macro_store_module, "write_macro", write_after_race)
+
+    with pytest.raises(FileExistsError):
+        store.create(
+            {
+                "name": "race",
+                "events": [{"type": 1, "code": 30, "value": 1, "t_us": 0}],
+            }
+        )
+
+    assert store.get("race")["events"] == [existing_event]
+
+
+def test_macro_store_rename_preserves_destination_created_after_precheck(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = MacroStore(tmp_path / "macros")
+    store.create(
+        {
+            "name": "macro_a",
+            "events": [{"type": 1, "code": 30, "value": 1, "t_us": 0}],
+        }
+    )
+    original_write_macro = macro_store_module.write_macro
+    existing_event = {"type": 1, "code": 99, "value": 1, "t_us": 0}
+
+    def write_after_race(
+        path: Path,
+        meta: MacroFileMeta,
+        events: Iterable[dict[str, object]],
+        *,
+        overwrite: bool = True,
+    ) -> None:
+        if meta.name == "macro_b" and not path.exists():
+            original_write_macro(
+                path,
+                MacroFileMeta(name="macro_b", event_count=1),
+                [existing_event],
+            )
+        original_write_macro(path, meta, events, overwrite=overwrite)
+
+    monkeypatch.setattr(macro_store_module, "write_macro", write_after_race)
+
+    with pytest.raises(FileExistsError):
+        store.rename("macro_a", "macro_b", expected_revision=1)
+
+    assert store.get("macro_a")["name"] == "macro_a"
+    assert store.get("macro_b")["events"] == [existing_event]
+
+
 def test_macro_store_create_from_events_returns_metadata_without_loading_full_payload(
     tmp_path: Path,
 ) -> None:
@@ -71,6 +180,20 @@ def test_macro_store_create_from_events_returns_metadata_without_loading_full_pa
     assert created["event_count"] == 3
     assert "events" not in created
     assert [event["code"] for event in store.iter_events("streamed")] == [0, 1, 2]
+
+
+def test_macro_store_create_from_events_requires_streamed_metadata(tmp_path: Path) -> None:
+    store = MacroStore(tmp_path / "macros")
+    events = iter(
+        [
+            {"device_type": "keyboard", "type": 1, "code": 30, "value": 1, "t_us": 5000},
+        ]
+    )
+
+    with pytest.raises(ValueError, match="event_count, duration_us, device_types"):
+        store.create_from_events({"name": "streamed"}, events, return_full=False)
+
+    assert not (tmp_path / "macros" / "streamed.kmacro.xz").exists()
 
 
 def test_macro_store_preserves_wait_controls(tmp_path: Path) -> None:
@@ -109,6 +232,34 @@ def test_macro_store_preserves_wait_controls(tmp_path: Path) -> None:
     assert loaded["duration_us"] == 2000
     assert updated["events"] == events
     assert updated["duration_us"] == 2000
+
+
+def test_macro_store_recomputes_meta_when_replacing_explicit_events(tmp_path: Path) -> None:
+    store = MacroStore(tmp_path / "macros")
+    replacement_events = [
+        {"device_type": "mouse", "type": 2, "code": 0, "value": 5, "t_us": 5000},
+    ]
+
+    store.create(
+        {
+            "name": "timed",
+            "events": [
+                {"device_type": "keyboard", "type": 1, "code": 30, "value": 1, "t_us": 1000},
+            ],
+            "duration_us": 1000,
+            "device_types": ["keyboard"],
+        }
+    )
+    updated = store.update("timed", {"events": replacement_events}, expected_revision=1)
+    meta = store.get_meta("timed")
+    list_meta = store.list_meta()
+
+    assert updated["duration_us"] == 5000
+    assert updated["device_types"] == ["mouse"]
+    assert meta["duration_us"] == 5000
+    assert meta["device_types"] == ["mouse"]
+    assert list_meta[0]["duration_us"] == 5000
+    assert list_meta[0]["device_types"] == ["mouse"]
 
 
 def test_macro_store_internal_meta_uses_shared_loop_stop_default(tmp_path: Path) -> None:

--- a/tests/test_profile_handoff.py
+++ b/tests/test_profile_handoff.py
@@ -1,4 +1,5 @@
 import asyncio
+from collections.abc import Callable
 
 import evdev
 import pytest
@@ -27,6 +28,7 @@ class _DummyGrabbedDevice:
         self.cleaned = False
         self.released = False
         self.held = False
+        self.held_checks = 0
 
     def release_tracked_outputs(self) -> None:
         self.cleaned = True
@@ -35,7 +37,27 @@ class _DummyGrabbedDevice:
         self.released = True
 
     def has_held_source_inputs(self) -> bool:
+        self.held_checks += 1
         return self.held
+
+
+async def _wait_until(
+    predicate: Callable[[], bool],
+    *,
+    timeout_s: float = 1.0,
+    interval_s: float = 0.005,
+) -> None:
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout_s
+    while loop.time() < deadline:
+        if predicate():
+            return
+        await asyncio.sleep(interval_s)
+    assert predicate()
+
+
+def _has_key_event(keyboard: _FakeUInput, code: int, value: int) -> bool:
+    return (evdev.ecodes.EV_KEY, code, value) in keyboard.events
 
 
 async def _noop_event_callback(*_args, **_kwargs) -> None:
@@ -113,7 +135,9 @@ async def test_rapidfire_release_uses_original_action_after_switch() -> None:
     up = evdev.InputEvent(0, 0, evdev.ecodes.EV_KEY, evdev.ecodes.BTN_SIDE, 0)
 
     await _process_event(device, down)
-    await asyncio.sleep(0.04)
+    key_a = evdev.ecodes.KEY_A
+    await _wait_until(lambda: _has_key_event(keyboard, key_a, 1))
+    await _wait_until(lambda: _has_key_event(keyboard, key_a, 0))
 
     mapping_ref["value"] = {
         "btn_side": MappingAction(
@@ -125,9 +149,8 @@ async def test_rapidfire_release_uses_original_action_after_switch() -> None:
         ),
     }
     await _process_event(device, up)
-    await asyncio.sleep(0.04)
+    await _wait_until(lambda: device.state.rapidfire_tasks == {})
 
-    key_a = evdev.ecodes.KEY_A
     key_b = evdev.ecodes.KEY_B
     key_events = [e for e in keyboard.events if e[0] == evdev.ecodes.EV_KEY]
     assert any(code == key_a and value == 1 for _, code, value in key_events)
@@ -179,7 +202,9 @@ async def test_release_device_uses_grace_period_and_cleans_outputs() -> None:
     assert result["scheduled"] is True
     assert dummy.cleaned is False
 
-    await asyncio.sleep(0.08)
+    await _wait_until(
+        lambda: dummy.released is True and "1234:5678" not in manager.grabbed_devices
+    )
 
     assert dummy.released is True
     assert "1234:5678" not in manager.grabbed_devices
@@ -200,12 +225,14 @@ async def test_release_device_retries_when_source_button_is_held() -> None:
     result = await manager.release_device("1234:5678", immediate=False, grace_s=0.03)
     assert result["scheduled"] is True
 
-    await asyncio.sleep(0.04)
+    await _wait_until(lambda: dummy.held_checks >= 1)
     assert "1234:5678" in manager.grabbed_devices
     assert dummy.released is False
 
     dummy.held = False
-    await asyncio.sleep(0.05)
+    await _wait_until(
+        lambda: dummy.released is True and "1234:5678" not in manager.grabbed_devices
+    )
 
     assert dummy.released is True
     assert "1234:5678" not in manager.grabbed_devices

--- a/tests/test_record_cli.py
+++ b/tests/test_record_cli.py
@@ -112,10 +112,11 @@ def test_main_status_prints_json(
     assert payload["source"] == "runtime"
 
 
-def test_main_unlock_runtime_extends_previous_expiry(
+def test_main_unlock_runtime_replaces_previous_expiry(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
     runtime_path = tmp_path / "runtime-lease"
+    runtime_path.write_text("20\n", encoding="utf-8")
     writes: list[tuple[Path, int]] = []
 
     monkeypatch.setattr(
@@ -126,7 +127,6 @@ def test_main_unlock_runtime_extends_previous_expiry(
     monkeypatch.setattr(record, "_require_privileged_caller", lambda: None)
     monkeypatch.setattr(record, "runtime_unlock_path", lambda uid: runtime_path)
     monkeypatch.setattr(record.time, "time", lambda: 10)
-    monkeypatch.setattr(record, "parse_unlock_expires_at", lambda _: 20)
 
     def _write(path: Path, expires_at: int) -> None:
         writes.append((path, expires_at))
@@ -135,9 +135,79 @@ def test_main_unlock_runtime_extends_previous_expiry(
 
     record.main()
 
-    assert writes == [(runtime_path, 21)]
+    assert writes == [(runtime_path, 15)]
     payload = json.loads(capsys.readouterr().out.strip())
-    assert payload["expires_at"] == 21
+    assert payload["expires_at"] == 15
+
+
+def test_main_unlock_runtime_extends_with_requested_ttl(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    runtime_path = tmp_path / "runtime-lease"
+    runtime_path.write_text("12\n", encoding="utf-8")
+    writes: list[tuple[Path, int]] = []
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["keymasq-record", "unlock-runtime", "--uid", "1000", "--ttl", "20"],
+    )
+    monkeypatch.setattr(record, "_require_privileged_caller", lambda: None)
+    monkeypatch.setattr(record, "runtime_unlock_path", lambda uid: runtime_path)
+    monkeypatch.setattr(record.time, "time", lambda: 10)
+
+    def _write(path: Path, expires_at: int) -> None:
+        writes.append((path, expires_at))
+
+    monkeypatch.setattr(record, "_write_lease", _write)
+
+    record.main()
+
+    assert writes == [(runtime_path, 30)]
+    payload = json.loads(capsys.readouterr().out.strip())
+    assert payload["expires_at"] == 30
+
+
+def test_main_unlock_runtime_ttl_zero_writes_non_expiring_lease(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    runtime_path = tmp_path / "runtime-lease"
+    writes: list[tuple[Path, int]] = []
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["keymasq-record", "unlock-runtime", "--uid", "1000", "--ttl", "0"],
+    )
+    monkeypatch.setattr(record, "_require_privileged_caller", lambda: None)
+    monkeypatch.setattr(record, "runtime_unlock_path", lambda uid: runtime_path)
+
+    def _write(path: Path, expires_at: int) -> None:
+        writes.append((path, expires_at))
+
+    monkeypatch.setattr(record, "_write_lease", _write)
+
+    record.main()
+
+    assert writes == [(runtime_path, 0)]
+    payload = json.loads(capsys.readouterr().out.strip())
+    assert payload["expires_at"] == 0
+
+
+def test_main_lock_runtime_removes_runtime_lease(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    runtime_path = tmp_path / "runtime-lease"
+    runtime_path.write_text("20\n", encoding="utf-8")
+    monkeypatch.setattr(sys, "argv", ["keymasq-record", "lock-runtime", "--uid", "1000"])
+    monkeypatch.setattr(record, "_require_privileged_caller", lambda: None)
+    monkeypatch.setattr(record, "runtime_unlock_path", lambda uid: runtime_path)
+
+    record.main()
+
+    assert runtime_path.exists() is False
+    payload = json.loads(capsys.readouterr().out.strip())
+    assert payload == {"status": "ok", "scope": "runtime", "locked": True}
 
 
 def test_main_rejects_persistent_unlock_command(

--- a/tests/test_recording_extended.py
+++ b/tests/test_recording_extended.py
@@ -213,6 +213,17 @@ async def test_recording_spool_spills_past_memory_event_limit(tmp_path: Path) ->
 
 
 @pytest.mark.asyncio
+async def test_recording_spool_duration_uses_latest_event_time(tmp_path: Path) -> None:
+    spool = RecordingSpool(tmp_path)
+    spool.append({"device_type": "keyboard", "t_us": 1_000_000})
+    spool.append({"device_type": "keyboard", "t_us": 1_000})
+
+    snapshot = await spool.finish()
+
+    assert snapshot.duration_ms == 1000
+
+
+@pytest.mark.asyncio
 async def test_pending_recording_claim_prevents_concurrent_discard(tmp_path: Path) -> None:
     recorder = RecordingManager(spool_dir=tmp_path)
     path = tmp_path / "recording-test.jsonl"
@@ -354,6 +365,31 @@ async def test_recording_manager_discards_expired_pending_recordings(tmp_path: P
     assert fresh_path.exists()
     assert await recorder.pending_recording(fresh.recording_id) is fresh
     fresh.cleanup()
+
+
+@pytest.mark.asyncio
+async def test_recording_manager_discards_expired_claimed_recordings(tmp_path: Path) -> None:
+    recorder = RecordingManager(spool_dir=tmp_path)
+    path = tmp_path / "recording-claimed.jsonl"
+    path.write_text('{"t_us":0}\n', encoding="utf-8")
+    snapshot = RecordingSnapshot(
+        recording_id="claimed",
+        duration_ms=0,
+        device_types=[],
+        event_count=1,
+        spool_path=path,
+        memory_events=(),
+    )
+    now = asyncio.get_running_loop().time()
+    recorder._pending_recordings[snapshot.recording_id] = snapshot
+    recorder._pending_recording_created_at[snapshot.recording_id] = now - 10
+
+    await recorder.claim_pending_recording(snapshot.recording_id)
+    await recorder.discard_expired_pending_recordings(ttl_s=5)
+
+    assert not path.exists()
+    assert snapshot.recording_id not in recorder._claimed_recordings
+    assert snapshot.recording_id not in recorder._claimed_recording_created_at
 
 
 def test_recording_manager_startup_spool_cleanup(tmp_path: Path) -> None:

--- a/tests/test_rewrite_build_metadata.py
+++ b/tests/test_rewrite_build_metadata.py
@@ -1,0 +1,73 @@
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+from typing import NoReturn
+
+import pytest
+
+SCRIPT_PATH = (
+    Path(__file__).resolve().parents[1] / "scripts/rewrite-build-metadata.py"
+)
+
+
+def _load_script() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("rewrite_build_metadata_test", SCRIPT_PATH)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        sys.modules.pop(spec.name, None)
+    return module
+
+
+def _fail_build_rules(*_args: object, **_kwargs: object) -> NoReturn:
+    pytest.fail("_build_rules should not be called for invalid version input")
+
+
+@pytest.mark.parametrize(
+    ("option", "value"),
+    [
+        ("--python-version", '1.2.3"\nBROKEN = "x'),
+        ("--debian-version", "1.2.3)\nkeymasq (9.9.9)"),
+        ("--rpm-version", '1.2.3"\nRELEASE="99'),
+        ("--rpm-version", "1.2.3$(touch bad)"),
+    ],
+)
+def test_rewrite_build_metadata_rejects_malformed_versions_before_rewrite(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    option: str,
+    value: str,
+) -> None:
+    script = _load_script()
+    monkeypatch.setattr(script, "_build_rules", _fail_build_rules)
+    monkeypatch.setattr(sys, "argv", [SCRIPT_PATH.name, option, value])
+
+    with pytest.raises(SystemExit) as excinfo:
+        script.main()
+
+    assert excinfo.value.code == 2
+    assert "invalid version format" in capsys.readouterr().err
+
+
+@pytest.mark.parametrize(
+    ("validator_name", "value"),
+    [
+        ("_validate_python_version", "1.2.3rc1"),
+        ("_validate_python_version", "1.2.3.dev4"),
+        ("_validate_debian_version", "1.2.3~rc1"),
+        ("_validate_rpm_version", "1.2.3~rc1"),
+    ],
+)
+def test_rewrite_build_metadata_accepts_ci_version_suffixes(
+    validator_name: str,
+    value: str,
+) -> None:
+    script = _load_script()
+    validator = getattr(script, validator_name)
+
+    assert validator(value) == value

--- a/tests/test_session_clients.py
+++ b/tests/test_session_clients.py
@@ -157,6 +157,58 @@ class _BlockingErrorSocket:
         self.closed = True
 
 
+class _ExistingSessionSocketPath:
+    def exists(self) -> bool:
+        return True
+
+    def __str__(self) -> str:
+        return "/tmp/keymasq-test-session.sock"
+
+
+class _ConnectBlockingSocket:
+    instances: list["_ConnectBlockingSocket"] = []
+    instances_lock = threading.Lock()
+
+    def __init__(self) -> None:
+        self.closed = False
+        self.connected_path: str | None = None
+        self._closed_event = threading.Event()
+        with self.instances_lock:
+            self.instances.append(self)
+
+    def settimeout(self, _timeout: float | None) -> None:
+        return
+
+    def connect(self, path: str) -> None:
+        self.connected_path = path
+
+    def recv(self, _size: int) -> bytes:
+        self._closed_event.wait(1.0)
+        return b""
+
+    def close(self) -> None:
+        self.closed = True
+        self._closed_event.set()
+
+
+class _ConnectFailingSocket:
+    instances: list["_ConnectFailingSocket"] = []
+
+    def __init__(self) -> None:
+        self.closed = False
+        self.timeout: float | None = None
+        self.instances.append(self)
+
+    def settimeout(self, timeout: float | None) -> None:
+        self.timeout = timeout
+
+    def connect(self, _path: str) -> None:
+        raise TimeoutError("connect timed out")
+
+    def close(self) -> None:
+        self.closed = True
+
+
 def _install_fake_glib(monkeypatch: pytest.MonkeyPatch) -> None:
     glib_module = types.ModuleType("GLib")
 
@@ -226,6 +278,62 @@ def test_persistent_session_request_timeout_closes_connection() -> None:
     assert sock.sent == b'{"command": "get_status"}\n'
     assert sock.closed is True
     assert connection._sock is None  # pyright: ignore[reportPrivateUsage]
+
+
+def test_persistent_session_failed_connect_closes_socket(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _ConnectFailingSocket.instances = []
+    connection = gui_session_client._PersistentSessionConnection()
+
+    def _fake_socket(_family: int, _kind: int) -> _ConnectFailingSocket:
+        return _ConnectFailingSocket()
+
+    monkeypatch.setattr(gui_session_client, "SESSION_SOCKET_PATH", _ExistingSessionSocketPath())
+    monkeypatch.setattr(gui_session_client._socket, "socket", _fake_socket)
+
+    assert connection._ensure_connected(timeout=0.5) is False  # pyright: ignore[reportPrivateUsage]
+    assert connection._ensure_connected(timeout=0.5) is False  # pyright: ignore[reportPrivateUsage]
+    assert [sock.closed for sock in _ConnectFailingSocket.instances] == [True, True]
+    assert connection._sock is None  # pyright: ignore[reportPrivateUsage]
+
+
+def test_persistent_session_concurrent_first_connect_uses_one_socket(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _ConnectBlockingSocket.instances = []
+    connection = gui_session_client._PersistentSessionConnection()
+    start = threading.Barrier(3)
+    results: list[bool] = []
+    results_lock = threading.Lock()
+
+    def _fake_socket(_family: int, _kind: int) -> _ConnectBlockingSocket:
+        return _ConnectBlockingSocket()
+
+    monkeypatch.setattr(gui_session_client, "SESSION_SOCKET_PATH", _ExistingSessionSocketPath())
+    monkeypatch.setattr(gui_session_client._socket, "socket", _fake_socket)
+
+    def _connect() -> None:
+        start.wait()
+        result = connection._ensure_connected(timeout=0.5)  # pyright: ignore[reportPrivateUsage]
+        with results_lock:
+            results.append(result)
+
+    threads = [threading.Thread(target=_connect) for _ in range(2)]
+    for thread in threads:
+        thread.start()
+    start.wait()
+    for thread in threads:
+        thread.join(1.0)
+
+    assert results == [True, True]
+    assert len(_ConnectBlockingSocket.instances) == 1
+    assert connection._sock is _ConnectBlockingSocket.instances[0]  # pyright: ignore[reportPrivateUsage]
+
+    connection._close_connection()  # pyright: ignore[reportPrivateUsage]
+    reader_thread = connection._reader_thread  # pyright: ignore[reportPrivateUsage]
+    if reader_thread is not None:
+        reader_thread.join(1.0)
 
 
 def test_persistent_session_reader_thread_survives_socket_swap(

--- a/tests/test_session_hardware.py
+++ b/tests/test_session_hardware.py
@@ -1,7 +1,9 @@
 import logging
+from typing import BinaryIO
 
 import pytest
 
+import keymasq.session.hardware as hardware_module
 from keymasq.common.models import (
     AnalogAxisDefinition,
     AnalogInputDefinition,
@@ -248,6 +250,66 @@ def test_hardware_manager_preserves_explicit_hardware_id(temp_config_dir) -> Non
 
     reloaded = HardwareManager().get_hardware(config.hardware_id)
     assert reloaded == config
+
+
+def test_hardware_manager_suffixes_colliding_sanitized_hardware_ids(temp_config_dir) -> None:
+    manager = HardwareManager()
+    first = HardwareConfig(
+        vendor_id="1234",
+        product_id="5678",
+        name="USB Path",
+        evdev_devices=[],
+        buttons=[],
+        id="1234:5678@usb/foo",
+    )
+    second = HardwareConfig(
+        vendor_id="1234",
+        product_id="5678",
+        name="USB Underscore",
+        evdev_devices=[],
+        buttons=[],
+        id="1234:5678@usb_foo",
+    )
+
+    manager.save_hardware(first)
+    manager.save_hardware(second)
+
+    saved_names = sorted(path.name for path in (temp_config_dir / "hardware").glob("*.toml"))
+    assert saved_names == ["1234_5678_usb_foo.toml", "1234_5678_usb_foo_2.toml"]
+
+    reloaded = HardwareManager()
+    assert reloaded.get_hardware(first.hardware_id) == first
+    assert reloaded.get_hardware(second.hardware_id) == second
+
+    assert reloaded.delete_hardware(second.hardware_id) is True
+    assert sorted(path.name for path in (temp_config_dir / "hardware").glob("*.toml")) == [
+        "1234_5678_usb_foo.toml"
+    ]
+    assert HardwareManager().get_hardware(first.hardware_id) == first
+
+
+def test_hardware_manager_cleans_reserved_path_when_save_fails(
+    temp_config_dir,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = HardwareManager()
+    config = HardwareConfig(
+        vendor_id="1234",
+        product_id="5678",
+        name="Broken Save",
+        evdev_devices=[],
+        buttons=[],
+    )
+
+    def fail_dump(_data: object, _file: BinaryIO) -> None:
+        raise RuntimeError("dump failed")
+
+    monkeypatch.setattr(hardware_module.tomli_w, "dump", fail_dump)
+
+    with pytest.raises(RuntimeError, match="dump failed"):
+        manager.save_hardware(config)
+
+    assert not (temp_config_dir / "hardware" / "1234_5678.toml").exists()
 
 
 def test_hardware_manager_rejects_mismatched_explicit_hardware_id(

--- a/tests/test_session_manager_recording.py
+++ b/tests/test_session_manager_recording.py
@@ -90,7 +90,9 @@ def test_owner_disconnect_clears_active_recording_owner() -> None:
 
 
 @pytest.mark.asyncio
-async def test_last_client_disconnect_cleans_runtime_unlock_without_owner() -> None:
+async def test_last_client_disconnect_cleans_runtime_unlock_without_owner(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     manager = SessionManager()
     peer = PeerCredentials(pid=222, uid=1000, gid=1000)
     writer = object()
@@ -99,7 +101,6 @@ async def test_last_client_disconnect_cleans_runtime_unlock_without_owner() -> N
     resolve_unlock_status_async = AsyncMock(
         return_value={"unlocked": True, "source": "runtime", "expires_at": 2000}
     )
-    monkeypatch = pytest.MonkeyPatch()
     monkeypatch.setattr(
         session_recording_module,
         "resolve_unlock_status_async",
@@ -119,7 +120,6 @@ async def test_last_client_disconnect_cleans_runtime_unlock_without_owner() -> N
             data={"uid": 1000, "cleanup": True},
         )
     )
-    monkeypatch.undo()
 
 
 @pytest.mark.asyncio
@@ -158,7 +158,9 @@ async def test_capture_combo_uses_all_known_hardware_ids_not_just_profile_layers
 
 
 @pytest.mark.asyncio
-async def test_claim_recording_unlock_refresh_creates_runtime_lease() -> None:
+async def test_claim_recording_unlock_refresh_creates_runtime_lease(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     manager = SessionManager()
     peer = PeerCredentials(pid=12, uid=101, gid=100)
     writer = object()
@@ -168,7 +170,6 @@ async def test_claim_recording_unlock_refresh_creates_runtime_lease() -> None:
             {"unlocked": True, "source": "runtime", "expires_at": 2000},
         ]
     )
-    monkeypatch = pytest.MonkeyPatch()
     monkeypatch.setattr(
         session_recording_module,
         "resolve_unlock_status_async",
@@ -186,7 +187,6 @@ async def test_claim_recording_unlock_refresh_creates_runtime_lease() -> None:
     assert manager.unlock_state.runtime_refresh_claim_consumed_until[peer.uid] == 2000
     assert resolve_unlock_status_async.await_count == 2
     manager.client.send_command.assert_awaited_once()
-    monkeypatch.undo()
 
 
 @pytest.mark.asyncio

--- a/tests/test_session_support.py
+++ b/tests/test_session_support.py
@@ -1,6 +1,8 @@
 import asyncio
 import logging
 import runpy
+import shlex
+import sys
 from collections.abc import Awaitable, Callable
 from pathlib import Path
 from typing import Any
@@ -236,28 +238,84 @@ async def test_action_handler_execute_command_kills_timed_out_process(
     monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
 ) -> None:
     handler = ActionHandler()
-    process = _FakeProcess(communicate=lambda: asyncio.sleep(360))
-    timeouts: list[float] = []
+    communicate_calls = 0
+
+    async def _communicate() -> tuple[bytes, bytes]:
+        nonlocal communicate_calls
+        communicate_calls += 1
+        if communicate_calls == 1:
+            await asyncio.Event().wait()
+        return b"", b""
+
+    process = _FakeProcess(communicate=_communicate)
 
     async def _create_subprocess_shell(*_args: Any, **_kwargs: Any) -> _FakeProcess:
         return process
 
-    async def _wait_for(_awaitable: Any, timeout: float) -> Any:
-        timeouts.append(timeout)
-        _awaitable.close()
-        raise TimeoutError
-
     monkeypatch.setattr(asyncio, "create_subprocess_shell", _create_subprocess_shell)
-    monkeypatch.setattr(asyncio, "wait_for", _wait_for)
 
     with caplog.at_level(logging.ERROR):
-        result = await handler.execute_command("sleep 999", timeout_s=0.25)
+        result = await handler.execute_command("sleep 999", timeout_s=0.001)
 
     assert result == -1
     assert process.killed is True
-    assert timeouts == [0.25]
-    assert process.waited is True
-    assert "Command timed out after 0.25s, killing: sleep 999" in caplog.text
+    assert process.waited is False
+    assert communicate_calls == 2
+    assert "Command timed out after 0.001s, killing: sleep 999" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_action_handler_execute_command_drains_after_cancel(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    handler = ActionHandler()
+    started = asyncio.Event()
+    communicate_calls = 0
+
+    async def _communicate() -> tuple[bytes, bytes]:
+        nonlocal communicate_calls
+        communicate_calls += 1
+        if communicate_calls == 1:
+            started.set()
+            await asyncio.Event().wait()
+        return b"", b""
+
+    process = _FakeProcess(communicate=_communicate)
+
+    async def _create_subprocess_shell(*_args: Any, **_kwargs: Any) -> _FakeProcess:
+        return process
+
+    monkeypatch.setattr(asyncio, "create_subprocess_shell", _create_subprocess_shell)
+
+    task = asyncio.create_task(handler.execute_command("sleep 999"))
+    await asyncio.wait_for(started.wait(), timeout=1.0)
+
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert process.killed is True
+    assert process.waited is False
+    assert communicate_calls == 2
+
+
+@pytest.mark.asyncio
+async def test_action_handler_execute_command_timeout_drains_pipe_backed_stdout() -> None:
+    handler = ActionHandler()
+    code = (
+        "import sys, time; "
+        "sys.stdout.buffer.write(b'x' * 1048576); "
+        "sys.stdout.flush(); "
+        "time.sleep(10)"
+    )
+    cmd = f"exec {shlex.quote(sys.executable)} -c {shlex.quote(code)}"
+
+    result = await asyncio.wait_for(
+        handler.execute_command(cmd, timeout_s=0.05),
+        timeout=3.0,
+    )
+
+    assert result == -1
 
 
 @pytest.mark.asyncio

--- a/tests/test_slurp.py
+++ b/tests/test_slurp.py
@@ -179,6 +179,52 @@ def test_capture_point_async_returns_parsed_result_and_calls_on_ready(monkeypatc
     assert events == ["spawn", "sleep", "ready", "communicate"]
 
 
+def test_capture_point_async_terminates_process_when_on_ready_fails(monkeypatch) -> None:
+    capture = SlurpCapture()
+    capture._available = True
+    capture._slurp_path = "/usr/bin/slurp"
+
+    class _FakeProcess:
+        returncode = 0
+
+        def __init__(self) -> None:
+            self.terminated = False
+            self.communicated = False
+
+        async def communicate(self) -> tuple[bytes, bytes]:
+            self.communicated = True
+            return b"50,60\n", b""
+
+        def terminate(self) -> None:
+            self.terminated = True
+
+        async def wait(self) -> None:
+            return None
+
+    process = _FakeProcess()
+
+    async def _create_subprocess_exec(*args: Any, **kwargs: Any) -> _FakeProcess:
+        return process
+
+    async def _on_ready() -> None:
+        raise RuntimeError("ready failed")
+
+    async def _sleep(_delay: float) -> None:
+        return None
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", _create_subprocess_exec)
+    monkeypatch.setattr(asyncio, "sleep", _sleep)
+
+    result = asyncio.run(
+        capture.capture_point_async(mode=SlurpMode.POINT_IMMEDIATE, on_ready=_on_ready)
+    )
+
+    assert result is None
+    assert process.terminated is True
+    assert process.communicated is False
+    assert capture._process is None
+
+
 def test_capture_point_async_returns_none_for_empty_output(monkeypatch) -> None:
     capture = SlurpCapture()
     capture._available = True
@@ -247,6 +293,77 @@ def test_capture_point_async_returns_none_and_kills_on_communicate_timeout(monke
     assert process.killed is True
     assert process.wait_calls == 2
     assert capture._process is None
+
+
+def test_capture_point_async_timeout_does_not_clear_overlapping_capture(monkeypatch) -> None:
+    capture = SlurpCapture()
+    capture._available = True
+    capture._slurp_path = "/usr/bin/slurp"
+    capture._process = None
+
+    async def _run() -> None:
+        first_waiting = asyncio.Event()
+        allow_first_timeout = asyncio.Event()
+        second_started = asyncio.Event()
+        second_release = asyncio.Event()
+
+        class _FakeProcess:
+            returncode = 0
+
+            def __init__(self, name: str) -> None:
+                self.name = name
+                self.terminated = False
+                self.waited = False
+
+            async def communicate(self) -> tuple[bytes, bytes]:
+                if self.name == "second":
+                    second_started.set()
+                    await second_release.wait()
+                    return b"70,80\n", b""
+                return b"", b""
+
+            def terminate(self) -> None:
+                self.terminated = True
+
+            async def wait(self) -> None:
+                self.waited = True
+
+        processes: list[_FakeProcess] = []
+
+        async def _create_subprocess_exec(*args: Any, **kwargs: Any) -> _FakeProcess:
+            process = _FakeProcess("first" if not processes else "second")
+            processes.append(process)
+            return process
+
+        async def _wait_for(awaitable: Awaitable[object], timeout: float) -> object:
+            if timeout == 0.01:
+                first_waiting.set()
+                await allow_first_timeout.wait()
+                awaitable.close()
+                raise TimeoutError
+            return await awaitable
+
+        monkeypatch.setattr(asyncio, "create_subprocess_exec", _create_subprocess_exec)
+        monkeypatch.setattr(asyncio, "wait_for", _wait_for)
+
+        first_task = asyncio.create_task(capture.capture_point_async(timeout=0.01))
+        await first_waiting.wait()
+        second_task = asyncio.create_task(capture.capture_point_async(timeout=5.0))
+        await second_started.wait()
+
+        allow_first_timeout.set()
+        assert await first_task is None
+        first_process, second_process = processes
+        assert first_process.terminated is True
+        assert first_process.waited is True
+        assert second_process.terminated is False
+        assert capture._process is second_process
+
+        second_release.set()
+        assert await second_task == SlurpResult(x=70, y=80)
+        assert capture._process is None
+
+    asyncio.run(_run())
 
 
 def test_capture_point_async_cancels_process_on_external_cancel(monkeypatch) -> None:

--- a/tests/test_superkey_state.py
+++ b/tests/test_superkey_state.py
@@ -432,6 +432,46 @@ async def test_tap_hold_can_fire_without_double_tap_slot() -> None:
 
 
 @pytest.mark.asyncio
+async def test_second_press_hold_uses_hold_slot_without_tap_hold_slot() -> None:
+    keyboard_uinput = MagicMock()
+    keyboard_uinput.write = MagicMock()
+    keyboard_uinput.syn = MagicMock()
+
+    machine = SuperkeyMachine(
+        config=SuperkeyConfig(
+            name="second_press_hold_without_tap_hold",
+            hold_threshold_ms=0,
+            hold_actions=[SuperkeyActionData(action_type="keyboard", target="key_c")],
+            double_tap_actions=[SuperkeyActionData(action_type="keyboard", target="key_b")],
+        ),
+        event_name="btn_side",
+        keyboard_uinput=keyboard_uinput,
+        mouse_uinput=MagicMock(),
+        gamepad_uinput=MagicMock(),
+    )
+
+    await machine.on_down()
+    await machine.on_up()
+
+    assert keyboard_uinput.write.call_args_list == []
+
+    await machine.on_down()
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+
+    assert [tuple(call.args) for call in keyboard_uinput.write.call_args_list] == [
+        (evdev.ecodes.EV_KEY, evdev.ecodes.KEY_C, 1),
+    ]
+
+    await machine.on_up()
+
+    assert [tuple(call.args) for call in keyboard_uinput.write.call_args_list] == [
+        (evdev.ecodes.EV_KEY, evdev.ecodes.KEY_C, 1),
+        (evdev.ecodes.EV_KEY, evdev.ecodes.KEY_C, 0),
+    ]
+
+
+@pytest.mark.asyncio
 async def test_stop_cancels_rapidfire_task_without_extra_writes() -> None:
     keyboard_uinput = MagicMock()
     keyboard_uinput.write = MagicMock()

--- a/tests/test_wayland_ext_client.py
+++ b/tests/test_wayland_ext_client.py
@@ -37,8 +37,12 @@ def test_ext_wayland_client_updates_tracker_metadata() -> None:
 
     handle_object_id = client._allocate_object_id("ext_foreign_toplevel_handle_v1")
     client._handle_list_event(list_id, 0, _pack_uint(handle_object_id))
-    client._handle_toplevel_event(handle_object_id, 3, _encode_string("Alacritty"))
-    client._handle_toplevel_event(handle_object_id, 2, _encode_string("terminal"))
+    asyncio.run(
+        client._handle_toplevel_event(handle_object_id, 3, _encode_string("Alacritty"))
+    )
+    asyncio.run(
+        client._handle_toplevel_event(handle_object_id, 2, _encode_string("terminal"))
+    )
 
     tracker.update_state(str(handle_object_id), {"activated": True})
     assert tracker.get_active_window() == ("Alacritty", "terminal")
@@ -53,10 +57,16 @@ def test_ext_wayland_client_close_clears_active_window() -> None:
 
     handle_object_id = client._allocate_object_id("ext_foreign_toplevel_handle_v1")
     client._handle_list_event(list_id, 0, _pack_uint(handle_object_id))
-    client._handle_toplevel_event(handle_object_id, 3, _encode_string("firefox"))
-    client._handle_toplevel_event(handle_object_id, 2, _encode_string("Mozilla"))
+    asyncio.run(
+        client._handle_toplevel_event(handle_object_id, 3, _encode_string("firefox"))
+    )
+    asyncio.run(
+        client._handle_toplevel_event(handle_object_id, 2, _encode_string("Mozilla"))
+    )
     tracker.update_state(str(handle_object_id), {"activated": True})
     assert tracker.get_active_window() == ("firefox", "Mozilla")
 
-    client._handle_toplevel_event(handle_object_id, 0, b"")
+    asyncio.run(client._handle_toplevel_event(handle_object_id, 0, b""))
     assert tracker.get_active_window() == ("", "")
+    assert handle_object_id not in client._objects
+    assert handle_object_id not in client._toplevel_handles

--- a/tests/test_wayland_protocol_trackers.py
+++ b/tests/test_wayland_protocol_trackers.py
@@ -56,6 +56,11 @@ def _wl_message(object_id: int, opcode: int, payload: bytes = b"") -> bytes:
     return struct.pack("<II", object_id, ((size & 0xFFFF) << 16) | (opcode & 0xFFFF)) + payload
 
 
+def _wl_message_object_opcode(message: bytes) -> tuple[int, int]:
+    object_id, size_opcode = struct.unpack_from("<II", message, 0)
+    return object_id, size_opcode & 0xFFFF
+
+
 def _fake_send_request_recorder(fake_socket: _FakeWaylandSocket) -> Any:
     async def send_request(object_id: int, opcode: int, payload: bytes) -> None:
         fake_socket.sendall(_wl_message(object_id, opcode, payload))
@@ -355,8 +360,10 @@ def test_ext_wayland_client_dispatches_registry_and_toplevel_events() -> None:
     assert fake_socket.sent
 
     client._handle_list_event(client._list_id, 0, struct.pack("<I", 40))
-    client._handle_toplevel_event(40, 2, _encode_string("Terminal"))
-    client._handle_toplevel_event(40, 3, _encode_string("org.example.Terminal"))
+    asyncio.run(client._handle_toplevel_event(40, 2, _encode_string("Terminal")))
+    asyncio.run(
+        client._handle_toplevel_event(40, 3, _encode_string("org.example.Terminal"))
+    )
     tracker.update_state("40", [2])
     assert tracker.get_active_window() == ("org.example.Terminal", "Terminal")
 
@@ -365,10 +372,34 @@ def test_ext_wayland_client_dispatches_registry_and_toplevel_events() -> None:
     client._handle_callback_event(99, 0)
     assert 99 not in client._sync_waiters
 
-    client._handle_toplevel_event(40, 0, b"")
+    asyncio.run(client._handle_toplevel_event(40, 0, b""))
     assert "40" not in tracker._windows
+    assert 40 not in client._objects
+    assert 40 not in client._toplevel_handles
+    assert _wl_message(40, 0) in fake_socket.sent
     client._handle_display_event(1, struct.pack("<I", 40))
     asyncio.run(client.stop())
+    assert fake_socket.closed is True
+
+
+def test_ext_wayland_client_stop_destroys_handles_before_list() -> None:
+    tracker = ExtForeignToplevelListTracker()
+    client = ExtForeignToplevelListWaylandClient(tracker)
+    fake_socket = _FakeWaylandSocket()
+    client._socket = fake_socket
+    client._send_request = _fake_send_request_recorder(fake_socket)
+
+    list_id = client._allocate_object_id(EXT_FOREIGN_TOPLEVEL_LIST_INTERFACE)
+    handle_id = client._allocate_object_id("ext_foreign_toplevel_handle_v1")
+    client._list_id = list_id
+    client._toplevel_handles.add(handle_id)
+
+    asyncio.run(client.stop())
+
+    assert [_wl_message_object_opcode(message) for message in fake_socket.sent] == [
+        (handle_id, 0),
+        (list_id, 1),
+    ]
     assert fake_socket.closed is True
 
 
@@ -391,13 +422,22 @@ def test_wlr_wayland_client_dispatches_manager_and_toplevel_events() -> None:
     assert client._manager_id is not None
 
     client._handle_manager_event(client._manager_id, 0, struct.pack("<I", 50))
-    client._handle_toplevel_event(50, 0, _encode_string("Editor"))
-    client._handle_toplevel_event(50, 1, _encode_string("code"))
-    client._handle_toplevel_event(50, 4, _encode_array([WLR_TOPLEVEL_STATE_ACTIVATED]))
+    asyncio.run(client._handle_toplevel_event(50, 0, _encode_string("Editor")))
+    asyncio.run(client._handle_toplevel_event(50, 1, _encode_string("code")))
+    asyncio.run(
+        client._handle_toplevel_event(
+            50,
+            4,
+            _encode_array([WLR_TOPLEVEL_STATE_ACTIVATED]),
+        )
+    )
     assert tracker.get_active_window() == ("code", "Editor")
 
-    client._handle_toplevel_event(50, 6, b"")
+    asyncio.run(client._handle_toplevel_event(50, 6, b""))
     assert tracker.get_active_window() == ("", "")
+    assert 50 not in client._objects
+    assert 50 not in client._toplevel_handles
+    assert _wl_message(50, 7) in fake_socket.sent
     asyncio.run(client.stop())
     assert fake_socket.closed is True
 
@@ -430,8 +470,10 @@ def test_cosmic_wayland_client_links_ext_handles_to_cosmic_state() -> None:
 
     asyncio.run(client._handle_list_event(client._list_id, 0, struct.pack("<I", 70)))
     cosmic_handle = client._ext_to_cosmic[70]
-    client._handle_toplevel_event(70, 2, _encode_string("Settings"))
-    client._handle_toplevel_event(70, 3, _encode_string("com.system76.Settings"))
+    asyncio.run(client._handle_toplevel_event(70, 2, _encode_string("Settings")))
+    asyncio.run(
+        client._handle_toplevel_event(70, 3, _encode_string("com.system76.Settings"))
+    )
     client._handle_cosmic_toplevel_event(cosmic_handle, 8, _encode_array([2]))
     assert tracker.get_active_window() == ("com.system76.Settings", "Settings")
 
@@ -441,10 +483,42 @@ def test_cosmic_wayland_client_links_ext_handles_to_cosmic_state() -> None:
         "Settings",
     )
 
-    client._handle_display_event(1, struct.pack("<I", 70))
+    asyncio.run(client._handle_toplevel_event(70, 0, b""))
     assert 70 not in client._toplevel_handles
+    assert 70 not in client._objects
     assert cosmic_handle not in client._cosmic_handles
+    assert cosmic_handle not in client._objects
+    assert _wl_message(cosmic_handle, 0) in fake_socket.sent
+    assert _wl_message(70, 0) in fake_socket.sent
     asyncio.run(client.stop())
+    assert fake_socket.closed is True
+
+
+def test_cosmic_wayland_client_stop_destroys_handles_before_list() -> None:
+    tracker = ExtForeignToplevelListTracker()
+    client = cosmic_client_module.CosmicToplevelInfoWaylandClient(tracker)
+    fake_socket = _FakeWaylandSocket()
+    client._socket = fake_socket
+    client._send_request = _fake_send_request_recorder(fake_socket)
+
+    list_id = client._allocate_object_id(cosmic_client_module.EXT_FOREIGN_TOPLEVEL_LIST_INTERFACE)
+    cosmic_info_id = client._allocate_object_id(cosmic_client_module.COSMIC_TOPLEVEL_INFO_INTERFACE)
+    handle_id = client._allocate_object_id("ext_foreign_toplevel_handle_v1")
+    cosmic_handle_id = client._allocate_object_id("zcosmic_toplevel_handle_v1")
+    client._list_id = list_id
+    client._cosmic_info_id = cosmic_info_id
+    client._toplevel_handles.add(handle_id)
+    client._cosmic_handles.add(cosmic_handle_id)
+    client._ext_to_cosmic[handle_id] = cosmic_handle_id
+    client._cosmic_to_ext[cosmic_handle_id] = handle_id
+
+    asyncio.run(client.stop())
+
+    assert [_wl_message_object_opcode(message) for message in fake_socket.sent] == [
+        (cosmic_handle_id, 0),
+        (handle_id, 0),
+        (list_id, 1),
+    ]
     assert fake_socket.closed is True
 
 
@@ -511,6 +585,63 @@ def test_wayland_clients_require_display_environment(monkeypatch) -> None:
                 raise AssertionError("client.start() unexpectedly succeeded")
 
     asyncio.run(start_clients())
+
+
+def test_wayland_clients_close_socket_when_start_fails_missing_global() -> None:
+    async def run_client(client: Any, expected_error: str, socket_name: str) -> None:
+        with _short_socket_path(socket_name) as socket_path:
+            disconnected = asyncio.Event()
+
+            async def handle_client(
+                reader: asyncio.StreamReader,
+                writer: asyncio.StreamWriter,
+            ) -> None:
+                await reader.read(4096)
+                writer.write(_wl_message(3, 0))
+                await writer.drain()
+                await reader.read(4096)
+                disconnected.set()
+                writer.close()
+                await writer.wait_closed()
+
+            server = await asyncio.start_unix_server(handle_client, path=str(socket_path))
+            client._socket_path = str(socket_path)
+            try:
+                try:
+                    await client.start()
+                except RuntimeError as exc:
+                    assert expected_error in str(exc)
+                else:
+                    raise AssertionError("client.start() unexpectedly succeeded")
+
+                assert client._socket is None
+                await asyncio.wait_for(disconnected.wait(), timeout=1.0)
+            finally:
+                server.close()
+                await server.wait_closed()
+
+    async def run_clients() -> None:
+        await run_client(
+            ExtForeignToplevelListWaylandClient(ExtForeignToplevelListTracker()),
+            "ext_foreign_toplevel_list_v1 is unavailable",
+            "ext-missing-global",
+        )
+        await run_client(
+            wlr_client_module.WlrForeignToplevelWaylandClient(
+                WlrForeignToplevelManagerTracker()
+            ),
+            "zwlr_foreign_toplevel_manager_v1 is unavailable",
+            "wlr-missing-global",
+        )
+        await run_client(
+            cosmic_client_module.CosmicToplevelInfoWaylandClient(
+                ExtForeignToplevelListTracker()
+            ),
+            "ext_foreign_toplevel_list_v1 is unavailable",
+            "cosmic-missing-global",
+        )
+
+    asyncio.run(run_clients())
 
 
 def test_ext_wayland_client_start_and_run_against_minimal_socket() -> None:

--- a/tests/test_wayland_wlr_client.py
+++ b/tests/test_wayland_wlr_client.py
@@ -36,9 +36,23 @@ def test_wlr_wayland_client_tracks_active_toplevel() -> None:
 
     handle_object_id = client._allocate_object_id("zwlr_foreign_toplevel_handle_v1")
     client._handle_manager_event(manager_id, 0, _pack_uint(handle_object_id))
-    client._handle_toplevel_event(handle_object_id, 1, _encode_string("firefox"))
-    client._handle_toplevel_event(handle_object_id, 0, _encode_string("Mozilla Firefox"))
-    client._handle_toplevel_event(handle_object_id, 4, _encode_array((2).to_bytes(4, "little")))
+    asyncio.run(
+        client._handle_toplevel_event(handle_object_id, 1, _encode_string("firefox"))
+    )
+    asyncio.run(
+        client._handle_toplevel_event(
+            handle_object_id,
+            0,
+            _encode_string("Mozilla Firefox"),
+        )
+    )
+    asyncio.run(
+        client._handle_toplevel_event(
+            handle_object_id,
+            4,
+            _encode_array((2).to_bytes(4, "little")),
+        )
+    )
 
     assert tracker.get_active_window() == ("firefox", "Mozilla Firefox")
 
@@ -54,5 +68,26 @@ def test_wlr_wayland_client_close_clears_active_window() -> None:
     tracker.update_state(str(handle_object_id), (2).to_bytes(4, "little"))
     assert tracker.get_active_window() == ("Alacritty", "term")
 
-    client._handle_toplevel_event(handle_object_id, 6, b"")
+    asyncio.run(client._handle_toplevel_event(handle_object_id, 6, b""))
     assert tracker.get_active_window() == ("", "")
+    assert handle_object_id not in client._objects
+    assert handle_object_id not in client._toplevel_handles
+
+
+def test_wlr_wayland_client_destroy_toplevel_handle_uses_destroy_opcode() -> None:
+    tracker = WlrForeignToplevelManagerTracker()
+    client = WlrForeignToplevelWaylandClient(tracker, socket_path="/tmp/nonexistent")
+    sent: list[tuple[int, int, bytes]] = []
+
+    async def record_send(obj: int, opcode: int, payload: bytes) -> None:
+        sent.append((obj, opcode, payload))
+
+    client._send_request = record_send  # type: ignore[method-assign]
+    handle_object_id = client._allocate_object_id("zwlr_foreign_toplevel_handle_v1")
+    client._toplevel_handles.add(handle_object_id)
+
+    asyncio.run(client._destroy_toplevel_handle(handle_object_id))
+
+    assert sent == [(handle_object_id, 7, b"")]
+    assert handle_object_id not in client._objects
+    assert handle_object_id not in client._toplevel_handles

--- a/tests/test_x11_listener.py
+++ b/tests/test_x11_listener.py
@@ -1,4 +1,4 @@
-import inspect
+import asyncio
 from types import SimpleNamespace
 
 from keymasq.session.listeners import x11 as x11_listener_module
@@ -61,7 +61,94 @@ def test_x11_handle_event_ignores_unrelated_window_metadata(monkeypatch) -> None
     assert listener._handle_x_event_unlocked(event) is False
 
 
-def test_x11_listener_uses_event_wait_not_poll_sleep() -> None:
-    source = inspect.getsource(X11Listener._listen)
-    assert "await self._fd_event.wait()" in source
-    assert "asyncio.sleep" not in source
+def test_x11_probe_available_requires_openable_display(monkeypatch) -> None:
+    async def _unexpected_socket_probe(*_args, **_kwargs):
+        raise AssertionError("probe_available should validate displays through Xlib")
+
+    monkeypatch.setattr(x11_listener_module, "has_x11_support", lambda: True)
+    monkeypatch.setattr(X11Listener, "_candidate_displays", classmethod(lambda _cls: [":0"]))
+    monkeypatch.setattr(X11Listener, "_can_open_display", classmethod(lambda _cls, _name: False))
+    monkeypatch.setattr(
+        x11_listener_module.asyncio,
+        "open_unix_connection",
+        _unexpected_socket_probe,
+    )
+
+    assert asyncio.run(X11Listener.probe_available()) is False
+
+
+def test_x11_listener_waits_for_fd_event_before_draining(monkeypatch) -> None:
+    async def run() -> None:
+        real_event = asyncio.Event
+
+        class _RecordingEvent:
+            def __init__(self) -> None:
+                self.wait_started = real_event()
+                self.release = real_event()
+                self.wait_count = 0
+                self.clear_count = 0
+                self._is_set = False
+                events.append(self)
+
+            async def wait(self) -> bool:
+                self.wait_count += 1
+                self.wait_started.set()
+                await self.release.wait()
+                return True
+
+            def set(self) -> None:
+                self._is_set = True
+                self.release.set()
+
+            def clear(self) -> None:
+                self.clear_count += 1
+                self._is_set = False
+
+            def is_set(self) -> bool:
+                return self._is_set
+
+        events: list[_RecordingEvent] = []
+        emitted: list[None] = []
+        drain_calls: list[None] = []
+        listener = X11Listener(_cb)
+        listener._xdisplay = object()
+        listener.running = True
+
+        async def _emit() -> None:
+            emitted.append(None)
+
+        def _drain() -> bool:
+            drain_calls.append(None)
+            listener.running = False
+            return False
+
+        monkeypatch.setattr(x11_listener_module.asyncio, "Event", _RecordingEvent)
+        listener._get_display_fd = lambda: -1
+        listener._emit_active_window_if_changed = _emit
+        listener._drain_events = _drain
+
+        task = asyncio.create_task(listener._listen())
+        try:
+            while not events:
+                await asyncio.sleep(0)
+            event = events[0]
+            await asyncio.wait_for(event.wait_started.wait(), timeout=1.0)
+
+            assert emitted == [None]
+            assert drain_calls == []
+            assert event.wait_count == 1
+
+            event.set()
+            await asyncio.wait_for(task, timeout=1.0)
+
+            assert drain_calls == [None]
+            assert event.clear_count == 1
+        finally:
+            if not task.done():
+                task.cancel()
+                try:
+                    await task
+                except asyncio.CancelledError:
+                    pass
+
+    asyncio.run(run())


### PR DESCRIPTION
| Area | Insertions | Deletions | Net increase |
|---|---:|---:|---:|
| Session | 296 | 195 | **+101** |
| keymasqd / daemon | 124 | 31 | **+93** |
| GUI | 250 | 107 | **+143** |

Total net increase across those three areas: **+337 production lines**.

## Summary

- **Daemon runtime**: hardened grab lifecycle, macro store/recording/spool, combo engine, superkey state, topology, and profile activation tracker; added missing device closure in `find_all_interfaces` and process lifecycle fixes in slurp capture
- **Session manager / listeners**: fixed compositor client reconnection, recording stop IPC, wayland protocol trackers, profile listing with empty profiles, and diagnostics interval validation
- **GUI**: hardened macro editor (event order stability, passthrough/control handling), combo editor/inspector refresh logic, session client locking, recording overlay status feedback, save-macro dialog inflight state, threshold range bar tick rendering for arbitrary ranges, and device tab caption/analog capture
- **CLI / common**: finite float parsing, IPC decode hardening (UnicodeDecodeError), virtual gamepad ID validation, and play-json includes device types in round-trip output
- **Test infrastructure**: added ~3,300 lines of new tests covering CLI commands, daemon capture/commands, device manager core/recovery/rapidfire, combo overlap, macro backend loops/recording, recording extended/settings, slurp, IPC, virtual devices, profile activation, timer precision, session manager commands/payloads/recording, GUI dialogs/windows/editors/icon assets, wayland protocol trackers, rewrite-build-metadata, and more; stabilized concurrency in recording settings test and added `restore_timer_slack` fixture

## Testing

- `./scripts/check.sh` passes (ruff, basedpyright, pytest suite)
- CI green in branch `refactor/kmq2`
- Manual smoke tests: profile list, macro record/play, GUI editors open/save, combo inspector, device tab
- New tests cover previously missing edge cases (empty profiles, finite float parsing, race conditions, Unicode IPC payloads, threshold range bar with arbitrary ranges)