### PR TITLE
Refactor recording pending-save state to dataclasses

### DIFF
--- a/keymasq/session/manager/core.py
+++ b/keymasq/session/manager/core.py
@@ -232,7 +232,7 @@ class SessionManager:
                 await topology_task
             self.profile_state.topology_refresh_task = None
 
-        save_task = cast(asyncio.Task[None] | None, self.recording_state.settings_save_task)
+        save_task = self.recording_state.settings_save_task
         if save_task:
             with contextlib.suppress(asyncio.CancelledError, Exception):
                 await save_task

--- a/keymasq/session/manager/recording_device_selection.py
+++ b/keymasq/session/manager/recording_device_selection.py
@@ -63,7 +63,7 @@ def queue_recording_settings_save(
     settings: JsonObject,
 ) -> None:
     manager.recording_state.settings_pending_save = settings
-    save_task = cast(asyncio.Task[None] | None, manager.recording_state.settings_save_task)
+    save_task = manager.recording_state.settings_save_task
     if save_task is not None and not save_task.done():
         return
     manager.recording_state.settings_save_task = asyncio.create_task(

--- a/keymasq/session/manager/recording_lifecycle.py
+++ b/keymasq/session/manager/recording_lifecycle.py
@@ -24,6 +24,7 @@ from .common import (
     str_value,
 )
 from .recording_device_selection import recording_device_id
+from .state import PendingSave, PendingSlot
 
 if TYPE_CHECKING:
     from .core import SessionManager
@@ -49,47 +50,49 @@ def normalize_pending_macro_recording_slot(value: object, *, default: int = 1) -
     return default if 1 <= default <= MAX_MACRO_RECORDING_SLOTS else 1
 
 
-def _sync_legacy_pending_macro_save(manager: "SessionManager") -> None:
+def _sync_pending_macro_save(manager: "SessionManager") -> None:
     state = manager.recording_state
     if not state.pending_slots:
-        state.pending_data = None
-        state.pending_save_token = None
-        state.pending_save_owner_writer_id = None
-        state.pending_save_owner_pid = None
-        state.pending_save_owner_uid = None
-        state.pending_save_created_at = 0.0
+        state.pending_save = None
         return
 
     slot = max(
         state.pending_slots,
-        key=lambda current_slot: state.pending_slot_created_at.get(current_slot, 0.0),
+        key=lambda current_slot: state.pending_slots[current_slot].created_at,
     )
-    state.pending_data = state.pending_slots.get(slot)
-    state.pending_save_token = state.pending_slot_tokens.get(slot)
-    state.pending_save_owner_writer_id = state.pending_slot_owner_writer_ids.get(slot)
-    state.pending_save_owner_pid = state.pending_slot_owner_pids.get(slot)
-    state.pending_save_owner_uid = state.pending_slot_owner_uids.get(slot)
-    state.pending_save_created_at = state.pending_slot_created_at.get(slot, 0.0)
+    pending_slot = state.pending_slots[slot]
+    state.pending_save = PendingSave(
+        data=pending_slot.data,
+        token=pending_slot.token,
+        owner_writer_id=pending_slot.owner_writer_id,
+        owner_pid=pending_slot.owner_pid,
+        owner_uid=pending_slot.owner_uid,
+        created_at=pending_slot.created_at,
+    )
 
 
-def _ensure_legacy_pending_macro_save_slot(manager: "SessionManager") -> None:
+def _ensure_pending_macro_save_slot(manager: "SessionManager") -> None:
     state = manager.recording_state
-    if state.pending_slots or not state.pending_data or not state.pending_save_token:
+    pending_save = state.pending_save
+    if state.pending_slots or pending_save is None or not pending_save.token:
         return
 
     slot = normalize_pending_macro_recording_slot(
-        state.pending_data.get("recording_slot"),
+        pending_save.data.get("recording_slot"),
         default=1,
     )
-    legacy_data = dict(state.pending_data)
-    legacy_data["recording_slot"] = slot
-    legacy_data["pending_save_token"] = state.pending_save_token
-    state.pending_slots[slot] = legacy_data
-    state.pending_slot_tokens[slot] = state.pending_save_token
-    state.pending_slot_owner_writer_ids[slot] = state.pending_save_owner_writer_id
-    state.pending_slot_owner_pids[slot] = state.pending_save_owner_pid
-    state.pending_slot_owner_uids[slot] = state.pending_save_owner_uid
-    state.pending_slot_created_at[slot] = state.pending_save_created_at or _monotonic()
+    data = dict(pending_save.data)
+    data["recording_slot"] = slot
+    data["pending_save_token"] = pending_save.token
+    state.pending_slots[slot] = PendingSlot(
+        data=data,
+        token=pending_save.token,
+        owner_writer_id=pending_save.owner_writer_id,
+        owner_pid=pending_save.owner_pid,
+        owner_uid=pending_save.owner_uid,
+        created_at=pending_save.created_at or _monotonic(),
+    )
+    _sync_pending_macro_save(manager)
 
 
 def pending_macro_save_slot_for_token(
@@ -99,9 +102,9 @@ def pending_macro_save_slot_for_token(
     token = str(token or "").strip()
     if not token:
         return 0
-    _ensure_legacy_pending_macro_save_slot(manager)
-    for slot, current_token in manager.recording_state.pending_slot_tokens.items():
-        if current_token == token:
+    _ensure_pending_macro_save_slot(manager)
+    for slot, pending_slot in manager.recording_state.pending_slots.items():
+        if pending_slot.token == token:
             return slot
     return 0
 
@@ -112,7 +115,7 @@ def pending_macro_save_slot(
     recording_slot: int = 0,
     pending_save_token: str = "",
 ) -> int:
-    _ensure_legacy_pending_macro_save_slot(manager)
+    _ensure_pending_macro_save_slot(manager)
     token = str(pending_save_token or "").strip()
     token_slot = pending_macro_save_slot_for_token(manager, pending_save_token)
     if token_slot:
@@ -137,14 +140,12 @@ def has_pending_macro_save(
     *,
     recording_slot: int = 0,
 ) -> bool:
-    _ensure_legacy_pending_macro_save_slot(manager)
+    _ensure_pending_macro_save_slot(manager)
     state = manager.recording_state
     slot = normalize_macro_recording_slot(recording_slot)
     if slot:
-        return slot in state.pending_slots and bool(state.pending_slot_tokens.get(slot))
-    return bool(state.pending_slots) or (
-        state.pending_data is not None and bool(state.pending_save_token)
-    )
+        return bool(state.pending_slots.get(slot))
+    return bool(state.pending_slots) or bool(state.pending_save)
 
 
 def macro_recording_disabled_response() -> JsonObject:
@@ -226,14 +227,16 @@ def begin_pending_macro_save(
     token = secrets.token_urlsafe(16)
     recording_data["recording_slot"] = slot
     recording_data["pending_save_token"] = token
-    state.pending_slots[slot] = recording_data
-    state.pending_slot_tokens[slot] = token
-    # Owner fields are retained for legacy status compatibility, not cleanup.
-    state.pending_slot_owner_writer_ids[slot] = state.active_owner_writer_id
-    state.pending_slot_owner_pids[slot] = state.active_owner_pid
-    state.pending_slot_owner_uids[slot] = state.active_owner_uid
-    state.pending_slot_created_at[slot] = _monotonic()
-    _sync_legacy_pending_macro_save(manager)
+    state.pending_slots[slot] = PendingSlot(
+        data=recording_data,
+        token=token,
+        # Owner fields are retained for status compatibility, not cleanup.
+        owner_writer_id=state.active_owner_writer_id,
+        owner_pid=state.active_owner_pid,
+        owner_uid=state.active_owner_uid,
+        created_at=_monotonic(),
+    )
+    _sync_pending_macro_save(manager)
     _clear_active_recording_owner(manager)
     return token
 
@@ -245,7 +248,7 @@ def clear_pending_macro_save(
     pending_save_token: str = "",
 ) -> None:
     state = manager.recording_state
-    _ensure_legacy_pending_macro_save_slot(manager)
+    _ensure_pending_macro_save_slot(manager)
     slot = pending_macro_save_slot(
         manager,
         recording_slot=recording_slot,
@@ -253,27 +256,12 @@ def clear_pending_macro_save(
     )
     if slot:
         state.pending_slots.pop(slot, None)
-        state.pending_slot_tokens.pop(slot, None)
-        state.pending_slot_owner_writer_ids.pop(slot, None)
-        state.pending_slot_owner_pids.pop(slot, None)
-        state.pending_slot_owner_uids.pop(slot, None)
-        state.pending_slot_created_at.pop(slot, None)
-        _sync_legacy_pending_macro_save(manager)
+        _sync_pending_macro_save(manager)
     else:
         if recording_slot or str(pending_save_token or "").strip():
             return
-        state.pending_data = None
-        state.pending_save_token = None
-        state.pending_save_owner_writer_id = None
-        state.pending_save_owner_pid = None
-        state.pending_save_owner_uid = None
-        state.pending_save_created_at = 0.0
+        state.pending_save = None
         state.pending_slots.clear()
-        state.pending_slot_tokens.clear()
-        state.pending_slot_owner_writer_ids.clear()
-        state.pending_slot_owner_pids.clear()
-        state.pending_slot_owner_uids.clear()
-        state.pending_slot_created_at.clear()
 
 
 async def delete_pending_macro_slot(
@@ -282,7 +270,7 @@ async def delete_pending_macro_slot(
     recording_slot: int = 0,
     pending_save_token: str = "",
 ) -> bool:
-    _ensure_legacy_pending_macro_save_slot(manager)
+    _ensure_pending_macro_save_slot(manager)
     slot = pending_macro_save_slot(
         manager,
         recording_slot=recording_slot,
@@ -291,7 +279,8 @@ async def delete_pending_macro_slot(
     if not slot:
         return False
 
-    pending_data = manager.recording_state.pending_slots.get(slot) or {}
+    pending_slot = manager.recording_state.pending_slots.get(slot)
+    pending_data = pending_slot.data if pending_slot is not None else {}
     pending_recording_id = str_value(pending_data.get("pending_recording_id"), "")
     if pending_recording_id:
         try:
@@ -319,14 +308,14 @@ async def store_pending_macro_save(
     pending_recording_id = str_value(recording_data.get("pending_recording_id"), "")
     existing = manager.recording_state.pending_slots.get(slot)
     if existing is not None:
-        existing_id = str_value(existing.get("pending_recording_id"), "")
+        existing_id = str_value(existing.data.get("pending_recording_id"), "")
         if pending_recording_id and existing_id == pending_recording_id:
-            token = manager.recording_state.pending_slot_tokens.get(slot, "") or ""
-            existing.update(recording_data)
-            existing["recording_slot"] = slot
+            token = existing.token
+            existing.data.update(recording_data)
+            existing.data["recording_slot"] = slot
             if token:
-                existing["pending_save_token"] = token
-            _sync_legacy_pending_macro_save(manager)
+                existing.data["pending_save_token"] = token
+            _sync_pending_macro_save(manager)
             return token
         await delete_pending_macro_slot(manager, recording_slot=slot)
 
@@ -359,18 +348,8 @@ def replace_pending_macro_slots_from_daemon(
 ) -> None:
     state = manager.recording_state
     old_slots = dict(state.pending_slots)
-    old_tokens = dict(state.pending_slot_tokens)
-    old_owner_writer_ids = dict(state.pending_slot_owner_writer_ids)
-    old_owner_pids = dict(state.pending_slot_owner_pids)
-    old_owner_uids = dict(state.pending_slot_owner_uids)
-    old_created_at = dict(state.pending_slot_created_at)
 
     state.pending_slots.clear()
-    state.pending_slot_tokens.clear()
-    state.pending_slot_owner_writer_ids.clear()
-    state.pending_slot_owner_pids.clear()
-    state.pending_slot_owner_uids.clear()
-    state.pending_slot_created_at.clear()
 
     for item in recordings:
         data = json_object(item)
@@ -381,16 +360,17 @@ def replace_pending_macro_slots_from_daemon(
         if not slot or not pending_recording_id:
             continue
 
-        existing = old_slots.get(slot) or {}
-        existing_id = str_value(existing.get("pending_recording_id"), "")
+        existing = old_slots.get(slot)
+        existing_data = existing.data if existing is not None else {}
+        existing_id = str_value(existing_data.get("pending_recording_id"), "")
         same_pending_recording = existing_id == pending_recording_id
         merged: JsonObject = {}
         if same_pending_recording:
-            merged.update(existing)
+            merged.update(existing_data)
         merged.update(data)
         token = ""
-        if same_pending_recording:
-            token = old_tokens.get(slot, "") or str_value(
+        if same_pending_recording and existing is not None:
+            token = existing.token or str_value(
                 merged.get("pending_save_token"),
                 "",
             )
@@ -400,20 +380,23 @@ def replace_pending_macro_slots_from_daemon(
         merged["recording_slot"] = int(slot)
         merged["pending_recording_id"] = pending_recording_id
         merged["pending_save_token"] = token
-        state.pending_slots[slot] = merged
-        state.pending_slot_tokens[slot] = token
-        if same_pending_recording:
-            state.pending_slot_owner_writer_ids[slot] = old_owner_writer_ids.get(slot)
-            state.pending_slot_owner_pids[slot] = old_owner_pids.get(slot)
-            state.pending_slot_owner_uids[slot] = old_owner_uids.get(slot)
-            state.pending_slot_created_at[slot] = old_created_at.get(slot, _monotonic())
+        if same_pending_recording and existing is not None:
+            state.pending_slots[slot] = PendingSlot(
+                data=merged,
+                token=token,
+                owner_writer_id=existing.owner_writer_id,
+                owner_pid=existing.owner_pid,
+                owner_uid=existing.owner_uid,
+                created_at=existing.created_at,
+            )
         else:
-            state.pending_slot_owner_writer_ids[slot] = None
-            state.pending_slot_owner_pids[slot] = None
-            state.pending_slot_owner_uids[slot] = None
-            state.pending_slot_created_at[slot] = _monotonic()
+            state.pending_slots[slot] = PendingSlot(
+                data=merged,
+                token=token,
+                created_at=_monotonic(),
+            )
 
-    _sync_legacy_pending_macro_save(manager)
+    _sync_pending_macro_save(manager)
 
 
 def pending_macro_save_token_matches(
@@ -507,7 +490,8 @@ async def play_macro_slot_trigger(manager: "SessionManager", data: JsonObject) -
             "message": f"Recording slot {slot} is empty.",
         }
 
-    pending_data = manager.recording_state.pending_slots.get(pending_slot) or {}
+    pending_slot_state = manager.recording_state.pending_slots.get(pending_slot)
+    pending_data = pending_slot_state.data if pending_slot_state is not None else {}
     pending_recording_id = str_value(pending_data.get("pending_recording_id"), "")
     if not pending_recording_id:
         return {
@@ -830,7 +814,8 @@ async def save_recording(
     if not slot:
         return {"status": "error", "message": "No pending recording"}
 
-    data: JsonObject = manager.recording_state.pending_slots.get(slot) or {}
+    pending_slot = manager.recording_state.pending_slots.get(slot)
+    data = pending_slot.data if pending_slot is not None else {}
     pending_recording_id = str_value(data.get("pending_recording_id"), "")
     if not pending_recording_id:
         return {"status": "error", "message": "No pending recording"}
@@ -865,18 +850,18 @@ async def save_recording(
     data["start_x"] = int(start_x)
     data["start_y"] = int(start_y)
     data["block_mouse_movement"] = bool(block_mouse_movement)
-    manager.recording_state.pending_slots[slot] = data
-    _sync_legacy_pending_macro_save(manager)
+    _sync_pending_macro_save(manager)
     manager.broadcast_to_session_clients({"event": "macro_saved", "name": created_name})
     return {"status": "ok", "name": created_name}
 
 
 def build_pending_macro_slot_meta(manager: "SessionManager") -> list[JsonObject]:
-    _ensure_legacy_pending_macro_save_slot(manager)
+    _ensure_pending_macro_save_slot(manager)
     out: list[JsonObject] = []
     for slot in sorted(manager.recording_state.pending_slots):
-        data = manager.recording_state.pending_slots.get(slot) or {}
-        token = manager.recording_state.pending_slot_tokens.get(slot, "")
+        pending_slot = manager.recording_state.pending_slots[slot]
+        data = pending_slot.data
+        token = pending_slot.token
         duration_ms = int_value(data.get("duration_ms"), 0)
         duration_us = int_value(data.get("duration_us"), duration_ms * 1000)
         device_types = [str(value) for value in json_list(data.get("device_types"))]

--- a/keymasq/session/manager/recording_lifecycle.py
+++ b/keymasq/session/manager/recording_lifecycle.py
@@ -867,7 +867,7 @@ def build_pending_macro_slot_meta(manager: "SessionManager") -> list[JsonObject]
         device_types = [str(value) for value in json_list(data.get("device_types"))]
         event_count = int_value(data.get("event_count"), 0)
         pending = True
-        playable = bool(pending or token)
+        playable = True
         out.append(
             {
                 "kind": "recording_slot",

--- a/keymasq/session/manager/state.py
+++ b/keymasq/session/manager/state.py
@@ -27,28 +27,38 @@ class CaptureRuntimeState:
 
 
 @dataclass
+class PendingSave:
+    data: JsonObject
+    token: str
+    owner_writer_id: int | None = None
+    owner_pid: int | None = None
+    owner_uid: int | None = None
+    created_at: float = 0.0
+
+
+@dataclass
+class PendingSlot:
+    data: JsonObject
+    token: str
+    owner_writer_id: int | None = None
+    owner_pid: int | None = None
+    owner_uid: int | None = None
+    created_at: float = 0.0
+
+
+@dataclass
 class RecordingRuntimeState:
     active: bool = False
     active_slot: int = 0
-    pending_data: JsonObject | None = None
-    pending_slots: dict[int, JsonObject] = field(default_factory=dict)
-    pending_slot_tokens: dict[int, str] = field(default_factory=dict)
-    pending_slot_owner_writer_ids: dict[int, int | None] = field(default_factory=dict)
-    pending_slot_owner_pids: dict[int, int | None] = field(default_factory=dict)
-    pending_slot_owner_uids: dict[int, int | None] = field(default_factory=dict)
-    pending_slot_created_at: dict[int, float] = field(default_factory=dict)
-    pending_save_token: str | None = None
-    pending_save_owner_writer_id: int | None = None
-    pending_save_owner_pid: int | None = None
-    pending_save_owner_uid: int | None = None
-    pending_save_created_at: float = 0.0
+    pending_slots: dict[int, PendingSlot] = field(default_factory=dict)
+    pending_save: PendingSave | None = None
     active_owner_writer_id: int | None = None
     active_owner_pid: int | None = None
     active_owner_uid: int | None = None
     start_cursor: tuple[int, int] | None = None
     settings: JsonObject = field(default_factory=default_recording_settings)
     settings_pending_save: JsonObject | None = None
-    settings_save_task: object | None = None
+    settings_save_task: asyncio.Task[None] | None = None
     devices_cache: list[JsonObject] = field(default_factory=list)
     selected_devices_cache: list[JsonObject] = field(default_factory=list)
     devices_cache_ready: bool = False

--- a/tests/session/test_session_manager_command_runtime.py
+++ b/tests/session/test_session_manager_command_runtime.py
@@ -19,7 +19,42 @@ from keymasq.common.security import PeerCredentials
 from keymasq.common.settings import GlobalSettings
 from keymasq.session.listeners.kde import KDEListener
 from keymasq.session.manager import SessionManager
+from keymasq.session.manager.state import PendingSave, PendingSlot
 from tests.session.support import grant_recording_refresh_owner
+
+
+def set_pending_recording_slot(
+    manager: SessionManager,
+    data: dict[str, object],
+    *,
+    slot: int = 1,
+    token: str = "pending-1",
+    owner_writer_id: int | None = None,
+    owner_pid: int | None = None,
+    owner_uid: int | None = None,
+    created_at: float = 0.0,
+) -> PendingSlot:
+    pending_data = dict(data)
+    pending_data["recording_slot"] = slot
+    pending_data["pending_save_token"] = token
+    pending_slot = PendingSlot(
+        data=pending_data,
+        token=token,
+        owner_writer_id=owner_writer_id,
+        owner_pid=owner_pid,
+        owner_uid=owner_uid,
+        created_at=created_at,
+    )
+    manager.recording_state.pending_slots[slot] = pending_slot
+    manager.recording_state.pending_save = PendingSave(
+        data=pending_slot.data,
+        token=pending_slot.token,
+        owner_writer_id=pending_slot.owner_writer_id,
+        owner_pid=pending_slot.owner_pid,
+        owner_uid=pending_slot.owner_uid,
+        created_at=pending_slot.created_at,
+    )
+    return pending_slot
 
 
 @pytest.mark.asyncio
@@ -941,7 +976,7 @@ async def test_recording_stopped_event_notifies_user_with_slot_summary() -> None
     assert broadcast["recording_slot"] == 2
     assert broadcast["duration_ms"] == 1300
     assert broadcast["event_count"] == 3
-    assert manager.recording_state.pending_slots[2]["pending_recording_id"] == "recording-2"
+    assert manager.recording_state.pending_slots[2].data["pending_recording_id"] == "recording-2"
 
 
 @pytest.mark.asyncio
@@ -974,14 +1009,17 @@ async def test_action_trigger_play_macro_slot_dispatches_slot_playback(
 @pytest.mark.asyncio
 async def test_play_macro_slot_trigger_sends_pending_recording_to_daemon() -> None:
     manager = SessionManager()
-    manager.recording_state.pending_slots[4] = {
-        "pending_recording_id": "recording-4",
-        "recording_slot": 4,
-        "move_to_start": True,
-        "start_x": 120,
-        "start_y": 240,
-        "block_mouse_movement": True,
-    }
+    set_pending_recording_slot(
+        manager,
+        {
+            "pending_recording_id": "recording-4",
+            "move_to_start": True,
+            "start_x": 120,
+            "start_y": 240,
+            "block_mouse_movement": True,
+        },
+        slot=4,
+    )
     manager.client.send_command = AsyncMock(
         return_value=Response(status="ok", data={"status": "ok", "played": True})
     )
@@ -1096,7 +1134,7 @@ async def test_list_macros_include_slots_syncs_slots_from_daemon() -> None:
     ]
     macros = cast(list[dict[str, object]], result["macros"])
     assert sent_commands == [CommandType.MACRO_LIST_META, CommandType.MACRO_LIST_RECORDINGS]
-    assert manager.recording_state.pending_slots[3]["pending_recording_id"] == "recording-3"
+    assert manager.recording_state.pending_slots[3].data["pending_recording_id"] == "recording-3"
     assert macros[0]["name"] == "stored"
     assert macros[1]["kind"] == "recording_slot"
     assert macros[1]["recording_slot"] == 3
@@ -2268,14 +2306,16 @@ async def test_save_recording_keeps_pending_macro_save_slot(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     manager = SessionManager()
-    manager.recording_state.pending_data = {
-        "pending_recording_id": "recording-1",
-        "duration_ms": 10,
-        "device_types": ["keyboard"],
-        "event_count": 1,
-    }
-    manager.recording_state.pending_save_token = "pending-1"
-    manager.recording_state.pending_save_owner_writer_id = 123
+    pending_slot = set_pending_recording_slot(
+        manager,
+        {
+            "pending_recording_id": "recording-1",
+            "duration_ms": 10,
+            "device_types": ["keyboard"],
+            "event_count": 1,
+        },
+        owner_writer_id=123,
+    )
     manager.client.send_command = AsyncMock(
         return_value=Response(status="ok", data={"macro": {"name": "Saved"}})
     )
@@ -2313,10 +2353,11 @@ async def test_save_recording_keeps_pending_macro_save_slot(
     assert sent_command.data["start_x"] == 100
     assert sent_command.data["start_y"] == 200
     assert sent_command.data["block_mouse_movement"] is True
-    assert manager.recording_state.pending_save_token == "pending-1"
-    assert manager.recording_state.pending_save_owner_writer_id == 123
-    assert manager.recording_state.pending_data is manager.recording_state.pending_slots[1]
-    assert manager.recording_state.pending_data == {
+    assert manager.recording_state.pending_save is not None
+    assert manager.recording_state.pending_save.token == "pending-1"
+    assert manager.recording_state.pending_save.owner_writer_id == 123
+    assert manager.recording_state.pending_save.data is pending_slot.data
+    assert pending_slot.data == {
         "pending_recording_id": "recording-1",
         "duration_ms": 10,
         "device_types": ["keyboard"],
@@ -2335,11 +2376,13 @@ async def test_save_recording_rejects_empty_sanitized_macro_name(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     manager = SessionManager()
-    manager.recording_state.pending_data = {
-        "pending_recording_id": "recording-1",
-        "duration_ms": 10,
-    }
-    manager.recording_state.pending_save_token = "pending-1"
+    set_pending_recording_slot(
+        manager,
+        {
+            "pending_recording_id": "recording-1",
+            "duration_ms": 10,
+        },
+    )
     manager.client.send_command = AsyncMock()
     peer = PeerCredentials(pid=1, uid=1000, gid=1000)
     writer = object()
@@ -2368,13 +2411,15 @@ async def test_save_recording_rejects_empty_sanitized_macro_name(
 async def test_save_recording_requires_active_unlock_owner() -> None:
     manager = SessionManager()
     manager.security_policy.recording_unlock_required = True
-    manager.recording_state.pending_data = {
-        "pending_recording_id": "recording-1",
-        "duration_ms": 10,
-        "device_types": ["keyboard"],
-        "event_count": 1,
-    }
-    manager.recording_state.pending_save_token = "pending-1"
+    set_pending_recording_slot(
+        manager,
+        {
+            "pending_recording_id": "recording-1",
+            "duration_ms": 10,
+            "device_types": ["keyboard"],
+            "event_count": 1,
+        },
+    )
     manager.client.send_command = AsyncMock()
     peer = PeerCredentials(pid=1, uid=1000, gid=1000)
 
@@ -2397,8 +2442,11 @@ async def test_save_recording_requires_active_unlock_owner() -> None:
 @pytest.mark.asyncio
 async def test_delete_recording_slot_rejects_stale_pending_macro_save_token() -> None:
     manager = SessionManager()
-    manager.recording_state.pending_data = {"events": [{"t_us": 0}]}
-    manager.recording_state.pending_save_token = "current"
+    pending_slot = set_pending_recording_slot(
+        manager,
+        {"events": [{"t_us": 0}]},
+        token="current",
+    )
     peer = PeerCredentials(pid=1, uid=1000, gid=1000)
 
     result = await manager._handle_session_request(
@@ -2410,8 +2458,9 @@ async def test_delete_recording_slot_rejects_stale_pending_macro_save_token() ->
 
     assert result["status"] == "error"
     assert result["error_code"] == "stale_pending_macro_save"
-    assert manager.recording_state.pending_data == {"events": [{"t_us": 0}]}
-    assert manager.recording_state.pending_save_token == "current"
+    assert pending_slot.data["events"] == [{"t_us": 0}]
+    assert manager.recording_state.pending_save is not None
+    assert manager.recording_state.pending_save.token == "current"
 
 
 @pytest.mark.asyncio
@@ -2426,13 +2475,21 @@ async def test_replaced_pending_slot_rejects_previous_pending_save_token(
         recording_slot=1,
     )
     old_token = "old-token"
-    manager.recording_state.pending_slot_tokens[1] = old_token
-    manager.recording_state.pending_slots[1]["pending_save_token"] = old_token
-    manager.recording_state.pending_save_token = old_token
-    manager.recording_state.pending_slot_owner_writer_ids[1] = 123
-    manager.recording_state.pending_slot_owner_pids[1] = 456
-    manager.recording_state.pending_slot_owner_uids[1] = 789
-    manager.recording_state.pending_slot_created_at[1] = 1.0
+    pending_slot = manager.recording_state.pending_slots[1]
+    pending_slot.token = old_token
+    pending_slot.data["pending_save_token"] = old_token
+    pending_slot.owner_writer_id = 123
+    pending_slot.owner_pid = 456
+    pending_slot.owner_uid = 789
+    pending_slot.created_at = 1.0
+    manager.recording_state.pending_save = PendingSave(
+        data=pending_slot.data,
+        token=old_token,
+        owner_writer_id=123,
+        owner_pid=456,
+        owner_uid=789,
+        created_at=1.0,
+    )
 
     def fake_token_urlsafe(_size: int) -> str:
         return "fresh-token"
@@ -2454,13 +2511,15 @@ async def test_replaced_pending_slot_rejects_previous_pending_save_token(
         ],
     )
 
-    assert manager.recording_state.pending_slot_tokens[1] == "fresh-token"
-    assert manager.recording_state.pending_save_token == "fresh-token"
-    assert manager.recording_state.pending_slots[1]["pending_save_token"] == "fresh-token"
-    assert manager.recording_state.pending_slot_owner_writer_ids[1] is None
-    assert manager.recording_state.pending_slot_owner_pids[1] is None
-    assert manager.recording_state.pending_slot_owner_uids[1] is None
-    assert manager.recording_state.pending_slot_created_at[1] == 20.0
+    refreshed_slot = manager.recording_state.pending_slots[1]
+    assert refreshed_slot.token == "fresh-token"
+    assert manager.recording_state.pending_save is not None
+    assert manager.recording_state.pending_save.token == "fresh-token"
+    assert refreshed_slot.data["pending_save_token"] == "fresh-token"
+    assert refreshed_slot.owner_writer_id is None
+    assert refreshed_slot.owner_pid is None
+    assert refreshed_slot.owner_uid is None
+    assert refreshed_slot.created_at == 20.0
     assert not session_recording_module.pending_macro_save_token_matches(manager, old_token)
 
     peer = PeerCredentials(pid=1, uid=1000, gid=1000)
@@ -2488,25 +2547,28 @@ def test_clear_pending_macro_save_keeps_slots_for_invalid_selector() -> None:
         {"pending_recording_id": "recording-1", "duration_ms": 10},
         recording_slot=1,
     )
-    manager.recording_state.pending_slot_tokens[1] = "current"
-    manager.recording_state.pending_slots[1]["pending_save_token"] = "current"
+    pending_slot = manager.recording_state.pending_slots[1]
+    pending_slot.token = "current"
+    pending_slot.data["pending_save_token"] = "current"
     session_recording_module.clear_pending_macro_save(
         manager,
         pending_save_token="stale",
     )
 
-    assert manager.recording_state.pending_slots[1]["pending_recording_id"] == "recording-1"
-    assert manager.recording_state.pending_slot_tokens[1] == "current"
+    assert manager.recording_state.pending_slots[1].data["pending_recording_id"] == "recording-1"
+    assert manager.recording_state.pending_slots[1].token == "current"
 
 
 @pytest.mark.asyncio
 async def test_delete_recording_slot_keeps_state_when_daemon_delete_fails() -> None:
     manager = SessionManager()
-    manager.recording_state.pending_data = {
-        "pending_recording_id": "recording-1",
-        "duration_ms": 10,
-    }
-    manager.recording_state.pending_save_token = "pending-1"
+    set_pending_recording_slot(
+        manager,
+        {
+            "pending_recording_id": "recording-1",
+            "duration_ms": 10,
+        },
+    )
     manager.client.send_command = AsyncMock(return_value=Response(status="error", error="boom"))
     peer = PeerCredentials(pid=1, uid=1000, gid=1000)
 
@@ -2518,16 +2580,19 @@ async def test_delete_recording_slot_keeps_state_when_daemon_delete_fails() -> N
     )
 
     assert result == {"status": "error", "message": "No pending recording"}
-    assert manager.recording_state.pending_slots[1]["pending_recording_id"] == "recording-1"
-    assert manager.recording_state.pending_save_token == "pending-1"
+    assert manager.recording_state.pending_slots[1].data["pending_recording_id"] == "recording-1"
+    assert manager.recording_state.pending_save is not None
+    assert manager.recording_state.pending_save.token == "pending-1"
 
 
 @pytest.mark.asyncio
 async def test_delete_recording_slot_clears_pending_macro_save_state() -> None:
     manager = SessionManager()
-    manager.recording_state.pending_data = {"events": [{"t_us": 0}]}
-    manager.recording_state.pending_save_token = "pending-1"
-    manager.recording_state.pending_save_owner_writer_id = 123
+    set_pending_recording_slot(
+        manager,
+        {"events": [{"t_us": 0}]},
+        owner_writer_id=123,
+    )
     peer = PeerCredentials(pid=1, uid=1000, gid=1000)
 
     result = await manager._handle_session_request(
@@ -2538,9 +2603,8 @@ async def test_delete_recording_slot_clears_pending_macro_save_state() -> None:
     )
 
     assert result == {"status": "ok"}
-    assert manager.recording_state.pending_data is None
-    assert manager.recording_state.pending_save_token is None
-    assert manager.recording_state.pending_save_owner_writer_id is None
+    assert manager.recording_state.pending_slots == {}
+    assert manager.recording_state.pending_save is None
 
 
 @pytest.mark.asyncio

--- a/tests/session/test_session_manager_recording_settings.py
+++ b/tests/session/test_session_manager_recording_settings.py
@@ -63,10 +63,7 @@ async def test_recording_settings_persistence_applies_latest_snapshot_last(
         manager,
         {"include_mouse_movement": True},
     )
-    first_save_task = cast(
-        asyncio.Task[None] | None,
-        manager.recording_state.settings_save_task,
-    )
+    first_save_task = manager.recording_state.settings_save_task
     assert first_save_task is not None
     await wait_for_event(stale_started, "stale settings save did not start")
 
@@ -75,10 +72,7 @@ async def test_recording_settings_persistence_applies_latest_snapshot_last(
         {"include_mouse_movement": False, "include_mouse_clicks": True},
     )
 
-    current_save_task = cast(
-        asyncio.Task[None] | None,
-        manager.recording_state.settings_save_task,
-    )
+    current_save_task = manager.recording_state.settings_save_task
     if current_save_task is not first_save_task:
         await wait_for_event(latest_finished, "latest settings save did not finish")
     release_stale.set()
@@ -388,7 +382,7 @@ async def test_update_recording_settings_recomputes_selected_devices_cache() -> 
         device["recording_id"] for device in manager.recording_state.selected_devices_cache
     ] == ["keymasq:output:keyboard", "physical:/dev/input/by-id/usb-Test_Mouse-event-mouse"]
 
-    save_task = cast(asyncio.Task[None] | None, manager.recording_state.settings_save_task)
+    save_task = manager.recording_state.settings_save_task
     if save_task is not None:
         await save_task
 
@@ -427,7 +421,7 @@ async def test_update_recording_settings_prunes_stale_device_overrides() -> None
         "keymasq:output:keyboard": False
     }
 
-    save_task = cast(asyncio.Task[None] | None, manager.recording_state.settings_save_task)
+    save_task = manager.recording_state.settings_save_task
     if save_task is not None:
         await save_task
 
@@ -459,7 +453,7 @@ async def test_update_recording_settings_preserves_overrides_when_cache_is_empty
         "physical:/dev/input/by-id/stale-mouse": True,
     }
 
-    save_task = cast(asyncio.Task[None] | None, manager.recording_state.settings_save_task)
+    save_task = manager.recording_state.settings_save_task
     if save_task is not None:
         await save_task
 
@@ -503,11 +497,11 @@ async def test_start_recording_replaces_pending_recording_in_selected_slot() -> 
         return Response(status="ok", data={"status": "ok"})
 
     manager.client = SimpleNamespace(send_command=send_command)  # type: ignore[assignment]
-    manager.recording_state.pending_data = {
-        "pending_recording_id": "recording-old",
-        "recording_slot": 1,
-    }
-    manager.recording_state.pending_save_token = "pending-1"
+    session_recording_module.begin_pending_macro_save(
+        manager,
+        {"pending_recording_id": "recording-old"},
+        recording_slot=1,
+    )
 
     result = await session_recording_module.start_recording(manager)
 
@@ -518,8 +512,8 @@ async def test_start_recording_replaces_pending_recording_in_selected_slot() -> 
     ]
     assert sent_commands[0].data["recording_slot"] == 1
     assert sent_commands[1].data == {"pending_recording_id": "recording-old"}
-    assert manager.recording_state.pending_data is None
-    assert manager.recording_state.pending_save_token is None
+    assert manager.recording_state.pending_slots == {}
+    assert manager.recording_state.pending_save is None
 
 
 @pytest.mark.asyncio

--- a/tests/test_session_manager_recording.py
+++ b/tests/test_session_manager_recording.py
@@ -101,7 +101,7 @@ async def test_start_recording_keeps_pending_slot_when_daemon_start_fails() -> N
         "message": "recording_locked",
         "error_code": "recording_locked",
     }
-    assert manager.recording_state.pending_slots[1]["pending_recording_id"] == "recording-1"
+    assert manager.recording_state.pending_slots[1].data["pending_recording_id"] == "recording-1"
     sent_command = manager.client.send_command.await_args.args[0]
     assert sent_command.command == CommandType.START_RECORDING
 


### PR DESCRIPTION
## Summary
- Migrated recording pending state in `keymasq/session/manager/state.py` from scattered per-slot dictionaries/legacy fields to structured `PendingSave` and `PendingSlot` dataclasses.
- Updated core save-task handling (`core.py`, `recording_device_selection.py`) to use the typed `settings_save_task: asyncio.Task[None] | None`, removing redundant casts.
- Refactored `recording_lifecycle.py` pending-slot logic to operate on dataclass-backed slots, including:
  - `_sync_pending_macro_save` replacement of legacy sync behavior.
  - `_ensure_pending_macro_save_slot` migration path from legacy fields.
  - token/owner/metadata handling in begin, clear, replace, and delete flows.
- Kept metadata/status behavior aligned by preserving latest slot selection, token regeneration, owner tracking, and fallback semantics while storing data in `pending_slot.data` and `pending_slot.token`.
- Updated tests to match new state shape and behavior in:
  - `tests/session/test_session_manager_command_runtime.py`
  - `tests/session/test_session_manager_recording_settings.py`
  - `tests/session/test_session_manager_recording.py`

## Testing
- nix develop -c ./scripts/check.sh passed: ruff: ok, basedpyright: ok, stylelint: ok, pytest: ok - 1829 passed
- nix build 'path:.#checks.x86_64-linux.daemon-session-integration-test'