### PR TITLE
Add custom gamepad button and axis fields to key selector

### DIFF
--- a/docs/ACTIONS.md
+++ b/docs/ACTIONS.md
@@ -194,6 +194,14 @@ Map to a gamepad button, trigger axis, or stick axis. Available inputs include:
 
 ![Gamepad tab — face buttons, shoulders, triggers, D-pad, and sticks](assets/screenshots/key_selector_gamepad.png)
 
+To map a button outside the template, use the **Button code** field below the
+controller diagram. It accepts an evdev button name (such as `btn_c` or
+`btn_trigger_happy1`) or a numeric key code (decimal or `0x`-prefixed), and
+routes through the same output selected above. This is an advanced option: the
+chosen output must actually support the button code for it to emit. Hardware
+gamepad outputs expose whatever buttons the physical device advertises, while
+the virtual gamepad outputs advertise the standard Xbox 360 button set.
+
 Gamepad actions can route to a specific output with `output_id`. Use
 `virtual-gamepad-1` through `virtual-gamepad-4` for configured virtual Xbox
 360 outputs, or a configured hardware gamepad ID such as `045e:028e@2`.
@@ -206,6 +214,13 @@ or `abs_rz`, and a raw evdev `value`. Stick axes accept `-32768..32767`;
 trigger axes accept `0..255`. Releasing the source input returns the axis to
 neutral `0`. LT and RT are axis actions (`abs_z` and `abs_rz`); `gamepad`
 actions are button-only.
+
+To target an axis outside the template, pick **Custom** in the axis dropdown
+and enter an evdev axis name (such as `abs_hat0x`, `abs_hat0y`, `abs_throttle`,
+or `abs_rudder`) or a numeric code, then enter the raw value to send. As with
+custom buttons, the chosen output must support the axis for it to emit; the
+virtual gamepad outputs include the standard stick, trigger, and `abs_hat0`
+axes.
 
 ## Analog Controls
 

--- a/keymasq/common/gamepad_axes.py
+++ b/keymasq/common/gamepad_axes.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+import evdev
+
 
 @dataclass(frozen=True)
 class GamepadAxisRange:
@@ -36,6 +38,14 @@ GAMEPAD_AXIS_ALIASES = {
 }
 
 
+def _is_custom_abs_axis(target: str) -> bool:
+    """Return True for a valid evdev ABS axis outside the standard template."""
+    if not target.startswith("abs_"):
+        return False
+    code = getattr(evdev.ecodes, target.upper(), None)
+    return isinstance(code, int) and code in evdev.ecodes.ABS
+
+
 def normalize_gamepad_axis_target(value: object) -> str | None:
     target = str(value or "").strip().lower()
     if not target:
@@ -45,7 +55,13 @@ def normalize_gamepad_axis_target(value: object) -> str | None:
         return target
     if target.startswith("abs"):
         target = f"abs_{target.removeprefix('abs').lstrip('_')}"
-    return GAMEPAD_AXIS_ALIASES.get(target, target if target in GAMEPAD_AXIS_RANGES else None)
+    normalized = GAMEPAD_AXIS_ALIASES.get(
+        target, target if target in GAMEPAD_AXIS_RANGES else None
+    )
+    if normalized is not None:
+        return normalized
+    # Advanced: accept any valid custom ABS axis code outside the template.
+    return target if _is_custom_abs_axis(target) else None
 
 
 def gamepad_axis_range(target: object) -> GamepadAxisRange | None:
@@ -62,12 +78,13 @@ def gamepad_axis_max_value(target: object) -> int:
 
 def clamp_gamepad_axis_value(target: object, value: object) -> int:
     axis_range = gamepad_axis_range(target)
-    if axis_range is None:
-        return 0
     try:
         raw_value = int(value)  # type: ignore[arg-type]
     except (TypeError, ValueError):
