### PR TITLE
Constrain dialog width, fix grid layout bug, prune dead CSS

### DIFF
--- a/keymasq/gui/style.css
+++ b/keymasq/gui/style.css
@@ -31,7 +31,6 @@ button.button-card-mapped-inactive {
   padding: 0;
   min-width: 0;
   min-height: 0;
-  text-align: left;
 }
 
 button.button-card-passthrough label,
@@ -65,19 +64,16 @@ button.button-card-mapped-inactive label {
   background: alpha(@accent_color, 0.08);
   border-left-color: @accent_color;
   opacity: 0.82;
-  cursor: pointer;
 }
 
 .button-card-mapped-active:hover {
   background: alpha(@success_color, 0.22);
   border-left-color: @success_color;
-  cursor: pointer;
 }
 
 .button-card-mapped-inactive:hover {
   background: alpha(@warning_color, 0.18);
   border-left-color: @warning_color;
-  cursor: pointer;
 }
 
 .button-card-passthrough:active {
@@ -200,11 +196,6 @@ button.button-card-mapped-inactive label {
 
 .combo-row:hover {
   background: alpha(@accent_color, 0.08);
-  cursor: pointer;
-}
-
-.combo-row-readonly:hover {
-  cursor: default;
 }
 
 .combo-row:active {
@@ -276,10 +267,6 @@ button.square-key-button {
 /* Diagnostics stat cells: tabular figures for column alignment */
 .diagnostics-stat {
   font-feature-settings: "tnum" 1;
-}
-
-.inspector-control-card:hover {
-  cursor: default;
 }
 
 .inspector-header-title {

--- a/keymasq/gui/widgets/combo_editor_dialog.py
+++ b/keymasq/gui/widgets/combo_editor_dialog.py
@@ -25,6 +25,7 @@ from keymasq.common.models import (
 )
 from keymasq.gui.session_client import session_request_async
 from keymasq.gui.widgets.action_labels import describe_mapping_action_compact
+from keymasq.gui.widgets.dialog_sizing import parent_constrained_dialog_width
 from keymasq.gui.widgets.key_selector_dialog import (
     EVDEV_TO_GAMEPAD,
     EVDEV_TO_KEY,
@@ -279,7 +280,11 @@ class ComboEditorDialog(Adw.Dialog):
         emergency_cancel_combo_enabled: bool = True,
     ) -> None:
         title = "Edit Combo" if combo else "Add Combo"
-        super().__init__(title=title, content_width=720, content_height=840)
+        super().__init__(
+            title=title,
+            content_width=parent_constrained_dialog_width(parent, 720),
+            content_height=840,
+        )
         self._parent = parent
         self._draft = deepcopy(combo) if combo else new_combo_draft()
         self._profile_name = profile_name

--- a/keymasq/gui/widgets/device_tab.py
+++ b/keymasq/gui/widgets/device_tab.py
@@ -887,7 +887,7 @@ class DeviceTab(ProfileManagedTab):
                 if col >= max_cols:
                     col = 0
                     r += 1
-                parent.append(grid)
+            parent.append(grid)
 
         if kind == "gamepad":
             buttons_by_id = {b.id: b for b in self.device.buttons}

--- a/keymasq/gui/widgets/dialog_sizing.py
+++ b/keymasq/gui/widgets/dialog_sizing.py
@@ -1,0 +1,22 @@
+import gi
+
+gi.require_version("Gtk", "4.0")
+
+from gi.repository import Gtk  # pyright: ignore[reportAttributeAccessIssue]
+
+_ADW_FLOATING_SHEET_WIDTH_OVERHEAD = 70
+
+
+def parent_constrained_dialog_width(
+    parent: Gtk.Widget,
+    preferred_width: int,
+    *,
+    min_width: int = 360,
+) -> int:
+    root = parent.get_root()
+    width_source = root if isinstance(root, Gtk.Widget) else parent
+    allocated_width = width_source.get_allocated_width()
+    if allocated_width <= 0:
+        return preferred_width
+    max_width = max(min_width, allocated_width - _ADW_FLOATING_SHEET_WIDTH_OVERHEAD)
+    return min(preferred_width, max_width)

--- a/keymasq/gui/widgets/superkey_dialog.py
+++ b/keymasq/gui/widgets/superkey_dialog.py
@@ -18,6 +18,7 @@ from keymasq.common.models import (
     superkey_action_to_mapping_action,
 )
 from keymasq.gui.widgets.action_labels import describe_mapping_action_verbose
+from keymasq.gui.widgets.dialog_sizing import parent_constrained_dialog_width
 from keymasq.gui.widgets.fuzzy_search import install_listbox_fuzzy_filter
 from keymasq.session.profiles import ProfileManager
 from keymasq.session.superkeys import SuperkeyManager
@@ -179,7 +180,11 @@ class ActionListDialog(Adw.Dialog):
         current_actions: list[SuperkeyAction] | list[MappingAction] | None = None,
         action_key: str | None = None,
     ):
-        super().__init__(title=title, content_width=720, content_height=520)
+        super().__init__(
+            title=title,
+            content_width=parent_constrained_dialog_width(parent, 720),
+            content_height=520,
+        )
         self._parent = parent
         self._list_mode = list_mode
         self._action_key = action_key or ""


### PR DESCRIPTION
## Summary

- **Constrain dialog width to parent window** via new `parent_constrained_dialog_width()` helper; prevents combo/superkey dialogs from overflowing on narrow windows
- **Fix grid layout bug** in `device_tab.py` where grid append was placed inside the wrong loop level, causing only the last device section to appear
- **Prune dead CSS**: remove `cursor`, `text-align: left`, and `.combo-row-readonly` rules that either had no effect or were overridden by GTK theme defaults

## Testing

- Launched GUI on a 1024×768 display; combo and superkey dialogs are now capped to the parent window width instead of overflowing
- Opened a device tab with multiple button groups (keyboard, mouse, gamepad); all sections render correctly after the loop fix
- Verified no GTK CSS warnings on startup
- Lint and type checks pass