### PR TITLE
Remember and restore last selected tab on launch

### DIFF
--- a/docs/PROFILES.md
+++ b/docs/PROFILES.md
@@ -310,6 +310,7 @@ In the GUI:
 - enabling or disabling a profile affects every device layer in that profile
 - active-state displays show the active profiles contributing to that device
 - `Passthrough` removes the mapping from the selected profile so lower profiles can still apply one
+- the app remembers the last selected device or combo tab and restores it on launch
 - right-clicking the device name in a device tab lets you edit the saved display
   name; hardware IDs, mappings, and device identity are unchanged
 - deleting a button from the device tab removes it from the hardware config and clears saved mappings for that button across profiles

--- a/keymasq/gui/preferences.py
+++ b/keymasq/gui/preferences.py
@@ -78,6 +78,24 @@ def load_hidden_tabs() -> set[str]:
     return set(_clean_string_list(data.get("hidden_tabs")))
 
 
+def load_selected_tab() -> str:
+    data = _load_settings()
+    selected_tab = data.get("selected_tab")
+    if isinstance(selected_tab, str):
+        return selected_tab.strip()
+    return ""
+
+
+def save_selected_tab(selected_tab: str) -> None:
+    data = _load_settings()
+    cleaned = selected_tab.strip()
+    if cleaned:
+        data["selected_tab"] = cleaned
+    else:
+        data.pop("selected_tab", None)
+    _save_settings(data)
+
+
 def save_tab_layout(tab_order: list[str], hidden_tabs: set[str]) -> None:
     data = _load_settings()
     cleaned_order = _clean_string_list(tab_order)