-        raw_value = axis_range.maximum
+        raw_value = axis_range.maximum if axis_range is not None else 0
+    if axis_range is None:
+        # Custom axes have no known range; pass the value through unclamped.
+        return raw_value if normalize_gamepad_axis_target(target) else 0
     return max(axis_range.minimum, min(axis_range.maximum, raw_value))
 
 

--- a/keymasq/gui/widgets/input_picker_shared.py
+++ b/keymasq/gui/widgets/input_picker_shared.py
@@ -423,19 +423,6 @@ def _build_gamepad_center_col(owner) -> Gtk.Box:
     box.set_valign(Gtk.Align.CENTER)
     box.set_hexpand(True)
 
-    svg_pic = Gtk.Picture()
-    svg_pic.set_halign(Gtk.Align.CENTER)
-    svg_pic.set_can_shrink(True)
-    svg_pic.set_size_request(260, 195)
-
-    try:
-        texture = Gdk.Texture.new_from_filename(_get_gamepad_svg_path())
-        svg_pic.set_paintable(texture)
-    except Exception:
-        pass
-
-    box.append(svg_pic)
-
     center_btns = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=8)
     center_btns.set_halign(Gtk.Align.CENTER)
 
@@ -449,7 +436,48 @@ def _build_gamepad_center_col(owner) -> Gtk.Box:
         center_btns.append(btn)
 
     box.append(center_btns)
+
+    svg_pic = Gtk.Picture()
+    svg_pic.set_halign(Gtk.Align.CENTER)
+    svg_pic.set_can_shrink(True)
+    svg_pic.set_size_request(260, 170)
+
+    try:
+        texture = Gdk.Texture.new_from_filename(_get_gamepad_svg_path())
+        svg_pic.set_paintable(texture)
+    except Exception:
+        pass
+
+    box.append(svg_pic)
+
+    if hasattr(owner, "_on_gamepad_code_clicked"):
+        box.append(_build_gamepad_code_row(owner))
+
     return box
+
+
+def _build_gamepad_code_row(owner) -> Gtk.Box:
+    row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=6)
+    row.set_halign(Gtk.Align.CENTER)
+
+    row.append(Gtk.Label(label="Button code:"))
+
+    entry = Gtk.Entry()
+    entry.set_placeholder_text("e.g. 305 or btn_c")
+    entry.set_width_chars(14)
+    entry.set_tooltip_text(
+        "Map a button outside the template by evdev name (e.g. btn_tl2, btn_tr2 "
+        "for digital triggers, btn_c, btn_trigger_happy1) or numeric code."
+    )
+    entry.connect("activate", owner._on_gamepad_code_clicked)
+    owner.gamepad_code_entry = entry
+    row.append(entry)
+
+    map_btn = Gtk.Button(label="Map Code")
+    map_btn.connect("clicked", owner._on_gamepad_code_clicked)
+    row.append(map_btn)
+
+    return row
 
 
 def _build_gamepad_right_col(owner) -> Gtk.Box:

--- a/keymasq/gui/widgets/key_selector_dialog.py
+++ b/keymasq/gui/widgets/key_selector_dialog.py
@@ -16,12 +16,13 @@ from gi.repository import (  # pyright: ignore[reportAttributeAccessIssue]
 )
 
 from keymasq import __version__
