### PR TITLE
Unify atomic config persistence

### DIFF
--- a/keymasq/common/config_files.py
+++ b/keymasq/common/config_files.py
@@ -1,0 +1,63 @@
+import contextlib
+import os
+import tempfile
+from collections.abc import Callable
+from pathlib import Path
+from typing import BinaryIO, cast
+
+import tomli_w
+
+
+def fsync_parent_dir(path: Path) -> None:
+    with contextlib.suppress(OSError):
+        dir_fd = os.open(path.parent, os.O_RDONLY | os.O_DIRECTORY)
+        try:
+            os.fsync(dir_fd)
+        finally:
+            os.close(dir_fd)
+
+
+def write_config_atomically(
+    path: Path,
+    write: Callable[[BinaryIO], None],
+    *,
+    overwrite: bool = True,
+    temp_suffix: str = "",
+) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, temp_name = tempfile.mkstemp(
+        prefix=f".{path.name}.",
+        suffix=temp_suffix,
+        dir=path.parent,
+    )
+    temp_path: Path | None = Path(temp_name)
+    try:
+        with os.fdopen(fd, "wb") as config_file:
+            binary_file = cast(BinaryIO, config_file)
+            write(binary_file)
+            binary_file.flush()
+            os.fsync(binary_file.fileno())
+
+        if overwrite:
+            os.replace(temp_path, path)
+        else:
+            os.link(temp_path, path)
+            temp_path.unlink()
+        temp_path = None
+        fsync_parent_dir(path)
+    finally:
+        if temp_path is not None:
+            with contextlib.suppress(FileNotFoundError):
+                temp_path.unlink()
+
+
+def write_toml_atomically(
+    path: Path,
+    data: dict[str, object],
+    *,
+    overwrite: bool = True,
+) -> None:
+    def write(config_file: BinaryIO) -> None:
+        tomli_w.dump(data, config_file)
+
+    write_config_atomically(path, write, overwrite=overwrite)

--- a/keymasq/common/config_files.py
+++ b/keymasq/common/config_files.py
@@ -9,12 +9,11 @@ import tomli_w
 
 
 def fsync_parent_dir(path: Path) -> None:
