### PR TITLE
Remove per-type recording toggles; prune stale device overrides

### DIFF
--- a/keymasq/session/manager/recording.py
+++ b/keymasq/session/manager/recording.py
@@ -1057,18 +1057,13 @@ def update_recording_settings(manager: "SessionManager", request: JsonObject) ->
         settings["include_mouse_clicks"] = bool(request.get("include_mouse_clicks"))
     if "record_start_position" in request:
         settings["record_start_position"] = bool(request.get("record_start_position"))
-    if "record_keyboard" in request:
-        settings["record_keyboard"] = bool(request.get("record_keyboard"))
-    if "record_mouse" in request:
-        settings["record_mouse"] = bool(request.get("record_mouse"))
-    if "record_gamepad" in request:
-        settings["record_gamepad"] = bool(request.get("record_gamepad"))
     if "device_overrides" in request:
         overrides = json_object(request.get("device_overrides"))
         if overrides is not None:
             settings["device_overrides"] = {
                 str(recording_id): bool(enabled) for recording_id, enabled in overrides.items()
             }
+    prune_stale_recording_device_overrides(manager, settings)
     update_selected_recording_devices_cache(manager)
     queue_recording_settings_save(manager, dict(settings))
 
@@ -1106,9 +1101,6 @@ def load_recording_settings_from_disk(manager: "SessionManager") -> None:
         settings["include_mouse_movement"] = bool(data.get("include_mouse_movement", False))
         settings["include_mouse_clicks"] = bool(data.get("include_mouse_clicks", False))
         settings["record_start_position"] = bool(data.get("record_start_position", False))