-from keymasq.common.devices import is_gamepad_button_name
+from keymasq.common.devices import is_gamepad_button_name, resolve_evdev_code
 from keymasq.common.gamepad_axes import (
     GAMEPAD_AXIS_RANGES,
     gamepad_axis_percent_from_value,
     gamepad_axis_range,
     gamepad_axis_value_from_percent,
+    normalize_gamepad_axis_target,
 )
 from keymasq.common.models import (
     DEFAULT_REPEAT_CATEGORIES,
@@ -125,6 +126,62 @@ def _format_current_virtual_output_choice(output_id: str) -> str:
     if is_virtual_gamepad_output_id(output_id):
         return f"{output_id} (unavailable)"
     return f"{output_id} (unknown)"
+
+
+def _resolve_gamepad_button_target(raw: str) -> str | None:
+    """Resolve free-form button input to a canonical evdev button name.
+
+    Accepts an evdev button name (e.g. ``btn_c``, ``btn_trigger_happy1``) or a
+    numeric key code (decimal or ``0x``-prefixed). Returns a lowercase ``btn_*``
+    name, or ``None`` when the input is not a recognized button code.
+    """
+    text = (raw or "").strip().lower()
+    if not text:
+        return None
+
+    if text.startswith("btn_"):
+        return text if resolve_evdev_code(text) is not None else None
+
+    try:
+        code = int(text, 0)
+    except ValueError:
+        return None
+
+    names = evdev.ecodes.BTN.get(code)
+    if isinstance(names, (list, tuple)):
+        # evdev orders aliases oldest-first; the last name is the canonical
+        # modern label (e.g. BTN_SOUTH over BTN_A).
+        names = names[-1] if names else None
+    if isinstance(names, str) and names.startswith("BTN_"):
+        return names.lower()
+    return None
+
+
+def _resolve_gamepad_axis_target(raw: str) -> str | None:
+    """Resolve free-form axis input to a canonical evdev ABS name.
+
+    Accepts an evdev axis name (e.g. ``abs_hat0x``, ``abs_throttle``) or a
+    numeric ABS code (decimal or ``0x``-prefixed). Returns a lowercase ``abs_*``
+    name, or ``None`` when the input is not a recognized axis code.
+    """
+    text = (raw or "").strip().lower()
+    if not text:
+        return None
+
+    if text.startswith("abs_"):
+        return text if resolve_evdev_code(text) is not None else None
+
+    try:
+        code = int(text, 0)
+    except ValueError:
+        return None
+
+    names = evdev.ecodes.ABS.get(code)
+    if isinstance(names, (list, tuple)):
+        names = names[-1] if names else None
+    if isinstance(names, str) and names.startswith("ABS_"):
+        return names.lower()
+    return None
 
 
 def _is_hardware_gamepad(config: object) -> bool:
@@ -476,22 +533,38 @@ def _ensure_compact_tabs_css() -> None:
     _compact_tabs_css_installed = True
 
 
+_GAMEPAD_AXIS_CUSTOM_SLOT = "custom"
+
+
 class _GamepadAxisControlsMixin:
     gamepad_axis_targets: list[str]
     gamepad_axis_dropdown: Gtk.DropDown
+    gamepad_axis_custom_entry: Gtk.Entry
     gamepad_axis_value: Gtk.SpinButton
     gamepad_axis_percent: Gtk.SpinButton
+    gamepad_axis_percent_label: Gtk.Label
+    gamepad_code_entry: Gtk.Entry
     _syncing_gamepad_axis_controls: bool
 
     def _build_gamepad_axis_controls(self) -> Gtk.Widget:
         row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=8)
         row.set_halign(Gtk.Align.CENTER)
 
-        self.gamepad_axis_targets = list(GAMEPAD_AXIS_RANGES)
-        labels = [GAMEPAD_AXIS_RANGES[target].label for target in self.gamepad_axis_targets]
+        self.gamepad_axis_targets = [*GAMEPAD_AXIS_RANGES, _GAMEPAD_AXIS_CUSTOM_SLOT]
+        labels = [GAMEPAD_AXIS_RANGES[target].label for target in GAMEPAD_AXIS_RANGES]
+        labels.append("Custom")
         self.gamepad_axis_dropdown = Gtk.DropDown.new_from_strings(labels)
         self.gamepad_axis_dropdown.connect("notify::selected", self._on_gamepad_axis_changed)
         row.append(self.gamepad_axis_dropdown)
