### PR TITLE
Refactor runtime protocol typings into shared adapters module

### DIFF
--- a/keymasq/keymasqd/capture_manager.py
+++ b/keymasq/keymasqd/capture_manager.py
@@ -23,20 +23,16 @@ from keymasq.common.devices import (
 )
 from keymasq.common.types import JsonObject
 from keymasq.keymasqd.runtime import device_path_resolver
+from keymasq.keymasqd.runtime.adapters import DeviceInfo
 
 log = logging.getLogger("keymasq.keymasqd.capture_manager")
-
-
-class _DeviceInfo(Protocol):
-    vendor: int
-    product: int
 
 
 class _CaptureInputDevice(Protocol):
     path: str
     name: str
     fd: int
-    info: _DeviceInfo
+    info: DeviceInfo
 
     def grab(self) -> None: ...
 

--- a/keymasq/keymasqd/device_manager.py
+++ b/keymasq/keymasqd/device_manager.py
@@ -89,15 +89,10 @@ type MacroPlayer = Callable[..., Awaitable[JsonObject]]
 type RapidfireTaskFactory = Callable[[], asyncio.Task[None]]
 
 
-class _DeviceInfo(Protocol):
-    vendor: int
-    product: int
-
-
 class _ManagedInputDevice(Protocol):
     path: str
     name: str | None
-    info: _DeviceInfo
+    info: runtime_adapters.DeviceInfo
 
     def grab(self) -> None: ...
 
@@ -262,19 +257,19 @@ class DesiredGrabConfig:
 @dataclass
 class OutputRuntimeState:
     device_count: int = 0
