### PR TITLE
Audit daemon/session exception handling and add debug logging

### DIFF
--- a/keymasq/keymasqd/capture_manager.py
+++ b/keymasq/keymasqd/capture_manager.py
@@ -324,11 +324,11 @@ class CaptureManager:
                 try:
                     device.ungrab()
                 except Exception:
-                    pass
+                    log.debug("Failed to ungrab capture device during capture end", exc_info=True)
             try:
                 device.close()
             except Exception:
-                pass
+                log.debug("Failed to close capture device during capture end", exc_info=True)
 
         log.info("Ended capture %s hardware_id=%s", token, session.hardware_id)
         return {"status": "ok", "ended": True}

--- a/keymasq/keymasqd/output_helpers.py
+++ b/keymasq/keymasqd/output_helpers.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
+import logging
 from typing import Protocol, cast
 
 import evdev
 
 from keymasq.common.devices import resolve_evdev_event_type
 from keymasq.common.gamepad_axes import gamepad_axis_range, normalize_gamepad_axis_target
+
+log = logging.getLogger("keymasqd.output_helpers")
 
 
 class _WritableUInput(Protocol):
@@ -100,4 +103,4 @@ def emit_mouse_move(
         uinput_dev.write(evdev.ecodes.EV_REL, evdev.ecodes.REL_Y, int(move_y))
         uinput_dev.syn()
     except Exception:
-        pass
+        log.debug("Failed to emit mouse movement", exc_info=True)

--- a/keymasq/keymasqd/recording.py
+++ b/keymasq/keymasqd/recording.py
@@ -180,7 +180,7 @@ class RecordingManager:
             async for event in device.async_read_loop():
                 self.record_event(classify_event_device_type(event, device_types), event)
         except Exception:
-            pass
+            log.debug("Extra recording device reader stopped after error", exc_info=True)
 
     async def stop(self) -> RecordingPayload:
         was_recording = not self._stopped
@@ -198,7 +198,7 @@ class RecordingManager:
             try:
                 device.close()
             except Exception:
-                pass
+                log.debug("Failed to close extra recording device", exc_info=True)
         self._extra_devices = []
         self._record_grabbed_source_keys = set()
         recording_slot = int(self._recording_slot)

--- a/keymasq/keymasqd/runtime/adapters.py
+++ b/keymasq/keymasqd/runtime/adapters.py
@@ -1,10 +1,13 @@
 import asyncio
+import logging
 from collections.abc import Awaitable, Callable, Iterator, Mapping
 from typing import Final, Protocol, TypeVar, cast
 
 import evdev
 
 _T = TypeVar("_T")
+
+log = logging.getLogger("keymasqd.runtime.adapters")
 
 
 class WritableUInput(Protocol):
@@ -85,7 +88,7 @@ def close_device(device: object) -> None:
     try:
         close()
     except Exception:
-        pass
+        log.debug("Failed to close evdev-style device", exc_info=True)
 
 
 class _ComboEcodesByType(Mapping[int, Mapping[int, object]]):

--- a/keymasq/keymasqd/runtime/grab_lifecycle.py
+++ b/keymasq/keymasqd/runtime/grab_lifecycle.py
@@ -486,8 +486,8 @@ def device_has_mapped_buttons(
                 )
                 if code_name.lower() in mapped_evdev_names:
                     return True
-            except Exception:
-                pass
+            except (KeyError, TypeError):
+                log.debug("Unable to resolve evdev capability name", exc_info=True)
     return False
 
 

--- a/keymasq/keymasqd/runtime/grabbed_device.py
+++ b/keymasq/keymasqd/runtime/grabbed_device.py
@@ -370,11 +370,14 @@ class GrabbedDevice:
             try:
                 uinput.close()
             except Exception:
-                pass
+                log.debug("Failed to close uinput after failed grab", exc_info=True)
             try:
                 runtime_outputs.unregister_passthrough_frame_output(uinput)
             except Exception:
-                pass
+                log.debug(
+                    "Failed to unregister passthrough output after failed grab",
+                    exc_info=True,
+                )
         self.uinput = None
 
         device = self.device
@@ -382,7 +385,7 @@ class GrabbedDevice:
             try:
                 device.close()
             except Exception:
-                pass
+                log.debug("Failed to close input device after failed grab", exc_info=True)
         self.device = None
 
     async def grab(self) -> None:

--- a/keymasq/keymasqd/runtime/macros.py
+++ b/keymasq/keymasqd/runtime/macros.py
@@ -766,7 +766,7 @@ def release_macro_held_for_instance(
         try:
             syn_if_passthrough_frame_closed(raw_uinput, writer)
         except Exception:
-            pass
+            deps.log.debug("Failed to synchronize macro cleanup outputs", exc_info=True)
 
 
 def acquire_macro_mouse_inhibit(

--- a/keymasq/keymasqd/socket_server.py
+++ b/keymasq/keymasqd/socket_server.py
@@ -388,7 +388,7 @@ class SocketServer:
 
             await self._wait_writer_closed(writer, context)
         except Exception:
-            pass
+            log.debug("Failed while disconnecting daemon client", exc_info=True)
 
         if self.disconnect_handler and not is_owner and not self.clients:
             await self.disconnect_handler()
@@ -397,7 +397,7 @@ class SocketServer:
         try:
             writer.close()
         except Exception:
-            pass
+            log.debug("Failed to request daemon client writer close", exc_info=True)
 
     async def _wait_writer_closed(
         self,
@@ -422,6 +422,6 @@ class SocketServer:
                 try:
                     transport.abort()
                 except Exception:
-                    pass
+                    log.debug("Failed to abort daemon client transport", exc_info=True)
         except Exception:
-            pass
+            log.debug("Failed while waiting for daemon client socket to close", exc_info=True)

--- a/keymasq/keymasqd/superkey_state.py
+++ b/keymasq/keymasqd/superkey_state.py
@@ -440,7 +440,7 @@ class SuperkeyMachine:
                     await self._execute_action_up(action)
                     await asyncio.sleep(wait)
         except Exception:
-            pass
+            log.debug("Rapidfire loop stopped after error", exc_info=True)
         finally:
             current_task = asyncio.current_task()
             if current_task is not None:

--- a/keymasq/session/client.py
+++ b/keymasq/session/client.py
@@ -46,7 +46,7 @@ class KeymasqdClient:
             try:
                 await writer.wait_closed()
             except Exception:
-                pass
+                log.debug("Failed while closing daemon client writer", exc_info=True)
 
         self.reader = None
         self.writer = None
@@ -133,6 +133,6 @@ class KeymasqdClient:
             try:
                 writer.close()
             except Exception:
-                pass
+                log.debug("Failed to close daemon client writer after disconnect", exc_info=True)
 
         self._disconnected_event.set()

--- a/keymasq/session/listeners/gnome.py
+++ b/keymasq/session/listeners/gnome.py
@@ -224,7 +224,8 @@ class GnomeListener(WindowListener):
         proc_dir = "/proc"
         try:
             entries = os.listdir(proc_dir)
-        except Exception:
+        except OSError:
+            log.debug("Unable to list processes while probing GNOME Shell", exc_info=True)
             return False
 
         for entry in entries:
@@ -234,7 +235,8 @@ class GnomeListener(WindowListener):
             try:
                 if os.stat(base).st_uid != uid:
                     continue
-            except Exception:
+            except OSError:
+                log.debug("Skipping process while probing GNOME Shell", exc_info=True)
                 continue
 
             comm_path = os.path.join(base, "comm")
@@ -244,16 +246,19 @@ class GnomeListener(WindowListener):
                     comm = handle.read().strip().lower()
                 if comm == "gnome-shell":
                     return True
-            except Exception:
-                pass
+            except OSError:
+                log.debug("Unable to read process comm while probing GNOME Shell", exc_info=True)
 
             try:
                 with open(cmdline_path, "rb") as handle:
                     raw = handle.read().replace(b"\x00", b" ").decode("utf-8", errors="replace")
                 if "gnome-shell" in raw.lower():
                     return True
-            except Exception:
-                pass
+            except OSError:
+                log.debug(
+                    "Unable to read process cmdline while probing GNOME Shell",
+                    exc_info=True,
+                )
         return False
 
     @classmethod
@@ -458,7 +463,7 @@ class GnomeListener(WindowListener):
                 self._writer.close()
                 await self._writer.wait_closed()
             except Exception:
-                pass
+                log.debug("Failed while closing GNOME bridge writer", exc_info=True)
             self._writer = None
 
         if self._server is not None:
@@ -515,7 +520,7 @@ class GnomeListener(WindowListener):
                 self._writer.close()
                 await self._writer.wait_closed()
             except Exception:
-                pass
+                log.debug("Failed while replacing GNOME bridge writer", exc_info=True)
 
         self._writer = writer
         self._bridge_protocol = None
@@ -546,7 +551,7 @@ class GnomeListener(WindowListener):
         except asyncio.CancelledError:
             raise
         except Exception:
-            pass
+            log.debug("GNOME bridge read loop stopped after error", exc_info=True)
         finally:
             if self._writer is writer:
                 self._writer = None
@@ -560,7 +565,7 @@ class GnomeListener(WindowListener):
                 writer.close()
                 await writer.wait_closed()
             except Exception:
-                pass
+                log.debug("Failed while closing GNOME bridge client writer", exc_info=True)
 
     async def _handle_bridge_message(self, payload: JsonObject) -> None:
         msg_type = _str_value(payload.get("type"), "")

--- a/keymasq/session/listeners/hyprland.py
+++ b/keymasq/session/listeners/hyprland.py
@@ -111,7 +111,7 @@ class HyprlandListener(WindowListener):
             try:
                 await self.writer.wait_closed()
             except Exception:
-                pass
+                log.debug("Failed while closing Hyprland listener writer", exc_info=True)
 
         log.info("Hyprland listener stopped")
 
@@ -272,7 +272,7 @@ class HyprlandListener(WindowListener):
                         cmd_writer.close()
                         await cmd_writer.wait_closed()
                     except Exception:
-                        pass
+                        log.debug("Failed while closing Hyprland command writer", exc_info=True)
             return None
 
     async def health_check(self) -> bool:

--- a/keymasq/session/listeners/niri.py
+++ b/keymasq/session/listeners/niri.py
@@ -270,7 +270,7 @@ class NiriListener(WindowListener):
             try:
                 await self.writer.wait_closed()
             except Exception:
-                pass
+                log.debug("Failed while closing Niri event writer", exc_info=True)
             self.writer = None
             self.reader = None
 
@@ -279,7 +279,7 @@ class NiriListener(WindowListener):
             try:
                 await self._cmd_writer.wait_closed()
             except Exception:
-                pass
+                log.debug("Failed while closing Niri command writer", exc_info=True)
             self._cmd_writer = None
             self._cmd_reader = None
 
@@ -728,7 +728,7 @@ class NiriListener(WindowListener):
                             cmd_writer.close()
                             await cmd_writer.wait_closed()
                     except Exception:
-                        pass
+                        log.debug("Failed while closing failed Niri command writer", exc_info=True)
                     self._cmd_reader = None
                     self._cmd_writer = None
             return False, None

--- a/keymasq/session/listeners/x11.py
+++ b/keymasq/session/listeners/x11.py
@@ -247,7 +247,7 @@ class X11Listener(WindowListener):
                 try:
                     self._loop.remove_reader(self._display_fd)
                 except Exception:
-                    pass
+                    log.debug("Failed to remove X11 display reader", exc_info=True)
             self._fd_event = None
             self._loop = None
             self._display_fd = None
@@ -295,12 +295,12 @@ class X11Listener(WindowListener):
                         event_mask=int(getattr(X, "NoEventMask", 0))
                     )
                 except Exception:
-                    pass
+                    log.debug("Failed to clear X11 active window event mask", exc_info=True)
 
             try:
                 self._xdisplay.close()
             except Exception:
-                pass
+                log.debug("Failed to close X11 display", exc_info=True)
 
             self._xdisplay = None
             self._root = None
@@ -377,7 +377,7 @@ class X11Listener(WindowListener):
                     event_mask=int(getattr(X, "NoEventMask", 0))
                 )
             except Exception:
-                pass
+                log.debug("Failed to clear previous X11 active window event mask", exc_info=True)
 
         self._active_window = None
         self._active_window_id = None

--- a/keymasq/session/manager/core.py
+++ b/keymasq/session/manager/core.py
@@ -275,7 +275,7 @@ class SessionManager:
                     Command(command=CommandType.CAPTURE_END, data={"token": token})
                 )
             except Exception:
-                pass
+                log.debug("Failed to end daemon capture during session shutdown", exc_info=True)
         self.capture_state.tokens.clear()
 
         await self.client.disconnect()
@@ -292,8 +292,8 @@ class SessionManager:
         if self._session_socket_owned and SESSION_SOCKET_PATH.exists():
             try:
                 SESSION_SOCKET_PATH.unlink()
-            except Exception:
-                pass
+            except OSError:
+                log.debug("Failed to remove owned session socket", exc_info=True)
             self._session_socket_owned = False
 
     async def _start_session_server(self) -> None:
@@ -305,8 +305,8 @@ class SessionManager:
                 raise RuntimeError(msg)
             try:
                 SESSION_SOCKET_PATH.unlink()
-            except Exception:
-                pass
+            except OSError:
+                log.debug("Failed to remove stale session socket", exc_info=True)
 
         self.session_server = await asyncio.start_unix_server(
             self._handle_session_client,
@@ -493,10 +493,12 @@ class SessionManager:
                 )
             transport = getattr(writer, "transport", None)
             if transport is not None:
-                with contextlib.suppress(Exception):
+                try:
                     transport.abort()
+                except Exception:
+                    log.debug("Failed to abort session client transport", exc_info=True)
         except Exception:
-            pass
+            log.debug("Failed while waiting for session client socket to close", exc_info=True)
 
     def _drop_session_client_writer(self, writer: asyncio.StreamWriter) -> None:
         self.session_clients.discard(writer)

--- a/keymasq/session/manager/events.py
+++ b/keymasq/session/manager/events.py
@@ -360,21 +360,21 @@ async def handle_stop_macro_trigger(
             recording_slot=recording_slot or active_slot,
         )
     except Exception:
-        pass
+        log.debug("Failed to handle stop macro recording trigger", exc_info=True)
 
 
 async def handle_cancel_macro_trigger(manager: "SessionManager") -> None:
     try:
         await manager.client.send_command(Command(command=CommandType.CANCEL_MACRO_PLAYBACK))
     except Exception:
-        pass
+        log.debug("Failed to send cancel macro playback trigger", exc_info=True)
 
 
 async def handle_emergency_reset_trigger(manager: "SessionManager") -> None:
     try:
         await manager.client.send_command(Command(command=CommandType.EMERGENCY_RESET))
     except Exception:
-        pass
+        log.debug("Failed to send emergency reset trigger", exc_info=True)
 
 
 async def handle_profile_trigger(manager: "SessionManager", data: JsonObject) -> None:
@@ -599,7 +599,7 @@ async def handle_exec_trigger(manager: "SessionManager", data: JsonObject) -> No
                 )
             )
         except Exception:
