### PR TITLE
Extract shared coercion and JSON helper types

### DIFF
--- a/keymasq/cli/commands.py
+++ b/keymasq/cli/commands.py
@@ -1,11 +1,11 @@
 import json
 import socket
 import sys
-from typing import Any, cast
+from typing import cast
 
 from keymasq.common.paths import SESSION_SOCKET_PATH
+from keymasq.common.types import JsonObject
 
-JsonObject = dict[str, Any]
 IntLike = int | float | str | bytes
 DIAGNOSTICS_CATEGORIES = ("mainline", "combo", "internal")
 

--- a/keymasq/common/coercion.py
+++ b/keymasq/common/coercion.py
@@ -66,15 +66,15 @@ def int_or_none(value: object, *, reject_bool: bool = True) -> int | None:
         return None
     try:
         return int(cast(IntLike, value))
-    except (TypeError, ValueError):
+    except (OverflowError, TypeError, ValueError):
         return None
 
 
 def int_value_or_default(value: object, default: int = 0) -> int:
-    """Return int(value), or default for TypeError and ValueError conversion failures."""
+    """Return int(value), or default for OverflowError, TypeError, and ValueError."""
     try:
         return int(cast(IntLike, value))
-    except (TypeError, ValueError):
+    except (OverflowError, TypeError, ValueError):
         return default
 
 
@@ -84,10 +84,10 @@ def int_or_none_value(value: object) -> int | None:
 
 
 def float_value_or_default(value: object, default: float = 0.0) -> float:
-    """Return float(value), or default for TypeError and ValueError conversion failures."""
+    """Return float(value), or default for OverflowError, TypeError, and ValueError."""
     try:
         return float(cast(FloatLike, value))
-    except (TypeError, ValueError):
+    except (OverflowError, TypeError, ValueError):
         return default
 
 
@@ -97,7 +97,7 @@ def int_like(value: object, default: int = 0) -> int:
         return default
     try:
         return int(cast(int | float | str, value))
-    except (TypeError, ValueError):
+    except (OverflowError, TypeError, ValueError):
         return default
 
 
@@ -107,7 +107,7 @@ def float_like(value: object, default: float = 0.0) -> float:
         return default
     try:
         return float(cast(int | float | str, value))
-    except (TypeError, ValueError):
+    except (OverflowError, TypeError, ValueError):
         return default
 
 

--- a/keymasq/common/coercion.py
+++ b/keymasq/common/coercion.py
@@ -7,36 +7,44 @@ type FloatLike = int | float | str | bytes
 
 
 def json_object(value: object) -> JsonObject | None:
+    """Return value as a JSON object when it is a dict, otherwise None."""
     return cast(JsonObject, value) if isinstance(value, dict) else None
 
 
 def json_object_or_empty(value: object) -> JsonObject:
+    """Return value as a JSON object when it is a dict, otherwise an empty dict."""
     return cast(JsonObject, value) if isinstance(value, dict) else {}
 
 
 def require_json_object(value: object) -> JsonObject:
+    """Return value as a JSON object when it is a dict, otherwise raise ValueError."""
     if not isinstance(value, dict):
         raise ValueError("Expected JSON object")
     return cast(JsonObject, value)
 
 
 def json_list(value: object) -> list[object]:
+    """Return value as a list when it is a list, otherwise an empty list."""
     return cast(list[object], value) if isinstance(value, list) else []
 
 
 def str_value(value: object, default: str = "") -> str:
+    """Return default only for None; all other values are converted with str()."""
     return default if value is None else str(value)
 
 
 def int_value(value: object, default: int = 0) -> int:
+    """Return default only for None; invalid int conversions raise TypeError or ValueError."""
     return default if value is None else int(cast(IntLike, value))
 
 
 def float_value(value: object, default: float = 0.0) -> float:
+    """Return default only for None; invalid float conversions raise TypeError or ValueError."""
     return default if value is None else float(cast(FloatLike, value))
 
 
 def optional_str(value: object) -> str | None:
+    """Convert value to stripped text, returning None for None or an empty stripped string."""
     if value is None:
         return None
     text = str(value).strip()
@@ -44,11 +52,17 @@ def optional_str(value: object) -> str | None:
 
 
 def str_or_none(value: object) -> str | None:
+    """Return None only for None; all other values are converted with str() unchanged."""
     return None if value is None else str(value)
 
 
-def int_or_none(value: object) -> int | None:
-    if value is None or isinstance(value, bool):
+def int_or_none(value: object, *, reject_bool: bool = True) -> int | None:
+    """Return None for None or failed int conversion.
+
+    By default, booleans are rejected so JSON true/false are not treated as 1/0; pass
+    reject_bool=False to allow bool conversion.
+    """
+    if value is None or (reject_bool and isinstance(value, bool)):
         return None
     try:
         return int(cast(IntLike, value))
@@ -57,6 +71,7 @@ def int_or_none(value: object) -> int | None:
 
 
 def int_value_or_default(value: object, default: int = 0) -> int:
+    """Return int(value), or default for TypeError and ValueError conversion failures."""
     try:
         return int(cast(IntLike, value))
     except (TypeError, ValueError):
@@ -64,15 +79,12 @@ def int_value_or_default(value: object, default: int = 0) -> int:
 
 
 def int_or_none_value(value: object) -> int | None:
-    if value is None:
-        return None
-    try:
-        return int(cast(IntLike, value))
-    except (TypeError, ValueError):
-        return None
+    """Return int_or_none(value, reject_bool=False) for callers that allow bool conversion."""
+    return int_or_none(value, reject_bool=False)
 
 
 def float_value_or_default(value: object, default: float = 0.0) -> float:
+    """Return float(value), or default for TypeError and ValueError conversion failures."""
     try:
         return float(cast(FloatLike, value))
     except (TypeError, ValueError):
@@ -80,14 +92,27 @@ def float_value_or_default(value: object, default: float = 0.0) -> float:
 
 
 def int_like(value: object, default: int = 0) -> int:
-    return default if value in {None, ""} else int(cast(int | float | str, value))
+    """Return default for None, empty string, or any failed int conversion."""
+    if value in {None, ""}:
+        return default
+    try:
+        return int(cast(int | float | str, value))
+    except (TypeError, ValueError):
+        return default
 
 
 def float_like(value: object, default: float = 0.0) -> float:
-    return default if value in {None, ""} else float(cast(int | float | str, value))
+    """Return default for None, empty string, or any failed float conversion."""
+    if value in {None, ""}:
+        return default
+    try:
+        return float(cast(int | float | str, value))
+    except (TypeError, ValueError):
+        return default
 
 
 def bool_value(value: object) -> bool:
+    """Parse booleans from bools and common truthy strings; other values use bool(value)."""
     if isinstance(value, bool):
         return value
     if isinstance(value, str):

--- a/keymasq/common/coercion.py
+++ b/keymasq/common/coercion.py
@@ -1,0 +1,95 @@
+from typing import cast
+
+from keymasq.common.types import JsonObject
+
+type IntLike = int | float | str | bytes
+type FloatLike = int | float | str | bytes
+
+
+def json_object(value: object) -> JsonObject | None:
+    return cast(JsonObject, value) if isinstance(value, dict) else None
+
+
+def json_object_or_empty(value: object) -> JsonObject:
+    return cast(JsonObject, value) if isinstance(value, dict) else {}
+
+
+def require_json_object(value: object) -> JsonObject:
+    if not isinstance(value, dict):
+        raise ValueError("Expected JSON object")
+    return cast(JsonObject, value)
+
+
+def json_list(value: object) -> list[object]:
+    return cast(list[object], value) if isinstance(value, list) else []
+
+
+def str_value(value: object, default: str = "") -> str:
+    return default if value is None else str(value)
+
+
+def int_value(value: object, default: int = 0) -> int:
+    return default if value is None else int(cast(IntLike, value))
+
+
+def float_value(value: object, default: float = 0.0) -> float:
+    return default if value is None else float(cast(FloatLike, value))
+
+
+def optional_str(value: object) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def str_or_none(value: object) -> str | None:
+    return None if value is None else str(value)
+
+
+def int_or_none(value: object) -> int | None:
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        return int(cast(IntLike, value))
+    except (TypeError, ValueError):
+        return None
+
+
+def int_value_or_default(value: object, default: int = 0) -> int:
+    try:
+        return int(cast(IntLike, value))
+    except (TypeError, ValueError):
+        return default
+
+
+def int_or_none_value(value: object) -> int | None:
+    if value is None:
+        return None
+    try:
+        return int(cast(IntLike, value))
+    except (TypeError, ValueError):
+        return None
+
+
+def float_value_or_default(value: object, default: float = 0.0) -> float:
+    try:
+        return float(cast(FloatLike, value))
+    except (TypeError, ValueError):
+        return default
+
+
+def int_like(value: object, default: int = 0) -> int:
+    return default if value in {None, ""} else int(cast(int | float | str, value))
+
+
+def float_like(value: object, default: float = 0.0) -> float:
+    return default if value in {None, ""} else float(cast(int | float | str, value))
+
+
+def bool_value(value: object) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "on"}
+    return bool(value)

--- a/keymasq/common/macro_compile.py
+++ b/keymasq/common/macro_compile.py
@@ -4,7 +4,8 @@ from typing import cast
 
 import evdev
 