--- a/keymasq/gui/window.py
+++ b/keymasq/gui/window.py
@@ -23,7 +23,9 @@ from keymasq.gui.preferences import (
     AppearanceMode,
     load_appearance_mode,
     load_hidden_tabs,
+    load_selected_tab,
     load_tab_order,
+    save_selected_tab,
     save_tab_layout,
 )
 from keymasq.gui.session_client import (
@@ -123,11 +125,14 @@ class MainWindow(Adw.ApplicationWindow):
         self._destroyed = False
         self._tab_order = load_tab_order()
         self._hidden_tabs = load_hidden_tabs()
+        self._selected_tab = load_selected_tab()
         self._device_pages: dict[str, Adw.TabPage] = {}
         self._combo_page: Adw.TabPage | None = None
         self._placeholder_page: Adw.TabPage | None = None
         self._allow_tab_page_close = False
         self._suppress_tab_layout_save = False
+        self._suppress_selected_tab_save = True
+        self._initial_tab_selection_pending = True
         self.combo_tab: ComboTab | None = None
         self._device_inspector_windows: dict[str, Gtk.Window] = {}
         self._combo_inspector_window: Gtk.Window | None = None
@@ -136,6 +141,7 @@ class MainWindow(Adw.ApplicationWindow):
         self.set_default_size(760, 1000)
 
         self._setup_content()
+        self._suppress_selected_tab_save = False
         self._start_startup_probe()
 
         if not self.demo_mode:
@@ -320,6 +326,13 @@ class MainWindow(Adw.ApplicationWindow):
             return _COMBO_TAB_ID
         return None
 
+    def _selected_tab_for_child(self, child: Gtk.Widget | None) -> str | None:
+        if isinstance(child, DeviceTab):
+            return child.device.hardware_id
+        if isinstance(child, ComboTab):
+            return _COMBO_TAB_ID
+        return None
+
     def _current_tab_order(self) -> list[str]:
         order: list[str] = []
         for page in self._iter_tab_pages():
@@ -383,6 +396,41 @@ class MainWindow(Adw.ApplicationWindow):
             hardware_id = tab_id.removeprefix(_DEVICE_TAB_PREFIX)
             return self._device_pages.get(hardware_id)
         return None
+
+    def _page_for_selected_tab(self, selected_tab: str) -> Adw.TabPage | None:
+        selected_tab = selected_tab.strip()
+        if selected_tab == _COMBO_TAB_ID:
+            return self._combo_page
+        return self._device_pages.get(selected_tab)
+
+    def _default_selected_tab_page(self) -> Adw.TabPage | None:
+        for tab_id in self._desired_visible_tab_order():
+            page = self._page_for_tab_id(tab_id)
+            if page is not None:
+                return page
+
+        for page in self._iter_tab_pages():
+            if self._tab_id_for_child(page.get_child()) is not None:
+                return page
+        return None
+
+    def _select_saved_or_default_tab(self) -> None:
+        page = self._page_for_selected_tab(self._selected_tab)
+        if page is None:
+            page = self._default_selected_tab_page()
+        if page is None:
+            self._initial_tab_selection_pending = False
+            return
+
+        self.tab_view.set_selected_page(page)
+        selected_tab = self._selected_tab_for_child(page.get_child())
+        if selected_tab is None:
+            self._initial_tab_selection_pending = False
+            return
+
+        self._selected_tab = selected_tab
+        save_selected_tab(selected_tab)
+        self._initial_tab_selection_pending = False
 
     def _default_visible_tab_order(self) -> list[str]:
         device_ids: list[str] = []
@@ -517,6 +565,14 @@ class MainWindow(Adw.ApplicationWindow):
     def _on_selected_tab_changed(self, _tab_view, _pspec) -> None:
         page = self.tab_view.get_selected_page()
         child = page.get_child() if page is not None else None
+        selected_tab = self._selected_tab_for_child(child)
+        if (
+            selected_tab is not None
+            and not self._suppress_selected_tab_save
+            and not self._initial_tab_selection_pending
+        ):
+            self._selected_tab = selected_tab
+            save_selected_tab(selected_tab)
         if isinstance(child, ProfileManagedTab):
             child.refresh_profiles(
                 preferred_profile_name=self._selected_profile_name,
@@ -1245,12 +1301,16 @@ class MainWindow(Adw.ApplicationWindow):
 
         if not devices:
             self._set_empty_placeholder_state()
+            self._select_saved_or_default_tab()
             return
 
         self._close_tab_page(self._page_for_child(self.placeholder))
         self._placeholder_page = None
 
+        suppress_layout_was = self._suppress_tab_layout_save
+        suppress_selected_was = self._suppress_selected_tab_save
         self._suppress_tab_layout_save = True
+        self._suppress_selected_tab_save = True
         try:
             for device in self._order_devices_for_tabs(devices):
                 if device.hardware_id in self._device_pages:
@@ -1258,7 +1318,9 @@ class MainWindow(Adw.ApplicationWindow):
                 self._add_device_tab(device, persist_order=False)
             self._reorder_visible_pages_to_saved_order()
         finally:
-            self._suppress_tab_layout_save = False
+            self._suppress_tab_layout_save = suppress_layout_was
+            self._suppress_selected_tab_save = suppress_selected_was
+        self._select_saved_or_default_tab()
 
     def _load_demo_devices(self) -> None:
         from keymasq.common.models import ButtonDefinition, DeviceType, EvdevDevice, HardwareConfig
@@ -1287,9 +1349,15 @@ class MainWindow(Adw.ApplicationWindow):
 
         self._close_tab_page(self._page_for_child(self.placeholder))
         self._placeholder_page = None
-        if demo_device.hardware_id not in self._device_pages:
-            self._add_device_tab(demo_device, persist_order=False)
-        self._reorder_visible_pages_to_saved_order()
+        suppress_selected_was = self._suppress_selected_tab_save
+        self._suppress_selected_tab_save = True
+        try:
+            if demo_device.hardware_id not in self._device_pages:
+                self._add_device_tab(demo_device, persist_order=False)
+            self._reorder_visible_pages_to_saved_order()
+        finally:
+            self._suppress_selected_tab_save = suppress_selected_was
+        self._select_saved_or_default_tab()
 
     def _setup_combo_tab(self) -> None:
         if _COMBO_TAB_ID in self._hidden_tabs:

--- a/tests/gui/test_application_and_reload.py
+++ b/tests/gui/test_application_and_reload.py
@@ -136,21 +136,26 @@ def test_gui_tab_layout_preference_round_trips_with_appearance(temp_config_dir) 
     from keymasq.gui.preferences import (
         load_hidden_tabs,
         load_appearance_mode,
+        load_selected_tab,
         load_tab_order,
         save_appearance_mode,
+        save_selected_tab,
         save_tab_layout,
     )
 
     assert load_tab_order() == []
     assert load_hidden_tabs() == set()
+    assert load_selected_tab() == ""
 
     save_appearance_mode("dark")
+    save_selected_tab(" 1234:5678 ")
     save_tab_layout(
         [" device:2222:0002 ", "combos", "device:1111:0001", "combos", ""],
         {"combos", " "},
     )
 
     assert load_appearance_mode() == "dark"
+    assert load_selected_tab() == "1234:5678"
     assert load_tab_order() == ["device:2222:0002", "combos", "device:1111:0001"]
     assert load_hidden_tabs() == {"combos"}
 

--- a/tests/gui/test_main_window.py
+++ b/tests/gui/test_main_window.py
@@ -518,6 +518,124 @@ class TestMainWindow:
         assert window._current_tab_order() == expected_order
         assert window.tab_view.get_n_pages() == 4
 
+    def test_main_window_persists_selected_tab(self, temp_config_dir):
+        from keymasq.common.models import ButtonDefinition, HardwareConfig
+        from keymasq.gui.preferences import load_selected_tab
+        from keymasq.gui.window import MainWindow
+
+        window = MainWindow(demo_mode=True)
+        devices = [
+            HardwareConfig(
+                vendor_id="1234",
+                product_id=product_id,
+                name=name,
+                evdev_devices=[],
+                buttons=[ButtonDefinition(id="btn_back", label="Back", evdev="btn_side")],
+            )
+            for product_id, name in (
+                ("5678", "Mouse One"),
+                ("5679", "Mouse Two"),
+            )
+        ]
+        window._apply_loaded_devices(devices)
+
+        second_page = window._page_for_hardware_id(devices[1].hardware_id)
+        combo_page = window._page_for_child(window.combo_tab)
+        assert second_page is not None
+        assert combo_page is not None
+
+        window.tab_view.set_selected_page(second_page)
+
+        assert load_selected_tab() == devices[1].hardware_id
+
+        window.tab_view.set_selected_page(combo_page)
+
+        assert load_selected_tab() == "combos"
+
+    def test_main_window_applies_saved_selected_device_tab_on_load(self, temp_config_dir):
+        from keymasq.common.models import ButtonDefinition, HardwareConfig
+        from keymasq.gui.preferences import save_selected_tab, save_tab_layout
+        from keymasq.gui.window import MainWindow
+
+        devices = [
+            HardwareConfig(
+                vendor_id="1234",
+                product_id=product_id,
+                name=name,
+                evdev_devices=[],
+                buttons=[ButtonDefinition(id="btn_back", label="Back", evdev="btn_side")],
+            )
+            for product_id, name in (
+                ("5678", "Mouse One"),
+                ("5679", "Mouse Two"),
+            )
+        ]
+        save_tab_layout(
+            [f"device:{devices[0].hardware_id}", "combos", f"device:{devices[1].hardware_id}"],
+            set(),
+        )
+        save_selected_tab(devices[1].hardware_id)
+
+        window = MainWindow(demo_mode=True)
+        window._apply_loaded_devices(devices)
+
+        assert window.tab_view.get_selected_page() is window._page_for_hardware_id(
+            devices[1].hardware_id
+        )
+
+    def test_main_window_applies_saved_selected_combo_tab_on_load(self, temp_config_dir):
+        from keymasq.common.models import ButtonDefinition, HardwareConfig
+        from keymasq.gui.preferences import save_selected_tab, save_tab_layout
+        from keymasq.gui.window import MainWindow
+
+        device = HardwareConfig(
+            vendor_id="1234",
+            product_id="5678",
+            name="Mouse One",
+            evdev_devices=[],
+            buttons=[ButtonDefinition(id="btn_back", label="Back", evdev="btn_side")],
+        )
+        save_tab_layout([f"device:{device.hardware_id}", "combos"], set())
+        save_selected_tab("combos")
+
+        window = MainWindow(demo_mode=True)
+        window._apply_loaded_devices([device])
+
+        assert window.combo_tab is not None
+        assert window.tab_view.get_selected_page() is window._page_for_child(window.combo_tab)
+
+    def test_main_window_invalid_selected_tab_falls_back_to_saved_order(self, temp_config_dir):
+        from keymasq.common.models import ButtonDefinition, HardwareConfig
+        from keymasq.gui.preferences import load_selected_tab, save_selected_tab, save_tab_layout
+        from keymasq.gui.window import MainWindow
+
+        devices = [
+            HardwareConfig(
+                vendor_id="1234",
+                product_id=product_id,
+                name=name,
+                evdev_devices=[],
+                buttons=[ButtonDefinition(id="btn_back", label="Back", evdev="btn_side")],
+            )
+            for product_id, name in (
+                ("5678", "Mouse One"),
+                ("5679", "Mouse Two"),
+            )
+        ]
+        save_tab_layout(
+            [f"device:{devices[1].hardware_id}", "combos", f"device:{devices[0].hardware_id}"],
+            set(),
+        )
+        save_selected_tab("missing-hardware")
+
+        window = MainWindow(demo_mode=True)
+        window._apply_loaded_devices(devices)
+
+        assert window.tab_view.get_selected_page() is window._page_for_hardware_id(
+            devices[1].hardware_id
+        )
+        assert load_selected_tab() == devices[1].hardware_id
+
     def test_main_window_hides_and_restores_combo_tab_from_menu(self, temp_config_dir):
         from keymasq.common.models import ButtonDefinition, HardwareConfig
         from keymasq.gui.preferences import load_hidden_tabs, load_tab_order


### PR DESCRIPTION
## Summary

- Users switching between device tabs and the combos tab now have their last selection restored on restart.
- Adds `load_selected_tab` / `save_selected_tab` to `keymasq/gui/preferences.py`.
- Extends `MainWindow` to save on every tab switch and restore via `_select_saved_or_default_tab` after building tabs.
- Handles stale saved IDs by falling back to the first visible tab in the saved tab order.
- Updates `docs/PROFILES.md` to document the behaviour.

## Testing

- `test_main_window_persists_selected_tab` – switching between device/combo tabs persists the correct identifier.
- `test_main_window_applies_saved_selected_device_tab_on_load` – saved device tab is restored after window rebuild.
- `test_main_window_applies_saved_selected_combo_tab_on_load` – saved combos tab is restored after window rebuild.
- `test_main_window_invalid_selected_tab_falls_back_to_saved_order` – stale device ID falls back to first tab in saved order.
- `test_gui_tab_layout_preference_round_trips_with_appearance` – preference round‑trip handles whitespace and empty strings.