### PR TITLE
Expand keymasqd session/DBus recovery and mapping parser test coverage

### DIFF
--- a/tests/keymasqd/test_device_manager_runtime_recovery.py
+++ b/tests/keymasqd/test_device_manager_runtime_recovery.py
@@ -363,6 +363,209 @@ class TestDeviceManagerHelpers:
 
         assert raw_device.close_count == 1
 
+    @pytest.mark.asyncio
+    async def test_grab_with_retry_waits_for_busy_device_then_succeeds(self) -> None:
+        sleep_calls: list[float] = []
+
+        class _Asyncio:
+            async def sleep(self, delay: float) -> None:
+                sleep_calls.append(delay)
+
+        class _BusyThenAvailableDevice:
+            def __init__(self) -> None:
+                self.attempts = 0
+
+            async def grab(self) -> None:
+                self.attempts += 1
+                if self.attempts < 3:
+                    raise OSError(errno.EBUSY, "busy")
+
+        device = _BusyThenAvailableDevice()
+
+        await ldm.grab_with_retry(
+            device,
+            "/dev/input/event0",
+            asyncio_mod=_Asyncio(),
+            log=logging.getLogger("test"),
+            errno_mod=errno,
+        )
+
+        assert device.attempts == 3
+        assert sleep_calls == [0.05, 0.10]
+
+    @pytest.mark.asyncio
+    async def test_grab_with_retry_reraises_last_busy_error_after_retries(self) -> None:
+        sleep_calls: list[float] = []
+
+        class _Asyncio:
+            async def sleep(self, delay: float) -> None:
+                sleep_calls.append(delay)
+
+        class _AlwaysBusyDevice:
+            def __init__(self) -> None:
+                self.attempts = 0
+
+            async def grab(self) -> None:
+                self.attempts += 1
+                raise OSError(errno.EBUSY, "busy")
+
+        device = _AlwaysBusyDevice()
+
+        with pytest.raises(OSError, match="busy"):
+            await ldm.grab_with_retry(
+                device,
+                "/dev/input/event0",
+                asyncio_mod=_Asyncio(),
+                log=logging.getLogger("test"),
+                errno_mod=errno,
+            )
+
+        assert device.attempts == 5
+        assert sleep_calls == [0.05, 0.10, 0.20, 0.40]
+
+    def test_pending_interface_release_cancellation_helpers_cancel_live_tasks(self) -> None:
+        class _FakeTask:
+            def __init__(self, *, done: bool = False) -> None:
+                self._done = done
+                self.cancelled = False
+
+            def done(self) -> bool:
+                return self._done
+
+            def cancel(self) -> None:
+                self.cancelled = True
+
+        manager = DeviceManager()
+        path_task = _FakeTask()
+        done_task = _FakeTask(done=True)
+        hardware_task = _FakeTask()
+        other_hardware_task = _FakeTask()
+
+        manager.grab_state.pending_interface_release[("hw", "/dev/input/event0")] = path_task
+        manager.grab_state.pending_interface_release[("hw", "/dev/input/event1")] = done_task
+        manager.grab_state.pending_interface_release[("hw", "/dev/input/event2")] = hardware_task
+        manager.grab_state.pending_interface_release[("other", "/dev/input/event3")] = (
+            other_hardware_task
+        )
+
+        ldm.cancel_pending_interface_release(manager, "hw", "/dev/input/event0")
+        ldm.cancel_pending_interface_releases_for_hardware(manager, "hw")
+
+        assert path_task.cancelled is True
+        assert done_task.cancelled is False
+        assert hardware_task.cancelled is True
+        assert other_hardware_task.cancelled is False
+        assert manager.grab_state.pending_interface_release == {
+            ("other", "/dev/input/event3"): other_hardware_task,
+        }
+
+    @pytest.mark.asyncio
+    async def test_delayed_interface_release_keeps_currently_desired_path(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        manager = DeviceManager()
+        release_interface = AsyncMock()
+        key = ("hw", "/dev/input/event0")
+        manager.grab_state.desired_paths["hw"] = {key[1]}
+        monkeypatch.setattr(ldm, "release_interface_unlocked", release_interface)
+
+        task = asyncio.create_task(
+            ldm.delayed_interface_release(
+                manager,
+                key[0],
+                key[1],
+                0.001,
+                asyncio_mod=ldm.ASYNCIO_RUNTIME,
+            )
+        )
+        manager.grab_state.pending_interface_release[key] = task
+
+        await task
+
+        release_interface.assert_not_awaited()
+        assert key not in manager.grab_state.pending_interface_release
+
+    @pytest.mark.asyncio
+    async def test_delayed_interface_release_cleans_up_after_cancellation(self) -> None:
+        manager = DeviceManager()
+        key = ("hw", "/dev/input/event0")
+        task = asyncio.create_task(
+            ldm.delayed_interface_release(
+                manager,
+                key[0],
+                key[1],
+                60.0,
+                asyncio_mod=ldm.ASYNCIO_RUNTIME,
+            )
+        )
+        manager.grab_state.pending_interface_release[key] = task
+
+        await asyncio.sleep(0)
+        task.cancel()
+        await task
+
+        assert key not in manager.grab_state.pending_interface_release
+
+    @pytest.mark.asyncio
+    async def test_release_interface_keeps_remaining_managed_devices(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        removed = SimpleNamespace(
+            path="/dev/input/event0",
+            interface_id="kbd",
+            release_tracked_outputs=Mock(),
+            release=AsyncMock(),
+        )
+        kept = SimpleNamespace(
+            path="/dev/input/event1",
+            interface_id="mouse",
+            release_tracked_outputs=Mock(),
+            release=AsyncMock(),
+        )
+        manager = DeviceManager()
+        manager.grabbed_devices = {"hw": [removed, kept]}
+        clear_combo_scope = AsyncMock()
+        monkeypatch.setattr(cdm, "clear_combo_runtime_for_binding_scope", clear_combo_scope)
+
+        await ldm.release_interface_unlocked(manager, "hw", "/dev/input/event0")
+
+        assert manager.grabbed_devices == {"hw": [kept]}
+        clear_combo_scope.assert_awaited_once()
+        removed.release_tracked_outputs.assert_called_once()
+        removed.release.assert_awaited_once()
+        kept.release.assert_not_awaited()
+
+    def test_grab_lifecycle_helpers_ignore_malformed_capabilities_and_analog_inputs(
+        self,
+    ) -> None:
+        caps = {
+            evdev.ecodes.EV_SYN: [evdev.ecodes.SYN_REPORT],
+            evdev.ecodes.EV_KEY: [
+                (),
+                ("not-an-int",),
+                "not-a-code",
+                (evdev.ecodes.KEY_A,),
+                evdev.ecodes.KEY_B,
+            ],
+        }
+        analog_inputs = {
+            "not-a-table": "bad",
+            "axes-not-list": {"axes": "bad"},
+            "axis-not-table": {"axes": ["bad"]},
+            "bad-code": {"axes": [{"evdev_code": "not-an-int"}]},
+            "hex-code": {"axes": [{"evdev_code": "0x1"}]},
+            "named-code": {"axes": [{"evdev": "abs_x"}]},
+        }
+
+        assert ldm.device_has_mapped_buttons(caps, {"key_b"}, None, evdev_mod=dm.evdev)
+        assert not ldm.device_has_mapped_buttons({999999: [1]}, set(), None, evdev_mod=dm.evdev)
+        assert ldm.analog_input_bindings(analog_inputs) == {
+            (evdev.ecodes.EV_ABS, 1),
+            (evdev.ecodes.EV_ABS, evdev.ecodes.ABS_X),
+        }
+
     def test_parse_action_supports_string_and_compositor_dispatch(self) -> None:
         manager = DeviceManager()
         string_action = adm.parse_action(

--- a/tests/session/test_dbus.py
+++ b/tests/session/test_dbus.py
@@ -1,0 +1,281 @@
+import pytest
+from dbus_next.constants import MessageType
+from dbus_next.message import Message
+
+import keymasq.session.dbus as dbus_module
+from keymasq.session.dbus import (
+    DBUS_INTERFACE,
+    DBUS_PATH,
+    DBUS_SERVICE,
+    NOTIFICATIONS_INTERFACE,
+    NOTIFICATIONS_PATH,
+    NOTIFICATIONS_SERVICE,
+    SessionDBus,
+)
+
+
+class _FakeProxy:
+    def __init__(self, interfaces: dict[str, object]) -> None:
+        self._interfaces = interfaces
+
+    def get_interface(self, interface: str) -> object:
+        return self._interfaces[interface]
+
+
+class _FakeBus:
+    def __init__(
+        self,
+        *,
+        call_replies: list[Message | None] | None = None,
+        call_error: Exception | None = None,
+        introspection_error: Exception | None = None,
+    ) -> None:
+        self.connected = True
+        self.disconnect_calls = 0
+        self.call_replies = list(call_replies or [])
+        self.call_error = call_error
+        self.introspection_error = introspection_error
+        self.introspection = object()
+        self.introspection_calls: list[tuple[str, str]] = []
+        self.proxy_requests: list[tuple[str, str, object]] = []
+        self.messages: list[Message] = []
+        self.interfaces: dict[str, object] = {}
+
+    def disconnect(self) -> None:
+        self.connected = False
+        self.disconnect_calls += 1
+
+    async def introspect(self, destination: str, path: str) -> object:
+        self.introspection_calls.append((destination, path))
+        if self.introspection_error is not None:
+            raise self.introspection_error
+        return self.introspection
+
+    def get_proxy_object(self, destination: str, path: str, introspection: object) -> _FakeProxy:
+        self.proxy_requests.append((destination, path, introspection))
+        return _FakeProxy(self.interfaces)
+
+    async def call(self, message: Message) -> Message | None:
+        self.messages.append(message)
+        if self.call_error is not None:
+            raise self.call_error
+        return self.call_replies.pop(0)
+
+
+class _NameOwnerInterface:
+    def __init__(self, result: object = True, error: Exception | None = None) -> None:
+        self.result = result
+        self.error = error
+        self.calls: list[str] = []
+
+    async def call_name_has_owner(self, name: str) -> object:
+        self.calls.append(name)
+        if self.error is not None:
+            raise self.error
+        return self.result
+
+
+class _SuppliedDBus:
+    def __init__(self, result: bool, error: Exception | None = None) -> None:
+        self.result = result
+        self.error = error
+        self.calls: list[tuple[str, float]] = []
+
+    async def name_has_owner(self, name: str, *, timeout: float = 0.6) -> bool:
+        self.calls.append((name, timeout))
+        if self.error is not None:
+            raise self.error
+        return self.result
+
+
+def _reply(signature: str = "", body: list[object] | None = None) -> Message:
+    return Message(
+        message_type=MessageType.METHOD_RETURN,
+        reply_serial=1,
+        signature=signature,
+        body=body or [],
+    )
+
+
+def _error_reply(message: str) -> Message:
+    return Message(
+        message_type=MessageType.ERROR,
+        error_name="org.keymasq.TestError",
+        reply_serial=1,
+        signature="s",
+        body=[message],
+    )
+
+
+def _patch_message_bus(monkeypatch: pytest.MonkeyPatch, buses: list[_FakeBus]) -> None:
+    class _MessageBusFactory:
+        async def connect(self) -> _FakeBus:
+            return buses.pop(0)
+
+    monkeypatch.setattr(dbus_module, "MessageBus", _MessageBusFactory)
+
+
+@pytest.mark.asyncio
+async def test_session_dbus_reconnects_when_cached_bus_is_disconnected(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    first_bus = _FakeBus()
+    second_bus = _FakeBus()
+    _patch_message_bus(monkeypatch, [first_bus, second_bus])
+    dbus = SessionDBus()
+
+    assert await dbus.connect() is first_bus
+    assert await dbus.bus() is first_bus
+
+    dbus._introspection_cache[(DBUS_SERVICE, DBUS_PATH)] = object()
+    first_bus.connected = False
+
+    assert await dbus.connect() is second_bus
+    assert dbus._introspection_cache == {}
+
+    dbus._introspection_cache[(DBUS_SERVICE, DBUS_PATH)] = object()
+    await dbus.disconnect()
+
+    assert second_bus.disconnect_calls == 1
+    assert dbus._introspection_cache == {}
+
+
+@pytest.mark.asyncio
+async def test_session_dbus_introspection_is_cached_and_disconnects_on_error() -> None:
+    bus = _FakeBus()
+    dbus = SessionDBus()
+    dbus._bus = bus
+
+    first = await dbus.introspect("org.example.Service", "/org/example/Object")
+    second = await dbus.introspect("org.example.Service", "/org/example/Object")
+
+    assert first is second
+    assert bus.introspection_calls == [("org.example.Service", "/org/example/Object")]
+
+    bus.introspection_error = RuntimeError("session bus went away")
+
+    with pytest.raises(RuntimeError, match="session bus went away"):
+        await dbus.introspect("org.example.Other", "/org/example/Other")
+
+    assert bus.disconnect_calls == 1
+    assert dbus._bus is None
+
+
+@pytest.mark.asyncio
+async def test_session_dbus_name_has_owner_uses_dbus_proxy_and_disconnects_on_error() -> None:
+    iface = _NameOwnerInterface(result=1)
+    bus = _FakeBus()
+    bus.interfaces[DBUS_INTERFACE] = iface
+    dbus = SessionDBus()
+    dbus._bus = bus
+
+    assert await dbus.name_has_owner("org.example.Service", timeout=0.1) is True
+    assert iface.calls == ["org.example.Service"]
+    assert bus.proxy_requests == [(DBUS_SERVICE, DBUS_PATH, bus.introspection)]
+
+    error_bus = _FakeBus()
+    error_bus.interfaces[DBUS_INTERFACE] = _NameOwnerInterface(
+        error=RuntimeError("owner lookup failed")
+    )
+    error_dbus = SessionDBus()
+    error_dbus._bus = error_bus
+
+    with pytest.raises(RuntimeError, match="owner lookup failed"):
+        await error_dbus.name_has_owner("org.example.Service", timeout=0.1)
+
+    assert error_bus.disconnect_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_session_dbus_notify_handles_success_empty_error_and_missing_replies() -> None:
+    bus = _FakeBus(
+        call_replies=[
+            _reply("u", [42]),
+            _reply(),
+            _error_reply("notifications disabled"),
+            None,
+        ]
+    )
+    dbus = SessionDBus()
+    dbus._bus = bus
+
+    assert (
+        await dbus.notify(
+            "Saved",
+            "Profile updated",
+            app_name="keymasq-test",
+            app_icon="dialog-information",
+            timeout_ms=123,
+        )
+        == 42
+    )
+    sent = bus.messages[0]
+    assert sent.destination == NOTIFICATIONS_SERVICE
+    assert sent.path == NOTIFICATIONS_PATH
+    assert sent.interface == NOTIFICATIONS_INTERFACE
+    assert sent.member == "Notify"
+    assert sent.body == [
+        "keymasq-test",
+        0,
+        "dialog-information",
+        "Saved",
+        "Profile updated",
+        [],
+        {},
+        123,
+    ]
+
+    assert await dbus.notify("Saved", "Profile updated") is None
+
+    with pytest.raises(RuntimeError, match="notifications disabled"):
+        await dbus.notify("Saved", "Profile updated")
+
+    with pytest.raises(RuntimeError, match="notification delivery failed"):
+        await dbus.notify("Saved", "Profile updated")
+
+
+@pytest.mark.asyncio
+async def test_session_dbus_notify_disconnects_after_call_error() -> None:
+    bus = _FakeBus(call_error=RuntimeError("notifications offline"))
+    dbus = SessionDBus()
+    dbus._bus = bus
+
+    with pytest.raises(RuntimeError, match="notifications offline"):
+        await dbus.notify("Saved", "Profile updated")
+
+    assert bus.disconnect_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_temporary_session_dbus_connects_and_disconnects(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    bus = _FakeBus()
+    _patch_message_bus(monkeypatch, [bus])
+
+    async with dbus_module.temporary_session_dbus() as dbus:
+        assert await dbus.bus() is bus
+
+    assert bus.disconnect_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_name_has_owner_helper_uses_supplied_or_temporary_dbus(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    supplied = _SuppliedDBus(True)
+
+    assert await dbus_module.name_has_owner("org.example.Service", supplied, timeout=0.2) is True
+    assert supplied.calls == [("org.example.Service", 0.2)]
+
+    failing = _SuppliedDBus(False, error=RuntimeError("no bus"))
+    assert await dbus_module.name_has_owner("org.example.Service", failing) is False
+
+    temporary_bus = _FakeBus()
+    temporary_iface = _NameOwnerInterface(result=True)
+    temporary_bus.interfaces[DBUS_INTERFACE] = temporary_iface
+    _patch_message_bus(monkeypatch, [temporary_bus])
+
+    assert await dbus_module.name_has_owner("org.example.Temporary") is True
+    assert temporary_iface.calls == ["org.example.Temporary"]
+    assert temporary_bus.disconnect_calls == 1

--- a/tests/test_toml.py
+++ b/tests/test_toml.py
@@ -1,3 +1,5 @@
+from unittest.mock import Mock
+
 import pytest
 
 from keymasq.common.models import (
@@ -30,6 +32,52 @@ def _parse_mapping_action_toml(data: dict[str, object]) -> MappingAction:
         action_type,
         rapidfire_warning_context="test config",
     )
+
+
+def test_mapping_action_type_from_toml_supports_legacy_rapidfire_alias() -> None:
+    action_type, action_data = mapping_action_type_from_toml(
+        {"action": "rapidfire", "target": "key_a"},
+        unknown_action="raise",
+    )
+
+    assert action_type == ActionType.KEYBOARD
+    assert action_data["action"] == "keyboard"
+    assert action_data["rapidfire_enabled"] is True
+
+
+def test_mapping_action_type_from_toml_can_passthrough_unknown_actions() -> None:
+    logger = Mock()
+
+    action_type, action_data = mapping_action_type_from_toml(
+        {"action": "future_action", "target": "key_a"},
+        unknown_action="passthrough",
+        logger=logger,
+    )
+
+    assert action_type == ActionType.PASSTHROUGH
+    assert action_data["target"] == "key_a"
+    logger.warning.assert_called_once()
+
+
+def test_mapping_action_toml_round_trips_repeat_and_keys_fields() -> None:
+    repeat = _parse_mapping_action_toml(
+        {"action": "repeat", "repeat_categories": ["keyboard", "mouse"]}
+    )
+    keyed = mapping_action_to_toml(
+        MappingAction(
+            action_type=ActionType.EXEC,
+            exec_ref=7,
+            keys=["key_a", "key_b"],
+        ),
+        rapidfire_warning_context="test config",
+    )
+
+    assert repeat.action_type == ActionType.REPEAT
+    assert mapping_action_to_toml(
+        repeat,
+        rapidfire_warning_context="test config",
+    )["repeat_categories"] == ["keyboard", "mouse"]
+    assert keyed["keys"] == ["key_a", "key_b"]
 
 
 @pytest.mark.parametrize("action_type", MACRO_RECORDING_SLOT_ACTION_TYPES)


### PR DESCRIPTION
## Summary
- Added `keymasqd` runtime recovery test coverage for grab/retry backoff behavior, delayed interface release cancellation/cleanup, tracked-device release logic, and malformed capability/analog binding handling.
- Added `session` DBus unit tests for bus reconnection, introspection caching/error cleanup, owner checks via DBus proxy, notification call/result/error paths, and temporary DBus context management.
- Extended TOML action parsing/serialization tests to cover the legacy `rapidfire` alias, unknown-action passthrough behavior with warning, and repeat/keys field round-tripping.

Coverage after full suite:
- `session/dbus.py`: 100% (was 58%)
- `keymasqd/runtime/grab_lifecycle.py`: 89% (was 79%)
- `session/action_toml.py`: 98% (was 89%)
- Targeted eight-module total: 90% (was 84%)


## Tests
- Focused changed tests: `61 passed`
- Full coverage run: `1804 passed, 25 skipped`
- `./scripts/check.sh`: passed (`ruff`, `basedpyright`, `stylelint`, full pytest)