+
+        self.gamepad_axis_custom_entry = Gtk.Entry()
+        self.gamepad_axis_custom_entry.set_placeholder_text("abs_ code")
+        self.gamepad_axis_custom_entry.set_width_chars(11)
+        self.gamepad_axis_custom_entry.set_tooltip_text(
+            "Custom axis evdev name (e.g. abs_hat0x, abs_hat0y, abs_throttle, "
+            "abs_rudder) or numeric code."
+        )
+        row.append(self.gamepad_axis_custom_entry)
 
         self.gamepad_axis_value = Gtk.SpinButton()
         self.gamepad_axis_value.set_numeric(True)
@@ -507,7 +580,8 @@ class _GamepadAxisControlsMixin:
         self.gamepad_axis_percent.set_tooltip_text("Percent")
         self.gamepad_axis_percent.connect("value-changed", self._on_gamepad_axis_percent_changed)
         row.append(self.gamepad_axis_percent)
-        row.append(Gtk.Label(label="%"))
+        self.gamepad_axis_percent_label = Gtk.Label(label="%")
+        row.append(self.gamepad_axis_percent_label)
 
         apply_btn = Gtk.Button(label="Map Analog")
         apply_btn.add_css_class("suggested-action")
@@ -517,15 +591,40 @@ class _GamepadAxisControlsMixin:
         self._on_gamepad_axis_changed(self.gamepad_axis_dropdown, None)
         return row
 
-    def _selected_gamepad_axis_target(self) -> str:
+    def _selected_gamepad_axis_slot(self) -> str:
         index = int(self.gamepad_axis_dropdown.get_selected())
         if index < 0 or index >= len(self.gamepad_axis_targets):
             return "abs_x"
         return self.gamepad_axis_targets[index]
 
+    def _selected_gamepad_axis_target(self) -> str | None:
+        slot = self._selected_gamepad_axis_slot()
+        if slot == _GAMEPAD_AXIS_CUSTOM_SLOT:
+            return _resolve_gamepad_axis_target(self.gamepad_axis_custom_entry.get_text())
+        return slot
+
     def _on_gamepad_axis_changed(self, dropdown, _param) -> None:
-        target = self._selected_gamepad_axis_target()
-        axis = gamepad_axis_range(target)
+        is_custom = self._selected_gamepad_axis_slot() == _GAMEPAD_AXIS_CUSTOM_SLOT
+        self.gamepad_axis_custom_entry.set_visible(is_custom)
+        self.gamepad_axis_percent.set_visible(not is_custom)
+        self.gamepad_axis_percent_label.set_visible(not is_custom)
+
+        if is_custom:
+            current = int(self.gamepad_axis_value.get_value())
+            self._syncing_gamepad_axis_controls = True
+            self.gamepad_axis_value.set_adjustment(
+                Gtk.Adjustment(
+                    value=current,
+                    lower=-2147483648,
+                    upper=2147483647,
+                    step_increment=1,
+                    page_increment=256,
+                )
+            )
+            self._syncing_gamepad_axis_controls = False
+            return
+
+        axis = gamepad_axis_range(self._selected_gamepad_axis_slot())
         if axis is None:
             return
         self._syncing_gamepad_axis_controls = True
@@ -548,6 +647,8 @@ class _GamepadAxisControlsMixin:
         if getattr(self, "_syncing_gamepad_axis_controls", False):
             return
         target = self._selected_gamepad_axis_target()