-        settings["record_keyboard"] = bool(data.get("record_keyboard", True))
-        settings["record_mouse"] = bool(data.get("record_mouse", False))
-        settings["record_gamepad"] = bool(data.get("record_gamepad", True))
         overrides = json_object(data.get("device_overrides"))
         if overrides is not None:
             settings["device_overrides"] = {
@@ -1131,9 +1123,6 @@ def save_recording_settings_to_disk(
             "include_mouse_movement": bool(settings.get("include_mouse_movement", False)),
             "include_mouse_clicks": bool(settings.get("include_mouse_clicks", False)),
             "record_start_position": bool(settings.get("record_start_position", False)),
-            "record_keyboard": bool(settings.get("record_keyboard", True)),
-            "record_mouse": bool(settings.get("record_mouse", False)),
-            "record_gamepad": bool(settings.get("record_gamepad", True)),
             "device_overrides": {
                 str(recording_id): bool(enabled)
                 for recording_id, enabled in (
@@ -1150,6 +1139,33 @@ def save_recording_settings_to_disk(
             "Failed to save recording settings to %s",
             manager.RECORDING_SETTINGS_PATH,
         )
+
+
+def prune_stale_recording_device_overrides(
+    manager: "SessionManager",
+    settings: JsonObject | None = None,
+) -> None:
+    if not manager.recording_state.devices_cache_ready:
+        return
+
+    known_ids = {
+        recording_id
+        for device in manager.recording_state.devices_cache
+        if (recording_id := _recording_device_id(device))
+    }
+    if not known_ids:
+        return
+
+    settings = settings or manager.recording_state.settings
+    overrides = json_object(settings.get("device_overrides")) or {}
+    if not overrides:
+        return
+
+    settings["device_overrides"] = {
+        str(recording_id): bool(enabled)
+        for recording_id, enabled in overrides.items()
+        if str(recording_id) in known_ids
+    }
 
 
 async def start_recording(

--- a/keymasq/session/manager/recording.py
+++ b/keymasq/session/manager/recording.py
@@ -1148,17 +1148,19 @@ def prune_stale_recording_device_overrides(
     if not manager.recording_state.devices_cache_ready:
         return
 
+    settings = settings if settings is not None else manager.recording_state.settings
     known_ids = {
         recording_id
         for device in manager.recording_state.devices_cache
         if (recording_id := _recording_device_id(device))
     }
     if not known_ids:
+        settings["device_overrides"] = {}
         return
 
-    settings = settings or manager.recording_state.settings
-    overrides = json_object(settings.get("device_overrides")) or {}
+    overrides = json_object(settings.get("device_overrides"))
     if not overrides:
+        settings["device_overrides"] = {}
         return
 
     settings["device_overrides"] = {

--- a/keymasq/session/manager/state.py
+++ b/keymasq/session/manager/state.py
@@ -14,9 +14,6 @@ def default_recording_settings() -> JsonObject:
         "include_mouse_movement": False,
         "include_mouse_clicks": False,
         "record_start_position": False,
-        "record_keyboard": True,
-        "record_mouse": False,
-        "record_gamepad": True,
         "device_overrides": {},
     }
 

--- a/tests/gui/test_gui_demo_and_dialogs.py
+++ b/tests/gui/test_gui_demo_and_dialogs.py
@@ -178,7 +178,7 @@ class TestRecordMacroDialog:
             },
             {
                 "path": "/dev/input/event0",
-                "recording_id": "physical:/dev/input/by-id/raw-mouse",
+                "recording_id": "physical:/dev/input/by-id/usb-Test_Mouse-event-mouse",
                 "recording_kind": "physical",
                 "device_type": "mouse",
                 "device_types": ["mouse"],
@@ -189,7 +189,12 @@ class TestRecordMacroDialog:
         dialog._populate_device_list()
 
         assert dialog._device_checks["keymasq:output:keyboard"].get_active() is True
-        assert dialog._device_checks["physical:/dev/input/by-id/raw-mouse"].get_active() is False
+        assert (
+            dialog._device_checks[
+                "physical:/dev/input/by-id/usb-Test_Mouse-event-mouse"
+            ].get_active()
+            is False
+        )
         assert dialog._selection_summary.get_label() == "1 selected (1kb)"
 
     def test_record_dialog_source_row_activation_toggles_checkbox(self, monkeypatch):
@@ -214,7 +219,7 @@ class TestRecordMacroDialog:
             },
             {
                 "path": "/dev/input/event0",
-                "recording_id": "physical:/dev/input/by-id/raw-mouse",
+                "recording_id": "physical:/dev/input/by-id/usb-Test_Mouse-event-mouse",
                 "recording_kind": "physical",
                 "device_type": "mouse",
                 "device_types": ["mouse"],
@@ -227,19 +232,34 @@ class TestRecordMacroDialog:
         raw_row = None
         row = dialog._device_listbox.get_first_child()
         while row is not None:
-            if getattr(row, "_recording_id", "") == "physical:/dev/input/by-id/raw-mouse":
+            if (
+                getattr(row, "_recording_id", "")
+                == "physical:/dev/input/by-id/usb-Test_Mouse-event-mouse"
+            ):
                 raw_row = row
                 break
             row = row.get_next_sibling()
 
         assert raw_row is not None
         dialog._on_device_row_activated(dialog._device_listbox, raw_row)
-        assert dialog._device_checks["physical:/dev/input/by-id/raw-mouse"].get_active() is True
-        assert dialog._device_overrides == {"physical:/dev/input/by-id/raw-mouse": True}
+        assert (
+            dialog._device_checks[
+                "physical:/dev/input/by-id/usb-Test_Mouse-event-mouse"
+            ].get_active()
+            is True
+        )
+        assert dialog._device_overrides == {
+            "physical:/dev/input/by-id/usb-Test_Mouse-event-mouse": True
+        }
         assert dialog._selection_summary.get_label() == "2 selected (1kb, 1m)"
 
         dialog._on_device_row_activated(dialog._device_listbox, raw_row)
-        assert dialog._device_checks["physical:/dev/input/by-id/raw-mouse"].get_active() is False
+        assert (
+            dialog._device_checks[
+                "physical:/dev/input/by-id/usb-Test_Mouse-event-mouse"
+            ].get_active()
+            is False
+        )
         assert dialog._device_overrides == {}
         assert dialog._selection_summary.get_label() == "1 selected (1kb)"
 
@@ -271,7 +291,7 @@ class TestRecordMacroDialog:
             },
             {
                 "path": "/dev/input/event0",
-                "recording_id": "physical:/dev/input/by-id/raw-mouse",
+                "recording_id": "physical:/dev/input/by-id/usb-Test_Mouse-event-mouse",
                 "recording_kind": "physical",
                 "device_type": "mouse",
                 "device_types": ["mouse"],
@@ -283,12 +303,22 @@ class TestRecordMacroDialog:
         assert dialog._selection_warning.get_visible() is True
 
         dialog._on_select_type_clicked(Gtk.Button(), "mouse", True)
-        assert dialog._device_checks["physical:/dev/input/by-id/raw-mouse"].get_active() is True
+        assert (
+            dialog._device_checks[
+                "physical:/dev/input/by-id/usb-Test_Mouse-event-mouse"
+            ].get_active()
+            is True
+        )
         assert dialog._selection_summary.get_label() == "2 selected (1kb, 1m)"
         assert dialog._selection_warning.get_visible() is False
 
         dialog._on_reset_to_recommended_clicked(Gtk.Button())
-        assert dialog._device_checks["physical:/dev/input/by-id/raw-mouse"].get_active() is False
+        assert (
+            dialog._device_checks[
+                "physical:/dev/input/by-id/usb-Test_Mouse-event-mouse"
+            ].get_active()
+            is False
+        )
         assert dialog._selection_warning.get_visible() is True
 
     def test_record_dialog_reset_sync_wins_over_inflight_selection(self, monkeypatch):
@@ -316,7 +346,9 @@ class TestRecordMacroDialog:
         monkeypatch.setattr(record_macro_dialog_module, "session_request", fake_session_request)
 
         dialog = RecordMacroDialog(Gtk.Window())
-        dialog._device_overrides = {"physical:/dev/input/by-id/raw-mouse": True}
+        dialog._device_overrides = {
+            "physical:/dev/input/by-id/usb-Test_Mouse-event-mouse": True
+        }
 
         dialog._sync_settings_async()
         assert first_started.wait(2.0)
@@ -335,7 +367,7 @@ class TestRecordMacroDialog:
             pytest.fail("settings sync worker did not finish")
 
         assert [payload["device_overrides"] for payload in captured_payloads] == [
-            {"physical:/dev/input/by-id/raw-mouse": True},
+            {"physical:/dev/input/by-id/usb-Test_Mouse-event-mouse": True},
             {},
         ]
 

--- a/tests/session/test_session_manager_recording_settings.py
+++ b/tests/session/test_session_manager_recording_settings.py
@@ -396,6 +396,36 @@ async def test_update_recording_settings_prunes_stale_device_overrides() -> None
 
 
 @pytest.mark.asyncio
+async def test_update_recording_settings_clears_overrides_when_cache_is_empty() -> None:
+    manager = SessionManager()
+    manager.recording_state.settings = {
+        "include_mouse_movement": False,
+        "include_mouse_clicks": False,
+        "record_start_position": False,
+        "device_overrides": {
+            "physical:/dev/input/by-id/stale-mouse": True,
+        },
+    }
+    manager.recording_state.devices_cache_ready = True
+    manager.recording_state.devices_cache = []
+
+    session_recording_module.update_recording_settings(
+        manager,
+        {
+            "device_overrides": {
+                "physical:/dev/input/by-id/stale-mouse": True,
+            }
+        },
+    )
+
+    assert manager.recording_state.settings["device_overrides"] == {}
+
+    save_task = cast(asyncio.Task[None] | None, manager.recording_state.settings_save_task)
+    if save_task is not None:
+        await save_task
+
+
+@pytest.mark.asyncio
 async def test_start_recording_blocks_when_macro_save_is_pending() -> None:
     manager = SessionManager()
     manager.send_notification = Mock()  # type: ignore[method-assign]

--- a/tests/session/test_session_manager_recording_settings.py
+++ b/tests/session/test_session_manager_recording_settings.py
@@ -91,9 +91,20 @@ def test_recording_settings_save_load_toml_uses_recording_ids(tmp_path) -> None:
         "include_mouse_movement": True,
         "include_mouse_clicks": True,
         "record_start_position": True,
+        # Legacy fields may still exist in old in-memory/test payloads, but new
+        # TOML writes should prune them.
         "record_keyboard": False,
         "record_mouse": True,
         "record_gamepad": False,
+        "device_overrides": {
+            "keymasq:passthrough:1234:5678:mouse": True,
+            "physical:/dev/input/by-id/usb-test-event-mouse": False,
+        },
+    }
+    expected = {
+        "include_mouse_movement": True,
+        "include_mouse_clicks": True,
+        "record_start_position": True,
         "device_overrides": {
             "keymasq:passthrough:1234:5678:mouse": True,
             "physical:/dev/input/by-id/usb-test-event-mouse": False,
@@ -104,13 +115,13 @@ def test_recording_settings_save_load_toml_uses_recording_ids(tmp_path) -> None:
 
     with manager.RECORDING_SETTINGS_PATH.open("rb") as f:
         written = tomllib.load(f)
-    assert written == manager.recording_state.settings
+    assert written == expected
 
     loaded_manager = SessionManager()
     loaded_manager.RECORDING_SETTINGS_PATH = manager.RECORDING_SETTINGS_PATH
     session_recording_module.load_recording_settings_from_disk(loaded_manager)
 
-    assert loaded_manager.recording_state.settings == manager.recording_state.settings
+    assert loaded_manager.recording_state.settings == expected
 
 
 def test_recording_settings_load_logs_errors(tmp_path, caplog) -> None:
@@ -168,9 +179,6 @@ async def test_start_recording_sends_selected_devices_from_cache() -> None:
         "include_mouse_movement": False,
         "include_mouse_clicks": False,
         "record_start_position": False,
-        "record_keyboard": True,
-        "record_mouse": False,
-        "record_gamepad": False,
         "device_overrides": {
             "keymasq:passthrough:1234:5678:kbd": True,
             "physical:/dev/input/by-id/usb-raw-event-kbd": False,
@@ -319,7 +327,7 @@ async def test_update_recording_settings_recomputes_selected_devices_cache() -> 
         },
         {
             "path": "/dev/input/event21",
-            "recording_id": "physical:/dev/input/by-id/raw-mouse",
+            "recording_id": "physical:/dev/input/by-id/usb-Test_Mouse-event-mouse",
             "recording_kind": "physical",
             "device_type": "mouse",
             "device_types": ["mouse"],
@@ -332,12 +340,55 @@ async def test_update_recording_settings_recomputes_selected_devices_cache() -> 
 
     session_recording_module.update_recording_settings(
         manager,
-        {"device_overrides": {"physical:/dev/input/by-id/raw-mouse": True}},
+        {
+            "device_overrides": {
+                "physical:/dev/input/by-id/usb-Test_Mouse-event-mouse": True
+            }
+        },
     )
 
     assert [
         device["recording_id"] for device in manager.recording_state.selected_devices_cache
-    ] == ["keymasq:output:keyboard", "physical:/dev/input/by-id/raw-mouse"]
+    ] == ["keymasq:output:keyboard", "physical:/dev/input/by-id/usb-Test_Mouse-event-mouse"]
+
+    save_task = cast(asyncio.Task[None] | None, manager.recording_state.settings_save_task)
+    if save_task is not None:
+        await save_task
+
+
+@pytest.mark.asyncio
+async def test_update_recording_settings_prunes_stale_device_overrides() -> None:
+    manager = SessionManager()
+    manager.recording_state.settings = {
+        "include_mouse_movement": False,
+        "include_mouse_clicks": False,
+        "record_start_position": False,
+        "device_overrides": {},
+    }
+    manager.recording_state.devices_cache_ready = True
+    manager.recording_state.devices_cache = [
+        {
+            "path": "/dev/input/event20",
+            "recording_id": "keymasq:output:keyboard",
+            "recording_kind": "keymasq_output",
+            "device_type": "keyboard",
+            "device_types": ["keyboard"],
+        },
+    ]
+
+    session_recording_module.update_recording_settings(
+        manager,
+        {
+            "device_overrides": {
+                "keymasq:output:keyboard": False,
+                "physical:/dev/input/by-id/stale-mouse": True,
+            }
+        },
+    )
+
+    assert manager.recording_state.settings["device_overrides"] == {
+        "keymasq:output:keyboard": False
+    }
 
     save_task = cast(asyncio.Task[None] | None, manager.recording_state.settings_save_task)
     if save_task is not None:


### PR DESCRIPTION
## Summary

- Removed the `record_keyboard`, `record_mouse`, and `record_gamepad` settings. Per-device overrides now provide equivalent control without redundant global toggles.
- Added `prune_stale_recording_device_overrides()` to automatically clean up overrides for devices that are no longer present in the device cache.
- Updated in-memory defaults, load/save paths, and the `update_recording_settings` handler to reflect the removed fields.
- Fixed test fixtures to use realistic recording IDs and added dedicated test coverage for the pruning logic.

## Testing

- Verified existing session manager and GUI unit tests pass with updated assertions
- Added `test_update_recording_settings_prunes_stale_device_overrides` to confirm stale overrides are removed during settings update
- Confirmed TOML save/load roundtrip no longer writes or reads the removed per-type fields
- Full lint/type check (`./scripts/check.sh`):  run