-    with contextlib.suppress(OSError):
-        dir_fd = os.open(path.parent, os.O_RDONLY | os.O_DIRECTORY)
-        try:
-            os.fsync(dir_fd)
-        finally:
-            os.close(dir_fd)
+    dir_fd = os.open(path.parent, os.O_RDONLY | os.O_DIRECTORY)
+    try:
+        os.fsync(dir_fd)
+    finally:
+        os.close(dir_fd)
 
 
 def write_config_atomically(

--- a/keymasq/gui/preferences.py
+++ b/keymasq/gui/preferences.py
@@ -3,9 +3,8 @@ import tomllib
 from pathlib import Path
 from typing import Literal, cast
 
-import tomli_w
-
 from keymasq.common import paths
+from keymasq.common.config_files import write_toml_atomically
 
 log = logging.getLogger(__name__)
 
@@ -36,8 +35,7 @@ def _load_settings() -> dict[str, object]:
 
 def _save_settings(data: dict[str, object]) -> None:
     paths.ensure_config_dirs()
-    with _settings_path().open("wb") as f:
-        tomli_w.dump(data, f)
+    write_toml_atomically(_settings_path(), data)
 
 
 def load_appearance_mode() -> AppearanceMode:

--- a/keymasq/keymasqd/macro_file.py
+++ b/keymasq/keymasqd/macro_file.py
@@ -1,14 +1,13 @@
 import io
 import json
 import lzma
-import os
-import secrets
 from collections.abc import Iterable, Iterator
 from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
-from typing import cast
+from typing import BinaryIO, cast
 
+from keymasq.common.config_files import write_config_atomically
 from keymasq.common.models import DEFAULT_MACRO_LOOP_STOP_BEHAVIOR
 
 MACRO_FILE_SUFFIX = ".kmacro.xz"
@@ -121,28 +120,15 @@ def write_macro(
     *,
     overwrite: bool = True,
 ) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    fd, tmp_path = _open_private_temp(path)
-    fileobj: io.BufferedWriter | None = None
-    try:
-        fileobj = os.fdopen(fd, "wb")
+    def write(fileobj: BinaryIO) -> None:
         with lzma.LZMAFile(fileobj, "wb") as raw:
             with io.TextIOWrapper(raw, encoding="utf-8", newline="\n") as f:
                 f.write(_json_line(meta.to_record()))
                 for event in events:
                     f.write(_json_line(event))
-        fileobj.flush()
-        os.fsync(fd)
-        _commit_temp_macro(tmp_path, path, overwrite=overwrite)
-        path.chmod(0o600)
-    except Exception:
-        tmp_path.unlink(missing_ok=True)
-        raise
-    finally:
-        if fileobj is None:
-            os.close(fd)
-        else:
-            fileobj.close()
+
+    write_config_atomically(path, write, overwrite=overwrite, temp_suffix=".tmp")
+    path.chmod(0o600)
 
 
 def macro_payload_from_events(
@@ -172,32 +158,6 @@ def macro_payload_from_events(
 def _open_text(path: Path, mode: str) -> io.TextIOWrapper:
     raw = lzma.LZMAFile(path, mode)
     return io.TextIOWrapper(raw, encoding="utf-8", newline="\n")
-
-
-def _open_private_temp(path: Path) -> tuple[int, Path]:
-    flags = os.O_CREAT | os.O_EXCL | os.O_WRONLY
-    if hasattr(os, "O_CLOEXEC"):
-        flags |= os.O_CLOEXEC
-    if hasattr(os, "O_NOFOLLOW"):
-        flags |= os.O_NOFOLLOW
-
-    for _ in range(100):
-        tmp_path = path.with_name(f".{path.name}.{secrets.token_hex(16)}.tmp")
-        try:
-            fd = os.open(tmp_path, flags, 0o600)
-        except FileExistsError:
-            continue
-        os.fchmod(fd, 0o600)
-        return fd, tmp_path
-    raise FileExistsError(f"Could not create temporary macro file for {path}")
-
-
-def _commit_temp_macro(tmp_path: Path, path: Path, *, overwrite: bool) -> None:
-    if overwrite:
-        os.replace(tmp_path, path)
-        return
-    os.link(tmp_path, path)
-    tmp_path.unlink()
 
 
 def _json_line(value: JsonObject) -> str:

--- a/keymasq/session/analog_controls.py
+++ b/keymasq/session/analog_controls.py
@@ -7,6 +7,7 @@ from typing import BinaryIO, cast
 import tomli_w
 
 from keymasq.common import paths
+from keymasq.common.config_files import write_config_atomically
 from keymasq.common.models import (
     ActionType,
     AnalogActionThreshold,
@@ -25,7 +26,6 @@ from keymasq.session.action_toml import (
     mapping_action_to_toml,
     mapping_action_type_from_toml,
 )
-from keymasq.session.config_files import write_config_atomically
 from keymasq.session.config_loading import load_config_files_sync
 
 log = logging.getLogger("keymasq-session.analog_controls")

--- a/keymasq/session/config_files.py
+++ b/keymasq/session/config_files.py
@@ -1,29 +1,11 @@
-import contextlib
-import os
-import tempfile
-from collections.abc import Callable
-from pathlib import Path
-from typing import BinaryIO, cast
+from keymasq.common.config_files import (
+    fsync_parent_dir,
+    write_config_atomically,
+    write_toml_atomically,
+)
 
-
-def write_config_atomically(path: Path, write: Callable[[BinaryIO], None]) -> None:
-    fd, temp_name = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
-    temp_path: Path | None = Path(temp_name)
-    try:
-        with os.fdopen(fd, "wb") as config_file:
-            binary_file = cast(BinaryIO, config_file)
-            write(binary_file)
-            binary_file.flush()
-            os.fsync(binary_file.fileno())
-        os.replace(temp_path, path)
-        temp_path = None
-        with contextlib.suppress(OSError):
-            dir_fd = os.open(path.parent, os.O_RDONLY | os.O_DIRECTORY)
-            try:
-                os.fsync(dir_fd)
-            finally:
-                os.close(dir_fd)
-    finally:
-        if temp_path is not None:
-            with contextlib.suppress(FileNotFoundError):
-                temp_path.unlink()
+__all__ = [
+    "fsync_parent_dir",
+    "write_config_atomically",
+    "write_toml_atomically",
+]

--- a/keymasq/session/hardware.py
+++ b/keymasq/session/hardware.py
@@ -1,4 +1,3 @@
-import contextlib
 import logging
 import re
 import tomllib
@@ -9,6 +8,7 @@ from typing import Any, BinaryIO, cast
 import tomli_w
 
 from keymasq.common import paths
+from keymasq.common.config_files import write_config_atomically
 from keymasq.common.devices import is_gamepad_button_name
 from keymasq.common.models import (
     AnalogAxisDefinition,
@@ -18,7 +18,6 @@ from keymasq.common.models import (
     EvdevDevice,
     HardwareConfig,
 )
-from keymasq.session.config_files import write_config_atomically
 from keymasq.session.config_loading import load_config_files_sync
 
 log = logging.getLogger("keymasq-session.hardware")
@@ -243,10 +242,7 @@ class HardwareManager:
 
         for attempt in range(1, MAX_HARDWARE_PATH_ATTEMPTS + 1):
             path = self._hardware_storage_path_candidate(hardware_id, attempt)
-            try:
-                with path.open("x", encoding="utf-8"):
-                    pass
-            except FileExistsError:
+            if path.exists():
                 continue
             return path, True
         raise ValueError(f"Could not allocate storage path for hardware '{hardware_id}'")
@@ -369,19 +365,14 @@ class HardwareManager:
         if config.image:
             data["hardware"]["image"] = config.image
 
-        path, reserved_path = self._path_for_hardware_id(config.hardware_id)
-        try:
-            def write_config(config_file: BinaryIO) -> None:
-                tomli_w.dump(data, config_file)
-                if is_keyboard_layout:
-                    config_file.write(KEYBOARD_LAYOUT_FOOTER)
+        path, new_path = self._path_for_hardware_id(config.hardware_id)
 
-            write_config_atomically(path, write_config)
-        except Exception:
-            if reserved_path:
-                with contextlib.suppress(OSError):
-                    path.unlink()
-            raise
+        def write_config(config_file: BinaryIO) -> None:
+            tomli_w.dump(data, config_file)
+            if is_keyboard_layout:
+                config_file.write(KEYBOARD_LAYOUT_FOOTER)
+
+        write_config_atomically(path, write_config, overwrite=not new_path)
 
         self._cache[config.hardware_id] = _HardwareEntry(path=path, config=config)
         log.info(f"Saved hardware config: {path}")

--- a/keymasq/session/manager/recording.py
+++ b/keymasq/session/manager/recording.py
@@ -7,8 +7,7 @@ from datetime import datetime
 from time import monotonic
 from typing import TYPE_CHECKING, cast
 
-import tomli_w
-
+from keymasq.common.config_files import write_toml_atomically
 from keymasq.common.devices import normalize_input_classes
 from keymasq.common.ipc import Command, CommandType
 from keymasq.common.models import (
@@ -1596,9 +1595,7 @@ def save_recording_settings_to_disk(
             },
         }
 
-        manager.RECORDING_SETTINGS_PATH.parent.mkdir(parents=True, exist_ok=True)
-        with manager.RECORDING_SETTINGS_PATH.open("wb") as f:
-            tomli_w.dump(data, f)
+        write_toml_atomically(manager.RECORDING_SETTINGS_PATH, data)
     except Exception:
         log.exception(
             "Failed to save recording settings to %s",

--- a/keymasq/session/profiles.py
+++ b/keymasq/session/profiles.py
@@ -10,10 +10,9 @@ from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, cast
 
-import tomli_w
-
 from keymasq.common import paths
 from keymasq.common.combos import normalize_combo_evdev, normalize_combo_restore_keys
+from keymasq.common.config_files import write_toml_atomically
 from keymasq.common.models import (
     ActionType,
     ComboConfig,
@@ -332,8 +331,7 @@ class ProfileManager:
                     return
 
             profile["created_at"] = created_at.isoformat()
-            with open(path, "wb") as f:
-                tomli_w.dump(data, f)
+            write_toml_atomically(path, data)
 
     def _parse_action(self, action_data: TomlDict | str) -> MappingAction:
         if isinstance(action_data, str):
@@ -878,15 +876,7 @@ class ProfileManager:
             ]
 
         with self._profile_file_lock:
-            if exclusive:
-                buffer = io.BytesIO()
-                tomli_w.dump(data, buffer)
-                with open(path, "xb") as f:
-                    f.write(buffer.getvalue())
-                return
-
-            with open(path, "wb") as f:
-                tomli_w.dump(data, f)
+            write_toml_atomically(path, data, overwrite=not exclusive)
             return
 
     def delete_profile(self, name: str) -> bool:

--- a/keymasq/session/settings.py
+++ b/keymasq/session/settings.py
@@ -1,14 +1,10 @@
-import contextlib
 import logging
-import os
-import tempfile
 import tomllib
 from pathlib import Path
 from typing import cast
 
-import tomli_w
-
 from keymasq.common import paths
+from keymasq.common.config_files import write_toml_atomically
 from keymasq.common.settings import (
     GlobalSettings,
     global_settings_from_toml,
@@ -51,24 +47,7 @@ def save_global_settings(settings: GlobalSettings) -> GlobalSettings:
     )
     paths.ensure_config_dirs()
     settings_path = _settings_path()
-    temp_path = ""
-    try:
-        with tempfile.NamedTemporaryFile(
-            "wb",
-            dir=settings_path.parent,
-            prefix=f".{settings_path.name}.",
-            delete=False,
-        ) as config_file:
-            temp_path = config_file.name
-            tomli_w.dump(global_settings_to_toml(normalized), config_file)
-            config_file.flush()
-            os.fsync(config_file.fileno())
-        os.replace(temp_path, settings_path)
-        temp_path = ""
-    finally:
-        if temp_path:
-            with contextlib.suppress(FileNotFoundError):
-                os.unlink(temp_path)
+    write_toml_atomically(settings_path, global_settings_to_toml(normalized))
     return normalized
 
 

--- a/keymasq/session/superkeys.py
+++ b/keymasq/session/superkeys.py
@@ -7,6 +7,7 @@ from typing import BinaryIO, cast
 import tomli_w
 
 from keymasq.common import paths
+from keymasq.common.config_files import write_config_atomically
 from keymasq.common.models import (
     ActionType,
     MappingAction,
@@ -22,7 +23,6 @@ from keymasq.session.action_toml import (
     mapping_action_to_toml,
     mapping_action_type_from_toml,
 )
-from keymasq.session.config_files import write_config_atomically
 from keymasq.session.config_loading import ConfigLoadError, ConfigLoadFailure
 
 log = logging.getLogger("keymasq-session.superkeys")

--- a/tests/common/test_profile_manager.py
+++ b/tests/common/test_profile_manager.py
@@ -1,9 +1,11 @@
 from datetime import datetime, timedelta
 from pathlib import Path
+from typing import BinaryIO
 
 import pytest
 import tomli_w
 
+from keymasq.common import config_files as config_files_module
 from keymasq.common.models import (
     ActionType,
     ComboConfig,
@@ -94,6 +96,35 @@ class TestProfileManager:
         content = profile.path.read_text(encoding="utf-8")
         assert 'activation_macro = "game_enter"' in content
         assert 'deactivation_macro = "game_leave"' in content
+
+    def test_profile_failed_overwrite_preserves_existing_file_and_state(
+        self,
+        temp_config_dir,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        manager = ProfileManager()
+        manager.save_profile(ProfileConfig(name="Saved Profile", enabled=True))
+        saved = manager.get_profile("Saved Profile")
+        assert saved is not None
+        original_content = saved.path.read_bytes()
+
+        def fail_dump(_data: object, config_file: BinaryIO) -> None:
+            config_file.write(b'[profile]\nname = "partial"\n')
+            raise OSError("disk full")
+
+        monkeypatch.setattr(config_files_module.tomli_w, "dump", fail_dump)
+
+        with pytest.raises(OSError, match="disk full"):
+            manager.save_profile(
+                ProfileConfig(name="Saved Profile", enabled=False),
+                path=saved.path,
+            )
+
+        loaded = manager.get_profile("Saved Profile")
+        assert saved.path.read_bytes() == original_content
+        assert loaded is not None
+        assert loaded.config.enabled is True
+        assert list((temp_config_dir / "profiles").glob(f".{saved.path.name}.*")) == []
 
     def test_profile_macro_action_accepts_macro_name_alias(self, temp_config_dir):
         _write_profile_toml(

--- a/tests/session/test_session_manager_recording_settings.py
+++ b/tests/session/test_session_manager_recording_settings.py
@@ -9,6 +9,7 @@ from unittest.mock import AsyncMock
 import pytest
 
 import keymasq.session.manager.recording as session_recording_module
+from keymasq.common import config_files as config_files_module
 from keymasq.common.ipc import Command, CommandType, Response
 from keymasq.session.manager import SessionManager
 
@@ -187,7 +188,7 @@ def test_recording_settings_save_logs_errors(tmp_path, caplog, monkeypatch) -> N
     def raise_dump_error(_data, _fp) -> None:
         raise OSError("disk full")
 
-    monkeypatch.setattr(session_recording_module.tomli_w, "dump", raise_dump_error)
+    monkeypatch.setattr(config_files_module.tomli_w, "dump", raise_dump_error)
     caplog.set_level(logging.ERROR, logger="keymasq-session")
 
     session_recording_module.save_recording_settings_to_disk(manager)

--- a/tests/test_session_config_files.py
+++ b/tests/test_session_config_files.py
@@ -4,7 +4,7 @@ from typing import BinaryIO
 
 import pytest
 
-from keymasq.session.config_files import write_config_atomically
+from keymasq.common.config_files import write_config_atomically
 
 
 def test_write_config_atomically_fsyncs_file_then_parent_directory(
@@ -104,3 +104,35 @@ def test_write_config_atomically_keeps_replaced_file_when_parent_fsync_fails(
     write_config_atomically(target_path, write_config)
 
     assert target_path.read_bytes() == b"name = \"Test\"\n"
+
+
+def test_write_config_atomically_exclusive_create_preserves_existing_file(
+    tmp_path: Path,
+) -> None:
+    target_path = tmp_path / "config.toml"
+    target_path.write_bytes(b'name = "Existing"\n')
+
+    def write_config(config_file: BinaryIO) -> None:
+        config_file.write(b'name = "Replacement"\n')
+
+    with pytest.raises(FileExistsError):
+        write_config_atomically(target_path, write_config, overwrite=False)
+
+    assert target_path.read_bytes() == b'name = "Existing"\n'
+    assert list(tmp_path.glob(f".{target_path.name}.*")) == []
+
+
+def test_write_config_atomically_exclusive_create_cleans_temp_on_write_failure(
+    tmp_path: Path,
+) -> None:
+    target_path = tmp_path / "config.toml"
+
+    def write_config(config_file: BinaryIO) -> None:
+        config_file.write(b'name = "Partial"\n')
+        raise OSError("disk full")
+
+    with pytest.raises(OSError, match="disk full"):
+        write_config_atomically(target_path, write_config, overwrite=False)
+
+    assert not target_path.exists()
+    assert list(tmp_path.glob(f".{target_path.name}.*")) == []

--- a/tests/test_session_config_files.py
+++ b/tests/test_session_config_files.py
@@ -65,11 +65,12 @@ def test_write_config_atomically_fsyncs_file_then_parent_directory(
     assert events == ["fsync_file", "replace", "open_dir", "fsync_dir", "close_dir"]
 
 
-def test_write_config_atomically_keeps_replaced_file_when_parent_fsync_fails(
+def test_write_config_atomically_propagates_parent_fsync_failures(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     target_path = tmp_path / "config.toml"
     directory_fd = 999_999
+    events: list[str] = []
     original_close = os.close
     original_open = os.open
 
@@ -88,10 +89,13 @@ def test_write_config_atomically_keeps_replaced_file_when_parent_fsync_fails(
 
     def fake_fsync(fd: int) -> None:
         if fd == directory_fd:
+            events.append("fsync_dir")
             raise OSError("directory fsync failed")
 
     def fake_close(fd: int) -> None:
-        if fd != directory_fd:
+        if fd == directory_fd:
+            events.append("close_dir")
+        else:
             original_close(fd)
 
     def write_config(config_file: BinaryIO) -> None:
@@ -101,7 +105,39 @@ def test_write_config_atomically_keeps_replaced_file_when_parent_fsync_fails(
     monkeypatch.setattr(os, "fsync", fake_fsync)
     monkeypatch.setattr(os, "close", fake_close)
 
-    write_config_atomically(target_path, write_config)
+    with pytest.raises(OSError, match="directory fsync failed"):
+        write_config_atomically(target_path, write_config)
+
+    assert target_path.read_bytes() == b"name = \"Test\"\n"
+    assert events == ["fsync_dir", "close_dir"]
+
+
+def test_write_config_atomically_propagates_parent_open_failures(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    target_path = tmp_path / "config.toml"
+    original_open = os.open
+
+    def fake_open(
+        path: str | bytes | os.PathLike[str] | os.PathLike[bytes],
+        flags: int,
+        mode: int = 0o777,
+        *,
+        dir_fd: int | None = None,
+    ) -> int:
+        if os.fspath(path) == os.fspath(tmp_path):
+            raise OSError("directory open failed")
+        if dir_fd is None:
+            return original_open(path, flags, mode)
+        return original_open(path, flags, mode, dir_fd=dir_fd)
+
+    def write_config(config_file: BinaryIO) -> None:
+        config_file.write(b"name = \"Test\"\n")
+
+    monkeypatch.setattr(os, "open", fake_open)
+
+    with pytest.raises(OSError, match="directory open failed"):
+        write_config_atomically(target_path, write_config)
 
     assert target_path.read_bytes() == b"name = \"Test\"\n"
 


### PR DESCRIPTION
## Summary
- Add `keymasq.common.config_files` as the shared atomic write path for persisted config data, including file fsync, parent-directory fsync, temp cleanup, and exclusive-create support.
- Route profile, hardware, superkey, analog control, global settings, GUI preferences, recording settings, and macro-file persistence through the shared helper while keeping the session module as a compatibility re-export.
- Remove hardware save placeholder files so first-time hardware writes are atomic from the start.
- Add regression coverage for exclusive atomic creates, parent-directory fsync/open error propagation, failed profile overwrites, and updated recording-settings error patching.

## Tests
- `nix develop -c pytest tests/test_superkeys.py tests/test_superkey_state.py tests/keymasqd/test_device_manager_superkeys.py tests/common/test_mapping_and_profile_state.py`
- `./scripts/check.sh full`