+        if target is None:
+            return
         self._syncing_gamepad_axis_controls = True
         self.gamepad_axis_value.set_value(
             gamepad_axis_value_from_percent(target, spin.get_value())
@@ -557,7 +658,11 @@ class _GamepadAxisControlsMixin:
     def _on_gamepad_axis_value_changed(self, spin: Gtk.SpinButton) -> None:
         if getattr(self, "_syncing_gamepad_axis_controls", False):
             return
+        if self._selected_gamepad_axis_slot() == _GAMEPAD_AXIS_CUSTOM_SLOT:
+            return
         target = self._selected_gamepad_axis_target()
+        if target is None:
+            return
         self._syncing_gamepad_axis_controls = True
         self.gamepad_axis_percent.set_value(
             gamepad_axis_percent_from_value(target, spin.get_value())
@@ -565,11 +670,48 @@ class _GamepadAxisControlsMixin:
         self._syncing_gamepad_axis_controls = False
 
     def _on_gamepad_axis_apply_clicked(self, btn) -> None:
+        target = self._selected_gamepad_axis_target()
+        if not target:
+            self.gamepad_axis_custom_entry.set_text("")
+            self.gamepad_axis_custom_entry.set_placeholder_text("Unknown axis code")
+            return
         self._on_gamepad_axis_clicked(
             btn,
-            self._selected_gamepad_axis_target(),
+            target,
             int(self.gamepad_axis_value.get_value()),
         )
+
+    def _prefill_gamepad_inputs(self) -> None:
+        """Restore the code/axis fields when editing an existing gamepad action."""
+        action = getattr(self, "_current_action", None)
+        if action is None:
+            return
+        action_type = getattr(action, "action_type", None)
+        target = str(getattr(action, "target", "") or "")
+
+        if action_type == ActionType.GAMEPAD:
+            # Pre-fill the free-form code field for buttons outside the template.
+            if target and target not in EVDEV_TO_GAMEPAD and hasattr(self, "gamepad_code_entry"):
+                self.gamepad_code_entry.set_text(target)
+            return
+
+        if action_type == ActionType.GAMEPAD_AXIS:
+            self._prefill_gamepad_axis(target, int(getattr(action, "axis_value", 0) or 0))
+
+    def _prefill_gamepad_axis(self, target: str, value: int) -> None:
+        normalized = normalize_gamepad_axis_target(target) or target
+        if normalized in GAMEPAD_AXIS_RANGES:
+            self.gamepad_axis_dropdown.set_selected(
+                self.gamepad_axis_targets.index(normalized)
+            )
+        elif _resolve_gamepad_axis_target(normalized):
+            self.gamepad_axis_dropdown.set_selected(
+                self.gamepad_axis_targets.index(_GAMEPAD_AXIS_CUSTOM_SLOT)
+            )
+            self.gamepad_axis_custom_entry.set_text(normalized)
+        else:
+            return
+        self.gamepad_axis_value.set_value(value)
 
     def _on_gamepad_axis_clicked(self, btn, axis_target: str, axis_value: int) -> None:
         raise NotImplementedError
@@ -1429,6 +1571,7 @@ class KeySelectorDialog(Adw.Dialog, _GamepadAxisControlsMixin):
         box.append(warning)
         box.append(build_shared_gamepad_tab(self))
         self._update_gamepad_output_warning()
+        self._prefill_gamepad_inputs()
         return box
 
     def _build_gamepad_output_header(self) -> Gtk.Widget | None:
@@ -2003,6 +2146,14 @@ class KeySelectorDialog(Adw.Dialog, _GamepadAxisControlsMixin):
         )
         self.emit("key-selected", action)
         self.close()
+
+    def _on_gamepad_code_clicked(self, widget) -> None:
+        evdev_name = _resolve_gamepad_button_target(self.gamepad_code_entry.get_text())
+        if not evdev_name:
+            self.gamepad_code_entry.set_text("")
+            self.gamepad_code_entry.set_placeholder_text("Unknown button code")
+            return
+        self._on_gamepad_clicked(widget, evdev_name)
 
     def _build_macro_tab(self) -> Gtk.Widget:
         outer = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=0)
@@ -3500,6 +3651,14 @@ class SuperkeyActionDialog(Adw.Dialog, _GamepadAxisControlsMixin):
         self.emit("action-selected", action)
         self.close()
 
+    def _on_gamepad_code_clicked(self, widget) -> None:
+        evdev_name = _resolve_gamepad_button_target(self.gamepad_code_entry.get_text())
+        if not evdev_name:
+            self.gamepad_code_entry.set_text("")
+            self.gamepad_code_entry.set_placeholder_text("Unknown button code")
+            return
+        self._on_gamepad_clicked(widget, evdev_name)
+
     def _set_initial_tab(self):
         if not self._current_action:
             return
