### PR TITLE
Refactor: add capture-unlock clarity, safety hardening, and scenario-aware integration testing

### DIFF
--- a/docs/COMBOS.md
+++ b/docs/COMBOS.md
@@ -136,7 +136,7 @@ output. This means:
   grabbed interface in scope.
 
 Capture uses the same security model as macro recording — it observes original
-input and requires the recording unlock flow.
+input and requires the capture unlock flow.
 
 ## Trigger Scope
 
@@ -340,7 +340,7 @@ values are preserved but ignored at runtime.
   (e.g. Hyprland). These interact with your desktop environment directly, so
   review what they do before assigning them to a combo.
 - **Combo capture** uses the same security model as macro recording — it
-  observes original input and requires the recording unlock flow.
+  observes original input and requires the capture unlock flow.
 
 ## Troubleshooting
 

--- a/docs/DAEMON_SESSION_INTEGRATION_TEST.md
+++ b/docs/DAEMON_SESSION_INTEGRATION_TEST.md
@@ -68,7 +68,7 @@ scenarios when chasing flakes:
 
 ```bash
 ./scripts/integration.sh daemon-session --scenario hotplug-replug
-./scripts/integration.sh --scenario profile-lifetime-direct-actions,hotplug-replug --repeat 10
+./scripts/integration.sh daemon-session --scenario profile-lifetime-direct-actions,hotplug-replug --repeat 10
 ```
 
 This is equivalent to running the Nix check directly:

--- a/docs/DAEMON_SESSION_INTEGRATION_TEST.md
+++ b/docs/DAEMON_SESSION_INTEGRATION_TEST.md
@@ -63,6 +63,14 @@ Run the VM check from the repository root:
 ./scripts/integration.sh daemon-session
 ```
 
+Run one or more scenarios by kebab-case scenario key, and repeat selected
+scenarios when chasing flakes:
+
+```bash
+./scripts/integration.sh daemon-session --scenario hotplug-replug
+./scripts/integration.sh --scenario profile-lifetime-direct-actions,hotplug-replug --repeat 10
+```
+
 This is equivalent to running the Nix check directly:
 
 ```bash

--- a/docs/DEPENDENCIES.md
+++ b/docs/DEPENDENCIES.md
@@ -68,7 +68,7 @@ Desktop GUI stack:
 - libadwaita
 - GObject introspection data for GTK4 and libadwaita
 
-Privileged recording/unlock flow:
+Privileged capture unlock and macro recording opt-in flow:
 
 - `polkit`
 - `pkexec`
@@ -121,7 +121,7 @@ differentiator is the compositor/session environment itself.
 feature/runtime dependency for supported Wayland environments rather than just a
 GUI convenience.
 
-### Recording unlock helper
+### Capture unlock helper
 
 - `keymasq-record` must be installed alongside the rest of Keymasq
 - the matching Polkit policy must be installed

--- a/docs/DEVICE_INSPECTOR.md
+++ b/docs/DEVICE_INSPECTOR.md
@@ -3,9 +3,9 @@
 The Device Inspector is a floating read-only window for checking one configured
 device at runtime.
 
-Open it from a device tab with the inspect button. Keymasq uses the same
-recording unlock flow as macro recording and live input capture before the
-window can start, because the inspector observes original hardware events.
+Open it from a device tab with the inspect button. Keymasq uses the capture
+unlock flow before the window can start, because the inspector observes
+original hardware events.
 
 ## What It Shows
 

--- a/docs/DEVICE_INSPECTOR.md
+++ b/docs/DEVICE_INSPECTOR.md
@@ -49,7 +49,8 @@ the normal profile grab state again.
 
 Starting the inspector and enabling suppression are sensitive session commands
 when `[recording_guard].unlock_required = true`. They require the active GUI
-recording-unlock owner, just like macro recording and live input capture.
+that owns the capture unlock flow, just like macro recording and live input
+capture.
 
 The inspector force-grabs configured interfaces for the selected device while it
 is open so raw events can be observed even if the current profile has no mapping

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -293,7 +293,7 @@ a warning when this happens so the missing optimization is visible.
 Packaged installs handle this automatically. Macro recording is enabled by a
 Polkit-backed `keymasq-record` opt-in from the GUI. Capture flows such as
 button/key capture, combo capture, and Device Inspector suppression use the
-separate recording unlock lease.
+separate capture unlock lease.
 
 For manual installs, if capture unlock requests do not appear or fail, you can
 disable the capture unlock requirement in `/etc/keymasq/security.toml`:

--- a/docs/LISTENER_VM_TESTS.md
+++ b/docs/LISTENER_VM_TESTS.md
@@ -76,8 +76,12 @@ Use the integration helper from the repository root:
 ```bash
 ./scripts/integration.sh cosmic
 ./scripts/integration.sh gnome
+./scripts/integration.sh cosmic --repeat 3
 ./scripts/integration.sh listeners
 ```
+
+`--repeat N` applies to every selected integration check, including individual
+listener shortcuts and the `listeners` group.
 
 List every shortcut with:
 

--- a/docs/MACROS.md
+++ b/docs/MACROS.md
@@ -423,7 +423,7 @@ could be misused as a keylogger.
   and exists so slots survive daemon restarts, not as a macro library API.
 
 - **Saving a slot requires unlock.** Persisting a temporary recording into the
-  macro library goes through the recording unlock flow even after macro
+  macro library goes through the capture unlock flow even after macro
   recording has been enabled.
 
 - **Macros are stored in `/var/lib/keymasq/macros/`**, owned by the `keymasq`

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -60,7 +60,7 @@ Both layers enforce authorization. Session-side checks are not advisory; daemon-
 
 ## Privileged Helper Path Pinning
 
-The GUI recording unlock flow uses `pkexec` to run the `keymasq-record` helper.
+The GUI capture unlock flow uses `pkexec` to run the `keymasq-record` helper.
 
 - Keymasq does not resolve that helper from `$PATH` during privileged execution
 - The helper path is treated as a trusted absolute executable path
@@ -121,7 +121,7 @@ daemon-private storage so slots survive daemon restarts. Saving a slot copies
 it into normal macro storage and leaves the slot in place; deleting or
 overwriting a slot removes the pending recording.
 
-Saving a temporary slot into the macro library requires the recording unlock
+Saving a temporary slot into the macro library requires the capture unlock
 flow when `unlock_required = true`. This is enforced in the GUI, the
 session broker, and the daemon command handler.
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -304,7 +304,7 @@ Current behavior:
 - Keymasq does not support touchpad remapping yet, so the GUI will not offer a
   touchpad as addable hardware
 
-### Polkit or recording unlock problems
+### Polkit or capture unlock problems
 
 Symptoms:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -44,7 +44,7 @@ and multi-step automation.
 
 ## Reference
 
-- [Security model](SECURITY.md) — daemon/session split, unlock flow,
+- [Security model](SECURITY.md) — daemon/session split, capture unlock flow,
   owner checks.
 - [Troubleshooting](TROUBLESHOOTING.md) — diagnostics for common problems.
 

--- a/keymasq/cli/__main__.py
+++ b/keymasq/cli/__main__.py
@@ -102,7 +102,7 @@ def main() -> None:
         action="store_true",
         help="Read canonical macro JSON instead of compact event tokens",
     )
-    play_parser.add_argument("--speed", type=_positive_float, default=1.0, help="Playback speed")
+    play_parser.add_argument("--speed", type=_positive_float, default=None, help="Playback speed")
     play_parser.add_argument(
         "--print-json",
         action="store_true",

--- a/keymasq/cli/commands.py
+++ b/keymasq/cli/commands.py
@@ -133,7 +133,7 @@ def status_cli(*, json_output: bool = False) -> None:
         unlock_state = f"unlocked ({source})"
     else:
         unlock_state = "locked"
-    print(f"recording unlock: {unlock_state}")
+    print(f"capture unlock: {unlock_state}")
 
     if "active_profiles" in result:
         print(f"active profiles: {_names(result.get('active_profiles'))}")
@@ -262,7 +262,7 @@ def play_adhoc_cli(
     tokens: list[str],
     *,
     input_json: bool = False,
-    speed: float = 1.0,
+    speed: float | None = None,
     print_json: bool = False,
     json_output: bool = False,
 ) -> None:
@@ -277,10 +277,15 @@ def play_adhoc_cli(
             if not isinstance(raw_events, list):
                 raise ValueError("macro JSON events must be a list")
             events = _macro_events_from_json(raw_events)
+            playback_speed = (
+                float(speed)
+                if speed is not None
+                else float(cast(IntLike, macro_data.get("speed", 1.0)))
+            )
             payload = build_macro_payload(
                 events,
                 name=str(macro_data.get("name", "") or ""),
-                speed=float(speed),
+                speed=playback_speed,
                 loop_mode=str(macro_data.get("loop_mode", "none") or "none"),
                 loop_count=int(cast(IntLike, macro_data.get("loop_count", 1) or 1)),
                 loop_stop_behavior=str(
@@ -300,13 +305,16 @@ def play_adhoc_cli(
                 )
 
                 events = build_compact_macro_events(event_tokens)
-                payload = build_macro_payload(events, speed=float(speed))
+                payload = build_macro_payload(
+                    events,
+                    speed=1.0 if speed is None else float(speed),
+                )
             else:
                 result = _request_or_error(
                     {
                         "command": "play_compact_macro",
                         "tokens": event_tokens,
-                        "speed": float(speed),
+                        "speed": 1.0 if speed is None else float(speed),
                     }
                 )
                 if _handled_json_or_error(result, json_output):

--- a/keymasq/common/ipc.py
+++ b/keymasq/common/ipc.py
@@ -40,6 +40,7 @@ class CommandType(Enum):
     MACRO_RENAME = "macro_rename"
     MACRO_DELETE = "macro_delete"
     MACRO_SAVE_RECORDING = "macro_save_recording"
+    MACRO_RECORDING_STATUS = "macro_recording_status"
     MACRO_LIST_RECORDINGS = "macro_list_recordings"
     MACRO_DELETE_RECORDING = "macro_delete_recording"
     MACRO_PLAY_RECORDING = "macro_play_recording"
@@ -62,6 +63,7 @@ class CommandType(Enum):
     DEVICE_INSPECTOR_STATUS = "device_inspector_status"
     REFRESH_RECORDING_UNLOCK = "refresh_recording_unlock"
     LOCK_RECORDING_UNLOCK = "lock_recording_unlock"
+    RECORDING_UNLOCK_STATUS = "recording_unlock_status"
 
 
 @dataclass

--- a/keymasq/common/recording_guard.py
+++ b/keymasq/common/recording_guard.py
@@ -74,6 +74,7 @@ def _resolve_status_from_paths(
     *,
     now: int | None = None,
 ) -> UnlockStatus:
+    unreadable = False
     runtime_expires = parse_unlock_expires_at(runtime_path)
     if runtime_expires is not None and is_unlock_value_active(runtime_expires, now=now):
         return {
@@ -82,6 +83,8 @@ def _resolve_status_from_paths(
             "expires_at": int(runtime_expires),
             "path": str(runtime_path),
         }
+    if runtime_expires is None and _path_exists_unreadable(runtime_path):
+        unreadable = True
 
     persistent_expires = parse_unlock_expires_at(persistent_path)
     if persistent_expires is not None and is_unlock_value_active(persistent_expires, now=now):
@@ -91,13 +94,28 @@ def _resolve_status_from_paths(
             "expires_at": int(persistent_expires),
             "path": str(persistent_path),
         }
+    if persistent_expires is None and _path_exists_unreadable(persistent_path):
+        unreadable = True
 
-    return {
+    status: UnlockStatus = {
         "unlocked": False,
         "source": "none",
         "expires_at": 0,
         "path": "",
     }
+    if unreadable:
+        status["unreadable"] = True
+    return status
+
+
+def _path_exists_unreadable(path: Path) -> bool:
+    try:
+        path.stat()
+    except FileNotFoundError:
+        return False
+    except OSError:
+        return True
+    return not os.access(path, os.R_OK)
 
 
 def _validate_unlock_parent(path: Path) -> None:
@@ -142,7 +160,7 @@ def write_unlock_expires_at(
     expires_at: int,
     owner_uid: int | None = None,
     owner_gid: int | None = None,
-    mode: int = 0o644,
+    mode: int = 0o600,
 ) -> None:
     _validate_unlock_parent(path)
     fd, tmp_name = tempfile.mkstemp(prefix=f".{path.name}.tmp-", dir=path.parent)

--- a/keymasq/common/recording_guard.py
+++ b/keymasq/common/recording_guard.py
@@ -110,10 +110,12 @@ def _resolve_status_from_paths(
 
 def _path_exists_unreadable(path: Path) -> bool:
     try:
-        path.stat()
+        path_stat = path.stat()
     except FileNotFoundError:
         return False
     except OSError:
+        return True
+    if not stat.S_ISREG(path_stat.st_mode):
         return True
     return not os.access(path, os.R_OK)
 

--- a/keymasq/gui/widgets/combo_tab.py
+++ b/keymasq/gui/widgets/combo_tab.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from copy import deepcopy
+
 import gi
 
 gi.require_version("Gtk", "4.0")
@@ -10,7 +12,7 @@ from gi.repository import Adw, Gdk, Gtk, Pango  # pyright: ignore[reportAttribut
 from keymasq.common.models import ComboConfig
 from keymasq.gui.icons import combo_icon_names, image_from_icon_names, resolve_icon_name
 from keymasq.gui.widgets.action_labels import describe_mapping_action_compact
-from keymasq.gui.widgets.combo_editor_dialog import ComboEditorDialog
+from keymasq.gui.widgets.combo_editor_dialog import ComboEditorDialog, combo_trigger_signature
 from keymasq.gui.widgets.combo_list import SORT_ACTION, SORT_NAME, SORT_TRIGGER, SortableComboList
 from keymasq.gui.widgets.combo_presentation import (
     combo_default_name,
@@ -19,7 +21,15 @@ from keymasq.gui.widgets.combo_presentation import (
     combo_trigger_label,
 )
 from keymasq.gui.widgets.profile_managed_tab import ProfileManagedTab
-from keymasq.session.profiles import ProfileManager
+from keymasq.session.profiles import ProfileInfo, ProfileManager
+
+_DUPLICATE_COMBO_TRIGGER_MESSAGE = "A combo with the same trigger already exists in this profile."
+_STALE_COMBO_EDIT_MESSAGE = (
+    "This combo changed before it could be saved. Reopen the combo editor and try again."
+)
+_DELETED_COMBO_EDIT_MESSAGE = (
+    "This combo was deleted before it could be saved. Reopen the combo editor and try again."
+)
 
 
 class ComboTab(ProfileManagedTab):
@@ -151,6 +161,22 @@ class ComboTab(ProfileManagedTab):
             return []
         return self._selected_profile.config.combos
 
+    def _resolve_combo_target_profile(
+        self,
+        target_profile: ProfileInfo | None,
+    ) -> ProfileInfo | None:
+        target_profile = target_profile or self._selected_profile
+        if target_profile is None:
+            return None
+        if self.profile_manager is None or self.demo_mode:
+            return target_profile
+        return self.profile_manager.get_profile(target_profile.config.name)
+
+    def _show_missing_combo_target_profile(self, profile_name: str) -> None:
+        self._show_profile_error_dialog(
+            f"Profile '{profile_name}' is no longer available. Select a profile and try again."
+        )
+
     def _after_profile_selection_applied(self) -> None:
         selected = self._selected_profile is not None
         self.add_combo_button.set_sensitive(selected)
@@ -241,6 +267,9 @@ class ComboTab(ProfileManagedTab):
         self._open_combo_editor(combo)
 
     def _open_combo_editor(self, combo: ComboConfig | None = None) -> None:
+        target_profile = self._selected_profile
+        if target_profile is None:
+            return
         emergency_cancel_combo_enabled = True
         policy_getter = getattr(self.main_window, "emergency_cancel_combo_enabled", None)
         if callable(policy_getter):
@@ -248,23 +277,85 @@ class ComboTab(ProfileManagedTab):
         dialog = ComboEditorDialog(
             self,
             combo,
-            profile_name=self.selected_profile_name(),
-            sibling_combos=self._selected_combos(),
+            profile_name=target_profile.config.name,
+            sibling_combos=target_profile.config.combos,
             emergency_cancel_combo_enabled=emergency_cancel_combo_enabled,
         )
-        dialog.connect("combo-saved", self._on_combo_saved)
+        dialog.connect(
+            "combo-saved",
+            self._on_combo_saved,
+            target_profile,
+            deepcopy(combo) if combo is not None else None,
+        )
         dialog.present(self)
 
-    def _on_combo_saved(self, _dialog: ComboEditorDialog, combo: ComboConfig) -> None:
-        combos = self._selected_combos()
-        for index, existing in enumerate(combos):
-            if existing.id == combo.id:
-                combos[index] = combo
-                break
-        else:
+    def _on_combo_saved(
+        self,
+        _dialog: ComboEditorDialog,
+        combo: ComboConfig,
+        target_profile: ProfileInfo | None = None,
+        original_combo: ComboConfig | None = None,
+    ) -> None:
+        profile_name = target_profile.config.name if target_profile is not None else ""
+        target_profile = self._resolve_combo_target_profile(target_profile)
+        if target_profile is None:
+            if profile_name:
+                self._show_missing_combo_target_profile(profile_name)
+            self._combo_list.render()
+            return
+        combos = target_profile.config.combos
+        existing_index = self._combo_index(combos, combo.id)
+        if original_combo is not None:
+            existing_index = self._combo_index(combos, original_combo.id)
+            if existing_index is None:
+                self._show_profile_error_dialog(_DELETED_COMBO_EDIT_MESSAGE)
+                self._combo_list.render()
+                return
+            if combos[existing_index] != original_combo:
+                self._show_profile_error_dialog(_STALE_COMBO_EDIT_MESSAGE)
+                self._combo_list.render()
+                return
+        ignore_combo_id = original_combo.id if original_combo is not None else combo.id
+        if self._has_duplicate_combo_trigger(combo, combos, ignore_combo_id=ignore_combo_id):
+            self._show_profile_error_dialog(_DUPLICATE_COMBO_TRIGGER_MESSAGE)
+            self._combo_list.render()
+            return
+        if existing_index is None:
             combos.append(combo)
-        self._save_profile()
+        else:
+            combos[existing_index] = combo
+        self._save_specific_profile(target_profile)
         self._combo_list.render()
+
+    def _combo_index(self, combos: list[ComboConfig], combo_id: str) -> int | None:
+        for index, combo in enumerate(combos):
+            if combo.id == combo_id:
+                return index
+        return None
+
+    def _has_duplicate_combo_trigger(
+        self,
+        combo: ComboConfig,
+        combos: list[ComboConfig],
+        *,
+        ignore_combo_id: str,
+    ) -> bool:
+        current_steps = combo_trigger_signature(
+            combo,
+            match_across_devices=bool(combo.match_across_devices),
+        )
+        if not current_steps:
+            return False
+        for existing in combos:
+            if existing.id == ignore_combo_id:
+                continue
+            existing_steps = combo_trigger_signature(
+                existing,
+                match_across_devices=bool(existing.match_across_devices),
+            )
+            if existing_steps == current_steps:
+                return True
+        return False
 
     def _on_add_combo_clicked(self, _button: Gtk.Button) -> None:
         if self._selected_profile is None:
@@ -272,7 +363,12 @@ class ComboTab(ProfileManagedTab):
         self._open_combo_editor()
 
     def _on_delete_combo_clicked(self, _button: Gtk.Button, combo_id: str) -> None:
-        combo = next((combo for combo in self._selected_combos() if combo.id == combo_id), None)
+        target_profile = self._selected_profile
+        if target_profile is None:
+            return
+        combo = next(
+            (combo for combo in target_profile.config.combos if combo.id == combo_id), None
+        )
         if combo is None:
             return
 
@@ -284,7 +380,7 @@ class ComboTab(ProfileManagedTab):
         dialog.set_response_appearance("delete", Adw.ResponseAppearance.DESTRUCTIVE)
         dialog.set_default_response("cancel")
         dialog.set_close_response("cancel")
-        dialog.connect("response", self._on_delete_combo_response, combo_id)
+        dialog.connect("response", self._on_delete_combo_response, combo_id, target_profile)
         dialog.present(self.get_root())
 
     def _on_delete_combo_response(
@@ -292,13 +388,25 @@ class ComboTab(ProfileManagedTab):
         _dialog: Adw.AlertDialog,
         response: str,
         combo_id: str,
+        target_profile: ProfileInfo | None = None,
     ) -> None:
         if response != "delete":
             return
-        self._delete_combo(combo_id)
+        self._delete_combo(combo_id, target_profile)
 
-    def _delete_combo(self, combo_id: str) -> None:
-        combos = self._selected_combos()
+    def _delete_combo(
+        self,
+        combo_id: str,
+        target_profile: ProfileInfo | None = None,
+    ) -> None:
+        profile_name = target_profile.config.name if target_profile is not None else ""
+        target_profile = self._resolve_combo_target_profile(target_profile)
+        if target_profile is None:
+            if profile_name:
+                self._show_missing_combo_target_profile(profile_name)
+            self._combo_list.render()
+            return
+        combos = target_profile.config.combos
         combos[:] = [combo for combo in combos if combo.id != combo_id]
-        self._save_profile()
+        self._save_specific_profile(target_profile)
         self._combo_list.render()

--- a/keymasq/gui/widgets/compositor_actions/core.py
+++ b/keymasq/gui/widgets/compositor_actions/core.py
@@ -112,6 +112,16 @@ def build_compositor_dispatch_definition(
     )
 
 
+def _definition_matches_action(
+    definition: CompositorActionDefinition,
+    action: MappingAction | None,
+) -> bool:
+    if action is None or action.action_type != definition.action_type:
+        return False
+    compositor_id = str(action.compositor_id or "").strip()
+    return bool(compositor_id) and definition.compositor_id == compositor_id
+
+
 class _CompositorDispatchPage(Gtk.Box):
     def __init__(
         self,
@@ -343,7 +353,10 @@ def build_compositor_action_pages_for_definitions(
     resolved_status = dict(status or {})
     pages: list[CompositorActionPage] = []
     for definition in definitions:
-        if not definition.is_available(current_action, resolved_status):
+        if (
+            not _definition_matches_action(definition, current_action)
+            and not definition.is_available(current_action, resolved_status)
+        ):
             continue
         pages.append(
             CompositorActionPage(
@@ -372,11 +385,7 @@ def compositor_action_tab_name_for_definitions(
     compositor_id = str(action.compositor_id or "").strip()
     if compositor_id:
         for definition in definitions:
-            if (
-                action.action_type == definition.action_type
-                and definition.compositor_id == compositor_id
-                and definition.is_available(action, resolved_status)
-            ):
+            if _definition_matches_action(definition, action):
                 return definition.page_id
     for definition in definitions:
         if (

--- a/keymasq/gui/widgets/input_picker_shared.py
+++ b/keymasq/gui/widgets/input_picker_shared.py
@@ -412,7 +412,10 @@ def _build_gamepad_left_col(owner) -> Gtk.Box:
         (1, 2, "LY+", "abs_y", 32767),
     ]:
         btn = owner._create_key_button(label, target)
-        btn.connect("clicked", owner._on_gamepad_axis_clicked, target, value)
+        if hasattr(owner, "_on_gamepad_axis_clicked"):
+            btn.connect("clicked", owner._on_gamepad_axis_clicked, target, value)
+        else:
+            btn.connect("clicked", owner._on_gamepad_clicked, target)
         lstick.attach(btn, gc, gr, 1, 1)
 
     ls_label, ls_evdev = _gamepad_button("LS")
@@ -548,7 +551,10 @@ def _build_gamepad_right_col(owner) -> Gtk.Box:
         (1, 2, "RY+", "abs_ry", 32767),
     ]:
         btn = owner._create_key_button(label, target)
-        btn.connect("clicked", owner._on_gamepad_axis_clicked, target, value)
+        if hasattr(owner, "_on_gamepad_axis_clicked"):
+            btn.connect("clicked", owner._on_gamepad_axis_clicked, target, value)
+        else:
+            btn.connect("clicked", owner._on_gamepad_clicked, target)
         rstick.attach(btn, gc, gr, 1, 1)
 
     rs_label, rs_evdev = _gamepad_button("RS")

--- a/keymasq/gui/widgets/macro_manager_dialog.py
+++ b/keymasq/gui/widgets/macro_manager_dialog.py
@@ -5,6 +5,7 @@ gi.require_version("Adw", "1")
 
 import logging
 from datetime import datetime
+from typing import cast
 
 from gi.repository import Adw, Gdk, GLib, Gtk  # pyright: ignore[reportAttributeAccessIssue]
 
@@ -319,8 +320,7 @@ class MacroManagerDialog(Adw.Dialog):
             if self._slot_dropdown is not None:
                 self._slot_dropdown.set_selected(active_slot - 1)
         self._sync_record_button_state()
-        self._macros = (macros or {}).get("macros", [])
-        self._populate_list()
+        self._apply_macros_response(macros)
         return False
 
     def _load_macros(self) -> bool:
@@ -331,9 +331,33 @@ class MacroManagerDialog(Adw.Dialog):
         return False
 
     def _on_macros_loaded(self, result: JsonDict | None) -> bool:
-        self._macros = (result or {}).get("macros", [])
-        self._populate_list()
+        self._apply_macros_response(result)
         return False
+
+    def _apply_macros_response(self, result: JsonDict | None) -> bool:
+        if not isinstance(result, dict):
+            self._show_macro_load_error("Failed to load macros")
+            return False
+
+        if result.get("status") not in (None, "ok"):
+            self._show_macro_load_error(result.get("message", "Failed to load macros"))
+            return False
+
+        macros = result.get("macros")
+        if not isinstance(macros, list):
+            self._show_macro_load_error(result.get("message", "Failed to load macros"))
+            return False
+
+        self._macros = cast(list[JsonDict], macros)
+        self._populate_list()
+        return True
+
+    def _show_macro_load_error(self, message: object) -> None:
+        dialog = Adw.AlertDialog()
+        dialog.set_heading("Load Macros")
+        dialog.set_body(str(message or "Failed to load macros"))
+        dialog.add_response("ok", "OK")
+        dialog.present(self._parent)
 
     def _populate_list(self) -> None:
         while self._listbox.get_first_child():

--- a/keymasq/gui/widgets/macro_manager_dialog.py
+++ b/keymasq/gui/widgets/macro_manager_dialog.py
@@ -348,7 +348,16 @@ class MacroManagerDialog(Adw.Dialog):
             self._show_macro_load_error(result.get("message", "Failed to load macros"))
             return False
 
-        self._macros = cast(list[JsonDict], macros)
+        validated_macros: list[JsonDict] = []
+        for index, macro in enumerate(macros):
+            if not isinstance(macro, dict) or not isinstance(macro.get("name"), str):
+                self._show_macro_load_error(
+                    f"Invalid macro entry at index {index}: expected an object with a name"
+                )
+                return False
+            validated_macros.append(cast(JsonDict, macro))
+
+        self._macros = validated_macros
         self._populate_list()
         return True
 

--- a/keymasq/gui/widgets/settings_dialog.py
+++ b/keymasq/gui/widgets/settings_dialog.py
@@ -31,7 +31,12 @@ class SettingsDialog(Adw.Dialog):
         self._parent = parent
         self._settings = load_global_settings()
         self._gamepad_count = self._settings.virtual_gamepad_count
+        self._applied_gamepad_count = self._gamepad_count
         self._save_seq = 0
+        self._applied_save_seq = 0
+        self._save_inflight = False
+        self._save_applied = False
+        self._latest_save_failed = False
 
         toolbar = Adw.ToolbarView()
         header = Adw.HeaderBar()
@@ -115,7 +120,7 @@ class SettingsDialog(Adw.Dialog):
         dialog.present(self._parent)
 
     def _on_loaded(self, response: dict[str, object] | None) -> bool:
-        if self._save_seq > 0:
+        if self._save_inflight or self._save_applied:
             return False
         if isinstance(response, dict) and response.get("status") == "ok":
             try:
@@ -127,6 +132,7 @@ class SettingsDialog(Adw.Dialog):
                 self._gamepad_count = clamp_virtual_gamepad_count(count)
             except (TypeError, ValueError):
                 self._gamepad_count = self._settings.virtual_gamepad_count
+            self._applied_gamepad_count = self._gamepad_count
             self._sync_gamepad_count_controls()
         return False
 
@@ -156,19 +162,40 @@ class SettingsDialog(Adw.Dialog):
         self._sync_gamepad_count_controls()
         self._save_seq += 1
         save_seq = self._save_seq
+        self._save_inflight = True
+        self._latest_save_failed = False
         self._status.set_text("")
 
         def on_response(response: dict[str, object] | None) -> bool:
-            if save_seq != self._save_seq:
-                return False
             if isinstance(response, dict) and response.get("status") == "ok":
                 raw_saved = response.get("virtual_gamepad_count", count)
                 saved_count = _count_value(raw_saved, count)
-                self._gamepad_count = clamp_virtual_gamepad_count(saved_count)
+                applied_count = clamp_virtual_gamepad_count(saved_count)
+                if save_seq != self._save_seq:
+                    if save_seq > self._applied_save_seq:
+                        self._applied_gamepad_count = applied_count
+                        self._applied_save_seq = save_seq
+                        self._save_applied = True
+                    if self._latest_save_failed and save_seq == self._applied_save_seq:
+                        self._gamepad_count = applied_count
+                        self._sync_gamepad_count_controls()
+                    return False
+                self._save_inflight = False
+                self._latest_save_failed = False
+                self._applied_gamepad_count = applied_count
+                self._applied_save_seq = save_seq
+                self._save_applied = True
+                self._gamepad_count = applied_count
                 self._sync_gamepad_count_controls()
                 return False
+            if save_seq != self._save_seq:
+                return False
+            self._save_inflight = False
             if isinstance(response, dict):
+                self._latest_save_failed = True
                 message = str(response.get("message") or "Failed to apply settings")
+                self._gamepad_count = self._applied_gamepad_count
+                self._sync_gamepad_count_controls()
                 self._status.set_text(message)
                 return False
             saved = save_global_settings(
@@ -177,7 +204,11 @@ class SettingsDialog(Adw.Dialog):
                 )
             )
             self._gamepad_count = saved.virtual_gamepad_count
+            self._applied_gamepad_count = self._gamepad_count
+            self._applied_save_seq = save_seq
             self._sync_gamepad_count_controls()
+            self._save_applied = True
+            self._latest_save_failed = False
             return False
 
         session_request_async(

--- a/keymasq/gui/window.py
+++ b/keymasq/gui/window.py
@@ -871,10 +871,19 @@ class MainWindow(Adw.ApplicationWindow):
     def macro_recording_enabled(self) -> bool:
         return bool(self._macro_recording_enabled)
 
-    def _refresh_macro_recording_state_from_session(self) -> None:
-        status = session_request({"command": "get_status"}, timeout=1.0)
-        if isinstance(status, dict):
-            self._update_macro_recording_state(status)
+    def _refresh_macro_recording_state_from_session(
+        self,
+        on_status: Callable[[dict | None], None] | None = None,
+    ) -> None:
+        def _on_status(status: dict | None) -> bool:
+            status_data = status if isinstance(status, dict) else None
+            if status_data is not None:
+                self._update_macro_recording_state(status_data)
+            if on_status is not None:
+                on_status(status_data)
+            return False
+
+        session_request_async({"command": "get_status"}, _on_status, timeout=1.0)
 
     def emergency_cancel_combo_enabled(self) -> bool:
         return bool(self._emergency_cancel_combo_enabled)
@@ -1661,49 +1670,53 @@ class MainWindow(Adw.ApplicationWindow):
         self._start_recording_unlock(on_success=on_success)
 
     def present_macro_recording_enable_dialog(self, on_success=None) -> None:
-        self._refresh_macro_recording_state_from_session()
-        if self._macro_recording_enabled:
-            if callable(on_success):
-                on_success()
-            return
+        def _after_refresh(_status: dict | None) -> None:
+            if self._macro_recording_enabled:
+                if callable(on_success):
+                    on_success()
+                return
 
-        dialog = Adw.AlertDialog(
-            heading="Enable Macro Recording",
-            body=(
-                "Macro recording is disabled until you opt in. Enabling it allows "
-                "recording triggers and the Macro Manager record button to create "
-                "temporary recording slots."
-            ),
-        )
-        dialog.add_response("cancel", "Cancel")
-        dialog.add_response("enable", "Enable")
-        dialog.set_default_response("enable")
-        dialog.set_close_response("cancel")
-        dialog.set_response_appearance("enable", Adw.ResponseAppearance.SUGGESTED)
-        dialog.connect("response", self._on_macro_recording_enable_response, on_success)
-        dialog.present(self)
+            dialog = Adw.AlertDialog(
+                heading="Enable Macro Recording",
+                body=(
+                    "Macro recording is disabled until you opt in. Enabling it allows "
+                    "recording triggers and the Macro Manager record button to create "
+                    "temporary recording slots."
+                ),
+            )
+            dialog.add_response("cancel", "Cancel")
+            dialog.add_response("enable", "Enable")
+            dialog.set_default_response("enable")
+            dialog.set_close_response("cancel")
+            dialog.set_response_appearance("enable", Adw.ResponseAppearance.SUGGESTED)
+            dialog.connect("response", self._on_macro_recording_enable_response, on_success)
+            dialog.present(self)
+
+        self._refresh_macro_recording_state_from_session(_after_refresh)
 
     def present_macro_recording_disable_dialog(self, on_success=None) -> None:
-        self._refresh_macro_recording_state_from_session()
-        if not self._macro_recording_enabled:
-            if callable(on_success):
-                on_success()
-            return
+        def _after_refresh(_status: dict | None) -> None:
+            if not self._macro_recording_enabled:
+                if callable(on_success):
+                    on_success()
+                return
 
-        dialog = Adw.AlertDialog(
-            heading="Disable Macro Recording",
-            body=(
-                "This turns off macro recording opt-in. Existing saved macros can still "
-                "be played."
-            ),
-        )
-        dialog.add_response("cancel", "Cancel")
-        dialog.add_response("disable", "Disable")
-        dialog.set_default_response("cancel")
-        dialog.set_close_response("cancel")
-        dialog.set_response_appearance("disable", Adw.ResponseAppearance.DESTRUCTIVE)
-        dialog.connect("response", self._on_macro_recording_disable_response, on_success)
-        dialog.present(self)
+            dialog = Adw.AlertDialog(
+                heading="Disable Macro Recording",
+                body=(
+                    "This turns off macro recording opt-in. Existing saved macros can still "
+                    "be played."
+                ),
+            )
+            dialog.add_response("cancel", "Cancel")
+            dialog.add_response("disable", "Disable")
+            dialog.set_default_response("cancel")
+            dialog.set_close_response("cancel")
+            dialog.set_response_appearance("disable", Adw.ResponseAppearance.DESTRUCTIVE)
+            dialog.connect("response", self._on_macro_recording_disable_response, on_success)
+            dialog.present(self)
+
+        self._refresh_macro_recording_state_from_session(_after_refresh)
 
     def _on_quit_clicked(self, _button: Gtk.Button) -> None:
         self.get_application().quit()

--- a/keymasq/gui/window.py
+++ b/keymasq/gui/window.py
@@ -13,7 +13,6 @@ from gi.repository import Adw, Gio, GLib, Gtk  # pyright: ignore[reportAttribute
 from keymasq.common.models import HardwareConfig
 from keymasq.common.paths import KEYMASQ_RECORD_HELPER_PATH, resolve_keymasq_record_helper_path
 from keymasq.common.recording_guard import (
-    resolve_macro_recording_status,
     resolve_unlock_status,
 )
 from keymasq.gui.icons import (
@@ -162,6 +161,17 @@ class MainWindow(Adw.ApplicationWindow):
         self.connect("destroy", self._on_destroy)
 
     def _probe_startup_state(self) -> tuple[dict[str, object], list[HardwareConfig]]:
+        if self.demo_mode:
+            return (
+                {
+                    "compositor_id": None,
+                    "support_details": {"supported": False, "warning": ""},
+                    "supported": False,
+                    "capabilities": [],
+                },
+                [],
+            )
+
         compositor_id = detect_compositor_sync()
         support_details = get_compositor_support_details_sync(compositor_id)
         supported = bool(support_details.get("supported", False))
@@ -178,6 +188,13 @@ class MainWindow(Adw.ApplicationWindow):
         )
 
     def _start_startup_probe(self) -> None:
+        if self.demo_mode:
+            GLib.idle_add(
+                self._on_startup_probe_finished,
+                GuiTaskResult(value=self._probe_startup_state()),
+            )
+            return
+
         run_gui_task(
             self._probe_startup_state,
             self._on_startup_probe_finished,
@@ -838,10 +855,7 @@ class MainWindow(Adw.ApplicationWindow):
             expires_at = status_data.get("macro_recording_expires_at")
 
         if enabled is None or source is None or expires_at is None:
-            local_status = resolve_macro_recording_status(os.getuid())
-            enabled = local_status.get("unlocked", False)
-            source = local_status.get("source", "none")
-            expires_at = local_status.get("expires_at", 0)
+            return
 
         self._macro_recording_enabled = bool(enabled)
         self._macro_recording_source = str(source or "none")
@@ -856,6 +870,11 @@ class MainWindow(Adw.ApplicationWindow):
 
     def macro_recording_enabled(self) -> bool:
         return bool(self._macro_recording_enabled)
+
+    def _refresh_macro_recording_state_from_session(self) -> None:
+        status = session_request({"command": "get_status"}, timeout=1.0)
+        if isinstance(status, dict):
+            self._update_macro_recording_state(status)
 
     def emergency_cancel_combo_enabled(self) -> bool:
         return bool(self._emergency_cancel_combo_enabled)
@@ -972,7 +991,7 @@ class MainWindow(Adw.ApplicationWindow):
 
         if self._recording_refresh_lease_id:
             try:
-                log.info("Window closing: locking runtime recording unlock lease")
+                log.info("Window closing: locking runtime capture unlock lease")
                 result = session_request(
                     {
                         "command": "lock_recording_unlock",
@@ -1117,7 +1136,7 @@ class MainWindow(Adw.ApplicationWindow):
 
         menu_box.append(self._create_menu_separator())
 
-        menu_unlock_btn = Gtk.Button(label="Unlock Recording")
+        menu_unlock_btn = Gtk.Button(label="Unlock Capture")
         self._configure_menu_button(menu_unlock_btn)
         menu_unlock_btn.set_tooltip_text(
             "Authorize raw original-input capture for adding inputs, combo capture, "
@@ -1642,7 +1661,7 @@ class MainWindow(Adw.ApplicationWindow):
         self._start_recording_unlock(on_success=on_success)
 
     def present_macro_recording_enable_dialog(self, on_success=None) -> None:
-        self._update_macro_recording_state(None)
+        self._refresh_macro_recording_state_from_session()
         if self._macro_recording_enabled:
             if callable(on_success):
                 on_success()
@@ -1665,7 +1684,7 @@ class MainWindow(Adw.ApplicationWindow):
         dialog.present(self)
 
     def present_macro_recording_disable_dialog(self, on_success=None) -> None:
-        self._update_macro_recording_state(None)
+        self._refresh_macro_recording_state_from_session()
         if not self._macro_recording_enabled:
             if callable(on_success):
                 on_success()
@@ -1697,7 +1716,7 @@ class MainWindow(Adw.ApplicationWindow):
             return
 
         if self.demo_mode:
-            self._show_unlock_error_dialog("Recording unlock is unavailable in demo mode.")
+            self._show_unlock_error_dialog("Capture unlock is unavailable in demo mode.")
             return
 
         self._unlock_request_inflight = True
@@ -1737,12 +1756,12 @@ class MainWindow(Adw.ApplicationWindow):
                 if not isinstance(claim_response, dict):
                     error_msg = (
                         "Authorization succeeded, but keymasq-session did not grant "
-                        "the recording unlock lease."
+                        "the capture unlock lease."
                     )
                 elif claim_response.get("status") != "ok":
                     error_msg = str(
                         claim_response.get("message")
-                        or "keymasq-session did not grant the recording unlock lease."
+                        or "keymasq-session did not grant the capture unlock lease."
                     )
 
             return error_msg, claim_response

--- a/keymasq/keymasqd/combo_engine.py
+++ b/keymasq/keymasqd/combo_engine.py
@@ -322,6 +322,7 @@ class ComboEngine:
         matching_ids: list[str] = []
         repeated_ids: list[str] = []
         scoped_ids: list[str] = []
+        scoped_nonmatching_ids: list[str] = []
         for combo_id, candidate in waiting_candidates.items():
             if event.binding in candidate.pressed_bindings:
                 repeated_ids.append(combo_id)
@@ -333,6 +334,7 @@ class ComboEngine:
                 continue
             if self._step_matches_scope(candidate.current_step(), event.binding):
                 scoped_ids.append(combo_id)
+                scoped_nonmatching_ids.append(combo_id)
 
         if repeated_ids and not matching_ids:
             return ComboDecision(consume_current_event=True)
@@ -346,6 +348,9 @@ class ComboEngine:
                 passthrough_current_event=True,
                 reset_candidates=not self._candidates,
             )
+
+        for combo_id in scoped_nonmatching_ids:
+            self._candidates.pop(combo_id, None)
 
         decision = ComboDecision()
         transitions: list[ComboActionTransition] = []
@@ -444,9 +449,18 @@ class ComboEngine:
         decision = ComboDecision()
         kept: dict[str, ActiveCandidate] = {}
         matched_step_binding = False
+        dropped_before_completion = False
+        released_was_passthrough = False
         transitions: list[ComboActionTransition] = []
         for combo_id, candidate in self._candidates.items():
             if not candidate.releasing:
+                if event.binding in candidate.pressed_bindings:
+                    dropped_before_completion = True
+                    released_was_passthrough = (
+                        released_was_passthrough
+                        or self._binding_was_passed_through(candidate, event.binding)
+                    )
+                    continue
                 kept[combo_id] = candidate
                 continue
             step = candidate.current_step()
@@ -495,6 +509,14 @@ class ComboEngine:
         self._candidates = kept
         if matched_step_binding:
             decision.consume_current_event = True
+        if dropped_before_completion:
+            if released_was_passthrough:
+                decision.passthrough_current_event = True
+            else:
+                decision.consume_current_event = True
+        if decision.consume_current_event:
+            decision.passthrough_current_event = False
+        if matched_step_binding or dropped_before_completion:
             if not self._candidates:
                 decision.reset_candidates = True
             return decision

--- a/keymasq/keymasqd/daemon.py
+++ b/keymasq/keymasqd/daemon.py
@@ -169,11 +169,8 @@ class Daemon:
 
         if self.socket_server:
             await self._run_async_cleanup("stop socket server", self.socket_server.stop)
-
-        try:
+        else:
             self._cleanup_socket_path()
-        except RuntimeError as exc:
-            log.warning("Failed to remove daemon socket path %s: %s", SOCKET_PATH, exc)
 
     async def _run_async_cleanup(
         self,
@@ -269,6 +266,14 @@ class Daemon:
         if command_type == CommandType.PING:
             return {"pong": True}
 
+        if command_type == CommandType.MACRO_RECORDING_STATUS:
+            uid = int(client.uid) if client is not None else int_like(data.get("uid"), os.getuid())
+            return cast(JsonObject, await asyncio.to_thread(resolve_macro_recording_status, uid))
+
+        if command_type == CommandType.RECORDING_UNLOCK_STATUS:
+            uid = int(client.uid) if client is not None else int_like(data.get("uid"), os.getuid())
+            return cast(JsonObject, await asyncio.to_thread(resolve_unlock_status, uid))
+
         macro_result = await daemon_macro_commands.handle_macro_command(
             cast(daemon_macro_commands.MacroCommandDaemon, self),
             command_type,
@@ -352,7 +357,7 @@ class Daemon:
 
         if source == "none":
             raise PermissionError(
-                "recording_locked: unlock required for capture/recording features"
+                "recording_locked: capture unlock required for input capture features"
             )
         raise PermissionError(f"recording_locked: unlock lease expired at {expires_at}")
 
@@ -427,9 +432,10 @@ class Daemon:
 
         if cached is not None:
             checked_mono, unlocked, expires_at, source = cached
-            if unlocked and (expires_at == 0 or expires_at >= now_wall):
+            cache_fresh = (now_mono - checked_mono) < self._unlock_cache_interval_s
+            if unlocked and cache_fresh and (expires_at == 0 or expires_at >= now_wall):
                 return unlocked, expires_at, source
-            if not unlocked and (now_mono - checked_mono) < self._unlock_cache_interval_s:
+            if not unlocked and cache_fresh:
                 return unlocked, expires_at, source
 
         status = resolve_unlock_status(uid)
@@ -537,7 +543,7 @@ class Daemon:
             expires_at,
             owner_uid=os.geteuid(),
             owner_gid=os.getegid(),
-            mode=0o644,
+            mode=0o600,
         )
         self._unlock_cache[uid] = (time.monotonic(), True, expires_at, "runtime")
         self._log_unlock_state_change(uid, True, "runtime", expires_at, reason="refresh")

--- a/keymasq/keymasqd/daemon.py
+++ b/keymasq/keymasqd/daemon.py
@@ -267,11 +267,13 @@ class Daemon:
             return {"pong": True}
 
         if command_type == CommandType.MACRO_RECORDING_STATUS:
-            uid = int(client.uid) if client is not None else int_like(data.get("uid"), os.getuid())
+            fallback_uid = int(client.uid) if client is not None else os.getuid()
+            uid = int_like(data.get("uid"), fallback_uid)
             return cast(JsonObject, await asyncio.to_thread(resolve_macro_recording_status, uid))
 
         if command_type == CommandType.RECORDING_UNLOCK_STATUS:
-            uid = int(client.uid) if client is not None else int_like(data.get("uid"), os.getuid())
+            fallback_uid = int(client.uid) if client is not None else os.getuid()
+            uid = int_like(data.get("uid"), fallback_uid)
             return cast(JsonObject, await asyncio.to_thread(resolve_unlock_status, uid))
 
         macro_result = await daemon_macro_commands.handle_macro_command(

--- a/keymasq/keymasqd/daemon_macro_commands.py
+++ b/keymasq/keymasqd/daemon_macro_commands.py
@@ -248,15 +248,18 @@ async def save_pending_recording(
         _PendingRecording,
         await daemon.recording_manager.claim_pending_recording(recording_id),
     )
+    save_succeeded = False
     try:
-        return await asyncio.to_thread(_save_pending_recording_sync, daemon, data, snapshot)
+        result = await asyncio.to_thread(_save_pending_recording_sync, daemon, data, snapshot)
+        save_succeeded = True
+        return result
     finally:
         is_slot_backed = bool(
             normalize_macro_recording_slot(getattr(snapshot, "recording_slot", 0))
         )
         await daemon.recording_manager.release_pending_recording_claim(
             recording_id,
-            saved=not is_slot_backed,
+            saved=save_succeeded and not is_slot_backed,
         )
 
 

--- a/keymasq/keymasqd/macro_store.py
+++ b/keymasq/keymasqd/macro_store.py
@@ -1,7 +1,11 @@
+import copy
+import fcntl
 import logging
 import os
 import re
+import threading
 from collections.abc import Iterable, Iterator
+from contextlib import contextmanager
 from datetime import datetime
 from pathlib import Path
 from typing import cast
@@ -17,6 +21,8 @@ from keymasq.keymasqd.macro_file import (
 )
 
 INTERNAL_MACRO_PREFIX = "__"
+_MUTATION_LOCK_NAME = ".macro-store.lock"
+_PROCESS_MUTATION_LOCK = threading.Lock()
 log = logging.getLogger("keymasqd.macros")
 type MacroEvent = dict[str, object]
 type MacroPayload = dict[str, object]
@@ -60,10 +66,12 @@ class MacroStore:
     def register_internal(self, name: str, events: list[MacroEvent], **extra: object) -> None:
         if not name.startswith(INTERNAL_MACRO_PREFIX):
             raise ValueError(f"Internal macro names must start with {INTERNAL_MACRO_PREFIX}")
-        self._internal_macros[name] = macro_payload_from_events(
-            {"name": name, "internal": True, **extra},
-            events,
-            name=name,
+        self._internal_macros[name] = copy.deepcopy(
+            macro_payload_from_events(
+                {"name": name, "internal": True, **extra},
+                events,
+                name=name,
+            )
         )
 
     def is_internal(self, name: str) -> bool:
@@ -89,7 +97,7 @@ class MacroStore:
 
     def get(self, name: str) -> MacroPayload:
         if name in self._internal_macros:
-            return dict(self._internal_macros[name])
+            return copy.deepcopy(self._internal_macros[name])
         path = self._macro_path(name)
         if not path.exists():
             raise FileNotFoundError(f"Macro '{name}' not found")
@@ -107,7 +115,7 @@ class MacroStore:
     def iter_events(self, name: str) -> Iterator[MacroEvent]:
         if name in self._internal_macros:
             events = _payload_events(self._internal_macros[name])
-            return iter(events)
+            return iter(copy.deepcopy(events))
         path = self._macro_path(name)
         if not path.exists():
             raise FileNotFoundError(f"Macro '{name}' not found")
@@ -143,77 +151,70 @@ class MacroStore:
     ) -> MacroPayload:
         if name in self._internal_macros:
             raise PermissionError(f"Cannot modify internal macro '{name}'")
-        current = self.get(name)
-        current_revision = _payload_int(current, "revision", 1)
-        if expected_revision is not None and expected_revision != current_revision:
-            raise ValueError(
-                f"Revision conflict: expected {expected_revision}, current {current_revision}"
-            )
+        with self._mutation_guard():
+            current = self.get(name)
+            current_revision = _payload_int(current, "revision", 1)
+            _raise_revision_conflict(expected_revision, current_revision)
 
-        data: MacroPayload = dict(current)
-        events_changed = "events" in payload
-        for key, value in payload.items():
-            if key in {"name", "created_at", "revision"}:
-                continue
-            data[key] = value
+            data: MacroPayload = dict(current)
+            events_changed = "events" in payload
+            for key, value in payload.items():
+                if key in {"name", "created_at", "revision"}:
+                    continue
+                data[key] = value
 
-        data["revision"] = current_revision + 1
-        data["event_count"] = len(_payload_events(data))
-        if events_changed:
-            if "duration_us" not in payload:
-                data.pop("duration_us", None)
-            if "device_types" not in payload:
-                data.pop("device_types", None)
-        self._write_payload(self._macro_path(name), data)
-        return self.get(name)
+            data["revision"] = current_revision + 1
+            data["event_count"] = len(_payload_events(data))
+            if events_changed:
+                if "duration_us" not in payload:
+                    data.pop("duration_us", None)
+                if "device_types" not in payload:
+                    data.pop("device_types", None)
+            self._write_payload(self._macro_path(name), data)
+            return self.get(name)
 
     def rename(self, old_name: str, new_name: str, expected_revision: int | None) -> MacroPayload:
         if old_name in self._internal_macros:
             raise PermissionError(f"Cannot rename internal macro '{old_name}'")
         if new_name.startswith(INTERNAL_MACRO_PREFIX):
             raise ValueError(f"Macro names starting with {INTERNAL_MACRO_PREFIX} are reserved")
-        current = self.get(old_name)
-        current_revision = _payload_int(current, "revision", 1)
-        if expected_revision is not None and expected_revision != current_revision:
-            raise ValueError(
-                f"Revision conflict: expected {expected_revision}, current {current_revision}"
-            )
-
         safe_new = self._sanitize_name(new_name)
         if not safe_new:
             raise ValueError("Invalid macro name")
 
         old_path = self._macro_path(old_name)
         new_path = self._macro_path(safe_new)
-        if new_path.exists():
-            raise FileExistsError(f"Macro '{safe_new}' already exists")
+        with self._mutation_guard():
+            current = self.get(old_name)
+            current_revision = _payload_int(current, "revision", 1)
+            _raise_revision_conflict(expected_revision, current_revision)
+            if new_path.exists():
+                raise FileExistsError(f"Macro '{safe_new}' already exists")
 
-        current["name"] = safe_new
-        current["revision"] = current_revision + 1
-        current["event_count"] = len(_payload_events(current))
-        try:
-            self._write_payload(new_path, current, overwrite=False)
-            renamed = self.get(safe_new)
-            if renamed != current:
-                raise ValueError(f"Renamed macro '{safe_new}' failed validation")
-        except FileExistsError:
-            raise
-        except Exception:
-            new_path.unlink(missing_ok=True)
-            raise
-        old_path.unlink(missing_ok=True)
-        return renamed
+            current["name"] = safe_new
+            current["revision"] = current_revision + 1
+            current["event_count"] = len(_payload_events(current))
+            try:
+                self._write_payload(new_path, current, overwrite=False)
+                renamed = self.get(safe_new)
+                if renamed != current:
+                    raise ValueError(f"Renamed macro '{safe_new}' failed validation")
+            except FileExistsError:
+                raise
+            except Exception:
+                new_path.unlink(missing_ok=True)
+                raise
+            old_path.unlink(missing_ok=True)
+            return renamed
 
     def delete(self, name: str, expected_revision: int | None) -> None:
         if name in self._internal_macros:
             raise PermissionError(f"Cannot delete internal macro '{name}'")
-        current = self.get_meta(name)
-        current_revision = _payload_int(current, "revision", 1)
-        if expected_revision is not None and expected_revision != current_revision:
-            raise ValueError(
-                f"Revision conflict: expected {expected_revision}, current {current_revision}"
-            )
-        self._macro_path(name).unlink(missing_ok=True)
+        with self._mutation_guard():
+            current = self.get_meta(name)
+            current_revision = _payload_int(current, "revision", 1)
+            _raise_revision_conflict(expected_revision, current_revision)
+            self._macro_path(name).unlink(missing_ok=True)
 
     def _create_from_events(
         self,
@@ -258,7 +259,36 @@ class MacroStore:
         meta = MacroFileMeta.from_payload(payload)
         write_macro(path, meta, events, overwrite=overwrite)
 
+    @contextmanager
+    def _mutation_guard(self) -> Iterator[None]:
+        self.ensure()
+        with _PROCESS_MUTATION_LOCK:
+            fd = self._open_mutation_lock()
+            try:
+                fcntl.flock(fd, fcntl.LOCK_EX)
+                try:
+                    yield
+                finally:
+                    fcntl.flock(fd, fcntl.LOCK_UN)
+            finally:
+                os.close(fd)
+
+    def _open_mutation_lock(self) -> int:
+        flags = os.O_CREAT | os.O_RDWR | os.O_CLOEXEC
+        if hasattr(os, "O_NOFOLLOW"):
+            flags |= os.O_NOFOLLOW
+        fd = os.open(self.base_dir / _MUTATION_LOCK_NAME, flags, 0o600)
+        os.fchmod(fd, 0o600)
+        return fd
+
 
 def _payload_events(payload: MacroPayload) -> list[MacroEvent]:
     events = _payload_list(payload, "events")
     return [cast(MacroEvent, event) for event in events if isinstance(event, dict)]
+
+
+def _raise_revision_conflict(expected_revision: int | None, current_revision: int) -> None:
+    if expected_revision is not None and expected_revision != current_revision:
+        raise ValueError(
+            f"Revision conflict: expected {expected_revision}, current {current_revision}"
+        )

--- a/keymasq/keymasqd/output_helpers.py
+++ b/keymasq/keymasqd/output_helpers.py
@@ -22,7 +22,7 @@ def _ecode_value(name: str) -> int | None:
         tuple_code = cast(tuple[object, ...], code)
         first = tuple_code[0] if tuple_code else None
         return first if isinstance(first, int) else None
-    return int(code)
+    return code if isinstance(code, int) else None
 
 
 def resolve_output_code(target: str | None) -> int | None:

--- a/keymasq/keymasqd/recording.py
+++ b/keymasq/keymasqd/recording.py
@@ -84,7 +84,11 @@ class RecordingManager:
         await self.discard_expired_pending_recordings()
         previous = await self.stop()
         pending_id = previous.get("pending_recording_id")
-        if isinstance(pending_id, str) and pending_id:
+        if (
+            isinstance(pending_id, str)
+            and pending_id
+            and not normalize_macro_recording_slot(previous.get("recording_slot"))
+        ):
             await self.discard_pending_recording(pending_id)
 
         self._spool = RecordingSpool(self._spool_dir)

--- a/keymasq/keymasqd/runtime/repeat.py
+++ b/keymasq/keymasqd/runtime/repeat.py
@@ -274,24 +274,13 @@ def _superkey_slot_action_lists(config: Any, slot: str | None) -> Iterable[Itera
         yield config.overload_up_actions
 
 
-def _superkey_all_action_lists(config: Any) -> Iterable[Iterable[Any]]:
-    for slot in (
-        SUPERKEY_SLOT_TAP,
-        SUPERKEY_SLOT_DOUBLE_TAP,
-        SUPERKEY_SLOT_HOLD,
-        SUPERKEY_SLOT_TAP_HOLD,
-        SUPERKEY_SLOT_OVERLOAD,
-    ):
-        yield from _superkey_slot_action_lists(config, slot)
-
-
-def _superkey_action_contains_exec(action: MappingAction) -> bool:
+def _superkey_slot_contains_exec_action(action: MappingAction, slot: str | None) -> bool:
     config = action.superkey_config
     if action.action_type != ActionType.SUPERKEY or config is None:
         return False
     return any(
         _is_exec_action_type(child.action_type)
-        for actions in _superkey_all_action_lists(config)
+        for actions in _superkey_slot_action_lists(config, slot)
         for child in actions
     )
 
@@ -327,8 +316,8 @@ def _is_profile_action_type(action_type: object) -> bool:
 
 
 def _repeat_entry_contains_exec_action(entry: RepeatHistoryEntry) -> bool:
-    return entry.action.action_type == ActionType.EXEC or _superkey_action_contains_exec(
-        entry.action
+    return entry.action.action_type == ActionType.EXEC or _superkey_slot_contains_exec_action(
+        entry.action, entry.superkey_slot
     )
 
 

--- a/keymasq/keymasqd/runtime/topology.py
+++ b/keymasq/keymasqd/runtime/topology.py
@@ -215,6 +215,10 @@ async def reconcile_topology_unlocked(
                 removed.append((hardware_id, device.path))
                 continue
 
+            if not live_interface_matches_desired(live_info, {hardware_id}):
+                removed.append((hardware_id, device.path))
+                continue
+
             live_path = str(getattr(live_info, "path", "") or "")
             grabbed_path = str(
                 getattr(device, "resolved_event_path", "") or device.path
@@ -236,7 +240,7 @@ def build_topology_events(
 
     for stable_path in sorted(previous.keys() - current.keys()):
         info = previous[stable_path]
-        if not hardware_id_matches_desired(info.hardware_id, desired_hardware_ids):
+        if not live_interface_matches_desired(info, desired_hardware_ids):
             continue
         events.append(
             (
@@ -250,14 +254,14 @@ def build_topology_events(
         current_info = current[stable_path]
         if not live_interface_changed(previous_info, current_info):
             continue
-        if hardware_id_matches_desired(previous_info.hardware_id, desired_hardware_ids):
+        if live_interface_matches_desired(previous_info, desired_hardware_ids):
             events.append(
                 (
                     manager._command_type.DEVICE_DISCONNECTED,
                     live_interface_payload(previous_info),
                 )
             )
-        if hardware_id_matches_desired(current_info.hardware_id, desired_hardware_ids):
+        if live_interface_matches_desired(current_info, desired_hardware_ids):
             events.append(
                 (
                     manager._command_type.DEVICE_CONNECTED,
@@ -267,7 +271,7 @@ def build_topology_events(
 
     for stable_path in sorted(current.keys() - previous.keys()):
         info = current[stable_path]
-        if not hardware_id_matches_desired(info.hardware_id, desired_hardware_ids):
+        if not live_interface_matches_desired(info, desired_hardware_ids):
             continue
         events.append(
             (
@@ -281,21 +285,56 @@ def build_topology_events(
 
 def live_interface_changed(previous_info: Any, current_info: Any) -> bool:
     return (
-        str(previous_info.path) != str(current_info.path)
+        normalize_hardware_id(previous_info.hardware_id)
+        != normalize_hardware_id(current_info.hardware_id)
+        or str(previous_info.path) != str(current_info.path)
         or str(previous_info.interface_id) != str(current_info.interface_id)
     )
 
 
-def hardware_id_matches_desired(hardware_id: str, desired_hardware_ids: set[str]) -> bool:
-    normalized = str(hardware_id or "").strip().lower()
+def normalize_hardware_id(hardware_id: object) -> str:
+    return str(hardware_id or "").strip().lower()
+
+
+def live_interface_matches_desired(info: Any, desired_hardware_ids: set[str]) -> bool:
+    return hardware_id_matches_desired(
+        info.hardware_id,
+        desired_hardware_ids,
+        interface_id=getattr(info, "interface_id", ""),
+    )
+
+
+def hardware_id_matches_desired(
+    hardware_id: str,
+    desired_hardware_ids: set[str],
+    *,
+    interface_id: str | None = None,
+) -> bool:
+    normalized = normalize_hardware_id(hardware_id)
     if not normalized:
         return False
-    if normalized in desired_hardware_ids:
-        return True
-    return any(
-        str(desired or "").strip().lower().startswith(f"{normalized}@")
-        for desired in desired_hardware_ids
-    )
+    normalized_interface = normalize_hardware_id(interface_id)
+    for desired in desired_hardware_ids:
+        desired_base, desired_interface = split_desired_hardware_id(desired)
+        if desired_base != normalized:
+            continue
+        # hardware_id_matches_desired compares parts produced by
+        # split_desired_hardware_id/normalize_hardware_id: numeric "@N" suffixes
+        # identify a device instance and intentionally wildcard the live
+        # interface, while named suffixes must match the normalized interface.
+        if not desired_interface or desired_interface.isdecimal():
+            return True
+        if desired_interface == normalized_interface:
+            return True
+    return False
+
+
+def split_desired_hardware_id(desired_hardware_id: object) -> tuple[str, str]:
+    normalized = normalize_hardware_id(desired_hardware_id)
+    desired_base, separator, desired_interface = normalized.partition("@")
+    if not separator:
+        return desired_base, ""
+    return desired_base, desired_interface
 
 
 def live_interface_payload(info: Any) -> JsonObject:

--- a/keymasq/keymasqd/socket_server.py
+++ b/keymasq/keymasqd/socket_server.py
@@ -69,16 +69,19 @@ class SocketServer:
         self._client_context: dict[asyncio.StreamWriter, ClientContext] = {}
         self._next_connection_id = 1
         self._owner_context: ClientContext | None = None
+        self._socket_stat: os.stat_result | None = None
 
     @property
     def owner_context(self) -> ClientContext | None:
         return self._owner_context
 
     async def start(self) -> None:
-        self.server = await asyncio.start_unix_server(
+        server = await asyncio.start_unix_server(
             self._handle_client,
             path=self.socket_path,
         )
+        self.server = server
+        socket_stat = self._socket_path_stat()
 
         try:
             os.chown(self.socket_path, os.geteuid(), os.getegid())
@@ -91,13 +94,68 @@ class SocketServer:
                 )
         except (PermissionError, OSError, RuntimeError) as exc:
             log.error(f"Failed to secure daemon socket: {exc}")
+            await self._cleanup_failed_start(server, socket_stat)
             raise
 
+        self._socket_stat = socket_stat
         log.info(f"Listening on {self.socket_path}")
 
+    def _socket_path_stat(self) -> os.stat_result | None:
+        try:
+            return os.lstat(self.socket_path)
+        except OSError:
+            return None
+
+    async def _cleanup_failed_start(
+        self,
+        server: asyncio.Server,
+        socket_stat: os.stat_result | None,
+    ) -> None:
+        server.close()
+        try:
+            await server.wait_closed()
+        except Exception as exc:
+            log.warning(f"Failed to close unsecured daemon socket: {exc}")
+        finally:
+            if self.server is server:
+                self.server = None
+
+        self._unlink_socket_path(socket_stat, "unsecured daemon socket")
+
+    def _unlink_socket_path(
+        self,
+        socket_stat: os.stat_result | None,
+        description: str,
+    ) -> None:
+        if socket_stat is None:
+            return
+
+        try:
+            current_stat = os.lstat(self.socket_path)
+        except FileNotFoundError:
+            return
+        except OSError as exc:
+            log.warning(f"Failed to inspect {description}: {exc}")
+            return
+
+        if (
+            current_stat.st_dev != socket_stat.st_dev
+            or current_stat.st_ino != socket_stat.st_ino
+        ):
+            return
+
+        try:
+            os.unlink(self.socket_path)
+        except FileNotFoundError:
+            pass
+        except OSError as exc:
+            log.warning(f"Failed to remove {description}: {exc}")
+
     async def stop(self) -> None:
-        if self.server:
-            self.server.close()
+        server = self.server
+        socket_stat = self._socket_stat
+        if server:
+            server.close()
 
         writers = set(self.clients) | set(self._buffer) | set(self._client_context)
         for writer in writers:
@@ -108,13 +166,18 @@ class SocketServer:
             return_exceptions=True,
         )
 
-        if self.server:
-            await self.server.wait_closed()
+        if server:
+            await server.wait_closed()
+            if self.server is server:
+                self.server = None
+
+        self._unlink_socket_path(socket_stat, "daemon socket")
 
         self.clients.clear()
         self._buffer.clear()
         self._client_context.clear()
         self._owner_context = None
+        self._socket_stat = None
 
     async def _handle_client(
         self,

--- a/keymasq/record.py
+++ b/keymasq/record.py
@@ -1,5 +1,6 @@
 import argparse
 import json
+import math
 import os
 import pwd
 import sys
@@ -42,7 +43,7 @@ def _require_privileged_caller() -> int:
 
 def _authorize_target_uid(target_uid: int, caller_euid: int | None) -> None:
     pkexec_uid = os.environ.get("PKEXEC_UID", "").strip()
-    if pkexec_uid:
+    if caller_euid == 0 and pkexec_uid:
         try:
             authorized_uid = int(pkexec_uid)
         except ValueError as exc:
@@ -61,25 +62,32 @@ def _runtime_expires_at(ttl: int) -> int:
     ttl = int(ttl)
     if ttl < 1:
         raise ValueError("runtime ttl must be at least 1 second")
-    return int(time.time()) + ttl
+    return math.ceil(time.time() + ttl)
 
 
-def _write_lease(path: Path, expires_at: int) -> None:
-    owner_uid = None
-    owner_gid = None
+def _write_lease(path: Path, expires_at: int, target_uid: int) -> None:
+    owner_uid = os.geteuid()
+    owner_gid = os.getegid()
+    target_gid = owner_gid
     try:
         keymasq_user = pwd.getpwnam("keymasq")
         owner_uid = keymasq_user.pw_uid
         owner_gid = keymasq_user.pw_gid
     except KeyError:
-        pass
+        if owner_uid == 0:
+            owner_gid = 0
+
+    try:
+        target_gid = pwd.getpwuid(int(target_uid)).pw_gid
+    except KeyError:
+        target_gid = owner_gid
 
     write_unlock_expires_at(
         path,
         expires_at,
         owner_uid=owner_uid,
-        owner_gid=owner_gid,
-        mode=0o644,
+        owner_gid=target_gid,
+        mode=0o440,
     )
 
 
@@ -94,14 +102,20 @@ def main() -> None:
     parser = argparse.ArgumentParser(prog="keymasq-record")
     subparsers = parser.add_subparsers(dest="command", required=True)
 
-    status_parser = subparsers.add_parser("status", help="Show unlock status")
+    status_parser = subparsers.add_parser("status", help="Show capture unlock status")
     status_parser.add_argument("--uid", type=int, required=True)
 
-    runtime_unlock_parser = subparsers.add_parser("unlock-runtime", help="Set runtime unlock")
+    runtime_unlock_parser = subparsers.add_parser(
+        "unlock-runtime",
+        help="Set runtime capture unlock",
+    )
     runtime_unlock_parser.add_argument("--uid", type=int, required=True)
     runtime_unlock_parser.add_argument("--ttl", type=int, default=900)
 
-    runtime_lock_parser = subparsers.add_parser("lock-runtime", help="Clear runtime unlock")
+    runtime_lock_parser = subparsers.add_parser(
+        "lock-runtime",
+        help="Clear runtime capture unlock",
+    )
     runtime_lock_parser.add_argument("--uid", type=int, required=True)
 
     macro_recording_status_parser = subparsers.add_parser(
@@ -138,7 +152,7 @@ def main() -> None:
 
     try:
         caller_euid = _require_privileged_caller()
-        if args.command in _MUTATING_COMMANDS:
+        if hasattr(args, "uid"):
             _authorize_target_uid(int(args.uid), caller_euid)
 
         if args.command == "status":
@@ -149,7 +163,7 @@ def main() -> None:
         if args.command == "unlock-runtime":
             runtime_path = runtime_unlock_path(args.uid)
             expires_at = _runtime_expires_at(args.ttl)
-            _write_lease(runtime_path, expires_at)
+            _write_lease(runtime_path, expires_at, args.uid)
             print(json.dumps({"status": "ok", "scope": "runtime", "expires_at": expires_at}))
             return
 
@@ -166,7 +180,7 @@ def main() -> None:
         if args.command == "enable-macro-recording-runtime":
             runtime_path = runtime_macro_recording_path(args.uid)
             expires_at = _runtime_expires_at(args.ttl)
-            _write_lease(runtime_path, expires_at)
+            _write_lease(runtime_path, expires_at, args.uid)
             print(
                 json.dumps(
                     {
@@ -179,7 +193,7 @@ def main() -> None:
             return
 
         if args.command == "enable-macro-recording-persistent":
-            _write_lease(persistent_macro_recording_path(args.uid), 0)
+            _write_lease(persistent_macro_recording_path(args.uid), 0, args.uid)
             print(
                 json.dumps(
                     {

--- a/keymasq/session/action_handler.py
+++ b/keymasq/session/action_handler.py
@@ -65,7 +65,8 @@ class ActionHandler:
             _, stderr = await asyncio.wait_for(process.communicate(), timeout=timeout_s)
 
             if process.returncode != 0:
-                log.warning(f"Command failed with code {process.returncode}: {stderr.decode()}")
+                stderr_text = stderr.decode(errors="replace")
+                log.warning(f"Command failed with code {process.returncode}: {stderr_text}")
             return int(process.returncode or 0)
 
         except TimeoutError:

--- a/keymasq/session/analog_controls.py
+++ b/keymasq/session/analog_controls.py
@@ -1,7 +1,8 @@
 import logging
 import tomllib
+from dataclasses import dataclass
 from pathlib import Path
-from typing import cast
+from typing import BinaryIO, cast
 
 import tomli_w
 
@@ -24,12 +25,19 @@ from keymasq.session.action_toml import (
     mapping_action_to_toml,
     mapping_action_type_from_toml,
 )
+from keymasq.session.config_files import write_config_atomically
 from keymasq.session.config_loading import load_config_files_sync
 
 log = logging.getLogger("keymasq-session.analog_controls")
 type TomlDict = dict[str, object]
 type _IntLike = int | float | str | bytes
 type _FloatLike = int | float | str | bytes
+
+
+@dataclass
+class _AnalogControlEntry:
+    path: Path
+    config: AnalogControlConfig
 
 
 def _as_toml_dict(value: object) -> TomlDict | None:
@@ -52,12 +60,12 @@ def _float_value(value: object, default: float = 0.0) -> float:
 class AnalogControlManager:
     def __init__(self) -> None:
         paths.ensure_config_dirs()
-        self._analog_controls: dict[str, AnalogControlConfig] = {}
+        self._analog_controls: dict[str, _AnalogControlEntry] = {}
         self._load_all()
 
     def _load_all(self, *, strict: bool = False) -> None:
-        loaded_analog_controls: dict[str, AnalogControlConfig] = {}
-        for _config_file, config in load_config_files_sync(
+        loaded_analog_controls: dict[str, _AnalogControlEntry] = {}
+        for config_file, config in load_config_files_sync(
             paths.ANALOG_CONTROLS_DIR,
             config_kind="analog control",
             strict=strict,
@@ -66,9 +74,49 @@ class AnalogControlManager:
             failure_log_message="Failed to load analog control %s: %s",
         ):
             if config is not None:
-                loaded_analog_controls[config.name] = config
+                self._add_loaded_analog_control(
+                    config_file,
+                    config,
+                    loaded_analog_controls,
+                )
 
         self._analog_controls = loaded_analog_controls
+
+    def _add_loaded_analog_control(
+        self,
+        path: Path,
+        config: AnalogControlConfig,
+        analog_controls: dict[str, _AnalogControlEntry],
+    ) -> None:
+        entry = _AnalogControlEntry(path=path, config=config)
+        existing = analog_controls.get(config.name)
+        if existing is None:
+            analog_controls[config.name] = entry
+            return
+
+        selected = self._select_duplicate_analog_control(config.name, existing, entry)
+        ignored = entry if selected is existing else existing
+        analog_controls[config.name] = selected
+        log.warning(
+            "Ignoring duplicate analog control name '%s' from %s; using %s",
+            config.name,
+            ignored.path,
+            selected.path,
+        )
+
+    def _select_duplicate_analog_control(
+        self,
+        name: str,
+        first: _AnalogControlEntry,
+        second: _AnalogControlEntry,
+    ) -> _AnalogControlEntry:
+        first_is_canonical = self._is_canonical_storage_path(name, first.path)
+        second_is_canonical = self._is_canonical_storage_path(name, second.path)
+        if first_is_canonical and not second_is_canonical:
+            return first
+        if second_is_canonical and not first_is_canonical:
+            return second
+        return first
 
     def _load_analog_control(self, path: Path) -> AnalogControlConfig | None:
         with open(path, "rb") as f:
@@ -170,20 +218,21 @@ class AnalogControlManager:
         )
 
     def get_analog_control(self, name: str) -> AnalogControlConfig | None:
-        return self._analog_controls.get(name)
+        entry = self._analog_controls.get(name)
+        return entry.config if entry is not None else None
 
     def list_analog_controls(self) -> list[str]:
         return sorted(self._analog_controls.keys())
 
     def get_all_analog_controls(self) -> dict[str, AnalogControlConfig]:
-        return self._analog_controls.copy()
+        return {name: entry.config for name, entry in self._analog_controls.items()}
 
-    def snapshot_analog_controls(self) -> dict[str, AnalogControlConfig]:
+    def snapshot_analog_controls(self) -> dict[str, _AnalogControlEntry]:
         return self._analog_controls.copy()
 
     def restore_analog_controls(
         self,
-        analog_controls: dict[str, AnalogControlConfig],
+        analog_controls: dict[str, _AnalogControlEntry],
     ) -> None:
         self._analog_controls = analog_controls.copy()
 
@@ -196,7 +245,15 @@ class AnalogControlManager:
         paths.ensure_config_dirs()
         config = normalize_analog_control_features(config)
         validate_analog_control_config(config)
-        path = self._path_for_name(config.name)
+        existing_entry = self._analog_controls.get(config.name)
+        if replacing_name and replacing_name != config.name:
+            if existing_entry is not None:
+                raise ValueError(f"Analog control '{config.name}' already exists")
+            path = self._path_for_name(config.name)
+        else:
+            path = existing_entry.path if existing_entry is not None else self._path_for_name(
+                config.name
+            )
         self._ensure_storage_path_available(config.name, path, replacing_name=replacing_name)
 
         data: dict[str, object] = {
@@ -259,14 +316,19 @@ class AnalogControlManager:
                 self._serialize_threshold(threshold) for threshold in config.thresholds
             ]
 
-        with open(path, "wb") as f:
-            tomli_w.dump(data, f)
+        def write_config(config_file: BinaryIO) -> None:
+            tomli_w.dump(data, config_file)
+
+        write_config_atomically(path, write_config)
         if replacing_name and replacing_name != config.name:
-            old_path = self._path_for_name(replacing_name)
+            old_entry = self._analog_controls.get(replacing_name)
+            old_path = old_entry.path if old_entry is not None else self._path_for_name(
+                replacing_name
+            )
             if old_path != path and old_path.exists():
                 old_path.unlink()
             self._analog_controls.pop(replacing_name, None)
-        self._analog_controls[config.name] = config
+        self._analog_controls[config.name] = _AnalogControlEntry(path=path, config=config)
         log.info("Saved analog control: %s", config.name)
 
     def _serialize_threshold(self, threshold: AnalogActionThreshold) -> TomlDict:
@@ -287,24 +349,26 @@ class AnalogControlManager:
         )
 
     def delete_analog_control(self, name: str) -> bool:
-        if name not in self._analog_controls:
+        entry = self._analog_controls.get(name)
+        if entry is None:
             return False
-        path = self._path_for_name(name)
-        if path.exists():
-            path.unlink()
+        if entry.path.exists():
+            entry.path.unlink()
         del self._analog_controls[name]
         log.info("Deleted analog control: %s", name)
         return True
 
     def rename_analog_control(self, old_name: str, new_name: str) -> bool:
-        if old_name not in self._analog_controls:
+        entry = self._analog_controls.get(old_name)
+        if entry is None:
             return False
+        if old_name == new_name:
+            return True
         if new_name in self._analog_controls and new_name != old_name:
             log.warning("Analog control '%s' already exists", new_name)
             return False
 
-        config = self._analog_controls[old_name]
-        old_path = self._path_for_name(old_name)
+        config = entry.config
         new_path = self._path_for_name(new_name)
         self._ensure_storage_path_available(new_name, new_path, replacing_name=old_name)
         config.name = new_name
@@ -313,9 +377,6 @@ class AnalogControlManager:
         except Exception:
             config.name = old_name
             raise
-        if old_path != new_path and old_path.exists():
-            old_path.unlink()
-        self._analog_controls.pop(old_name, None)
         log.info("Renamed analog control: %s -> %s", old_name, new_name)
         return True
 
@@ -325,6 +386,9 @@ class AnalogControlManager:
 
     def _path_for_name(self, name: str) -> Path:
         return paths.ANALOG_CONTROLS_DIR / f"{self._sanitize_name(name)}.toml"
+
+    def _is_canonical_storage_path(self, name: str, path: Path) -> bool:
+        return path == self._path_for_name(name)
 
     def _storage_file_name(self, path: Path) -> str | None:
         if not path.exists():

--- a/keymasq/session/config_files.py
+++ b/keymasq/session/config_files.py
@@ -1,0 +1,29 @@
+import contextlib
+import os
+import tempfile
+from collections.abc import Callable
+from pathlib import Path
+from typing import BinaryIO, cast
+
+
+def write_config_atomically(path: Path, write: Callable[[BinaryIO], None]) -> None:
+    fd, temp_name = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+    temp_path: Path | None = Path(temp_name)
+    try:
+        with os.fdopen(fd, "wb") as config_file:
+            binary_file = cast(BinaryIO, config_file)
+            write(binary_file)
+            binary_file.flush()
+            os.fsync(binary_file.fileno())
+        os.replace(temp_path, path)
+        temp_path = None
+        with contextlib.suppress(OSError):
+            dir_fd = os.open(path.parent, os.O_RDONLY | os.O_DIRECTORY)
+            try:
+                os.fsync(dir_fd)
+            finally:
+                os.close(dir_fd)
+    finally:
+        if temp_path is not None:
+            with contextlib.suppress(FileNotFoundError):
+                temp_path.unlink()

--- a/keymasq/session/hardware.py
+++ b/keymasq/session/hardware.py
@@ -2,8 +2,9 @@ import contextlib
 import logging
 import re
 import tomllib
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, cast
+from typing import Any, BinaryIO, cast
 
 import tomli_w
 
@@ -17,10 +18,24 @@ from keymasq.common.models import (
     EvdevDevice,
     HardwareConfig,
 )
+from keymasq.session.config_files import write_config_atomically
 from keymasq.session.config_loading import load_config_files_sync
 
 log = logging.getLogger("keymasq-session.hardware")
 MAX_HARDWARE_PATH_ATTEMPTS = 10000
+KEYBOARD_LAYOUT_FOOTER = (
+    b"\n"
+    b"# Optional special keys (not shown in GUI by default)\n"
+    b"# Add entries below into [hardware.layout.buttons] if needed\n"
+    b"# Example entries:\n"
+    b'# { id = "key_volumedown", label = "Volume Down", '
+    b'evdev = "key_volumedown", type = "key" }\n'
+    b'# { id = "key_volumeup", label = "Volume Up", '
+    b'evdev = "key_volumeup", type = "key" }\n'
+    b'# { id = "key_mute", label = "Mute", evdev = "key_mute", type = "key" }\n'
+    b'# { id = "key_playpause", label = "Play Pause", '
+    b'evdev = "key_playpause", type = "key" }\n'
+)
 
 
 def _valid_hardware_id_for_model(hardware_id: str, model_id: str) -> bool:
@@ -32,22 +47,31 @@ def _hardware_storage_stem(hardware_id: str) -> str:
     return (safe or "hardware").lower()
 
 
+@dataclass
+class _HardwareEntry:
+    path: Path
+    config: HardwareConfig
+
+
 class HardwareManager:
     def __init__(self) -> None:
         paths.ensure_config_dirs()
-        self._cache: dict[str, HardwareConfig] = {}
+        self._cache: dict[str, _HardwareEntry] = {}
         self._load_all()
 
     def _load_all(self, *, strict: bool = False) -> None:
-        loaded_cache: dict[str, HardwareConfig] = {}
-        for _config_file, config in load_config_files_sync(
+        loaded_cache: dict[str, _HardwareEntry] = {}
+        for config_file, config in load_config_files_sync(
             paths.HARDWARE_DIR,
             config_kind="hardware",
             strict=strict,
             load_config=self._load_config,
             logger=log,
         ):
-            loaded_cache[config.hardware_id] = config
+            self._add_loaded_hardware(
+                _HardwareEntry(path=config_file, config=config),
+                loaded_cache,
+            )
 
         self._cache = loaded_cache
 
@@ -136,17 +160,53 @@ class HardwareManager:
             id=hardware_id or None,
         )
 
-    def get_hardware(self, hardware_id: str) -> HardwareConfig | None:
-        return self._cache.get(hardware_id)
+    def _add_loaded_hardware(
+        self,
+        entry: _HardwareEntry,
+        hardware: dict[str, _HardwareEntry],
+    ) -> None:
+        hardware_id = entry.config.hardware_id
+        existing = hardware.get(hardware_id)
+        if existing is None:
+            hardware[hardware_id] = entry
+            return
 
-    def snapshot_hardware(self) -> dict[str, HardwareConfig]:
+        selected = self._select_duplicate_hardware(existing, entry)
+        ignored = entry if selected is existing else existing
+        hardware[hardware_id] = selected
+        log.warning(
+            "Ignoring duplicate hardware_id '%s' from %s; using %s",
+            hardware_id,
+            ignored.path,
+            selected.path,
+        )
+
+    def _select_duplicate_hardware(
+        self,
+        first: _HardwareEntry,
+        second: _HardwareEntry,
+    ) -> _HardwareEntry:
+        hardware_id = first.config.hardware_id
+        first_is_canonical = self._is_canonical_storage_path(hardware_id, first.path)
+        second_is_canonical = self._is_canonical_storage_path(hardware_id, second.path)
+        if first_is_canonical and not second_is_canonical:
+            return first
+        if second_is_canonical and not first_is_canonical:
+            return second
+        return first
+
+    def get_hardware(self, hardware_id: str) -> HardwareConfig | None:
+        entry = self._cache.get(hardware_id)
+        return entry.config if entry is not None else None
+
+    def snapshot_hardware(self) -> dict[str, _HardwareEntry]:
         return self._cache.copy()
 
-    def restore_hardware(self, hardware: dict[str, HardwareConfig]) -> None:
+    def restore_hardware(self, hardware: dict[str, _HardwareEntry]) -> None:
         self._cache = hardware.copy()
 
     def list_hardware(self) -> list[HardwareConfig]:
-        return list(self._cache.values())
+        return [entry.config for entry in self._cache.values()]
 
     def list_hardware_ids(self) -> list[str]:
         return list(self._cache.keys())
@@ -164,7 +224,19 @@ class HardwareManager:
                 f"Hardware storage path '{path.name}' already exists but could not be read"
             ) from exc
 
+    def _storage_path_matches_hardware_id(self, path: Path, hardware_id: str) -> bool:
+        try:
+            return self._load_config(path).hardware_id == hardware_id
+        except Exception:
+            return False
+
     def _path_for_hardware_id(self, hardware_id: str) -> tuple[Path, bool]:
+        existing_entry = self._cache.get(hardware_id)
+        if existing_entry is not None:
+            if self._storage_path_matches_hardware_id(existing_entry.path, hardware_id):
+                return existing_entry.path, False
+            self._cache.pop(hardware_id, None)
+
         existing_path = self._existing_path_for_hardware_id(hardware_id)
         if existing_path is not None:
             return existing_path, False
@@ -179,11 +251,17 @@ class HardwareManager:
             return path, True
         raise ValueError(f"Could not allocate storage path for hardware '{hardware_id}'")
 
+    def _is_canonical_storage_path(self, hardware_id: str, path: Path) -> bool:
+        stem = _hardware_storage_stem(hardware_id)
+        if not path.stem.startswith(stem):
+            return False
+        suffix = path.stem.removeprefix(stem)
+        return not suffix or (suffix.startswith("_") and suffix[1:].isdigit())
+
     def _existing_path_for_hardware_id(self, hardware_id: str) -> Path | None:
         stem = _hardware_storage_stem(hardware_id)
         for path in sorted(paths.HARDWARE_DIR.glob(f"{stem}*.toml")):
-            suffix = path.stem.removeprefix(stem)
-            if suffix and not (suffix.startswith("_") and suffix[1:].isdigit()):
+            if not self._is_canonical_storage_path(hardware_id, path):
                 continue
             if self._storage_file_hardware_id(path) == hardware_id:
                 return path
@@ -293,46 +371,32 @@ class HardwareManager:
 
         path, reserved_path = self._path_for_hardware_id(config.hardware_id)
         try:
-            with open(path, "wb") as f:
-                tomli_w.dump(data, f)
+            def write_config(config_file: BinaryIO) -> None:
+                tomli_w.dump(data, config_file)
+                if is_keyboard_layout:
+                    config_file.write(KEYBOARD_LAYOUT_FOOTER)
 
-            if is_keyboard_layout:
-                with open(path, "a", encoding="utf-8") as f:
-                    f.write("\n")
-                    f.write("# Optional special keys (not shown in GUI by default)\n")
-                    f.write("# Add entries below into [hardware.layout.buttons] if needed\n")
-                    f.write("# Example entries:\n")
-                    f.write(
-                        '# { id = "key_volumedown", label = "Volume Down", '
-                        'evdev = "key_volumedown", type = "key" }\n'
-                    )
-                    f.write(
-                        '# { id = "key_volumeup", label = "Volume Up", '
-                        'evdev = "key_volumeup", type = "key" }\n'
-                    )
-                    f.write(
-                        '# { id = "key_mute", label = "Mute", evdev = "key_mute", type = "key" }\n'
-                    )
-                    f.write(
-                        '# { id = "key_playpause", label = "Play Pause", '
-                        'evdev = "key_playpause", type = "key" }\n'
-                    )
+            write_config_atomically(path, write_config)
         except Exception:
             if reserved_path:
                 with contextlib.suppress(OSError):
                     path.unlink()
             raise
 
-        self._cache[config.hardware_id] = config
+        self._cache[config.hardware_id] = _HardwareEntry(path=path, config=config)
         log.info(f"Saved hardware config: {path}")
 
     def delete_hardware(self, hardware_id: str) -> bool:
-        if hardware_id not in self._cache:
+        entry = self._cache.get(hardware_id)
+        if entry is None:
             return False
 
-        path = self._existing_path_for_hardware_id(hardware_id)
+        path = entry.path
 
-        if path is not None and path.exists():
+        if path.exists():
+            if not self._storage_path_matches_hardware_id(path, hardware_id):
+                del self._cache[hardware_id]
+                return False
             try:
                 path.unlink()
             except Exception as e:

--- a/keymasq/session/hardware.py
+++ b/keymasq/session/hardware.py
@@ -393,15 +393,22 @@ class HardwareManager:
 
         path = entry.path
 
-        if path.exists():
-            if not self._storage_path_matches_hardware_id(path, hardware_id):
+        if not path.exists():
+            resolved_path = self._existing_path_for_hardware_id(hardware_id)
+            if resolved_path is None:
                 del self._cache[hardware_id]
+                log.info(f"Dropped stale hardware cache entry: {hardware_id}")
                 return False
-            try:
-                path.unlink()
-            except Exception as e:
-                log.error(f"Failed to delete {path}: {e}")
-                return False
+            path = resolved_path
+
+        if not self._storage_path_matches_hardware_id(path, hardware_id):
+            del self._cache[hardware_id]
+            return False
+        try:
+            path.unlink()
+        except Exception as e:
+            log.error(f"Failed to delete {path}: {e}")
+            return False
 
         del self._cache[hardware_id]
         log.info(f"Deleted hardware config: {hardware_id}")

--- a/keymasq/session/manager/commands.py
+++ b/keymasq/session/manager/commands.py
@@ -56,7 +56,12 @@ async def handle_session_request(
     if runtime_recording.is_sensitive_session_command(
         manager,
         command, policy
-    ) and not runtime_recording.is_refresh_owner_request(manager, peer, writer):
+    ) and not await runtime_recording.authorize_sensitive_session_command(
+        manager,
+        command,
+        peer,
+        writer,
+    ):
         return {
             "status": "error",
             "error_code": "sensitive_command_denied",
@@ -416,7 +421,12 @@ async def _handle_compositor_commands(
             **runtime_recording.serialize_recording_unlock_state(
                 manager,
                 unlock_status,
-                refresh_owner=runtime_recording.is_refresh_owner_request(manager, peer, writer),
+                refresh_owner=runtime_recording.is_active_refresh_owner_request(
+                    manager,
+                    peer,
+                    writer,
+                    unlock_status,
+                ),
             ),
             **runtime_recording.serialize_macro_recording_state(macro_recording_status),
         }
@@ -476,7 +486,12 @@ async def _handle_recording_commands(
             **runtime_recording.serialize_recording_unlock_state(
                 manager,
                 unlock_status,
-                refresh_owner=runtime_recording.is_refresh_owner_request(manager, peer, writer),
+                refresh_owner=runtime_recording.is_active_refresh_owner_request(
+                    manager,
+                    peer,
+                    writer,
+                    unlock_status,
+                ),
             ),
             **runtime_recording.serialize_macro_recording_state(macro_recording_status),
             **manager.recording_state.settings,

--- a/keymasq/session/manager/compositor.py
+++ b/keymasq/session/manager/compositor.py
@@ -161,7 +161,10 @@ async def run_compositor_setup_action(
 
 
 async def get_active_window_payload(manager: "SessionManager") -> JsonObject:
+    previous_window = dict(manager.compositor_state.current_window)
     window_info = await refresh_current_window_from_listener(manager)
+    if previous_window != manager.compositor_state.current_window:
+        await runtime_profiles.reevaluate_profiles(manager, reason="active window changed")
     if window_info is not None:
         return {"status": "ok", **window_info}
 
@@ -416,9 +419,11 @@ async def switch_compositor(manager: "SessionManager", compositor_id: str | None
     manager.compositor_state.listener_retry_after.pop(compositor_id, None)
     manager.compositor_state.listener_last_error.pop(compositor_id, None)
     manager.compositor_state.listener_last_log_at.pop(compositor_id, None)
-    window_refreshed = await refresh_current_window_from_listener(manager)
+    previous_window = dict(manager.compositor_state.current_window)
+    await refresh_current_window_from_listener(manager)
+    window_changed = previous_window != manager.compositor_state.current_window
     listener_changed = not had_listener
-    if binding_changed or listener_changed or window_cleared or window_refreshed is not None:
+    if binding_changed or listener_changed or window_cleared or window_changed:
         await runtime_profiles.reevaluate_profiles(manager, reason="compositor changed")
 
     if previous != compositor_id:

--- a/keymasq/session/manager/compositor.py
+++ b/keymasq/session/manager/compositor.py
@@ -161,22 +161,9 @@ async def run_compositor_setup_action(
 
 
 async def get_active_window_payload(manager: "SessionManager") -> JsonObject:
-    if manager.compositor_state.window_listener is not None:
-        try:
-            window_class, window_title, window_tags = (
-                await manager.compositor_state.window_listener.get_active_window()
-            )
-            window_info = normalize_window_info(window_class, window_title, window_tags)
-            if window_info["class"] or window_info["title"] or window_info["tags"]:
-                manager.compositor_state.current_window = cast(JsonObject, window_info)
-                return {"status": "ok", **window_info}
-        except Exception as e:
-            log.debug(
-                "Active window query failed (compositor_id=%s listener=%s): %s",
-                manager.compositor_state.compositor_id,
-                getattr(manager.compositor_state.window_listener, "name", "unknown"),
-                e,
-            )
+    window_info = await refresh_current_window_from_listener(manager)
+    if window_info is not None:
+        return {"status": "ok", **window_info}
 
     if manager.compositor_state.current_window:
         return {
@@ -210,6 +197,38 @@ def normalize_window_info_from_dict(
         str_value(window_info.get("title"), ""),
         [str(tag) for tag in json_list(window_info.get("tags")) if str(tag or "").strip()],
     )
+
+
+def clear_current_window(manager: "SessionManager") -> bool:
+    if not manager.compositor_state.current_window:
+        return False
+    manager.compositor_state.current_window = {}
+    return True
+
+
+async def refresh_current_window_from_listener(
+    manager: "SessionManager",
+) -> JsonObject | None:
+    listener = manager.compositor_state.window_listener
+    if listener is None:
+        return None
+    try:
+        window_class, window_title, window_tags = await listener.get_active_window()
+    except Exception as e:
+        log.debug(
+            "Active window query failed (compositor_id=%s listener=%s): %s",
+            manager.compositor_state.compositor_id,
+            getattr(listener, "name", "unknown"),
+            e,
+        )
+        return None
+
+    window_info = normalize_window_info(window_class, window_title, window_tags)
+    if not (window_info["class"] or window_info["title"] or window_info["tags"]):
+        manager.compositor_state.current_window = {}
+        return None
+    manager.compositor_state.current_window = cast(JsonObject, window_info)
+    return cast(JsonObject, window_info)
 
 
 async def activate_title(manager: "SessionManager", title: str) -> JsonObject:
@@ -303,8 +322,7 @@ async def ensure_compositor_listener(manager: "SessionManager") -> None:
 
     if manager.compositor_state.window_listener is not None and not current_healthy:
         log.warning("Window listener became unhealthy, restarting compositor binding")
-        await stop_window_listener(manager)
-        manager.compositor_state.compositor_id = None
+        await switch_compositor(manager, None)
 
     if manager.compositor_state.candidate_hits < 2:
         return
@@ -332,9 +350,16 @@ async def switch_compositor(manager: "SessionManager", compositor_id: str | None
         and manager.compositor_state.window_listener is None
     ):
         if not listener_retry_ready(manager, compositor_id):
+            if clear_current_window(manager):
+                await runtime_profiles.reevaluate_profiles(
+                    manager,
+                    reason="compositor changed",
+                )
             return
 
     previous = manager.compositor_state.compositor_id
+    previous_capabilities = list(manager.compositor_state.compositor_capabilities)
+    had_listener = manager.compositor_state.window_listener is not None
     await stop_window_listener(manager)
 
     manager.compositor_state.compositor_id = compositor_id
@@ -343,10 +368,17 @@ async def switch_compositor(manager: "SessionManager", compositor_id: str | None
     manager.compositor_state.compositor_capabilities = get_compositor_capabilities(
         manager.compositor_state.compositor_id
     )
+    binding_changed = (
+        previous != compositor_id
+        or previous_capabilities != manager.compositor_state.compositor_capabilities
+    )
+    window_cleared = clear_current_window(manager)
 
     if compositor_id is None:
         if previous is not None:
             log.info("Compositor transitioned %s -> none (headless mode)", previous)
+        if binding_changed or had_listener or window_cleared:
+            await runtime_profiles.reevaluate_profiles(manager, reason="compositor changed")
         return
 
     compositor_name = get_compositor_name(compositor_id)
@@ -366,6 +398,8 @@ async def switch_compositor(manager: "SessionManager", compositor_id: str | None
                 or f"listener support unavailable for {compositor_name}"
             ),
         )
+        if binding_changed or had_listener or window_cleared:
+            await runtime_profiles.reevaluate_profiles(manager, reason="compositor changed")
         return
 
     await start_window_listener(manager)
@@ -375,11 +409,17 @@ async def switch_compositor(manager: "SessionManager", compositor_id: str | None
             compositor_id,
             manager.compositor_state.last_listener_start_error,
         )
+        if binding_changed or had_listener or window_cleared:
+            await runtime_profiles.reevaluate_profiles(manager, reason="compositor changed")
         return
 
     manager.compositor_state.listener_retry_after.pop(compositor_id, None)
     manager.compositor_state.listener_last_error.pop(compositor_id, None)
     manager.compositor_state.listener_last_log_at.pop(compositor_id, None)
+    window_refreshed = await refresh_current_window_from_listener(manager)
+    listener_changed = not had_listener
+    if binding_changed or listener_changed or window_cleared or window_refreshed is not None:
+        await runtime_profiles.reevaluate_profiles(manager, reason="compositor changed")
 
     if previous != compositor_id:
         log.info("Compositor transitioned %s -> %s", previous or "none", compositor_id)

--- a/keymasq/session/manager/core.py
+++ b/keymasq/session/manager/core.py
@@ -203,6 +203,7 @@ class SessionManager:
         self.running = False
 
         self._shutdown_event.set()
+        await runtime_profiles.cancel_all_grab_retries(self)
 
         if self.compositor_state.supervisor_task:
             self.compositor_state.supervisor_task.cancel()

--- a/keymasq/session/manager/events.py
+++ b/keymasq/session/manager/events.py
@@ -494,6 +494,10 @@ async def _handle_lifetime_profile_trigger(
                 manager,
                 reason=f"runtime profile activation tracking failed {profile_name}",
             )
+    else:
+        current = manager.profile_state.runtime_profile_activations.get(profile_name)
+        if current is not None and current.activation_id == activation.activation_id:
+            current.tracked = True
 
 
 async def _track_runtime_profile_activation(

--- a/keymasq/session/manager/profiles.py
+++ b/keymasq/session/manager/profiles.py
@@ -192,6 +192,17 @@ def cancel_grab_retry(manager: "SessionManager", hardware_id: str) -> None:
         task.cancel()
 
 
+async def cancel_all_grab_retries(manager: "SessionManager") -> None:
+    tasks = list(manager.profile_state.grab_retry_tasks.values())
+    if not tasks:
+        return
+    for task in tasks:
+        if not task.done():
+            task.cancel()
+    manager.profile_state.grab_retry_tasks.clear()
+    await asyncio.gather(*tasks, return_exceptions=True)
+
+
 def schedule_grab_retry(
     manager: "SessionManager",
     hardware_id: str,

--- a/keymasq/session/manager/profiles.py
+++ b/keymasq/session/manager/profiles.py
@@ -6,7 +6,12 @@ from datetime import datetime
 from typing import TYPE_CHECKING, cast
 
 from keymasq.common.ipc import Command, CommandType
-from keymasq.common.models import ActionType, HardwareConfig, ProfileConfig
+from keymasq.common.models import (
+    ActionType,
+    HardwareConfig,
+    ProfileConfig,
+    profile_deactivation_policy_to_dict,
+)
 from keymasq.session.profiles import ResolvedCombo, ResolvedDeviceProfile
 
 from . import payloads as runtime_payloads
@@ -120,19 +125,51 @@ def build_active_profiles_payload(manager: "SessionManager") -> JsonObject:
         inspector_suppressed = bool(
             inspector_state is not None and hardware_id in suppressed_hardware_ids
         )
+        mapping_count = int(getattr(resolved, "mapping_count", 0))
+        if hasattr(resolved, "mappings"):
+            mapping_signature = runtime_payloads.resolved_mapping_signature(
+                manager,
+                resolved,
+                hardware_id,
+            )
+            mapping_applied = (
+                mapping_count <= 0
+                or manager.profile_state.last_sent_mapping_signatures.get(hardware_id)
+                == mapping_signature
+            )
+        else:
+            mapping_applied = (
+                mapping_count <= 0
+                or hardware_id in manager.profile_state.last_sent_mapping_signatures
+            )
         devices[hardware_id] = {
             "device_name": hardware.name if hardware else hardware_id,
             "profiles": list(resolved.active_profile_names),
-            "mapping_count": resolved.mapping_count,
+            "mapping_count": mapping_count,
             "always_grab_all": resolved.always_grab_all,
+            "grabbed": hardware_id in manager.profile_state.grabbed_devices,
+            "waiting_for_device": hardware_id in manager.profile_state.grab_waiting_devices,
+            "grabbed_interfaces": dict(
+                manager.profile_state.grabbed_interfaces.get(hardware_id, {})
+            ),
+            "mapping_applied": mapping_applied,
             "device_inspector_active": inspector_active,
             "device_inspector_suppressed": inspector_suppressed,
+        }
+
+    runtime_activations: dict[str, JsonObject] = {}
+    for name, activation in sorted(manager.profile_state.runtime_profile_activations.items()):
+        runtime_activations[name] = {
+            "activation_id": activation.activation_id,
+            "tracked": activation.tracked,
+            "deactivation": profile_deactivation_policy_to_dict(activation.deactivation),
         }
 
     return {
         "status": "ok",
         "active_profiles": list(manager.profile_state.active_profile_names),
         "devices": devices,
+        "runtime_profile_activations": runtime_activations,
     }
 
 

--- a/keymasq/session/manager/recording.py
+++ b/keymasq/session/manager/recording.py
@@ -497,7 +497,7 @@ async def resolve_unlock_status_async(
     if manager.connected:
         try:
             response = await manager.client.send_command(
-                Command(CommandType.RECORDING_UNLOCK_STATUS),
+                Command(CommandType.RECORDING_UNLOCK_STATUS, data={"uid": int(uid)}),
                 timeout=3.0,
             )
         except Exception as exc:
@@ -527,7 +527,7 @@ async def resolve_macro_recording_status_async(
     if manager.connected:
         try:
             response = await manager.client.send_command(
-                Command(CommandType.MACRO_RECORDING_STATUS),
+                Command(CommandType.MACRO_RECORDING_STATUS, data={"uid": int(uid)}),
                 timeout=3.0,
             )
         except Exception as exc:

--- a/keymasq/session/manager/recording.py
+++ b/keymasq/session/manager/recording.py
@@ -18,6 +18,7 @@ from keymasq.common.models import (
     normalize_macro_recording_slot,
 )
 from keymasq.common.recording_guard import (
+    is_unlock_value_active,
     resolve_macro_recording_status,
     resolve_unlock_status,
 )
@@ -424,14 +425,17 @@ def replace_pending_macro_slots_from_daemon(
 
         existing = old_slots.get(slot) or {}
         existing_id = str_value(existing.get("pending_recording_id"), "")
+        same_pending_recording = existing_id == pending_recording_id
         merged: JsonObject = {}
-        if existing_id == pending_recording_id:
+        if same_pending_recording:
             merged.update(existing)
         merged.update(data)
-        token = old_tokens.get(slot, "") or str_value(
-            merged.get("pending_save_token"),
-            "",
-        )
+        token = ""
+        if same_pending_recording:
+            token = old_tokens.get(slot, "") or str_value(
+                merged.get("pending_save_token"),
+                "",
+            )
         if not token:
             token = secrets.token_urlsafe(16)
 
@@ -440,10 +444,16 @@ def replace_pending_macro_slots_from_daemon(
         merged["pending_save_token"] = token
         state.pending_slots[slot] = merged
         state.pending_slot_tokens[slot] = token
-        state.pending_slot_owner_writer_ids[slot] = old_owner_writer_ids.get(slot)
-        state.pending_slot_owner_pids[slot] = old_owner_pids.get(slot)
-        state.pending_slot_owner_uids[slot] = old_owner_uids.get(slot)
-        state.pending_slot_created_at[slot] = old_created_at.get(slot, monotonic())
+        if same_pending_recording:
+            state.pending_slot_owner_writer_ids[slot] = old_owner_writer_ids.get(slot)
+            state.pending_slot_owner_pids[slot] = old_owner_pids.get(slot)
+            state.pending_slot_owner_uids[slot] = old_owner_uids.get(slot)
+            state.pending_slot_created_at[slot] = old_created_at.get(slot, monotonic())
+        else:
+            state.pending_slot_owner_writer_ids[slot] = None
+            state.pending_slot_owner_pids[slot] = None
+            state.pending_slot_owner_uids[slot] = None
+            state.pending_slot_created_at[slot] = monotonic()
 
     _sync_legacy_pending_macro_save(manager)
 
@@ -455,18 +465,93 @@ def pending_macro_save_token_matches(
     return bool(pending_macro_save_slot_for_token(manager, token))
 
 
+def _status_is_active(status: dict[str, bool | int | str] | None) -> bool:
+    if status is None or not bool(status.get("unlocked", False)):
+        return False
+    return is_unlock_value_active(int_value(status.get("expires_at"), 0))
+
+
+def _cache_or_fallback_status(
+    cache: dict[int, dict[str, bool | int | str]],
+    uid: int,
+    status: dict[str, bool | int | str],
+) -> dict[str, bool | int | str]:
+    uid = int(uid)
+    if _status_is_active(status):
+        cache[uid] = dict(status)
+        return status
+
+    if bool(status.get("unreadable", False)):
+        cached = cache.get(uid)
+        if cached is not None and _status_is_active(cached):
+            return dict(cached)
+
+    cache.pop(uid, None)
+    return status
+
+
 async def resolve_unlock_status_async(
-    _manager: "SessionManager",
+    manager: "SessionManager",
     uid: int,
 ) -> dict[str, bool | int | str]:
-    return await asyncio.to_thread(resolve_unlock_status, uid)
+    if manager.connected:
+        try:
+            response = await manager.client.send_command(
+                Command(CommandType.RECORDING_UNLOCK_STATUS),
+                timeout=3.0,
+            )
+        except Exception as exc:
+            log.warning("Failed to query daemon recording unlock status: %s", exc)
+        else:
+            if response.status == "ok" and isinstance(response.data, dict):
+                status = cast(dict[str, bool | int | str], response.data)
+                return _cache_or_fallback_status(
+                    manager.unlock_state.unlock_status_cache,
+                    uid,
+                    status,
+                )
+            log.warning(
+                "Daemon recording unlock status query failed: status=%s error=%s",
+                response.status,
+                response.error,
+            )
+
+    status = await asyncio.to_thread(resolve_unlock_status, uid)
+    return _cache_or_fallback_status(manager.unlock_state.unlock_status_cache, uid, status)
 
 
 async def resolve_macro_recording_status_async(
-    _manager: "SessionManager",
+    manager: "SessionManager",
     uid: int,
 ) -> dict[str, bool | int | str]:
-    return await asyncio.to_thread(resolve_macro_recording_status, uid)
+    if manager.connected:
+        try:
+            response = await manager.client.send_command(
+                Command(CommandType.MACRO_RECORDING_STATUS),
+                timeout=3.0,
+            )
+        except Exception as exc:
+            log.warning("Failed to query daemon macro recording status: %s", exc)
+        else:
+            if response.status == "ok" and isinstance(response.data, dict):
+                status = cast(dict[str, bool | int | str], response.data)
+                return _cache_or_fallback_status(
+                    manager.unlock_state.macro_recording_status_cache,
+                    uid,
+                    status,
+                )
+            log.warning(
+                "Daemon macro recording status query failed: status=%s error=%s",
+                response.status,
+                response.error,
+            )
+
+    status = await asyncio.to_thread(resolve_macro_recording_status, uid)
+    return _cache_or_fallback_status(
+        manager.unlock_state.macro_recording_status_cache,
+        uid,
+        status,
+    )
 
 
 def serialize_recording_unlock_state(
@@ -514,6 +599,42 @@ def is_refresh_owner_request(
         and owner.get("pid") == int(peer.pid)
         and owner.get("writer_id") == id(writer)
     )
+
+
+def _clear_refresh_owner_for_uid(manager: "SessionManager", uid: int) -> None:
+    owner = manager.unlock_state.refresh_owner
+    if owner is None or owner.get("uid") != int(uid):
+        return
+    manager.unlock_state.refresh_owner = None
+    manager.unlock_state.runtime_refresh_claim_consumed_until.pop(int(uid), None)
+
+
+def is_active_refresh_owner_request(
+    manager: "SessionManager",
+    peer: PeerCredentials,
+    writer: asyncio.StreamWriter,
+    unlock_status: dict[str, bool | int | str],
+) -> bool:
+    if not is_refresh_owner_request(manager, peer, writer):
+        return False
+    if bool(unlock_status.get("unlocked", False)):
+        return True
+    _clear_refresh_owner_for_uid(manager, int(peer.uid))
+    return False
+
+
+async def authorize_sensitive_session_command(
+    manager: "SessionManager",
+    command: str,
+    peer: PeerCredentials,
+    writer: asyncio.StreamWriter,
+) -> bool:
+    if not is_refresh_owner_request(manager, peer, writer):
+        return False
+    if command == "end_capture":
+        return True
+    unlock_status = await resolve_unlock_status_async(manager, peer.uid)
+    return is_active_refresh_owner_request(manager, peer, writer, unlock_status)
 
 
 def _has_other_session_client_for_uid(
@@ -601,7 +722,7 @@ async def claim_recording_unlock_refresh(
         return {
             "status": "error",
             "error_code": "recording_locked",
-            "message": "recording_locked: unlock required before claiming refresh",
+            "message": "recording_locked: capture unlock required before claiming refresh",
         }
 
     source = str(unlock_status.get("source", "none") or "none")
@@ -651,10 +772,11 @@ async def claim_recording_unlock_refresh(
             return {
                 "status": "error",
                 "error_code": "recording_refresh_denied",
-                "message": refresh_result.error or "Failed to establish recording refresh lease",
+                "message": refresh_result.error or "Failed to establish capture unlock lease",
             }
 
     unlock_status = await resolve_unlock_status_async(manager, peer.uid)
+    refresh_owner = is_active_refresh_owner_request(manager, peer, writer, unlock_status)
     return {
         "status": "ok",
         "lease_id": lease_id,
@@ -665,7 +787,7 @@ async def claim_recording_unlock_refresh(
                 "source": source,
                 "expires_at": int(unlock_status.get("expires_at", expires_at) or expires_at),
             },
-            refresh_owner=True,
+            refresh_owner=refresh_owner,
         ),
     }
 
@@ -717,10 +839,11 @@ async def refresh_recording_unlock(
         return {"status": "error", "message": "Daemon unavailable"}
 
     if result.status != "ok":
+        _clear_refresh_owner_for_uid(manager, int(peer.uid))
         return {
             "status": "error",
             "error_code": "recording_refresh_denied",
-            "message": result.error or "Failed to refresh recording unlock",
+            "message": result.error or "Failed to refresh capture unlock",
         }
 
     unlock_status = await resolve_unlock_status_async(manager, peer.uid)
@@ -731,15 +854,17 @@ async def refresh_recording_unlock(
         )
         if expires_at > consumed_until:
             manager.unlock_state.runtime_refresh_claim_consumed_until[int(peer.uid)] = expires_at
-    if not bool(unlock_status.get("unlocked", False)):
-        manager.unlock_state.refresh_owner = None
-
     return {
         "status": "ok",
         **serialize_recording_unlock_state(
             manager,
             unlock_status,
-            refresh_owner=is_refresh_owner_request(manager, peer, writer),
+            refresh_owner=is_active_refresh_owner_request(
+                manager,
+                peer,
+                writer,
+                unlock_status,
+            ),
         ),
     }
 
@@ -791,7 +916,7 @@ async def lock_recording_unlock(
         return {
             "status": "error",
             "error_code": "recording_lock_denied",
-            "message": result.error or "Failed to lock recording unlock",
+            "message": result.error or "Failed to lock capture unlock",
         }
 
     manager.unlock_state.refresh_owner = None
@@ -1879,6 +2004,6 @@ def notify_recording_unlock_required(
         return
 
     manager.send_notification(
-        "Keymasq: Recording Locked",
-        "Recording/capture requires unlock in Keymasq GUI.",
+        "Keymasq: Capture Unlock Required",
+        "Capture unlock is required in Keymasq GUI.",
     )

--- a/keymasq/session/manager/state.py
+++ b/keymasq/session/manager/state.py
@@ -100,6 +100,7 @@ class RuntimeProfileActivation:
     activation_id: str
     sequence: int
     deactivation: ProfileDeactivationPolicy
+    tracked: bool = False
     source_device: str = ""
     source_button: str = ""
     trigger_id: str = ""

--- a/keymasq/session/manager/state.py
+++ b/keymasq/session/manager/state.py
@@ -58,6 +58,10 @@ class RecordingRuntimeState:
 class UnlockRuntimeState:
     refresh_owner: JsonObject | None = None
     runtime_refresh_claim_consumed_until: dict[int, int] = field(default_factory=dict)
+    unlock_status_cache: dict[int, dict[str, bool | int | str]] = field(default_factory=dict)
+    macro_recording_status_cache: dict[int, dict[str, bool | int | str]] = field(
+        default_factory=dict
+    )
     refresh_ttl_s: int = 60
 
 

--- a/keymasq/session/profiles.py
+++ b/keymasq/session/profiles.py
@@ -3,6 +3,7 @@ import copy
 import io
 import logging
 import re
+import threading
 import tomllib
 from dataclasses import dataclass, field
 from datetime import datetime
@@ -120,6 +121,7 @@ class ProfileManager:
         self._auto_create_default_if_empty = auto_create_default_if_empty
         self._profiles: dict[str, ProfileInfo] = {}
         self._pending_repairs: set[asyncio.Task[None]] = set()
+        self._profile_file_lock = threading.RLock()
         self._load_all()
         self._ensure_default_profile_exists()
 
@@ -283,9 +285,9 @@ class ProfileManager:
         path: Path,
         reason: str,
     ) -> None:
-        repair_config = copy.deepcopy(config)
+        created_at = config.created_at or datetime.now()
         log.warning(
-            "Profile %s has %s; rewriting created_at with current time",
+            "Profile %s has %s; repairing created_at with current time",
             path,
             reason,
         )
@@ -293,25 +295,45 @@ class ProfileManager:
             loop = asyncio.get_running_loop()
         except RuntimeError:
             try:
-                self._write_profile_file(repair_config, path, validate_window_rules=False)
+                self._repair_created_at_if_needed(created_at, path)
             except Exception as exc:
                 log.error("Failed to repair created_at for %s: %s", path, exc)
             return
 
-        task = loop.create_task(self._repair_created_at_async(repair_config, path))
+        task = loop.create_task(self._repair_created_at_async(created_at, path))
         self._pending_repairs.add(task)
         task.add_done_callback(self._pending_repairs.discard)
 
-    async def _repair_created_at_async(self, config: ProfileConfig, path: Path) -> None:
+    async def _repair_created_at_async(self, created_at: datetime, path: Path) -> None:
         try:
             await asyncio.to_thread(
-                self._write_profile_file,
-                config,
+                self._repair_created_at_if_needed,
+                created_at,
                 path,
-                False,
             )
         except Exception as exc:
             log.error("Failed to repair created_at for %s: %s", path, exc)
+
+    def _repair_created_at_if_needed(self, created_at: datetime, path: Path) -> None:
+        with self._profile_file_lock:
+            data = cast(TomlDict, tomllib.load(io.BytesIO(path.read_bytes())))
+            profile = _as_toml_dict(data.get("profile"))
+            if profile is None:
+                profile = {}
+                data["profile"] = profile
+
+            current_created_at = profile.get("created_at")
+            if isinstance(current_created_at, str):
+                try:
+                    datetime.fromisoformat(current_created_at)
+                except ValueError:
+                    pass
+                else:
+                    return
+
+            profile["created_at"] = created_at.isoformat()
+            with open(path, "wb") as f:
+                tomli_w.dump(data, f)
 
     def _parse_action(self, action_data: TomlDict | str) -> MappingAction:
         if isinstance(action_data, str):
@@ -855,15 +877,17 @@ class ProfileManager:
                 for combo in config.combos
             ]
 
-        if exclusive:
-            buffer = io.BytesIO()
-            tomli_w.dump(data, buffer)
-            with open(path, "xb") as f:
-                f.write(buffer.getvalue())
-            return
+        with self._profile_file_lock:
+            if exclusive:
+                buffer = io.BytesIO()
+                tomli_w.dump(data, buffer)
+                with open(path, "xb") as f:
+                    f.write(buffer.getvalue())
+                return
 
-        with open(path, "wb") as f:
-            tomli_w.dump(data, f)
+            with open(path, "wb") as f:
+                tomli_w.dump(data, f)
+            return
 
     def delete_profile(self, name: str) -> bool:
         profile = self._profiles.get(name)

--- a/keymasq/session/superkeys.py
+++ b/keymasq/session/superkeys.py
@@ -1,5 +1,6 @@
 import logging
 import tomllib
+from dataclasses import dataclass
 from pathlib import Path
 from typing import cast
 
@@ -29,6 +30,12 @@ log = logging.getLogger("keymasq-session.superkeys")
 type TomlDict = dict[str, object]
 type _IntLike = int | float | str | bytes
 type _FloatLike = int | float | str | bytes
+
+
+@dataclass(frozen=True)
+class SuperkeySnapshot:
+    superkeys: dict[str, SuperkeyConfig]
+    paths: dict[str, Path]
 
 
 class UnknownActionTypeError(ValueError):
@@ -70,14 +77,17 @@ class SuperkeyManager:
     def __init__(self) -> None:
         paths.ensure_config_dirs()
         self._superkeys: dict[str, SuperkeyConfig] = {}
+        self._superkey_paths: dict[str, Path] = {}
         self._load_all()
 
     def _load_all(self, *, strict: bool = False) -> None:
         loaded_superkeys: dict[str, SuperkeyConfig] = {}
+        loaded_paths: dict[str, Path] = {}
         failures: list[ConfigLoadFailure] = []
 
         if not paths.SUPERKEYS_DIR.exists():
             self._superkeys = loaded_superkeys
+            self._superkey_paths = loaded_paths
             return
 
         for superkey_file in paths.SUPERKEYS_DIR.glob("*.toml"):
@@ -85,6 +95,7 @@ class SuperkeyManager:
                 config = self._load_superkey(superkey_file)
                 if config:
                     loaded_superkeys[config.name] = config
+                    loaded_paths[config.name] = superkey_file
             except Exception as e:
                 log.error(f"Failed to load superkey {superkey_file}: {e}")
                 failures.append(ConfigLoadFailure(superkey_file, str(e)))
@@ -93,6 +104,7 @@ class SuperkeyManager:
             raise ConfigLoadError("superkey", failures)
 
         self._superkeys = loaded_superkeys
+        self._superkey_paths = loaded_paths
 
     def _load_superkey(self, path: Path) -> SuperkeyConfig | None:
         with open(path, "rb") as f:
@@ -334,11 +346,26 @@ class SuperkeyManager:
     def get_all_superkeys(self) -> dict[str, SuperkeyConfig]:
         return self._superkeys.copy()
 
-    def snapshot_superkeys(self) -> dict[str, SuperkeyConfig]:
-        return self._superkeys.copy()
+    def snapshot_superkeys(self) -> SuperkeySnapshot:
+        return SuperkeySnapshot(
+            superkeys=self._superkeys.copy(),
+            paths=self._superkey_paths.copy(),
+        )
 
-    def restore_superkeys(self, superkeys: dict[str, SuperkeyConfig]) -> None:
-        self._superkeys = superkeys.copy()
+    def restore_superkeys(
+        self,
+        snapshot: SuperkeySnapshot | dict[str, SuperkeyConfig],
+    ) -> None:
+        if isinstance(snapshot, SuperkeySnapshot):
+            self._superkeys = snapshot.superkeys.copy()
+            self._superkey_paths = snapshot.paths.copy()
+            return
+
+        self._superkeys = snapshot.copy()
+        self._superkey_paths = {
+            name: self._superkey_paths.get(name, self._path_for_name(config.name))
+            for name, config in self._superkeys.items()
+        }
 
     def save_superkey(self, config: SuperkeyConfig, *, replacing_name: str | None = None) -> None:
         paths.ensure_config_dirs()
@@ -403,6 +430,7 @@ class SuperkeyManager:
             tomli_w.dump(data, f)
 
         self._superkeys[config.name] = config
+        self._superkey_paths[config.name] = path
         log.info("Saved superkey: %s", config.name)
 
     def _validate_before_save(self, config: SuperkeyConfig) -> None:
@@ -519,13 +547,13 @@ class SuperkeyManager:
             return False
 
         config = self._superkeys[name]
-        safe_name = self._sanitize_name(config.name)
-        path = paths.SUPERKEYS_DIR / f"{safe_name}.toml"
+        path = self._superkey_paths.get(name, self._path_for_name(config.name))
 
         if path.exists():
             path.unlink()
 
         del self._superkeys[name]
+        self._superkey_paths.pop(name, None)
         log.info("Deleted superkey: %s", name)
         return True
 
@@ -541,7 +569,7 @@ class SuperkeyManager:
             return False
 
         config = self._superkeys[old_name]
-        old_path = self._path_for_name(old_name)
+        old_path = self._superkey_paths.get(old_name, self._path_for_name(old_name))
         new_path = self._path_for_name(new_name)
         self._ensure_storage_path_available(new_name, new_path, replacing_name=old_name)
 
@@ -556,6 +584,7 @@ class SuperkeyManager:
             old_path.unlink()
 
         del self._superkeys[old_name]
+        self._superkey_paths.pop(old_name, None)
 
         log.info("Renamed superkey: %s -> %s", old_name, new_name)
         return True

--- a/keymasq/session/superkeys.py
+++ b/keymasq/session/superkeys.py
@@ -372,8 +372,16 @@ class SuperkeyManager:
         paths.ensure_config_dirs()
         self._validate_before_save(config)
 
-        path = self._path_for_name(config.name)
+        tracked_name = replacing_name or config.name
+        path = self._superkey_paths.get(tracked_name, self._path_for_name(config.name))
         self._ensure_storage_path_available(config.name, path, replacing_name=replacing_name)
+        canonical_path = self._path_for_name(config.name)
+        if path != canonical_path:
+            self._ensure_storage_path_available(
+                config.name,
+                canonical_path,
+                replacing_name=replacing_name,
+            )
 
         data: dict[str, object] = {
             "name": config.name,
@@ -432,6 +440,9 @@ class SuperkeyManager:
 
         write_config_atomically(path, write_config)
 
+        if replacing_name is not None and replacing_name != config.name:
+            self._superkeys.pop(replacing_name, None)
+            self._superkey_paths.pop(replacing_name, None)
         self._superkeys[config.name] = config
         self._superkey_paths[config.name] = path
         log.info("Saved superkey: %s", config.name)
@@ -583,10 +594,11 @@ class SuperkeyManager:
             config.name = old_name
             raise
 
-        if old_path != new_path and old_path.exists():
+        saved_path = self._superkey_paths.get(new_name, new_path)
+        if old_path != saved_path and old_path.exists():
             old_path.unlink()
 
-        del self._superkeys[old_name]
+        self._superkeys.pop(old_name, None)
         self._superkey_paths.pop(old_name, None)
 
         log.info("Renamed superkey: %s -> %s", old_name, new_name)

--- a/keymasq/session/superkeys.py
+++ b/keymasq/session/superkeys.py
@@ -2,7 +2,7 @@ import logging
 import tomllib
 from dataclasses import dataclass
 from pathlib import Path
-from typing import cast
+from typing import BinaryIO, cast
 
 import tomli_w
 
@@ -24,6 +24,7 @@ from keymasq.common.models import (
     resolve_rapidfire_fields,
     superkey_action_to_mapping_action,
 )
+from keymasq.session.config_files import write_config_atomically
 from keymasq.session.config_loading import ConfigLoadError, ConfigLoadFailure
 
 log = logging.getLogger("keymasq-session.superkeys")
@@ -426,8 +427,10 @@ class SuperkeyManager:
         if actions:
             data["actions"] = actions
 
-        with open(path, "wb") as f:
-            tomli_w.dump(data, f)
+        def write_config(config_file: BinaryIO) -> None:
+            tomli_w.dump(data, config_file)
+
+        write_config_atomically(path, write_config)
 
         self._superkeys[config.name] = config
         self._superkey_paths[config.name] = path

--- a/nix/daemon-session-integration-test.nix
+++ b/nix/daemon-session-integration-test.nix
@@ -18,9 +18,17 @@ let
       export KEYMASQ_INTEGRATION_SYSTEMCTL="${pkgs.systemd}/bin/systemctl"
       export KEYMASQ_INTEGRATION_SUDO="/run/wrappers/bin/sudo"
       export KEYMASQ_INTEGRATION_RECORD_HELPER="${keymasqPackage}/bin/keymasq-record"
-      exec ${testPython}/bin/python ${testSource}/runner.py
+      exec ${testPython}/bin/python ${testSource}/runner.py "$@"
     '';
   };
+  validScenarioFilter =
+    value:
+    value == "" || (builtins.match "[A-Za-z0-9_.-]+(,[A-Za-z0-9_.-]+)*" value) != null;
+  validRepeatCount =
+    value:
+    value == "" || (builtins.match "[1-9][0-9]*" value) != null;
+  selectedScenarioFilter = builtins.getEnv "KEYMASQ_INTEGRATION_SCENARIOS";
+  selectedRepeatCount = builtins.getEnv "KEYMASQ_INTEGRATION_REPEAT";
 
   userCommand =
     cmd:
@@ -33,10 +41,31 @@ let
       name,
       unlockRequired,
       scenarioFilter ? "",
+      repeatCount ? "",
     }:
     let
+      checkedScenarioFilter =
+        assert validScenarioFilter scenarioFilter;
+        scenarioFilter;
+      checkedRepeatCount =
+        assert validRepeatCount repeatCount;
+        repeatCount;
       scenarioEnv =
-        if scenarioFilter == "" then "" else "KEYMASQ_INTEGRATION_SCENARIOS=${scenarioFilter} ";
+        if checkedScenarioFilter == "" then
+          ""
+        else
+          "KEYMASQ_INTEGRATION_SCENARIOS=${checkedScenarioFilter} ";
+      repeatEnv =
+        if checkedRepeatCount == "" then
+          ""
+        else
+          "KEYMASQ_INTEGRATION_REPEAT=${checkedRepeatCount} ";
+      repeatMultiplier =
+        if checkedRepeatCount == "" then
+          1
+        else
+          pkgs.lib.toInt checkedRepeatCount;
+      runnerTimeout = 300 * repeatMultiplier;
     in
     pkgs.testers.runNixOSTest {
       inherit name;
@@ -200,13 +229,13 @@ let
             as_user(
                 f"rm -f {output_path} {status_path}; "
                 "set +e; "
-                "${scenarioEnv}keymasq-daemon-session-integration-test "
+                "${scenarioEnv}${repeatEnv}keymasq-daemon-session-integration-test "
                 f"> {output_path} 2>&1; "
                 "status=$?; "
                 f"echo \"$status\" > {status_path}; "
                 "exit 0"
             ),
-            timeout=300,
+            timeout=${toString runnerTimeout},
         )
         if status_code != 0:
             raise Exception(f"failed to launch integration runner: {runner_output}")
@@ -225,6 +254,13 @@ in
     daemon-session-integration-test = mkDaemonSessionIntegrationTest {
       name = "daemon-session-integration-test";
       unlockRequired = false;
+    };
+
+    daemon-session-selected-integration-test = mkDaemonSessionIntegrationTest {
+      name = "daemon-session-selected-integration-test";
+      unlockRequired = false;
+      scenarioFilter = selectedScenarioFilter;
+      repeatCount = selectedRepeatCount;
     };
 
     daemon-session-macro-slot-locked-playback-test = mkDaemonSessionIntegrationTest {

--- a/nix/daemon-session-integration-test.nix
+++ b/nix/daemon-session-integration-test.nix
@@ -17,6 +17,7 @@ let
       export PYTHONPATH="${testSource}"
       export KEYMASQ_INTEGRATION_SYSTEMCTL="${pkgs.systemd}/bin/systemctl"
       export KEYMASQ_INTEGRATION_SUDO="/run/wrappers/bin/sudo"
+      export KEYMASQ_INTEGRATION_RECORD_HELPER="${keymasqPackage}/bin/keymasq-record"
       exec ${testPython}/bin/python ${testSource}/runner.py
     '';
   };
@@ -27,11 +28,18 @@ let
     + "export XDG_RUNTIME_DIR=${runtimeDir}; "
     + "export DBUS_SESSION_BUS_ADDRESS=unix:path=${runtimeDir}/bus; "
     + "${cmd}'";
-in
-{
-  checks = {
-    daemon-session-integration-test = pkgs.testers.runNixOSTest {
-      name = "daemon-session-integration-test";
+  mkDaemonSessionIntegrationTest =
+    {
+      name,
+      unlockRequired,
+      scenarioFilter ? "",
+    }:
+    let
+      scenarioEnv =
+        if scenarioFilter == "" then "" else "KEYMASQ_INTEGRATION_SCENARIOS=${scenarioFilter} ";
+    in
+    pkgs.testers.runNixOSTest {
+      inherit name;
 
       nodes.machine =
         { ... }:
@@ -58,7 +66,7 @@ in
               daemon_allowed_uids = [ vmUid ];
               session_allowed_uids = [ vmUid ];
               recording_guard = {
-                unlock_required = false;
+                unlock_required = unlockRequired;
                 macro_edit_requires_unlock = false;
               };
             };
@@ -86,6 +94,10 @@ in
                   commands = [
                     {
                       command = "${pkgs.systemd}/bin/systemctl restart keymasqd.service";
+                      options = [ "NOPASSWD" ];
+                    }
+                    {
+                      command = "${keymasqPackage}/bin/keymasq-record";
                       options = [ "NOPASSWD" ];
                     }
                   ];
@@ -188,7 +200,7 @@ in
             as_user(
                 f"rm -f {output_path} {status_path}; "
                 "set +e; "
-                "keymasq-daemon-session-integration-test "
+                "${scenarioEnv}keymasq-daemon-session-integration-test "
                 f"> {output_path} 2>&1; "
                 "status=$?; "
                 f"echo \"$status\" > {status_path}; "
@@ -206,6 +218,19 @@ in
             dump_debug("daemon/session integration test failed")
             raise Exception("daemon-session-integration-test failed")
       '';
+    };
+in
+{
+  checks = {
+    daemon-session-integration-test = mkDaemonSessionIntegrationTest {
+      name = "daemon-session-integration-test";
+      unlockRequired = false;
+    };
+
+    daemon-session-macro-slot-locked-playback-test = mkDaemonSessionIntegrationTest {
+      name = "daemon-session-macro-slot-locked-playback-test";
+      unlockRequired = true;
+      scenarioFilter = "mapped-macro-slot-playback-without-capture-unlock";
     };
   };
 }

--- a/nix/daemon-session-integration-test/runner.py
+++ b/nix/daemon-session-integration-test/runner.py
@@ -1,38 +1,105 @@
 #!/usr/bin/env python3
 
+import argparse
 import os
+import sys
 
 from scenarios import SCENARIOS
 from support import ScenarioCase, ScenarioContext
 
 
 def _scenario_key(name: str) -> str:
-    return name.strip().lower().replace(" ", "-")
+    return name.strip().lower().replace("_", "-").replace(" ", "-")
 
 
-def selected_scenarios() -> list[ScenarioCase]:
-    raw = os.environ.get("KEYMASQ_INTEGRATION_SCENARIOS", "").strip()
-    if not raw:
+def _split_scenario_filter(values: list[str]) -> list[str]:
+    names: list[str] = []
+    for value in values:
+        names.extend(name.strip() for name in value.split(",") if name.strip())
+    return names
+
+
+def selected_scenarios(raw_names: list[str]) -> list[ScenarioCase]:
+    wanted = _split_scenario_filter(raw_names)
+    if not wanted:
         return SCENARIOS
 
-    wanted = [name.strip() for name in raw.split(",") if name.strip()]
     by_name = {
         key: scenario
         for scenario in SCENARIOS
-        for key in (scenario.name, _scenario_key(scenario.name))
+        for key in (scenario.name, scenario.name.lower(), _scenario_key(scenario.name))
     }
-    missing = [name for name in wanted if name not in by_name]
+    missing = [
+        name
+        for name in wanted
+        if name not in by_name and _scenario_key(name) not in by_name
+    ]
     if missing:
         raise AssertionError(f"unknown integration scenarios: {missing}")
-    return [by_name[name] for name in wanted]
+    return [
+        by_name[name] if name in by_name else by_name[_scenario_key(name)]
+        for name in wanted
+    ]
 
 
-def main() -> int:
+def _env_repeat_count() -> int:
+    raw = os.environ.get("KEYMASQ_INTEGRATION_REPEAT", "").strip()
+    if not raw:
+        return 1
+    try:
+        repeat = int(raw)
+    except ValueError as exc:
+        raise AssertionError(f"invalid KEYMASQ_INTEGRATION_REPEAT={raw!r}") from exc
+    if repeat < 1:
+        raise AssertionError("KEYMASQ_INTEGRATION_REPEAT must be >= 1")
+    return repeat
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run daemon/session integration scenarios")
+    parser.add_argument(
+        "scenarios",
+        nargs="*",
+        help="Scenario names or kebab-case scenario keys; comma-separated values are accepted.",
+    )
+    parser.add_argument(
+        "--scenario",
+        "-s",
+        action="append",
+        default=[],
+        help="Scenario name/key to run. Can be passed multiple times or comma-separated.",
+    )
+    parser.add_argument(
+        "--repeat",
+        "-r",
+        type=int,
+        default=None,
+        help="Run the selected scenarios this many times.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(sys.argv[1:] if argv is None else argv)
+    scenario_filters = list(args.scenario) + list(args.scenarios)
+    if not scenario_filters:
+        env_filter = os.environ.get("KEYMASQ_INTEGRATION_SCENARIOS", "").strip()
+        if env_filter:
+            scenario_filters.append(env_filter)
+    repeat = args.repeat if args.repeat is not None else _env_repeat_count()
+    if repeat < 1:
+        raise AssertionError("--repeat must be >= 1")
+    scenarios = selected_scenarios(scenario_filters)
+
     context = ScenarioContext()
     try:
         context.setup()
-        for scenario in selected_scenarios():
-            context.subtest(scenario.name, lambda run=scenario.run: run(context))
+        for index in range(1, repeat + 1):
+            if repeat > 1:
+                print(f"integration: repeat {index}/{repeat}", flush=True)
+            for scenario in scenarios:
+                label = scenario.name if repeat == 1 else f"{scenario.name} [{index}/{repeat}]"
+                context.subtest(label, lambda run=scenario.run: run(context))
     finally:
         context.cleanup()
 

--- a/nix/daemon-session-integration-test/runner.py
+++ b/nix/daemon-session-integration-test/runner.py
@@ -1,14 +1,37 @@
 #!/usr/bin/env python3
 
+import os
+
 from scenarios import SCENARIOS
-from support import ScenarioContext
+from support import ScenarioCase, ScenarioContext
+
+
+def _scenario_key(name: str) -> str:
+    return name.strip().lower().replace(" ", "-")
+
+
+def selected_scenarios() -> list[ScenarioCase]:
+    raw = os.environ.get("KEYMASQ_INTEGRATION_SCENARIOS", "").strip()
+    if not raw:
+        return SCENARIOS
+
+    wanted = [name.strip() for name in raw.split(",") if name.strip()]
+    by_name = {
+        key: scenario
+        for scenario in SCENARIOS
+        for key in (scenario.name, _scenario_key(scenario.name))
+    }
+    missing = [name for name in wanted if name not in by_name]
+    if missing:
+        raise AssertionError(f"unknown integration scenarios: {missing}")
+    return [by_name[name] for name in wanted]
 
 
 def main() -> int:
     context = ScenarioContext()
     try:
         context.setup()
-        for scenario in SCENARIOS:
+        for scenario in selected_scenarios():
             context.subtest(scenario.name, lambda run=scenario.run: run(context))
     finally:
         context.cleanup()

--- a/nix/daemon-session-integration-test/scenarios/__init__.py
+++ b/nix/daemon-session-integration-test/scenarios/__init__.py
@@ -36,6 +36,9 @@ from .profile_toggle import run as profile_toggle
 from .rapidfire_keyboard import run as rapidfire_keyboard
 from .recording_capture import run as recording_capture
 from .recording_capture import run_mapped_slot_actions as macro_slot_actions
+from .recording_capture import (
+    run_mapped_slot_playback_without_unlock as macro_slot_playback_without_unlock,
+)
 from .repeat_combo_superkey import run as repeat_combo_superkey
 from .repeat_direct_actions import run as repeat_direct_actions
 from .repeat_passthrough import run as repeat_passthrough
@@ -92,4 +95,8 @@ SCENARIOS = [
     ScenarioCase("recording and capture", recording_capture),
     ScenarioCase("restart recovery", restart_recovery),
     ScenarioCase("hotplug replug", hotplug_replug),
+    ScenarioCase(
+        "mapped macro slot playback without capture unlock",
+        macro_slot_playback_without_unlock,
+    ),
 ]

--- a/nix/daemon-session-integration-test/scenarios/hotplug_replug.py
+++ b/nix/daemon-session-integration-test/scenarios/hotplug_replug.py
@@ -1,11 +1,17 @@
 import evdev
-from support import ScenarioContext
+from support import SECOND_HARDWARE_ID, ScenarioContext
 
 
 def run(ctx: ScenarioContext) -> None:
-    ctx.tap_secondary_source(evdev.ecodes.KEY_G)
-    ctx.expect_keys([(evdev.ecodes.KEY_5, 1), (evdev.ecodes.KEY_5, 0)])
+    ctx.wait_for_hardware_mapping(SECOND_HARDWARE_ID)
+    ctx.tap_secondary_source_until_keys(
+        evdev.ecodes.KEY_G,
+        [(evdev.ecodes.KEY_5, 1), (evdev.ecodes.KEY_5, 0)],
+    )
 
     ctx.recreate_secondary_source()
-    ctx.tap_secondary_source(evdev.ecodes.KEY_G)
-    ctx.expect_keys([(evdev.ecodes.KEY_5, 1), (evdev.ecodes.KEY_5, 0)])
+    ctx.wait_for_hardware_mapping(SECOND_HARDWARE_ID)
+    ctx.tap_secondary_source_until_keys(
+        evdev.ecodes.KEY_G,
+        [(evdev.ecodes.KEY_5, 1), (evdev.ecodes.KEY_5, 0)],
+    )

--- a/nix/daemon-session-integration-test/scenarios/recording_capture.py
+++ b/nix/daemon-session-integration-test/scenarios/recording_capture.py
@@ -79,17 +79,21 @@ def run(ctx: ScenarioContext) -> None:
     assert_recording_slot_listed(ctx, RECORDING_SLOT)
 
     saved_name = "integration-recorded-macro"
-    ctx.request(
-        {
-            "command": "save_recording",
-            "name": saved_name,
-            "recording_slot": RECORDING_SLOT,
-            "pending_save_token": token,
-        }
-    )
-    assert_recording_slot_listed(ctx, RECORDING_SLOT)
-    ctx.request({"command": "play_macro", "name": saved_name})
-    ctx.expect_keys([(evdev.ecodes.KEY_Q, 1), (evdev.ecodes.KEY_Q, 0)])
+    ctx.request({"command": "delete_macro", "name": saved_name}, ok=False)
+    try:
+        ctx.request(
+            {
+                "command": "save_recording",
+                "name": saved_name,
+                "recording_slot": RECORDING_SLOT,
+                "pending_save_token": token,
+            }
+        )
+        assert_recording_slot_listed(ctx, RECORDING_SLOT)
+        ctx.request({"command": "play_macro", "name": saved_name})
+        ctx.expect_keys([(evdev.ecodes.KEY_Q, 1), (evdev.ecodes.KEY_Q, 0)])
+    finally:
+        ctx.request({"command": "delete_macro", "name": saved_name}, ok=False)
 
 
 def run_mapped_slot_actions(ctx: ScenarioContext) -> None:

--- a/nix/daemon-session-integration-test/scenarios/recording_capture.py
+++ b/nix/daemon-session-integration-test/scenarios/recording_capture.py
@@ -114,6 +114,34 @@ def run_mapped_slot_actions(ctx: ScenarioContext) -> None:
         ctx.set_profile_enabled(MACRO_SLOT_PROFILE_NAME, enabled=False)
 
 
+def run_mapped_slot_playback_without_unlock(ctx: ScenarioContext) -> None:
+    try:
+        ctx.enable_macro_recording_opt_in()
+        assert_macro_recording_enabled(ctx)
+        assert_recording_locked_if_required(ctx)
+
+        ctx.set_profile_enabled(MACRO_SLOT_PROFILE_NAME, enabled=True)
+        assert_macro_recording_enabled(ctx)
+
+        ctx.tap_source(evdev.ecodes.KEY_F23)
+        wait_for_recording_state(ctx, active=True, recording_slot=RECORDING_SLOT)
+
+        ctx.tap_source(evdev.ecodes.KEY_Q)
+
+        ctx.tap_source(evdev.ecodes.KEY_F23)
+        wait_for_recording_state(ctx, active=False, recording_slot=0)
+        assert_recording_slot_listed(ctx, RECORDING_SLOT)
+
+        assert_recording_locked_if_required(ctx)
+
+        ctx.drain_outputs()
+        ctx.tap_source(evdev.ecodes.KEY_F24)
+        ctx.expect_keys([(evdev.ecodes.KEY_Q, 1), (evdev.ecodes.KEY_Q, 0)])
+    finally:
+        ctx.request({"command": "stop_recording", "recording_slot": RECORDING_SLOT}, ok=False)
+        ctx.set_profile_enabled(MACRO_SLOT_PROFILE_NAME, enabled=False)
+
+
 def assert_macro_recording_enabled(ctx: ScenarioContext) -> None:
     status = ctx.request({"command": "get_status"})
     if status.get("macro_recording_enabled") is not True:
@@ -134,6 +162,13 @@ def wait_for_recording_state(
 
     label = f"recording active={active} slot={recording_slot}"
     ctx.wait_until(label, matches, timeout_s=5)
+
+
+def assert_recording_locked_if_required(ctx: ScenarioContext) -> None:
+    status = ctx.request({"command": "get_status"})
+    if status.get("recording_unlock_required") is True:
+        if status.get("recording_unlocked") is not False:
+            raise AssertionError(f"capture unlock was unexpectedly active: {status}")
 
 
 def assert_recording_slot_listed(ctx: ScenarioContext, recording_slot: int) -> None:

--- a/nix/daemon-session-integration-test/scenarios/repeat_direct_actions.py
+++ b/nix/daemon-session-integration-test/scenarios/repeat_direct_actions.py
@@ -5,6 +5,8 @@ from support import REPEAT_PROFILE_NAME, SECOND_PROFILE_NAME, ScenarioContext
 def run(ctx: ScenarioContext) -> None:
     try:
         ctx.set_profile_enabled(REPEAT_PROFILE_NAME, enabled=True)
+        ctx.tap_source(evdev.ecodes.KEY_T)
+        ctx.wait_for_active_profile(REPEAT_PROFILE_NAME, enabled=True)
         ctx.subtest("repeat has no output before history", lambda: _repeat_without_history(ctx))
         ctx.subtest(
             "repeat follows keyboard press/repeat/release",

--- a/nix/daemon-session-integration-test/support.py
+++ b/nix/daemon-session-integration-test/support.py
@@ -56,6 +56,22 @@ recording_slot = 1
 """.strip()
 
 
+def _float_env(name: str, default: float) -> float:
+    raw = os.environ.get(name, "").strip()
+    if not raw:
+        return default
+    try:
+        return max(0.001, float(raw))
+    except ValueError:
+        return default
+
+
+EVENT_TIMEOUT_S = _float_env("KEYMASQ_INTEGRATION_EVENT_TIMEOUT_S", 5.0)
+PROFILE_TIMEOUT_S = _float_env("KEYMASQ_INTEGRATION_PROFILE_TIMEOUT_S", 15.0)
+POLL_INTERVAL_S = _float_env("KEYMASQ_INTEGRATION_POLL_INTERVAL_S", 0.05)
+PROFILE_STABLE_S = _float_env("KEYMASQ_INTEGRATION_PROFILE_STABLE_S", 0.0)
+
+
 @dataclass(frozen=True)
 class ScenarioCase:
     name: str
@@ -180,7 +196,7 @@ class ScenarioContext:
                     message = json.loads(line)
                     if not isinstance(message, dict):
                         continue
-                    if "event" in message and "status" not in message:
+                    if "event" in message:
                         continue
                     if ok and message.get("status") not in {"ok", None}:
                         raise AssertionError(f"session request failed: {payload} -> {message}")
@@ -558,15 +574,43 @@ type = "key"
         self.drain_outputs()
         fn()
 
-    def tap_source(self, code: int, *, pause_s: float = 0.03) -> None:
+    def tap_source(self, code: int, *, pause_s: float = 0.05) -> None:
         self.source_key(code, 1)
         time.sleep(pause_s)
         self.source_key(code, 0)
 
-    def tap_secondary_source(self, code: int, *, pause_s: float = 0.03) -> None:
+    def tap_secondary_source(self, code: int, *, pause_s: float = 0.05) -> None:
         self.secondary_key(code, 1)
         time.sleep(pause_s)
         self.secondary_key(code, 0)
+
+    def tap_secondary_source_until_keys(
+        self,
+        source_code: int,
+        expected: list[tuple[int, int]],
+        *,
+        timeout_s: float = PROFILE_TIMEOUT_S,
+    ) -> None:
+        deadline = time.monotonic() + timeout_s
+        attempts = 0
+        last_error = ""
+        last_status: dict[str, Any] | None = None
+        while time.monotonic() < deadline:
+            attempts += 1
+            self.drain_outputs(quiet_s=0.03, timeout_s=0.25)
+            self.tap_secondary_source(source_code)
+            remaining = max(0.1, deadline - time.monotonic())
+            try:
+                self.expect_keys(expected, timeout_s=min(EVENT_TIMEOUT_S, remaining))
+                return
+            except AssertionError as exc:
+                last_error = str(exc)
+                last_status = self.request({"command": "get_active_profiles"}, ok=False)
+                time.sleep(POLL_INTERVAL_S)
+        raise AssertionError(
+            "secondary source did not produce expected key sequence "
+            f"after {attempts} attempt(s): {last_error}; active_profiles={last_status}"
+        )
 
     def source_key(self, code: int, value: int) -> None:
         if self.source is None:
@@ -586,7 +630,12 @@ type = "key"
         self.secondary_source.write(evdev.ecodes.EV_KEY, code, value)
         self.secondary_source.syn()
 
-    def expect_keys(self, expected: list[tuple[int, int]], *, timeout_s: float = 3.0) -> None:
+    def expect_keys(
+        self,
+        expected: list[tuple[int, int]],
+        *,
+        timeout_s: float = EVENT_TIMEOUT_S,
+    ) -> None:
         self.expect_events(
             self.keyboard_output,
             [(evdev.ecodes.EV_KEY, code, value) for code, value in expected],
@@ -598,7 +647,7 @@ type = "key"
         self,
         expected: list[tuple[int, int, int]],
         *,
-        timeout_s: float = 3.0,
+        timeout_s: float = EVENT_TIMEOUT_S,
     ) -> None:
         self.expect_events(self.mouse_output, expected, label="mouse", timeout_s=timeout_s)
 
@@ -606,7 +655,7 @@ type = "key"
         self,
         expected: list[tuple[int, int, int]],
         *,
-        timeout_s: float = 3.0,
+        timeout_s: float = EVENT_TIMEOUT_S,
     ) -> None:
         self.expect_events(self.gamepad_output, expected, label="gamepad", timeout_s=timeout_s)
 
@@ -616,7 +665,7 @@ type = "key"
         expected: list[tuple[int, int, int]],
         *,
         label: str,
-        timeout_s: float = 3.0,
+        timeout_s: float = EVENT_TIMEOUT_S,
     ) -> None:
         if device is None:
             raise AssertionError(f"output {label} is not available")
@@ -688,23 +737,105 @@ type = "key"
             observed_names = [self.event_label(event) for event in observed]
             raise AssertionError(f"unexpected {label} output events: {observed_names}")
 
-    def wait_for_active_profile(self, profile_name: str, *, enabled: bool) -> None:
-        deadline = time.monotonic() + 5
+    def _device_mapping_applied(self, device: dict[str, Any]) -> bool:
+        try:
+            mapping_count = int(device.get("mapping_count", 0))
+        except (TypeError, ValueError):
+            mapping_count = 0
+        return mapping_count <= 0 or bool(device.get("mapping_applied"))
+
+    def _profile_payload_ready(
+        self,
+        payload: dict[str, Any],
+        profile_name: str,
+        *,
+        enabled: bool,
+    ) -> bool:
+        active = set(str(name) for name in payload.get("active_profiles", []))
+        if (profile_name in active) is not enabled:
+            return False
+
+        activations_raw = payload.get("runtime_profile_activations", {})
+        activation = (
+            activations_raw.get(profile_name)
+            if isinstance(activations_raw, dict)
+            else None
+        )
+        if enabled and isinstance(activation, dict) and activation.get("tracked") is False:
+            return False
+
+        devices_raw = payload.get("devices", {})
+        if not isinstance(devices_raw, dict):
+            return True
+
+        devices = [device for device in devices_raw.values() if isinstance(device, dict)]
+        matching_devices: list[dict[str, Any]] = []
+        for device in devices:
+            profiles_raw = device.get("profiles", [])
+            profiles = (
+                {str(name) for name in profiles_raw}
+                if isinstance(profiles_raw, list)
+                else set()
+            )
+            if profile_name in profiles:
+                matching_devices.append(device)
+
+        if enabled:
+            return bool(matching_devices) and all(
+                self._device_mapping_applied(device) for device in matching_devices
+            )
+
+        if matching_devices:
+            return False
+        return all(self._device_mapping_applied(device) for device in devices)
+
+    def wait_for_active_profile(
+        self,
+        profile_name: str,
+        *,
+        enabled: bool,
+        timeout_s: float = PROFILE_TIMEOUT_S,
+        stable_s: float = PROFILE_STABLE_S,
+    ) -> None:
+        deadline = time.monotonic() + timeout_s
         last: dict[str, Any] | None = None
         matched_at: float | None = None
         while time.monotonic() < deadline:
             last = self.request({"command": "get_active_profiles"}, ok=False)
-            active = set(str(name) for name in last.get("active_profiles", []))
-            if (profile_name in active) is enabled:
+            if self._profile_payload_ready(last, profile_name, enabled=enabled):
                 now = time.monotonic()
-                if matched_at is not None and now - matched_at >= 0.15:
+                if stable_s <= 0:
+                    return
+                if matched_at is not None and now - matched_at >= stable_s:
                     return
                 if matched_at is None:
                     matched_at = now
             else:
                 matched_at = None
-            time.sleep(0.1)
+            time.sleep(POLL_INTERVAL_S)
         raise AssertionError(f"profile {profile_name} enabled={enabled} not observed: {last}")
+
+    def wait_for_hardware_mapping(
+        self,
+        hardware_id: str,
+        *,
+        timeout_s: float = PROFILE_TIMEOUT_S,
+    ) -> None:
+        deadline = time.monotonic() + timeout_s
+        last: dict[str, Any] | None = None
+        while time.monotonic() < deadline:
+            last = self.request({"command": "get_active_profiles"}, ok=False)
+            devices = last.get("devices", {})
+            device = devices.get(hardware_id) if isinstance(devices, dict) else None
+            if (
+                isinstance(device, dict)
+                and bool(device.get("grabbed"))
+                and not bool(device.get("waiting_for_device"))
+                and self._device_mapping_applied(device)
+            ):
+                return
+            time.sleep(POLL_INTERVAL_S)
+        raise AssertionError(f"hardware {hardware_id} mapping not ready: {last}")
 
     def set_profile_enabled(self, profile_name: str, *, enabled: bool) -> None:
         command = "enable_profile" if enabled else "disable_profile"
@@ -716,13 +847,13 @@ type = "key"
         label: str,
         predicate: Callable[[], bool],
         *,
-        timeout_s: float = 5,
+        timeout_s: float = PROFILE_TIMEOUT_S,
     ) -> None:
         deadline = time.monotonic() + timeout_s
         while time.monotonic() < deadline:
             if predicate():
                 return
-            time.sleep(0.1)
+            time.sleep(POLL_INTERVAL_S)
         raise AssertionError(f"timed out waiting for {label}")
 
     def output_devices(self) -> list[evdev.InputDevice]:
@@ -732,15 +863,18 @@ type = "key"
             if device is not None
         ]
 
-    def drain_outputs(self) -> None:
-        end = time.monotonic() + 0.05
-        while time.monotonic() < end:
+    def drain_outputs(self, *, quiet_s: float = 0.05, timeout_s: float = 1.0) -> None:
+        deadline = time.monotonic() + timeout_s
+        quiet_deadline = time.monotonic() + quiet_s
+        while time.monotonic() < deadline and time.monotonic() < quiet_deadline:
             events = [
                 event
                 for device in self.output_devices()
                 for event in self.read_output_events(device)
             ]
-            if not events:
+            if events:
+                quiet_deadline = time.monotonic() + quiet_s
+            else:
                 time.sleep(0.005)
 
     def read_output_events(self, device: evdev.InputDevice) -> list[evdev.InputEvent]:

--- a/nix/daemon-session-integration-test/support.py
+++ b/nix/daemon-session-integration-test/support.py
@@ -476,6 +476,19 @@ type = "key"
         self.request({"command": "reevaluate_hardware"})
         self.reopen_outputs()
 
+    def enable_macro_recording_opt_in(self) -> None:
+        subprocess.run(
+            [
+                os.environ.get("KEYMASQ_INTEGRATION_SUDO", "sudo"),
+                os.environ.get("KEYMASQ_INTEGRATION_RECORD_HELPER", "keymasq-record"),
+                "enable-macro-recording-persistent",
+                "--uid",
+                str(os.getuid()),
+            ],
+            check=True,
+            timeout=10,
+        )
+
     def recreate_secondary_source(self) -> None:
         if self.source is None:
             raise AssertionError("primary source keyboard is not available")

--- a/scripts/integration.sh
+++ b/scripts/integration.sh
@@ -259,7 +259,7 @@ for index in "${!resolved_tests[@]}"; do
     echo "integration: ${test} scenarios=${scenario_filter:-all} repeat=${run_count} -> ${target}"
     (
       export KEYMASQ_INTEGRATION_SCENARIOS="$scenario_filter"
-      export KEYMASQ_INTEGRATION_REPEAT="$repeat_count"
+      export KEYMASQ_INTEGRATION_REPEAT="${repeat_count:-$run_count}"
       build_or_rebuild "$target" "$repeat_requested" "${nix_args[@]}"
     )
   else

--- a/scripts/integration.sh
+++ b/scripts/integration.sh
@@ -25,9 +25,16 @@ Tests:
   listeners       all listener VM tests
   all             daemon-session plus all listener VM tests
 
+Options:
+  -s, --scenario NAME[,NAME]  Run selected daemon-session scenario keys
+  -r, --repeat N              Repeat selected integration checks N times
+
 Examples:
   ./scripts/integration.sh cosmic
   ./scripts/integration.sh daemon-session
+  ./scripts/integration.sh daemon-session --scenario hotplug-replug
+  ./scripts/integration.sh --scenario profile-lifetime-direct-actions --repeat 10
+  ./scripts/integration.sh cosmic --repeat 3
   ./scripts/integration.sh listeners
 
 Use path: flake references so newly added or uncommitted VM files are included.
@@ -100,33 +107,125 @@ expand_group() {
   esac
 }
 
+append_scenario_filter() {
+  local value="$1"
+  local normalized
+  normalized="${value//_/-}"
+  normalized="${normalized,,}"
+  if [[ ! "$normalized" =~ ^[a-z0-9_.-]+(,[a-z0-9_.-]+)*$ ]]; then
+    echo "Invalid scenario filter: $value" >&2
+    echo "Use scenario keys such as: hotplug-replug,profile-lifetime-direct-actions" >&2
+    exit 1
+  fi
+  if [[ -n "$scenario_filter" ]]; then
+    scenario_filter="${scenario_filter},${normalized}"
+  else
+    scenario_filter="$normalized"
+  fi
+}
+
+set_repeat_count() {
+  local value="$1"
+  if [[ ! "$value" =~ ^[1-9][0-9]*$ ]]; then
+    echo "Invalid repeat count: $value" >&2
+    exit 1
+  fi
+  repeat_count="$value"
+  repeat_requested=1
+}
+
+build_or_rebuild() {
+  local target="$1"
+  local force_rebuild="$2"
+  shift 2
+  local nix_args=("$@")
+  local log_file
+  local status
+
+  if [[ "$force_rebuild" != "1" ]]; then
+    nix build --no-link "${nix_args[@]}" "$target"
+    return
+  fi
+
+  log_file="$(mktemp)"
+  set +e
+  nix build --no-link --rebuild "${nix_args[@]}" "$target" 2>&1 | tee "$log_file"
+  status=${PIPESTATUS[0]}
+  set -e
+
+  if [[ "$status" -eq 0 ]]; then
+    rm -f "$log_file"
+    return
+  fi
+
+  if grep -q "not valid, so checking is not possible" "$log_file"; then
+    rm -f "$log_file"
+    nix build --no-link "${nix_args[@]}" "$target"
+    return
+  fi
+
+  rm -f "$log_file"
+  return "$status"
+}
+
 if [[ $# -eq 0 ]]; then
   usage
   exit 0
 fi
 
-case "$1" in
-  -h|--help|help|list|--list)
-    usage
-    exit 0
-    ;;
-esac
-
-tests=()
-for arg in "$@"; do
-  case "$arg" in
+scenario_filter=""
+repeat_count=""
+repeat_requested=0
+raw_tests=()
+while [[ $# -gt 0 ]]; do
+  case "$1" in
     -h|--help|help|list|--list)
       usage
       exit 0
       ;;
+    -s|--scenario)
+      if [[ $# -lt 2 ]]; then
+        echo "Missing value for $1" >&2
+        exit 1
+      fi
+      shift
+      append_scenario_filter "$1"
+      ;;
+    --scenario=*)
+      append_scenario_filter "${1#*=}"
+      ;;
+    -r|--repeat)
+      if [[ $# -lt 2 ]]; then
+        echo "Missing value for $1" >&2
+        exit 1
+      fi
+      shift
+      set_repeat_count "$1"
+      ;;
+    --repeat=*)
+      set_repeat_count "${1#*=}"
+      ;;
+    *)
+      raw_tests+=("$1")
+      ;;
   esac
+  shift
+done
 
+tests=()
+if [[ ${#raw_tests[@]} -eq 0 && (-n "$scenario_filter" || -n "$repeat_count") ]]; then
+  raw_tests=(daemon-session)
+fi
+
+for arg in "${raw_tests[@]}"; do
   while IFS= read -r expanded; do
     [[ -n "$expanded" ]] || continue
     tests+=("$expanded")
   done < <(expand_group "$arg")
 done
 
+resolved_tests=()
+resolved_checks=()
 for test in "${tests[@]}"; do
   if ! check_name="$(check_name_for_test "$test")"; then
     echo "Unknown integration test: $test" >&2
@@ -135,7 +234,42 @@ for test in "${tests[@]}"; do
     exit 1
   fi
 
+  if [[ -n "$scenario_filter" && "$check_name" != "daemon-session-integration-test" ]]; then
+    echo "Scenario selection is only supported for daemon-session tests" >&2
+    exit 1
+  fi
+
+  resolved_tests+=("$test")
+  resolved_checks+=("$check_name")
+done
+
+for index in "${!resolved_tests[@]}"; do
+  test="${resolved_tests[$index]}"
+  check_name="${resolved_checks[$index]}"
+
+  nix_args=()
+  run_count="${repeat_count:-1}"
+  if [[ "$check_name" == "daemon-session-integration-test" && (-n "$scenario_filter" || -n "$repeat_count") ]]; then
+    check_name="daemon-session-selected-integration-test"
+    nix_args+=(--impure)
+  fi
+
   target="path:.#checks.${SYSTEM}.${check_name}"
-  echo "integration: ${test} -> ${target}"
-  nix build "$target"
+  if [[ "$check_name" == "daemon-session-selected-integration-test" ]]; then
+    echo "integration: ${test} scenarios=${scenario_filter:-all} repeat=${run_count} -> ${target}"
+    (
+      export KEYMASQ_INTEGRATION_SCENARIOS="$scenario_filter"
+      export KEYMASQ_INTEGRATION_REPEAT="$repeat_count"
+      build_or_rebuild "$target" "$repeat_requested" "${nix_args[@]}"
+    )
+  else
+    for iteration in $(seq 1 "$run_count"); do
+      if [[ "$run_count" -gt 1 ]]; then
+        echo "integration: ${test} repeat ${iteration}/${run_count} -> ${target}"
+      else
+        echo "integration: ${test} -> ${target}"
+      fi
+      build_or_rebuild "$target" "$repeat_requested"
+    done
+  fi
 done

--- a/scripts/release-version.py
+++ b/scripts/release-version.py
@@ -8,6 +8,7 @@ import re
 import sys
 import tomllib
 from datetime import UTC, datetime
+from email.utils import format_datetime
 from pathlib import Path
 from types import ModuleType
 
@@ -34,7 +35,7 @@ def _release_date() -> str:
 
 def _debian_timestamp(release_date: str) -> str:
     timestamp = datetime.strptime(release_date, "%Y-%m-%d").replace(tzinfo=UTC)
-    return timestamp.strftime("%a, %d %b %Y 00:00:00 +0000")
+    return format_datetime(timestamp)
 
 
 def _current_version(root: Path) -> str:
@@ -46,9 +47,7 @@ def _current_version(root: Path) -> str:
     return version
 
 
-def _build_rules(
-    root: Path, version: str, release_date: str, current_version: str
-) -> list[RewriteRule]:
+def _build_rules(root: Path, version: str, release_date: str) -> list[RewriteRule]:
     rules = [
         *python_metadata_rules(root, version),
         rpm_metadata_rule(root, version),
@@ -59,14 +58,13 @@ def _build_rules(
         ),
         debian_changelog_upstream_version_rule(root, version),
     ]
-    if current_version != version:
-        rules.append(
-            RewriteRule(
-                root / "debian/changelog",
-                re.compile(r"(?m)^ -- nyrda <nyrda@keymasq.tools>  .+$"),
-                f" -- nyrda <nyrda@keymasq.tools>  {_debian_timestamp(release_date)}",
-            )
+    rules.append(
+        RewriteRule(
+            root / "debian/changelog",
+            re.compile(r"(?m)^ -- nyrda <nyrda@keymasq.tools>  .+$"),
+            f" -- nyrda <nyrda@keymasq.tools>  {_debian_timestamp(release_date)}",
         )
+    )
     return rules
 
 
@@ -78,7 +76,7 @@ def _rewrite_changelog(
     if current_version == version:
         return False
 
-    release_header = f"## {version}"
+    release_header = f"## {version} - {release_date}"
     release_pattern = re.compile(
         CHANGELOG_RELEASE_RE_TEMPLATE.format(version=re.escape(version))
     )
@@ -118,13 +116,9 @@ def _build_metainfo_release(version: str, release_date: str) -> str:
     )
 
 
-def _rewrite_metainfo(
-    root: Path, version: str, release_date: str, current_version: str, dry_run: bool
-) -> bool:
+def _rewrite_metainfo(root: Path, version: str, release_date: str, dry_run: bool) -> bool:
     path = root / "assets/tools.keymasq.keymasq.metainfo.xml"
     content = path.read_text(encoding="utf-8")
-    if current_version == version:
-        return False
 
     release_line = f'    <release version="{version}" date="{release_date}">'
     release_pattern = re.compile(
@@ -239,20 +233,22 @@ def main() -> int:
         parser.error("version must use the form X.Y.Z")
     release_date = str(args.release_date).strip()
     try:
-        datetime.strptime(release_date, "%Y-%m-%d")
+        parsed_release_date = datetime.strptime(release_date, "%Y-%m-%d").date()
     except ValueError as exc:
         parser.error(f"release date must use the form YYYY-MM-DD: {exc}")
+    if release_date != parsed_release_date.isoformat():
+        parser.error("release date must use the form YYYY-MM-DD")
 
     root = repo_root()
     current_version = _current_version(root)
     changed_paths = apply_rules(
         root,
-        _build_rules(root, version, release_date, current_version),
+        _build_rules(root, version, release_date),
         dry_run=args.dry_run,
     )
     if _rewrite_changelog(root, version, release_date, current_version, dry_run=args.dry_run):
         changed_paths.append(Path("CHANGELOG.md"))
-    if _rewrite_metainfo(root, version, release_date, current_version, dry_run=args.dry_run):
+    if _rewrite_metainfo(root, version, release_date, dry_run=args.dry_run):
         changed_paths.append(Path("assets/tools.keymasq.keymasq.metainfo.xml"))
     changed_paths.extend(_render_pacman_outputs(root, version, dry_run=args.dry_run))
     changed_paths = list(dict.fromkeys(changed_paths))

--- a/scripts/release-version.py
+++ b/scripts/release-version.py
@@ -68,13 +68,9 @@ def _build_rules(root: Path, version: str, release_date: str) -> list[RewriteRul
     return rules
 
 
-def _rewrite_changelog(
-    root: Path, version: str, release_date: str, current_version: str, dry_run: bool
-) -> bool:
+def _rewrite_changelog(root: Path, version: str, release_date: str, dry_run: bool) -> bool:
     path = root / "CHANGELOG.md"
     content = path.read_text(encoding="utf-8")
-    if current_version == version:
-        return False
 
     release_header = f"## {version} - {release_date}"
     release_pattern = re.compile(
@@ -246,7 +242,7 @@ def main() -> int:
         _build_rules(root, version, release_date),
         dry_run=args.dry_run,
     )
-    if _rewrite_changelog(root, version, release_date, current_version, dry_run=args.dry_run):
+    if _rewrite_changelog(root, version, release_date, dry_run=args.dry_run):
         changed_paths.append(Path("CHANGELOG.md"))
     if _rewrite_metainfo(root, version, release_date, dry_run=args.dry_run):
         changed_paths.append(Path("assets/tools.keymasq.keymasq.metainfo.xml"))

--- a/tests/common/test_collection_markers.py
+++ b/tests/common/test_collection_markers.py
@@ -18,3 +18,14 @@ def test_collection_category_uses_repo_tests_segment_for_absolute_paths() -> Non
 
 def test_collection_category_does_not_use_root_level_basename_fallback() -> None:
     assert _category_for_test_path(Path("tests/test_daemon.py")) is None
+
+
+def test_collection_category_uses_top_level_filename_before_ancestor_category() -> None:
+    assert (
+        _category_for_test_path(Path("/tmp/tests/common/keymasq/tests/test_daemon.py"))
+        == "keymasqd"
+    )
+    assert (
+        _category_for_test_path(Path("/tmp/tests/keymasqd/keymasq/tests/test_session_clients.py"))
+        == "session"
+    )

--- a/tests/common/test_collection_markers.py
+++ b/tests/common/test_collection_markers.py
@@ -16,8 +16,8 @@ def test_collection_category_uses_repo_tests_segment_for_absolute_paths() -> Non
     assert _category_for_test_path(path) == "common"
 
 
-def test_collection_category_does_not_use_root_level_basename_fallback() -> None:
-    assert _category_for_test_path(Path("tests/test_daemon.py")) is None
+def test_collection_category_uses_root_level_basename_fallback() -> None:
+    assert _category_for_test_path(Path("tests/test_daemon.py")) == "keymasqd"
 
 
 def test_collection_category_uses_top_level_filename_before_ancestor_category() -> None:

--- a/tests/common/test_profile_manager.py
+++ b/tests/common/test_profile_manager.py
@@ -736,6 +736,52 @@ created_at = "not-a-date"
         assert 'created_at = "' in content
         assert 'created_at = "not-a-date"' not in content
 
+    def test_pending_created_at_repair_does_not_overwrite_newer_profile_save(
+        self,
+        temp_config_dir,
+    ):
+        profile_path = Path(temp_config_dir) / "profiles" / "missing-created-at.toml"
+        profile_path.write_text(
+            """
+[profile]
+name = "Missing Created"
+enabled = true
+is_permanent = true
+priority = 1
+notify_on_activation = true
+
+[devices."1234:5678"]
+always_grab_all = false
+
+[devices."1234:5678".mapping.btn_back]
+action = "keyboard"
+target = "key_1"
+""".strip(),
+            encoding="utf-8",
+        )
+        manager = ProfileManager()
+        loaded = manager.get_profile("Missing Created")
+        assert loaded is not None
+
+        layer = loaded.config.device_layers["1234:5678"]
+        layer.mappings["btn_forward"] = MappingAction(
+            action_type=ActionType.KEYBOARD,
+            target="key_2",
+        )
+        manager.save_profile(loaded.config)
+
+        manager._repair_created_at_if_needed(
+            loaded.config.created_at or datetime.now(),
+            profile_path,
+        )
+
+        reloaded = ProfileManager()
+        saved = reloaded.get_profile("Missing Created")
+        assert saved is not None
+        mappings = saved.config.device_layers["1234:5678"].mappings
+        assert mappings["btn_back"].target == "key_1"
+        assert mappings["btn_forward"].target == "key_2"
+
     def test_remove_device_button_mappings_clears_matching_profile_entries(self, temp_config_dir):
         manager = ProfileManager()
         profile = ProfileConfig(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -237,8 +237,7 @@ def _category_for_test_path(item_path: Path) -> str | None:
         subtree = parts[tests_index + 1]
         if subtree in _CATEGORY_SUBTREES:
             return subtree
-        if "tests" in parts[:tests_index]:
-            return _CATEGORY_BY_FILE.get(item_path.name)
+        return _CATEGORY_BY_FILE.get(item_path.name)
     return None
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -223,6 +223,10 @@ def event_loop():
 
 
 _CATEGORY_SUBTREES = {"common", "keymasqd", "session", "gui"}
+_CATEGORY_BY_FILE = {
+    "test_daemon.py": "keymasqd",
+    "test_session_clients.py": "session",
+}
 
 
 def _category_for_test_path(item_path: Path) -> str | None:
@@ -233,6 +237,8 @@ def _category_for_test_path(item_path: Path) -> str | None:
         subtree = parts[tests_index + 1]
         if subtree in _CATEGORY_SUBTREES:
             return subtree
+        if "tests" in parts[:tests_index]:
+            return _CATEGORY_BY_FILE.get(item_path.name)
     return None
 
 

--- a/tests/gui/test_combo_tab_widget.py
+++ b/tests/gui/test_combo_tab_widget.py
@@ -6,6 +6,7 @@ from tests.gui.support import collect_listbox_row_labels
 pytest.importorskip("gi")
 
 
+
 class TestComboTabWidget:
     def test_combo_tab_does_not_start_active_profile_polling(self, monkeypatch):
         from keymasq.gui.widgets.combo_tab import ComboTab
@@ -201,6 +202,229 @@ class TestComboTabWidget:
 
         assert tab._selected_combos() == []
         assert tab.section_label.get_text() == "No combos in this profile."
+
+    def test_combo_tab_rejects_stale_duplicate_combo_save(self, temp_config_dir, monkeypatch):
+        from keymasq.common.models import (
+            ActionType,
+            ComboConfig,
+            ComboEvent,
+            ComboStep,
+            MappingAction,
+            ProfileConfig,
+        )
+        from keymasq.gui.widgets.combo_tab import ComboTab
+        from keymasq.session.profiles import ProfileManager
+
+        def combo(combo_id: str, name: str) -> ComboConfig:
+            return ComboConfig(
+                id=combo_id,
+                name=name,
+                steps=[
+                    ComboStep(
+                        events=[
+                            ComboEvent(
+                                evdev="key_s",
+                                hardware_id="1234:5678",
+                                source="kbd",
+                            )
+                        ]
+                    )
+                ],
+                action=MappingAction(action_type=ActionType.KEYBOARD, target="key_f5"),
+            )
+
+        profile_manager = ProfileManager()
+        profile_manager.save_profile(ProfileConfig(name="Desktop"))
+
+        tab = ComboTab(profile_manager=profile_manager, demo_mode=True)
+        tab.refresh_profiles(preferred_profile_name="Desktop", publish_selection=False)
+        assert tab._selected_profile is not None
+        errors: list[str] = []
+        monkeypatch.setattr(tab, "_show_profile_error_dialog", errors.append)
+
+        target_profile = tab._selected_profile
+        tab._on_combo_saved(None, combo("combo-1", "First"), target_profile)
+        tab._on_combo_saved(None, combo("combo-2", "Second"), target_profile)
+
+        assert [combo.id for combo in target_profile.config.combos] == ["combo-1"]
+        assert errors == ["A combo with the same trigger already exists in this profile."]
+
+    def test_combo_tab_save_uses_profile_selected_when_editor_opened(
+        self,
+        temp_config_dir,
+        monkeypatch,
+    ):
+        from keymasq.common.models import (
+            ActionType,
+            ComboConfig,
+            ComboEvent,
+            ComboStep,
+            MappingAction,
+            ProfileConfig,
+        )
+        import keymasq.gui.widgets.combo_tab as combo_tab_module
+        from keymasq.gui.widgets.combo_tab import ComboTab
+        from keymasq.session.profiles import ProfileManager
+
+        def combo(name: str) -> ComboConfig:
+            return ComboConfig(
+                id="shared-combo",
+                name=name,
+                steps=[
+                    ComboStep(
+                        events=[
+                            ComboEvent(
+                                evdev="key_s",
+                                hardware_id="1234:5678",
+                                source="kbd",
+                            )
+                        ]
+                    )
+                ],
+                action=MappingAction(action_type=ActionType.KEYBOARD, target="key_f5"),
+            )
+
+        class FakeComboEditorDialog:
+            instances = []
+
+            def __init__(
+                self,
+                _parent,
+                _combo=None,
+                profile_name=None,
+                sibling_combos=None,
+                emergency_cancel_combo_enabled=True,
+            ):
+                self.profile_name = profile_name
+                self.sibling_combos = sibling_combos
+                self.emergency_cancel_combo_enabled = emergency_cancel_combo_enabled
+                self.handlers = []
+                FakeComboEditorDialog.instances.append(self)
+
+            def connect(self, signal, callback, *user_data):
+                self.handlers.append((signal, callback, user_data))
+
+            def present(self, _parent):
+                pass
+
+        monkeypatch.setattr(combo_tab_module, "ComboEditorDialog", FakeComboEditorDialog)
+
+        profile_manager = ProfileManager()
+        profile_manager.save_profile(ProfileConfig(name="Desktop", combos=[combo("Desktop")]))
+        profile_manager.save_profile(ProfileConfig(name="Gaming", combos=[combo("Gaming")]))
+
+        tab = ComboTab(profile_manager=profile_manager, demo_mode=True)
+        tab.refresh_profiles(preferred_profile_name="Desktop", publish_selection=False)
+        desktop_combo = profile_manager.get_profile("Desktop").config.combos[0]
+
+        tab._open_combo_editor(desktop_combo)
+
+        dialog = FakeComboEditorDialog.instances[0]
+        assert dialog.profile_name == "Desktop"
+        assert [combo.name for combo in dialog.sibling_combos] == ["Desktop"]
+
+        tab.refresh_profiles(preferred_profile_name="Gaming", publish_selection=False)
+        signal, callback, user_data = dialog.handlers[0]
+        assert signal == "combo-saved"
+
+        callback(None, combo("Desktop Updated"), *user_data)
+
+        assert profile_manager.get_profile("Desktop").config.combos[0].name == "Desktop Updated"
+        assert profile_manager.get_profile("Gaming").config.combos[0].name == "Gaming"
+        assert tab._selected_profile.config.name == "Gaming"
+
+    def test_combo_tab_delete_uses_profile_selected_when_dialog_opened(
+        self,
+        temp_config_dir,
+        monkeypatch,
+    ):
+        from keymasq.common.models import (
+            ActionType,
+            ComboConfig,
+            ComboEvent,
+            ComboStep,
+            MappingAction,
+            ProfileConfig,
+        )
+        import keymasq.gui.widgets.combo_tab as combo_tab_module
+        from keymasq.gui.widgets.combo_tab import ComboTab
+        from keymasq.session.profiles import ProfileManager
+
+        def combo(name: str) -> ComboConfig:
+            return ComboConfig(
+                id="shared-combo",
+                name=name,
+                steps=[
+                    ComboStep(
+                        events=[
+                            ComboEvent(
+                                evdev="key_s",
+                                hardware_id="1234:5678",
+                                source="kbd",
+                            )
+                        ]
+                    )
+                ],
+                action=MappingAction(action_type=ActionType.KEYBOARD, target="key_f5"),
+            )
+
+        class FakeAlertDialog:
+            instances = []
+
+            def __init__(self):
+                self.handlers = []
+                FakeAlertDialog.instances.append(self)
+
+            def set_heading(self, heading):
+                self.heading = heading
+
+            def set_body(self, body):
+                self.body = body
+
+            def add_response(self, *_args):
+                pass
+
+            def set_response_appearance(self, *_args):
+                pass
+
+            def set_default_response(self, *_args):
+                pass
+
+            def set_close_response(self, *_args):
+                pass
+
+            def connect(self, signal, callback, *user_data):
+                self.handlers.append((signal, callback, user_data))
+
+            def present(self, _parent):
+                pass
+
+        monkeypatch.setattr(combo_tab_module.Adw, "AlertDialog", FakeAlertDialog)
+
+        profile_manager = ProfileManager()
+        profile_manager.save_profile(ProfileConfig(name="Desktop", combos=[combo("Desktop")]))
+        profile_manager.save_profile(ProfileConfig(name="Gaming", combos=[combo("Gaming")]))
+
+        tab = ComboTab(profile_manager=profile_manager, demo_mode=True)
+        tab.refresh_profiles(preferred_profile_name="Desktop", publish_selection=False)
+
+        tab._on_delete_combo_clicked(None, "shared-combo")
+
+        dialog = FakeAlertDialog.instances[0]
+        assert dialog.heading == "Delete Combo"
+        assert "Desktop" in dialog.body
+
+        tab.refresh_profiles(preferred_profile_name="Gaming", publish_selection=False)
+        signal, callback, user_data = dialog.handlers[0]
+        assert signal == "response"
+
+        callback(dialog, "delete", *user_data)
+
+        assert profile_manager.get_profile("Desktop").config.combos == []
+        assert [combo.name for combo in profile_manager.get_profile("Gaming").config.combos] == [
+            "Gaming"
+        ]
+        assert tab._selected_profile.config.name == "Gaming"
 
     def test_combo_tab_marks_active_profile_from_session_payload(self, temp_config_dir):
         from keymasq.common.models import ProfileConfig

--- a/tests/gui/test_gui_demo_and_dialogs.py
+++ b/tests/gui/test_gui_demo_and_dialogs.py
@@ -1746,6 +1746,66 @@ class TestDialogConstruction:
 
         assert dialog._empty_label.get_visible() is True
 
+    def test_macro_manager_list_load_errors_keep_existing_rows(self, monkeypatch):
+        gi.require_version("Gtk", "4.0")
+        from gi.repository import GLib, Gtk
+
+        from keymasq.gui.session_client import GuiTaskResult
+        import keymasq.gui.widgets.macro_manager_dialog as macro_manager_dialog_module
+        from keymasq.gui.widgets.macro_manager_dialog import MacroManagerDialog
+
+        monkeypatch.setattr(GLib, "idle_add", lambda callback, *args: 0)
+        alerts: list[tuple[object, object]] = []
+        monkeypatch.setattr(
+            macro_manager_dialog_module.Adw.AlertDialog,
+            "present",
+            lambda alert, parent: alerts.append((alert, parent)),
+        )
+
+        parent = Gtk.Window()
+        dialog = MacroManagerDialog(parent)
+        dialog._on_macros_loaded(
+            {
+                "status": "ok",
+                "macros": [
+                    {
+                        "name": "stored",
+                        "duration_us": 250_000,
+                        "device_types": ["keyboard"],
+                        "event_count": 2,
+                    }
+                ],
+            }
+        )
+
+        assert dialog._listbox.get_row_at_index(0) is not None
+        assert dialog._empty_label.get_visible() is False
+
+        assert dialog._on_macros_loaded({"status": "error", "message": "boom"}) is False
+
+        assert dialog._macros[0]["name"] == "stored"
+        assert dialog._listbox.get_row_at_index(0) is not None
+        assert dialog._empty_label.get_visible() is False
+        assert len(alerts) == 1
+        alert, alert_parent = alerts[0]
+        assert alert_parent is parent
+        assert alert.get_heading() == "Load Macros"
+        assert alert.get_body() == "boom"
+
+        result = GuiTaskResult(
+            value=(
+                {"macro_recording_enabled": True},
+                {"status": "error", "message": "initial boom"},
+            )
+        )
+
+        assert dialog._on_initial_state_loaded(result) is False
+        assert dialog._macros[0]["name"] == "stored"
+        assert dialog._listbox.get_row_at_index(0) is not None
+        assert dialog._empty_label.get_visible() is False
+        assert len(alerts) == 2
+        assert alerts[1][0].get_body() == "initial boom"
+
     def test_macro_manager_duplicate_request_and_finish_paths(self, monkeypatch):
         gi.require_version("Gtk", "4.0")
         from gi.repository import GLib, Gtk

--- a/tests/gui/test_gui_device_tab_misc.py
+++ b/tests/gui/test_gui_device_tab_misc.py
@@ -2122,7 +2122,7 @@ def test_key_selector_dialog_profile_lifetime_requires_disabled_profile(monkeypa
     assert results[0].profile_deactivation is None
 
 
-def test_key_selector_dialog_only_shows_hyprland_actions_for_active_hyprland_listener():
+def test_key_selector_dialog_shows_hyprland_actions_for_active_listener_or_saved_action():
     from gi.repository import Gtk
 
     from keymasq.common.models import ActionType, MappingAction
@@ -2138,7 +2138,7 @@ def test_key_selector_dialog_only_shows_hyprland_actions_for_active_hyprland_lis
     )
     assert active_dialog.stack.get_child_by_name("hyprland") is not None
 
-    hidden_dialog = KeySelectorDialog(
+    saved_dialog = KeySelectorDialog(
         Gtk.Box(),
         "Back",
         MappingAction(
@@ -2152,10 +2152,11 @@ def test_key_selector_dialog_only_shows_hyprland_actions_for_active_hyprland_lis
             "compositor_dispatch_available": False,
         },
     )
-    assert hidden_dialog.stack.get_child_by_name("hyprland") is None
+    assert saved_dialog.stack.get_child_by_name("hyprland") is not None
+    assert saved_dialog.stack.get_visible_child_name() == "hyprland"
 
 
-def test_key_selector_dialog_only_shows_niri_dispatch_for_active_niri_listener():
+def test_key_selector_dialog_shows_niri_dispatch_for_active_listener_or_saved_action():
     from gi.repository import Gtk
 
     from keymasq.common.models import ActionType, MappingAction
@@ -2179,7 +2180,7 @@ def test_key_selector_dialog_only_shows_niri_dispatch_for_active_niri_listener()
     assert page._dispatcher_entry.get_editable() is True
     assert page._args_entry.get_editable() is True
 
-    hidden_dialog = KeySelectorDialog(
+    saved_dialog = KeySelectorDialog(
         Gtk.Box(),
         "Back",
         MappingAction(
@@ -2193,7 +2194,8 @@ def test_key_selector_dialog_only_shows_niri_dispatch_for_active_niri_listener()
             "compositor_dispatch_available": False,
         },
     )
-    assert hidden_dialog.stack.get_child_by_name("niri") is None
+    assert saved_dialog.stack.get_child_by_name("niri") is not None
+    assert saved_dialog.stack.get_visible_child_name() == "niri"
 
 
 def test_key_selector_dialog_shows_gnome_dispatch_for_active_gnome_listener():
@@ -2227,6 +2229,23 @@ def test_key_selector_dialog_shows_gnome_dispatch_for_active_gnome_listener():
     assert page._args_entry.get_text() == "2"
     assert page._dispatcher_entry.get_editable() is False
     assert page._args_entry.get_editable() is False
+
+    saved_dialog = KeySelectorDialog(
+        Gtk.Box(),
+        "Back",
+        MappingAction(
+            action_type=ActionType.COMPOSITOR_DISPATCH,
+            compositor_id="gnome",
+            compositor_dispatcher="workspace",
+            compositor_args="2",
+        ),
+        compositor_action_status={
+            "listener_name": "x11",
+            "compositor_dispatch_available": False,
+        },
+    )
+    assert saved_dialog.stack.get_child_by_name("gnome") is not None
+    assert saved_dialog.stack.get_visible_child_name() == "gnome"
 
 
 def test_key_selector_dialog_compositor_set_cursor_reuses_position_capture(monkeypatch):
@@ -2317,7 +2336,7 @@ def test_key_selector_dialog_reopens_set_cursor_with_captured_coordinates():
     assert page._capture_row.get_visible() is True
 
 
-def test_key_selector_dialog_only_shows_kde_dispatch_for_active_kde_listener():
+def test_key_selector_dialog_shows_kde_dispatch_for_active_listener_or_saved_action():
     from gi.repository import Gtk
 
     from keymasq.common.models import ActionType, MappingAction
@@ -2342,7 +2361,7 @@ def test_key_selector_dialog_only_shows_kde_dispatch_for_active_kde_listener():
     assert page._dispatcher_entry.get_editable() is False
     assert page._args_entry.get_editable() is False
 
-    hidden_dialog = KeySelectorDialog(
+    saved_dialog = KeySelectorDialog(
         Gtk.Box(),
         "Back",
         MappingAction(
@@ -2356,7 +2375,8 @@ def test_key_selector_dialog_only_shows_kde_dispatch_for_active_kde_listener():
             "compositor_dispatch_available": False,
         },
     )
-    assert hidden_dialog.stack.get_child_by_name("kde") is None
+    assert saved_dialog.stack.get_child_by_name("kde") is not None
+    assert saved_dialog.stack.get_visible_child_name() == "kde"
 
 
 def test_key_selector_dialog_keeps_hyprland_custom_dispatch_enabled():
@@ -2721,6 +2741,54 @@ def test_shared_gamepad_picker_buttons_use_shared_metadata():
     metadata_buttons = set(GAMEPAD_BUTTONS.values())
     assert rendered_buttons == metadata_buttons
     assert {EVDEV_TO_GAMEPAD[evdev_id] for evdev_id in rendered_buttons} == set(GAMEPAD_BUTTONS)
+
+
+def test_shared_gamepad_picker_falls_back_without_axis_handler():
+    from gi.repository import Gtk
+
+    from keymasq.gui.widgets.input_picker_shared import build_gamepad_tab
+
+    class _Owner:
+        def __init__(self) -> None:
+            self.clicked: list[str] = []
+
+        def _create_key_button(
+            self,
+            label: str,
+            evdev: str,
+            width: float = 1,
+            large: bool = False,
+            protected: bool = False,
+        ) -> Gtk.Button:
+            return Gtk.Button(label=label)
+
+        def _on_gamepad_clicked(self, _btn, evdev_id: str) -> None:
+            self.clicked.append(evdev_id)
+
+    def collect_buttons(widget: Gtk.Widget) -> list[Gtk.Button]:
+        buttons: list[Gtk.Button] = []
+        if isinstance(widget, Gtk.Button):
+            buttons.append(widget)
+        child = widget.get_first_child()
+        while child is not None:
+            buttons.extend(collect_buttons(child))
+            child = child.get_next_sibling()
+        return buttons
+
+    owner = _Owner()
+    widget = build_gamepad_tab(owner)
+
+    assert isinstance(widget, Gtk.Box)
+    buttons_by_label = {
+        button.get_label(): button
+        for button in collect_buttons(widget)
+        if button.get_label()
+    }
+
+    for label in ("LT", "LX+", "RY-", "RT"):
+        buttons_by_label[label].emit("clicked")
+
+    assert owner.clicked == ["abs_z", "abs_x", "abs_ry", "abs_rz"]
 
 
 def test_key_selector_dialog_opens_media_tab_for_media_key_action():

--- a/tests/gui/test_input_picker_shared.py
+++ b/tests/gui/test_input_picker_shared.py
@@ -1,0 +1,72 @@
+# ruff: noqa: F403, F405, I001, E402
+import gi
+
+from tests.gui.support import *
+
+gi.require_version("Gtk", "4.0")
+from gi.repository import Gtk  # pyright: ignore[reportAttributeAccessIssue]
+
+
+class _GamepadOwner:
+    def __init__(self) -> None:
+        self.clicked: list[str] = []
+
+    def _create_key_button(
+        self,
+        label: str,
+        evdev: str,
+        width: float = 1,
+        large: bool = False,
+        protected: bool = False,
+    ) -> Gtk.Button:
+        _ = width, large, protected
+        return Gtk.Button(label=label)
+
+    def _on_gamepad_clicked(self, _button: Gtk.Button, evdev_id: str) -> None:
+        self.clicked.append(evdev_id)
+
+    def _on_gamepad_axis_clicked(
+        self,
+        _button: Gtk.Button,
+        _target: str,
+        _value: int,
+    ) -> None:
+        return
+
+
+def _collect_buttons(widget: Gtk.Widget) -> list[Gtk.Button]:
+    buttons: list[Gtk.Button] = []
+    child = widget.get_first_child()
+    while child is not None:
+        if isinstance(child, Gtk.Button):
+            buttons.append(child)
+        buttons.extend(_collect_buttons(child))
+        child = child.get_next_sibling()
+    return buttons
+
+
+def test_gamepad_face_buttons_emit_positional_targets() -> None:
+    from keymasq.gui.widgets.input_picker_shared import build_gamepad_tab
+    from keymasq.gui.widgets.key_selector_dialog import GAMEPAD_BUTTONS
+
+    expected = {
+        "A": "btn_south",
+        "B": "btn_east",
+        "X": "btn_north",
+        "Y": "btn_west",
+    }
+    owner = _GamepadOwner()
+    tab = build_gamepad_tab(owner)
+    face_buttons = {
+        button.get_label() or "": button
+        for button in _collect_buttons(tab)
+        if (button.get_label() or "") in expected
+    }
+
+    assert set(face_buttons) == set(expected)
+    assert {label: GAMEPAD_BUTTONS[label] for label in expected} == expected
+
+    for label, _evdev_id in expected.items():
+        face_buttons[label].emit("clicked")
+
+    assert owner.clicked == list(expected.values())

--- a/tests/gui/test_macro_editor_parser.py
+++ b/tests/gui/test_macro_editor_parser.py
@@ -58,9 +58,7 @@ def test_parse_reconstruct_preserves_abs_and_repeat_events() -> None:
     editable, rel_events, passthrough, synthetic_moves, control_events = parse_events(raw)
     rebuilt = reconstruct_events(editable, rel_events, passthrough, synthetic_moves, control_events)
 
-    assert any(e["type"] == evdev.ecodes.EV_ABS for e in rebuilt)
-    assert any(e["type"] == evdev.ecodes.EV_REL for e in rebuilt)
-    assert any(e["type"] == evdev.ecodes.EV_KEY and e["value"] == 2 for e in rebuilt)
+    assert rebuilt == raw
 
 
 def test_describe_passthrough_abs_event_uses_event_type_name() -> None:

--- a/tests/gui/test_main_window.py
+++ b/tests/gui/test_main_window.py
@@ -94,6 +94,31 @@ class TestMainWindow:
         assert tab2._selected_profile is not None
         assert tab2._selected_profile.config.name == "Profile 2"
 
+    def test_main_window_demo_mode_uses_sample_startup_without_system_probe(
+        self, temp_config_dir, monkeypatch
+    ):
+        from keymasq.gui import window as window_module
+        from keymasq.gui.window import MainWindow
+
+        def fail_system_probe(*args, **kwargs):
+            raise AssertionError("demo startup should not probe the real system")
+
+        monkeypatch.setattr(window_module, "detect_compositor_sync", fail_system_probe)
+        monkeypatch.setattr(window_module.HardwareManager, "list_hardware", fail_system_probe)
+        monkeypatch.setattr(window_module, "run_gui_task", fail_system_probe)
+        monkeypatch.setattr(
+            window_module.GLib,
+            "idle_add",
+            lambda callback, *args: callback(*args),
+        )
+
+        window = MainWindow(demo_mode=True)
+        demo_tab = window._child_for_hardware_id("1234:5678")
+
+        assert window._startup_probe_done is True
+        assert demo_tab is not None
+        assert demo_tab.device.name == "Demo Mouse"
+
     def test_main_window_add_device_action_does_not_require_unlock(self, temp_config_dir):
         from keymasq.gui.window import MainWindow
 
@@ -972,6 +997,38 @@ class TestMainWindow:
         assert registered == [("*", window._on_session_event)]
         assert removed == [11, 22]
         assert unregistered == [("*", window._on_session_event)]
+
+    def test_main_window_macro_recording_dialog_refreshes_session_status(
+        self,
+        temp_config_dir,
+        monkeypatch,
+    ):
+        from keymasq.gui import window as window_module
+        from keymasq.gui.window import MainWindow
+
+        requests: list[tuple[dict[str, object], float]] = []
+
+        def fake_session_request(payload, timeout=5.0):
+            requests.append((payload, timeout))
+            return {
+                "status": "ok",
+                "macro_recording_enabled": True,
+                "macro_recording_source": "persistent",
+                "macro_recording_expires_at": 0,
+            }
+
+        monkeypatch.setattr(window_module, "session_request", fake_session_request)
+
+        window = MainWindow(demo_mode=True)
+        requests.clear()
+        window._macro_recording_enabled = False
+        called: list[bool] = []
+
+        window.present_macro_recording_enable_dialog(on_success=lambda: called.append(True))
+
+        assert requests == [({"command": "get_status"}, 1.0)]
+        assert window._macro_recording_enabled is True
+        assert called == [True]
 
     def test_main_window_status_error_keeps_last_runtime_profile_state(self, temp_config_dir):
         from keymasq.common.models import (

--- a/tests/gui/test_main_window.py
+++ b/tests/gui/test_main_window.py
@@ -1008,16 +1008,16 @@ class TestMainWindow:
 
         requests: list[tuple[dict[str, object], float]] = []
 
-        def fake_session_request(payload, timeout=5.0):
+        def fake_session_request_async(payload, callback, timeout=5.0):
             requests.append((payload, timeout))
-            return {
+            callback({
                 "status": "ok",
                 "macro_recording_enabled": True,
                 "macro_recording_source": "persistent",
                 "macro_recording_expires_at": 0,
-            }
+            })
 
-        monkeypatch.setattr(window_module, "session_request", fake_session_request)
+        monkeypatch.setattr(window_module, "session_request_async", fake_session_request_async)
 
         window = MainWindow(demo_mode=True)
         requests.clear()

--- a/tests/gui/test_settings_dialog.py
+++ b/tests/gui/test_settings_dialog.py
@@ -69,12 +69,20 @@ def test_settings_dialog_shows_session_apply_error(
     )
 
     dialog = SettingsDialog()
+    load_callback = callbacks[0][1]
     dialog._set_gamepad_count(2)
 
     callbacks[-1][1]({"status": "error", "message": "daemon rejected request"})
 
     assert dialog._status.get_text() == "daemon rejected request"
+    assert dialog._gamepad_count == 1
+    assert dialog._count_label.get_text() == "1"
     assert saves == []
+
+    load_callback({"status": "ok", "virtual_gamepad_count": 3})
+
+    assert dialog._gamepad_count == 3
+    assert dialog._count_label.get_text() == "3"
 
 
 def test_settings_dialog_local_saves_only_without_session_response(
@@ -241,3 +249,153 @@ def test_settings_dialog_plus_minus_auto_applies(monkeypatch, temp_config_dir) -
 
     dialog._on_decrement_gamepads_clicked(dialog._minus_button)
     assert callbacks[-1][0]["virtual_gamepad_count"] == 1
+
+
+def test_settings_dialog_reverts_to_stale_success_when_newest_save_fails(
+    monkeypatch,
+    temp_config_dir,
+) -> None:
+    from keymasq.gui.widgets import settings_dialog as dialog_module
+    from keymasq.gui.widgets.settings_dialog import SettingsDialog
+
+    callbacks = []
+
+    def fake_session_request_async(payload, callback, timeout=5.0):
+        callbacks.append((payload, callback))
+
+    monkeypatch.setattr(dialog_module, "session_request_async", fake_session_request_async)
+
+    dialog = SettingsDialog()
+    callbacks[0][1](
+        {
+            "status": "ok",
+            "virtual_gamepad_count": 1,
+        }
+    )
+
+    dialog._on_increment_gamepads_clicked(dialog._plus_button)
+    first_save_callback = callbacks[-1][1]
+    assert callbacks[-1][0] == {
+        "command": "set_settings",
+        "virtual_gamepad_count": 2,
+    }
+
+    dialog._on_increment_gamepads_clicked(dialog._plus_button)
+    newest_save_callback = callbacks[-1][1]
+    assert callbacks[-1][0] == {
+        "command": "set_settings",
+        "virtual_gamepad_count": 3,
+    }
+
+    first_save_callback({"status": "ok", "virtual_gamepad_count": 2})
+    assert dialog._count_label.get_text() == "3"
+
+    newest_save_callback({"status": "error", "message": "failed"})
+
+    assert dialog._status.get_text() == "failed"
+    assert dialog._gamepad_count == 2
+    assert dialog._applied_gamepad_count == 2
+    assert dialog._count_label.get_text() == "2"
+
+
+def test_settings_dialog_ignores_stale_success_after_newest_save_applies(
+    monkeypatch,
+    temp_config_dir,
+) -> None:
+    from keymasq.gui.widgets import settings_dialog as dialog_module
+    from keymasq.gui.widgets.settings_dialog import SettingsDialog
+
+    callbacks = []
+
+    def fake_session_request_async(payload, callback, timeout=5.0):
+        callbacks.append((payload, callback))
+
+    monkeypatch.setattr(dialog_module, "session_request_async", fake_session_request_async)
+
+    dialog = SettingsDialog()
+    callbacks[0][1](
+        {
+            "status": "ok",
+            "virtual_gamepad_count": 1,
+        }
+    )
+
+    dialog._on_increment_gamepads_clicked(dialog._plus_button)
+    first_save_callback = callbacks[-1][1]
+    assert callbacks[-1][0] == {
+        "command": "set_settings",
+        "virtual_gamepad_count": 2,
+    }
+
+    dialog._on_increment_gamepads_clicked(dialog._plus_button)
+    newest_save_callback = callbacks[-1][1]
+    assert callbacks[-1][0] == {
+        "command": "set_settings",
+        "virtual_gamepad_count": 3,
+    }
+
+    newest_save_callback({"status": "ok", "virtual_gamepad_count": 3})
+    first_save_callback({"status": "ok", "virtual_gamepad_count": 2})
+
+    assert dialog._gamepad_count == 3
+    assert dialog._applied_gamepad_count == 3
+    assert dialog._count_label.get_text() == "3"
+
+    dialog._on_decrement_gamepads_clicked(dialog._minus_button)
+    assert callbacks[-1][0] == {
+        "command": "set_settings",
+        "virtual_gamepad_count": 2,
+    }
+    callbacks[-1][1]({"status": "error", "message": "failed"})
+
+    assert dialog._status.get_text() == "failed"
+    assert dialog._gamepad_count == 3
+    assert dialog._applied_gamepad_count == 3
+    assert dialog._count_label.get_text() == "3"
+
+
+def test_settings_dialog_syncs_late_stale_success_after_newest_save_fails(
+    monkeypatch,
+    temp_config_dir,
+) -> None:
+    from keymasq.gui.widgets import settings_dialog as dialog_module
+    from keymasq.gui.widgets.settings_dialog import SettingsDialog
+
+    callbacks = []
+
+    def fake_session_request_async(payload, callback, timeout=5.0):
+        callbacks.append((payload, callback))
+
+    monkeypatch.setattr(dialog_module, "session_request_async", fake_session_request_async)
+
+    dialog = SettingsDialog()
+    callbacks[0][1](
+        {
+            "status": "ok",
+            "virtual_gamepad_count": 1,
+        }
+    )
+
+    dialog._on_increment_gamepads_clicked(dialog._plus_button)
+    first_save_callback = callbacks[-1][1]
+    assert callbacks[-1][0] == {
+        "command": "set_settings",
+        "virtual_gamepad_count": 2,
+    }
+
+    dialog._on_increment_gamepads_clicked(dialog._plus_button)
+    newest_save_callback = callbacks[-1][1]
+    assert callbacks[-1][0] == {
+        "command": "set_settings",
+        "virtual_gamepad_count": 3,
+    }
+
+    newest_save_callback({"status": "error", "message": "failed"})
+    assert dialog._count_label.get_text() == "1"
+
+    first_save_callback({"status": "ok", "virtual_gamepad_count": 2})
+
+    assert dialog._status.get_text() == "failed"
+    assert dialog._gamepad_count == 2
+    assert dialog._applied_gamepad_count == 2
+    assert dialog._count_label.get_text() == "2"

--- a/tests/keymasqd/macro_backend_support.py
+++ b/tests/keymasqd/macro_backend_support.py
@@ -1,4 +1,14 @@
+from typing import cast
+
 import evdev
+
+import keymasq.keymasqd.device_manager as dm
+from keymasq.common.models import (
+    DEFAULT_MACRO_LOOP_STOP_BEHAVIOR,
+    normalize_macro_loop_stop_behavior,
+)
+from keymasq.keymasqd.device_manager import DeviceManager
+from keymasq.keymasqd.runtime import macros as mdm
 
 
 class FakeRecorder:
@@ -8,3 +18,33 @@ class FakeRecorder:
 
     def record_event(self, device_type: str, event: evdev.InputEvent) -> None:
         self.calls.append((device_type, event))
+
+
+async def play_macro_task_helper(manager: DeviceManager, **kwargs: object) -> None:
+    instance_id = int(kwargs["instance_id"])
+    loop_stop_behavior = normalize_macro_loop_stop_behavior(
+        kwargs.get("loop_stop_behavior", DEFAULT_MACRO_LOOP_STOP_BEHAVIOR)
+    )
+    manager.macro_state.instance_meta.setdefault(instance_id, {})[
+        "loop_stop_behavior"
+    ] = loop_stop_behavior
+    await mdm.play_macro_task(
+        manager,
+        instance_id=instance_id,
+        macro_events=cast(list[dict[str, object]], kwargs["macro_events"]),
+        macro_name=str(kwargs["macro_name"]),
+        replay_mouse_movement=bool(kwargs["replay_mouse_movement"]),
+        replay_mouse_clicks=bool(kwargs["replay_mouse_clicks"]),
+        speed=float(kwargs["speed"]),
+        loop_mode=str(kwargs["loop_mode"]),
+        loop_count=int(kwargs["loop_count"]),
+        move_to_start=bool(kwargs["move_to_start"]),
+        start_x=int(kwargs["start_x"]),
+        start_y=int(kwargs["start_y"]),
+        block_mouse_movement=bool(kwargs["block_mouse_movement"]),
+        deps=dm._macro_runtime_deps(),
+        macro_event_source=cast(
+            mdm.MacroEventSource | None,
+            kwargs.get("macro_event_source"),
+        ),
+    )

--- a/tests/keymasqd/macro_backend_support.py
+++ b/tests/keymasqd/macro_backend_support.py
@@ -3,10 +3,6 @@ from typing import cast
 import evdev
 
 import keymasq.keymasqd.device_manager as dm
-from keymasq.common.models import (
-    DEFAULT_MACRO_LOOP_STOP_BEHAVIOR,
-    normalize_macro_loop_stop_behavior,
-)
 from keymasq.keymasqd.device_manager import DeviceManager
 from keymasq.keymasqd.runtime import macros as mdm
 
@@ -22,12 +18,6 @@ class FakeRecorder:
 
 async def play_macro_task_helper(manager: DeviceManager, **kwargs: object) -> None:
     instance_id = int(kwargs["instance_id"])
-    loop_stop_behavior = normalize_macro_loop_stop_behavior(
-        kwargs.get("loop_stop_behavior", DEFAULT_MACRO_LOOP_STOP_BEHAVIOR)
-    )
-    manager.macro_state.instance_meta.setdefault(instance_id, {})[
-        "loop_stop_behavior"
-    ] = loop_stop_behavior
     await mdm.play_macro_task(
         manager,
         instance_id=instance_id,

--- a/tests/keymasqd/test_combo_engine_progression.py
+++ b/tests/keymasqd/test_combo_engine_progression.py
@@ -215,25 +215,49 @@ def test_overlapping_multi_step_combos_with_shared_first_step_progress_independe
     assert press_1.consume_current_event is True
     assert press_1.action_transition is not None
     assert press_1.action_transition.combo_id == "combo-1"
+    assert set(engine._candidates) == {"combo-1"}
 
-    release_1 = handle_combo_event(engine, key_1, 0, 0.5)
+    press_2 = handle_combo_event(engine, key_2, 1, 0.5)
+    assert press_2.consume_current_event is False
+    assert press_2.action_transition is None
+
+    release_1 = handle_combo_event(engine, key_1, 0, 0.6)
     assert release_1.consume_current_event is True
     assert release_1.action_transition is not None
     assert release_1.action_transition.combo_id == "combo-1"
     assert release_1.action_transition.kind == "release"
-
-    press_2 = handle_combo_event(engine, key_2, 1, 0.6)
-    assert press_2.consume_current_event is True
-    assert press_2.action_transition is not None
-    assert press_2.action_transition.combo_id == "combo-2"
-
-    release_2 = handle_combo_event(engine, key_2, 0, 0.7)
-    assert release_2.consume_current_event is True
-    assert release_2.action_transition is not None
-    assert release_2.action_transition.combo_id == "combo-2"
-    assert release_2.action_transition.kind == "release"
-    assert release_2.reset_candidates is True
     assert engine._candidates == {}
+
+
+def test_sibling_sequence_candidate_drops_after_other_branch_matches():
+    engine = ComboEngine()
+    key_a = binding("key_a")
+    key_b = binding("key_b")
+    key_c = binding("key_c")
+    engine.set_combos(
+        [
+            combo("combo-a-b", (key_a,), (key_b,)),
+            combo(
+                "combo-a-c",
+                (key_a,),
+                (key_c,),
+                action=MappingAction(action_type=ActionType.KEYBOARD, target="key_f6"),
+            ),
+        ]
+    )
+
+    handle_combo_event(engine, key_a, 1, 0.0)
+    handle_combo_event(engine, key_a, 0, 0.1)
+
+    press_b = handle_combo_event(engine, key_b, 1, 0.2)
+    assert press_b.consume_current_event is True
+    assert press_b.action_transition is not None
+    assert press_b.action_transition.combo_id == "combo-a-b"
+    assert set(engine._candidates) == {"combo-a-b"}
+
+    press_c = handle_combo_event(engine, key_c, 1, 0.3)
+    assert press_c.consume_current_event is False
+    assert press_c.action_transition is None
 
 
 def test_overlapping_multi_step_combos_with_shared_first_step_can_hold_outputs_together():
@@ -241,7 +265,7 @@ def test_overlapping_multi_step_combos_with_shared_first_step_can_hold_outputs_t
     meta = binding("key_leftmeta")
     key_a = binding("key_a")
     key_1 = binding("key_1")
-    key_2 = binding("key_2")
+    key_2 = binding("key_2", source="mouse")
     engine.set_combos(
         [
             combo("combo-1", (meta, key_a), (key_1,)),
@@ -283,6 +307,43 @@ def test_overlapping_multi_step_combos_with_shared_first_step_can_hold_outputs_t
     assert release_2.action_transition.combo_id == "combo-2"
     assert release_2.action_transition.kind == "release"
     assert engine._candidates == {}
+
+
+def test_mixed_releasing_release_drops_unfinished_candidate():
+    engine = ComboEngine()
+    alt = binding("key_leftalt")
+    key_1 = binding("key_1")
+    leader = binding("key_f")
+    key_a = binding("key_a")
+    key_b = binding("key_b")
+    engine.set_combos(
+        [
+            combo("held-combo", (alt, key_1)),
+            combo(
+                "sequence-combo",
+                (leader,),
+                (key_a, key_b),
+                action=MappingAction(action_type=ActionType.KEYBOARD, target="key_f6"),
+            ),
+        ]
+    )
+
+    handle_combo_event(engine, alt, 1, 0.0)
+    handle_combo_event(engine, key_1, 1, 0.1)
+    handle_combo_event(engine, leader, 1, 0.2)
+    handle_combo_event(engine, leader, 0, 0.3)
+
+    partial_press = handle_combo_event(engine, key_a, 1, 0.4)
+    assert partial_press.passthrough_current_event is True
+
+    partial_release = handle_combo_event(engine, key_a, 0, 0.5)
+    assert partial_release.passthrough_current_event is True
+    assert partial_release.reset_candidates is False
+    assert set(engine._candidates) == {"held-combo"}
+
+    final_press = handle_combo_event(engine, key_b, 1, 0.6)
+    assert final_press.action_transition is None
+    assert final_press.consume_current_event is False
 
 
 def test_single_step_combo_with_wheel_pulse_fires_without_sticking():

--- a/tests/keymasqd/test_daemon_capture_commands.py
+++ b/tests/keymasqd/test_daemon_capture_commands.py
@@ -244,6 +244,36 @@ async def test_macro_save_recording_releases_unslotted_snapshot_as_saved(daemon_
 
 
 @pytest.mark.asyncio
+async def test_macro_save_recording_keeps_failed_unslotted_snapshot_retryable(
+    daemon_testbed,
+):
+    daemon, _device_manager, recording_manager, macro_store, _capture_manager = daemon_testbed
+
+    class Snapshot:
+        recording_id = "recording-1"
+        duration_ms = 5
+        device_types = ["keyboard"]
+        event_count = 1
+
+        def iter_events(self):
+            yield {"type": 1, "code": 30, "value": 1, "t_us": 0}
+
+    recording_manager.claim_pending_recording.return_value = Snapshot()
+    macro_store.create_from_events.side_effect = RuntimeError("duplicate macro")
+
+    with pytest.raises(RuntimeError, match="duplicate macro"):
+        await daemon._handle_command(
+            CommandType.MACRO_SAVE_RECORDING,
+            {"pending_recording_id": "recording-1", "name": "saved"},
+        )
+
+    recording_manager.release_pending_recording_claim.assert_awaited_once_with(
+        "recording-1",
+        saved=False,
+    )
+
+
+@pytest.mark.asyncio
 async def test_macro_play_recording_claims_snapshot_and_releases_without_saving(
     daemon_testbed,
 ):
@@ -862,6 +892,25 @@ async def test_start_cleans_up_resources_when_socket_start_fails(
     device_manager.stop_topology_watcher.assert_awaited_once()
     device_manager.cancel_macro_playback.assert_awaited_once()
     device_manager.release_all_devices.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_stop_lets_socket_server_own_socket_path_cleanup(
+    daemon_testbed,
+    monkeypatch,
+):
+    daemon, device_manager, _recording_manager, _macro_store, _capture_manager = daemon_testbed
+    socket_server = SimpleNamespace(stop=AsyncMock())
+    cleanup_socket_path = Mock()
+    daemon.running = True
+    daemon.socket_server = socket_server
+    monkeypatch.setattr(daemon, "_cleanup_socket_path", cleanup_socket_path)
+
+    await daemon.stop()
+
+    socket_server.stop.assert_awaited_once()
+    cleanup_socket_path.assert_not_called()
+    device_manager.shutdown_output_devices.assert_called_once()
 
 
 @pytest.mark.asyncio

--- a/tests/keymasqd/test_daemon_runtime_unlock.py
+++ b/tests/keymasqd/test_daemon_runtime_unlock.py
@@ -41,7 +41,7 @@ async def test_set_diagnostics_forwards_categories(daemon_testbed):
 
 
 @pytest.mark.asyncio
-async def test_macro_recording_status_uses_peer_uid(daemon_testbed, monkeypatch):
+async def test_macro_recording_status_uses_requested_uid(daemon_testbed, monkeypatch):
     daemon, _device_manager, _recording_manager, _macro_store, _capture_manager = daemon_testbed
     resolved_uids: list[int] = []
 
@@ -63,11 +63,11 @@ async def test_macro_recording_status_uses_peer_uid(daemon_testbed, monkeypatch)
     )
 
     assert result == {"unlocked": True, "source": "persistent", "expires_at": 0}
-    assert resolved_uids == [1000]
+    assert resolved_uids == [9999]
 
 
 @pytest.mark.asyncio
-async def test_recording_unlock_status_uses_peer_uid(daemon_testbed, monkeypatch):
+async def test_recording_unlock_status_uses_requested_uid(daemon_testbed, monkeypatch):
     daemon, _device_manager, _recording_manager, _macro_store, _capture_manager = daemon_testbed
     resolved_uids: list[int] = []
 
@@ -89,7 +89,7 @@ async def test_recording_unlock_status_uses_peer_uid(daemon_testbed, monkeypatch
     )
 
     assert result == {"unlocked": True, "source": "runtime", "expires_at": 123}
-    assert resolved_uids == [1000]
+    assert resolved_uids == [9999]
 
 
 @pytest.mark.asyncio

--- a/tests/keymasqd/test_daemon_runtime_unlock.py
+++ b/tests/keymasqd/test_daemon_runtime_unlock.py
@@ -1,3 +1,4 @@
+import os
 from pathlib import Path
 from unittest.mock import Mock
 
@@ -37,6 +38,58 @@ async def test_set_diagnostics_forwards_categories(daemon_testbed):
         3.25,
         ["mainline", "combo"],
     )
+
+
+@pytest.mark.asyncio
+async def test_macro_recording_status_uses_peer_uid(daemon_testbed, monkeypatch):
+    daemon, _device_manager, _recording_manager, _macro_store, _capture_manager = daemon_testbed
+    resolved_uids: list[int] = []
+
+    def fake_resolve_macro_recording_status(uid: int) -> dict[str, object]:
+        resolved_uids.append(uid)
+        status: dict[str, object] = {"unlocked": True, "source": "persistent", "expires_at": 0}
+        return status
+
+    monkeypatch.setattr(
+        daemon_module,
+        "resolve_macro_recording_status",
+        fake_resolve_macro_recording_status,
+    )
+
+    result = await daemon._handle_command(
+        CommandType.MACRO_RECORDING_STATUS,
+        {"uid": 9999},
+        client=client_context(uid=1000),
+    )
+
+    assert result == {"unlocked": True, "source": "persistent", "expires_at": 0}
+    assert resolved_uids == [1000]
+
+
+@pytest.mark.asyncio
+async def test_recording_unlock_status_uses_peer_uid(daemon_testbed, monkeypatch):
+    daemon, _device_manager, _recording_manager, _macro_store, _capture_manager = daemon_testbed
+    resolved_uids: list[int] = []
+
+    def fake_resolve_unlock_status(uid: int) -> dict[str, object]:
+        resolved_uids.append(uid)
+        status: dict[str, object] = {"unlocked": True, "source": "runtime", "expires_at": 123}
+        return status
+
+    monkeypatch.setattr(
+        daemon_module,
+        "resolve_unlock_status",
+        fake_resolve_unlock_status,
+    )
+
+    result = await daemon._handle_command(
+        CommandType.RECORDING_UNLOCK_STATUS,
+        {"uid": 9999},
+        client=client_context(uid=1000),
+    )
+
+    assert result == {"unlocked": True, "source": "runtime", "expires_at": 123}
+    assert resolved_uids == [1000]
 
 
 @pytest.mark.asyncio
@@ -101,6 +154,41 @@ async def test_macro_save_recording_requires_recording_unlock(daemon_testbed, mo
             {"pending_recording_id": "recording-1", "name": "saved"},
             client=client_context(),
         )
+
+
+@pytest.mark.asyncio
+async def test_macro_play_recording_does_not_require_recording_unlock(
+    daemon_testbed,
+    monkeypatch,
+):
+    daemon, device_manager, recording_manager, _macro_store, _capture_manager = daemon_testbed
+    daemon.security_policy = SecurityPolicy(recording_unlock_required=True)
+    monkeypatch.setattr(daemon, "_recording_unlocked_for_uid", lambda _uid: (False, 0, "none"))
+
+    class Snapshot:
+        recording_id = "recording-1"
+        duration_ms = 5
+        device_types = ["keyboard"]
+        event_count = 1
+
+        def iter_events(self):
+            yield {"type": 1, "code": 30, "value": 1, "t_us": 0}
+
+    recording_manager.claim_pending_recording.return_value = Snapshot()
+
+    result = await daemon._handle_command(
+        CommandType.MACRO_PLAY_RECORDING,
+        {"pending_recording_id": "recording-1"},
+        client=client_context(),
+    )
+
+    assert result == {"played": True}
+    recording_manager.claim_pending_recording.assert_awaited_once_with("recording-1")
+    recording_manager.release_pending_recording_claim.assert_awaited_once_with(
+        "recording-1",
+        saved=False,
+    )
+    device_manager.play_macro.assert_awaited_once()
 
 
 @pytest.mark.asyncio
@@ -242,7 +330,13 @@ async def test_refresh_then_lock_runtime_unlock_updates_owner_cache_and_file(
     assert refreshed["expires_at"] == 1001
     assert daemon._recording_refresh_owners[uid] == (600, 9)
     assert daemon._unlock_cache[uid] == (500.0, True, 1001, "runtime")
-    write_unlock.assert_called_once()
+    write_unlock.assert_called_once_with(
+        unlock_file,
+        1001,
+        owner_uid=os.geteuid(),
+        owner_gid=os.getegid(),
+        mode=0o600,
+    )
 
     locked = daemon._lock_runtime_unlock(uid, client)
     assert locked == {"status": "ok", "uid": uid, "source": "runtime", "locked": True}
@@ -269,6 +363,50 @@ def test_expired_unlocked_cache_entry_is_re_resolved(daemon_testbed, monkeypatch
     assert daemon._recording_unlocked_for_uid(uid) == (False, 0, "none")
     assert resolved_uids == [uid]
     assert daemon._unlock_cache[uid] == (500.25, False, 0, "none")
+
+
+@pytest.mark.asyncio
+async def test_stale_unlocked_cache_entry_is_re_resolved_before_sensitive_command(
+    daemon_testbed,
+    monkeypatch,
+):
+    daemon, _device_manager, _recording_manager, _macro_store, capture_manager = daemon_testbed
+    daemon.security_policy = SecurityPolicy(recording_unlock_required=True)
+    daemon._unlock_cache_interval_s = 0.25
+    uid = 5555
+    now_mono = 500.0
+    statuses: list[dict[str, object]] = [
+        {"unlocked": True, "source": "runtime", "expires_at": 2000},
+        {"unlocked": False, "source": "none", "expires_at": 0},
+    ]
+    resolved_uids: list[int] = []
+
+    def fake_resolve_unlock_status(requested_uid: int) -> dict[str, object]:
+        resolved_uids.append(requested_uid)
+        return statuses[min(len(resolved_uids) - 1, len(statuses) - 1)]
+
+    monkeypatch.setattr(daemon_module, "resolve_unlock_status", fake_resolve_unlock_status)
+    monkeypatch.setattr(daemon_module.time, "time", lambda: 1000)
+    monkeypatch.setattr(daemon_module.time, "monotonic", lambda: now_mono)
+
+    client = client_context(uid=uid, pid=600, connection_id=9)
+    result = await daemon._handle_command(
+        CommandType.CAPTURE_BEGIN,
+        {"hardware_id": "1234:5678"},
+        client=client,
+    )
+    assert result == {"token": "cap-token"}
+
+    now_mono = 500.3
+    with pytest.raises(PermissionError, match="recording_locked"):
+        await daemon._handle_command(
+            CommandType.CAPTURE_READ,
+            {"token": "cap-token"},
+            client=client,
+        )
+
+    assert resolved_uids == [uid, uid]
+    capture_manager.read.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/tests/keymasqd/test_device_manager_combo_runtime.py
+++ b/tests/keymasqd/test_device_manager_combo_runtime.py
@@ -113,7 +113,7 @@ class TestCombos:
         ]
 
     @pytest.mark.asyncio
-    async def test_combo_overlapping_multistep_first_step_releases_outputs_cleanly(
+    async def test_combo_overlapping_multistep_first_step_drops_sibling_sequence_branch(
         self,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
@@ -206,12 +206,12 @@ class TestCombos:
         assert passthrough.writes == [
             (evdev.ecodes.EV_KEY, evdev.ecodes.KEY_LEFTMETA, 1),
             (evdev.ecodes.EV_KEY, evdev.ecodes.KEY_LEFTMETA, 0),
+            (evdev.ecodes.EV_KEY, evdev.ecodes.KEY_2, 1),
+            (evdev.ecodes.EV_KEY, evdev.ecodes.KEY_2, 0),
         ]
         assert keyboard.writes == [
             (evdev.ecodes.EV_KEY, evdev.ecodes.KEY_F13, 1),
             (evdev.ecodes.EV_KEY, evdev.ecodes.KEY_F13, 0),
-            (evdev.ecodes.EV_KEY, evdev.ecodes.KEY_F14, 1),
-            (evdev.ecodes.EV_KEY, evdev.ecodes.KEY_F14, 0),
         ]
         assert manager.combo_state.active_actions == {}
         assert manager.combo_state.engine._candidates == {}
@@ -220,7 +220,7 @@ class TestCombos:
         assert device.state.held_output_keys["keyboard"] == set()
 
     @pytest.mark.asyncio
-    async def test_combo_overlapping_multistep_first_step_can_hold_second_step_outputs_together(
+    async def test_combo_overlapping_multistep_first_step_passes_through_dropped_sibling(
         self,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
@@ -313,12 +313,12 @@ class TestCombos:
         assert passthrough.writes == [
             (evdev.ecodes.EV_KEY, evdev.ecodes.KEY_LEFTMETA, 1),
             (evdev.ecodes.EV_KEY, evdev.ecodes.KEY_LEFTMETA, 0),
+            (evdev.ecodes.EV_KEY, evdev.ecodes.KEY_2, 1),
+            (evdev.ecodes.EV_KEY, evdev.ecodes.KEY_2, 0),
         ]
         assert keyboard.writes == [
             (evdev.ecodes.EV_KEY, evdev.ecodes.KEY_F13, 1),
-            (evdev.ecodes.EV_KEY, evdev.ecodes.KEY_F14, 1),
             (evdev.ecodes.EV_KEY, evdev.ecodes.KEY_F13, 0),
-            (evdev.ecodes.EV_KEY, evdev.ecodes.KEY_F14, 0),
         ]
         assert manager.combo_state.active_actions == {}
         assert manager.combo_state.engine._candidates == {}

--- a/tests/keymasqd/test_device_manager_core.py
+++ b/tests/keymasqd/test_device_manager_core.py
@@ -1148,6 +1148,97 @@ class TestListDevices:
             )
         ]
 
+    def test_topology_events_match_interface_qualified_desired_hardware_id(
+        self,
+    ) -> None:
+        manager = SimpleNamespace(_command_type=CommandType)
+        snapshot = {
+            "/dev/input/by-id/test-kbd": dm.LiveInterfaceInfo(
+                hardware_id="1234:5678",
+                vendor_id="1234",
+                product_id="5678",
+                stable_path="/dev/input/by-id/test-kbd",
+                path="/dev/input/event10",
+                interface_id="kbd",
+            ),
+            "/dev/input/by-id/test-mouse": dm.LiveInterfaceInfo(
+                hardware_id="1234:5678",
+                vendor_id="1234",
+                product_id="5678",
+                stable_path="/dev/input/by-id/test-mouse",
+                path="/dev/input/event11",
+                interface_id="mouse",
+            ),
+        }
+
+        events = tdm.build_topology_events(
+            manager,
+            {},
+            snapshot,
+            {"1234:5678@kbd"},
+        )
+
+        assert events == [
+            (
+                CommandType.DEVICE_CONNECTED,
+                {
+                    "hardware_id": "1234:5678",
+                    "vendor_id": "1234",
+                    "product_id": "5678",
+                    "path": "/dev/input/event10",
+                    "stable_path": "/dev/input/by-id/test-kbd",
+                    "interface_id": "kbd",
+                },
+            )
+        ]
+
+    def test_hardware_id_matches_desired_normalizes_desired_ids(self) -> None:
+        assert tdm.hardware_id_matches_desired("abcd:1234", {"ABCD:1234"})
+        assert tdm.hardware_id_matches_desired(
+            "abcd:1234",
+            {"ABCD:1234@interface"},
+            interface_id="INTERFACE",
+        )
+        assert not tdm.hardware_id_matches_desired(
+            "abcd:1234",
+            {"ABCD:1234@interface"},
+            interface_id="other",
+        )
+
+    def test_hardware_id_matches_desired_numeric_instance_wildcards_interface(
+        self,
+    ) -> None:
+        desired = {tdm.normalize_hardware_id("046D:C08B@2")}
+        hardware_id = tdm.normalize_hardware_id("046d:c08b")
+
+        assert tdm.hardware_id_matches_desired(
+            hardware_id,
+            desired,
+            interface_id=tdm.normalize_hardware_id("kbd"),
+        )
+        assert tdm.hardware_id_matches_desired(
+            hardware_id,
+            desired,
+            interface_id=tdm.normalize_hardware_id("mouse"),
+        )
+
+    def test_hardware_id_matches_desired_named_interface_requires_exact_match(
+        self,
+    ) -> None:
+        desired = {tdm.normalize_hardware_id("046D:C08B@eth0")}
+        hardware_id = tdm.normalize_hardware_id("046d:c08b")
+
+        assert tdm.hardware_id_matches_desired(
+            hardware_id,
+            desired,
+            interface_id=tdm.normalize_hardware_id("ETH0"),
+        )
+        assert not tdm.hardware_id_matches_desired(
+            hardware_id,
+            desired,
+            interface_id=tdm.normalize_hardware_id("wlan0"),
+        )
+
     def test_topology_events_report_reconnect_for_same_stable_path(self) -> None:
         manager = SimpleNamespace(_command_type=CommandType)
         stable_path = "/dev/input/by-id/test-pad"
@@ -1204,6 +1295,53 @@ class TestListDevices:
             ),
         ]
 
+    def test_topology_events_report_disconnect_when_stable_path_hardware_changes(
+        self,
+    ) -> None:
+        manager = SimpleNamespace(_command_type=CommandType)
+        stable_path = "/dev/input/by-id/test-pad"
+        previous = {
+            stable_path: dm.LiveInterfaceInfo(
+                hardware_id="1234:5678",
+                vendor_id="1234",
+                product_id="5678",
+                stable_path=stable_path,
+                path="/dev/input/event10",
+                interface_id="gamepad",
+            )
+        }
+        current = {
+            stable_path: dm.LiveInterfaceInfo(
+                hardware_id="8765:4321",
+                vendor_id="8765",
+                product_id="4321",
+                stable_path=stable_path,
+                path="/dev/input/event10",
+                interface_id="gamepad",
+            )
+        }
+
+        events = tdm.build_topology_events(
+            manager,
+            previous,
+            current,
+            {"1234:5678"},
+        )
+
+        assert events == [
+            (
+                CommandType.DEVICE_DISCONNECTED,
+                {
+                    "hardware_id": "1234:5678",
+                    "vendor_id": "1234",
+                    "product_id": "5678",
+                    "path": "/dev/input/event10",
+                    "stable_path": stable_path,
+                    "interface_id": "gamepad",
+                },
+            )
+        ]
+
     @pytest.mark.asyncio
     async def test_reconcile_topology_releases_stale_grab_when_live_event_path_changes(
         self,
@@ -1238,6 +1376,82 @@ class TestListDevices:
         release_interface.assert_awaited_once_with(
             manager,
             "1234:5678",
+            "/dev/input/event5",
+        )
+
+    @pytest.mark.asyncio
+    async def test_reconcile_topology_releases_stale_grab_when_live_hardware_changes(
+        self,
+    ) -> None:
+        stable_path = "/dev/input/by-id/test-kbd"
+        manager = SimpleNamespace(
+            grabbed_devices={
+                "1234:5678": [
+                    SimpleNamespace(
+                        path="/dev/input/event5",
+                        stable_path=stable_path,
+                        resolved_event_path="/dev/input/event5",
+                        interface_id="kbd",
+                    )
+                ]
+            }
+        )
+        snapshot = {
+            stable_path: dm.LiveInterfaceInfo(
+                hardware_id="8765:4321",
+                vendor_id="8765",
+                product_id="4321",
+                stable_path=stable_path,
+                path="/dev/input/event5",
+                interface_id="kbd",
+            )
+        }
+        release_interface = AsyncMock()
+        deps = SimpleNamespace(release_interface_fn=release_interface)
+
+        await tdm.reconcile_topology_unlocked(manager, snapshot, deps=deps)
+
+        release_interface.assert_awaited_once_with(
+            manager,
+            "1234:5678",
+            "/dev/input/event5",
+        )
+
+    @pytest.mark.asyncio
+    async def test_reconcile_topology_releases_interface_qualified_grab_on_mismatch(
+        self,
+    ) -> None:
+        stable_path = "/dev/input/by-id/test-kbd"
+        manager = SimpleNamespace(
+            grabbed_devices={
+                "1234:5678@kbd": [
+                    SimpleNamespace(
+                        path="/dev/input/event5",
+                        stable_path=stable_path,
+                        resolved_event_path="/dev/input/event5",
+                        interface_id="kbd",
+                    )
+                ]
+            }
+        )
+        snapshot = {
+            stable_path: dm.LiveInterfaceInfo(
+                hardware_id="1234:5678",
+                vendor_id="1234",
+                product_id="5678",
+                stable_path=stable_path,
+                path="/dev/input/event5",
+                interface_id="mouse",
+            )
+        }
+        release_interface = AsyncMock()
+        deps = SimpleNamespace(release_interface_fn=release_interface)
+
+        await tdm.reconcile_topology_unlocked(manager, snapshot, deps=deps)
+
+        release_interface.assert_awaited_once_with(
+            manager,
+            "1234:5678@kbd",
             "/dev/input/event5",
         )
 

--- a/tests/keymasqd/test_device_manager_runtime_recovery.py
+++ b/tests/keymasqd/test_device_manager_runtime_recovery.py
@@ -503,7 +503,12 @@ class TestDeviceManagerHelpers:
     def test_forget_exec_actions_prunes_superkey_history_with_nested_exec_refs(
         self,
     ) -> None:
-        from keymasq.keymasqd.runtime.repeat import RepeatHistoryEntry, forget_exec_actions
+        from keymasq.keymasqd.runtime.repeat import (
+            SUPERKEY_SLOT_OVERLOAD,
+            SUPERKEY_SLOT_TAP,
+            RepeatHistoryEntry,
+            forget_exec_actions,
+        )
 
         manager = DeviceManager()
         manager.repeat_state.history.extend(
@@ -521,6 +526,7 @@ class TestDeviceManagerHelpers:
                     ),
                     source_device="kbd",
                     source_button="key_f13",
+                    superkey_slot=SUPERKEY_SLOT_TAP,
                 ),
                 RepeatHistoryEntry(
                     category="special",
@@ -535,6 +541,7 @@ class TestDeviceManagerHelpers:
                     ),
                     source_device="mouse",
                     source_button="btn_side",
+                    superkey_slot=SUPERKEY_SLOT_TAP,
                 ),
                 RepeatHistoryEntry(
                     category="special",
@@ -550,6 +557,7 @@ class TestDeviceManagerHelpers:
                     ),
                     source_device="kbd",
                     source_button="combo:launch",
+                    superkey_slot=SUPERKEY_SLOT_OVERLOAD,
                 ),
                 RepeatHistoryEntry(
                     category="special",
@@ -567,6 +575,7 @@ class TestDeviceManagerHelpers:
                     ),
                     source_device="kbd",
                     source_button="key_f14",
+                    superkey_slot=SUPERKEY_SLOT_TAP,
                 ),
                 RepeatHistoryEntry(
                     category="special",
@@ -587,6 +596,51 @@ class TestDeviceManagerHelpers:
             "btn_side",
             "combo:launch",
             "key_f14",
+        ]
+
+    def test_forget_exec_actions_checks_remembered_superkey_slot(self) -> None:
+        from keymasq.keymasqd.runtime.repeat import (
+            SUPERKEY_SLOT_HOLD,
+            SUPERKEY_SLOT_TAP,
+            RepeatHistoryEntry,
+            forget_exec_actions,
+        )
+
+        manager = DeviceManager()
+        superkey_config = SuperkeyConfig(
+            name="mixed",
+            tap_actions=[SuperkeyActionData(action_type="keyboard", target="key_a")],
+            hold_actions=[SuperkeyActionData(action_type="exec", exec_ref=14)],
+        )
+        manager.repeat_state.history.extend(
+            [
+                RepeatHistoryEntry(
+                    category="special",
+                    action=dm.MappingAction(
+                        action_type=ActionType.SUPERKEY,
+                        superkey_config=superkey_config,
+                    ),
+                    source_device="kbd",
+                    source_button="key_f16",
+                    superkey_slot=SUPERKEY_SLOT_TAP,
+                ),
+                RepeatHistoryEntry(
+                    category="special",
+                    action=dm.MappingAction(
+                        action_type=ActionType.SUPERKEY,
+                        superkey_config=superkey_config,
+                    ),
+                    source_device="kbd",
+                    source_button="key_f17",
+                    superkey_slot=SUPERKEY_SLOT_HOLD,
+                ),
+            ]
+        )
+
+        forget_exec_actions(manager.repeat_state, source_device="kbd")
+
+        assert [entry.superkey_slot for entry in manager.repeat_state.history] == [
+            SUPERKEY_SLOT_TAP,
         ]
 
     def test_parse_action_warns_and_strips_unsupported_rapidfire(

--- a/tests/keymasqd/test_integration_lifecycle.py
+++ b/tests/keymasqd/test_integration_lifecycle.py
@@ -1,5 +1,6 @@
 import asyncio
 import os
+from unittest.mock import Mock
 
 import evdev
 import pytest
@@ -60,7 +61,7 @@ class TestIntegrationLifecycle(IntegrationTestBase):
         await writer.wait_closed()
 
     async def test_event_passthrough(self, full_system, virtual_mouse):
-        _server, _manager = full_system
+        _server, manager = full_system
         mouse_path = virtual_mouse.device.path
 
         reader, writer = await asyncio.open_unix_connection(str(paths.SOCKET_PATH))
@@ -73,15 +74,39 @@ class TestIntegrationLifecycle(IntegrationTestBase):
                 data={
                     "hardware_id": "1234:5678",
                     "evdev_paths": [mouse_path],
-                    "button_map": {},
+                    "button_map": {"btn_left": "btn_left"},
                 },
             ),
         )
 
+        grabbed = manager.grabbed_devices["1234:5678"][0]
+        original_passthrough = grabbed.uinput
+        assert original_passthrough is not None
+        passthrough = Mock()
+        grabbed.uinput = passthrough  # type: ignore[assignment]
+        original_passthrough.close()
+
         virtual_mouse.write(evdev.ecodes.EV_KEY, evdev.ecodes.BTN_LEFT, 1)
         virtual_mouse.syn()
+        await self._wait_until(
+            lambda: any(
+                call.args == (evdev.ecodes.EV_KEY, evdev.ecodes.BTN_LEFT, 1)
+                for call in passthrough.write.call_args_list
+            ),
+            reason="BTN_LEFT passthrough press",
+        )
+        assert evdev.ecodes.BTN_LEFT in grabbed.state.held_output_keys["passthrough"]
+
         virtual_mouse.write(evdev.ecodes.EV_KEY, evdev.ecodes.BTN_LEFT, 0)
         virtual_mouse.syn()
+        await self._wait_until(
+            lambda: any(
+                call.args == (evdev.ecodes.EV_KEY, evdev.ecodes.BTN_LEFT, 0)
+                for call in passthrough.write.call_args_list
+            ),
+            reason="BTN_LEFT passthrough release",
+        )
+        assert evdev.ecodes.BTN_LEFT not in grabbed.state.held_output_keys["passthrough"]
 
         await self._send_command(
             reader,
@@ -111,6 +136,10 @@ class TestIntegrationLifecycle(IntegrationTestBase):
             ),
         )
 
+        grabbed = manager.grabbed_devices["1234:5678"][0]
+        keyboard_output = Mock()
+        grabbed.keyboard_uinput = keyboard_output  # type: ignore[assignment]
+
         await self._send_command(
             reader,
             writer,
@@ -131,7 +160,40 @@ class TestIntegrationLifecycle(IntegrationTestBase):
             ),
         )
 
-        assert "1234:5678" in manager.grabbed_devices
+        def target_writes(value: int) -> list:
+            return [
+                call
+                for call in keyboard_output.write.call_args_list
+                if call.args == (evdev.ecodes.EV_KEY, evdev.ecodes.BTN_LEFT, value)
+            ]
+
+        virtual_mouse.write(evdev.ecodes.EV_KEY, evdev.ecodes.BTN_SIDE, 1)
+        virtual_mouse.syn()
+        await self._wait_until(
+            lambda: grabbed.state.rapidfire_active.get("btn_side") is True,
+            reason="rapidfire active",
+        )
+        await self._wait_until(
+            lambda: len(target_writes(1)) >= 2,
+            reason="repeated BTN_LEFT rapidfire presses",
+        )
+        assert target_writes(0)
+
+        virtual_mouse.write(evdev.ecodes.EV_KEY, evdev.ecodes.BTN_SIDE, 0)
+        virtual_mouse.syn()
+        await self._wait_until(
+            lambda: grabbed.state.rapidfire_active.get("btn_side", False) is False
+            and "btn_side" not in grabbed.state.rapidfire_tasks,
+            reason="rapidfire stop",
+        )
+        await self._wait_until(
+            lambda: evdev.ecodes.BTN_LEFT not in grabbed.state.held_output_keys["keyboard"],
+            reason="rapidfire output release",
+        )
+        stopped_write_count = len(keyboard_output.write.call_args_list)
+        await asyncio.sleep(0.08)
+        assert len(keyboard_output.write.call_args_list) == stopped_write_count
+        assert grabbed.state.rapidfire_outputs == {}
 
         await self._send_command(
             reader,

--- a/tests/keymasqd/test_macro_backend_recording.py
+++ b/tests/keymasqd/test_macro_backend_recording.py
@@ -1,6 +1,7 @@
 import asyncio
 from pathlib import Path
 from types import SimpleNamespace
+from typing import cast
 from unittest.mock import AsyncMock, MagicMock
 
 import evdev
@@ -8,7 +9,12 @@ import pytest
 
 import keymasq.keymasqd.device_manager as dm
 import keymasq.keymasqd.recording as recording_module
-from keymasq.common.models import ActionType, DeviceType, MappingAction
+from keymasq.common.models import (
+    DEFAULT_MACRO_LOOP_STOP_BEHAVIOR,
+    ActionType,
+    DeviceType,
+    MappingAction,
+)
 from keymasq.keymasqd.device_manager import DeviceManager
 from keymasq.keymasqd.recording import RecordingManager
 from keymasq.keymasqd.runtime import grabbed_device as gdm
@@ -16,7 +22,7 @@ from keymasq.keymasqd.runtime import grabbed_device_events as gde
 from keymasq.keymasqd.runtime import macros as mdm
 from keymasq.keymasqd.runtime.grabbed_device import GrabbedDevice
 from tests.keymasqd.device_manager_support import grabbed_event_processing_deps
-from tests.keymasqd.macro_backend_support import FakeRecorder
+from tests.keymasqd.macro_backend_support import FakeRecorder, play_macro_task_helper
 
 
 async def _recorded_events(
@@ -80,6 +86,32 @@ async def test_recording_slot_survives_recording_manager_restart(tmp_path: Path)
 
     await restored.discard_pending_recording(recording_id)
     assert list(tmp_path.glob("slot-*")) == []
+
+
+@pytest.mark.asyncio
+async def test_starting_new_recording_preserves_implicit_slot_stop(
+    tmp_path: Path,
+) -> None:
+    recorder = RecordingManager(spool_dir=tmp_path)
+    await recorder.start([], recording_slot=2)
+    recorder.record_event(
+        "keyboard",
+        evdev.InputEvent(10, 100, evdev.ecodes.EV_KEY, evdev.ecodes.KEY_A, 1),
+    )
+
+    await recorder.start([], recording_slot=3)
+    try:
+        recordings = await recorder.list_pending_recordings()
+        assert len(recordings) == 1
+        assert recordings[0]["recording_slot"] == 2
+
+        snapshot = await recorder.pending_recording(
+            str(recordings[0]["pending_recording_id"])
+        )
+        assert snapshot.recording_slot == 2
+        assert list(snapshot.iter_events())[0]["code"] == evdev.ecodes.KEY_A
+    finally:
+        await recorder.stop()
 
 
 @pytest.mark.asyncio
@@ -611,6 +643,51 @@ async def test_play_macro_can_skip_stored_lookup_for_empty_explicit_events() -> 
 
     assert result == {"status": "ok"}
     get_meta.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_play_macro_task_helper_preserves_loop_stop_behavior(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = DeviceManager()
+    observed: list[str] = []
+
+    async def fake_play_macro_task(
+        observed_manager: DeviceManager,
+        **kwargs: object,
+    ) -> None:
+        instance_id = cast(int, kwargs["instance_id"])
+        meta = observed_manager.macro_state.instance_meta[instance_id]
+        observed.append(str(meta["loop_stop_behavior"]))
+
+    monkeypatch.setattr(mdm, "play_macro_task", fake_play_macro_task)
+
+    base_kwargs = {
+        "macro_events": [],
+        "macro_name": "loop",
+        "replay_mouse_movement": True,
+        "replay_mouse_clicks": True,
+        "speed": 1.0,
+        "loop_mode": "hold",
+        "loop_count": 1,
+        "move_to_start": False,
+        "start_x": 0,
+        "start_y": 0,
+        "block_mouse_movement": False,
+    }
+    await play_macro_task_helper(
+        manager,
+        instance_id=1,
+        loop_stop_behavior="cancel_run",
+        **base_kwargs,
+    )
+    await play_macro_task_helper(
+        manager,
+        instance_id=2,
+        **base_kwargs,
+    )
+
+    assert observed == ["cancel_run", DEFAULT_MACRO_LOOP_STOP_BEHAVIOR]
 
 
 @pytest.mark.asyncio

--- a/tests/keymasqd/test_macro_backend_recording.py
+++ b/tests/keymasqd/test_macro_backend_recording.py
@@ -646,10 +646,14 @@ async def test_play_macro_can_skip_stored_lookup_for_empty_explicit_events() -> 
 
 
 @pytest.mark.asyncio
-async def test_play_macro_task_helper_preserves_loop_stop_behavior(
+async def test_play_macro_task_helper_uses_existing_loop_stop_behavior_metadata(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     manager = DeviceManager()
+    manager.macro_state.instance_meta[1] = {"loop_stop_behavior": "cancel_run"}
+    manager.macro_state.instance_meta[2] = {
+        "loop_stop_behavior": DEFAULT_MACRO_LOOP_STOP_BEHAVIOR
+    }
     observed: list[str] = []
 
     async def fake_play_macro_task(
@@ -678,7 +682,6 @@ async def test_play_macro_task_helper_preserves_loop_stop_behavior(
     await play_macro_task_helper(
         manager,
         instance_id=1,
-        loop_stop_behavior="cancel_run",
         **base_kwargs,
     )
     await play_macro_task_helper(

--- a/tests/session/support.py
+++ b/tests/session/support.py
@@ -1,0 +1,32 @@
+from unittest.mock import AsyncMock
+
+import pytest
+
+import keymasq.session.manager.recording as session_recording_module
+from keymasq.common.security import PeerCredentials
+from keymasq.session.manager import SessionManager
+
+
+def grant_recording_refresh_owner(
+    manager: SessionManager,
+    peer: PeerCredentials,
+    writer: object,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    lease_id: str = "lease-test",
+) -> AsyncMock:
+    manager.unlock_state.refresh_owner = {
+        "uid": peer.uid,
+        "pid": peer.pid,
+        "writer_id": id(writer),
+        "lease_id": lease_id,
+    }
+    resolve_unlock_status_async = AsyncMock(
+        return_value={"unlocked": True, "source": "runtime", "expires_at": 9999999999}
+    )
+    monkeypatch.setattr(
+        session_recording_module,
+        "resolve_unlock_status_async",
+        resolve_unlock_status_async,
+    )
+    return resolve_unlock_status_async

--- a/tests/session/test_session_manager_command_acl.py
+++ b/tests/session/test_session_manager_command_acl.py
@@ -9,6 +9,7 @@ import keymasq.session.manager.recording as session_recording_module
 from keymasq.common.security import PeerCredentials, SecurityPolicy
 from keymasq.session.listeners.hyprland import HyprlandListener
 from keymasq.session.manager import SessionManager
+from tests.session.support import grant_recording_refresh_owner
 
 
 @pytest.mark.asyncio
@@ -22,12 +23,13 @@ async def test_sensitive_command_requires_active_recording_owner(
 
     lock_recording_unlock = AsyncMock(return_value={"status": "ok"})
     monkeypatch.setattr(session_recording_module, "lock_recording_unlock", lock_recording_unlock)
-    manager.unlock_state.refresh_owner = {
-        "uid": 1000,
-        "pid": 111,
-        "writer_id": id(owner_writer),
-        "lease_id": "lease-1",
-    }
+    grant_recording_refresh_owner(
+        manager,
+        peer,
+        owner_writer,
+        monkeypatch,
+        lease_id="lease-1",
+    )
 
     denied = await manager._handle_session_request(
         {"command": "lock_recording_unlock"},
@@ -46,6 +48,44 @@ async def test_sensitive_command_requires_active_recording_owner(
     )
     assert allowed["status"] == "ok"
     lock_recording_unlock.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_sensitive_command_rejects_refresh_owner_when_unlock_expired(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = SessionManager()
+    manager.security_policy.macro_edit_requires_unlock = True
+    manager.client.send_command = AsyncMock()
+    peer = PeerCredentials(pid=111, uid=1000, gid=1000)
+    writer = object()
+    manager.unlock_state.refresh_owner = {
+        "uid": peer.uid,
+        "pid": peer.pid,
+        "writer_id": id(writer),
+        "lease_id": "lease-1",
+    }
+    resolve_unlock_status_async = AsyncMock(
+        return_value={"unlocked": False, "source": "none", "expires_at": 0}
+    )
+    monkeypatch.setattr(
+        session_recording_module,
+        "resolve_unlock_status_async",
+        resolve_unlock_status_async,
+    )
+
+    result = await manager._handle_session_request(
+        {"command": "get_macro", "name": "Secret"},
+        "client",
+        peer,
+        writer,  # type: ignore[arg-type]
+    )
+
+    assert result["status"] == "error"
+    assert result["error_code"] == "sensitive_command_denied"
+    assert manager.unlock_state.refresh_owner is None
+    manager.client.send_command.assert_not_awaited()
+    resolve_unlock_status_async.assert_awaited_once_with(manager, peer.uid)
 
 
 @pytest.mark.asyncio

--- a/tests/session/test_session_manager_command_runtime.py
+++ b/tests/session/test_session_manager_command_runtime.py
@@ -19,6 +19,7 @@ from keymasq.common.security import PeerCredentials
 from keymasq.common.settings import GlobalSettings
 from keymasq.session.listeners.kde import KDEListener
 from keymasq.session.manager import SessionManager
+from tests.session.support import grant_recording_refresh_owner
 
 
 @pytest.mark.asyncio
@@ -239,6 +240,132 @@ async def test_get_status_uses_async_unlock_helper(monkeypatch: pytest.MonkeyPat
     assert result["macro_recording_source"] == "persistent"
     resolve_unlock_status_async.assert_awaited_once_with(manager, peer.uid)
     resolve_macro_recording_status_async.assert_awaited_once_with(manager, peer.uid)
+
+
+@pytest.mark.asyncio
+async def test_macro_recording_status_prefers_daemon_when_connected() -> None:
+    manager = SessionManager()
+    manager.connected = True
+    manager.client.send_command = AsyncMock(
+        return_value=Response(
+            status="ok",
+            data={"unlocked": True, "source": "persistent", "expires_at": 0},
+        )
+    )
+
+    result = await session_recording_module.resolve_macro_recording_status_async(
+        manager,
+        1000,
+    )
+
+    assert result == {"unlocked": True, "source": "persistent", "expires_at": 0}
+    sent_command = manager.client.send_command.await_args.args[0]
+    assert sent_command.command == CommandType.MACRO_RECORDING_STATUS
+    assert sent_command.data == {}
+
+
+@pytest.mark.asyncio
+async def test_macro_recording_status_uses_cached_daemon_status_for_unreadable_local_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = SessionManager()
+    manager.connected = True
+    daemon_status = {"unlocked": True, "source": "persistent", "expires_at": 0}
+    manager.client.send_command = AsyncMock(
+        return_value=Response(status="ok", data=daemon_status),
+    )
+
+    result = await session_recording_module.resolve_macro_recording_status_async(
+        manager,
+        1000,
+    )
+
+    assert result == daemon_status
+
+    monkeypatch.setattr(
+        session_recording_module,
+        "resolve_macro_recording_status",
+        lambda uid: {
+            "unlocked": False,
+            "source": "none",
+            "expires_at": 0,
+            "unreadable": True,
+        },
+    )
+    manager.connected = False
+
+    result = await session_recording_module.resolve_macro_recording_status_async(
+        manager,
+        1000,
+    )
+
+    assert result == daemon_status
+    manager.client.send_command.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_recording_unlock_status_prefers_daemon_when_connected() -> None:
+    manager = SessionManager()
+    manager.connected = True
+    manager.client.send_command = AsyncMock(
+        return_value=Response(
+            status="ok",
+            data={"unlocked": True, "source": "runtime", "expires_at": 123},
+        )
+    )
+
+    result = await session_recording_module.resolve_unlock_status_async(
+        manager,
+        1000,
+    )
+
+    assert result == {"unlocked": True, "source": "runtime", "expires_at": 123}
+    sent_command = manager.client.send_command.await_args.args[0]
+    assert sent_command.command == CommandType.RECORDING_UNLOCK_STATUS
+    assert sent_command.data == {}
+
+
+@pytest.mark.asyncio
+async def test_recording_unlock_status_uses_cached_daemon_status_for_unreadable_local_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = SessionManager()
+    manager.connected = True
+    daemon_status = {
+        "unlocked": True,
+        "source": "runtime",
+        "expires_at": 4_102_444_800,
+    }
+    manager.client.send_command = AsyncMock(
+        return_value=Response(status="ok", data=daemon_status),
+    )
+
+    result = await session_recording_module.resolve_unlock_status_async(
+        manager,
+        1000,
+    )
+
+    assert result == daemon_status
+
+    monkeypatch.setattr(
+        session_recording_module,
+        "resolve_unlock_status",
+        lambda uid: {
+            "unlocked": False,
+            "source": "none",
+            "expires_at": 0,
+            "unreadable": True,
+        },
+    )
+    manager.connected = False
+
+    result = await session_recording_module.resolve_unlock_status_async(
+        manager,
+        1000,
+    )
+
+    assert result == daemon_status
+    manager.client.send_command.assert_awaited_once()
 
 
 @pytest.mark.asyncio
@@ -758,8 +885,8 @@ async def test_start_macro_trigger_requests_auth_for_locked_recording(
     await session_events_module.handle_start_macro_trigger(manager, {"recording_slot": 3})
 
     manager.send_notification.assert_called_once_with(  # type: ignore[attr-defined]
-        "Keymasq: Recording Locked",
-        "Recording/capture requires unlock in Keymasq GUI.",
+        "Keymasq: Capture Unlock Required",
+        "Capture unlock is required in Keymasq GUI.",
     )
     manager.broadcast_to_session_clients.assert_called_once_with(  # type: ignore[attr-defined]
         {"event": "recording_auth_requested"}
@@ -1645,16 +1772,12 @@ async def test_get_status_reports_effective_unlock_when_unlock_not_required(
 @pytest.mark.parametrize("command", ["begin_capture", "capture_read", "end_capture"])
 async def test_capture_commands_with_owner_return_error_on_missing_hardware_id(
     command: str,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     manager = SessionManager()
     peer = PeerCredentials(pid=1, uid=1000, gid=1000)
     writer = object()
-    manager.unlock_state.refresh_owner = {
-        "uid": peer.uid,
-        "pid": peer.pid,
-        "writer_id": id(writer),
-        "lease_id": "lease-test",
-    }
+    grant_recording_refresh_owner(manager, peer, writer, monkeypatch)
 
     result = await manager._handle_session_request(
         {"command": command},
@@ -1667,7 +1790,51 @@ async def test_capture_commands_with_owner_return_error_on_missing_hardware_id(
 
 
 @pytest.mark.asyncio
-async def test_begin_capture_rejects_duplicate_for_same_hardware() -> None:
+async def test_end_capture_allows_owner_after_unlock_expiry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = SessionManager()
+    manager.connected = True
+    manager.security_policy.recording_unlock_required = True
+    manager.capture_state.tokens["1234:5678"] = "capture-token"
+    manager.client.send_command = AsyncMock(
+        return_value=Response(status="ok", data={"ended": True})
+    )
+    peer = PeerCredentials(pid=1, uid=1000, gid=1000)
+    writer = object()
+    manager.unlock_state.refresh_owner = {
+        "uid": peer.uid,
+        "pid": peer.pid,
+        "writer_id": id(writer),
+        "lease_id": "lease-test",
+    }
+    resolve_unlock_status_async = AsyncMock(
+        return_value={"unlocked": False, "source": "none", "expires_at": 0}
+    )
+    monkeypatch.setattr(
+        session_recording_module,
+        "resolve_unlock_status_async",
+        resolve_unlock_status_async,
+    )
+
+    result = await manager._handle_session_request(
+        {"command": "end_capture", "hardware_id": "1234:5678"},
+        "client",
+        peer,
+        writer,
+    )
+
+    assert result["status"] == "ok"
+    resolve_unlock_status_async.assert_not_awaited()
+    sent_command = manager.client.send_command.await_args.args[0]
+    assert sent_command.command == CommandType.CAPTURE_END
+    assert sent_command.data == {"token": "capture-token"}
+
+
+@pytest.mark.asyncio
+async def test_begin_capture_rejects_duplicate_for_same_hardware(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     manager = SessionManager()
     hardware_id = "2dc8:3106"
     manager.client.send_command = AsyncMock(
@@ -1678,12 +1845,7 @@ async def test_begin_capture_rejects_duplicate_for_same_hardware() -> None:
     )
     peer = PeerCredentials(pid=1, uid=1000, gid=1000)
     writer = object()
-    manager.unlock_state.refresh_owner = {
-        "uid": peer.uid,
-        "pid": peer.pid,
-        "writer_id": id(writer),
-        "lease_id": "lease-test",
-    }
+    grant_recording_refresh_owner(manager, peer, writer, monkeypatch)
 
     first = await manager._handle_session_request(
         {"command": "begin_capture", "hardware_id": hardware_id},
@@ -1725,12 +1887,7 @@ async def test_clear_captures_for_writer_ends_owned_capture_on_disconnect(
     monkeypatch.setattr(session_profiles_module, "reevaluate_profiles", reevaluate_profiles)
     peer = PeerCredentials(pid=1, uid=1000, gid=1000)
     writer = object()
-    manager.unlock_state.refresh_owner = {
-        "uid": peer.uid,
-        "pid": peer.pid,
-        "writer_id": id(writer),
-        "lease_id": "lease-test",
-    }
+    grant_recording_refresh_owner(manager, peer, writer, monkeypatch)
 
     result = await manager._handle_session_request(
         {
@@ -1767,7 +1924,9 @@ async def test_clear_captures_for_writer_ends_owned_capture_on_disconnect(
 
 
 @pytest.mark.asyncio
-async def test_begin_capture_for_numbered_hardware_uses_configured_paths() -> None:
+async def test_begin_capture_for_numbered_hardware_uses_configured_paths(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     manager = SessionManager()
     hardware_id = "1234:5678@2"
     manager.hardware.get_hardware = lambda _hardware_id: SimpleNamespace(  # type: ignore[assignment]
@@ -1778,12 +1937,7 @@ async def test_begin_capture_for_numbered_hardware_uses_configured_paths() -> No
     )
     peer = PeerCredentials(pid=1, uid=1000, gid=1000)
     writer = object()
-    manager.unlock_state.refresh_owner = {
-        "uid": peer.uid,
-        "pid": peer.pid,
-        "writer_id": id(writer),
-        "lease_id": "lease-test",
-    }
+    grant_recording_refresh_owner(manager, peer, writer, monkeypatch)
 
     result = await manager._handle_session_request(
         {"command": "begin_capture", "hardware_id": hardware_id},
@@ -1814,12 +1968,7 @@ async def test_begin_capture_default_lifetime_survives_request_writer_disconnect
     monkeypatch.setattr(session_profiles_module, "reevaluate_profiles", reevaluate_profiles)
     peer = PeerCredentials(pid=1, uid=1000, gid=1000)
     writer = cast(asyncio.StreamWriter, object())
-    manager.unlock_state.refresh_owner = {
-        "uid": peer.uid,
-        "pid": peer.pid,
-        "writer_id": id(writer),
-        "lease_id": "lease-test",
-    }
+    grant_recording_refresh_owner(manager, peer, writer, monkeypatch)
 
     result = await manager._handle_session_request(
         {"command": "begin_capture", "hardware_id": hardware_id},
@@ -1843,8 +1992,11 @@ async def test_begin_capture_default_lifetime_survives_request_writer_disconnect
     manager.client.send_command.assert_awaited_once()
     reevaluate_profiles.assert_not_awaited()
 
+
 @pytest.mark.asyncio
-async def test_begin_capture_with_paths_uses_configured_interfaces_when_omitted() -> None:
+async def test_begin_capture_with_paths_uses_configured_interfaces_when_omitted(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     manager = SessionManager()
     hardware_id = "2dc8:3106"
     manager.hardware.get_hardware = lambda _hardware_id: SimpleNamespace(  # type: ignore[assignment]
@@ -1863,12 +2015,7 @@ async def test_begin_capture_with_paths_uses_configured_interfaces_when_omitted(
     )
     peer = PeerCredentials(pid=1, uid=1000, gid=1000)
     writer = object()
-    manager.unlock_state.refresh_owner = {
-        "uid": peer.uid,
-        "pid": peer.pid,
-        "writer_id": id(writer),
-        "lease_id": "lease-test",
-    }
+    grant_recording_refresh_owner(manager, peer, writer, monkeypatch)
 
     result = await manager._handle_session_request(
         {
@@ -1902,7 +2049,9 @@ async def test_begin_capture_with_paths_uses_configured_interfaces_when_omitted(
 
 
 @pytest.mark.asyncio
-async def test_begin_capture_with_explicit_path_does_not_use_saved_interface() -> None:
+async def test_begin_capture_with_explicit_path_does_not_use_saved_interface(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     manager = SessionManager()
     hardware_id = "2dc8:3106"
     manager.hardware.get_hardware = lambda _hardware_id: SimpleNamespace(  # type: ignore[assignment]
@@ -1921,12 +2070,7 @@ async def test_begin_capture_with_explicit_path_does_not_use_saved_interface() -
     )
     peer = PeerCredentials(pid=1, uid=1000, gid=1000)
     writer = object()
-    manager.unlock_state.refresh_owner = {
-        "uid": peer.uid,
-        "pid": peer.pid,
-        "writer_id": id(writer),
-        "lease_id": "lease-test",
-    }
+    grant_recording_refresh_owner(manager, peer, writer, monkeypatch)
 
     result = await manager._handle_session_request(
         {
@@ -1949,7 +2093,9 @@ async def test_begin_capture_with_explicit_path_does_not_use_saved_interface() -
 
 
 @pytest.mark.asyncio
-async def test_begin_capture_with_duplicate_logical_paths_preserves_interfaces() -> None:
+async def test_begin_capture_with_duplicate_logical_paths_preserves_interfaces(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     manager = SessionManager()
     hardware_id = "2dc8:3106"
     manager.hardware.get_hardware = lambda _hardware_id: SimpleNamespace(  # type: ignore[assignment]
@@ -1975,12 +2121,7 @@ async def test_begin_capture_with_duplicate_logical_paths_preserves_interfaces()
     )
     peer = PeerCredentials(pid=1, uid=1000, gid=1000)
     writer = object()
-    manager.unlock_state.refresh_owner = {
-        "uid": peer.uid,
-        "pid": peer.pid,
-        "writer_id": id(writer),
-        "lease_id": "lease-test",
-    }
+    grant_recording_refresh_owner(manager, peer, writer, monkeypatch)
 
     result = await manager._handle_session_request(
         {
@@ -2019,19 +2160,16 @@ async def test_begin_capture_with_duplicate_logical_paths_preserves_interfaces()
 
 
 @pytest.mark.asyncio
-async def test_begin_capture_for_numbered_hardware_requires_configured_paths() -> None:
+async def test_begin_capture_for_numbered_hardware_requires_configured_paths(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     manager = SessionManager()
     hardware_id = "1234:5678@2"
     manager.hardware.get_hardware = lambda _hardware_id: None  # type: ignore[assignment]
     manager.client.send_command = AsyncMock()
     peer = PeerCredentials(pid=1, uid=1000, gid=1000)
     writer = object()
-    manager.unlock_state.refresh_owner = {
-        "uid": peer.uid,
-        "pid": peer.pid,
-        "writer_id": id(writer),
-        "lease_id": "lease-test",
-    }
+    grant_recording_refresh_owner(manager, peer, writer, monkeypatch)
 
     result = await manager._handle_session_request(
         {"command": "begin_capture", "hardware_id": hardware_id},
@@ -2080,7 +2218,9 @@ async def test_handle_session_request_create_macro_broadcasts_saved_event(
 
 
 @pytest.mark.asyncio
-async def test_save_recording_keeps_pending_macro_save_slot() -> None:
+async def test_save_recording_keeps_pending_macro_save_slot(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     manager = SessionManager()
     manager.recording_state.pending_data = {
         "pending_recording_id": "recording-1",
@@ -2096,12 +2236,13 @@ async def test_save_recording_keeps_pending_macro_save_slot() -> None:
     manager.broadcast_to_session_clients = Mock()  # type: ignore[method-assign]
     peer = PeerCredentials(pid=1, uid=1000, gid=1000)
     writer = object()
-    manager.unlock_state.refresh_owner = {
-        "uid": peer.uid,
-        "pid": peer.pid,
-        "writer_id": id(writer),
-        "lease_id": "lease-1",
-    }
+    grant_recording_refresh_owner(
+        manager,
+        peer,
+        writer,
+        monkeypatch,
+        lease_id="lease-1",
+    )
 
     result = await manager._handle_session_request(
         {
@@ -2191,6 +2332,73 @@ async def test_delete_recording_slot_rejects_stale_pending_macro_save_token() ->
     assert result["error_code"] == "stale_pending_macro_save"
     assert manager.recording_state.pending_data == {"events": [{"t_us": 0}]}
     assert manager.recording_state.pending_save_token == "current"
+
+
+@pytest.mark.asyncio
+async def test_replaced_pending_slot_rejects_previous_pending_save_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = SessionManager()
+    manager.security_policy.recording_unlock_required = False
+    session_recording_module.begin_pending_macro_save(
+        manager,
+        {"pending_recording_id": "recording-a", "duration_ms": 10},
+        recording_slot=1,
+    )
+    old_token = "old-token"
+    manager.recording_state.pending_slot_tokens[1] = old_token
+    manager.recording_state.pending_slots[1]["pending_save_token"] = old_token
+    manager.recording_state.pending_save_token = old_token
+    manager.recording_state.pending_slot_owner_writer_ids[1] = 123
+    manager.recording_state.pending_slot_owner_pids[1] = 456
+    manager.recording_state.pending_slot_owner_uids[1] = 789
+    manager.recording_state.pending_slot_created_at[1] = 1.0
+
+    def fake_token_urlsafe(_size: int) -> str:
+        return "fresh-token"
+
+    def fake_monotonic() -> float:
+        return 20.0
+
+    monkeypatch.setattr(session_recording_module.secrets, "token_urlsafe", fake_token_urlsafe)
+    monkeypatch.setattr(session_recording_module, "monotonic", fake_monotonic)
+
+    session_recording_module.replace_pending_macro_slots_from_daemon(
+        manager,
+        [
+            {
+                "pending_recording_id": "recording-b",
+                "recording_slot": 1,
+                "duration_ms": 20,
+            }
+        ],
+    )
+
+    assert manager.recording_state.pending_slot_tokens[1] == "fresh-token"
+    assert manager.recording_state.pending_save_token == "fresh-token"
+    assert manager.recording_state.pending_slots[1]["pending_save_token"] == "fresh-token"
+    assert manager.recording_state.pending_slot_owner_writer_ids[1] is None
+    assert manager.recording_state.pending_slot_owner_pids[1] is None
+    assert manager.recording_state.pending_slot_owner_uids[1] is None
+    assert manager.recording_state.pending_slot_created_at[1] == 20.0
+    assert not session_recording_module.pending_macro_save_token_matches(manager, old_token)
+
+    peer = PeerCredentials(pid=1, uid=1000, gid=1000)
+    manager.client.send_command = AsyncMock()
+    for request in (
+        {"command": "save_recording", "name": "Saved", "pending_save_token": old_token},
+        {"command": "delete_recording_slot", "pending_save_token": old_token},
+    ):
+        result = await manager._handle_session_request(
+            request,
+            "client",
+            peer,
+            object(),
+        )
+
+        assert result["status"] == "error"
+        assert result["error_code"] == "stale_pending_macro_save"
+    manager.client.send_command.assert_not_awaited()
 
 
 def test_clear_pending_macro_save_keeps_slots_for_invalid_selector() -> None:
@@ -2316,7 +2524,9 @@ async def test_handle_session_request_delete_macro_broadcasts_deleted_event(
 
 
 @pytest.mark.asyncio
-async def test_capture_combo_session_command_round_trip() -> None:
+async def test_capture_combo_session_command_round_trip(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     manager = SessionManager()
     manager.hardware.list_hardware_ids = lambda: ["1234:5678"]  # type: ignore[assignment]
     manager.hardware.get_hardware = lambda _hardware_id: SimpleNamespace(  # type: ignore[assignment]
@@ -2351,12 +2561,7 @@ async def test_capture_combo_session_command_round_trip() -> None:
 
     peer = PeerCredentials(pid=1, uid=1000, gid=1000)
     writer = object()
-    manager.unlock_state.refresh_owner = {
-        "uid": peer.uid,
-        "pid": peer.pid,
-        "writer_id": id(writer),
-        "lease_id": "lease-test",
-    }
+    grant_recording_refresh_owner(manager, peer, writer, monkeypatch)
 
     capture = await manager._handle_session_request(
         {"command": "capture_combo", "profile_name": "Desktop"},

--- a/tests/session/test_session_manager_command_runtime.py
+++ b/tests/session/test_session_manager_command_runtime.py
@@ -261,7 +261,7 @@ async def test_macro_recording_status_prefers_daemon_when_connected() -> None:
     assert result == {"unlocked": True, "source": "persistent", "expires_at": 0}
     sent_command = manager.client.send_command.await_args.args[0]
     assert sent_command.command == CommandType.MACRO_RECORDING_STATUS
-    assert sent_command.data == {}
+    assert sent_command.data == {"uid": 1000}
 
 
 @pytest.mark.asyncio
@@ -322,7 +322,7 @@ async def test_recording_unlock_status_prefers_daemon_when_connected() -> None:
     assert result == {"unlocked": True, "source": "runtime", "expires_at": 123}
     sent_command = manager.client.send_command.await_args.args[0]
     assert sent_command.command == CommandType.RECORDING_UNLOCK_STATUS
-    assert sent_command.data == {}
+    assert sent_command.data == {"uid": 1000}
 
 
 @pytest.mark.asyncio

--- a/tests/test_action_handler.py
+++ b/tests/test_action_handler.py
@@ -11,6 +11,16 @@ import pytest
 from keymasq.session.action_handler import ActionHandler
 
 
+@pytest.mark.asyncio
+async def test_execute_command_returns_nonzero_code_with_non_utf8_stderr() -> None:
+    script = "import sys\nsys.stderr.buffer.write(b'\\xff')\nsys.exit(7)\n"
+    cmd = f"{shlex.quote(sys.executable)} -c {shlex.quote(script)}"
+
+    result = await ActionHandler().execute_command(cmd)
+
+    assert result == 7
+
+
 def _process_exists(pid: int) -> bool:
     try:
         os.kill(pid, 0)

--- a/tests/test_analog_controls.py
+++ b/tests/test_analog_controls.py
@@ -1,5 +1,9 @@
+from pathlib import Path
+from typing import BinaryIO
+
 import pytest
 
+import keymasq.session.analog_controls as analog_controls_module
 from keymasq.common.models import (
     SAME_DEVICE_OUTPUT_ID,
     ActionType,
@@ -14,6 +18,10 @@ from keymasq.session.analog_controls import (
     analog_control_mouse_wheel_template,
     analog_control_wasd_template,
 )
+
+
+def _write_analog_control(path: Path, name: str) -> None:
+    path.write_text(f'name = "{name}"\n', encoding="utf-8")
 
 
 def test_gamepad_output_deadzone_defaults_to_zero() -> None:
@@ -63,6 +71,86 @@ def test_analog_control_save_replacing_name_removes_old_config(temp_config_dir) 
     assert sorted(path.name for path in (temp_config_dir / "analog_controls").glob("*.toml")) == [
         "new_name.toml"
     ]
+
+
+def test_analog_control_failed_overwrite_preserves_existing_file_and_state(
+    temp_config_dir,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = AnalogControlManager()
+    manager.save_analog_control(
+        AnalogControlConfig(name="Saved Control", description="original")
+    )
+    path = temp_config_dir / "analog_controls" / "saved_control.toml"
+    original_content = path.read_bytes()
+
+    def fail_dump(_data: object, config_file: BinaryIO) -> None:
+        config_file.write(b'name = "partial"\n')
+        raise OSError("disk full")
+
+    monkeypatch.setattr(analog_controls_module.tomli_w, "dump", fail_dump)
+
+    with pytest.raises(OSError, match="disk full"):
+        manager.save_analog_control(
+            AnalogControlConfig(name="Saved Control", description="updated")
+        )
+
+    loaded = manager.get_analog_control("Saved Control")
+    assert path.read_bytes() == original_content
+    assert loaded is not None
+    assert loaded.description == "original"
+    assert sorted(item.name for item in (temp_config_dir / "analog_controls").iterdir()) == [
+        "saved_control.toml"
+    ]
+
+
+def test_analog_control_delete_uses_loaded_noncanonical_path(temp_config_dir) -> None:
+    analog_controls_dir = temp_config_dir / "analog_controls"
+    _write_analog_control(analog_controls_dir / "custom.toml", "FPS Mouse")
+    _write_analog_control(analog_controls_dir / "fps_mouse.toml", "Other Control")
+
+    manager = AnalogControlManager()
+
+    assert manager.delete_analog_control("FPS Mouse") is True
+    assert not (analog_controls_dir / "custom.toml").exists()
+    assert (analog_controls_dir / "fps_mouse.toml").exists()
+    assert AnalogControlManager().list_analog_controls() == ["Other Control"]
+
+
+def test_analog_control_rename_uses_loaded_noncanonical_path(temp_config_dir) -> None:
+    analog_controls_dir = temp_config_dir / "analog_controls"
+    _write_analog_control(analog_controls_dir / "custom.toml", "FPS Mouse")
+    _write_analog_control(analog_controls_dir / "fps_mouse.toml", "Other Control")
+
+    manager = AnalogControlManager()
+
+    assert manager.rename_analog_control("FPS Mouse", "Look Mouse") is True
+    assert not (analog_controls_dir / "custom.toml").exists()
+    assert (analog_controls_dir / "fps_mouse.toml").exists()
+    assert (analog_controls_dir / "look_mouse.toml").exists()
+    assert AnalogControlManager().list_analog_controls() == ["Look Mouse", "Other Control"]
+
+
+def test_analog_control_replacing_save_removes_loaded_noncanonical_path(
+    temp_config_dir,
+) -> None:
+    analog_controls_dir = temp_config_dir / "analog_controls"
+    _write_analog_control(analog_controls_dir / "custom.toml", "Old Name")
+    _write_analog_control(analog_controls_dir / "old_name.toml", "Other Control")
+
+    manager = AnalogControlManager()
+    manager.save_analog_control(
+        AnalogControlConfig(name="New Name"),
+        replacing_name="Old Name",
+    )
+
+    assert not (analog_controls_dir / "custom.toml").exists()
+    assert (analog_controls_dir / "old_name.toml").exists()
+    assert sorted(path.name for path in analog_controls_dir.glob("*.toml")) == [
+        "new_name.toml",
+        "old_name.toml",
+    ]
+    assert AnalogControlManager().list_analog_controls() == ["New Name", "Other Control"]
 
 
 def test_analog_control_manager_normalizes_obsolete_mouse_plus_digital(

--- a/tests/test_cli_commands_helpers.py
+++ b/tests/test_cli_commands_helpers.py
@@ -240,7 +240,7 @@ def test_status_cli_prints_runtime_summary(
     assert "compositor: GNOME Shell (gnome)" in out
     assert "listener: active (gnome)" in out
     assert "macro recording: disabled" in out
-    assert "recording unlock: locked" in out
+    assert "capture unlock: locked" in out
     assert "active profiles: Base" in out
     assert "Example Keyboard (1234:5678)" in out
     assert "window: firefox - Example" in out
@@ -371,15 +371,39 @@ def test_play_adhoc_cli_reads_json_payload(monkeypatch: pytest.MonkeyPatch) -> N
     monkeypatch.setattr(commands, "_session_request", _session_request)
 
     commands.play_adhoc_cli(
-        ['{"events":[{"device_type":"keyboard","type":1,"code":30,"value":1,"t_us":0}]}'],
+        [
+            '{"events":[{"device_type":"keyboard","type":1,"code":30,"value":1,"t_us":0}],'
+            '"speed":2.0}'
+        ],
         input_json=True,
     )
 
     payload = sent[0]
     assert payload["command"] == "play_macro_payload"
+    assert payload["speed"] == 2.0
     assert payload["macro_events"] == [
         {"device_type": "keyboard", "type": 1, "code": 30, "value": 1, "t_us": 0}
     ]
+
+
+def test_play_adhoc_cli_cli_speed_overrides_json_payload(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sent: list[dict[str, object]] = []
+
+    def _session_request(payload: dict[str, object]) -> dict[str, object]:
+        sent.append(payload)
+        return {"status": "ok"}
+
+    monkeypatch.setattr(commands, "_session_request", _session_request)
+
+    commands.play_adhoc_cli(
+        ['{"events":[{"device_type":"keyboard","t_us":0}],"speed":2.0}'],
+        input_json=True,
+        speed=0.5,
+    )
+
+    assert sent[0]["speed"] == 0.5
 
 
 def test_play_adhoc_cli_rejects_non_object_json_event(

--- a/tests/test_entrypoints_and_cli.py
+++ b/tests/test_entrypoints_and_cli.py
@@ -296,6 +296,24 @@ def test_cli_main_play_routes_json_input_to_helper(monkeypatch: pytest.MonkeyPat
     ]
 
 
+def test_cli_main_play_omits_speed_override_when_not_provided(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from keymasq.cli import __main__ as cli_main
+    from keymasq.cli import commands
+
+    calls: list[dict[str, object]] = []
+
+    def _play_cli(events: list[str], **kwargs: object) -> None:
+        calls.append({"events": events, **kwargs})
+
+    monkeypatch.setattr(commands, "play_adhoc_cli", _play_cli)
+    monkeypatch.setattr(sys, "argv", ["keymasq", "play", "--json", '{"events":[],"speed":2}'])
+
+    cli_main.main()
+    assert calls[0]["speed"] is None
+
+
 @pytest.mark.parametrize(
     "argv",
     [

--- a/tests/test_macro_store.py
+++ b/tests/test_macro_store.py
@@ -1,6 +1,7 @@
 import logging
 import lzma
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable, Iterator
+from contextlib import contextmanager
 from pathlib import Path
 
 import pytest
@@ -8,6 +9,26 @@ import pytest
 from keymasq.keymasqd import macro_store as macro_store_module
 from keymasq.keymasqd.macro_file import MacroFileMeta
 from keymasq.keymasqd.macro_store import MacroStore
+
+
+def _run_before_mutation_guard(
+    store: MacroStore,
+    monkeypatch: pytest.MonkeyPatch,
+    callback: Callable[[], None],
+) -> None:
+    original_guard = store._mutation_guard
+    callback_ran = False
+
+    @contextmanager
+    def mutation_guard() -> Iterator[None]:
+        nonlocal callback_ran
+        if not callback_ran:
+            callback_ran = True
+            callback()
+        with original_guard():
+            yield
+
+    monkeypatch.setattr(store, "_mutation_guard", mutation_guard)
 
 
 def test_macro_store_crud_and_revision(tmp_path: Path) -> None:
@@ -48,6 +69,73 @@ def test_macro_store_revision_conflict(tmp_path: Path) -> None:
 
     with pytest.raises(ValueError):
         store.update("macro_a", {"duration_us": 10_000}, expected_revision=7)
+
+
+def test_macro_store_update_rechecks_revision_under_mutation_lock(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = MacroStore(tmp_path / "macros")
+    contender = MacroStore(tmp_path / "macros")
+    store.create({"name": "macro_a", "events": [], "duration_us": 0})
+
+    _run_before_mutation_guard(
+        store,
+        monkeypatch,
+        lambda: contender.update("macro_a", {"duration_us": 50_000}, expected_revision=1),
+    )
+
+    with pytest.raises(ValueError, match="Revision conflict"):
+        store.update("macro_a", {"duration_us": 10_000}, expected_revision=1)
+
+    current = store.get("macro_a")
+    assert current["duration_us"] == 50_000
+    assert current["revision"] == 2
+
+
+def test_macro_store_rename_rechecks_revision_under_mutation_lock(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = MacroStore(tmp_path / "macros")
+    contender = MacroStore(tmp_path / "macros")
+    store.create({"name": "macro_a", "events": [], "duration_us": 0})
+
+    _run_before_mutation_guard(
+        store,
+        monkeypatch,
+        lambda: contender.update("macro_a", {"duration_us": 50_000}, expected_revision=1),
+    )
+
+    with pytest.raises(ValueError, match="Revision conflict"):
+        store.rename("macro_a", "macro_b", expected_revision=1)
+
+    current = store.get("macro_a")
+    assert current["duration_us"] == 50_000
+    assert current["revision"] == 2
+    assert not (tmp_path / "macros" / "macro_b.kmacro.xz").exists()
+
+
+def test_macro_store_delete_rechecks_revision_under_mutation_lock(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = MacroStore(tmp_path / "macros")
+    contender = MacroStore(tmp_path / "macros")
+    store.create({"name": "macro_a", "events": [], "duration_us": 0})
+
+    _run_before_mutation_guard(
+        store,
+        monkeypatch,
+        lambda: contender.update("macro_a", {"duration_us": 50_000}, expected_revision=1),
+    )
+
+    with pytest.raises(ValueError, match="Revision conflict"):
+        store.delete("macro_a", expected_revision=1)
+
+    current = store.get("macro_a")
+    assert current["duration_us"] == 50_000
+    assert current["revision"] == 2
 
 
 def test_macro_store_rename_keeps_source_when_destination_validation_fails(

--- a/tests/test_macro_store_internal.py
+++ b/tests/test_macro_store_internal.py
@@ -90,3 +90,35 @@ def test_get_returns_copy_of_internal_macro():
         macro2 = store.get("__test")
 
         assert macro1 is not macro2
+
+
+def test_internal_macro_reads_do_not_expose_store_state():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        store = MacroStore(Path(tmpdir))
+        event = {"device_type": "keyboard", "type": 1, "code": 30, "value": 1, "t_us": 0}
+        device_types = ["keyboard"]
+        expected_events = [event.copy()]
+        store.register_internal("__test", events=[event], device_types=device_types)
+
+        event["code"] = 99
+        device_types.append("mouse")
+
+        macro = store.get("__test")
+        events = macro["events"]
+        assert isinstance(events, list)
+        returned_event = events[0]
+        assert isinstance(returned_event, dict)
+        returned_event["code"] = 31
+        events.append({"device_type": "mouse", "type": 2, "code": 0, "value": 1, "t_us": 50})
+
+        iter_event = next(store.iter_events("__test"))
+        iter_event["code"] = 32
+
+        meta = store.get_meta("__test")
+        meta_device_types = meta["device_types"]
+        assert isinstance(meta_device_types, list)
+        meta_device_types.append("mouse")
+
+        assert store.get("__test")["events"] == expected_events
+        assert list(store.iter_events("__test")) == expected_events
+        assert store.get_meta("__test")["device_types"] == ["keyboard"]

--- a/tests/test_output_helpers.py
+++ b/tests/test_output_helpers.py
@@ -8,12 +8,19 @@ from keymasq.keymasqd import output_helpers
 def test_resolve_output_code_handles_known_tuple_and_unknown_targets(monkeypatch) -> None:
     monkeypatch.setattr(output_helpers.evdev.ecodes, "FAKE_TUPLE", (123, "fake"), raising=False)
     monkeypatch.setattr(output_helpers.evdev.ecodes, "fake_lower", (456, "fake"), raising=False)
+    monkeypatch.setattr(
+        output_helpers.evdev.ecodes,
+        "NON_CODE_ATTR",
+        {"not": "a code"},
+        raising=False,
+    )
 
     assert output_helpers.resolve_output_code(None) is None
     assert output_helpers.resolve_output_code("btn_left") == evdev.ecodes.BTN_LEFT
     assert output_helpers.resolve_output_code("fake_tuple") == 123
     assert output_helpers.resolve_output_code("fake_lower") == 456
     assert output_helpers.resolve_output_code("missing_code") is None
+    assert output_helpers.resolve_output_code("non_code_attr") is None
 
 
 def test_resolve_gamepad_axis_code_requires_axis_targets() -> None:

--- a/tests/test_record_cli.py
+++ b/tests/test_record_cli.py
@@ -1,4 +1,5 @@
 import json
+import stat
 import sys
 from pathlib import Path
 from types import SimpleNamespace
@@ -45,6 +46,18 @@ def test_authorize_target_uid_rejects_non_root_caller_mismatch(
         record._authorize_target_uid(1001, 777)
 
 
+def test_runtime_expires_at_rounds_up_fractional_now(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    now = 100.999
+    monkeypatch.setattr(record.time, "time", lambda: now)
+
+    expires_at = record._runtime_expires_at(1)
+
+    assert expires_at == 102
+    assert expires_at >= now + 1
+
+
 def test_write_lease_and_remove_lease(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     lease = tmp_path / "lease"
     monkeypatch.setattr(
@@ -52,6 +65,7 @@ def test_write_lease_and_remove_lease(monkeypatch: pytest.MonkeyPatch, tmp_path:
         "getpwnam",
         lambda _: SimpleNamespace(pw_uid=1000, pw_gid=1000),
     )
+    monkeypatch.setattr(record.pwd, "getpwuid", lambda _: SimpleNamespace(pw_gid=1235))
 
     calls: list[tuple[int, int]] = []
 
@@ -60,9 +74,10 @@ def test_write_lease_and_remove_lease(monkeypatch: pytest.MonkeyPatch, tmp_path:
 
     monkeypatch.setattr(record.os, "fchown", _chown)
 
-    record._write_lease(lease, 42)
+    record._write_lease(lease, 42, 1234)
     assert lease.read_text(encoding="utf-8") == "42\n"
-    assert calls == [(1000, 1000)]
+    assert stat.S_IMODE(lease.stat().st_mode) == 0o440
+    assert calls == [(1000, 1235)]
 
     record._remove_lease(lease)
     assert lease.exists() is False
@@ -79,7 +94,7 @@ def test_write_lease_propagates_unexpected_user_lookup_error(
     monkeypatch.setattr(record.pwd, "getpwnam", _raise)
 
     with pytest.raises(RuntimeError, match="lookup failed"):
-        record._write_lease(lease, 42)
+        record._write_lease(lease, 42, 1234)
 
     assert lease.exists() is False
 
@@ -98,7 +113,7 @@ def test_write_lease_rejects_preexisting_symlink(
     )
 
     with pytest.raises(PermissionError, match="symlink"):
-        record._write_lease(lease, 42)
+        record._write_lease(lease, 42, 1234)
 
     assert target.read_text(encoding="utf-8") == "keep\n"
     assert lease.is_symlink()
@@ -121,7 +136,7 @@ def test_write_lease_keeps_existing_lease_when_replace_fails(
     monkeypatch.setattr(record.os, "replace", _replace)
 
     with pytest.raises(OSError, match="replace failed"):
-        record._write_lease(lease, 42)
+        record._write_lease(lease, 42, 1234)
 
     assert lease.read_text(encoding="utf-8") == "41\n"
     assert list(tmp_path.glob(".lease.tmp-*")) == []
@@ -146,12 +161,49 @@ def test_main_status_prints_json(
     assert payload["source"] == "runtime"
 
 
+@pytest.mark.parametrize(
+    ("argv", "resolver_name"),
+    [
+        (["keymasq-record", "status", "--uid", "1001"], "resolve_unlock_status"),
+        (
+            ["keymasq-record", "macro-recording-status", "--uid", "1001"],
+            "resolve_macro_recording_status",
+        ),
+    ],
+)
+def test_main_status_commands_reject_pkexec_uid_mismatch(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    argv: list[str],
+    resolver_name: str,
+) -> None:
+    resolved: list[int] = []
+
+    monkeypatch.setattr(sys, "argv", argv)
+    monkeypatch.setattr(record, "_require_privileged_caller", lambda: 0)
+    monkeypatch.setenv("PKEXEC_UID", "1000")
+    monkeypatch.setattr(
+        record,
+        resolver_name,
+        lambda uid: resolved.append(uid) or {"unlocked": True},
+    )
+
+    with pytest.raises(SystemExit) as excinfo:
+        record.main()
+
+    assert excinfo.value.code == 1
+    assert resolved == []
+    payload = json.loads(capsys.readouterr().out.strip())
+    assert payload["status"] == "error"
+    assert "Target uid" in payload["message"]
+
+
 def test_main_unlock_runtime_replaces_previous_expiry(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
     runtime_path = tmp_path / "runtime-lease"
     runtime_path.write_text("20\n", encoding="utf-8")
-    writes: list[tuple[Path, int]] = []
+    writes: list[tuple[Path, int, int]] = []
 
     monkeypatch.setattr(
         sys,
@@ -162,14 +214,14 @@ def test_main_unlock_runtime_replaces_previous_expiry(
     monkeypatch.setattr(record, "runtime_unlock_path", lambda uid: runtime_path)
     monkeypatch.setattr(record.time, "time", lambda: 10)
 
-    def _write(path: Path, expires_at: int) -> None:
-        writes.append((path, expires_at))
+    def _write(path: Path, expires_at: int, target_uid: int) -> None:
+        writes.append((path, expires_at, target_uid))
 
     monkeypatch.setattr(record, "_write_lease", _write)
 
     record.main()
 
-    assert writes == [(runtime_path, 15)]
+    assert writes == [(runtime_path, 15, 1000)]
     payload = json.loads(capsys.readouterr().out.strip())
     assert payload["expires_at"] == 15
 
@@ -179,7 +231,7 @@ def test_main_unlock_runtime_extends_with_requested_ttl(
 ) -> None:
     runtime_path = tmp_path / "runtime-lease"
     runtime_path.write_text("12\n", encoding="utf-8")
-    writes: list[tuple[Path, int]] = []
+    writes: list[tuple[Path, int, int]] = []
 
     monkeypatch.setattr(
         sys,
@@ -190,14 +242,14 @@ def test_main_unlock_runtime_extends_with_requested_ttl(
     monkeypatch.setattr(record, "runtime_unlock_path", lambda uid: runtime_path)
     monkeypatch.setattr(record.time, "time", lambda: 10)
 
-    def _write(path: Path, expires_at: int) -> None:
-        writes.append((path, expires_at))
+    def _write(path: Path, expires_at: int, target_uid: int) -> None:
+        writes.append((path, expires_at, target_uid))
 
     monkeypatch.setattr(record, "_write_lease", _write)
 
     record.main()
 
-    assert writes == [(runtime_path, 30)]
+    assert writes == [(runtime_path, 30, 1000)]
     payload = json.loads(capsys.readouterr().out.strip())
     assert payload["expires_at"] == 30
 
@@ -206,7 +258,7 @@ def test_main_unlock_runtime_ttl_zero_rejected(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
     runtime_path = tmp_path / "runtime-lease"
-    writes: list[tuple[Path, int]] = []
+    writes: list[tuple[Path, int, int]] = []
 
     monkeypatch.setattr(
         sys,
@@ -216,8 +268,8 @@ def test_main_unlock_runtime_ttl_zero_rejected(
     monkeypatch.setattr(record, "_require_privileged_caller", lambda: None)
     monkeypatch.setattr(record, "runtime_unlock_path", lambda uid: runtime_path)
 
-    def _write(path: Path, expires_at: int) -> None:
-        writes.append((path, expires_at))
+    def _write(path: Path, expires_at: int, target_uid: int) -> None:
+        writes.append((path, expires_at, target_uid))
 
     monkeypatch.setattr(record, "_write_lease", _write)
 
@@ -247,7 +299,7 @@ def test_main_macro_recording_runtime_ttl_zero_rejected(
     monkeypatch.setattr(
         record,
         "_write_lease",
-        lambda path, expires_at: writes.append((path, expires_at)),
+        lambda path, expires_at, target_uid: writes.append((path, expires_at, target_uid)),
     )
 
     with pytest.raises(SystemExit) as excinfo:
@@ -264,7 +316,7 @@ def test_main_mutation_rejects_pkexec_uid_mismatch(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
     runtime_path = tmp_path / "runtime-lease"
-    writes: list[tuple[Path, int]] = []
+    writes: list[tuple[Path, int, int]] = []
 
     monkeypatch.setattr(
         sys,
@@ -277,7 +329,37 @@ def test_main_mutation_rejects_pkexec_uid_mismatch(
     monkeypatch.setattr(
         record,
         "_write_lease",
-        lambda path, expires_at: writes.append((path, expires_at)),
+        lambda path, expires_at, target_uid: writes.append((path, expires_at, target_uid)),
+    )
+
+    with pytest.raises(SystemExit) as excinfo:
+        record.main()
+
+    assert excinfo.value.code == 1
+    assert writes == []
+    payload = json.loads(capsys.readouterr().out.strip())
+    assert payload["status"] == "error"
+    assert "Target uid" in payload["message"]
+
+
+def test_main_mutation_rejects_non_root_forged_pkexec_uid(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    runtime_path = tmp_path / "runtime-lease"
+    writes: list[tuple[Path, int, int]] = []
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["keymasq-record", "unlock-runtime", "--uid", "1001", "--ttl", "5"],
+    )
+    monkeypatch.setattr(record, "_require_privileged_caller", lambda: 777)
+    monkeypatch.setenv("PKEXEC_UID", "1001")
+    monkeypatch.setattr(record, "runtime_unlock_path", lambda uid: runtime_path)
+    monkeypatch.setattr(
+        record,
+        "_write_lease",
+        lambda path, expires_at, target_uid: writes.append((path, expires_at, target_uid)),
     )
 
     with pytest.raises(SystemExit) as excinfo:
@@ -313,7 +395,7 @@ def test_main_enable_and_disable_macro_recording_persistent(
 ) -> None:
     persistent_path = tmp_path / "macro-enabled"
     runtime_path = tmp_path / "macro-runtime"
-    writes: list[tuple[Path, int]] = []
+    writes: list[tuple[Path, int, int]] = []
 
     monkeypatch.setattr(record, "_require_privileged_caller", lambda: None)
     monkeypatch.setattr(record, "persistent_macro_recording_path", lambda uid: persistent_path)
@@ -321,7 +403,7 @@ def test_main_enable_and_disable_macro_recording_persistent(
     monkeypatch.setattr(
         record,
         "_write_lease",
-        lambda path, expires_at: writes.append((path, expires_at)),
+        lambda path, expires_at, target_uid: writes.append((path, expires_at, target_uid)),
     )
 
     monkeypatch.setattr(
@@ -331,7 +413,7 @@ def test_main_enable_and_disable_macro_recording_persistent(
     )
     record.main()
 
-    assert writes == [(persistent_path, 0)]
+    assert writes == [(persistent_path, 0, 1000)]
     payload = json.loads(capsys.readouterr().out.strip())
     assert payload["scope"] == "macro_recording_persistent"
 

--- a/tests/test_recording_guard.py
+++ b/tests/test_recording_guard.py
@@ -95,11 +95,20 @@ def test_resolve_unlock_status_marks_existing_unreadable_lease(
 
     runtime_path = runtime_dir / "recording-unlock-1000"
     runtime_path.write_text("105\n", encoding="utf-8")
-    runtime_path.chmod(0)
-    try:
-        status = recording_guard.resolve_unlock_status(1000, now=100)
-    finally:
-        runtime_path.chmod(0o600)
+    original_read_text = Path.read_text
+
+    def read_text(path: Path, *args: object, **kwargs: object) -> str:
+        if path == runtime_path:
+            raise PermissionError("permission denied")
+        return original_read_text(path, *args, **kwargs)
+
+    def access(path: object, mode: int) -> bool:
+        return Path(path) != runtime_path
+
+    monkeypatch.setattr(Path, "read_text", read_text)
+    monkeypatch.setattr(recording_guard.os, "access", access)
+
+    status = recording_guard.resolve_unlock_status(1000, now=100)
 
     assert status == {
         "unlocked": False,

--- a/tests/test_recording_guard.py
+++ b/tests/test_recording_guard.py
@@ -82,6 +82,34 @@ def test_resolve_unlock_status_none(monkeypatch: pytest.MonkeyPatch, tmp_path: P
     assert status == {"unlocked": False, "source": "none", "expires_at": 0, "path": ""}
 
 
+def test_resolve_unlock_status_marks_existing_unreadable_lease(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    runtime_dir = tmp_path / "run"
+    persistent_dir = tmp_path / "etc"
+    runtime_dir.mkdir()
+    persistent_dir.mkdir()
+
+    monkeypatch.setattr(recording_guard, "RECORDING_UNLOCK_RUNTIME_DIR", runtime_dir)
+    monkeypatch.setattr(recording_guard, "RECORDING_UNLOCK_PERSISTENT_DIR", persistent_dir)
+
+    runtime_path = runtime_dir / "recording-unlock-1000"
+    runtime_path.write_text("105\n", encoding="utf-8")
+    runtime_path.chmod(0)
+    try:
+        status = recording_guard.resolve_unlock_status(1000, now=100)
+    finally:
+        runtime_path.chmod(0o600)
+
+    assert status == {
+        "unlocked": False,
+        "source": "none",
+        "expires_at": 0,
+        "path": "",
+        "unreadable": True,
+    }
+
+
 def test_resolve_macro_recording_status_uses_macro_recording_paths(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/tests/test_release_version.py
+++ b/tests/test_release_version.py
@@ -1,0 +1,186 @@
+import importlib.util
+import re
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+SCRIPT_PATH = Path(__file__).resolve().parents[1] / "scripts/release-version.py"
+
+
+def _load_script() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("release_version_test", SCRIPT_PATH)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    scripts_dir = str(SCRIPT_PATH.parent)
+    sys.path.insert(0, scripts_dir)
+    sys.modules[spec.name] = module
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        sys.modules.pop(spec.name, None)
+        sys.path.remove(scripts_dir)
+    return module
+
+
+def _write_release_fixture(root: Path) -> None:
+    (root / "keymasq").mkdir()
+    (root / "packaging/rpm").mkdir(parents=True)
+    (root / "debian").mkdir()
+    (root / "assets").mkdir()
+
+    (root / "pyproject.toml").write_text(
+        '[project]\nversion = "1.2.3"\n',
+        encoding="utf-8",
+    )
+    (root / "keymasq/_version.py").write_text(
+        '__version__ = "1.2.3"\n',
+        encoding="utf-8",
+    )
+    (root / "packaging/rpm/metadata.env").write_text(
+        'VERSION="1.2.3"\n',
+        encoding="utf-8",
+    )
+    (root / "flake.nix").write_text(
+        '{\n          version = "1.2.3";\n}\n',
+        encoding="utf-8",
+    )
+    (root / "debian/changelog").write_text(
+        "\n".join(
+            [
+                "keymasq (1.2.3-1) unstable; urgency=medium",
+                "",
+                "  * Existing release.",
+                "",
+                " -- nyrda <nyrda@keymasq.tools>  Mon, 01 Jan 2024 00:00:00 +0000",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    (root / "CHANGELOG.md").write_text(
+        "# Changelog\n\n## 1.2.3\n\n- Existing release.\n",
+        encoding="utf-8",
+    )
+    (root / "assets/tools.keymasq.keymasq.metainfo.xml").write_text(
+        "\n".join(
+            [
+                '<component type="desktop-application">',
+                "  <id>tools.keymasq.keymasq</id>",
+                "  <releases>",
+                '    <release version="1.2.3" date="2024-01-01">',
+                "      <description>",
+                "        <p>Existing release.</p>",
+                "      </description>",
+                "    </release>",
+                "  </releases>",
+                "</component>",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_release_version_refreshes_same_version_dated_metadata(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    script = _load_script()
+    _write_release_fixture(tmp_path)
+    monkeypatch.setattr(script, "repo_root", lambda: tmp_path)
+    monkeypatch.setattr(script, "_render_pacman_outputs", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [SCRIPT_PATH.name, "1.2.3", "--release-date", "2026-05-31"],
+    )
+
+    assert script.main() == 0
+
+    assert (
+        " -- nyrda <nyrda@keymasq.tools>  Sun, 31 May 2026 00:00:00 +0000"
+        in (tmp_path / "debian/changelog").read_text(encoding="utf-8")
+    )
+    assert (
+        '    <release version="1.2.3" date="2026-05-31">'
+        in (tmp_path / "assets/tools.keymasq.keymasq.metainfo.xml").read_text(
+            encoding="utf-8"
+        )
+    )
+    output = capsys.readouterr().out
+    assert "Updated: debian/changelog" in output
+    assert "Updated: assets/tools.keymasq.keymasq.metainfo.xml" in output
+
+
+def test_rewrite_changelog_refreshes_dated_release_header(tmp_path: Path) -> None:
+    script = _load_script()
+    (tmp_path / "CHANGELOG.md").write_text(
+        "# Changelog\n\n## 1.2.3 - 2026-05-01\n\n- Existing release.\n",
+        encoding="utf-8",
+    )
+
+    changed = script._rewrite_changelog(
+        tmp_path, "1.2.3", "2026-06-01", "1.2.2", dry_run=False
+    )
+
+    assert changed is True
+    assert (tmp_path / "CHANGELOG.md").read_text(encoding="utf-8") == (
+        "# Changelog\n\n## 1.2.3 - 2026-06-01\n\n- Existing release.\n"
+    )
+
+
+def test_rewrite_changelog_stamps_undated_release_header(tmp_path: Path) -> None:
+    script = _load_script()
+    (tmp_path / "CHANGELOG.md").write_text(
+        "# Changelog\n\n## 1.2.3\n\n- Existing release.\n",
+        encoding="utf-8",
+    )
+
+    changed = script._rewrite_changelog(
+        tmp_path, "1.2.3", "2026-06-01", "1.2.2", dry_run=False
+    )
+
+    assert changed is True
+    assert (tmp_path / "CHANGELOG.md").read_text(encoding="utf-8") == (
+        "# Changelog\n\n## 1.2.3 - 2026-06-01\n\n- Existing release.\n"
+    )
+
+
+def test_release_version_apply_rules_limits_duplicate_matches(tmp_path: Path) -> None:
+    script = _load_script()
+    target = tmp_path / "metadata.env"
+    target.write_text('VERSION="1.0.0"\nVERSION="1.0.0"\n', encoding="utf-8")
+    rule = script.RewriteRule(
+        target,
+        re.compile(r'(?m)^VERSION=".*"$'),
+        'VERSION="2.0.0"',
+    )
+
+    changed_paths = script.apply_rules(tmp_path, [rule], dry_run=False)
+
+    assert changed_paths == [Path("metadata.env")]
+    assert target.read_text(encoding="utf-8") == (
+        'VERSION="2.0.0"\nVERSION="1.0.0"\n'
+    )
+
+
+def test_release_version_rejects_non_canonical_release_date(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    script = _load_script()
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [SCRIPT_PATH.name, "1.2.3", "--release-date", "2026-5-1"],
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        script.main()
+
+    assert exc_info.value.code == 2
+    assert "release date must use the form YYYY-MM-DD" in capsys.readouterr().err

--- a/tests/test_release_version.py
+++ b/tests/test_release_version.py
@@ -111,7 +111,11 @@ def test_release_version_refreshes_same_version_dated_metadata(
             encoding="utf-8"
         )
     )
+    assert "## 1.2.3 - 2026-05-31" in (tmp_path / "CHANGELOG.md").read_text(
+        encoding="utf-8"
+    )
     output = capsys.readouterr().out
+    assert "Updated: CHANGELOG.md" in output
     assert "Updated: debian/changelog" in output
     assert "Updated: assets/tools.keymasq.keymasq.metainfo.xml" in output
 
@@ -123,9 +127,7 @@ def test_rewrite_changelog_refreshes_dated_release_header(tmp_path: Path) -> Non
         encoding="utf-8",
     )
 
-    changed = script._rewrite_changelog(
-        tmp_path, "1.2.3", "2026-06-01", "1.2.2", dry_run=False
-    )
+    changed = script._rewrite_changelog(tmp_path, "1.2.3", "2026-06-01", dry_run=False)
 
     assert changed is True
     assert (tmp_path / "CHANGELOG.md").read_text(encoding="utf-8") == (
@@ -140,9 +142,7 @@ def test_rewrite_changelog_stamps_undated_release_header(tmp_path: Path) -> None
         encoding="utf-8",
     )
 
-    changed = script._rewrite_changelog(
-        tmp_path, "1.2.3", "2026-06-01", "1.2.2", dry_run=False
-    )
+    changed = script._rewrite_changelog(tmp_path, "1.2.3", "2026-06-01", dry_run=False)
 
     assert changed is True
     assert (tmp_path / "CHANGELOG.md").read_text(encoding="utf-8") == (

--- a/tests/test_rewrite_build_metadata.py
+++ b/tests/test_rewrite_build_metadata.py
@@ -1,4 +1,5 @@
 import importlib.util
+import re
 import sys
 from pathlib import Path
 from types import ModuleType
@@ -30,6 +31,26 @@ def _load_script() -> ModuleType:
 
 def _fail_build_rules(*_args: object, **_kwargs: object) -> NoReturn:
     pytest.fail("_build_rules should not be called for invalid version input")
+
+
+def test_rewrite_build_metadata_apply_rules_limits_duplicate_matches(
+    tmp_path: Path,
+) -> None:
+    script = _load_script()
+    target = tmp_path / "metadata.env"
+    target.write_text('VERSION="1.0.0"\nVERSION="1.0.0"\n', encoding="utf-8")
+    rule = script.RewriteRule(
+        target,
+        re.compile(r'(?m)^VERSION=".*"$'),
+        'VERSION="2.0.0"',
+    )
+
+    changed_paths = script.apply_rules(tmp_path, [rule])
+
+    assert changed_paths == [Path("metadata.env")]
+    assert target.read_text(encoding="utf-8") == (
+        'VERSION="2.0.0"\nVERSION="1.0.0"\n'
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/test_session_config_files.py
+++ b/tests/test_session_config_files.py
@@ -1,0 +1,106 @@
+import os
+from pathlib import Path
+from typing import BinaryIO
+
+import pytest
+
+from keymasq.session.config_files import write_config_atomically
+
+
+def test_write_config_atomically_fsyncs_file_then_parent_directory(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    target_path = tmp_path / "config.toml"
+    events: list[str] = []
+    directory_fd = 999_999
+    original_close = os.close
+    original_open = os.open
+    original_replace = os.replace
+
+    def fake_open(
+        path: str | bytes | os.PathLike[str] | os.PathLike[bytes],
+        flags: int,
+        mode: int = 0o777,
+        *,
+        dir_fd: int | None = None,
+    ) -> int:
+        if os.fspath(path) == os.fspath(tmp_path):
+            events.append("open_dir")
+            assert flags & os.O_DIRECTORY
+            return directory_fd
+        if dir_fd is None:
+            return original_open(path, flags, mode)
+        return original_open(path, flags, mode, dir_fd=dir_fd)
+
+    def fake_fsync(fd: int) -> None:
+        if fd == directory_fd:
+            events.append("fsync_dir")
+        else:
+            events.append("fsync_file")
+
+    def fake_close(fd: int) -> None:
+        if fd == directory_fd:
+            events.append("close_dir")
+        else:
+            original_close(fd)
+
+    def fake_replace(
+        src: str | bytes | os.PathLike[str] | os.PathLike[bytes],
+        dst: str | bytes | os.PathLike[str] | os.PathLike[bytes],
+    ) -> None:
+        events.append("replace")
+        original_replace(src, dst)
+
+    def write_config(config_file: BinaryIO) -> None:
+        config_file.write(b"name = \"Test\"\n")
+
+    monkeypatch.setattr(os, "open", fake_open)
+    monkeypatch.setattr(os, "fsync", fake_fsync)
+    monkeypatch.setattr(os, "close", fake_close)
+    monkeypatch.setattr(os, "replace", fake_replace)
+
+    write_config_atomically(target_path, write_config)
+
+    assert target_path.read_bytes() == b"name = \"Test\"\n"
+    assert events == ["fsync_file", "replace", "open_dir", "fsync_dir", "close_dir"]
+
+
+def test_write_config_atomically_keeps_replaced_file_when_parent_fsync_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    target_path = tmp_path / "config.toml"
+    directory_fd = 999_999
+    original_close = os.close
+    original_open = os.open
+
+    def fake_open(
+        path: str | bytes | os.PathLike[str] | os.PathLike[bytes],
+        flags: int,
+        mode: int = 0o777,
+        *,
+        dir_fd: int | None = None,
+    ) -> int:
+        if os.fspath(path) == os.fspath(tmp_path):
+            return directory_fd
+        if dir_fd is None:
+            return original_open(path, flags, mode)
+        return original_open(path, flags, mode, dir_fd=dir_fd)
+
+    def fake_fsync(fd: int) -> None:
+        if fd == directory_fd:
+            raise OSError("directory fsync failed")
+
+    def fake_close(fd: int) -> None:
+        if fd != directory_fd:
+            original_close(fd)
+
+    def write_config(config_file: BinaryIO) -> None:
+        config_file.write(b"name = \"Test\"\n")
+
+    monkeypatch.setattr(os, "open", fake_open)
+    monkeypatch.setattr(os, "fsync", fake_fsync)
+    monkeypatch.setattr(os, "close", fake_close)
+
+    write_config_atomically(target_path, write_config)
+
+    assert target_path.read_bytes() == b"name = \"Test\"\n"

--- a/tests/test_session_hardware.py
+++ b/tests/test_session_hardware.py
@@ -305,6 +305,35 @@ def test_hardware_manager_delete_ignores_stale_cached_path(
     assert HardwareManager().get_hardware("9999:0001") is not None
 
 
+def test_hardware_manager_delete_re_resolves_missing_cached_path(
+    temp_config_dir,
+) -> None:
+    hardware_dir = temp_config_dir / "hardware"
+    custom_path = hardware_dir / "custom.toml"
+    canonical_path = hardware_dir / "1234_5678.toml"
+    _write_minimal_hardware_config(custom_path, name="Custom Mouse")
+    manager = HardwareManager()
+    custom_path.unlink()
+    _write_minimal_hardware_config(canonical_path, name="Canonical Mouse")
+
+    assert manager.delete_hardware("1234:5678") is True
+    assert not canonical_path.exists()
+    assert HardwareManager().get_hardware("1234:5678") is None
+
+
+def test_hardware_manager_delete_returns_false_for_only_stale_cached_path(
+    temp_config_dir,
+) -> None:
+    hardware_dir = temp_config_dir / "hardware"
+    custom_path = hardware_dir / "custom.toml"
+    _write_minimal_hardware_config(custom_path, name="Custom Mouse")
+    manager = HardwareManager()
+    custom_path.unlink()
+
+    assert manager.delete_hardware("1234:5678") is False
+    assert manager.get_hardware("1234:5678") is None
+
+
 def test_hardware_manager_preserves_keymasq_logical_path(temp_config_dir) -> None:
     manager = HardwareManager()
     config = HardwareConfig(

--- a/tests/test_session_hardware.py
+++ b/tests/test_session_hardware.py
@@ -1,4 +1,5 @@
 import logging
+from pathlib import Path
 from typing import BinaryIO
 
 import pytest
@@ -13,6 +14,30 @@ from keymasq.common.models import (
     HardwareConfig,
 )
 from keymasq.session.hardware import HardwareManager
+
+
+def _write_minimal_hardware_config(
+    path: Path,
+    *,
+    name: str,
+    vendor_id: str = "1234",
+    product_id: str = "5678",
+) -> None:
+    path.write_text(
+        f"""
+[hardware]
+name = "{name}"
+vendor_id = "{vendor_id}"
+product_id = "{product_id}"
+
+[hardware.evdev]
+devices = []
+
+[hardware.layout]
+buttons = []
+""".strip(),
+        encoding="utf-8",
+    )
 
 
 def test_hardware_manager_loads_existing_configs(temp_config_dir) -> None:
@@ -193,6 +218,93 @@ def test_hardware_manager_save_load_and_delete_round_trip(temp_config_dir) -> No
     assert manager.delete_hardware("1111:2222") is False
 
 
+def test_hardware_manager_delete_uses_loaded_noncanonical_path(temp_config_dir) -> None:
+    hardware_dir = temp_config_dir / "hardware"
+    custom_path = hardware_dir / "custom.toml"
+    _write_minimal_hardware_config(custom_path, name="Custom Mouse")
+
+    manager = HardwareManager()
+
+    assert manager.delete_hardware("1234:5678") is True
+    assert not custom_path.exists()
+    assert HardwareManager().get_hardware("1234:5678") is None
+
+
+def test_hardware_manager_save_updates_loaded_noncanonical_path(
+    temp_config_dir,
+) -> None:
+    hardware_dir = temp_config_dir / "hardware"
+    custom_path = hardware_dir / "custom.toml"
+    canonical_path = hardware_dir / "1234_5678.toml"
+    _write_minimal_hardware_config(custom_path, name="Custom Mouse")
+    manager = HardwareManager()
+    updated = HardwareConfig(
+        vendor_id="1234",
+        product_id="5678",
+        name="Updated Mouse",
+        evdev_devices=[],
+        buttons=[],
+    )
+
+    manager.save_hardware(updated)
+
+    assert custom_path.exists()
+    assert not canonical_path.exists()
+    assert 'name = "Updated Mouse"' in custom_path.read_text(encoding="utf-8")
+    assert sorted(path.name for path in hardware_dir.glob("*.toml")) == ["custom.toml"]
+    assert HardwareManager().get_hardware("1234:5678") == updated
+
+
+def test_hardware_manager_save_ignores_stale_cached_path(
+    temp_config_dir,
+) -> None:
+    hardware_dir = temp_config_dir / "hardware"
+    custom_path = hardware_dir / "custom.toml"
+    canonical_path = hardware_dir / "1234_5678.toml"
+    _write_minimal_hardware_config(custom_path, name="Custom Mouse")
+    manager = HardwareManager()
+    _write_minimal_hardware_config(
+        custom_path,
+        name="Other Device",
+        vendor_id="9999",
+        product_id="0001",
+    )
+    updated = HardwareConfig(
+        vendor_id="1234",
+        product_id="5678",
+        name="Updated Mouse",
+        evdev_devices=[],
+        buttons=[],
+    )
+
+    manager.save_hardware(updated)
+
+    assert 'name = "Other Device"' in custom_path.read_text(encoding="utf-8")
+    assert 'name = "Updated Mouse"' in canonical_path.read_text(encoding="utf-8")
+    assert HardwareManager().get_hardware("1234:5678") == updated
+    assert HardwareManager().get_hardware("9999:0001") is not None
+
+
+def test_hardware_manager_delete_ignores_stale_cached_path(
+    temp_config_dir,
+) -> None:
+    hardware_dir = temp_config_dir / "hardware"
+    custom_path = hardware_dir / "custom.toml"
+    _write_minimal_hardware_config(custom_path, name="Custom Mouse")
+    manager = HardwareManager()
+    _write_minimal_hardware_config(
+        custom_path,
+        name="Other Device",
+        vendor_id="9999",
+        product_id="0001",
+    )
+
+    assert manager.delete_hardware("1234:5678") is False
+    assert custom_path.exists()
+    assert manager.get_hardware("1234:5678") is None
+    assert HardwareManager().get_hardware("9999:0001") is not None
+
+
 def test_hardware_manager_preserves_keymasq_logical_path(temp_config_dir) -> None:
     manager = HardwareManager()
     config = HardwareConfig(
@@ -310,6 +422,39 @@ def test_hardware_manager_cleans_reserved_path_when_save_fails(
         manager.save_hardware(config)
 
     assert not (temp_config_dir / "hardware" / "1234_5678.toml").exists()
+
+
+def test_hardware_manager_failed_overwrite_preserves_existing_file_and_state(
+    temp_config_dir,
+    sample_hardware_config: HardwareConfig,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = HardwareManager()
+    manager.save_hardware(sample_hardware_config)
+    path = temp_config_dir / "hardware" / "1234_5678.toml"
+    original_content = path.read_bytes()
+    updated_config = HardwareConfig(
+        vendor_id="1234",
+        product_id="5678",
+        name="Updated Mouse",
+        evdev_devices=[],
+        buttons=[],
+    )
+
+    def fail_dump(_data: object, config_file: BinaryIO) -> None:
+        config_file.write(b"[hardware]\nname = \"partial\"\n")
+        raise OSError("disk full")
+
+    monkeypatch.setattr(hardware_module.tomli_w, "dump", fail_dump)
+
+    with pytest.raises(OSError, match="disk full"):
+        manager.save_hardware(updated_config)
+
+    assert path.read_bytes() == original_content
+    assert manager.get_hardware("1234:5678") == sample_hardware_config
+    assert sorted(item.name for item in (temp_config_dir / "hardware").iterdir()) == [
+        "1234_5678.toml"
+    ]
 
 
 def test_hardware_manager_rejects_mismatched_explicit_hardware_id(

--- a/tests/test_session_manager_compositor.py
+++ b/tests/test_session_manager_compositor.py
@@ -152,6 +152,62 @@ async def test_refresh_current_window_clears_stale_window_on_empty_listener_data
 
 
 @pytest.mark.asyncio
+async def test_get_active_window_reevaluates_when_listener_updates_window(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = SessionManager()
+    manager.compositor_state.window_listener = SimpleNamespace(
+        get_active_window=AsyncMock(return_value=("steam", "Game", ["fullscreen"]))
+    )
+    reevaluate_profiles = AsyncMock()
+    monkeypatch.setattr(
+        session_compositor_module.runtime_profiles,
+        "reevaluate_profiles",
+        reevaluate_profiles,
+    )
+
+    result = await session_compositor_module.get_active_window_payload(manager)
+
+    assert result == {
+        "status": "ok",
+        "class": "steam",
+        "title": "Game",
+        "tags": ["fullscreen"],
+    }
+    reevaluate_profiles.assert_awaited_once_with(manager, reason="active window changed")
+
+
+@pytest.mark.asyncio
+async def test_get_active_window_reevaluates_when_listener_clears_window(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = SessionManager()
+    manager.compositor_state.window_listener = SimpleNamespace(
+        get_active_window=AsyncMock(return_value=("", "", []))
+    )
+    manager.compositor_state.current_window = {
+        "class": "Game",
+        "title": "stale",
+        "tags": [],
+    }
+    reevaluate_profiles = AsyncMock()
+    monkeypatch.setattr(
+        session_compositor_module.runtime_profiles,
+        "reevaluate_profiles",
+        reevaluate_profiles,
+    )
+
+    result = await session_compositor_module.get_active_window_payload(manager)
+
+    assert result == {
+        "status": "error",
+        "message": "Active window is unavailable on this compositor",
+    }
+    assert manager.compositor_state.current_window == {}
+    reevaluate_profiles.assert_awaited_once_with(manager, reason="active window changed")
+
+
+@pytest.mark.asyncio
 async def test_compositor_degraded_mode_retries_when_unsupported_or_listener_missing(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_session_manager_compositor.py
+++ b/tests/test_session_manager_compositor.py
@@ -99,6 +99,59 @@ async def test_run_compositor_setup_action_delegates_to_gnome_and_refreshes(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("target_compositor", [None, "wayland"])
+async def test_switch_compositor_clears_stale_window_and_reevaluates(
+    monkeypatch: pytest.MonkeyPatch,
+    target_compositor: str | None,
+) -> None:
+    manager = SessionManager()
+    listener = SimpleNamespace(stop=AsyncMock())
+    manager.compositor_state.window_listener = listener
+    manager.compositor_state.compositor_id = "x11"
+    manager.compositor_state.current_window = {
+        "class": "Game",
+        "title": "stale",
+        "tags": [],
+    }
+
+    async def unsupported(_compositor_id: str | None, _dbus=None) -> bool:
+        return False
+
+    reevaluate_profiles = AsyncMock()
+    monkeypatch.setattr(session_compositor_module, "is_compositor_supported", unsupported)
+    monkeypatch.setattr(
+        session_compositor_module.runtime_profiles,
+        "reevaluate_profiles",
+        reevaluate_profiles,
+    )
+
+    await session_compositor_module.switch_compositor(manager, target_compositor)
+
+    assert manager.compositor_state.current_window == {}
+    assert manager.compositor_state.compositor_id == target_compositor
+    listener.stop.assert_awaited_once()
+    reevaluate_profiles.assert_awaited_once_with(manager, reason="compositor changed")
+
+
+@pytest.mark.asyncio
+async def test_refresh_current_window_clears_stale_window_on_empty_listener_data() -> None:
+    manager = SessionManager()
+    manager.compositor_state.window_listener = SimpleNamespace(
+        get_active_window=AsyncMock(return_value=("", "", []))
+    )
+    manager.compositor_state.current_window = {
+        "class": "Game",
+        "title": "stale",
+        "tags": [],
+    }
+
+    result = await session_compositor_module.refresh_current_window_from_listener(manager)
+
+    assert result is None
+    assert manager.compositor_state.current_window == {}
+
+
+@pytest.mark.asyncio
 async def test_compositor_degraded_mode_retries_when_unsupported_or_listener_missing(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_session_manager_core.py
+++ b/tests/test_session_manager_core.py
@@ -154,6 +154,26 @@ async def test_stop_cancels_tracked_event_tasks() -> None:
 
 
 @pytest.mark.asyncio
+async def test_stop_cancels_grab_retry_tasks(monkeypatch: pytest.MonkeyPatch) -> None:
+    manager = SessionManager()
+    manager.running = True
+    manager.client.disconnect = AsyncMock()  # type: ignore[method-assign]
+    manager.dbus.disconnect = AsyncMock()  # type: ignore[method-assign]
+    reevaluate_profiles = AsyncMock()
+    monkeypatch.setattr(session_profiles_module, "reevaluate_profiles", reevaluate_profiles)
+
+    session_profiles_module.schedule_grab_retry(manager, "1234:5678", delay_s=0.05)
+    retry_task = manager.profile_state.grab_retry_tasks["1234:5678"]
+
+    await manager.stop()
+    await asyncio.sleep(0.1)
+
+    assert manager.profile_state.grab_retry_tasks == {}
+    assert retry_task.done()
+    reevaluate_profiles.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_stop_times_out_hanging_session_client_wait_closed() -> None:
     manager = SessionManager()
     manager.running = True

--- a/tests/test_session_manager_recording.py
+++ b/tests/test_session_manager_recording.py
@@ -230,3 +230,33 @@ async def test_claim_recording_unlock_refresh_blocks_reclaimed_runtime_lease(
             "unlock again to re-establish owner"
         ),
     }
+
+
+@pytest.mark.asyncio
+async def test_refresh_recording_unlock_clears_owner_when_daemon_rejects_lease() -> None:
+    manager = SessionManager()
+    peer = PeerCredentials(pid=12, uid=303, gid=100)
+    writer = object()
+    manager.unlock_state.refresh_owner = {
+        "uid": peer.uid,
+        "pid": peer.pid,
+        "writer_id": id(writer),
+        "lease_id": "lease-1",
+    }
+    manager.client.send_command = AsyncMock(
+        return_value=Response(
+            status="error",
+            error="recording_refresh_denied: runtime unlock lease is not active",
+        )
+    )
+
+    result = await session_recording_module.refresh_recording_unlock(
+        manager,
+        peer,
+        writer,  # type: ignore[arg-type]
+        "lease-1",
+    )
+
+    assert result["status"] == "error"
+    assert result["error_code"] == "recording_refresh_denied"
+    assert manager.unlock_state.refresh_owner is None

--- a/tests/test_socket_server.py
+++ b/tests/test_socket_server.py
@@ -145,6 +145,29 @@ class TestSocketServer:
 
         await server.stop()
 
+    async def test_start_cleans_up_when_socket_hardening_fails(
+        self,
+        monkeypatch,
+        temp_socket_dir,
+    ):
+        real_chmod = os.chmod
+        server = SocketServer(str(paths.SOCKET_PATH), _ok_handler)
+
+        def fail_chmod(_path: str, _mode: int) -> None:
+            raise OSError("chmod failed")
+
+        monkeypatch.setattr(os, "chmod", fail_chmod)
+
+        with pytest.raises(OSError, match="chmod failed"):
+            await server.start()
+
+        assert server.server is None
+        assert not paths.SOCKET_PATH.exists()
+
+        monkeypatch.setattr(os, "chmod", real_chmod)
+        await server.start()
+        await server.stop()
+
     async def test_denied_peer_is_disconnected(self, temp_socket_dir):
         cmd_handler = MockCommandHandler()
         server = SocketServer(
@@ -632,6 +655,7 @@ class TestSocketServer:
 
         await asyncio.wait_for(server.stop(), timeout=1.0)
 
+        assert not paths.SOCKET_PATH.exists()
         assert not server.clients
         assert not server._buffer
         assert not server._client_context

--- a/tests/test_superkeys.py
+++ b/tests/test_superkeys.py
@@ -233,6 +233,99 @@ def test_superkey_manager_rename_to_same_name_keeps_active_config(
     assert (superkeys_dir / "work.toml").exists()
 
 
+def test_superkey_manager_delete_removes_loaded_noncanonical_path(
+    temp_config_dir,
+    monkeypatch,
+) -> None:
+    superkeys_dir = temp_config_dir / "superkeys"
+    superkeys_dir.mkdir()
+    monkeypatch.setattr(paths, "SUPERKEYS_DIR", superkeys_dir)
+    legacy_path = superkeys_dir / "legacy.toml"
+    legacy_path.write_text(
+        """
+name = "Work Mode"
+mode = "pattern"
+
+[[actions.tap]]
+action = "keyboard"
+target = "key_a"
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    manager = SuperkeyManager()
+
+    assert manager.delete_superkey("Work Mode") is True
+    assert not legacy_path.exists()
+    assert SuperkeyManager().get_superkey("Work Mode") is None
+
+
+def test_superkey_manager_rename_removes_loaded_noncanonical_path(
+    temp_config_dir,
+    monkeypatch,
+) -> None:
+    superkeys_dir = temp_config_dir / "superkeys"
+    superkeys_dir.mkdir()
+    monkeypatch.setattr(paths, "SUPERKEYS_DIR", superkeys_dir)
+    legacy_path = superkeys_dir / "legacy.toml"
+    legacy_path.write_text(
+        """
+name = "Work Mode"
+mode = "pattern"
+
+[[actions.tap]]
+action = "keyboard"
+target = "key_a"
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    manager = SuperkeyManager()
+
+    assert manager.rename_superkey("Work Mode", "Focus Mode") is True
+    assert not legacy_path.exists()
+    assert (superkeys_dir / "focus_mode.toml").exists()
+    assert SuperkeyManager().get_superkey("Work Mode") is None
+    assert SuperkeyManager().get_superkey("Focus Mode") is not None
+
+
+def test_superkey_manager_restore_preserves_snapshot_storage_paths(
+    temp_config_dir,
+    monkeypatch,
+) -> None:
+    superkeys_dir = temp_config_dir / "superkeys"
+    superkeys_dir.mkdir()
+    monkeypatch.setattr(paths, "SUPERKEYS_DIR", superkeys_dir)
+    legacy_path = superkeys_dir / "legacy.toml"
+    legacy_path.write_text(
+        """
+name = "Work Mode"
+mode = "pattern"
+
+[[actions.tap]]
+action = "keyboard"
+target = "key_a"
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    manager = SuperkeyManager()
+    snapshot = manager.snapshot_superkeys()
+    canonical_path = superkeys_dir / "work_mode.toml"
+    manager.save_superkey(_pattern_superkey("Work Mode", "key_b"))
+
+    assert canonical_path.exists()
+
+    manager.restore_superkeys(snapshot)
+
+    assert manager.delete_superkey("Work Mode") is True
+    assert not legacy_path.exists()
+    assert canonical_path.exists()
+
+
 def test_superkey_action_roundtrip_preserves_shared_fields() -> None:
     action = MappingAction(
         action_type=ActionType.KEYBOARD,

--- a/tests/test_superkeys.py
+++ b/tests/test_superkeys.py
@@ -261,7 +261,42 @@ target = "key_a"
     assert SuperkeyManager().get_superkey("Work Mode") is None
 
 
-def test_superkey_manager_rename_removes_loaded_noncanonical_path(
+def test_superkey_manager_save_preserves_loaded_noncanonical_path(
+    temp_config_dir,
+    monkeypatch,
+) -> None:
+    superkeys_dir = temp_config_dir / "superkeys"
+    superkeys_dir.mkdir()
+    monkeypatch.setattr(paths, "SUPERKEYS_DIR", superkeys_dir)
+    legacy_path = superkeys_dir / "legacy.toml"
+    canonical_path = superkeys_dir / "work_mode.toml"
+    legacy_path.write_text(
+        """
+name = "Work Mode"
+mode = "pattern"
+
+[[actions.tap]]
+action = "keyboard"
+target = "key_a"
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+    manager = SuperkeyManager()
+    config = manager.get_superkey("Work Mode")
+    assert config is not None
+    config.tap_actions[0].target = "key_b"
+
+    manager.save_superkey(config)
+
+    assert legacy_path.exists()
+    assert not canonical_path.exists()
+    reloaded = SuperkeyManager().get_superkey("Work Mode")
+    assert reloaded is not None
+    assert reloaded.tap_actions[0].target == "key_b"
+
+
+def test_superkey_manager_rename_preserves_loaded_noncanonical_path(
     temp_config_dir,
     monkeypatch,
 ) -> None:
@@ -285,8 +320,9 @@ target = "key_a"
     manager = SuperkeyManager()
 
     assert manager.rename_superkey("Work Mode", "Focus Mode") is True
-    assert not legacy_path.exists()
-    assert (superkeys_dir / "focus_mode.toml").exists()
+    assert legacy_path.exists()
+    assert not (superkeys_dir / "focus_mode.toml").exists()
+    assert 'name = "Focus Mode"' in legacy_path.read_text(encoding="utf-8")
     assert SuperkeyManager().get_superkey("Work Mode") is None
     assert SuperkeyManager().get_superkey("Focus Mode") is not None
 
@@ -317,13 +353,14 @@ target = "key_a"
     canonical_path = superkeys_dir / "work_mode.toml"
     manager.save_superkey(_pattern_superkey("Work Mode", "key_b"))
 
-    assert canonical_path.exists()
+    assert legacy_path.exists()
+    assert not canonical_path.exists()
 
     manager.restore_superkeys(snapshot)
 
     assert manager.delete_superkey("Work Mode") is True
     assert not legacy_path.exists()
-    assert canonical_path.exists()
+    assert not canonical_path.exists()
 
 
 def test_superkey_action_roundtrip_preserves_shared_fields() -> None:


### PR DESCRIPTION
## Summary
- Adds scenario selection and repeat controls to the integration test runner and docs, including `--scenario` and `--repeat` for targeted/retryable VM checks.
- Standardizes terminology/UI/API wording from "recording unlock" to "capture unlock" where actions observe raw hardware input (including GUI status text, docs, tooltips, helper flow, and security notes).
- Hardens unlock-state handling by tracking unreadable/unavailable unlock paths, tightening file mode defaults, and adding explicit capture-recording status command plumbing.
- Improves combo profile mutation safety in GUI: handles stale/missing target profiles and deleted combos, detects duplicate triggers, and saves changes against the correct resolved profile instance.
- Updates runtime combo engine behavior to drop non-matching scoped candidates and handle passthrough/consumption decisions more safely during release/drop transitions.
- Improves async state handling for settings writes and session status refresh to avoid stale in-flight responses and out-of-order state updates.
- Updates CLI macro playback to preserve macro-embedded speed when `--speed` is not provided, while still allowing explicit overrides.
- Expands test coverage substantially across GUI/session/keymasqd/common integration paths and adds focused new tests for scenarios, runtime behavior, and config safety edges.

## Testing
./scripts/integration.sh all
./scripts/check.sh full
clean