-JsonObject = dict[str, object]
+from keymasq.common.types import JsonObject
+
 IntLike = int | float | str | bytes
 
 _TYPE_MACRO_TEXT_TRANSLATION = str.maketrans(

--- a/keymasq/common/types.py
+++ b/keymasq/common/types.py
@@ -5,7 +5,7 @@ type JsonObject = dict[str, Any]
 type JsonObjectList = list[JsonObject]
 
 
-@dataclass
+@dataclass(init=False)
 class SyntheticInputEvent:
     type: int
     code: int

--- a/keymasq/common/types.py
+++ b/keymasq/common/types.py
@@ -1,0 +1,27 @@
+from dataclasses import dataclass
+from typing import Any
+
+type JsonObject = dict[str, Any]
+type JsonObjectList = list[JsonObject]
+
+
+@dataclass
+class SyntheticInputEvent:
+    type: int
+    code: int
+    value: int
+
+    def __init__(self, event_type: int, code: int, value: int) -> None:
+        self.type = int(event_type)
+        self.code = int(code)
+        self.value = int(value)
+
+
+_SyntheticInputEvent = SyntheticInputEvent
+
+__all__ = [
+    "JsonObject",
+    "JsonObjectList",
+    "SyntheticInputEvent",
+    "_SyntheticInputEvent",
+]

--- a/keymasq/gui/widgets/combo_inspector_window.py
+++ b/keymasq/gui/widgets/combo_inspector_window.py
@@ -11,7 +11,7 @@ gi.require_version("Adw", "1")
 from gi.repository import Adw, Gdk, Gtk, Pango  # pyright: ignore[reportAttributeAccessIssue]
 
 from keymasq.common.coercion import float_value_or_default as _float_value
-from keymasq.common.coercion import int_or_none_value as _int_or_none
+from keymasq.common.coercion import int_or_none as _int_or_none
 from keymasq.common.coercion import int_value_or_default as _int_value
 from keymasq.common.models import (
     DEFAULT_MACRO_LOOP_STOP_BEHAVIOR,
@@ -476,7 +476,10 @@ def _snapshot_signature(snapshot: JsonDict) -> str:
             ]
             steps.append(
                 {
-                    "timeout_ms": _int_or_none(step_payload.get("timeout_ms")),
+                    "timeout_ms": _int_or_none(
+                        step_payload.get("timeout_ms"),
+                        reject_bool=False,
+                    ),
                     "events": events,
                 }
             )
@@ -561,7 +564,7 @@ def _combo_item_from_payload(payload: JsonDict) -> ComboInspectorItem | None:
             search_parts.extend([evdev, hardware_id, source, device_name])
         if not events:
             continue
-        timeout_ms = _int_or_none(step_payload.get("timeout_ms"))
+        timeout_ms = _int_or_none(step_payload.get("timeout_ms"), reject_bool=False)
         if timeout_ms is not None:
             search_parts.append(f"{timeout_ms}ms")
         steps.append(ComboStep(events=events, timeout_ms=timeout_ms))

--- a/keymasq/gui/widgets/combo_inspector_window.py
+++ b/keymasq/gui/widgets/combo_inspector_window.py
@@ -1,7 +1,7 @@
 import json
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Any, cast
+from typing import cast
 
 import gi
 
@@ -10,6 +10,9 @@ gi.require_version("Adw", "1")
 
 from gi.repository import Adw, Gdk, Gtk, Pango  # pyright: ignore[reportAttributeAccessIssue]
 
+from keymasq.common.coercion import float_value_or_default as _float_value
+from keymasq.common.coercion import int_or_none_value as _int_or_none
+from keymasq.common.coercion import int_value_or_default as _int_value
 from keymasq.common.models import (
     DEFAULT_MACRO_LOOP_STOP_BEHAVIOR,
     ActionType,
@@ -766,30 +769,3 @@ def _text(value: object, default: str = "") -> str:
 def _optional_text(value: object) -> str | None:
     text = _text(value).strip()
     return text or None
-
-
-def _int_value(value: object, default: int = 0) -> int:
-    if value is None:
-        return default
-    try:
-        return int(cast(Any, value))
-    except (TypeError, ValueError):
-        return default
-
-
-def _int_or_none(value: object) -> int | None:
-    if value is None:
-        return None
-    try:
-        return int(cast(Any, value))
-    except (TypeError, ValueError):
-        return None
-
-
-def _float_value(value: object, default: float = 0.0) -> float:
-    if value is None:
-        return default
-    try:
-        return float(cast(Any, value))
-    except (TypeError, ValueError):
-        return default

--- a/keymasq/gui/widgets/combo_inspector_window.py
+++ b/keymasq/gui/widgets/combo_inspector_window.py
@@ -476,10 +476,7 @@ def _snapshot_signature(snapshot: JsonDict) -> str:
             ]
             steps.append(
                 {
-                    "timeout_ms": _int_or_none(
-                        step_payload.get("timeout_ms"),
-                        reject_bool=False,
-                    ),
+                    "timeout_ms": _int_or_none(step_payload.get("timeout_ms")),
                     "events": events,
                 }
             )
@@ -564,7 +561,7 @@ def _combo_item_from_payload(payload: JsonDict) -> ComboInspectorItem | None:
             search_parts.extend([evdev, hardware_id, source, device_name])
         if not events:
             continue
-        timeout_ms = _int_or_none(step_payload.get("timeout_ms"), reject_bool=False)
+        timeout_ms = _int_or_none(step_payload.get("timeout_ms"))
         if timeout_ms is not None:
             search_parts.append(f"{timeout_ms}ms")
         steps.append(ComboStep(events=events, timeout_ms=timeout_ms))

--- a/keymasq/gui/widgets/device_inspector_window.py
+++ b/keymasq/gui/widgets/device_inspector_window.py
@@ -8,6 +8,7 @@ gi.require_version("Adw", "1")
 
 from gi.repository import Adw, Gdk, GLib, Gtk, Pango  # pyright: ignore[reportAttributeAccessIssue]
 
+from keymasq.common.coercion import bool_value as _bool_value
 from keymasq.common.models import ActionType, HardwareConfig, MappingAction
 from keymasq.gui.icons import device_icon_names, image_from_icon_names
 from keymasq.gui.session_client import (
@@ -159,15 +160,6 @@ def _int_or_none(value: object) -> int | None:
         return int(cast(int | float | str | bytes, value))
     except (TypeError, ValueError):
         return None
-
-
-def _bool_value(value: object) -> bool:
-    if isinstance(value, bool):
-        return value
-    if isinstance(value, str):
-        return value.strip().lower() in {"1", "true", "yes", "on"}
-    return bool(value)
-
 
 def _mapping_action_from_payload(action: object) -> MappingAction | None:
     if not isinstance(action, dict):

--- a/keymasq/keymasqd/capture_manager.py
+++ b/keymasq/keymasqd/capture_manager.py
@@ -21,10 +21,10 @@ from keymasq.common.devices import (
     resolve_stable_path,
     wheel_button_id,
 )
+from keymasq.common.types import JsonObject
 from keymasq.keymasqd.runtime import device_path_resolver
 
 log = logging.getLogger("keymasq.keymasqd.capture_manager")
-type JsonObject = dict[str, object]
 
 
 class _DeviceInfo(Protocol):

--- a/keymasq/keymasqd/daemon_helpers.py
+++ b/keymasq/keymasqd/daemon_helpers.py
@@ -1,16 +1,10 @@
-from typing import cast
+from keymasq.common.coercion import float_like, int_like, str_value
+from keymasq.common.types import JsonObject, JsonObjectList
 
-type JsonObject = dict[str, object]
-type JsonObjectList = list[JsonObject]
-
-
-def int_like(value: object, default: int = 0) -> int:
-    return default if value in {None, ""} else int(cast(int | float | str, value))
-
-
-def float_like(value: object, default: float = 0.0) -> float:
-    return default if value in {None, ""} else float(cast(int | float | str, value))
-
-
-def str_value(value: object, default: str = "") -> str:
-    return default if value is None else str(value)
+__all__ = [
+    "JsonObject",
+    "JsonObjectList",
+    "float_like",
+    "int_like",
+    "str_value",
+]

--- a/keymasq/keymasqd/daemon_macro_commands.py
+++ b/keymasq/keymasqd/daemon_macro_commands.py
@@ -423,6 +423,11 @@ def _macro_runtime_options(
 
 
 def _strict_int_like(value: object, default: int = 0) -> int:
+    """Convert value to int, returning default when value is None or "".
+
+    Unlike coercion.int_value, this treats empty strings like missing JSON/form fields;
+    otherwise it returns int(value) or lets conversion errors propagate.
+    """
     return default if value in {None, ""} else int(cast(int | float | str, value))
 
 

--- a/keymasq/keymasqd/daemon_macro_commands.py
+++ b/keymasq/keymasqd/daemon_macro_commands.py
@@ -401,23 +401,29 @@ def _macro_runtime_options(
     payload: JsonObject,
     *,
     defaults: MacroRuntimeOptions | None = None,
+    lenient: bool = True,
 ) -> MacroRuntimeOptions:
     if defaults is None:
         defaults = MacroRuntimeOptions()
+    int_value = int_like if lenient else _strict_int_like
     return MacroRuntimeOptions(
         loop_mode=str_value(payload.get("loop_mode", defaults.loop_mode), defaults.loop_mode)
         or defaults.loop_mode,
-        loop_count=int_like(payload.get("loop_count", defaults.loop_count), defaults.loop_count),
+        loop_count=int_value(payload.get("loop_count", defaults.loop_count), defaults.loop_count),
         loop_stop_behavior=normalize_macro_loop_stop_behavior(
             payload.get("loop_stop_behavior", defaults.loop_stop_behavior)
         ),
         move_to_start=bool(payload.get("move_to_start", defaults.move_to_start)),
-        start_x=int_like(payload.get("start_x", defaults.start_x), defaults.start_x),
-        start_y=int_like(payload.get("start_y", defaults.start_y), defaults.start_y),
+        start_x=int_value(payload.get("start_x", defaults.start_x), defaults.start_x),
+        start_y=int_value(payload.get("start_y", defaults.start_y), defaults.start_y),
         block_mouse_movement=bool(
             payload.get("block_mouse_movement", defaults.block_mouse_movement)
         ),
     )
+
+
+def _strict_int_like(value: object, default: int = 0) -> int:
+    return default if value in {None, ""} else int(cast(int | float | str, value))
 
 
 def _macro_playback_options(
@@ -446,7 +452,7 @@ def _macro_playback_options(
 
 def apply_macro_definition(action_data: JsonObject, macro: JsonObject) -> JsonObject:
     updated: JsonObject = dict(action_data)
-    runtime_options = _macro_runtime_options(macro)
+    runtime_options = _macro_runtime_options(macro, lenient=False)
     updated["macro_loop_mode"] = runtime_options.loop_mode
     updated["macro_loop_count"] = runtime_options.loop_count
     updated["macro_loop_stop_behavior"] = runtime_options.loop_stop_behavior

--- a/keymasq/keymasqd/device_manager.py
+++ b/keymasq/keymasqd/device_manager.py
@@ -11,6 +11,10 @@ from typing import Any, Protocol, cast
 import evdev
 
 from keymasq.common import devices as common_devices
+from keymasq.common.coercion import int_or_none_value as _int_or_none
+from keymasq.common.coercion import json_list as _json_list
+from keymasq.common.coercion import json_object as _json_object
+from keymasq.common.coercion import str_or_none as _optional_str
 from keymasq.common.combos import (
     EMERGENCY_CANCEL_COMBO_EVDEVS,
     is_emergency_cancel_combo_evdevs,
@@ -31,6 +35,7 @@ from keymasq.common.models import (
     SuperkeyMode,
     parse_profile_deactivation_policy,
 )
+from keymasq.common.types import JsonObject
 from keymasq.common.virtual_devices import (
     DEFAULT_VIRTUAL_GAMEPADS,
     clamp_virtual_gamepad_count,
@@ -77,7 +82,6 @@ EMERGENCY_CANCEL_COMBO_PROFILE = "__keymasq_internal"
 EMERGENCY_CANCEL_DOUBLE_TAP_WINDOW_MS = 200
 TOPOLOGY_POLL_INTERVAL_S = 0.5
 TOPOLOGY_DEBOUNCE_S = 0.5
-type JsonObject = dict[str, object]
 type BroadcastCallback = Callable[[CommandType, JsonObject], Awaitable[None]]
 type MappingGetter = Callable[[], dict[str, MappingAction]]
 type DeviceEventCallback = Callable[..., Awaitable[ComboDecision | bool | None]]
@@ -115,22 +119,6 @@ class _ManagedInputDevice(Protocol):
 
 
 ASYNCIO_RUNTIME = runtime_adapters.ASYNCIO_RUNTIME
-
-
-def _json_object(value: object) -> JsonObject | None:
-    return cast(JsonObject, value) if isinstance(value, dict) else None
-
-
-def _json_list(value: object) -> list[object]:
-    return cast(list[object], value) if isinstance(value, list) else []
-
-
-def _optional_str(value: object) -> str | None:
-    return None if value is None else str(value)
-
-
-def _int_or_none(value: object) -> int | None:
-    return None if value is None else _int_value(value)
 
 
 def _device_input(path: str) -> _ManagedInputDevice:

--- a/keymasq/keymasqd/device_manager.py
+++ b/keymasq/keymasqd/device_manager.py
@@ -11,7 +11,7 @@ from typing import Any, Protocol, cast
 import evdev
 
 from keymasq.common import devices as common_devices
-from keymasq.common.coercion import int_or_none_value as _int_or_none
+from keymasq.common.coercion import int_or_none
 from keymasq.common.coercion import json_list as _json_list
 from keymasq.common.coercion import json_object as _json_object
 from keymasq.common.coercion import str_or_none as _optional_str
@@ -119,6 +119,10 @@ class _ManagedInputDevice(Protocol):
 
 
 ASYNCIO_RUNTIME = runtime_adapters.ASYNCIO_RUNTIME
+
+
+def _int_or_none(value: object) -> int | None:
+    return int_or_none(value, reject_bool=False)
 
 
 def _device_input(path: str) -> _ManagedInputDevice:

--- a/keymasq/keymasqd/macro_file.py
+++ b/keymasq/keymasqd/macro_file.py
@@ -7,8 +7,8 @@ from datetime import datetime
 from pathlib import Path
 from typing import BinaryIO, cast
 
-from keymasq.common.config_files import write_config_atomically
 from keymasq.common.coercion import require_json_object as _json_object
+from keymasq.common.config_files import write_config_atomically
 from keymasq.common.models import DEFAULT_MACRO_LOOP_STOP_BEHAVIOR
 from keymasq.common.types import JsonObject
 

--- a/keymasq/keymasqd/macro_file.py
+++ b/keymasq/keymasqd/macro_file.py
@@ -8,13 +8,14 @@ from pathlib import Path
 from typing import BinaryIO, cast
 
 from keymasq.common.config_files import write_config_atomically
+from keymasq.common.coercion import require_json_object as _json_object
 from keymasq.common.models import DEFAULT_MACRO_LOOP_STOP_BEHAVIOR
+from keymasq.common.types import JsonObject
 
 MACRO_FILE_SUFFIX = ".kmacro.xz"
 MACRO_FILE_FORMAT = "keymasq-macro"
 MACRO_FILE_VERSION = 1
 
-type JsonObject = dict[str, object]
 type MacroEvent = dict[str, object]
 
 
@@ -162,13 +163,6 @@ def _open_text(path: Path, mode: str) -> io.TextIOWrapper:
 
 def _json_line(value: JsonObject) -> str:
     return json.dumps(value, separators=(",", ":")) + "\n"
-
-
-def _json_object(value: object) -> JsonObject:
-    if not isinstance(value, dict):
-        raise ValueError("Expected JSON object")
-    return cast(JsonObject, value)
-
 
 def _validate_meta_record(record: JsonObject) -> None:
     if record.get("format") != MACRO_FILE_FORMAT:

--- a/keymasq/keymasqd/recording.py
+++ b/keymasq/keymasqd/recording.py
@@ -12,6 +12,8 @@ from typing import Protocol, cast
 
 import evdev
 
+from keymasq.common.coercion import int_value_or_default as _int_value
+from keymasq.common.coercion import str_value as _str_value
 from keymasq.common.devices import (
     classify_event_device_type,
     high_res_wheel_low_res_code,
@@ -663,18 +665,6 @@ def _is_wheel_event(event: evdev.InputEvent) -> bool:
     return event.code in (evdev.ecodes.REL_WHEEL, evdev.ecodes.REL_HWHEEL) or (
         high_res_wheel_low_res_code(int(event.code)) is not None
     )
-
-
-def _str_value(value: object, default: str = "") -> str:
-    return default if value is None else str(value)
-
-
-def _int_value(value: object, default: int = 0) -> int:
-    try:
-        return int(cast(int | float | str, value))
-    except (TypeError, ValueError):
-        return default
-
 
 def _physical_source_key(stable_path: str) -> str:
     return f"physical:{stable_path}"

--- a/keymasq/keymasqd/runtime/action_runner.py
+++ b/keymasq/keymasqd/runtime/action_runner.py
@@ -10,6 +10,7 @@ from keymasq.common.models import (
     normalize_macro_loop_stop_behavior,
     profile_deactivation_policy_to_dict,
 )
+from keymasq.common.types import JsonObject, SyntheticInputEvent
 from keymasq.keymasqd.output_helpers import (
     resolve_gamepad_axis_code,
     resolve_output_code,
@@ -55,12 +56,13 @@ from keymasq.keymasqd.runtime.repeat import (
     select_repeated_entry,
 )
 
-type JsonObject = dict[str, object]
 type BroadcastCallback = Callable[[CommandType, JsonObject], Awaitable[None]]
 type FireAndObserve = Callable[[Awaitable[object], str], asyncio.Task[object]]
 type OutputTracker = Callable[[str, int, int], bool]
 type ResolveCodeFn = Callable[[str], int | None]
 type CancelMacroPlayback = Callable[[], Awaitable[JsonObject]]
+
+_SyntheticInputEvent = SyntheticInputEvent
 
 
 class SuperkeyExecutor(Protocol):
@@ -631,14 +633,6 @@ def _dispatch_trigger_action(
     )
     register_action_task(execution_handle, task)
     return True
-
-
-class _SyntheticInputEvent:
-    def __init__(self, event_type: int, code: int, value: int) -> None:
-        self.type = int(event_type)
-        self.code = int(code)
-        self.value = int(value)
-
 
 async def _execute_repeat_action(
     device_runtime: ActionRuntime,

--- a/keymasq/keymasqd/runtime/actions.py
+++ b/keymasq/keymasqd/runtime/actions.py
@@ -21,9 +21,8 @@ from keymasq.common.models import (
 from keymasq.common.models import (
     SuperkeyConfig as CommonSuperkeyConfig,
 )
+from keymasq.common.types import JsonObject
 from keymasq.keymasqd.superkey_state import SuperkeyActionData, SuperkeyConfig
-
-type JsonObject = dict[str, object]
 
 log = logging.getLogger("keymasqd.runtime.actions")
 

--- a/keymasq/keymasqd/runtime/analog_controls.py
+++ b/keymasq/keymasqd/runtime/analog_controls.py
@@ -2,7 +2,6 @@ import asyncio
 import logging
 import math
 import time
-from dataclasses import dataclass
 from typing import cast
 
 from keymasq.common.devices import resolve_evdev_code
@@ -15,6 +14,7 @@ from keymasq.common.models import (
     analog_control_primary_mode,
     analog_gamepad_output_distance,
 )
+from keymasq.common.types import SyntheticInputEvent as _SyntheticInputEvent
 from keymasq.keymasqd.runtime import grabbed_device_actions as runtime_actions
 from keymasq.keymasqd.runtime.action_runner import source_trigger_id
 from keymasq.keymasqd.runtime.grabbed_device_outputs import (
@@ -42,14 +42,6 @@ TRIGGER_OUTPUT_AXES = {
     "left_trigger": "ABS_Z",
     "right_trigger": "ABS_RZ",
 }
-
-
-@dataclass
-class _SyntheticInputEvent:
-    type: int
-    code: int
-    value: int
-
 
 def normalize_axis_value(
     raw_value: int,

--- a/keymasq/keymasqd/runtime/combos.py
+++ b/keymasq/keymasqd/runtime/combos.py
@@ -58,7 +58,6 @@ from keymasq.keymasqd.superkey_state import SuperkeyMachine
 
 log = logging.getLogger("keymasqd.runtime.combos")
 
-type JsonObject = dict[str, object]
 type IntValueFn = Callable[..., int]
 type StrValueFn = Callable[..., str]
 type ResolveStablePathFn = Callable[[str], str]

--- a/keymasq/keymasqd/runtime/device_path_resolver.py
+++ b/keymasq/keymasqd/runtime/device_path_resolver.py
@@ -18,10 +18,10 @@ from keymasq.common.devices import (
     resolve_stable_path,
 )
 from keymasq.common.models import DeviceType
+from keymasq.common.types import JsonObject
 from keymasq.keymasqd.runtime.adapters import close_device
 
 log = logging.getLogger("keymasqd.device_path_resolver")
-type JsonObject = dict[str, object]
 
 
 class _DeviceInfo(Protocol):

--- a/keymasq/keymasqd/runtime/grab_lifecycle.py
+++ b/keymasq/keymasqd/runtime/grab_lifecycle.py
@@ -7,6 +7,7 @@ import evdev
 
 from keymasq.common.devices import resolve_evdev_code, resolve_evdev_event_type
 from keymasq.common.models import MappingAction
+from keymasq.common.types import JsonObject
 from keymasq.keymasqd.combo_engine import ComboDecision
 from keymasq.keymasqd.output_helpers import resolve_output_code
 from keymasq.keymasqd.runtime import actions as runtime_actions
@@ -16,7 +17,6 @@ from keymasq.keymasqd.runtime import device_path_resolver
 from keymasq.keymasqd.runtime import outputs as runtime_outputs
 
 log = logging.getLogger("keymasqd.devices")
-type JsonObject = dict[str, object]
 type JsonObjectFn = Callable[[object], JsonObject | None]
 type StrValueFn = Callable[..., str]
 type OptionalStrFn = Callable[..., str | None]

--- a/keymasq/keymasqd/runtime/grabbed_device_actions.py
+++ b/keymasq/keymasqd/runtime/grabbed_device_actions.py
@@ -4,6 +4,7 @@ from typing import cast
 
 from keymasq.common.ipc import CommandType
 from keymasq.common.models import ActionType, MappingAction, SuperkeyMode
+from keymasq.common.types import SyntheticInputEvent as _SyntheticInputEvent
 from keymasq.keymasqd.output_helpers import resolve_output_code
 from keymasq.keymasqd.runtime import action_runner as shared_action_runner
 from keymasq.keymasqd.runtime.action_runner import (
@@ -172,14 +173,6 @@ async def execute_action_pulse(
         shared_abs_output_tracker=shared_abs_output_tracker,
         record_repeat=False,
     )
-
-
-class _SyntheticInputEvent:
-    def __init__(self, event_type: int, code: int, value: int) -> None:
-        self.type = int(event_type)
-        self.code = int(code)
-        self.value = int(value)
-
 
 def _observe_overload_profile_trigger(
     device_runtime: GrabbedDeviceRuntime,

--- a/keymasq/keymasqd/runtime/grabbed_device_events.py
+++ b/keymasq/keymasqd/runtime/grabbed_device_events.py
@@ -3,7 +3,6 @@ import contextlib
 import logging
 import time
 from collections.abc import Awaitable, Callable
-from dataclasses import dataclass
 from typing import cast
 
 import evdev
@@ -18,6 +17,7 @@ from keymasq.common.devices import (
     wheel_button_id,
 )
 from keymasq.common.models import ActionType, MappingAction
+from keymasq.common.types import SyntheticInputEvent as _SyntheticInputEvent
 from keymasq.keymasqd.combo_engine import ComboDecision
 from keymasq.keymasqd.runtime import analog_controls as runtime_analog_controls
 from keymasq.keymasqd.runtime import grabbed_device_actions as runtime_actions
@@ -36,13 +36,6 @@ from keymasq.keymasqd.runtime.grabbed_device_types import (
     identity_uinput_writer,
     runtime_is_running,
 )
-
-
-@dataclass
-class _SyntheticInputEvent:
-    type: int
-    code: int
-    value: int
 
 
 def _fire_and_observe(coro: Awaitable[object], label: str) -> asyncio.Task[object]:

--- a/keymasq/keymasqd/runtime/macros.py
+++ b/keymasq/keymasqd/runtime/macros.py
@@ -13,7 +13,6 @@ from keymasq.common.models import (
 )
 from keymasq.keymasqd.runtime.grabbed_device_outputs import syn_if_passthrough_frame_closed
 
-type JsonObject = dict[str, object]
 type IntValueFn = Callable[[object, int], int]
 type StrValueFn = Callable[[object, str], str]
 type _MacroManager = Any

--- a/keymasq/keymasqd/runtime/profile_activation_tracker.py
+++ b/keymasq/keymasqd/runtime/profile_activation_tracker.py
@@ -5,8 +5,8 @@ from collections.abc import Callable
 from dataclasses import dataclass
 
 from keymasq.common.models import ProfileDeactivationPolicy
+from keymasq.common.types import JsonObject
 
-type JsonObject = dict[str, object]
 type BroadcastDeactivateRequest = Callable[[JsonObject], None]
 
 log = logging.getLogger("keymasqd.runtime.profile_activation_tracker")

--- a/keymasq/keymasqd/runtime/topology.py
+++ b/keymasq/keymasqd/runtime/topology.py
@@ -6,10 +6,10 @@ from dataclasses import dataclass
 from typing import Any
 
 from keymasq.common.ipc import CommandType
+from keymasq.common.types import JsonObject
 from keymasq.keymasqd.runtime import adapters as runtime_adapters
 from keymasq.keymasqd.runtime import device_path_resolver
 
-type JsonObject = dict[str, object]
 type Snapshot = dict[str, Any]
 type _TopologyManager = Any
 type ClearDevicePathCacheFn = Callable[[], None]

--- a/keymasq/keymasqd/socket_server.py
+++ b/keymasq/keymasqd/socket_server.py
@@ -12,9 +12,9 @@ from keymasq.common.ipc import (
     encode_response,
 )
 from keymasq.common.security import PeerCredentials, get_peer_credentials
+from keymasq.common.types import JsonObject
 
 log = logging.getLogger("keymasqd.socket")
-type JsonObject = dict[str, object]
 
 
 @dataclass

--- a/keymasq/keymasqd/superkey_state.py
+++ b/keymasq/keymasqd/superkey_state.py
@@ -20,6 +20,7 @@ from keymasq.common.models import (
     normalize_profile_deactivation_policy,
     superkey_action_shared_kwargs,
 )
+from keymasq.common.types import SyntheticInputEvent as _SyntheticInputEvent
 from keymasq.keymasqd.runtime.mouse_actions import (
     emit_relative_pulse,
     rapidfire_relative_pulses,
@@ -558,10 +559,3 @@ class SuperkeyMachine:
             action_type=ActionType(action.action_type),
             **action_kwargs,
         )
-
-
-class _SyntheticInputEvent:
-    def __init__(self, event_type: int, code: int, value: int) -> None:
-        self.type = int(event_type)
-        self.code = int(code)
-        self.value = int(value)

--- a/keymasq/session/action_toml.py
+++ b/keymasq/session/action_toml.py
@@ -1,6 +1,8 @@
 import logging
 from typing import Literal, cast
 
+from keymasq.common.coercion import float_value as _float_value
+from keymasq.common.coercion import int_value as _int_value
 from keymasq.common.gamepad_axes import gamepad_axis_max_value
 from keymasq.common.models import (
     ActionType,
@@ -15,8 +17,6 @@ from keymasq.common.models import (
 )
 
 type TomlDict = dict[str, object]
-type _IntLike = int | float | str | bytes
-type _FloatLike = int | float | str | bytes
 type UnknownActionPolicy = Literal["raise", "passthrough"]
 
 MACRO_RECORDING_SLOT_ACTION_TYPES: tuple[ActionType, ...] = (
@@ -38,29 +38,6 @@ PROFILE_REF_ACTION_TYPES: tuple[ActionType, ...] = (
 
 class UnknownActionTypeError(ValueError):
     pass
-
-
-def _int_value(value: object, default: int) -> int:
-    if value is None:
-        return default
-    try:
-        return int(cast(_IntLike, value))
-    except (TypeError, ValueError) as exc:
-        raise ValueError(
-            f"Expected integer value, got {type(value).__name__}: {value!r}"
-        ) from exc
-
-
-def _float_value(value: object, default: float) -> float:
-    if value is None:
-        return default
-    try:
-        return float(cast(_FloatLike, value))
-    except (TypeError, ValueError) as exc:
-        raise ValueError(
-            f"Expected float value, got {type(value).__name__}: {value!r}"
-        ) from exc
-
 
 def mapping_action_type_from_toml(
     action_data: TomlDict,

--- a/keymasq/session/analog_controls.py
+++ b/keymasq/session/analog_controls.py
@@ -7,9 +7,9 @@ from typing import BinaryIO, cast
 import tomli_w
 
 from keymasq.common import paths
-from keymasq.common.config_files import write_config_atomically
 from keymasq.common.coercion import float_value as _float_value
 from keymasq.common.coercion import int_value as _int_value
+from keymasq.common.config_files import write_config_atomically
 from keymasq.common.models import (
     ActionType,
     AnalogActionThreshold,

--- a/keymasq/session/analog_controls.py
+++ b/keymasq/session/analog_controls.py
@@ -8,6 +8,8 @@ import tomli_w
 
 from keymasq.common import paths
 from keymasq.common.config_files import write_config_atomically
+from keymasq.common.coercion import float_value as _float_value
+from keymasq.common.coercion import int_value as _int_value
 from keymasq.common.models import (
     ActionType,
     AnalogActionThreshold,
@@ -30,8 +32,6 @@ from keymasq.session.config_loading import load_config_files_sync
 
 log = logging.getLogger("keymasq-session.analog_controls")
 type TomlDict = dict[str, object]
-type _IntLike = int | float | str | bytes
-type _FloatLike = int | float | str | bytes
 
 
 @dataclass
@@ -47,15 +47,6 @@ def _as_toml_dict(value: object) -> TomlDict | None:
 def _toml_str(data: TomlDict, key: str, default: str | None = None) -> str | None:
     value = data.get(key, default)
     return value if isinstance(value, str) else default
-
-
-def _int_value(value: object, default: int = 0) -> int:
-    return default if value is None else int(cast(_IntLike, value))
-
-
-def _float_value(value: object, default: float = 0.0) -> float:
-    return default if value is None else float(cast(_FloatLike, value))
-
 
 class AnalogControlManager:
     def __init__(self) -> None:

--- a/keymasq/session/listeners/gnome.py
+++ b/keymasq/session/listeners/gnome.py
@@ -4,11 +4,14 @@ import json
 import logging
 import os
 from pathlib import Path
-from typing import cast
 
 import keymasq.session.gnome_shell as gnome_shell
+from keymasq.common.coercion import int_value as _int_value
+from keymasq.common.coercion import json_object as _json_object
+from keymasq.common.coercion import str_value as _str_value
 from keymasq.common.paths import GNOME_BRIDGE_SOCKET_PATH
 from keymasq.common.security import get_peer_credentials
+from keymasq.common.types import JsonObject
 from keymasq.session.dbus import SessionDBus, name_has_owner
 from keymasq.session.gnome_shell import GnomeShellDBusError
 from keymasq.session.listeners._socket_helpers import (
@@ -19,19 +22,6 @@ from keymasq.session.listeners.base import WindowChangeCallback, WindowListener
 from keymasq.session.wayland_protocols.registry_probe import list_registry_globals
 
 log = logging.getLogger("keymasq-session.listeners.gnome")
-type JsonObject = dict[str, object]
-
-
-def _json_object(value: object) -> JsonObject | None:
-    return cast(JsonObject, value) if isinstance(value, dict) else None
-
-
-def _str_value(value: object, default: str = "") -> str:
-    return default if value is None else str(value)
-
-
-def _int_value(value: object, default: int = 0) -> int:
-    return default if value is None else int(cast(int | float | str | bytes, value))
 
 
 class GnomeListener(WindowListener):

--- a/keymasq/session/listeners/kde.py
+++ b/keymasq/session/listeners/kde.py
@@ -15,11 +15,11 @@ from dbus_next.constants import MessageType
 from dbus_next.message import Message
 from dbus_next.service import ServiceInterface, method
 
+from keymasq.common.types import JsonObject
 from keymasq.session.dbus import SessionDBus, name_has_owner
 from keymasq.session.listeners.base import WindowChangeCallback, WindowListener
 
 log = logging.getLogger("keymasq-session.listeners.kde")
-type JsonObject = dict[str, object]
 s = str
 
 KDE_DBUS_INTERFACE = "keymasq.kde.Listener"

--- a/keymasq/session/listeners/niri.py
+++ b/keymasq/session/listeners/niri.py
@@ -9,7 +9,10 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import cast
 
+from keymasq.common.coercion import int_or_none as _int_or_none
+from keymasq.common.coercion import json_object as _json_object
 from keymasq.common.slurp import get_slurp_capture
+from keymasq.common.types import JsonObject
 from keymasq.session.dbus import SessionDBus
 from keymasq.session.listeners._socket_helpers import unix_socket_connectable
 from keymasq.session.listeners.base import WindowChangeCallback, WindowListener
@@ -17,18 +20,12 @@ from keymasq.session.slurp import capture_slurp_cursor_position
 
 log = logging.getLogger("keymasq-session.listeners.niri")
 
-type JsonObject = dict[str, object]
 type NiriDispatchBuilder = Callable[[str], tuple[bool, str, JsonObject | None]]
 
 NIRI_DISPATCH_TIMEOUT_SECONDS = 1.5
 NIRI_FOCUSED_WINDOW_TIMEOUT_SECONDS = 0.6
 NIRI_ACTIVATE_TIMEOUT_SECONDS = 2.0
 NIRI_CLI_DISPATCH_TIMEOUT_SECONDS = 3.0
-
-
-def _json_object(value: object) -> JsonObject | None:
-    return cast(JsonObject, value) if isinstance(value, dict) else None
-
 
 def _normalize_string(value: object) -> str:
     if isinstance(value, str):
@@ -362,7 +359,7 @@ class NiriListener(WindowListener):
             return
 
         if event_type == "WindowClosed":
-            window_id = self._int_value(body.get("id"))
+            window_id = _int_or_none(body.get("id"))
             if window_id is None:
                 return
             self._windows.pop(window_id, None)
@@ -372,20 +369,12 @@ class NiriListener(WindowListener):
             return
 
         if event_type == "WindowFocusChanged":
-            focused_window_id = self._int_value(body.get("id"))
+            focused_window_id = _int_or_none(body.get("id"))
             self._mark_window_focused(focused_window_id)
             await self._emit_current_window_if_changed()
 
     def _window_id(self, window: JsonObject) -> int | None:
-        return self._int_value(window.get("id"))
-
-    def _int_value(self, value: object) -> int | None:
-        if isinstance(value, bool) or value is None:
-            return None
-        try:
-            return int(cast(int | float | str, value))
-        except Exception:
-            return None
+        return _int_or_none(window.get("id"))
 
     def _window_info(self, window: JsonObject | None) -> tuple[str, str]:
         if window is None:

--- a/keymasq/session/manager/common.py
+++ b/keymasq/session/manager/common.py
@@ -1,30 +1,22 @@
-from typing import cast
-
+from keymasq.common.coercion import (
+    float_value,
+    int_value,
+    json_list,
+    json_object,
+    str_value,
+)
+from keymasq.common.types import JsonObject
 from keymasq.session.listeners.base import WindowListener
 
-type JsonObject = dict[str, object]
-type IntLike = int | float | str | bytes
-type FloatLike = int | float | str | bytes
-
-
-def json_object(value: object) -> JsonObject | None:
-    return cast(JsonObject, value) if isinstance(value, dict) else None
-
-
-def json_list(value: object) -> list[object]:
-    return cast(list[object], value) if isinstance(value, list) else []
-
-
-def str_value(value: object, default: str = "") -> str:
-    return default if value is None else str(value)
-
-
-def int_value(value: object, default: int = 0) -> int:
-    return default if value is None else int(cast(IntLike, value))
-
-
-def float_value(value: object, default: float = 0.0) -> float:
-    return default if value is None else float(cast(FloatLike, value))
+__all__ = [
+    "JsonObject",
+    "float_value",
+    "int_value",
+    "json_list",
+    "json_object",
+    "merge_support_details",
+    "str_value",
+]
 
 
 def merge_support_details(

--- a/keymasq/session/manager/recording.py
+++ b/keymasq/session/manager/recording.py
@@ -1557,7 +1557,7 @@ def load_recording_settings_from_disk(manager: "SessionManager") -> None:
         if not manager.RECORDING_SETTINGS_PATH.exists():
             return
         with manager.RECORDING_SETTINGS_PATH.open("rb") as f:
-            data = cast(JsonObject, tomllib.load(f))
+            data = tomllib.load(f)
         settings = manager.recording_state.settings
         if "include_mouse_movement" in data:
             settings["include_mouse_movement"] = bool(data.get("include_mouse_movement"))

--- a/keymasq/session/profiles.py
+++ b/keymasq/session/profiles.py
@@ -11,6 +11,8 @@ from pathlib import Path
 from typing import TYPE_CHECKING, cast
 
 from keymasq.common import paths
+from keymasq.common.coercion import int_value as _int_value
+from keymasq.common.coercion import optional_str as _optional_str
 from keymasq.common.combos import normalize_combo_evdev, normalize_combo_restore_keys
 from keymasq.common.config_files import write_toml_atomically
 from keymasq.common.models import (
@@ -35,7 +37,6 @@ log = logging.getLogger("keymasq-session.profiles")
 MAX_PROFILE_PATH_ATTEMPTS = 10000
 DEFAULT_PROFILE_NAME = "Default"
 type TomlDict = dict[str, object]
-type _IntLike = int | float | str | bytes
 
 
 def _as_toml_dict(value: object) -> TomlDict | None:
@@ -44,18 +45,6 @@ def _as_toml_dict(value: object) -> TomlDict | None:
 
 def _as_toml_list(value: object) -> list[object]:
     return cast(list[object], value) if isinstance(value, list) else []
-
-
-def _int_value(value: object, default: int) -> int:
-    return default if value is None else int(cast(_IntLike, value))
-
-
-def _optional_str(value: object) -> str | None:
-    if value is None:
-        return None
-    text = str(value).strip()
-    return text or None
-
 
 @dataclass
 class ProfileInfo:

--- a/tests/keymasqd/test_daemon_helpers.py
+++ b/tests/keymasqd/test_daemon_helpers.py
@@ -5,6 +5,7 @@ def test_int_like_uses_default_for_none_and_empty_string() -> None:
     assert int_like(None) == 0
     assert int_like(None, 7) == 7
     assert int_like("", 7) == 7
+    assert int_like("bad", 7) == 7
     assert int_like("3", 7) == 3
 
 
@@ -12,6 +13,7 @@ def test_float_like_uses_default_for_none_and_empty_string() -> None:
     assert float_like(None) == 0.0
     assert float_like(None, 1.5) == 1.5
     assert float_like("", 1.5) == 1.5
+    assert float_like("bad", 1.5) == 1.5
     assert float_like("2.25", 1.5) == 2.25
 
 


### PR DESCRIPTION
## Summary
- Added `keymasq/common/coercion.py` for shared JSON/coercion helpers used across CLI, daemon, runtime, session, and GUI code.
- Added `keymasq/common/types.py` for shared `JsonObject`, `JsonObjectList`, and `SyntheticInputEvent` definitions.
- Replaced duplicated local helper/type definitions in 30+ modules while preserving compatibility re-exports from `keymasq/keymasqd/daemon_helpers.py` and `keymasq/session/manager/common.py`.

## Validation
- `./scripts/check.sh`
  - ruff: ok
  - basedpyright: ok
  - stylelint: ok
  - pytest: ok - 1778 passed, 25 skipped, 3 warnings