-    keyboard_uinput: runtime_adapters.WritableUInput | None = None
-    mouse_uinput: runtime_adapters.WritableUInput | None = None
-    virtual_gamepad_uinputs: dict[str, runtime_adapters.WritableUInput] = field(
+    keyboard_uinput: runtime_adapters.ClosableUInput | None = None
+    mouse_uinput: runtime_adapters.ClosableUInput | None = None
+    virtual_gamepad_uinputs: dict[str, runtime_adapters.ClosableUInput] = field(
         default_factory=dict
     )
     virtual_gamepad_count: int = DEFAULT_VIRTUAL_GAMEPADS
 
     @property
-    def gamepad_uinput(self) -> runtime_adapters.WritableUInput | None:
+    def gamepad_uinput(self) -> runtime_adapters.ClosableUInput | None:
         return self.virtual_gamepad_uinputs.get("virtual-gamepad-1")
 
     @gamepad_uinput.setter
-    def gamepad_uinput(self, value: runtime_adapters.WritableUInput | None) -> None:
+    def gamepad_uinput(self, value: runtime_adapters.ClosableUInput | None) -> None:
         if value is None:
             self.virtual_gamepad_uinputs.pop("virtual-gamepad-1", None)
         else:

--- a/keymasq/keymasqd/output_helpers.py
+++ b/keymasq/keymasqd/output_helpers.py
@@ -1,20 +1,15 @@
 from __future__ import annotations
 
 import logging
-from typing import Protocol, cast
+from typing import cast
 
 import evdev
 
 from keymasq.common.devices import resolve_evdev_event_type
 from keymasq.common.gamepad_axes import gamepad_axis_range, normalize_gamepad_axis_target
+from keymasq.keymasqd.runtime.adapters import WritableUInput
 
 log = logging.getLogger("keymasqd.output_helpers")
-
-
-class _WritableUInput(Protocol):
-    def write(self, event_type: int, code: int, value: int) -> None: ...
-
-    def syn(self) -> None: ...
 
 
 def _ecode_value(name: str) -> int | None:
@@ -84,7 +79,7 @@ def resolve_gamepad_axis_code(target: str | None) -> int | None:
 
 
 def emit_mouse_move(
-    uinput_dev: _WritableUInput | None,
+    uinput_dev: WritableUInput | None,
     move_x: int,
     move_y: int,
     *,

--- a/keymasq/keymasqd/runtime/action_runner.py
+++ b/keymasq/keymasqd/runtime/action_runner.py
@@ -15,6 +15,7 @@ from keymasq.keymasqd.output_helpers import (
     resolve_gamepad_axis_code,
     resolve_output_code,
 )
+from keymasq.keymasqd.runtime.adapters import AsyncioEvent
 from keymasq.keymasqd.runtime.grabbed_device_outputs import (
     bucket_for_uinput,
     passthrough,
@@ -37,7 +38,6 @@ from keymasq.keymasqd.runtime.grabbed_device_repeat import (
 from keymasq.keymasqd.runtime.grabbed_device_types import (
     ActionExecutionDeps,
     ActionRuntime,
-    AsyncioEvent,
     CursorPositionSetter,
     EmergencyResetter,
     GrabbedDeviceState,

--- a/keymasq/keymasqd/runtime/adapters.py
+++ b/keymasq/keymasqd/runtime/adapters.py
@@ -10,15 +10,30 @@ _T = TypeVar("_T")
 log = logging.getLogger("keymasqd.runtime.adapters")
 
 
+class DeviceInfo(Protocol):
+    vendor: int
+    product: int
+
+
 class WritableUInput(Protocol):
     def write(self, event_type: int, code: int, value: int) -> None: ...
 
     def syn(self) -> None: ...
 
+
+class ClosableUInput(WritableUInput, Protocol):
     def close(self) -> None: ...
 
 
 type UInputWriter = Callable[[object | None], WritableUInput | None]
+
+
+class ErrnoModule(Protocol):
+    EAGAIN: Final[int]
+    EWOULDBLOCK: Final[int]
+    ENOENT: Final[int]
+    ENODEV: Final[int]
+    EBUSY: Final[int]
 
 
 class AsyncioEvent(Protocol):

--- a/keymasq/keymasqd/runtime/device_path_resolver.py
+++ b/keymasq/keymasqd/runtime/device_path_resolver.py
@@ -19,14 +19,9 @@ from keymasq.common.devices import (
 )
 from keymasq.common.models import DeviceType
 from keymasq.common.types import JsonObject
-from keymasq.keymasqd.runtime.adapters import close_device
+from keymasq.keymasqd.runtime.adapters import DeviceInfo, close_device
 
 log = logging.getLogger("keymasqd.device_path_resolver")
-
-
-class _DeviceInfo(Protocol):
-    vendor: int
-    product: int
 
 
 class InputDeviceLike(Protocol):
@@ -34,7 +29,7 @@ class InputDeviceLike(Protocol):
     name: str | None
 
     @property
-    def info(self) -> _DeviceInfo: ...
+    def info(self) -> DeviceInfo: ...
 
     def input_props(self) -> Iterable[int]: ...
 

--- a/keymasq/keymasqd/runtime/grab_lifecycle.py
+++ b/keymasq/keymasqd/runtime/grab_lifecycle.py
@@ -30,7 +30,6 @@ type DesiredGrabConfigFactory = Callable[..., object]
 type GrabbedDeviceFactory = Callable[..., Any]
 type _ManagedGrabbedDevice = Any
 type _GrabManager = Any
-type _ErrnoModule = Any
 
 
 ASYNCIO_RUNTIME = runtime_adapters.ASYNCIO_RUNTIME
@@ -86,7 +85,7 @@ async def grab_device_unlocked(
     int_or_none_fn: IntOrNoneFn,
     float_value_fn: FloatValueFn,
     fire_and_observe_fn: FireAndObserve,
-    errno_mod: _ErrnoModule,
+    errno_mod: runtime_adapters.ErrnoModule,
 ) -> dict[str, object]:
     clear_device_path_cache_fn()
     cancel_pending_hardware_release(manager, hardware_id)
@@ -423,7 +422,7 @@ async def grab_with_retry(
     *,
     asyncio_mod: runtime_adapters.AsyncioRuntimeAdapter,
     log: logging.Logger,
-    errno_mod: _ErrnoModule,
+    errno_mod: runtime_adapters.ErrnoModule,
 ) -> None:
     delays = [0.05, 0.10, 0.20, 0.40, 0.80]
     last_error: Exception | None = None

--- a/keymasq/keymasqd/runtime/grabbed_device.py
+++ b/keymasq/keymasqd/runtime/grabbed_device.py
@@ -25,6 +25,7 @@ from keymasq.keymasqd.runtime import analog_controls as runtime_analog_controls
 from keymasq.keymasqd.runtime import grabbed_device_events as runtime_events
 from keymasq.keymasqd.runtime import grabbed_device_grab as runtime_grab
 from keymasq.keymasqd.runtime import grabbed_device_outputs as runtime_outputs
+from keymasq.keymasqd.runtime.adapters import identity_uinput_writer
 from keymasq.keymasqd.runtime.grabbed_device_types import (
     AsyncioModule as _AsyncioModule,
 )
@@ -41,7 +42,6 @@ from keymasq.keymasqd.runtime.grabbed_device_types import (
     GrabbedDeviceState,
     MacroPlayer,
     MappingGetter,
-    identity_uinput_writer,
 )
 from keymasq.keymasqd.runtime.grabbed_device_types import (
     ManagedInputDevice as _ManagedInputDevice,

--- a/keymasq/keymasqd/runtime/grabbed_device_actions.py
+++ b/keymasq/keymasqd/runtime/grabbed_device_actions.py
@@ -13,6 +13,7 @@ from keymasq.keymasqd.runtime.action_runner import (
     ResolveCodeFn,
     source_trigger_id,
 )
+from keymasq.keymasqd.runtime.adapters import WritableUInput
 from keymasq.keymasqd.runtime.grabbed_device_outputs import (
     track_superkey_abs_output,
     track_superkey_output,
@@ -22,7 +23,6 @@ from keymasq.keymasqd.runtime.grabbed_device_types import (
     ActionRuntime,
     GrabbedDeviceRuntime,
     InputEventLike,
-    WritableUInput,
 )
 from keymasq.keymasqd.runtime.repeat import (
     SUPERKEY_SLOT_OVERLOAD,

--- a/keymasq/keymasqd/runtime/grabbed_device_events.py
+++ b/keymasq/keymasqd/runtime/grabbed_device_events.py
@@ -24,6 +24,7 @@ from keymasq.keymasqd.runtime import grabbed_device_actions as runtime_actions
 from keymasq.keymasqd.runtime import grabbed_device_outputs as runtime_outputs
 from keymasq.keymasqd.runtime import repeat as runtime_repeat
 from keymasq.keymasqd.runtime.action_runner import source_trigger_id
+from keymasq.keymasqd.runtime.adapters import identity_uinput_writer
 from keymasq.keymasqd.runtime.grabbed_device_types import (
     ActionExecutionDeps,
     AsyncioModule,
@@ -33,7 +34,6 @@ from keymasq.keymasqd.runtime.grabbed_device_types import (
     GrabbedDeviceRuntime,
     InputEventLike,
     TimeModule,
-    identity_uinput_writer,
     runtime_is_running,
 )
 

--- a/keymasq/keymasqd/runtime/grabbed_device_grab.py
+++ b/keymasq/keymasqd/runtime/grabbed_device_grab.py
@@ -11,12 +11,11 @@ from keymasq.keymasqd.output_helpers import (
 )
 from keymasq.keymasqd.runtime import grabbed_device_events as runtime_events
 from keymasq.keymasqd.runtime import grabbed_device_outputs as runtime_outputs
+from keymasq.keymasqd.runtime.adapters import ErrnoModule, identity_uinput_writer
 from keymasq.keymasqd.runtime.grabbed_device_types import (
     AsyncioModule,
-    ErrnoModule,
     GrabbedDeviceRuntime,
     TimeModule,
-    identity_uinput_writer,
 )
 
 

--- a/keymasq/keymasqd/runtime/grabbed_device_outputs.py
+++ b/keymasq/keymasqd/runtime/grabbed_device_outputs.py
@@ -5,13 +5,15 @@ import evdev
 
 from keymasq.common.models import ActionType, MappingAction
 from keymasq.keymasqd.output_helpers import emit_mouse_move
+from keymasq.keymasqd.runtime.adapters import (
+    UInputWriter,
+    WritableUInput,
+    identity_uinput_writer,
+)
 from keymasq.keymasqd.runtime.grabbed_device_types import (
     ActionRuntime,
     EvdevModule,
     InputEventLike,
-    UInputWriter,
-    WritableUInput,
-    identity_uinput_writer,
 )
 
 log = logging.getLogger("keymasqd.devices")

--- a/keymasq/keymasqd/runtime/grabbed_device_repeat.py
+++ b/keymasq/keymasqd/runtime/grabbed_device_repeat.py
@@ -9,6 +9,11 @@ from keymasq.common.models import (
     clamp_rapidfire_hold_ms,
     clamp_rapidfire_wait_ms,
 )
+from keymasq.keymasqd.runtime.adapters import (
+    AsyncioEvent,
+    UInputWriter,
+    identity_uinput_writer,
+)
 from keymasq.keymasqd.runtime.grabbed_device_outputs import (
     emit_configured_mouse_move,
     ensure_abs_axis_released,
@@ -18,14 +23,11 @@ from keymasq.keymasqd.runtime.grabbed_device_outputs import (
 )
 from keymasq.keymasqd.runtime.grabbed_device_types import (
     ActionRuntime,
-    AsyncioEvent,
     AsyncioModule,
     EvdevModule,
     OutputTracker,
     RapidfireOutputState,
     TaskFactory,
-    UInputWriter,
-    identity_uinput_writer,
     runtime_is_running,
 )
 from keymasq.keymasqd.runtime.mouse_actions import (

--- a/keymasq/keymasqd/runtime/grabbed_device_types.py
+++ b/keymasq/keymasqd/runtime/grabbed_device_types.py
@@ -10,7 +10,7 @@ from collections.abc import (
     Sequence,
 )
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Final, Protocol, TypeVar, cast
+from typing import TYPE_CHECKING, Final, Protocol, TypeVar
 
 import evdev
 
@@ -18,6 +18,12 @@ from keymasq.common.ipc import CommandType
 from keymasq.common.models import MappingAction
 from keymasq.keymasqd.combo_engine import ComboDecision
 from keymasq.keymasqd.recording import RecordingManager
+from keymasq.keymasqd.runtime.adapters import (
+    AsyncioEvent,
+    AsyncioLoop,
+    DeviceInfo,
+    UInputWriter,
+)
 from keymasq.keymasqd.runtime.repeat import RepeatRuntimeState
 
 if TYPE_CHECKING:
@@ -48,11 +54,6 @@ class InputEventLike(Protocol):
     value: int
 
 
-class DeviceInfo(Protocol):
-    vendor: int
-    product: int
-
-
 class ManagedInputDevice(Protocol):
     path: str
     name: str | None
@@ -79,35 +80,9 @@ class ManagedInputDevice(Protocol):
     def close(self) -> None: ...
 
 
-class WritableUInput(Protocol):
-    def write(self, event_type: int, code: int, value: int) -> None: ...
-
-    def syn(self) -> None: ...
-
-    def close(self) -> None: ...
-
-
-type UInputWriter = Callable[[object | None], WritableUInput | None]
 type TaskFactory = Callable[[], asyncio.Task[None]]
 type RelativePulseEmitter = Callable[[], None]
 type RelativePulseActive = Callable[[], bool]
-
-
-class ErrnoModule(Protocol):
-    EAGAIN: Final[int]
-    EWOULDBLOCK: Final[int]
-
-
-class AsyncioEvent(Protocol):
-    def set(self) -> None: ...
-
-    async def wait(self) -> object: ...
-
-
-class AsyncioLoop(Protocol):
-    def add_reader(self, fd: int, callback: Callable[[], object], /) -> None: ...
-
-    def remove_reader(self, fd: int) -> bool: ...
 
 
 class AsyncioModule(Protocol):
@@ -157,10 +132,6 @@ class EvdevModule(Protocol):
 
 
 type ClassifyEventDeviceTypeFn = Callable[[evdev.InputEvent, list[str]], str]
-
-
-def identity_uinput_writer(device: object | None) -> WritableUInput | None:
-    return cast(WritableUInput | None, device)
 
 
 @dataclass(frozen=True)

--- a/keymasq/keymasqd/runtime/mouse_actions.py
+++ b/keymasq/keymasqd/runtime/mouse_actions.py
@@ -7,19 +7,13 @@ from typing import Protocol
 import evdev
 
 from keymasq.keymasqd.output_helpers import parse_mouse_output_target
-
-
-class _WritableUInput(Protocol):
-    def write(self, event_type: int, code: int, value: int) -> None: ...
-
-    def syn(self) -> None: ...
+from keymasq.keymasqd.runtime.adapters import UInputWriter, WritableUInput
 
 
 class _AsyncioModule(Protocol):
     async def sleep(self, delay: float, /) -> None: ...
 
 
-type UInputWriter = Callable[[object | None], _WritableUInput | None]
 type RelativePulseEmitter = Callable[[], None]
 type RelativePulseActive = Callable[[], bool]
 
@@ -53,7 +47,7 @@ _HI_RES_SCROLL = (
 
 
 def emit_relative_pulse(
-    uinput: _WritableUInput | None,
+    uinput: WritableUInput | None,
     code: int,
     value: int,
     *,

--- a/keymasq/keymasqd/runtime/outputs.py
+++ b/keymasq/keymasqd/runtime/outputs.py
@@ -1,11 +1,16 @@
 import logging
 import os
 import re
-from collections.abc import Callable, Mapping, Sequence
+from collections.abc import Mapping, Sequence
 from hashlib import blake2b
 from typing import Any, Final, Protocol, cast
 
 from keymasq.common.virtual_devices import clamp_virtual_gamepad_count, virtual_gamepad_output_id
+from keymasq.keymasqd.runtime.adapters import (
+    ClosableUInput,
+    UInputWriter,
+    WritableUInput,
+)
 
 TEST_UINPUT_ENV = "KEYMASQ_TEST_UINPUT"
 TEST_UINPUT_PREFIX = "keymasq-test"
@@ -19,25 +24,12 @@ TEST_UINPUT_PRODUCTS = {
 }
 
 
-class _ClosableUInput(Protocol):
-    def close(self) -> None: ...
-
-
-class _WritableUInput(_ClosableUInput, Protocol):
-    def write(self, event_type: int, code: int, value: int) -> None: ...
-
-    def syn(self) -> None: ...
-
-
-type UInputWriter = Callable[[_ClosableUInput | None], _WritableUInput | None]
-
-
 class _OutputState(Protocol):
     device_count: int
-    keyboard_uinput: _ClosableUInput | None
-    mouse_uinput: _ClosableUInput | None
-    gamepad_uinput: _ClosableUInput | None
-    virtual_gamepad_uinputs: dict[str, _ClosableUInput]
+    keyboard_uinput: ClosableUInput | None
+    mouse_uinput: ClosableUInput | None
+    gamepad_uinput: ClosableUInput | None
+    virtual_gamepad_uinputs: dict[str, ClosableUInput]
     virtual_gamepad_count: int
 
 
@@ -61,7 +53,7 @@ class _UInputFactory(Protocol):
         product: int = ...,
         version: int = ...,
         bustype: int = ...,
-    ) -> _ClosableUInput: ...
+    ) -> ClosableUInput: ...
 
 
 class _Ecodes(Protocol):
@@ -326,7 +318,7 @@ def gamepad_caps(evdev_mod: _EvdevModule) -> dict[int, Sequence[object]]:
 
 
 def _initialize_gamepad_axes(
-    uinput_dev: _WritableUInput | None,
+    uinput_dev: WritableUInput | None,
     evdev_mod: _EvdevModule,
 ) -> None:
     if uinput_dev is None:
@@ -351,7 +343,7 @@ def create_virtual_gamepad(
     index: int,
     evdev_mod: _EvdevModule,
     uinput_writer: UInputWriter,
-) -> _ClosableUInput:
+) -> ClosableUInput:
     normal_name = "keymasq-gamepad" if index == 1 else f"keymasq-gamepad-{index}"
     gamepad_name, gamepad_vendor, gamepad_product = uinput_identity(
         normal_name,
@@ -382,7 +374,7 @@ def configure_virtual_gamepads(
     output_state = cast(Any, manager.output_state)
     if not hasattr(output_state, "virtual_gamepad_uinputs"):
         output_state.virtual_gamepad_uinputs = {}
-    current = cast(dict[str, _ClosableUInput], output_state.virtual_gamepad_uinputs)
+    current = cast(dict[str, ClosableUInput], output_state.virtual_gamepad_uinputs)
     desired_ids = {virtual_gamepad_output_id(index) for index in range(1, count + 1)}
 
     for output_id in sorted(set(current) - desired_ids):

--- a/keymasq/keymasqd/superkey_state.py
+++ b/keymasq/keymasqd/superkey_state.py
@@ -4,7 +4,7 @@ import logging
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import TYPE_CHECKING, Any, Protocol, cast
+from typing import TYPE_CHECKING, Any, cast
 
 import evdev
 
@@ -21,6 +21,7 @@ from keymasq.common.models import (
     superkey_action_shared_kwargs,
 )
 from keymasq.common.types import SyntheticInputEvent as _SyntheticInputEvent
+from keymasq.keymasqd.runtime.adapters import WritableUInput, identity_uinput_writer
 from keymasq.keymasqd.runtime.mouse_actions import (
     emit_relative_pulse,
     rapidfire_relative_pulses,
@@ -138,12 +139,6 @@ class SuperkeyConfig:
                 raise ValueError("nested superkeys are not allowed inside superkeys")
 
 
-class _WritableUInput(Protocol):
-    def write(self, event_type: int, code: int, value: int) -> None: ...
-
-    def syn(self) -> None: ...
-
-
 type CursorPositionSetter = Callable[[int, int], Awaitable[dict[str, object]]]
 type CancelMacroPlayback = Callable[[], Awaitable[dict[str, object]]]
 type MacroPlayer = Callable[..., Awaitable[dict[str, object]]]
@@ -153,7 +148,6 @@ type EmergencyResetter = Callable[[], Awaitable[dict[str, object]]]
 def _default_action_deps() -> "ActionExecutionDeps":
     from keymasq.keymasqd.runtime.grabbed_device_types import (
         ActionExecutionDeps,
-        identity_uinput_writer,
     )
 
     return ActionExecutionDeps(
@@ -169,9 +163,9 @@ class SuperkeyMachine:
         self,
         config: SuperkeyConfig,
         event_name: str,
-        keyboard_uinput: _WritableUInput,
-        mouse_uinput: _WritableUInput,
-        gamepad_uinput: _WritableUInput,
+        keyboard_uinput: WritableUInput,
+        mouse_uinput: WritableUInput,
+        gamepad_uinput: WritableUInput,
         source_device: str = "",
         broadcast_callback: Callable[[dict[str, object]], Awaitable[None]] | None = None,
         cursor_position_setter: CursorPositionSetter | None = None,

--- a/tests/keymasqd/test_analog_controls_runtime.py
+++ b/tests/keymasqd/test_analog_controls_runtime.py
@@ -16,6 +16,7 @@ from keymasq.common.models import (
     ProfileDeactivationPolicy,
 )
 from keymasq.keymasqd.device_manager import DeviceManager
+from keymasq.keymasqd.runtime.adapters import identity_uinput_writer
 from keymasq.keymasqd.runtime.analog_controls import (
     _axis_motion_delta,
     _motion_delta,
@@ -29,7 +30,6 @@ from keymasq.keymasqd.runtime.grabbed_device_outputs import release_all_keys
 from keymasq.keymasqd.runtime.grabbed_device_types import (
     ActionExecutionDeps,
     GrabbedDeviceState,
-    identity_uinput_writer,
 )
 
 

--- a/tests/keymasqd/test_device_manager_runtime_recovery.py
+++ b/tests/keymasqd/test_device_manager_runtime_recovery.py
@@ -11,13 +11,13 @@ from keymasq.common.models import ActionType, DeviceType, SuperkeyMode
 from keymasq.keymasqd import device_manager as dm
 from keymasq.keymasqd.device_manager import DeviceManager
 from keymasq.keymasqd.runtime import actions as adm
+from keymasq.keymasqd.runtime import adapters as runtime_adapters
 from keymasq.keymasqd.runtime import combos as cdm
 from keymasq.keymasqd.runtime import grab_lifecycle as ldm
 from keymasq.keymasqd.runtime import grabbed_device as gdm
 from keymasq.keymasqd.runtime import grabbed_device_actions as gda
 from keymasq.keymasqd.runtime import grabbed_device_events as gde
 from keymasq.keymasqd.runtime import grabbed_device_outputs as gdo
-from keymasq.keymasqd.runtime import grabbed_device_types as gdt
 from keymasq.keymasqd.runtime import topology as tdm
 from keymasq.keymasqd.superkey_state import SuperkeyActionData, SuperkeyConfig
 from tests.keymasqd.device_manager_support import (
@@ -113,7 +113,7 @@ class TestRuntimeFailureCleanup:
             evdev.ecodes.KEY_A,
             1,
             evdev_mod=evdev,
-            uinput_writer=gdt.identity_uinput_writer,
+            uinput_writer=runtime_adapters.identity_uinput_writer,
         )
 
         await gde.recover_from_event_processing_error(device)

--- a/tests/keymasqd/test_grabbed_device_runtime_helpers.py
+++ b/tests/keymasqd/test_grabbed_device_runtime_helpers.py
@@ -17,6 +17,7 @@ from keymasq.common.models import (
 )
 from keymasq.keymasqd import device_manager as dm
 from keymasq.keymasqd.device_manager import DeviceManager
+from keymasq.keymasqd.runtime import adapters as runtime_adapters
 from keymasq.keymasqd.runtime import grab_lifecycle as ldm
 from keymasq.keymasqd.runtime import grabbed_device as gdm
 from keymasq.keymasqd.runtime import grabbed_device_actions as gda
@@ -505,7 +506,7 @@ class TestGrabbedDeviceHelpers:
 
         gdo.flush_passthrough_frame(
             target_uinput,
-            uinput_writer=gdt.identity_uinput_writer,
+            uinput_writer=runtime_adapters.identity_uinput_writer,
         )
 
         assert target_uinput.syn_count == 1
@@ -1140,7 +1141,9 @@ class TestGrabbedDeviceHelpers:
         gdo.release_all_keys(
             device,
             evdev_mod=evdev,
-            uinput_writer=lambda device: cast(gdt.WritableUInput | None, device),
+            uinput_writer=lambda device: cast(
+                runtime_adapters.WritableUInput | None, device
+            ),
         )
 
         assert passthrough.writes == [(evdev.ecodes.EV_KEY, evdev.ecodes.KEY_A, 0)]
@@ -1174,7 +1177,9 @@ class TestGrabbedDeviceHelpers:
                 device,
                 evdev.ecodes.ABS_Z,
                 evdev_mod=evdev,
-                uinput_writer=lambda device: cast(gdt.WritableUInput | None, device),
+                uinput_writer=lambda device: cast(
+                    runtime_adapters.WritableUInput | None, device
+                ),
             )
 
         assert "Failed to release output key" in caplog.text
@@ -1195,7 +1200,9 @@ class TestGrabbedDeviceHelpers:
             gdo.release_all_keys(
                 device,
                 evdev_mod=evdev,
-                uinput_writer=lambda device: cast(gdt.WritableUInput | None, device),
+                uinput_writer=lambda device: cast(
+                    runtime_adapters.WritableUInput | None, device
+                ),
             )
 
         assert device.state.held_output_keys["keyboard"] == {evdev.ecodes.KEY_A}
@@ -1403,7 +1410,7 @@ class TestGrabbedDeviceHelpers:
             device.gamepad_uinput,
             asyncio_mod=gdm.ASYNCIO_RUNTIME,
             evdev_mod=evdev,
-            uinput_writer=gdt.identity_uinput_writer,
+            uinput_writer=runtime_adapters.identity_uinput_writer,
         )
         move_action = dm.MappingAction(
             action_type=ActionType.MOUSE_MOVE_REL,
@@ -2441,7 +2448,9 @@ class TestGrabbedDeviceHelpers:
         gdo.release_all_keys(
             device,
             evdev_mod=evdev,
-            uinput_writer=lambda device: cast(gdt.WritableUInput | None, device),
+            uinput_writer=lambda device: cast(
+                runtime_adapters.WritableUInput | None, device
+            ),
         )
 
         assert (evdev.ecodes.EV_ABS, evdev.ecodes.ABS_Z, 0) in second_gamepad.writes
@@ -2568,7 +2577,9 @@ class TestGrabbedDeviceHelpers:
         gdo.release_all_keys(
             device,
             evdev_mod=evdev,
-            uinput_writer=lambda device: cast(gdt.WritableUInput | None, device),
+            uinput_writer=lambda device: cast(
+                runtime_adapters.WritableUInput | None, device
+            ),
         )
 
         assert bucket not in device.state.held_output_keys


### PR DESCRIPTION
## Summary
- Moved duplicate runtime typing protocols into `keymasq/keymasqd/runtime/adapters.py` and referenced them from runtime and daemon modules.
- Consolidated `DeviceInfo`, `WritableUInput`, `ClosableUInput`, `ErrnoModule`, `AsyncioEvent`, and related typing helpers to reduce duplication and keep protocol definitions in one place.
- Updated runtime modules to import shared adapters (`grab_lifecycle`, `device_manager`, `capture_manager`, `grabbed_device_*`, `mouse_actions`, `superkey_state`, `outputs`, etc.).
- Removed per-file local protocol definitions and re-routed tests to import shared identities from `runtime.adapters`.
- Adjusted `OutputRuntimeState`/output protocol annotations to use shared close-capable and writable input types without changing runtime behavior.

## Testing
 `./scripts/check.sh full`
 `nix build 'path:.#checks.x86_64-linux.daemon-session-integration-test'`