@@ -3583,6 +3742,7 @@ class SuperkeyActionDialog(Adw.Dialog, _GamepadAxisControlsMixin):
         outer.append(warning)
         outer.append(build_shared_gamepad_tab(self))
         self._update_gamepad_output_warning()
+        self._prefill_gamepad_inputs()
         return outer
 
     def _gamepad_output_choices(self) -> list[tuple[str | None, str]]:

--- a/keymasq/keymasqd/output_helpers.py
+++ b/keymasq/keymasqd/output_helpers.py
@@ -72,9 +72,12 @@ def resolve_gamepad_axis_code(target: str | None) -> int | None:
 
     target_lower = target.strip().lower()
     axis_range = gamepad_axis_range(normalize_gamepad_axis_target(target_lower))
-    if axis_range is None:
-        return None
-    return _ecode_value(axis_range.evdev_name)
+    if axis_range is not None:
+        return _ecode_value(axis_range.evdev_name)
+    # Advanced: resolve any custom ABS axis code outside the standard template.
+    if target_lower.startswith("abs_"):
+        return _ecode_value(target_lower.upper())
+    return None
 
 
 def emit_mouse_move(

--- a/tests/gui/test_gui_device_tab_misc.py
+++ b/tests/gui/test_gui_device_tab_misc.py
@@ -1576,6 +1576,163 @@ def test_key_selector_dialog_map_code_handles_valid_and_invalid_input():
     assert invalid_dialog.kb_code_entry.get_placeholder_text() == "Unknown key code"
 
 
+def test_resolve_gamepad_button_target_accepts_names_and_codes():
+    from keymasq.gui.widgets.key_selector_dialog import _resolve_gamepad_button_target
+
+    assert _resolve_gamepad_button_target("btn_c") == "btn_c"
+    assert _resolve_gamepad_button_target("  BTN_Z ") == "btn_z"
+    assert _resolve_gamepad_button_target("btn_trigger_happy1") == "btn_trigger_happy1"
+    assert _resolve_gamepad_button_target("305") == "btn_east"
+    assert _resolve_gamepad_button_target("0x132") == "btn_c"
+    # Non-button codes and garbage are rejected.
+    assert _resolve_gamepad_button_target("125") is None
+    assert _resolve_gamepad_button_target("key_a") is None
+    assert _resolve_gamepad_button_target("abs_x") is None
+    assert _resolve_gamepad_button_target("not-a-button") is None
+    assert _resolve_gamepad_button_target("") is None
+
+
+def test_resolve_gamepad_axis_target_accepts_names_and_codes():
+    from keymasq.gui.widgets.key_selector_dialog import _resolve_gamepad_axis_target
+
+    assert _resolve_gamepad_axis_target("abs_hat0x") == "abs_hat0x"
+    assert _resolve_gamepad_axis_target("  ABS_THROTTLE ") == "abs_throttle"
+    assert _resolve_gamepad_axis_target("16") == "abs_hat0x"
+    assert _resolve_gamepad_axis_target("0x10") == "abs_hat0x"
+    assert _resolve_gamepad_axis_target("btn_c") is None
+    assert _resolve_gamepad_axis_target("key_a") is None
+    assert _resolve_gamepad_axis_target("abs_nope") is None
+    assert _resolve_gamepad_axis_target("") is None
+
+
+def test_key_selector_dialog_custom_axis_maps_and_toggles_percent():
+    from gi.repository import Gtk
+
+    from keymasq.common.models import ActionType, MappingAction
+    from keymasq.gui.widgets.key_selector_dialog import KeySelectorDialog
+
+    dialog = KeySelectorDialog(Gtk.Box(), "Back")
+    results: list[MappingAction] = []
+    dialog.connect("key-selected", lambda _dialog, action: results.append(action))
+
+    dialog.stack.set_visible_child_name("gamepad")
+
+    # Standard axis: percent shown, custom entry hidden.
+    assert dialog.gamepad_axis_percent.get_visible() is True
+    assert dialog.gamepad_axis_custom_entry.get_visible() is False
+
+    custom_index = dialog.gamepad_axis_targets.index("custom")
+    dialog.gamepad_axis_dropdown.set_selected(custom_index)
+
+    # Custom: percent hidden, custom entry shown.
+    assert dialog.gamepad_axis_percent.get_visible() is False
+    assert dialog.gamepad_axis_percent_label.get_visible() is False
+    assert dialog.gamepad_axis_custom_entry.get_visible() is True
+
+    dialog.gamepad_axis_custom_entry.set_text("abs_hat0x")
+    dialog.gamepad_axis_value.set_value(1)
+    dialog._on_gamepad_axis_apply_clicked(None)
+
+    assert len(results) == 1
+    assert results[0].action_type == ActionType.GAMEPAD_AXIS
+    assert results[0].target == "abs_hat0x"
+    assert results[0].axis_value == 1
+
+    invalid = KeySelectorDialog(Gtk.Box(), "Back")
+    invalid.stack.set_visible_child_name("gamepad")
+    invalid.gamepad_axis_dropdown.set_selected(
+        invalid.gamepad_axis_targets.index("custom")
+    )
+    invalid.gamepad_axis_custom_entry.set_text("not-an-axis")
+    invalid._on_gamepad_axis_apply_clicked(None)
+
+    assert invalid.gamepad_axis_custom_entry.get_text() == ""
+    assert invalid.gamepad_axis_custom_entry.get_placeholder_text() == "Unknown axis code"
+
+
+def test_key_selector_dialog_prefills_custom_button_and_axis_fields():
+    from gi.repository import Gtk
+
+    from keymasq.common.models import ActionType, MappingAction
+    from keymasq.gui.widgets.key_selector_dialog import KeySelectorDialog
+
+    # Custom button code pre-fills the free-form field; a template button does not.
+    custom_btn = KeySelectorDialog(
+        Gtk.Box(),
+        "B",
+        current_action=MappingAction(action_type=ActionType.GAMEPAD, target="btn_tr2"),
+    )
+    assert custom_btn.gamepad_code_entry.get_text() == "btn_tr2"
+
+    template_btn = KeySelectorDialog(
+        Gtk.Box(),
+        "A",
+        current_action=MappingAction(action_type=ActionType.GAMEPAD, target="btn_south"),
+    )
+    assert template_btn.gamepad_code_entry.get_text() == ""
+
+    # Custom axis selects Custom, fills the abs code, and restores the raw value.
+    custom_axis = KeySelectorDialog(
+        Gtk.Box(),
+        "A",
+        current_action=MappingAction(
+            action_type=ActionType.GAMEPAD_AXIS, target="abs_hat2x", axis_value=200
+        ),
+    )
+    assert custom_axis._selected_gamepad_axis_slot() == "custom"
+    assert custom_axis.gamepad_axis_custom_entry.get_text() == "abs_hat2x"
+    assert int(custom_axis.gamepad_axis_value.get_value()) == 200
+    assert custom_axis.gamepad_axis_percent.get_visible() is False
+
+    # Standard axis selects its dropdown entry and restores the value.
+    standard_axis = KeySelectorDialog(
+        Gtk.Box(),
+        "A",
+        current_action=MappingAction(
+            action_type=ActionType.GAMEPAD_AXIS, target="abs_ry", axis_value=-16384
+        ),
+    )
+    assert standard_axis._selected_gamepad_axis_slot() == "abs_ry"
+    assert int(standard_axis.gamepad_axis_value.get_value()) == -16384
+    assert standard_axis.gamepad_axis_custom_entry.get_visible() is False
+
+
+def test_key_selector_dialog_gamepad_code_maps_and_routes(monkeypatch):
+    from gi.repository import Gtk
+
+    from keymasq.common.models import ActionType, MappingAction
+    from keymasq.gui.widgets import key_selector_dialog as dialog_module
+    from keymasq.gui.widgets.key_selector_dialog import KeySelectorDialog
+
+    monkeypatch.setattr(dialog_module, "load_virtual_gamepad_count", lambda: 2)
+    monkeypatch.setattr(
+        dialog_module,
+        "HardwareManager",
+        lambda: SimpleNamespace(list_hardware=lambda: []),
+    )
+
+    dialog = KeySelectorDialog(Gtk.Box(), "Extra Button 13")
+    results: list[MappingAction] = []
+    dialog.connect("key-selected", lambda _dialog, action: results.append(action))
+
+    # Off-standard button by numeric code, routed to the selected output.
+    dialog._selected_gamepad_output_id = "virtual-gamepad-2"
+    dialog.gamepad_code_entry.set_text("305")
+    dialog._on_gamepad_code_clicked(None)
+
+    assert len(results) == 1
+    assert results[0].action_type == ActionType.GAMEPAD
+    assert results[0].target == "btn_east"
+    assert results[0].output_id == "virtual-gamepad-2"
+
+    invalid = KeySelectorDialog(Gtk.Box(), "Extra Button 13")
+    invalid.gamepad_code_entry.set_text("not-a-button")
+    invalid._on_gamepad_code_clicked(None)
+
+    assert invalid.gamepad_code_entry.get_text() == ""
+    assert invalid.gamepad_code_entry.get_placeholder_text() == "Unknown button code"
+
+
 def test_key_selector_dialog_profile_tab_populates_and_maps_selected_action(monkeypatch):
     from gi.repository import Gtk
 

--- a/tests/test_output_helpers.py
+++ b/tests/test_output_helpers.py
@@ -25,6 +25,12 @@ def test_resolve_gamepad_axis_code_requires_axis_targets() -> None:
     assert output_helpers.resolve_gamepad_axis_code("key_a") is None
 
 
+def test_resolve_gamepad_axis_code_resolves_custom_abs_targets() -> None:
+    assert output_helpers.resolve_gamepad_axis_code("abs_hat0x") == evdev.ecodes.ABS_HAT0X
+    assert output_helpers.resolve_gamepad_axis_code("abs_throttle") == evdev.ecodes.ABS_THROTTLE
+    assert output_helpers.resolve_gamepad_axis_code("abs_nope") is None
+
+
 def test_emit_mouse_move_supports_absolute_mode_and_swallows_errors() -> None:
     uinput = MagicMock()
 


### PR DESCRIPTION
## Summary

- Adds a "Button code" field below the controller diagram for mapping off-template evdev buttons by name (e.g. `btn_c`, `btn_trigger_happy1`) or numeric code.
- Adds a "Custom" axis dropdown option that accepts evdev ABS axes (e.g. `abs_hat0x`, `abs_throttle`) or numeric code, with free-form value entry.
- Standard axes continue to use the percent slider; custom axes show a raw-value spin button with a wide range.
- Pre-fills the custom fields when editing existing mappings with non-template targets.
- Handles validation and clear-on-error UX for both custom button and axis inputs.
- Expands `resolve_gamepad_axis_code` in `output_helpers` to resolve custom ABS codes outside the predefined template.

## Testing

- `test_resolve_gamepad_button_target_accepts_names_and_codes` — evdev names, hex/decimal codes, and rejections
- `test_resolve_gamepad_axis_target_accepts_names_and_codes` — axis names, codes, and rejections
- `test_key_selector_dialog_custom_axis_maps_and_toggles_percent` — UI visibility toggles, mapping, invalid entry error state
- `test_key_selector_dialog_prefills_custom_button_and_axis_fields` — pre-fill on edit for custom button, custom axis, and standard axis
- `test_key_selector_dialog_gamepad_code_maps_and_routes` — full map flow with output routing, plus invalid input handling
- `test_resolve_gamepad_axis_code_resolves_custom_abs_targets` — `resolve_gamepad_axis_code` for custom axes and unknown names