-            pass
+            log.debug("Failed to report macro exec completion", exc_info=True)
         return
 
     if is_async:

--- a/keymasq/session/manager/recording_device_selection.py
+++ b/keymasq/session/manager/recording_device_selection.py
@@ -171,7 +171,7 @@ async def refresh_recording_devices_cache(manager: "SessionManager") -> None:
         manager.recording_state.devices_cache_ready = True
         update_selected_recording_devices_cache(manager)
     except Exception:
-        pass
+        log.debug("Failed to refresh recording devices cache", exc_info=True)
 
 
 def update_selected_recording_devices_cache(manager: "SessionManager") -> None:

--- a/keymasq/session/manager/recording_lifecycle.py
+++ b/keymasq/session/manager/recording_lifecycle.py
@@ -709,7 +709,7 @@ async def start_recording(
                     recording_slot=slot,
                 )
         except Exception:
-            pass
+            log.debug("Failed to stop active recording before starting a new one", exc_info=True)
         manager.recording_state.active = False
         manager.recording_state.active_slot = 0
         _clear_active_recording_owner(manager)

--- a/keymasq/session/wayland_protocols/cosmic_toplevel_info_client.py
+++ b/keymasq/session/wayland_protocols/cosmic_toplevel_info_client.py
@@ -1,3 +1,5 @@
+import logging
+
 from keymasq.session.wayland_protocols import client_transport as _transport
 from keymasq.session.wayland_protocols.ext_foreign_toplevel_list import (
     ExtForeignToplevelListTracker,
@@ -16,6 +18,8 @@ _pack_uint = _transport.pack_uint
 _encode_string = _transport.encode_string
 _decode_array = _transport.decode_array
 _decode_uint_array = _transport.decode_uint_array
+
+log = logging.getLogger("keymasq-session.wayland.cosmic_toplevel_info")
 
 
 class CosmicToplevelInfoWaylandClient(ExtForeignToplevelListClientBase):
@@ -108,7 +112,7 @@ class CosmicToplevelInfoWaylandClient(ExtForeignToplevelListClientBase):
         try:
             await self._send_request(object_id, 0, b"")
         except Exception:
-            pass
+            log.debug("Failed to destroy COSMIC toplevel info handle", exc_info=True)
         self._objects.pop(object_id, None)
         self._cosmic_handles.discard(object_id)
         ext_id = self._cosmic_to_ext.pop(object_id, None)

--- a/keymasq/session/wayland_protocols/ext_foreign_toplevel_list_client.py
+++ b/keymasq/session/wayland_protocols/ext_foreign_toplevel_list_client.py
@@ -1,3 +1,4 @@
+import logging
 import struct
 
 from keymasq.session.wayland_protocols import client_transport as _transport
@@ -11,6 +12,8 @@ EXT_FOREIGN_TOPLEVEL_HANDLE_INTERFACE = "ext_foreign_toplevel_handle_v1"
 _pack_uint = _transport.pack_uint
 _encode_string = _transport.encode_string
 _decode_string = _transport.decode_string
+
+log = logging.getLogger("keymasq-session.wayland.ext_foreign_toplevel")
 
 
 class ExtForeignToplevelListClientBase(_transport.WaylandClientTransport):
@@ -43,7 +46,7 @@ class ExtForeignToplevelListClientBase(_transport.WaylandClientTransport):
             try:
                 await self._send_request(self._list_id, 1, b"")
             except Exception:
-                pass
+                log.debug("Failed to destroy ext foreign toplevel list", exc_info=True)
             self._objects.pop(self._list_id, None)
             self._list_id = None
 
@@ -133,7 +136,7 @@ class ExtForeignToplevelListClientBase(_transport.WaylandClientTransport):
         try:
             await self._send_request(object_id, 0, b"")
         except Exception:
-            pass
+            log.debug("Failed to destroy ext foreign toplevel handle", exc_info=True)
         self._objects.pop(object_id, None)
         self._toplevel_handles.discard(object_id)
 

--- a/keymasq/session/wayland_protocols/wlr_foreign_toplevel_client.py
+++ b/keymasq/session/wayland_protocols/wlr_foreign_toplevel_client.py
@@ -1,3 +1,4 @@
+import logging
 import struct
 
 from keymasq.session.wayland_protocols import client_transport as _transport
@@ -12,6 +13,8 @@ _encode_string = _transport.encode_string
 _decode_string = _transport.decode_string
 _decode_array = _transport.decode_array
 _decode_uint_array = _transport.decode_uint_array
+
+log = logging.getLogger("keymasq-session.wayland.wlr_foreign_toplevel")
 
 
 class WlrForeignToplevelWaylandClient(_transport.WaylandClientTransport):
@@ -42,7 +45,7 @@ class WlrForeignToplevelWaylandClient(_transport.WaylandClientTransport):
                 try:
                     await self._send_request(self._manager_id, 0, b"")
                 except Exception:
-                    pass
+                    log.debug("Failed to destroy wlr foreign toplevel manager", exc_info=True)
                 self._objects.pop(self._manager_id, None)
                 self._manager_id = None
             self._close_socket()
@@ -101,7 +104,7 @@ class WlrForeignToplevelWaylandClient(_transport.WaylandClientTransport):
         try:
             await self._send_request(object_id, 7, b"")
         except Exception:
-            pass
+            log.debug("Failed to destroy wlr foreign toplevel handle", exc_info=True)
         self._objects.pop(object_id, None)
         self._toplevel_handles.discard(object_id)
 


### PR DESCRIPTION
## Summary
- Replaced broad silent `except Exception: pass` handlers with `log.debug(..., exc_info=True)`.
- Narrowed the GNOME `/proc` probe catches to `OSError`.
- Narrowed one evdev capability lookup catch to `(KeyError, TypeError)`.
- Added local loggers where modules previously had none.

## Tests
- Focused AST scan: `exact broad except-pass count: 0`
- `nix develop -c ./scripts/check.sh`: passed