### PR TITLE
Harden exception handling and expand session-manager test coverage

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1775732571,
-        "narHash": "sha256-cd6wKenSQ6G6jikqxFLvyel47TkY30uOSvOBV9gYDX0=",
+        "lastModified": 1780336545,
+        "narHash": "sha256-vhVhuXzFrIOfcssC/9hDHx7MHzDKjF3keHuREOQqQiQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "02f3fa0374fa13707d42d55d58ecc76b091f223c",
+        "rev": "4df1b885d76a54e1aa1a318f8d16fd6005b6401f",
         "type": "github"
       },
       "original": {

--- a/keymasq/cli/commands.py
+++ b/keymasq/cli/commands.py
@@ -40,7 +40,7 @@ def _session_request(payload: JsonObject, timeout: float = 5.0) -> JsonObject | 
         if isinstance(decoded, dict):
             return cast(JsonObject, decoded)
         return None
-    except Exception:
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
         return None
 
 

--- a/keymasq/common/asyncio_runtime.py
+++ b/keymasq/common/asyncio_runtime.py
@@ -30,9 +30,13 @@ def ensure_uvloop(logger: logging.Logger | None = None) -> bool:
                 asyncio.set_event_loop_policy(uvloop_policy_type())
             _runtime_status = _STATUS_UVLOOP
             _runtime_detail = "uvloop.EventLoopPolicy installed"
+        except (ImportError, AttributeError, RuntimeError) as exc:
+            _runtime_status = _STATUS_DEFAULT
+            _runtime_detail = str(exc).strip() or exc.__class__.__name__
         except Exception as exc:
             _runtime_status = _STATUS_DEFAULT
             _runtime_detail = str(exc).strip() or exc.__class__.__name__
+            log.exception("Unexpected failure configuring uvloop")
 
     if logger is not None and _runtime_status not in _logged_statuses:
         if _runtime_status == _STATUS_UVLOOP:

--- a/keymasq/common/devices.py
+++ b/keymasq/common/devices.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import re
 from collections.abc import Callable, Iterable, Mapping, Sequence
@@ -11,6 +12,7 @@ from keymasq.common.models import DeviceType
 
 INPUT_CLASS_ORDER = ("mouse", "touchpad", "keyboard", "gamepad", "pointstick", "other")
 KEYMASQ_DEVICE_PATH_PREFIX = "keymasq:"
+log = logging.getLogger("keymasq.common.devices")
 INPUT_CLASS_LABELS = {
     "mouse": "Mouse",
     "touchpad": "Touchpad",
@@ -392,7 +394,7 @@ def detect_input_classes_from_capabilities(
 def detect_input_classes(device: _CapabilityDevice) -> list[str]:
     try:
         input_props = list(device.input_props())
-    except Exception:
+    except (OSError, RuntimeError, AttributeError):
         input_props = []
     return detect_input_classes_from_capabilities(device.capabilities(), input_props)
 
@@ -631,13 +633,15 @@ def find_all_interfaces(vendor_id: str, product_id: str) -> list[dict[str, str]]
                         "phys": str(getattr(device, "phys", "") or ""),
                     }
                 )
+        except OSError as exc:
+            log.debug("Skipping evdev interface %s during VID:PID probe: %s", path, exc)
         except Exception:
-            continue
+            log.exception("Unexpected failure probing evdev interface %s for VID:PID match", path)
         finally:
             if device is not None:
                 try:
                     device.close()
-                except Exception:
-                    pass
+                except (OSError, RuntimeError) as exc:
+                    log.debug("Failed to close evdev interface %s: %s", path, exc)
 
     return interfaces

--- a/keymasq/common/recording_guard.py
+++ b/keymasq/common/recording_guard.py
@@ -32,7 +32,16 @@ def persistent_macro_recording_path(uid: int) -> Path:
 def parse_unlock_expires_at(path: Path) -> int | None:
     try:
         text = path.read_text(encoding="utf-8").strip()
+    except FileNotFoundError:
+        return None
+    except OSError as exc:
+        log.warning("Failed to read recording unlock file %s: %s", path, exc)
+        return None
+    except UnicodeDecodeError as exc:
+        log.warning("Failed to decode recording unlock file %s: %s", path, exc)
+        return None
     except Exception:
+        log.exception("Unexpected failure reading recording unlock file %s", path)
         return None
 
     if not text:
@@ -40,7 +49,8 @@ def parse_unlock_expires_at(path: Path) -> int | None:
 
     try:
         value = int(text)
-    except (TypeError, ValueError):
+    except ValueError:
+        log.debug("Ignoring invalid recording unlock value in %s: %r", path, text)
         return None
 
     return value

--- a/keymasq/common/security.py
+++ b/keymasq/common/security.py
@@ -1,9 +1,12 @@
+import logging
 import socket
 import struct
 import tomllib
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, cast
+
+log = logging.getLogger(__name__)
 
 
 @dataclass
@@ -128,7 +131,12 @@ def get_peer_credentials(transport_socket: Any) -> PeerCredentials | None:
             struct.calcsize("3i"),
         )
         pid, uid, gid = struct.unpack("3i", creds)
+    except OSError:
+        return None
+    except struct.error:
+        return None
     except Exception:
+        log.exception("Unexpected failure reading peer credentials")
         return None
 
     return PeerCredentials(pid=pid, uid=uid, gid=gid)

--- a/keymasq/common/slurp.py
+++ b/keymasq/common/slurp.py
@@ -182,14 +182,25 @@ class SlurpCapture:
         try:
             process.terminate()
             await asyncio.wait_for(process.wait(), timeout=1.0)
+            return
         except TimeoutError:
-            try:
-                process.kill()
-                await asyncio.wait_for(process.wait(), timeout=1.0)
-            except Exception:
-                log.debug("slurp process did not exit after kill", exc_info=True)
+            pass
+        except OSError as exc:
+            log.debug("failed to terminate slurp process: %s", exc)
+            return
         except Exception:
-            log.debug("failed to terminate slurp process", exc_info=True)
+            log.exception("Unexpected failure terminating slurp process")
+            return
+
+        try:
+            process.kill()
+            await asyncio.wait_for(process.wait(), timeout=1.0)
+        except TimeoutError:
+            log.warning("slurp process did not exit after kill")
+        except OSError as exc:
+            log.debug("failed to kill slurp process: %s", exc)
+        except Exception:
+            log.exception("Unexpected failure killing slurp process")
 
     def _parse_output(self, output: str) -> SlurpResult | None:
         parts = output.split(",")

--- a/keymasq/gui/preferences.py
+++ b/keymasq/gui/preferences.py
@@ -26,8 +26,11 @@ def _load_settings() -> dict[str, object]:
     try:
         with settings_path.open("rb") as f:
             data = tomllib.load(f)
+    except (OSError, tomllib.TOMLDecodeError) as exc:
+        log.warning("Failed to load GUI settings %s: %s", settings_path, exc)
+        return {}
     except Exception:
-        log.warning("Failed to load GUI settings: %s", settings_path, exc_info=True)
+        log.exception("Unexpected failure loading GUI settings: %s", settings_path)
         return {}
 
     return dict(data)

--- a/keymasq/gui/session_client.py
+++ b/keymasq/gui/session_client.py
@@ -70,8 +70,8 @@ class _PersistentSessionConnection:
                     self._close_connection()
                     return None
                 return response
-            except Exception as e:
-                log.debug(f"persistent request failed: {e}")
+            except Exception:
+                log.exception("persistent request failed")
                 self._close_connection()
                 return None
             finally:
@@ -111,12 +111,12 @@ class _PersistentSessionConnection:
                 sock.settimeout(timeout)
                 sock.connect(str(SESSION_SOCKET_PATH))
                 sock.settimeout(None)
-            except Exception as e:
+            except OSError as e:
                 log.debug(f"persistent connect failed: {e}")
                 if sock is not None:
                     try:
                         sock.close()
-                    except Exception:
+                    except OSError:
                         pass
                 return False
 
@@ -172,8 +172,8 @@ class _PersistentSessionConnection:
                             response_queue.put_nowait(message)
                         except queue.Full:
                             pass
-            except Exception as e:
-                log.debug(f"persistent reader error: {e}")
+            except Exception:
+                log.exception("persistent reader error")
                 if sock is not None and self._close_connection_if_current(sock):
                     return
                 continue
@@ -189,17 +189,33 @@ class _PersistentSessionConnection:
         if not callbacks:
             return
 
+        idle_add: Callable[..., object] | None = None
         try:
             from gi.repository import GLib  # pyright: ignore[reportAttributeAccessIssue]
-
-            for callback in callbacks:
-                GLib.idle_add(self._dispatch_event_callback_once, callback, message)
+        except ImportError:
+            pass
         except Exception:
-            for callback in callbacks:
-                try:
-                    callback(message)
-                except Exception:
-                    pass
+            log.exception("Unexpected failure loading GLib for session event dispatch")
+        else:
+            raw_idle_add = getattr(GLib, "idle_add", None)
+            if callable(raw_idle_add):
+                idle_add = raw_idle_add
+            else:
+                log.warning("GLib.idle_add unavailable; dispatching session callbacks directly")
+
+        for callback in callbacks:
+            if idle_add is None:
+                self._dispatch_event_callback_once(callback, message)
+                continue
+
+            try:
+                idle_add(self._dispatch_event_callback_once, callback, message)
+            except (RuntimeError, TypeError) as exc:
+                log.warning("Failed to schedule session event callback with GLib: %s", exc)
+                self._dispatch_event_callback_once(callback, message)
+            except Exception:
+                log.exception("Unexpected failure scheduling session event callback")
+                self._dispatch_event_callback_once(callback, message)
 
     @staticmethod
     def _dispatch_event_callback_once(
@@ -220,7 +236,7 @@ class _PersistentSessionConnection:
         if sock is not None:
             try:
                 sock.close()
-            except Exception:
+            except OSError:
                 pass
 
         with self._state_lock:
@@ -228,7 +244,7 @@ class _PersistentSessionConnection:
         if response_queue is not None:
             try:
                 response_queue.put_nowait(None)
-            except Exception:
+            except queue.Full:
                 pass
 
     def _close_connection_if_current(self, sock: _socket.socket) -> bool:
@@ -244,13 +260,13 @@ class _PersistentSessionConnection:
 
         try:
             sock.close()
-        except Exception:
+        except OSError:
             pass
 
         if current and response_queue is not None:
             try:
                 response_queue.put_nowait(None)
-            except Exception:
+            except queue.Full:
                 pass
         return current
 

--- a/keymasq/gui/session_client.py
+++ b/keymasq/gui/session_client.py
@@ -201,21 +201,26 @@ class _PersistentSessionConnection:
             if callable(raw_idle_add):
                 idle_add = raw_idle_add
             else:
-                log.warning("GLib.idle_add unavailable; dispatching session callbacks directly")
+                log.warning("GLib.idle_add unavailable; dropping session event callback")
 
         for callback in callbacks:
             if idle_add is None:
-                self._dispatch_event_callback_once(callback, message)
+                log.warning(
+                    "Cannot marshal session event callback to GTK main loop; dropping event %s",
+                    event,
+                )
                 continue
 
             try:
                 idle_add(self._dispatch_event_callback_once, callback, message)
             except (RuntimeError, TypeError) as exc:
-                log.warning("Failed to schedule session event callback with GLib: %s", exc)
-                self._dispatch_event_callback_once(callback, message)
+                log.warning(
+                    "Failed to schedule session event callback with GLib: %s; dropping event %s",
+                    exc,
+                    event,
+                )
             except Exception:
                 log.exception("Unexpected failure scheduling session event callback")
-                self._dispatch_event_callback_once(callback, message)
 
     @staticmethod
     def _dispatch_event_callback_once(

--- a/keymasq/gui/session_reload.py
+++ b/keymasq/gui/session_reload.py
@@ -1,12 +1,19 @@
+import logging
 from collections.abc import Callable
 
 from keymasq.gui.session_client import JsonDict, session_request, session_request_async
+
+log = logging.getLogger(__name__)
 
 
 def notify_session_reload(timeout: float = 5.0) -> bool:
     try:
         result = session_request({"command": "reload"}, timeout=timeout)
+    except OSError as exc:
+        log.debug("Could not notify session reload: %s", exc)
+        return False
     except Exception:
+        log.exception("Unexpected failure notifying session reload")
         return False
 
     return isinstance(result, dict) and result.get("status") == "ok"

--- a/keymasq/gui/widgets/analog_control_dialog.py
+++ b/keymasq/gui/widgets/analog_control_dialog.py
@@ -1271,7 +1271,7 @@ class AnalogControlDialog(Adw.Dialog):
     ) -> None:
         try:
             state = gesture.get_current_event_state()
-        except Exception:
+        except (RuntimeError, TypeError, ValueError):
             state = Gdk.ModifierType(0)
         if state & _SPLIT_SPEED_DESYNC_MODIFIERS:
             self._request_split_mouse_speed_desync(axis)
@@ -1334,7 +1334,7 @@ class AnalogControlDialog(Adw.Dialog):
         gesture.set_state(Gtk.EventSequenceState.CLAIMED)
         try:
             state = gesture.get_current_event_state()
-        except Exception:
+        except (RuntimeError, TypeError, ValueError):
             state = Gdk.ModifierType(0)
         if split_speed_axis and state & _SPLIT_SPEED_DESYNC_MODIFIERS:
             self._request_split_mouse_speed_desync(split_speed_axis)
@@ -1540,7 +1540,8 @@ class AnalogControlDialog(Adw.Dialog):
         count = virtual_gamepad_count()
         try:
             hardware_configs = list(HardwareManager().list_hardware())
-        except Exception:
+        except (OSError, RuntimeError) as exc:
+            log.debug("Unable to load hardware configs for gamepad outputs: %s", exc)
             hardware_configs = []
         self._hardware_output_configs = {
             str(getattr(config, "hardware_id", "") or ""): config
@@ -2339,8 +2340,8 @@ class AnalogControlDialog(Adw.Dialog):
         try:
             launcher = Gtk.UriLauncher.new(url)
             launcher.launch(None, None, None)
-        except Exception as exc:
-            log.warning("Could not open Analog Controls documentation %s: %s", url, exc)
+        except Exception:
+            log.exception("Could not open Analog Controls documentation %s", url)
 
     def _set_capture_status(
         self,

--- a/keymasq/gui/widgets/device_tab.py
+++ b/keymasq/gui/widgets/device_tab.py
@@ -2130,7 +2130,7 @@ class DeviceTab(ProfileManagedTab):
         try:
             code = int(cast(int, code_raw))
             value = int(cast(int, value_raw))
-        except Exception:
+        except (TypeError, ValueError):
             return
         source = str(captured.get("source", "") or "")
         key = f"{source}:{code}"
@@ -2228,7 +2228,7 @@ class DeviceTab(ProfileManagedTab):
             return "y"
         try:
             code = int(cast(int, candidate.get("code")))
-        except Exception:
+        except (TypeError, ValueError):
             return None
         if code in {0, 3, 16}:
             return "x"
@@ -2953,11 +2953,11 @@ class DeviceTab(ProfileManagedTab):
     ) -> bool:
         try:
             captured_code = int(cast(int, evdev_code)) if evdev_code is not None else None
-        except Exception:
+        except (TypeError, ValueError):
             captured_code = None
         try:
             captured_value = int(cast(int, evdev_value)) if evdev_value is not None else None
-        except Exception:
+        except (TypeError, ValueError):
             captured_value = None
 
         captured_name = canonical_gamepad_button_name(evdev_name)

--- a/keymasq/gui/widgets/diagnostics_dialog.py
+++ b/keymasq/gui/widgets/diagnostics_dialog.py
@@ -443,8 +443,8 @@ class DiagnosticsDialog(Adw.Dialog):
         try:
             launcher = Gtk.UriLauncher.new(url)
             launcher.launch(None, None, None)
-        except Exception as exc:
-            log.warning("Could not open Diagnostics documentation %s: %s", url, exc)
+        except Exception:
+            log.exception("Could not open Diagnostics documentation %s", url)
 
     def _update_status_tick(self) -> bool:
         if self._last_snapshot_time is None:

--- a/keymasq/gui/widgets/feedback_dialog.py
+++ b/keymasq/gui/widgets/feedback_dialog.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import os
 import platform
 import urllib.error
@@ -20,6 +21,7 @@ from keymasq.gui.session_client import GuiTaskResult, run_gui_task
 
 DEFAULT_FEEDBACK_ENDPOINT = "https://feedback.keymasq.tools/api/feedback"
 OS_RELEASE_PATH = Path("/etc/os-release")
+log = logging.getLogger("keymasq.gui.widgets.feedback_dialog")
 
 
 @dataclass(frozen=True)
@@ -247,8 +249,9 @@ class FeedbackDialog(Adw.Dialog):
         if callable(list_hardware):
             try:
                 loaded_devices = list_hardware()
-            except Exception:
-                pass
+            except (OSError, RuntimeError) as exc:
+                log.debug("Unable to load hardware configs for feedback diagnostics: %s", exc)
+                loaded_devices = []
             else:
                 if isinstance(loaded_devices, Iterable):
                     for device in loaded_devices:

--- a/keymasq/gui/widgets/gamepad_output_choices.py
+++ b/keymasq/gui/widgets/gamepad_output_choices.py
@@ -1,3 +1,4 @@
+import logging
 from collections.abc import Sequence
 
 from keymasq.common.devices import is_gamepad_button_name
@@ -7,11 +8,14 @@ from keymasq.common.virtual_devices import (
 )
 from keymasq.session.settings import load_virtual_gamepad_count
 
+log = logging.getLogger("keymasq.gui.widgets.gamepad_output_choices")
+
 
 def virtual_gamepad_count() -> int:
     try:
         return max(0, int(load_virtual_gamepad_count()))
     except Exception:
+        log.exception("Unable to load virtual gamepad count; using default of 1")
         return 1
 
 

--- a/keymasq/gui/widgets/gnome_setup_dialog.py
+++ b/keymasq/gui/widgets/gnome_setup_dialog.py
@@ -1,3 +1,4 @@
+import logging
 from collections.abc import Callable
 from dataclasses import dataclass
 
@@ -13,6 +14,7 @@ from keymasq.gui.session_client import JsonDict, session_request_async
 from keymasq.gui.widgets.docs_links import docs_page_url
 
 GNOME_BRIDGE_UUID = "gnome-bridge@keymasq.tools"
+log = logging.getLogger("keymasq.gui.widgets.gnome_setup_dialog")
 
 
 GNOME_SETUP_DOCS_URL = docs_page_url("GNOME", version=__version__)
@@ -215,6 +217,7 @@ class GnomeSetupDialog(Adw.Dialog):
             launcher = Gtk.UriLauncher.new(GNOME_SETUP_DOCS_URL)
             launcher.launch(self._parent, None, None)
         except Exception:
+            log.exception("Could not open GNOME setup guide %s", GNOME_SETUP_DOCS_URL)
             self._set_status(
                 f"Could not open the setup guide. Visit {GNOME_SETUP_DOCS_URL}",
                 error=True,

--- a/keymasq/gui/widgets/input_picker_shared.py
+++ b/keymasq/gui/widgets/input_picker_shared.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import os
 from collections.abc import Mapping, Sequence
 
@@ -10,6 +11,8 @@ gi.require_version("Gtk", "4.0")
 from gi.repository import Gdk, Gtk  # pyright: ignore[reportAttributeAccessIssue]
 
 from keymasq.common.gamepad_axes import gamepad_axis_max_value
+
+log = logging.getLogger("keymasq.gui.widgets.input_picker_shared")
 
 GAMEPAD_BUTTONS: dict[str, str] = {
     "A": "btn_south",
@@ -470,7 +473,7 @@ def _build_gamepad_center_col(owner) -> Gtk.Box:
         texture = Gdk.Texture.new_from_filename(_get_gamepad_svg_path())
         svg_pic.set_paintable(texture)
     except Exception:
-        pass
+        log.exception("Failed to load gamepad picker texture")
 
     box.append(svg_pic)
 

--- a/keymasq/gui/widgets/key_selector_dialog.py
+++ b/keymasq/gui/widgets/key_selector_dialog.py
@@ -1349,7 +1349,7 @@ class KeySelectorDialog(Adw.Dialog, _GamepadAxisControlsMixin):
                 key_name = evdev.ecodes.KEY.get(code)
                 if isinstance(key_name, str) and key_name.startswith("KEY_"):
                     evdev_name = key_name.lower()
-            except Exception:
+            except (TypeError, ValueError):
                 evdev_name = None
         if not evdev_name:
             self.kb_code_entry.set_text("")
@@ -1560,7 +1560,8 @@ class KeySelectorDialog(Adw.Dialog, _GamepadAxisControlsMixin):
         count = virtual_gamepad_count()
         try:
             hardware_configs = list(HardwareManager().list_hardware())
-        except Exception:
+        except (OSError, RuntimeError) as exc:
+            log.debug("Unable to load hardware configs for gamepad outputs: %s", exc)
             hardware_configs = []
         return gamepad_output_choices_for(
             self._selected_gamepad_output_id,
@@ -1765,8 +1766,8 @@ class KeySelectorDialog(Adw.Dialog, _GamepadAxisControlsMixin):
         try:
             launcher = Gtk.UriLauncher.new(url)
             launcher.launch(None, None, None)
-        except Exception as exc:
-            log.warning("Could not open action documentation %s: %s", url, exc)
+        except Exception:
+            log.exception("Could not open action documentation %s", url)
 
     def _warn_and_clear_unsupported_rapidfire(self, action_type: ActionType) -> None:
         if not self._rapidfire_enabled or action_type_supports_rapidfire(action_type):
@@ -3526,8 +3527,8 @@ class SuperkeyActionDialog(Adw.Dialog, _GamepadAxisControlsMixin):
         try:
             launcher = Gtk.UriLauncher.new(url)
             launcher.launch(None, None, None)
-        except Exception as exc:
-            log.warning("Could not open action documentation %s: %s", url, exc)
+        except Exception:
+            log.exception("Could not open action documentation %s", url)
 
     def _warn_and_clear_unsupported_rapidfire(self, action_type: ActionType) -> None:
         if not self._rapidfire_enabled or action_type_supports_rapidfire(action_type):
@@ -3836,7 +3837,8 @@ class SuperkeyActionDialog(Adw.Dialog, _GamepadAxisControlsMixin):
         count = virtual_gamepad_count()
         try:
             hardware_configs = list(HardwareManager().list_hardware())
-        except Exception:
+        except (OSError, RuntimeError) as exc:
+            log.debug("Unable to load hardware configs for gamepad outputs: %s", exc)
             hardware_configs = []
         return gamepad_output_choices_for(
             self._selected_gamepad_output_id,

--- a/keymasq/gui/widgets/macro_editor_dialog.py
+++ b/keymasq/gui/widgets/macro_editor_dialog.py
@@ -1407,7 +1407,7 @@ class TimelineWidget(Gtk.DrawingArea):
     def _on_scroll(self, controller, dx, dy) -> bool:
         try:
             state = controller.get_current_event_state()
-        except Exception:
+        except (RuntimeError, TypeError, ValueError):
             state = 0
         zoom_modifier = bool(state & (Gdk.ModifierType.CONTROL_MASK | Gdk.ModifierType.SHIFT_MASK))
         if zoom_modifier:
@@ -1822,7 +1822,7 @@ class MacroEditorDialog(Adw.Dialog):
             status = session_request({"command": "get_status"}) or {}
             timeout_max = int(status.get("macro_exec_timeout_max_ms", 30000) or 30000)
             compositor_status = dict(status)
-        except Exception:
+        except (OSError, RuntimeError, TypeError, ValueError):
             timeout_max = 30000
 
         macro: dict | None = None
@@ -1831,7 +1831,7 @@ class MacroEditorDialog(Adw.Dialog):
             loaded_macro = response.get("macro")
             if response.get("status") == "ok" and isinstance(loaded_macro, dict):
                 macro = loaded_macro
-        except Exception:
+        except (OSError, RuntimeError, TypeError, ValueError):
             macro = None
 
         return {

--- a/keymasq/gui/widgets/macro_manager_dialog.py
+++ b/keymasq/gui/widgets/macro_manager_dialog.py
@@ -622,8 +622,8 @@ class MacroManagerDialog(Adw.Dialog):
         try:
             launcher = Gtk.UriLauncher.new(url)
             launcher.launch(None, None, None)
-        except Exception as exc:
-            log.warning("Could not open Macros documentation %s: %s", url, exc)
+        except Exception:
+            log.exception("Could not open Macros documentation %s", url)
 
     def _on_delete_clicked(self, btn: Gtk.Button, name: str) -> None:
         dialog = Adw.AlertDialog()

--- a/keymasq/gui/widgets/profile_managed_tab.py
+++ b/keymasq/gui/widgets/profile_managed_tab.py
@@ -468,8 +468,8 @@ class ProfileManagedTab(Gtk.Box):
         try:
             launcher = Gtk.UriLauncher.new(url)
             launcher.launch(None, None, None)
-        except Exception as exc:
-            log.warning("Could not open Profiles documentation %s: %s", url, exc)
+        except Exception:
+            log.exception("Could not open Profiles documentation %s", url)
 
     def _on_delete_profile(
         self,

--- a/keymasq/gui/widgets/record_macro_dialog.py
+++ b/keymasq/gui/widgets/record_macro_dialog.py
@@ -313,8 +313,8 @@ class RecordMacroDialog(Adw.Dialog):
         try:
             launcher = Gtk.UriLauncher.new(url)
             launcher.launch(None, None, None)
-        except Exception as exc:
-            log.warning("Could not open macro recording documentation %s: %s", url, exc)
+        except Exception:
+            log.exception("Could not open macro recording documentation %s", url)
 
     def _register_parent_events(self) -> None:
         register_event_handler = getattr(self._parent, "register_event_handler", None)
@@ -902,7 +902,7 @@ class RecordMacroDialog(Adw.Dialog):
             try:
                 session_request(self._settings_payload(), timeout=0.5)
             except Exception:
-                pass
+                log.exception("Failed to sync macro recording settings")
 
             with self._settings_sync_lock:
                 if generation == self._settings_sync_generation:

--- a/keymasq/gui/widgets/superkey_dialog.py
+++ b/keymasq/gui/widgets/superkey_dialog.py
@@ -5,7 +5,12 @@ import gi
 gi.require_version("Gtk", "4.0")
 gi.require_version("Adw", "1")
 
-from gi.repository import Adw, Gdk, GObject, Gtk  # pyright: ignore[reportAttributeAccessIssue]
+from gi.repository import (  # pyright: ignore[reportAttributeAccessIssue]
+    Adw,  # pyright: ignore[reportAttributeAccessIssue]
+    Gdk,  # pyright: ignore[reportAttributeAccessIssue]
+    GObject,  # pyright: ignore[reportAttributeAccessIssue]
+    Gtk,  # pyright: ignore[reportAttributeAccessIssue]
+)
 
 from keymasq import __version__
 from keymasq.common.models import (
@@ -1305,5 +1310,5 @@ class SuperkeyDialog(Adw.Dialog):
         try:
             launcher = Gtk.UriLauncher.new(url)
             launcher.launch(None, None, None)
-        except Exception as exc:
-            log.warning("Could not open Super Keys documentation %s: %s", url, exc)
+        except Exception:
+            log.exception("Could not open Super Keys documentation %s", url)

--- a/keymasq/gui/window.py
+++ b/keymasq/gui/window.py
@@ -748,7 +748,7 @@ class MainWindow(Adw.ApplicationWindow):
                     self._set_connection_issue("keymasqd")
             else:
                 self._update_status_disconnected()
-        except Exception:
+        except (OSError, RuntimeError, TypeError, ValueError):
             self._update_unlock_state(None)
             self._update_macro_recording_state(None)
             self._update_status_disconnected()
@@ -1017,7 +1017,7 @@ class MainWindow(Adw.ApplicationWindow):
                 else:
                     log.info("Runtime unlock lease locked on close")
             except Exception:
-                pass
+                log.exception("Failed to lock runtime unlock lease on close")
 
         unregister_session_event_callback("*", self._on_session_event)
 

--- a/keymasq/gui/wizards/hardware_setup.py
+++ b/keymasq/gui/wizards/hardware_setup.py
@@ -786,65 +786,80 @@ class HardwareSetupDialog(Adw.Dialog):
         for path in sorted(evdev.list_devices(), key=local_sort_key):
             try:
                 device = evdev.InputDevice(path)
-                if self._should_skip_detected_device(device):
-                    continue
-                info = device.info
-                vendor_id = f"{info.vendor:04x}"
-                product_id = f"{info.product:04x}"
-                vid_pid = f"{vendor_id}:{product_id}"
-                device_types = detect_input_classes(device)
-                if not self._should_include_detected_interface(device_types):
-                    continue
-                stable_path = resolve_stable_path(path)
-                phys = str(getattr(device, "phys", "") or "")
-                identity_key = self._detected_identity_key(
-                    model_id=vid_pid,
-                    device_types=device_types,
-                    stable_path=stable_path,
-                    phys=phys,
-                    path=path,
-                )
-                configured_hardware_id = configured_identity_hardware_ids.get(identity_key, "")
-                if not self._show_raw_evdev_devices and (
-                    configured_hardware_id
-                    or (not has_config_inventory and self._hardware_config_exists(vid_pid))
-                ):
-                    continue
-                if self._show_raw_evdev_devices and configured_hardware_id:
-                    hardware_id = configured_hardware_id
-                    device_key = _in_use_row_key(hardware_id, path, stable_path)
-                    configured_fields = {"configured_hardware_id": hardware_id}
-                elif self._show_raw_evdev_devices:
-                    hardware_id = vid_pid
-                    device_key = _raw_row_key(path, stable_path)
-                    configured_fields = {}
-                else:
-                    hardware_id = pending_identity_hardware_ids.get(identity_key)
-                    if hardware_id is None:
-                        hardware_id = self._allocate_hardware_id(vid_pid, used_hardware_ids)
-                        used_hardware_ids.add(hardware_id)
-                        pending_identity_hardware_ids[identity_key] = hardware_id
-                    device_key = hardware_id
-                    configured_fields = {}
-                device_type = primary_input_class(device_types)
-                lsusb_entry = lsusb_map.get(vid_pid)
-                display_name = (
-                    lsusb_entry["name"] if lsusb_entry and lsusb_entry["name"] else device.name
-                )
-                human_name = (
-                    lsusb_entry["name"] if lsusb_entry and lsusb_entry["name"] else device.name
-                )
+                try:
+                    if self._should_skip_detected_device(device):
+                        continue
+                    info = device.info
+                    vendor_id = f"{info.vendor:04x}"
+                    product_id = f"{info.product:04x}"
+                    vid_pid = f"{vendor_id}:{product_id}"
+                    device_types = detect_input_classes(device)
+                    if not self._should_include_detected_interface(device_types):
+                        continue
+                    stable_path = resolve_stable_path(path)
+                    phys = str(getattr(device, "phys", "") or "")
+                    identity_key = self._detected_identity_key(
+                        model_id=vid_pid,
+                        device_types=device_types,
+                        stable_path=stable_path,
+                        phys=phys,
+                        path=path,
+                    )
+                    configured_hardware_id = configured_identity_hardware_ids.get(identity_key, "")
+                    if not self._show_raw_evdev_devices and (
+                        configured_hardware_id
+                        or (not has_config_inventory and self._hardware_config_exists(vid_pid))
+                    ):
+                        continue
+                    if self._show_raw_evdev_devices and configured_hardware_id:
+                        hardware_id = configured_hardware_id
+                        device_key = _in_use_row_key(hardware_id, path, stable_path)
+                        configured_fields = {"configured_hardware_id": hardware_id}
+                    elif self._show_raw_evdev_devices:
+                        hardware_id = vid_pid
+                        device_key = _raw_row_key(path, stable_path)
+                        configured_fields = {}
+                    else:
+                        hardware_id = pending_identity_hardware_ids.get(identity_key)
+                        if hardware_id is None:
+                            hardware_id = self._allocate_hardware_id(vid_pid, used_hardware_ids)
+                            used_hardware_ids.add(hardware_id)
+                            pending_identity_hardware_ids[identity_key] = hardware_id
+                        device_key = hardware_id
+                        configured_fields = {}
+                    device_type = primary_input_class(device_types)
+                    lsusb_entry = lsusb_map.get(vid_pid)
+                    display_name = (
+                        lsusb_entry["name"] if lsusb_entry and lsusb_entry["name"] else device.name
+                    )
+                    human_name = (
+                        lsusb_entry["name"] if lsusb_entry and lsusb_entry["name"] else device.name
+                    )
 
-                if device_key not in detected_devices:
-                    detected_devices[device_key] = {
-                        "name": human_name,
-                        "display_name": display_name,
-                        "hardware_id": hardware_id,
-                        "model_id": vid_pid,
-                        "vendor_id": vendor_id,
-                        "product_id": product_id,
-                        "paths": [path],
-                        "interfaces": [
+                    if device_key not in detected_devices:
+                        detected_devices[device_key] = {
+                            "name": human_name,
+                            "display_name": display_name,
+                            "hardware_id": hardware_id,
+                            "model_id": vid_pid,
+                            "vendor_id": vendor_id,
+                            "product_id": product_id,
+                            "paths": [path],
+                            "interfaces": [
+                                {
+                                    "path": path,
+                                    "stable_path": stable_path,
+                                    "name": device.name,
+                                    "phys": phys,
+                                    "device_type": device_type,
+                                    "device_types": device_types,
+                                    **configured_fields,
+                                }
+                            ],
+                        }
+                    else:
+                        detected_devices[device_key]["paths"].append(path)
+                        detected_devices[device_key]["interfaces"].append(
                             {
                                 "path": path,
                                 "stable_path": stable_path,
@@ -854,21 +869,9 @@ class HardwareSetupDialog(Adw.Dialog):
                                 "device_types": device_types,
                                 **configured_fields,
                             }
-                        ],
-                    }
-                else:
-                    detected_devices[device_key]["paths"].append(path)
-                    detected_devices[device_key]["interfaces"].append(
-                        {
-                            "path": path,
-                            "stable_path": stable_path,
-                            "name": device.name,
-                            "phys": phys,
-                            "device_type": device_type,
-                            "device_types": device_types,
-                            **configured_fields,
-                        }
-                    )
+                        )
+                finally:
+                    device.close()
 
             except Exception:
                 log.exception("Skipping local input device %s", path)

--- a/keymasq/gui/wizards/hardware_setup.py
+++ b/keymasq/gui/wizards/hardware_setup.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import re
 import subprocess
@@ -57,6 +58,7 @@ from keymasq.session.hardware import HardwareManager
 DetectedDevice = dict[str, Any]
 DetectedInterface = dict[str, Any]
 DetectedButton = dict[str, Any]
+log = logging.getLogger("keymasq.gui.hardware_setup")
 
 
 def _make_capture_status_row(status_label: Gtk.Label) -> tuple[Gtk.Box, Gtk.Widget]:
@@ -778,7 +780,7 @@ class HardwareSetupDialog(Adw.Dialog):
         def local_sort_key(path: str) -> str:
             try:
                 return resolve_stable_path(path)
-            except Exception:
+            except (OSError, RuntimeError, ValueError):
                 return path
 
         for path in sorted(evdev.list_devices(), key=local_sort_key):
@@ -869,7 +871,7 @@ class HardwareSetupDialog(Adw.Dialog):
                     )
 
             except Exception:
-                pass
+                log.exception("Skipping local input device %s", path)
 
     def _detect_devices_via_session(self, detected_devices: dict[str, dict]) -> bool:
         result = session_request(
@@ -1045,6 +1047,7 @@ class HardwareSetupDialog(Adw.Dialog):
             try:
                 configured_ids = list_ids()
             except Exception:
+                log.exception("Unable to list configured hardware IDs")
                 configured_ids = []
             if isinstance(configured_ids, list):
                 return {str(item) for item in configured_ids}
@@ -1058,6 +1061,7 @@ class HardwareSetupDialog(Adw.Dialog):
                     if str(getattr(config, "hardware_id", "") or "")
                 }
             except Exception:
+                log.exception("Unable to list configured hardware")
                 return set()
 
         return set()
@@ -1072,6 +1076,7 @@ class HardwareSetupDialog(Adw.Dialog):
         try:
             configs = cast(list[object], list_hardware())
         except Exception:
+            log.exception("Unable to list configured hardware identity keys")
             return {}
 
         keys: dict[str, str] = {}
@@ -1102,15 +1107,12 @@ class HardwareSetupDialog(Adw.Dialog):
 
     def _configured_raw_identity_keys(self, path: str) -> set[str]:
         candidates = {str(path or "")}
-        try:
-            stable_path = self._configured_device_stable_path(path)
-        except Exception:
-            stable_path = ""
+        stable_path = self._configured_device_stable_path(path)
         if stable_path:
             candidates.add(stable_path)
         try:
             real_path = os.path.realpath(path)
-        except Exception:
+        except OSError:
             real_path = ""
         if real_path:
             candidates.add(real_path)
@@ -1123,7 +1125,7 @@ class HardwareSetupDialog(Adw.Dialog):
         candidates = [path]
         try:
             real_path = os.path.realpath(path)
-        except Exception:
+        except OSError:
             real_path = ""
         if real_path and real_path != path:
             candidates.append(real_path)
@@ -1131,9 +1133,10 @@ class HardwareSetupDialog(Adw.Dialog):
         for candidate in candidates:
             try:
                 stable_path = resolve_stable_path(candidate)
-            except Exception:
-                continue
-            if _looks_like_by_id_path(stable_path):
+            except (OSError, RuntimeError, ValueError) as exc:
+                log.debug("Unable to resolve configured device path %s: %s", candidate, exc)
+                stable_path = ""
+            if stable_path and _looks_like_by_id_path(stable_path):
                 return stable_path
         return path
 
@@ -1148,15 +1151,16 @@ class HardwareSetupDialog(Adw.Dialog):
 
         try:
             input_device = evdev.InputDevice(path)
-        except Exception:
+        except (OSError, RuntimeError) as exc:
+            log.debug("Unable to read configured input device %s: %s", path, exc)
             return ""
         try:
             return str(getattr(input_device, "phys", "") or "")
         finally:
             try:
                 input_device.close()
-            except Exception:
-                pass
+            except (OSError, RuntimeError) as exc:
+                log.debug("Failed to close configured input device %s: %s", path, exc)
 
     def _allocate_hardware_id(self, model_id: str, used_hardware_ids: set[str]) -> str:
         if model_id not in used_hardware_ids:
@@ -1340,7 +1344,8 @@ class HardwareSetupDialog(Adw.Dialog):
     def _get_lsusb_name_map(self) -> dict[str, dict[str, str]]:
         try:
             output = subprocess.check_output(["lsusb"], text=True, stderr=subprocess.DEVNULL)
-        except Exception:
+        except (OSError, subprocess.SubprocessError) as exc:
+            log.debug("Unable to read USB device names with lsusb: %s", exc)
             return {}
 
         result: dict[str, dict[str, str]] = {}
@@ -2031,18 +2036,20 @@ class HardwareSetupDialog(Adw.Dialog):
 
         try:
             device = evdev.InputDevice(raw_path)
-        except Exception:
+        except (OSError, RuntimeError) as exc:
+            log.debug("Unable to open interface capability probe device %s: %s", raw_path, exc)
             return ([], {})
 
         try:
             raw_capabilities = cast(dict[int, list[object]], device.capabilities())
         except Exception:
+            log.exception("Unable to read capabilities from %s", raw_path)
             raw_capabilities = {}
         finally:
             try:
                 device.close()
-            except Exception:
-                pass
+            except (OSError, RuntimeError) as exc:
+                log.debug("Failed to close capability probe device %s: %s", raw_path, exc)
 
         return (capability_names_from_capabilities(raw_capabilities), raw_capabilities)
 

--- a/keymasq/keymasqd/capture_manager.py
+++ b/keymasq/keymasqd/capture_manager.py
@@ -1,5 +1,4 @@
 import asyncio
-import contextlib
 import errno
 import logging
 import os
@@ -154,10 +153,7 @@ class CaptureManager:
             raise ValueError("Invalid capture token")
 
         for device in session.devices:
-            try:
-                event = device.read_one()
-            except Exception:
-                continue
+            event = _read_one_device_event(device)
 
             if event is None:
                 continue
@@ -265,10 +261,7 @@ class CaptureManager:
             return {"event": None}
 
         for device in session.devices:
-            try:
-                event = device.read_one()
-            except Exception:
-                continue
+            event = _read_one_device_event(device)
 
             if event is None:
                 continue
@@ -317,14 +310,8 @@ class CaptureManager:
 
         for device in session.devices:
             if session.hardware_id != "__combo__":
-                try:
-                    device.ungrab()
-                except Exception:
-                    log.debug("Failed to ungrab capture device during capture end", exc_info=True)
-            try:
-                device.close()
-            except Exception:
-                log.debug("Failed to close capture device during capture end", exc_info=True)
+                _ungrab_device(device)
+            _close_device(device, context="capture device during capture end")
 
         log.info("Ended capture %s hardware_id=%s", token, session.hardware_id)
         return {"status": "ok", "ended": True}
@@ -350,7 +337,7 @@ class CaptureManager:
         while not session.stop_event.is_set():
             try:
                 ready, _, _ = select.select(list(fd_map), [], [], 0.1)
-            except Exception as e:
+            except (OSError, ValueError) as e:
                 log.debug("Combo capture select failed token=%s error=%s", session.token, e)
                 return
 
@@ -387,12 +374,11 @@ class CaptureManager:
                         device.path,
                         e,
                     )
-                except Exception as e:
-                    log.debug(
-                        "Combo capture unexpected read failure token=%s path=%s error=%s",
+                except Exception:
+                    log.exception(
+                        "Combo capture unexpected read failure token=%s path=%s",
                         session.token,
                         device.path,
-                        e,
                     )
 
     def _parse_hardware_id(self, hardware_id: str) -> tuple[str, str]:
@@ -409,7 +395,7 @@ class CaptureManager:
         for path in list_devices():
             try:
                 device = cast(_CaptureInputDevice, evdev.InputDevice(path))
-            except Exception:
+            except OSError:
                 continue
             if (
                 f"{device.info.vendor:04x}" == vendor_id
@@ -431,7 +417,7 @@ class CaptureManager:
             seen.add(normalized)
             try:
                 devices.append(cast(_CaptureInputDevice, evdev.InputDevice(normalized)))
-            except Exception:
+            except OSError:
                 continue
         return devices
 
@@ -454,7 +440,7 @@ class CaptureManager:
                 devices.append(device)
                 if interface.interface_id:
                     path_sources[device.path] = interface.interface_id
-            except Exception:
+            except OSError:
                 continue
         return devices, path_sources
 
@@ -500,7 +486,7 @@ class CaptureManager:
             keep_device = False
             try:
                 device = cast(_CaptureInputDevice, evdev.InputDevice(path))
-            except Exception:
+            except OSError:
                 continue
 
             try:
@@ -516,10 +502,7 @@ class CaptureManager:
                     if device_hardware_id not in hardware_ids:
                         continue
 
-                try:
-                    key_codes = device.capabilities().get(evdev.ecodes.EV_KEY, [])
-                except Exception:
-                    key_codes = []
+                key_codes = _device_key_codes(device)
 
                 has_supported_key = False
                 for code in cast(list[object], key_codes):
@@ -666,10 +649,18 @@ class CaptureManager:
 
 def _path_aliases(path: str) -> set[str]:
     aliases = {str(path)}
-    with contextlib.suppress(Exception):
+    try:
         aliases.add(resolve_stable_path(path))
-    with contextlib.suppress(Exception):
+    except OSError as exc:
+        log.debug("Unable to resolve stable path alias for %s: %s", path, exc)
+    except Exception:
+        log.exception("Unexpected failure resolving stable path alias for %s", path)
+    try:
         aliases.add(os.path.realpath(path))
+    except OSError as exc:
+        log.debug("Unable to resolve real path alias for %s: %s", path, exc)
+    except Exception:
+        log.exception("Unexpected failure resolving real path alias for %s", path)
     return {alias for alias in aliases if alias}
 
 
@@ -710,15 +701,70 @@ def _capture_mode(mode: str) -> str:
     return normalized
 
 
-def _close_device(device: _CaptureInputDevice) -> None:
-    with contextlib.suppress(Exception):
+def _read_one_device_event(device: _CaptureInputDevice) -> evdev.InputEvent | None:
+    try:
+        return device.read_one()
+    except BlockingIOError:
+        return None
+    except OSError as exc:
+        log.debug("Failed to read capture device %s: %s", device.path, exc)
+        return None
+    except Exception:
+        log.exception("Unexpected failure reading capture device %s", device.path)
+        return None
+
+
+def _ungrab_device(device: _CaptureInputDevice) -> None:
+    try:
+        device.ungrab()
+    except OSError as exc:
+        log.debug("Failed to ungrab capture device %s during capture end: %s", device.path, exc)
+    except Exception:
+        log.exception(
+            "Unexpected failure ungrabbing capture device %s during capture end",
+            device.path,
+        )
+
+
+def _close_device(device: _CaptureInputDevice, *, context: str = "capture device") -> None:
+    try:
         device.close()
+    except OSError as exc:
+        log.debug("Failed to close %s %s: %s", context, device.path, exc)
+    except Exception:
+        log.exception("Unexpected failure closing %s %s", context, device.path)
+
+
+def _device_key_codes(device: _CaptureInputDevice) -> Sequence[object]:
+    try:
+        return device.capabilities().get(evdev.ecodes.EV_KEY, [])
+    except OSError as exc:
+        log.debug("Unable to read combo capture capabilities from %s: %s", device.path, exc)
+        return []
+    except Exception:
+        log.exception("Unexpected failure reading combo capture capabilities from %s", device.path)
+        return []
 
 
 def _abs_info_payload(device: _CaptureInputDevice, code: int) -> JsonObject:
     try:
         info = device.absinfo(code)
+    except KeyError:
+        return {}
+    except OSError as exc:
+        log.debug(
+            "Unable to read absinfo from capture device %s code=%s: %s",
+            device.path,
+            code,
+            exc,
+        )
+        return {}
     except Exception:
+        log.exception(
+            "Unexpected failure reading absinfo from capture device %s code=%s",
+            device.path,
+            code,
+        )
         return {}
     fields = {
         "value": getattr(info, "value", None),

--- a/keymasq/keymasqd/daemon.py
+++ b/keymasq/keymasqd/daemon.py
@@ -62,7 +62,7 @@ def sd_notify(state: str) -> None:
         with socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM) as sock:
             sock.connect(notify_socket)
             sock.sendall(f"{state}\n".encode())
-    except Exception:
+    except (OSError, RuntimeError):
         log.debug("Failed to send sd_notify state", exc_info=True)
 
 
@@ -179,14 +179,14 @@ class Daemon:
     ) -> None:
         try:
             await cleanup()
-        except Exception as exc:
-            log.warning("Failed to %s during daemon cleanup: %s", label, exc, exc_info=True)
+        except Exception:
+            log.exception("Failed to %s during daemon cleanup", label)
 
     def _run_sync_cleanup(self, label: str, cleanup: Callable[[], object]) -> None:
         try:
             cleanup()
-        except Exception as exc:
-            log.warning("Failed to %s during daemon cleanup: %s", label, exc, exc_info=True)
+        except Exception:
+            log.exception("Failed to %s during daemon cleanup", label)
 
     def _prepare_macro_store(self) -> None:
         self.macro_store.ensure()
@@ -781,8 +781,8 @@ def main() -> None:
         asyncio.run(daemon.start())
     except KeyboardInterrupt:
         pass
-    except Exception as e:
-        log.error(f"Fatal error: {e}")
+    except Exception:
+        log.exception("Fatal error")
         sys.exit(1)
 
 

--- a/keymasq/keymasqd/daemon_macro_commands.py
+++ b/keymasq/keymasqd/daemon_macro_commands.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 from collections.abc import Callable, Iterable
 from dataclasses import dataclass, field
 from datetime import datetime
@@ -30,6 +31,7 @@ SUPERKEY_ACTION_KEYS = (
     "overload_down_actions",
     "overload_up_actions",
 )
+log = logging.getLogger("keymasqd.macros")
 
 
 @dataclass(frozen=True)
@@ -385,7 +387,27 @@ async def load_macro_definitions(
     async def load_macro(name: str) -> tuple[str, JsonObject | None]:
         try:
             macro = await asyncio.to_thread(_load_macro_meta_sync, macro_store, name)
+        except FileNotFoundError as exc:
+            log.warning("Macro definition %s is referenced but not installed: %s", name, exc)
+            return name, None
+        except PermissionError as exc:
+            log.error(
+                "Could not load macro definition %s: %s. Check macro file ownership and "
+                "permissions for the keymasqd user.",
+                name,
+                exc,
+            )
+            return name, None
+        except OSError as exc:
+            log.error(
+                "Could not load macro definition %s due to a filesystem error: %s. Check "
+                "the macro directory and file permissions for the keymasqd user.",
+                name,
+                exc,
+            )
+            return name, None
         except Exception:
+            log.exception("Could not load macro definition %s", name)
             return name, None
         return name, macro
 

--- a/keymasq/keymasqd/device_manager.py
+++ b/keymasq/keymasqd/device_manager.py
@@ -1299,12 +1299,14 @@ class DeviceManager:
                         **(grabbed_source or {}),
                     }
                 )
-            except Exception as e:
-                log.debug(f"Could not read device {path}: {e}")
+            except Exception:
+                log.exception("Could not read device %s", path)
             finally:
                 if device is not None:
-                    with contextlib.suppress(Exception):
-                        device.close()
+                    close = getattr(device, "close", None)
+                    if callable(close):
+                        with contextlib.suppress(OSError, RuntimeError):
+                            close()
 
         return {"devices": devices}
 

--- a/keymasq/keymasqd/macro_store.py
+++ b/keymasq/keymasqd/macro_store.py
@@ -1,10 +1,12 @@
 import copy
 import fcntl
+import json
 import logging
+import lzma
 import os
 import re
 import threading
-from collections.abc import Iterable, Iterator
+from collections.abc import Generator, Iterable, Iterator
 from contextlib import contextmanager
 from datetime import datetime
 from pathlib import Path
@@ -90,9 +92,27 @@ class MacroStore:
                 if meta.name.startswith(INTERNAL_MACRO_PREFIX):
                     continue
                 macros.append(meta.to_payload())
-            except Exception as exc:
+            except FileNotFoundError as exc:
+                log.debug("Macro file disappeared while listing %s: %s", path, exc)
+            except PermissionError as exc:
+                log.warning(
+                    "Skipping unreadable macro file %s: %s. Check macro file ownership and "
+                    "permissions for the keymasqd user.",
+                    path,
+                    exc,
+                )
+            except OSError as exc:
                 log.warning("Skipping unreadable macro file %s: %s", path, exc)
-                continue
+            except lzma.LZMAError as exc:
+                log.warning("Skipping corrupt compressed macro file %s: %s", path, exc)
+            except json.JSONDecodeError as exc:
+                log.warning("Skipping malformed macro file %s: invalid JSON: %s", path, exc)
+            except UnicodeDecodeError as exc:
+                log.warning("Skipping malformed macro file %s: invalid UTF-8: %s", path, exc)
+            except ValueError as exc:
+                log.warning("Skipping malformed macro file %s: %s", path, exc)
+            except Exception:
+                log.exception("Unexpected failure reading macro file %s", path)
         return macros
 
     def get(self, name: str) -> MacroPayload:
@@ -260,7 +280,7 @@ class MacroStore:
         write_macro(path, meta, events, overwrite=overwrite)
 
     @contextmanager
-    def _mutation_guard(self) -> Iterator[None]:
+    def _mutation_guard(self) -> Generator[None]:
         self.ensure()
         with _PROCESS_MUTATION_LOCK:
             fd = self._open_mutation_lock()

--- a/keymasq/keymasqd/output_helpers.py
+++ b/keymasq/keymasqd/output_helpers.py
@@ -97,5 +97,7 @@ def emit_mouse_move(
         uinput_dev.write(evdev.ecodes.EV_REL, evdev.ecodes.REL_X, int(move_x))
         uinput_dev.write(evdev.ecodes.EV_REL, evdev.ecodes.REL_Y, int(move_y))
         uinput_dev.syn()
-    except Exception:
+    except OSError:
         log.debug("Failed to emit mouse movement", exc_info=True)
+    except Exception:
+        log.exception("Unexpected failure emitting mouse movement")

--- a/keymasq/keymasqd/recording.py
+++ b/keymasq/keymasqd/recording.py
@@ -109,22 +109,28 @@ class RecordingManager:
                 continue
             try:
                 input_dev = await asyncio.to_thread(_open_recording_input_device, path_value)
-                self._extra_devices.append(input_dev)
-                raw_classes = dev.get("device_types")
-                classes = (
-                    [str(value) for value in cast(list[object], raw_classes)]
-                    if isinstance(raw_classes, list)
-                    else None
-                )
-                primary = dev.get("device_type", "other")
-                device_types = normalize_input_classes(
-                    classes,
-                    primary if isinstance(primary, str) else "other",
-                )
-                task = asyncio.create_task(self._read_extra_device(input_dev, device_types))
-                self._monitoring_tasks.append(task)
+            except OSError:
+                log.debug("Failed to open extra recording device %s", path_value, exc_info=True)
+                input_dev = None
             except Exception:
+                log.exception("Unexpected failure opening extra recording device %s", path_value)
+                input_dev = None
+            if input_dev is None:
                 continue
+            self._extra_devices.append(input_dev)
+            raw_classes = dev.get("device_types")
+            classes = (
+                [str(value) for value in cast(list[object], raw_classes)]
+                if isinstance(raw_classes, list)
+                else None
+            )
+            primary = dev.get("device_type", "other")
+            device_types = normalize_input_classes(
+                classes,
+                primary if isinstance(primary, str) else "other",
+            )
+            task = asyncio.create_task(self._read_extra_device(input_dev, device_types))
+            self._monitoring_tasks.append(task)
 
         self._progress_task = asyncio.create_task(self._monitor_progress())
 
@@ -179,8 +185,10 @@ class RecordingManager:
         try:
             async for event in device.async_read_loop():
                 self.record_event(classify_event_device_type(event, device_types), event)
+        except OSError:
+            log.debug("Extra recording device reader stopped after device error", exc_info=True)
         except Exception:
-            log.debug("Extra recording device reader stopped after error", exc_info=True)
+            log.exception("Extra recording device reader stopped after unexpected error")
 
     async def stop(self) -> RecordingPayload:
         was_recording = not self._stopped
@@ -195,10 +203,7 @@ class RecordingManager:
             self._progress_task = None
 
         for device in self._extra_devices:
-            try:
-                device.close()
-            except Exception:
-                log.debug("Failed to close extra recording device", exc_info=True)
+            _close_recording_input_device(device)
         self._extra_devices = []
         self._record_grabbed_source_keys = set()
         recording_slot = int(self._recording_slot)
@@ -414,12 +419,40 @@ class RecordingManager:
                 self._pending_recordings[recording_id] = snapshot
                 self._pending_recording_created_at[recording_id] = time.monotonic()
                 loaded_event_paths.add(event_path)
-            except Exception as exc:
+            except FileNotFoundError as exc:
+                log.debug(
+                    "Recording slot metadata disappeared while loading %s: %s",
+                    meta_path,
+                    exc,
+                )
+            except PermissionError as exc:
+                log.warning(
+                    "Ignoring unreadable recording slot metadata %s: %s. Check recording "
+                    "spool ownership and permissions for the keymasqd user.",
+                    meta_path,
+                    exc,
+                )
+            except OSError as exc:
+                log.warning("Ignoring unreadable recording slot metadata %s: %s", meta_path, exc)
+            except json.JSONDecodeError as exc:
+                log.warning(
+                    "Ignoring invalid recording slot metadata %s: invalid JSON: %s",
+                    meta_path,
+                    exc,
+                )
+                _remove_invalid_slot_metadata(meta_path)
+            except UnicodeDecodeError as exc:
+                log.warning(
+                    "Ignoring invalid recording slot metadata %s: invalid UTF-8: %s",
+                    meta_path,
+                    exc,
+                )
+                _remove_invalid_slot_metadata(meta_path)
+            except ValueError as exc:
                 log.warning("Ignoring invalid recording slot metadata %s: %s", meta_path, exc)
-                try:
-                    meta_path.unlink(missing_ok=True)
-                except OSError:
-                    pass
+                _remove_invalid_slot_metadata(meta_path)
+            except Exception:
+                log.exception("Unexpected failure loading recording slot metadata %s", meta_path)
 
         try:
             event_paths = list(self._spool_dir.glob("slot-*-*.jsonl"))
@@ -657,6 +690,24 @@ def _open_recording_input_device(path: str) -> _RecordingInputDevice:
     device = cast(object, evdev.InputDevice(path))
     set_evdev_clock_monotonic(device, device_path=path, logger=log)
     return cast(_RecordingInputDevice, device)
+
+
+def _close_recording_input_device(device: _RecordingInputDevice) -> None:
+    try:
+        device.close()
+    except OSError:
+        log.debug("Failed to close extra recording device", exc_info=True)
+    except Exception:
+        log.exception("Unexpected failure closing extra recording device")
+
+
+def _remove_invalid_slot_metadata(meta_path: Path) -> None:
+    try:
+        meta_path.unlink(missing_ok=True)
+    except OSError as exc:
+        log.debug("Failed to remove invalid recording slot metadata %s: %s", meta_path, exc)
+    except Exception:
+        log.exception("Unexpected failure removing invalid recording slot metadata %s", meta_path)
 
 
 def _is_wheel_event(event: evdev.InputEvent) -> bool:

--- a/keymasq/keymasqd/recording_spool.py
+++ b/keymasq/keymasqd/recording_spool.py
@@ -182,7 +182,7 @@ class RecordingSpool:
                 await asyncio.to_thread(self._write_chunk, chunk)
         except asyncio.CancelledError:
             raise
-        except Exception as exc:
+        except Exception as exc:  # noqa: BLE001 - command handling logs the recorded fatal error.
             self._fatal_error = exc
         finally:
             if self._flush_task is asyncio.current_task():

--- a/keymasq/keymasqd/runtime/adapters.py
+++ b/keymasq/keymasqd/runtime/adapters.py
@@ -102,7 +102,7 @@ def close_device(device: object) -> None:
         return
     try:
         close()
-    except Exception:
+    except (OSError, RuntimeError, TypeError):
         log.debug("Failed to close evdev-style device", exc_info=True)
 
 

--- a/keymasq/keymasqd/runtime/device_path_resolver.py
+++ b/keymasq/keymasqd/runtime/device_path_resolver.py
@@ -106,8 +106,10 @@ class DeviceCache:
                     ),
                     is_virtual=_is_keymasq_virtual_device(device),
                 )
+            except OSError as exc:
+                log.debug("Skipping device path resolver cache entry %s: %s", path, exc)
             except Exception:
-                continue
+                log.exception("Unexpected failure caching device path resolver entry %s", path)
             finally:
                 if device is not None:
                     close_device(device)
@@ -385,7 +387,11 @@ def _probe_cached_device(
             ),
             is_virtual=_is_keymasq_virtual_device(device),
         )
+    except OSError as exc:
+        log.debug("Skipping device path resolver probe for %s: %s", path, exc)
+        return None
     except Exception:
+        log.exception("Unexpected failure probing device path resolver candidate %s", path)
         return None
     finally:
         if device is not None:
@@ -404,7 +410,11 @@ def _is_excluded_path(
         return False
     try:
         stable_path = resolve_stable_path_fn(path)
+    except OSError as exc:
+        log.debug("Unable to resolve stable path for excluded candidate %s: %s", path, exc)
+        return False
     except Exception:
+        log.exception("Unexpected failure resolving stable path for excluded candidate %s", path)
         return False
     return stable_path in excluded_paths
 

--- a/keymasq/keymasqd/runtime/grabbed_device.py
+++ b/keymasq/keymasqd/runtime/grabbed_device.py
@@ -161,7 +161,11 @@ def _passthrough_input_props(device: _ManagedInputDevice) -> Sequence[int] | Non
                 return None
             converted.append(parsed)
         return converted
+    except OSError as exc:
+        log.debug("Failed to read passthrough input props: %s", exc)
+        return None
     except Exception:
+        log.exception("Unexpected failure reading passthrough input props")
         return None
 
 
@@ -369,23 +373,24 @@ class GrabbedDevice:
         if uinput is not None:
             try:
                 uinput.close()
-            except Exception:
+            except OSError:
                 log.debug("Failed to close uinput after failed grab", exc_info=True)
+            except Exception:
+                log.exception("Unexpected failure closing uinput after failed grab")
             try:
                 runtime_outputs.unregister_passthrough_frame_output(uinput)
             except Exception:
-                log.debug(
-                    "Failed to unregister passthrough output after failed grab",
-                    exc_info=True,
-                )
+                log.exception("Failed to unregister passthrough output after failed grab")
         self.uinput = None
 
         device = self.device
         if device is not None:
             try:
                 device.close()
-            except Exception:
+            except OSError:
                 log.debug("Failed to close input device after failed grab", exc_info=True)
+            except Exception:
+                log.exception("Unexpected failure closing input device after failed grab")
         self.device = None
 
     async def grab(self) -> None:
@@ -506,18 +511,24 @@ class GrabbedDevice:
         if self.device:
             try:
                 self.device.ungrab()
-            except Exception as exc:
+            except OSError as exc:
                 log.warning("Failed to ungrab %s: %s", self.path, exc)
+            except Exception:
+                log.exception("Unexpected failure ungrabbing %s", self.path)
             try:
                 self.device.close()
-            except Exception as exc:
+            except OSError as exc:
                 log.warning("Failed to close input device %s: %s", self.path, exc)
+            except Exception:
+                log.exception("Unexpected failure closing input device %s", self.path)
 
         if self.uinput:
             try:
                 self.uinput.close()
-            except Exception as exc:
+            except OSError as exc:
                 log.warning("Failed to close passthrough uinput for %s: %s", self.path, exc)
+            except Exception:
+                log.exception("Unexpected failure closing passthrough uinput for %s", self.path)
             finally:
                 runtime_outputs.unregister_passthrough_frame_output(self.uinput)
 
@@ -675,7 +686,13 @@ class GrabbedDevice:
         for (_event_type, code), (analog_id, role) in self.analog_axis_bindings.items():
             try:
                 info = self.device.absinfo(int(code))
+            except OSError as exc:
+                log.debug("Failed to read ABS info for %s code=%s: %s", self.path, code, exc)
+                info = None
             except Exception:
+                log.exception("Unexpected failure reading ABS info for %s code=%s", self.path, code)
+                info = None
+            if info is None:
                 continue
             minimum = getattr(info, "min", None)
             maximum = getattr(info, "max", None)

--- a/keymasq/keymasqd/runtime/grabbed_device_events.py
+++ b/keymasq/keymasqd/runtime/grabbed_device_events.py
@@ -2,7 +2,7 @@ import asyncio
 import contextlib
 import logging
 import time
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Hashable, Mapping
 from typing import cast
 
 import evdev
@@ -82,6 +82,29 @@ def _evdev_code_name(raw_name: object, fallback: int) -> str:
         first: object = names[0] if names else str(fallback)
         return str(first).lower()
     return str(raw_name).lower()
+
+
+def _event_code_int(value: object) -> int | None:
+    try:
+        return int(cast(int | float | str | bytes, value))
+    except (TypeError, ValueError):
+        return None
+
+
+def _evdev_code_names(
+    event_type: object, *, evdev_mod: EvdevModule
+) -> Mapping[object, object] | None:
+    if not isinstance(event_type, Hashable):
+        return None
+    ecodes = cast(object, getattr(evdev_mod, "ecodes", None))
+    raw_bytype = cast(object, getattr(ecodes, "bytype", None))
+    if not isinstance(raw_bytype, Mapping):
+        return None
+    bytype = cast(Mapping[object, object], raw_bytype)
+    raw_names = bytype.get(event_type)
+    if not isinstance(raw_names, Mapping):
+        return None
+    return cast(Mapping[object, object], raw_names)
 
 
 def _record_diagnostics(
@@ -243,13 +266,12 @@ async def event_loop(
                     deps=build_event_processing_deps(log=log),
                 )
                 error_backoff = 0.01
-            except Exception as exc:
+            except Exception:
                 if runtime_is_running(device_runtime):
                     await recover_from_event_processing_error(device_runtime)
-                    log.warning(
-                        "Event processing error on %s: %s (backoff %.3fs)",
+                    log.exception(
+                        "Event processing error on %s (backoff %.3fs)",
                         device_runtime.path,
-                        exc,
                         error_backoff,
                     )
                     await asyncio_mod.sleep(error_backoff)
@@ -271,26 +293,22 @@ async def cleanup_runtime_failure(
                 device_runtime.hardware_id,
                 device_runtime.interface_id,
             )
-        except Exception as exc:
-            log.warning(
-                "Failed to clear combo runtime after device error on %s: %s",
+        except Exception:
+            log.exception(
+                "Failed to clear combo runtime after device error on %s",
                 device_runtime.path,
-                exc,
             )
     try:
         await device_runtime.reset_analog_controls()
-    except Exception as exc:
-        log.warning(
-            "Failed to reset analog controls after event error on %s: %s",
+    except Exception:
+        log.exception(
+            "Failed to reset analog controls after event error on %s",
             device_runtime.path,
-            exc,
         )
     try:
         await device_runtime.reset_superkeys()
-    except Exception as exc:
-        log.warning(
-            "Failed to reset superkeys after event error on %s: %s", device_runtime.path, exc
-        )
+    except Exception:
+        log.exception("Failed to reset superkeys after event error on %s", device_runtime.path)
     observe_profile_trigger_end_for_held_sources(device_runtime)
     runtime_outputs.release_all_keys(
         device_runtime,
@@ -318,23 +336,25 @@ def observe_profile_trigger_end_for_held_sources(
 
 
 def get_event_name(event: InputEventLike, *, evdev_mod: EvdevModule) -> str:
-    try:
-        raw_code_name: object = evdev_mod.ecodes.bytype[event.type].get(
-            event.code, str(event.code)
-        )
-        return _evdev_code_name(raw_code_name, int(event.code))
-    except Exception:
+    raw_code: object = event.code
+    code = _event_code_int(raw_code)
+    if code is None:
+        return str(raw_code)
+    names = _evdev_code_names(event.type, evdev_mod=evdev_mod)
+    if names is None:
         return str(event.code)
+    raw_code_name = names.get(raw_code, str(raw_code))
+    return _evdev_code_name(raw_code_name, code)
 
 
 def get_key_name(code: int, *, evdev_mod: EvdevModule) -> str | None:
-    try:
-        raw_code_name: object = evdev_mod.ecodes.bytype[evdev_mod.ecodes.EV_KEY].get(
-            code, str(code)
-        )
-        return _evdev_code_name(raw_code_name, code)
-    except Exception:
+    ecodes = cast(object, getattr(evdev_mod, "ecodes", None))
+    ev_key = cast(object, getattr(ecodes, "EV_KEY", None))
+    names = _evdev_code_names(ev_key, evdev_mod=evdev_mod)
+    if names is None:
         return None
+    raw_code_name = names.get(code, str(code))
+    return _evdev_code_name(raw_code_name, code)
 
 
 def _inspector_active(device_runtime: GrabbedDeviceRuntime) -> bool:

--- a/keymasq/keymasqd/runtime/grabbed_device_events.py
+++ b/keymasq/keymasqd/runtime/grabbed_device_events.py
@@ -343,7 +343,7 @@ def get_event_name(event: InputEventLike, *, evdev_mod: EvdevModule) -> str:
     names = _evdev_code_names(event.type, evdev_mod=evdev_mod)
     if names is None:
         return str(event.code)
-    raw_code_name = names.get(raw_code, str(raw_code))
+    raw_code_name = names.get(code, str(raw_code))
     return _evdev_code_name(raw_code_name, code)
 
 

--- a/keymasq/keymasqd/runtime/grabbed_device_grab.py
+++ b/keymasq/keymasqd/runtime/grabbed_device_grab.py
@@ -40,8 +40,8 @@ async def broadcast_grab_status(
                 "waited_s": float(waited_s),
             },
         )
-    except Exception as exc:
-        log.warning("Failed to broadcast grab status for %s: %s", device_runtime.hardware_id, exc)
+    except Exception:
+        log.exception("Failed to broadcast grab status for %s", device_runtime.hardware_id)
 
 
 async def wait_for_active_key_activity(
@@ -81,11 +81,10 @@ async def wait_for_active_key_activity(
                 exc,
             )
             break
-        except Exception as exc:
-            log.warning(
-                "[%s] failed to drain pending events before grab: %s",
+        except Exception:
+            log.exception(
+                "[%s] unexpected failure draining pending events before grab",
                 device_runtime.hardware_id,
-                exc,
             )
             break
         if event is None:
@@ -114,11 +113,17 @@ async def wait_for_active_keys_to_clear(
             active_codes = list(
                 await asyncio_mod.to_thread(device_runtime.device.active_keys) or []
             )
-        except Exception as exc:
+        except OSError as exc:
             log.warning(
                 "[%s] failed to read active keys before grab: %s; proceeding with grab",
                 device_runtime.hardware_id,
                 exc,
+            )
+            return
+        except Exception:
+            log.exception(
+                "[%s] unexpected failure reading active keys before grab; proceeding with grab",
+                device_runtime.hardware_id,
             )
             return
 
@@ -217,7 +222,20 @@ def seed_startup_held_actions(device_runtime: GrabbedDeviceRuntime) -> None:
 
     try:
         active_codes = list(device_runtime.device.active_keys() or [])
+    except OSError as exc:
+        logging.getLogger("keymasqd.devices").warning(
+            "[%s] failed to read startup active keys; continuing without startup "
+            "held-state reconciliation: %s",
+            device_runtime.hardware_id,
+            exc,
+        )
+        return
     except Exception:
+        logging.getLogger("keymasqd.devices").exception(
+            "[%s] unexpected failure reading startup active keys; continuing without "
+            "startup held-state reconciliation",
+            device_runtime.hardware_id,
+        )
         return
 
     mapping = device_runtime.mapping_getter()

--- a/keymasq/keymasqd/runtime/grabbed_device_outputs.py
+++ b/keymasq/keymasqd/runtime/grabbed_device_outputs.py
@@ -320,13 +320,19 @@ def ensure_abs_axis_released(
             uinput_writer=uinput_writer,
             bucket=bucket,
         )
-    except Exception as exc:
+    except OSError as exc:
         log.debug(
             "Failed to release gamepad ABS axis %s on %s: %s",
             axis_code,
             device_runtime.path,
             exc,
             exc_info=True,
+        )
+    except Exception:
+        log.exception(
+            "Unexpected failure releasing gamepad ABS axis %s on %s",
+            axis_code,
+            device_runtime.path,
         )
 
 
@@ -348,7 +354,7 @@ def ensure_key_released(
                 uinput_writer=identity_uinput_writer,
                 bucket=bucket,
             )
-    except Exception as exc:
+    except OSError as exc:
         log.debug(
             "Failed to release output key %s on %s bucket=%s: %s",
             code,
@@ -356,6 +362,13 @@ def ensure_key_released(
             bucket_for_uinput(device_runtime, uinput_dev) or "unknown",
             exc,
             exc_info=True,
+        )
+    except Exception:
+        log.exception(
+            "Unexpected failure releasing output key %s on %s bucket=%s",
+            code,
+            device_runtime.path,
+            bucket_for_uinput(device_runtime, uinput_dev) or "unknown",
         )
 
 
@@ -436,7 +449,7 @@ def release_all_keys(
             for code in held:
                 writer.write(evdev_mod.ecodes.EV_KEY, int(code), 0)
             writer.syn()
-        except Exception as exc:
+        except OSError as exc:
             log.debug(
                 "Failed to release held output keys on %s bucket=%s keys=%s: %s",
                 device_runtime.path,
@@ -444,6 +457,13 @@ def release_all_keys(
                 held,
                 exc,
                 exc_info=True,
+            )
+        except Exception:
+            log.exception(
+                "Unexpected failure releasing held output keys on %s bucket=%s keys=%s",
+                device_runtime.path,
+                bucket,
+                held,
             )
         else:
             _clear_held_output_bucket(device_runtime, bucket, held_abs=False)
@@ -466,13 +486,19 @@ def release_all_keys(
             for axis_code in sorted(axes):
                 writer.write(evdev_mod.ecodes.EV_ABS, int(axis_code), 0)
             writer.syn()
-        except Exception as exc:
+        except OSError as exc:
             log.debug(
                 "Failed to release gamepad ABS axes on %s bucket=%s: %s",
                 device_runtime.path,
                 bucket,
                 exc,
                 exc_info=True,
+            )
+        except Exception:
+            log.exception(
+                "Unexpected failure releasing gamepad ABS axes on %s bucket=%s",
+                device_runtime.path,
+                bucket,
             )
         else:
             _clear_held_output_bucket(

--- a/keymasq/keymasqd/runtime/macros.py
+++ b/keymasq/keymasqd/runtime/macros.py
@@ -537,8 +537,8 @@ async def play_macro_task(
                 break
     except asyncio_mod.CancelledError:
         pass
-    except Exception as exc:
-        deps.log.warning("Macro playback aborted: %s", exc)
+    except Exception:
+        deps.log.exception("Macro playback aborted")
     finally:
         manager.macro_state.cancel_instance_ids.discard(instance_id)
         release_macro_held_for_instance(
@@ -732,8 +732,15 @@ def release_macro_held_for_instance(
             try:
                 writer.write(deps.evdev_mod.ecodes.EV_KEY, int(code), 0)
                 synced.add(device_class)
+            except OSError:
+                deps.log.debug("Failed to release macro-held output key", exc_info=True)
             except Exception:
-                continue
+                deps.log.exception(
+                    "Unexpected failure releasing macro-held output key "
+                    "device_class=%s code=%s",
+                    device_class,
+                    code,
+                )
         else:
             held_refcount[key] = count - 1
 
@@ -751,8 +758,15 @@ def release_macro_held_for_instance(
             try:
                 writer.write(deps.evdev_mod.ecodes.EV_ABS, int(code), 0)
                 synced.add(device_class)
+            except OSError:
+                deps.log.debug("Failed to release macro-held ABS output", exc_info=True)
             except Exception:
-                continue
+                deps.log.exception(
+                    "Unexpected failure releasing macro-held ABS output "
+                    "device_class=%s code=%s",
+                    device_class,
+                    code,
+                )
         else:
             held_abs_refcount[key] = count - 1
 
@@ -765,8 +779,13 @@ def release_macro_held_for_instance(
             continue
         try:
             syn_if_passthrough_frame_closed(raw_uinput, writer)
-        except Exception:
+        except OSError:
             deps.log.debug("Failed to synchronize macro cleanup outputs", exc_info=True)
+        except Exception:
+            deps.log.exception(
+                "Unexpected failure synchronizing macro cleanup outputs device_class=%s",
+                device_class,
+            )
 
 
 def acquire_macro_mouse_inhibit(

--- a/keymasq/keymasqd/runtime/outputs.py
+++ b/keymasq/keymasqd/runtime/outputs.py
@@ -381,8 +381,10 @@ def configure_virtual_gamepads(
         uinput_dev = current.pop(output_id)
         try:
             uinput_dev.close()
-        except Exception as exc:
+        except OSError as exc:
             log.warning("Failed to close virtual gamepad %s: %s", output_id, exc)
+        except Exception:
+            log.exception("Unexpected failure closing virtual gamepad %s", output_id)
 
     for index in range(1, count + 1):
         output_id = virtual_gamepad_output_id(index)
@@ -609,8 +611,10 @@ def destroy_global_uinputs(manager: _OutputManager, *, log: logging.Logger) -> N
             if uinput_dev:
                 try:
                     uinput_dev.close()
-                except Exception as exc:
+                except OSError as exc:
                     log.warning("Failed to close global uinput device: %s", exc)
+                except Exception:
+                    log.exception("Unexpected failure closing global uinput device")
 
         manager.output_state.keyboard_uinput = None
         manager.output_state.mouse_uinput = None

--- a/keymasq/keymasqd/runtime/topology.py
+++ b/keymasq/keymasqd/runtime/topology.py
@@ -124,7 +124,7 @@ async def topology_watch_loop(
             except asyncio.CancelledError:
                 raise
             except Exception as exc:
-                log.warning("Topology scan failed: %s", exc)
+                log.exception("Topology scan failed: %s", exc)
                 continue
 
             if snapshot != manager.topology_state.live_snapshot:
@@ -170,7 +170,7 @@ def schedule_topology_reconcile(
         except asyncio.CancelledError:
             raise
         except Exception as exc:
-            log.warning("Topology reconcile failed: %s", exc)
+            log.exception("Topology reconcile failed: %s", exc)
         finally:
             current = manager.topology_state.reconcile_task
             if current is asyncio_mod.current_task():
@@ -198,8 +198,8 @@ async def reconcile_topology(
             continue
         try:
             await manager.broadcast_callback(event_type, payload)
-        except Exception as exc:
-            log.warning("Failed to broadcast topology event %s: %s", event_type.value, exc)
+        except Exception:
+            log.exception("Failed to broadcast topology event %s", event_type.value)
 
 
 async def reconcile_topology_unlocked(
@@ -382,7 +382,9 @@ def scan_live_interfaces_sync(
                 path=path,
                 interface_id=str(get_interface_id_fn(stable_path) or "").lower(),
             )
-        except Exception as exc:
+        except OSError as exc:
             log.debug("Could not read live topology device %s: %s", path, exc)
+        except Exception:
+            log.exception("Unexpected failure reading live topology device %s", path)
 
     return snapshot

--- a/keymasq/keymasqd/socket_server.py
+++ b/keymasq/keymasqd/socket_server.py
@@ -114,7 +114,7 @@ class SocketServer:
         server.close()
         try:
             await server.wait_closed()
-        except Exception as exc:
+        except (OSError, RuntimeError) as exc:
             log.warning(f"Failed to close unsecured daemon socket: {exc}")
         finally:
             if self.server is server:
@@ -199,6 +199,7 @@ class SocketServer:
             try:
                 allowed, client_class, deny_reason = self.peer_validator(peer)
             except Exception as exc:
+                log.exception("Peer validator failed")
                 allowed = False
                 deny_reason = f"peer validator exception: {exc}"
 
@@ -286,8 +287,8 @@ class SocketServer:
 
         except asyncio.CancelledError:
             pass
-        except Exception as e:
-            log.error(f"Error handling client: {e}")
+        except Exception:
+            log.exception("Error handling client")
         finally:
             log.info(f"Client disconnected: {addr}")
             await self._drop_client(writer)
@@ -301,7 +302,7 @@ class SocketServer:
                 request_id=cmd.request_id,
             )
         except Exception as e:
-            log.error(f"Command error: {e}")
+            log.exception("Command error")
             return Response(
                 status="error",
                 error=str(e),
@@ -348,8 +349,14 @@ class SocketServer:
                 timeout=self.broadcast_drain_timeout_s,
             )
             return None
-        except Exception as e:
-            log.warning(f"Failed to send event to client: {e}")
+        except TimeoutError:
+            log.warning("Timed out sending event to client")
+            return writer
+        except OSError as exc:
+            log.warning("Failed to send event to client: %s", exc)
+            return writer
+        except Exception:
+            log.exception("Unexpected failure sending event to client")
             return writer
 
     async def _drop_client(self, writer: asyncio.StreamWriter) -> None:
@@ -388,7 +395,7 @@ class SocketServer:
 
             await self._wait_writer_closed(writer, context)
         except Exception:
-            log.debug("Failed while disconnecting daemon client", exc_info=True)
+            log.exception("Failed while disconnecting daemon client")
 
         if self.disconnect_handler and not is_owner and not self.clients:
             await self.disconnect_handler()
@@ -396,7 +403,7 @@ class SocketServer:
     def _request_writer_close(self, writer: asyncio.StreamWriter) -> None:
         try:
             writer.close()
-        except Exception:
+        except (OSError, RuntimeError):
             log.debug("Failed to request daemon client writer close", exc_info=True)
 
     async def _wait_writer_closed(
@@ -421,7 +428,7 @@ class SocketServer:
             if transport is not None:
                 try:
                     transport.abort()
-                except Exception:
+                except (OSError, RuntimeError):
                     log.debug("Failed to abort daemon client transport", exc_info=True)
-        except Exception:
+        except (OSError, ConnectionError, RuntimeError):
             log.debug("Failed while waiting for daemon client socket to close", exc_info=True)

--- a/keymasq/keymasqd/superkey_state.py
+++ b/keymasq/keymasqd/superkey_state.py
@@ -433,15 +433,22 @@ class SuperkeyMachine:
 
                     await self._execute_action_up(action)
                     await asyncio.sleep(wait)
-        except Exception:
+        except OSError:
             log.debug("Rapidfire loop stopped after error", exc_info=True)
+        except Exception:
+            log.exception("Rapidfire loop stopped after unexpected error")
         finally:
             current_task = asyncio.current_task()
             if current_task is not None:
                 with contextlib.suppress(ValueError):
                     self._rapidfire_tasks.remove(cast(asyncio.Task[None], current_task))
             if not is_relative_mouse:
-                await self._execute_action_up(action)
+                try:
+                    await self._execute_action_up(action)
+                except OSError:
+                    log.debug("Failed to release rapidfire action after loop stop", exc_info=True)
+                except Exception:
+                    log.exception("Unexpected failure releasing rapidfire action after loop stop")
 
     async def _stop_rapidfire_tasks(self) -> None:
         if not self._rapidfire_tasks:

--- a/keymasq/record.py
+++ b/keymasq/record.py
@@ -1,5 +1,6 @@
 import argparse
 import json
+import logging
 import math
 import os
 import pwd
@@ -16,6 +17,8 @@ from keymasq.common.recording_guard import (
     write_unlock_expires_at,
 )
 
+log = logging.getLogger("keymasq.record")
+
 _MUTATING_COMMANDS = {
     "unlock-runtime",
     "lock-runtime",
@@ -24,6 +27,11 @@ _MUTATING_COMMANDS = {
     "disable-macro-recording",
     "disable-macro-recording-persistent",
 }
+
+
+def _exit_error(message: object) -> None:
+    print(json.dumps({"status": "error", "message": str(message)}))
+    sys.exit(1)
 
 
 def _require_privileged_caller() -> int:
@@ -233,9 +241,11 @@ def main() -> None:
             return
 
         raise ValueError("Unknown command")
+    except (PermissionError, OSError, ValueError) as exc:
+        _exit_error(exc)
     except Exception as exc:
-        print(json.dumps({"status": "error", "message": str(exc)}))
-        sys.exit(1)
+        log.exception("Unexpected keymasq-record failure")
+        _exit_error(exc)
 
 
 if __name__ == "__main__":

--- a/keymasq/session/action_handler.py
+++ b/keymasq/session/action_handler.py
@@ -57,7 +57,7 @@ class ActionHandler:
                 stderr=asyncio.subprocess.PIPE,
                 start_new_session=True,
             )
-        except Exception as e:
+        except (OSError, RuntimeError, ValueError) as e:
             log.error(f"Failed to execute command: {e}")
             return -1
 
@@ -77,7 +77,7 @@ class ActionHandler:
             log.debug("Command task cancelled, killing: %s", cmd)
             await _kill_and_drain_process(process)
             raise
-        except Exception as e:
+        except (OSError, RuntimeError, ValueError) as e:
             log.error(f"Failed to execute command: {e}")
             return -1
 

--- a/keymasq/session/client.py
+++ b/keymasq/session/client.py
@@ -42,18 +42,20 @@ class KeymasqdClient:
             self._listen_task = None
 
         if writer:
-            writer.close()
             try:
+                writer.close()
                 await writer.wait_closed()
-            except Exception:
+            except OSError:
                 log.debug("Failed while closing daemon client writer", exc_info=True)
+            except Exception:
+                log.exception("Unexpected failure while closing daemon client writer")
 
         self.reader = None
         self.writer = None
 
     async def send_command(self, command: Command, timeout: float = 10.0) -> Response:
         if not self.writer:
-            raise RuntimeError("Not connected to keymasqd")
+            raise ConnectionError("Not connected to keymasqd")
 
         self._request_counter += 1
         request_id = str(self._request_counter)
@@ -96,8 +98,10 @@ class KeymasqdClient:
 
         except asyncio.CancelledError:
             pass
-        except Exception as e:
-            log.error(f"Listen error: {e}")
+        except OSError as exc:
+            log.warning("Daemon client listen I/O error: %s", exc)
+        except Exception:
+            log.exception("Unexpected daemon client listen error")
         finally:
             self._finalize_disconnect()
 
@@ -116,7 +120,7 @@ class KeymasqdClient:
                 data = response.data.get("data", {})
                 await self.event_handler(event_type, data)
             except Exception as e:
-                log.error(f"Event handler error: {e}")
+                log.exception("Event handler error: %s", e)
 
     def _finalize_disconnect(self) -> None:
         error = ConnectionError("Disconnected from keymasqd")
@@ -132,7 +136,9 @@ class KeymasqdClient:
         if writer is not None:
             try:
                 writer.close()
-            except Exception:
+            except OSError:
                 log.debug("Failed to close daemon client writer after disconnect", exc_info=True)
+            except Exception:
+                log.exception("Unexpected failure closing daemon client writer after disconnect")
 
         self._disconnected_event.set()

--- a/keymasq/session/config_loading.py
+++ b/keymasq/session/config_loading.py
@@ -1,6 +1,7 @@
 import asyncio
 import inspect
 import logging
+import tomllib
 from collections.abc import Awaitable, Callable
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
@@ -31,6 +32,14 @@ def _config_files(config_dir: Path, *, sort_paths: bool) -> list[Path]:
     return files
 
 
+def _append_config_load_failure(
+    failures: list[ConfigLoadFailure],
+    path: Path,
+    exc: BaseException,
+) -> None:
+    failures.append(ConfigLoadFailure(path, str(exc) or type(exc).__name__))
+
+
 async def load_config_files[ConfigT](
     config_dir: Path,
     *,
@@ -50,9 +59,19 @@ async def load_config_files[ConfigT](
             if inspect.isawaitable(loaded_config):
                 loaded_config = await cast(Awaitable[ConfigT], loaded_config)
             loaded_configs.append((config_file, cast(ConfigT, loaded_config)))
-        except Exception as exc:
+        except tomllib.TOMLDecodeError as exc:
             logger.error(failure_log_message, config_file, exc)
-            failures.append(ConfigLoadFailure(config_file, str(exc)))
+            _append_config_load_failure(failures, config_file, exc)
+        except (OSError, ValueError, KeyError) as exc:
+            logger.error(failure_log_message, config_file, exc)
+            _append_config_load_failure(failures, config_file, exc)
+        except Exception as exc:
+            logger.exception(
+                "Unexpected error while loading %s config %s",
+                config_kind,
+                config_file,
+            )
+            _append_config_load_failure(failures, config_file, exc)
 
     if strict and failures:
         raise ConfigLoadError(config_kind, failures)

--- a/keymasq/session/dbus.py
+++ b/keymasq/session/dbus.py
@@ -1,10 +1,12 @@
 import asyncio
-from collections.abc import AsyncIterator
+import logging
+from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 from typing import Any
 
 from dbus_next.aio.message_bus import MessageBus
 from dbus_next.constants import MessageType
+from dbus_next.errors import AuthError, DBusError, InterfaceNotFoundError, InvalidAddressError
 from dbus_next.message import Message
 
 DBUS_SERVICE = "org.freedesktop.DBus"
@@ -13,6 +15,7 @@ DBUS_INTERFACE = "org.freedesktop.DBus"
 NOTIFICATIONS_SERVICE = "org.freedesktop.Notifications"
 NOTIFICATIONS_PATH = "/org/freedesktop/Notifications"
 NOTIFICATIONS_INTERFACE = "org.freedesktop.Notifications"
+log = logging.getLogger("keymasq-session.dbus")
 
 
 class SessionDBus:
@@ -107,7 +110,7 @@ class SessionDBus:
 
 
 @asynccontextmanager
-async def temporary_session_dbus() -> AsyncIterator[SessionDBus]:
+async def temporary_session_dbus() -> AsyncGenerator[SessionDBus]:
     dbus = SessionDBus()
     try:
         await dbus.connect()
@@ -127,5 +130,15 @@ async def name_has_owner(
             return await dbus.name_has_owner(name, timeout=timeout)
         async with temporary_session_dbus() as temporary_dbus:
             return await temporary_dbus.name_has_owner(name, timeout=timeout)
+    except TimeoutError as exc:
+        log.debug("Timed out while checking D-Bus owner %s: %s", name, exc)
+        return False
+    except OSError as exc:
+        log.debug("D-Bus owner lookup transport error for %s: %s", name, exc)
+        return False
+    except (AuthError, DBusError, InterfaceNotFoundError, InvalidAddressError) as exc:
+        log.debug("D-Bus owner lookup failed for %s: %s", name, exc)
+        return False
     except Exception:
+        log.exception("Unexpected D-Bus owner lookup failure for %s", name)
         return False

--- a/keymasq/session/gnome_shell.py
+++ b/keymasq/session/gnome_shell.py
@@ -1,5 +1,5 @@
 import asyncio
-from collections.abc import AsyncIterator
+from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 from typing import cast
 
@@ -28,7 +28,7 @@ class GnomeShellDBusError(RuntimeError):
 
 
 @asynccontextmanager
-async def _dbus_context(dbus: SessionDBus | None) -> AsyncIterator[SessionDBus]:
+async def _dbus_context(dbus: SessionDBus | None) -> AsyncGenerator[SessionDBus]:
     if dbus is not None:
         yield dbus
         return

--- a/keymasq/session/hardware.py
+++ b/keymasq/session/hardware.py
@@ -218,7 +218,12 @@ class HardwareManager:
     def _storage_file_hardware_id(self, path: Path) -> str:
         try:
             return self._load_config(path).hardware_id
+        except (OSError, ValueError, KeyError) as exc:
+            raise ValueError(
+                f"Hardware storage path '{path.name}' already exists but could not be read"
+            ) from exc
         except Exception as exc:
+            log.exception("Unexpected error while reading hardware storage path %s", path)
             raise ValueError(
                 f"Hardware storage path '{path.name}' already exists but could not be read"
             ) from exc
@@ -226,7 +231,16 @@ class HardwareManager:
     def _storage_path_matches_hardware_id(self, path: Path, hardware_id: str) -> bool:
         try:
             return self._load_config(path).hardware_id == hardware_id
+        except (OSError, ValueError, KeyError) as exc:
+            log.debug(
+                "Hardware storage path %s does not match %s: %s",
+                path,
+                hardware_id,
+                exc,
+            )
+            return False
         except Exception:
+            log.exception("Unexpected error while checking hardware storage path %s", path)
             return False
 
     def _path_for_hardware_id(self, hardware_id: str) -> tuple[Path, bool]:
@@ -397,8 +411,11 @@ class HardwareManager:
             return False
         try:
             path.unlink()
-        except Exception as e:
-            log.error(f"Failed to delete {path}: {e}")
+        except OSError as exc:
+            log.error("Failed to delete %s: %s", path, exc)
+            return False
+        except Exception:
+            log.exception("Unexpected error deleting hardware config %s", path)
             return False
 
         del self._cache[hardware_id]

--- a/keymasq/session/listeners/_socket_helpers.py
+++ b/keymasq/session/listeners/_socket_helpers.py
@@ -1,6 +1,9 @@
 import asyncio
+import logging
 import os
 from pathlib import Path
+
+log = logging.getLogger("keymasq-session.listeners.socket_helpers")
 
 
 def runtime_dir() -> Path:
@@ -27,8 +30,21 @@ async def unix_socket_connectable(socket_path: Path, timeout_s: float = 0.2) -> 
     try:
         connect_coro = asyncio.open_unix_connection(path=str(socket_path))
         _reader, writer = await asyncio.wait_for(connect_coro, timeout=timeout_s)
-        writer.close()
-        await writer.wait_closed()
-        return True
-    except Exception:
+    except TimeoutError as exc:
+        log.debug("Timed out probing Unix socket %s: %s", socket_path, exc)
         return False
+    except OSError as exc:
+        log.debug("Could not connect to Unix socket %s: %s", socket_path, exc)
+        return False
+    except Exception:
+        log.exception("Unexpected error probing Unix socket %s", socket_path)
+        return False
+
+    writer.close()
+    try:
+        await writer.wait_closed()
+    except OSError as exc:
+        log.debug("Failed to close Unix socket probe connection %s: %s", socket_path, exc)
+    except Exception:
+        log.exception("Unexpected error closing Unix socket probe connection %s", socket_path)
+    return True

--- a/keymasq/session/listeners/gnome.py
+++ b/keymasq/session/listeners/gnome.py
@@ -130,7 +130,7 @@ class GnomeListener(WindowListener):
     ) -> bool | None:
         try:
             return await gnome_shell.extension_visible(cls._EXTENSION_UUID, dbus)
-        except Exception:
+        except GnomeShellDBusError:
             return None
 
     @classmethod
@@ -140,14 +140,14 @@ class GnomeListener(WindowListener):
     ) -> bool | None:
         try:
             return not await gnome_shell.user_extensions_enabled(dbus)
-        except Exception:
+        except GnomeShellDBusError:
             return None
 
     @classmethod
     async def _bridge_extension_enabled(cls, dbus: SessionDBus | None = None) -> bool | None:
         try:
             return await gnome_shell.extension_enabled(cls._EXTENSION_UUID, dbus)
-        except Exception:
+        except GnomeShellDBusError:
             return None
 
     @classmethod
@@ -179,9 +179,7 @@ class GnomeListener(WindowListener):
             if action == "refresh":
                 return True, "GNOME bridge status refreshed."
 
-        except GnomeShellDBusError as exc:
-            return False, str(exc)
-        except Exception as exc:
+        except (GnomeShellDBusError, OSError, RuntimeError) as exc:
             return False, str(exc)
 
         return False, "Unsupported GNOME setup action."
@@ -419,25 +417,19 @@ class GnomeListener(WindowListener):
             )
 
         GNOME_BRIDGE_SOCKET_PATH.parent.mkdir(parents=True, exist_ok=True)
-        try:
+        with contextlib.suppress(OSError):
             os.chmod(GNOME_BRIDGE_SOCKET_PATH.parent, 0o700)
-        except OSError:
-            pass
 
         if GNOME_BRIDGE_SOCKET_PATH.exists():
-            try:
+            with contextlib.suppress(OSError):
                 GNOME_BRIDGE_SOCKET_PATH.unlink()
-            except OSError:
-                pass
 
         self._server = await asyncio.start_unix_server(
             self._handle_bridge_client,
             path=str(GNOME_BRIDGE_SOCKET_PATH),
         )
-        try:
+        with contextlib.suppress(OSError):
             os.chmod(GNOME_BRIDGE_SOCKET_PATH, 0o600)
-        except OSError:
-            pass
 
         self.running = True
         log.info("GNOME bridge listener started on %s", GNOME_BRIDGE_SOCKET_PATH)
@@ -454,7 +446,7 @@ class GnomeListener(WindowListener):
 
         if self._reader_task is not None:
             self._reader_task.cancel()
-            with contextlib.suppress(asyncio.CancelledError, Exception):
+            with contextlib.suppress(asyncio.CancelledError, OSError, RuntimeError):
                 await self._reader_task
             self._reader_task = None
 
@@ -462,8 +454,10 @@ class GnomeListener(WindowListener):
             try:
                 self._writer.close()
                 await self._writer.wait_closed()
+            except OSError as exc:
+                log.debug("Failed while closing GNOME bridge writer: %s", exc)
             except Exception:
-                log.debug("Failed while closing GNOME bridge writer", exc_info=True)
+                log.exception("Unexpected failure while closing GNOME bridge writer")
             self._writer = None
 
         if self._server is not None:
@@ -497,10 +491,8 @@ class GnomeListener(WindowListener):
         self._pending_dispatch.clear()
 
         if GNOME_BRIDGE_SOCKET_PATH.exists():
-            try:
+            with contextlib.suppress(OSError):
                 GNOME_BRIDGE_SOCKET_PATH.unlink()
-            except OSError:
-                pass
 
         log.info("GNOME bridge listener stopped")
 
@@ -519,8 +511,10 @@ class GnomeListener(WindowListener):
             try:
                 self._writer.close()
                 await self._writer.wait_closed()
+            except OSError as exc:
+                log.debug("Failed while replacing GNOME bridge writer: %s", exc)
             except Exception:
-                log.debug("Failed while replacing GNOME bridge writer", exc_info=True)
+                log.exception("Unexpected failure while replacing GNOME bridge writer")
 
         self._writer = writer
         self._bridge_protocol = None
@@ -543,15 +537,24 @@ class GnomeListener(WindowListener):
                     break
                 try:
                     payload = _json_object(json.loads(raw.decode("utf-8")))
-                except Exception:
+                except UnicodeDecodeError as exc:
+                    log.debug("Ignoring GNOME bridge message with invalid UTF-8: %s", exc)
+                    continue
+                except json.JSONDecodeError as exc:
+                    log.debug("Ignoring malformed GNOME bridge JSON message: %s", exc)
                     continue
                 if payload is None:
+                    log.debug("Ignoring GNOME bridge JSON message that is not an object")
                     continue
                 await self._handle_bridge_message(payload)
         except asyncio.CancelledError:
             raise
+        except asyncio.IncompleteReadError as exc:
+            log.debug("GNOME bridge read loop stopped after incomplete read: %s", exc)
+        except OSError as exc:
+            log.debug("GNOME bridge read loop stopped after I/O error: %s", exc)
         except Exception:
-            log.debug("GNOME bridge read loop stopped after error", exc_info=True)
+            log.exception("Unexpected GNOME bridge read loop error")
         finally:
             if self._writer is writer:
                 self._writer = None
@@ -564,8 +567,10 @@ class GnomeListener(WindowListener):
             try:
                 writer.close()
                 await writer.wait_closed()
+            except OSError as exc:
+                log.debug("Failed while closing GNOME bridge client writer: %s", exc)
             except Exception:
-                log.debug("Failed while closing GNOME bridge client writer", exc_info=True)
+                log.exception("Unexpected failure while closing GNOME bridge client writer")
 
     async def _handle_bridge_message(self, payload: JsonObject) -> None:
         msg_type = _str_value(payload.get("type"), "")
@@ -719,6 +724,19 @@ class GnomeListener(WindowListener):
                 )
         return details
 
+    def _pending_bridge_requests_for(
+        self,
+        msg_type: str,
+    ) -> dict[int, asyncio.Future[JsonObject | None]] | None:
+        pending_by_type = {
+            "get_active_window": self._pending_window,
+            "get_pointer": self._pending_pointer,
+            "set_pointer": self._pending_pointer_set,
+            "activate_title": self._pending_activate,
+            "dispatch": self._pending_dispatch,
+        }
+        return pending_by_type.get(msg_type)
+
     async def _send_request(self, payload: JsonObject, timeout: float) -> JsonObject | None:
         if self._writer is None:
             return None
@@ -729,31 +747,26 @@ class GnomeListener(WindowListener):
         request_payload["request_id"] = request_id
         future: asyncio.Future[JsonObject | None] = asyncio.get_running_loop().create_future()
         msg_type = _str_value(request_payload.get("type"), "")
-
-        if msg_type == "get_active_window":
-            self._pending_window[request_id] = future
-        elif msg_type == "get_pointer":
-            self._pending_pointer[request_id] = future
-        elif msg_type == "set_pointer":
-            self._pending_pointer_set[request_id] = future
-        elif msg_type == "activate_title":
-            self._pending_activate[request_id] = future
-        elif msg_type == "dispatch":
-            self._pending_dispatch[request_id] = future
-        else:
+        pending_requests = self._pending_bridge_requests_for(msg_type)
+        if pending_requests is None:
             return None
+        pending_requests[request_id] = future
 
         try:
             self._writer.write((json.dumps(request_payload) + "\n").encode("utf-8"))
             await self._writer.drain()
             result = await asyncio.wait_for(future, timeout=timeout)
-        except Exception:
-            self._pending_window.pop(request_id, None)
-            self._pending_pointer.pop(request_id, None)
-            self._pending_pointer_set.pop(request_id, None)
-            self._pending_activate.pop(request_id, None)
-            self._pending_dispatch.pop(request_id, None)
+        except TimeoutError as exc:
+            log.debug("Timed out waiting for GNOME bridge %s response: %s", msg_type, exc)
             return None
+        except OSError as exc:
+            log.debug("GNOME bridge %s request failed: %s", msg_type, exc)
+            return None
+        except Exception:
+            log.exception("Unexpected GNOME bridge %s request failure", msg_type)
+            return None
+        finally:
+            pending_requests.pop(request_id, None)
 
         return result
 

--- a/keymasq/session/listeners/hyprland.py
+++ b/keymasq/session/listeners/hyprland.py
@@ -107,11 +107,13 @@ class HyprlandListener(WindowListener):
                 pass
 
         if self.writer:
-            self.writer.close()
             try:
+                self.writer.close()
                 await self.writer.wait_closed()
+            except OSError as exc:
+                log.debug("Failed while closing Hyprland listener writer: %s", exc)
             except Exception:
-                log.debug("Failed while closing Hyprland listener writer", exc_info=True)
+                log.exception("Unexpected failure while closing Hyprland listener writer")
 
         log.info("Hyprland listener stopped")
 
@@ -134,8 +136,12 @@ class HyprlandListener(WindowListener):
 
         except asyncio.CancelledError:
             pass
-        except Exception as e:
-            log.error(f"Hyprland listener error: {e}")
+        except UnicodeDecodeError as exc:
+            log.debug("Hyprland listener received invalid UTF-8 event data: %s", exc)
+        except OSError as exc:
+            log.debug("Hyprland listener stopped after I/O error: %s", exc)
+        except Exception:
+            log.exception("Unexpected Hyprland listener error")
 
     async def _handle_event(self, event_line: str) -> None:
         if ">>" not in event_line:
@@ -157,43 +163,53 @@ class HyprlandListener(WindowListener):
         elif event_type == "activewindowv2":
             log.debug(f"Active window address: {data}")
 
-    async def _get_window_tags(self) -> list[str]:
+    @staticmethod
+    def _parse_active_window_response(
+        response: bytes,
+        *,
+        context: str,
+    ) -> tuple[str, str, list[str]] | None:
         try:
-            response = await self._send_cmd("j/activewindow", read_size=8192)
-            if response is None:
-                return []
+            payload = json.loads(response.decode("utf-8"))
+        except UnicodeDecodeError as exc:
+            log.debug("Hyprland %s response was not UTF-8: %s", context, exc)
+            return None
+        except json.JSONDecodeError as exc:
+            log.debug("Hyprland %s response was malformed JSON: %s", context, exc)
+            return None
 
-            data = json.loads(response.decode())
-            tags = data.get("tags", [])
-            if not isinstance(tags, list):
-                return []
-            tag_items = cast(list[object], tags)
-            return [str(tag) for tag in tag_items]
+        if not isinstance(payload, dict):
+            log.debug("Hyprland %s response was not a JSON object", context)
+            return None
 
-        except Exception as e:
-            log.debug(f"Failed to get window tags: {e}")
+        data = cast(dict[str, object], payload)
+        tags = data.get("tags", [])
+        if not isinstance(tags, list):
+            tags = []
+        tag_items = cast(list[object], tags)
+        window_class = data.get("class", "")
+        window_title = data.get("title", "")
+        return (
+            str(window_class) if window_class is not None else "",
+            str(window_title) if window_title is not None else "",
+            [str(tag) for tag in tag_items],
+        )
+
+    async def _get_window_tags(self) -> list[str]:
+        response = await self._send_cmd("j/activewindow", read_size=8192)
+        if response is None:
             return []
 
+        parsed = self._parse_active_window_response(response, context="active window tags")
+        return parsed[2] if parsed is not None else []
+
     async def get_active_window(self) -> tuple[str, str, list[str]]:
-        try:
-            response = await self._send_cmd("j/activewindow", read_size=8192)
-            if response is None:
-                return "", "", []
-
-            data = json.loads(response.decode())
-            tags = data.get("tags", [])
-            if not isinstance(tags, list):
-                tags = []
-            tag_items = cast(list[object], tags)
-            return (
-                data.get("class", ""),
-                data.get("title", ""),
-                [str(tag) for tag in tag_items],
-            )
-
-        except Exception as e:
-            log.error(f"Failed to get active window: {e}")
+        response = await self._send_cmd("j/activewindow", read_size=8192)
+        if response is None:
             return "", "", []
+
+        parsed = self._parse_active_window_response(response, context="active window")
+        return parsed if parsed is not None else ("", "", [])
 
     async def get_cursor_position(self) -> tuple[int, int] | None:
         try:
@@ -205,7 +221,7 @@ class HyprlandListener(WindowListener):
             if len(parts) != 2:
                 return None
             return int(float(parts[0])), int(float(parts[1]))
-        except Exception:
+        except (OSError, UnicodeDecodeError, ValueError):
             return None
 
     async def set_cursor_position(self, x: int, y: int) -> tuple[bool, str]:
@@ -263,16 +279,24 @@ class HyprlandListener(WindowListener):
                 if not response:
                     return None
                 return response
-            except Exception as exc:
+            except TimeoutError as exc:
+                log.debug("Hyprland command timed out: %s", exc)
+                return None
+            except OSError as exc:
                 log.debug("Hyprland command failed: %s", exc)
+                return None
+            except Exception:
+                log.exception("Unexpected Hyprland command failure")
                 return None
             finally:
                 if cmd_writer is not None:
                     try:
                         cmd_writer.close()
                         await cmd_writer.wait_closed()
+                    except OSError as exc:
+                        log.debug("Failed while closing Hyprland command writer: %s", exc)
                     except Exception:
-                        log.debug("Failed while closing Hyprland command writer", exc_info=True)
+                        log.exception("Unexpected failure while closing Hyprland command writer")
             return None
 
     async def health_check(self) -> bool:

--- a/keymasq/session/listeners/kde.py
+++ b/keymasq/session/listeners/kde.py
@@ -64,7 +64,7 @@ def _parse_json_object(payload: str) -> JsonObject | None:
         data = json.loads(payload)
         if isinstance(data, str):
             data = json.loads(data)
-    except Exception:
+    except (json.JSONDecodeError, TypeError):
         return None
     return cast(JsonObject, data) if isinstance(data, dict) else None
 
@@ -101,7 +101,7 @@ def parse_kde_cursor_payload(payload: str) -> tuple[str, int, int] | None:
     try:
         x = int(float(str(x_raw)))
         y = int(float(str(y_raw)))
-    except Exception:
+    except (TypeError, ValueError):
         return None
 
     return request_id, x, y
@@ -237,6 +237,7 @@ class KDEListener(WindowListener):
                 raise RuntimeError("KDE script interface returned a non-awaitable run result")
             await cast(Awaitable[object], result)
         except Exception:
+            log.exception("KDE Wayland listener failed to start")
             await self.stop()
             raise
 
@@ -261,7 +262,7 @@ class KDEListener(WindowListener):
             self._dispatch_waiters.pop(request_id, None)
 
         if self._window_script_iface:
-            with contextlib.suppress(Exception):
+            with contextlib.suppress(AttributeError, OSError, RuntimeError, TypeError):
                 call_stop = getattr(self._window_script_iface, "call_stop", None)
                 if callable(call_stop):
                     result = call_stop()
@@ -270,7 +271,7 @@ class KDEListener(WindowListener):
             self._window_script_iface = None
 
         if self._kwin_scripting and self._plugin_name:
-            with contextlib.suppress(Exception):
+            with contextlib.suppress(OSError, RuntimeError):
                 await self._call_unload_script(self._plugin_name)
 
         self._script_id = None
@@ -278,12 +279,12 @@ class KDEListener(WindowListener):
         self._plugin_name = ""
 
         if self._script_path:
-            with contextlib.suppress(Exception):
+            with contextlib.suppress(OSError):
                 self._script_path.unlink(missing_ok=True)
             self._script_path = None
 
         if self._bus and self._bridge:
-            with contextlib.suppress(Exception):
+            with contextlib.suppress(OSError, RuntimeError, TypeError):
                 self._bus.unexport(KDE_DBUS_OBJECT_PATH, self._bridge)
         self._bridge = None
         self._bus = None
@@ -320,7 +321,7 @@ class KDEListener(WindowListener):
         except TimeoutError:
             log.debug("KDE cursor get timed out waiting for response")
             return None
-        except Exception:
+        except (OSError, RuntimeError, TypeError, ValueError):
             log.debug("KDE cursor get failed", exc_info=True)
             return None
         finally:
@@ -363,7 +364,7 @@ class KDEListener(WindowListener):
         except TimeoutError:
             log.debug("KDE dispatch timed out waiting for response")
             return False, "timed out waiting for KDE dispatch response"
-        except Exception:
+        except (OSError, RuntimeError, TypeError, ValueError):
             log.debug("KDE dispatch failed", exc_info=True)
             return False, "KDE dispatch failed"
         finally:
@@ -399,17 +400,17 @@ class KDEListener(WindowListener):
             return await asyncio.wait_for(result_future, timeout=timeout)
         finally:
             if script_iface is not None:
-                with contextlib.suppress(Exception):
+                with contextlib.suppress(AttributeError, OSError, RuntimeError, TypeError):
                     call_stop = getattr(script_iface, "call_stop", None)
                     if callable(call_stop):
                         result = call_stop()
                         if inspect.isawaitable(result):
                             await cast(Awaitable[object], result)
             if self._kwin_scripting:
-                with contextlib.suppress(Exception):
+                with contextlib.suppress(OSError, RuntimeError):
                     await self._call_unload_script(plugin_name)
             if script_path:
-                with contextlib.suppress(Exception):
+                with contextlib.suppress(OSError):
                     await asyncio.to_thread(script_path.unlink, missing_ok=True)
 
     def handle_window_payload(self, payload: str) -> None:

--- a/keymasq/session/listeners/kde.py
+++ b/keymasq/session/listeners/kde.py
@@ -101,7 +101,7 @@ def parse_kde_cursor_payload(payload: str) -> tuple[str, int, int] | None:
     try:
         x = int(float(str(x_raw)))
         y = int(float(str(y_raw)))
-    except (TypeError, ValueError):
+    except (TypeError, ValueError, OverflowError):
         return None
 
     return request_id, x, y

--- a/keymasq/session/listeners/niri.py
+++ b/keymasq/session/listeners/niri.py
@@ -740,11 +740,14 @@ class NiriListener(WindowListener):
                 except TimeoutError as exc:
                     log.debug("Niri command request timed out: %s", exc)
                     await self._reset_failed_cmd_connection()
-                except OSError as exc:
-                    log.debug("Niri command request failed: %s", exc)
+                except (ConnectionError, RuntimeError) as exc:
+                    log.debug("Niri command socket dropped: %s", exc)
                     await self._reset_failed_cmd_connection()
                 except (json.JSONDecodeError, ValueError) as exc:
                     log.debug("Niri command reply was invalid: %s", exc)
+                    await self._reset_failed_cmd_connection()
+                except OSError as exc:
+                    log.debug("Niri command request failed: %s", exc)
                     await self._reset_failed_cmd_connection()
                 except Exception:
                     log.exception("Unexpected Niri command request failure")

--- a/keymasq/session/listeners/niri.py
+++ b/keymasq/session/listeners/niri.py
@@ -154,7 +154,7 @@ NIRI_DISPATCH_BUILDERS: dict[str, NiriDispatchBuilder] = {
 def parse_niri_event(payload: str) -> tuple[str, JsonObject] | None:
     try:
         data = cast(object, json.loads(payload))
-    except Exception:
+    except (json.JSONDecodeError, TypeError):
         return None
 
     event = _json_object(data)
@@ -269,7 +269,7 @@ class NiriListener(WindowListener):
             self.writer.close()
             try:
                 await self.writer.wait_closed()
-            except Exception:
+            except (OSError, ConnectionError, RuntimeError):
                 log.debug("Failed while closing Niri event writer", exc_info=True)
             self.writer = None
             self.reader = None
@@ -278,7 +278,7 @@ class NiriListener(WindowListener):
             self._cmd_writer.close()
             try:
                 await self._cmd_writer.wait_closed()
-            except Exception:
+            except (OSError, ConnectionError, RuntimeError):
                 log.debug("Failed while closing Niri command writer", exc_info=True)
             self._cmd_writer = None
             self._cmd_reader = None
@@ -309,8 +309,8 @@ class NiriListener(WindowListener):
                 await self._handle_event(*event)
         except asyncio.CancelledError:
             pass
-        except Exception as exc:
-            log.error("Niri listener error: %s", exc)
+        except (OSError, ConnectionError, RuntimeError, UnicodeDecodeError):
+            log.exception("Niri listener error")
 
     async def _send_event_stream_request(self) -> None:
         writer = self.writer
@@ -659,7 +659,7 @@ class NiriListener(WindowListener):
             )
         except FileNotFoundError:
             return False, "niri command is not installed"
-        except Exception as exc:
+        except (OSError, RuntimeError) as exc:
             return False, f"failed to launch niri msg: {exc}"
 
         try:
@@ -667,10 +667,10 @@ class NiriListener(WindowListener):
                 process.communicate(),
                 timeout=NIRI_CLI_DISPATCH_TIMEOUT_SECONDS,
             )
-        except Exception:
+        except TimeoutError:
             with contextlib.suppress(ProcessLookupError):
                 process.kill()
-            with contextlib.suppress(Exception):
+            with contextlib.suppress(OSError, RuntimeError):
                 await process.communicate()
             return False, f"niri msg action timed out: {dispatcher}"
 
@@ -690,10 +690,26 @@ class NiriListener(WindowListener):
                 self.socket_path
             )
             return True
-        except Exception:
+        except (OSError, ConnectionError, RuntimeError):
             self._cmd_reader = None
             self._cmd_writer = None
             return False
+
+    async def _reset_failed_cmd_connection(self) -> None:
+        cmd_writer = self._cmd_writer
+        self._cmd_reader = None
+        self._cmd_writer = None
+
+        if cmd_writer is None:
+            return
+
+        try:
+            cmd_writer.close()
+            await cmd_writer.wait_closed()
+        except OSError as exc:
+            log.debug("Failed while closing failed Niri command writer: %s", exc)
+        except Exception:
+            log.exception("Unexpected failure while closing failed Niri command writer")
 
     async def _send_cmd_request(
         self,
@@ -721,14 +737,16 @@ class NiriListener(WindowListener):
                         return True, body
                     log.debug("Niri request failed: %s", body)
                     return False, body
+                except TimeoutError as exc:
+                    log.debug("Niri command request timed out: %s", exc)
+                    await self._reset_failed_cmd_connection()
+                except OSError as exc:
+                    log.debug("Niri command request failed: %s", exc)
+                    await self._reset_failed_cmd_connection()
+                except (json.JSONDecodeError, ValueError) as exc:
+                    log.debug("Niri command reply was invalid: %s", exc)
+                    await self._reset_failed_cmd_connection()
                 except Exception:
-                    try:
-                        cmd_writer = self._cmd_writer
-                        if cmd_writer is not None:
-                            cmd_writer.close()
-                            await cmd_writer.wait_closed()
-                    except Exception:
-                        log.debug("Failed while closing failed Niri command writer", exc_info=True)
-                    self._cmd_reader = None
-                    self._cmd_writer = None
+                    log.exception("Unexpected Niri command request failure")
+                    await self._reset_failed_cmd_connection()
             return False, None

--- a/keymasq/session/listeners/wayland_toplevel.py
+++ b/keymasq/session/listeners/wayland_toplevel.py
@@ -114,8 +114,8 @@ class WaylandToplevelListener[
             await self._client.run()
         except asyncio.CancelledError:
             raise
-        except Exception as exc:
-            self._logger.error("%s error: %s", self._listener_error_label, exc)
+        except Exception:
+            self._logger.exception("%s error", self._listener_error_label)
 
     async def health_check(self) -> bool:
         if not await super().health_check():

--- a/keymasq/session/listeners/x11.py
+++ b/keymasq/session/listeners/x11.py
@@ -12,17 +12,36 @@ from keymasq.session.listeners.base import WindowChangeCallback, WindowListener
 log = logging.getLogger("keymasq-session.listeners.x11")
 
 _x_module = None
+_expected_x_errors: tuple[type[BaseException], ...] = (OSError,)
 xdisplay: object | None
 try:
     from Xlib import X as XLIB_X
     from Xlib import display
-except Exception:
+    from Xlib import error as xerror
+except ImportError:
     xdisplay = None
 else:
     _x_module = XLIB_X
     xdisplay = display
+    _expected_x_errors = (
+        OSError,
+        cast(type[BaseException], xerror.DisplayError),
+        cast(type[BaseException], xerror.XError),
+        cast(type[BaseException], xerror.XauthError),
+    )
 
 X = _x_module
+
+
+def _is_expected_x_error(exc: BaseException) -> bool:
+    return isinstance(exc, _expected_x_errors)
+
+
+def _log_x_failure(message: str, exc: BaseException) -> None:
+    if _is_expected_x_error(exc):
+        log.debug("%s: %s", message, exc)
+        return
+    log.exception(message)
 
 
 class _XDisplayModule(Protocol):
@@ -160,7 +179,8 @@ class X11Listener(WindowListener):
             disp = display_mod.Display(display_name)
             disp.close()
             return True
-        except Exception:
+        except Exception as exc:  # noqa: BLE001 - Xlib can raise backend-specific errors.
+            _log_x_failure(f"Could not open X11 display {display_name}", exc)
             return False
 
     @classmethod
@@ -206,15 +226,15 @@ class X11Listener(WindowListener):
     async def get_active_window(self) -> tuple[str, str, list[str]]:
         try:
             return await asyncio.to_thread(self._query_active_window)
-        except Exception:
-            log.debug("X11 active window query failed", exc_info=True)
+        except Exception as exc:  # noqa: BLE001 - keep the listener query fallback alive.
+            _log_x_failure("X11 active window query failed", exc)
             return "", "", []
 
     async def get_cursor_position(self) -> tuple[int, int] | None:
         try:
             return await asyncio.to_thread(self._query_cursor_position)
-        except Exception:
-            log.debug("X11 cursor get failed", exc_info=True)
+        except Exception as exc:  # noqa: BLE001 - keep the cursor query fallback alive.
+            _log_x_failure("X11 cursor get failed", exc)
             return None
 
     async def _listen(self) -> None:
@@ -240,13 +260,13 @@ class X11Listener(WindowListener):
                     await self._emit_active_window_if_changed()
         except asyncio.CancelledError:
             raise
-        except Exception:
-            log.error("X11 listener error", exc_info=True)
+        except Exception as exc:  # noqa: BLE001 - listener task must log and stop cleanly.
+            _log_x_failure("X11 listener error", exc)
         finally:
             if self._loop and self._display_fd is not None:
                 try:
                     self._loop.remove_reader(self._display_fd)
-                except Exception:
+                except (RuntimeError, ValueError):
                     log.debug("Failed to remove X11 display reader", exc_info=True)
             self._fd_event = None
             self._loop = None
@@ -294,13 +314,13 @@ class X11Listener(WindowListener):
                     self._active_window.change_attributes(
                         event_mask=int(getattr(X, "NoEventMask", 0))
                     )
-                except Exception:
-                    log.debug("Failed to clear X11 active window event mask", exc_info=True)
+                except Exception as exc:  # noqa: BLE001 - cleanup should not block shutdown.
+                    _log_x_failure("Failed to clear X11 active window event mask", exc)
 
             try:
                 self._xdisplay.close()
-            except Exception:
-                log.debug("Failed to close X11 display", exc_info=True)
+            except Exception as exc:  # noqa: BLE001 - cleanup should not block shutdown.
+                _log_x_failure("Failed to close X11 display", exc)
 
             self._xdisplay = None
             self._root = None
@@ -334,7 +354,8 @@ class X11Listener(WindowListener):
                     event = self._xdisplay.next_event()
                     if self._handle_x_event_unlocked(event):
                         changed = True
-            except Exception:
+            except Exception as exc:  # noqa: BLE001 - Xlib event drains can fail broadly.
+                _log_x_failure("Failed to drain X11 events", exc)
                 return False
 
             return changed
@@ -376,8 +397,8 @@ class X11Listener(WindowListener):
                 self._active_window.change_attributes(
                     event_mask=int(getattr(X, "NoEventMask", 0))
                 )
-            except Exception:
-                log.debug("Failed to clear previous X11 active window event mask", exc_info=True)
+            except Exception as exc:  # noqa: BLE001 - cleanup should not block watch updates.
+                _log_x_failure("Failed to clear previous X11 active window event mask", exc)
 
         self._active_window = None
         self._active_window_id = None
@@ -391,7 +412,8 @@ class X11Listener(WindowListener):
             self._active_window = win
             self._active_window_id = next_window_id
             self._xdisplay.sync()
-        except Exception:
+        except Exception as exc:  # noqa: BLE001 - Xlib resource creation can fail broadly.
+            _log_x_failure("Failed to watch X11 active window", exc)
             self._active_window = None
             self._active_window_id = None
 
@@ -416,7 +438,10 @@ class X11Listener(WindowListener):
         if not raw_window_id:
             return None
 
-        window_id = int(cast(int | str | bytes | bytearray, raw_window_id))
+        try:
+            window_id = int(cast(int | str | bytes | bytearray, raw_window_id))
+        except (TypeError, ValueError):
+            return None
         if window_id == 0:
             return None
 
@@ -445,7 +470,8 @@ class X11Listener(WindowListener):
                     class_data = win.get_wm_class()
                     if class_data:
                         wm_class = str(class_data[-1] or class_data[0] or "")
-                except Exception:
+                except Exception as exc:  # noqa: BLE001 - Xlib metadata reads can fail broadly.
+                    _log_x_failure("Failed to read X11 window class", exc)
                     wm_class = ""
 
                 title = ""
@@ -460,18 +486,21 @@ class X11Listener(WindowListener):
                             title = raw.decode(errors="replace")
                         else:
                             title = str(raw)
-                except Exception:
+                except Exception as exc:  # noqa: BLE001 - Xlib metadata reads can fail broadly.
+                    _log_x_failure("Failed to read X11 window title", exc)
                     title = ""
 
                 if not title:
                     try:
                         fallback = win.get_wm_name()
                         title = str(fallback or "")
-                    except Exception:
+                    except Exception as exc:  # noqa: BLE001 - Xlib metadata reads can fail broadly.
+                        _log_x_failure("Failed to read fallback X11 window title", exc)
                         title = ""
 
                 return wm_class, title, []
-            except Exception:
+            except Exception as exc:  # noqa: BLE001 - keep the active-window fallback alive.
+                _log_x_failure("Failed to query X11 active window", exc)
                 return "", "", []
 
     def _query_cursor_position(self) -> tuple[int, int] | None:
@@ -481,5 +510,8 @@ class X11Listener(WindowListener):
             try:
                 pointer = self._root.query_pointer()
                 return int(pointer.root_x), int(pointer.root_y)
-            except Exception:
+            except (TypeError, ValueError):
+                return None
+            except Exception as exc:  # noqa: BLE001 - Xlib cursor query can fail broadly.
+                _log_x_failure("Failed to query X11 cursor position", exc)
                 return None

--- a/keymasq/session/manager/commands.py
+++ b/keymasq/session/manager/commands.py
@@ -2,7 +2,7 @@ import asyncio
 import logging
 from typing import TYPE_CHECKING, cast
 
-from keymasq.common.ipc import Command, CommandType
+from keymasq.common.ipc import Command, CommandType, Response
 from keymasq.common.models import (
     MAX_MACRO_RECORDING_SLOTS,
     normalize_macro_loop_stop_behavior,
@@ -37,6 +37,21 @@ if TYPE_CHECKING:
 log = logging.getLogger("keymasq-session")
 
 
+def _daemon_unavailable_response() -> JsonObject:
+    return {"status": "error", "message": "Daemon unavailable"}
+
+
+async def _send_daemon_request(
+    manager: "SessionManager",
+    command: Command,
+) -> Response | None:
+    try:
+        return await manager.client.send_command(command)
+    except OSError as exc:
+        log.debug("Daemon request %s failed: %s", command.command.value, exc, exc_info=True)
+        return None
+
+
 async def handle_session_request(
     manager: "SessionManager",
     request: JsonObject,
@@ -51,11 +66,10 @@ async def handle_session_request(
         return {
             "status": "error",
             "message": f"{client_class} is not allowed to call '{command}'",
-    }
+        }
 
     if runtime_recording.is_sensitive_session_command(
-        manager,
-        command, policy
+        manager, command, policy
     ) and not await runtime_recording.authorize_sensitive_session_command(
         manager,
         command,
@@ -167,15 +181,15 @@ async def _handle_profile_commands(
         if not hardware_id:
             return {"status": "error", "message": "missing hardware_id"}
         immediate = bool(request.get("immediate", True))
-        try:
-            result = await manager.client.send_command(
-                Command(
-                    command=CommandType.RELEASE_DEVICE,
-                    data={"hardware_id": hardware_id, "immediate": immediate},
-                )
-            )
-        except Exception:
-            return {"status": "error", "message": "Daemon unavailable"}
+        result = await _send_daemon_request(
+            manager,
+            Command(
+                command=CommandType.RELEASE_DEVICE,
+                data={"hardware_id": hardware_id, "immediate": immediate},
+            ),
+        )
+        if result is None:
+            return _daemon_unavailable_response()
         if result.status != "ok":
             return {
                 "status": "error",
@@ -227,9 +241,11 @@ async def _handle_virtual_gamepad_commands(
         int_value(request.get("count"), manager.virtual_gamepad_count)
     )
     if manager.connected:
-        response = await manager.client.send_command(
-            Command(command=CommandType.SET_VIRTUAL_GAMEPADS, data={"count": count})
+        response = await _send_daemon_request(
+            manager, Command(command=CommandType.SET_VIRTUAL_GAMEPADS, data={"count": count})
         )
+        if response is None:
+            return _daemon_unavailable_response()
         if response.status != "ok":
             return {"status": "error", "message": response.error or "daemon rejected count"}
         if isinstance(response.data, dict):
@@ -311,12 +327,18 @@ async def _handle_settings_commands(
     )
 
     if manager.connected:
-        response = await manager.client.send_command(
+        response = await _send_daemon_request(
+            manager,
             Command(
                 command=CommandType.SET_VIRTUAL_GAMEPADS,
                 data={"count": count},
-            )
+            ),
         )
+        if response is None:
+            payload = _settings_payload(manager)
+            payload["status"] = "error"
+            payload["message"] = "Daemon unavailable"
+            return payload
         if response.status != "ok":
             payload = _settings_payload(manager)
             payload["status"] = "error"
@@ -572,10 +594,9 @@ async def _handle_macro_commands(
     request: JsonObject,
 ) -> JsonObject | None:
     if command == "list_macros":
-        try:
-            result = await manager.client.send_command(Command(command=CommandType.MACRO_LIST_META))
-        except Exception:
-            return {"status": "error", "message": "Daemon unavailable"}
+        result = await _send_daemon_request(manager, Command(command=CommandType.MACRO_LIST_META))
+        if result is None:
+            return _daemon_unavailable_response()
         result_data = json_object(result.data)
         if result.status == "ok" and result_data is not None:
             macros = list(json_list(result_data.get("macros")))
@@ -587,12 +608,12 @@ async def _handle_macro_commands(
 
     if command == "get_macro":
         name = str_value(request.get("name"), "")
-        try:
-            result = await manager.client.send_command(
-                Command(command=CommandType.MACRO_GET, data={"name": name})
-            )
-        except Exception:
-            return {"status": "error", "message": "Daemon unavailable"}
+        result = await _send_daemon_request(
+            manager,
+            Command(command=CommandType.MACRO_GET, data={"name": name}),
+        )
+        if result is None:
+            return _daemon_unavailable_response()
         result_data = json_object(result.data)
         if result.status == "ok" and result_data is not None:
             return {"status": "ok", "macro": result_data.get("macro")}
@@ -602,12 +623,12 @@ async def _handle_macro_commands(
         macro = json_object(request.get("macro"))
         if macro is None:
             return {"status": "error", "message": "macro payload required"}
-        try:
-            result = await manager.client.send_command(
-                Command(command=CommandType.MACRO_CREATE, data={"macro": macro})
-            )
-        except Exception:
-            return {"status": "error", "message": "Daemon unavailable"}
+        result = await _send_daemon_request(
+            manager,
+            Command(command=CommandType.MACRO_CREATE, data={"macro": macro}),
+        )
+        if result is None:
+            return _daemon_unavailable_response()
         result_data = json_object(result.data)
         if result.status == "ok" and result_data is not None:
             created = json_object(result_data.get("macro")) or {}
@@ -626,12 +647,12 @@ async def _handle_macro_commands(
         update_payload: JsonObject = {"name": name, "macro": macro}
         if "expected_revision" in request:
             update_payload["expected_revision"] = request.get("expected_revision")
-        try:
-            result = await manager.client.send_command(
-                Command(command=CommandType.MACRO_UPDATE, data=update_payload)
-            )
-        except Exception:
-            return {"status": "error", "message": "Daemon unavailable"}
+        result = await _send_daemon_request(
+            manager,
+            Command(command=CommandType.MACRO_UPDATE, data=update_payload),
+        )
+        if result is None:
+            return _daemon_unavailable_response()
         result_data = json_object(result.data)
         if result.status == "ok" and result_data is not None:
             updated = json_object(result_data.get("macro")) or {}
@@ -647,12 +668,12 @@ async def _handle_macro_commands(
         delete_payload: JsonObject = {"name": name}
         if "expected_revision" in request:
             delete_payload["expected_revision"] = request.get("expected_revision")
-        try:
-            result = await manager.client.send_command(
-                Command(command=CommandType.MACRO_DELETE, data=delete_payload)
-            )
-        except Exception:
-            return {"status": "error", "message": "Daemon unavailable"}
+        result = await _send_daemon_request(
+            manager,
+            Command(command=CommandType.MACRO_DELETE, data=delete_payload),
+        )
+        if result is None:
+            return _daemon_unavailable_response()
         if result.status != "ok":
             return {"status": "error", "message": result.error or "Failed to delete macro"}
         await runtime_profiles.refresh_macro_bindings(manager)
@@ -666,12 +687,12 @@ async def _handle_macro_commands(
         }
         if "expected_revision" in request:
             rename_payload["expected_revision"] = request.get("expected_revision")
-        try:
-            result = await manager.client.send_command(
-                Command(command=CommandType.MACRO_RENAME, data=rename_payload)
-            )
-        except Exception:
-            return {"status": "error", "message": "Daemon unavailable"}
+        result = await _send_daemon_request(
+            manager,
+            Command(command=CommandType.MACRO_RENAME, data=rename_payload),
+        )
+        if result is None:
+            return _daemon_unavailable_response()
         if result.status != "ok":
             return {"status": "error", "message": result.error or "Failed to rename macro"}
         await runtime_profiles.refresh_macro_bindings(manager)
@@ -689,20 +710,20 @@ async def _handle_macro_commands(
 
     if command == "play_macro":
         name = str_value(request.get("name"), "")
-        try:
-            result = await manager.client.send_command(
-                Command(
-                    command=CommandType.MACRO_PLAY_BY_NAME,
-                    data={
-                        "name": name,
-                        "replay_mouse_movement": request.get("replay_mouse_movement", True),
-                        "replay_mouse_clicks": request.get("replay_mouse_clicks", True),
-                        "speed": float_value(request.get("speed"), 1.0),
-                    },
-                )
-            )
-        except Exception:
-            return {"status": "error", "message": "Daemon unavailable"}
+        result = await _send_daemon_request(
+            manager,
+            Command(
+                command=CommandType.MACRO_PLAY_BY_NAME,
+                data={
+                    "name": name,
+                    "replay_mouse_movement": request.get("replay_mouse_movement", True),
+                    "replay_mouse_clicks": request.get("replay_mouse_clicks", True),
+                    "speed": float_value(request.get("speed"), 1.0),
+                },
+            ),
+        )
+        if result is None:
+            return _daemon_unavailable_response()
         if result.status == "ok":
             response_data = json_object(result.data)
             return response_data if response_data else {"status": "ok"}
@@ -751,12 +772,12 @@ async def _handle_macro_commands(
         return await _send_adhoc_macro_payload(manager, request)
 
     if command == "cancel_macro_playback":
-        try:
-            result = await manager.client.send_command(
-                Command(command=CommandType.CANCEL_MACRO_PLAYBACK)
-            )
-        except Exception:
-            return {"status": "error", "message": "Daemon unavailable"}
+        result = await _send_daemon_request(
+            manager,
+            Command(command=CommandType.CANCEL_MACRO_PLAYBACK),
+        )
+        if result is None:
+            return _daemon_unavailable_response()
         if result.status == "ok":
             response_data = json_object(result.data)
             return response_data if response_data else {"status": "ok", "cancelled": True}
@@ -812,21 +833,19 @@ async def _send_adhoc_macro_payload(
         "speed": float_value(payload.get("speed"), 1.0),
         "loop_mode": str_value(payload.get("loop_mode", "none"), "none") or "none",
         "loop_count": int_value(payload.get("loop_count"), 1),
-        "loop_stop_behavior": normalize_macro_loop_stop_behavior(
-            payload.get("loop_stop_behavior")
-        ),
+        "loop_stop_behavior": normalize_macro_loop_stop_behavior(payload.get("loop_stop_behavior")),
         "move_to_start": bool(payload.get("move_to_start", False)),
         "start_x": int_value(payload.get("start_x"), 0),
         "start_y": int_value(payload.get("start_y"), 0),
         "block_mouse_movement": bool(payload.get("block_mouse_movement", False)),
     }
 
-    try:
-        result = await manager.client.send_command(
-            Command(command=CommandType.PLAY_MACRO, data=adhoc_payload)
-        )
-    except Exception:
-        return {"status": "error", "message": "Daemon unavailable"}
+    result = await _send_daemon_request(
+        manager,
+        Command(command=CommandType.PLAY_MACRO, data=adhoc_payload),
+    )
+    if result is None:
+        return _daemon_unavailable_response()
     if result.status == "ok":
         response_data = json_object(result.data)
         return response_data if response_data else {"status": "ok"}
@@ -915,15 +934,15 @@ async def _handle_set_diagnostics(
         for category in json_list(request.get("categories"))
         if str_value(category, "")
     ]
-    try:
-        result = await manager.client.send_command(
-            Command(
-                command=CommandType.SET_DIAGNOSTICS,
-                data={"enabled": enabled, "interval": interval, "categories": categories},
-            )
-        )
-    except Exception:
-        return {"status": "error", "message": "Daemon unavailable"}
+    result = await _send_daemon_request(
+        manager,
+        Command(
+            command=CommandType.SET_DIAGNOSTICS,
+            data={"enabled": enabled, "interval": interval, "categories": categories},
+        ),
+    )
+    if result is None:
+        return _daemon_unavailable_response()
 
     if result.status == "ok":
         return {"status": "ok", "data": result.data or {}}

--- a/keymasq/session/manager/compositor.py
+++ b/keymasq/session/manager/compositor.py
@@ -1,5 +1,4 @@
 import asyncio
-import contextlib
 import inspect
 import logging
 from typing import TYPE_CHECKING, cast
@@ -111,8 +110,8 @@ async def query_support_details(
             "supported": False,
             "warning": "Compositor support status query timed out.",
         }
-    except Exception as exc:
-        log.debug("Failed to query compositor support details for %s: %s", compositor_id, exc)
+    except Exception:
+        log.exception("Failed to query compositor support details for %s", compositor_id)
         return {
             "supported": False,
             "warning": "Compositor support status query failed.",
@@ -217,12 +216,11 @@ async def refresh_current_window_from_listener(
         return None
     try:
         window_class, window_title, window_tags = await listener.get_active_window()
-    except Exception as e:
-        log.debug(
-            "Active window query failed (compositor_id=%s listener=%s): %s",
+    except Exception:
+        log.exception(
+            "Active window query failed (compositor_id=%s listener=%s)",
             manager.compositor_state.compositor_id,
             getattr(listener, "name", "unknown"),
-            e,
         )
         return None
 
@@ -262,6 +260,7 @@ async def activate_title(manager: "SessionManager", title: str) -> JsonObject:
             "details": result,
         }
     except Exception as exc:
+        log.exception("Window activation failed")
         return {"status": "error", "message": str(exc)}
 
 
@@ -271,12 +270,11 @@ async def get_cursor_position_payload(manager: "SessionManager") -> JsonObject:
     if manager.compositor_state.window_listener:
         try:
             pos = await manager.compositor_state.window_listener.get_cursor_position()
-        except Exception as e:
-            log.debug(
-                "Cursor query failed (compositor_id=%s listener=%s): %s",
+        except Exception:
+            log.exception(
+                "Cursor query failed (compositor_id=%s listener=%s)",
                 manager.compositor_state.compositor_id,
                 getattr(manager.compositor_state.window_listener, "name", "unknown"),
-                e,
             )
 
     if pos is None:
@@ -293,8 +291,8 @@ async def compositor_supervisor_loop(manager: "SessionManager") -> None:
             await ensure_compositor_listener(manager)
         except asyncio.CancelledError:
             raise
-        except Exception as e:
-            log.debug("Compositor supervisor error: %s", e)
+        except Exception:
+            log.exception("Compositor supervisor error")
 
         stable = (
             manager.compositor_state.window_listener is not None
@@ -320,8 +318,10 @@ async def ensure_compositor_listener(manager: "SessionManager") -> None:
 
     current_healthy = False
     if manager.compositor_state.window_listener is not None:
-        with contextlib.suppress(Exception):
+        try:
             current_healthy = await manager.compositor_state.window_listener.health_check()
+        except Exception:
+            log.exception("Window listener health check failed")
 
     if manager.compositor_state.window_listener is not None and not current_healthy:
         log.warning("Window listener became unhealthy, restarting compositor binding")
@@ -437,8 +437,8 @@ async def stop_window_listener(manager: "SessionManager") -> None:
         return
     try:
         await manager.compositor_state.window_listener.stop()
-    except Exception as e:
-        log.debug("Error stopping window listener: %s", e)
+    except Exception:
+        log.exception("Error stopping window listener")
     manager.compositor_state.window_listener = None
 
 
@@ -510,7 +510,7 @@ async def start_window_listener(manager: "SessionManager") -> None:
         manager.compositor_state.window_listener = None
     except Exception as e:
         manager.compositor_state.last_listener_start_error = str(e)
-        log.debug("Failed to start window listener: %s", e)
+        log.exception("Failed to start window listener")
         manager.compositor_state.window_listener = None
 
 

--- a/keymasq/session/manager/core.py
+++ b/keymasq/session/manager/core.py
@@ -9,7 +9,6 @@ import signal
 import socket
 import struct
 import sys
-import traceback
 from pathlib import Path
 from typing import cast
 
@@ -66,6 +65,7 @@ from .state import (
 )
 
 log = logging.getLogger("keymasq-session")
+_TASK_SHUTDOWN_ERRORS = (asyncio.CancelledError, OSError, RuntimeError)
 GRAB_DEVICE_TIMEOUT_S = 330.0
 GRAB_RETRY_DELAY_S = 5.0
 TOPOLOGY_REFRESH_DEBOUNCE_S = 0.5
@@ -106,7 +106,7 @@ class SessionManager:
         async def _client_event_handler(event_type: CommandType, data: JsonObject) -> None:
             await runtime_events.handle_event(self, event_type, data)
 
-        self.client = KeymasqdClient(_client_event_handler)
+        self.client: KeymasqdClient = KeymasqdClient(_client_event_handler)
         self.superkeys = SuperkeyManager()
         self.analog_controls = AnalogControlManager()
         self.profiles = ProfileManager(
@@ -207,7 +207,7 @@ class SessionManager:
 
         if self.compositor_state.supervisor_task:
             self.compositor_state.supervisor_task.cancel()
-            with contextlib.suppress(asyncio.CancelledError, Exception):
+            with contextlib.suppress(*_TASK_SHUTDOWN_ERRORS):
                 await self.compositor_state.supervisor_task
             self.compositor_state.supervisor_task = None
 
@@ -221,20 +221,20 @@ class SessionManager:
         profile_apply_task = self.profile_state.apply_task
         if profile_apply_task:
             profile_apply_task.cancel()
-            with contextlib.suppress(asyncio.CancelledError, Exception):
+            with contextlib.suppress(*_TASK_SHUTDOWN_ERRORS):
                 await profile_apply_task
             self.profile_state.apply_task = None
 
         topology_task = self.profile_state.topology_refresh_task
         if topology_task:
             topology_task.cancel()
-            with contextlib.suppress(asyncio.CancelledError, Exception):
+            with contextlib.suppress(*_TASK_SHUTDOWN_ERRORS):
                 await topology_task
             self.profile_state.topology_refresh_task = None
 
         save_task = cast(asyncio.Task[None] | None, self.recording_state.settings_save_task)
         if save_task:
-            with contextlib.suppress(asyncio.CancelledError, Exception):
+            with contextlib.suppress(*_TASK_SHUTDOWN_ERRORS):
                 await save_task
             self.recording_state.settings_save_task = None
 
@@ -274,8 +274,10 @@ class SessionManager:
                 await self.client.send_command(
                     Command(command=CommandType.CAPTURE_END, data={"token": token})
                 )
-            except Exception:
+            except OSError:
                 log.debug("Failed to end daemon capture during session shutdown", exc_info=True)
+            except Exception:
+                log.exception("Unexpected failure ending daemon capture during session shutdown")
         self.capture_state.tokens.clear()
 
         await self.client.disconnect()
@@ -285,7 +287,7 @@ class SessionManager:
 
         if self.connect_task:
             self.connect_task.cancel()
-            with contextlib.suppress(asyncio.CancelledError, Exception):
+            with contextlib.suppress(*_TASK_SHUTDOWN_ERRORS):
                 await self.connect_task
             self.connect_task = None
 
@@ -403,13 +405,23 @@ class SessionManager:
                         await writer.drain()
         except asyncio.CancelledError:
             pass
-        except Exception as e:
-            log.debug(f"Session client error: {e}")
+        except OSError:
+            log.debug("Session client I/O error", exc_info=True)
+        except Exception:
+            log.exception(
+                "Unexpected session client error pid=%s uid=%s",
+                peer.pid,
+                peer.uid,
+            )
         finally:
-            with contextlib.suppress(Exception):
+            try:
                 await runtime_device_inspector.clear_device_inspectors_for_writer(self, writer)
-            with contextlib.suppress(Exception):
+            except Exception:
+                log.exception("Failed to clear device inspectors for disconnected session client")
+            try:
                 await runtime_recording.clear_captures_for_writer(self, writer)
+            except Exception:
+                log.exception("Failed to clear captures for disconnected session client")
             runtime_recording.clear_active_recording_owner_if_writer(self, writer)
             await runtime_recording.clear_recording_refresh_owner_if_writer(self, peer, writer)
             self._drop_session_client_writer(writer)
@@ -455,15 +467,27 @@ class SessionManager:
                     self.session_client_drain_tasks[writer] = asyncio.create_task(
                         self._drain_session_writer(writer)
                     )
-            except Exception:
+            except OSError:
+                peer = self.session_client_peers.get(writer)
                 self._drop_session_client_writer(writer)
+                asyncio.create_task(self._close_session_writer(writer, peer))
+            except Exception:
+                log.exception("Unexpected failure broadcasting to session client")
+                peer = self.session_client_peers.get(writer)
+                self._drop_session_client_writer(writer)
+                asyncio.create_task(self._close_session_writer(writer, peer))
 
     async def _drain_session_writer(self, writer: asyncio.StreamWriter) -> None:
         try:
             await asyncio.wait_for(writer.drain(), timeout=2.0)
         except asyncio.CancelledError:
             raise
+        except OSError:
+            peer = self.session_client_peers.get(writer)
+            self._drop_session_client_writer(writer)
+            await self._close_session_writer(writer, peer)
         except Exception:
+            log.exception("Unexpected failure draining session client writer")
             peer = self.session_client_peers.get(writer)
             self._drop_session_client_writer(writer)
             await self._close_session_writer(writer, peer)
@@ -495,10 +519,12 @@ class SessionManager:
             if transport is not None:
                 try:
                     transport.abort()
-                except Exception:
+                except (OSError, RuntimeError):
                     log.debug("Failed to abort session client transport", exc_info=True)
-        except Exception:
+        except OSError:
             log.debug("Failed while waiting for session client socket to close", exc_info=True)
+        except Exception:
+            log.exception("Unexpected failure closing session client socket")
 
     def _drop_session_client_writer(self, writer: asyncio.StreamWriter) -> None:
         self.session_clients.discard(writer)
@@ -616,7 +642,7 @@ class SessionManager:
         self._refresh_config_watches()
         try:
             asyncio.get_running_loop().add_reader(fd, self._handle_config_watch_events)
-        except Exception as exc:
+        except (OSError, RuntimeError, ValueError) as exc:
             log.warning("Failed to register user config watcher: %s", exc)
             self._stop_config_watcher()
 
@@ -630,7 +656,7 @@ class SessionManager:
         if fd is None:
             return
 
-        with contextlib.suppress(Exception):
+        with contextlib.suppress(RuntimeError, ValueError):
             asyncio.get_running_loop().remove_reader(fd)
         with contextlib.suppress(OSError):
             os.close(fd)
@@ -735,7 +761,7 @@ class SessionManager:
                 raw_count = data.get("count", self.virtual_gamepad_count)
                 if isinstance(raw_count, (int, float, str)):
                     self.virtual_gamepad_count = int(raw_count)
-        except Exception as exc:
+        except OSError as exc:
             log.warning("Failed to configure virtual gamepads in keymasqd: %s", exc)
 
     async def connect_loop(self) -> None:
@@ -754,9 +780,8 @@ class SessionManager:
 
                 try:
                     await runtime_profiles.activate_initial_profiles(self)
-                except Exception as e:
-                    log.error(f"Failed to activate initial profiles: {e}")
-                    traceback.print_exc()
+                except Exception:
+                    log.exception("Failed to activate initial profiles")
                 await runtime_recording.sync_pending_macro_slots_from_daemon(self)
                 await runtime_recording.refresh_recording_devices_cache(self)
 
@@ -769,8 +794,11 @@ class SessionManager:
                     self._shutdown_event.set()
                     return
 
-            except Exception as e:
+            except OSError as e:
                 log.warning(f"Connection failed: {e}")
+                self._handle_keymasqd_disconnect()
+            except Exception:
+                log.exception("Unexpected keymasqd connection loop failure")
                 self._handle_keymasqd_disconnect()
 
             if self.running:
@@ -833,8 +861,8 @@ class SessionManager:
     async def _send_notification_async(self, title: str, message: str) -> None:
         try:
             await self.dbus.notify(title, message, app_name="keymasq", timeout_ms=5000)
-        except Exception as e:
-            log.debug(f"Failed to send notification: {e}")
+        except Exception:
+            log.exception("Failed to send notification")
 
 
 def _inotify_init() -> int:
@@ -899,8 +927,8 @@ def main() -> None:
             sys.exit(75)
     except KeyboardInterrupt:
         pass
-    except Exception as e:
-        log.error(f"Fatal error: {e}")
+    except Exception:
+        log.exception("Fatal error")
         raise
 
 

--- a/keymasq/session/manager/core.py
+++ b/keymasq/session/manager/core.py
@@ -760,7 +760,13 @@ class SessionManager:
                 data = cast(JsonObject, response.data)
                 raw_count = data.get("count", self.virtual_gamepad_count)
                 if isinstance(raw_count, (int, float, str)):
-                    self.virtual_gamepad_count = int(raw_count)
+                    try:
+                        self.virtual_gamepad_count = int(raw_count)
+                    except (TypeError, ValueError, OverflowError):
+                        log.warning(
+                            "Ignoring malformed virtual gamepad count from keymasqd: %r",
+                            raw_count,
+                        )
         except OSError as exc:
             log.warning("Failed to configure virtual gamepads in keymasqd: %s", exc)
 

--- a/keymasq/session/manager/device_inspector.py
+++ b/keymasq/session/manager/device_inspector.py
@@ -234,11 +234,10 @@ async def clear_device_inspectors_for_writer(
                 hardware_id,
                 reason=f"device inspector owner disconnected {hardware_id}",
             )
-        except Exception as exc:
-            log.warning(
-                "Failed to stop device inspector for disconnected owner hardware_id=%s: %s",
+        except Exception:
+            log.exception(
+                "Failed to stop device inspector for disconnected owner hardware_id=%s",
                 hardware_id,
-                exc,
             )
 
 
@@ -311,7 +310,13 @@ async def _send_inspector_command(
 ) -> JsonObject:
     try:
         result = await manager.client.send_command(Command(command=command_type, data=data))
-    except Exception:
+    except OSError as exc:
+        log.debug(
+            "Device inspector daemon request %s failed: %s",
+            command_type.value,
+            exc,
+            exc_info=True,
+        )
         return {"status": "error", "message": "Daemon unavailable"}
 
     result_data = json_object(result.data)
@@ -425,4 +430,3 @@ def _serialize_axis(axis: AnalogAxisDefinition) -> JsonObject:
         "rest": axis.rest,
         "invert": bool(axis.invert),
     }
-

--- a/keymasq/session/manager/events.py
+++ b/keymasq/session/manager/events.py
@@ -359,22 +359,28 @@ async def handle_stop_macro_trigger(
             error_if_idle=False,
             recording_slot=recording_slot or active_slot,
         )
-    except Exception:
+    except OSError:
         log.debug("Failed to handle stop macro recording trigger", exc_info=True)
+    except Exception:
+        log.exception("Unexpected failure handling stop macro recording trigger")
 
 
 async def handle_cancel_macro_trigger(manager: "SessionManager") -> None:
     try:
         await manager.client.send_command(Command(command=CommandType.CANCEL_MACRO_PLAYBACK))
-    except Exception:
+    except OSError:
         log.debug("Failed to send cancel macro playback trigger", exc_info=True)
+    except Exception:
+        log.exception("Unexpected failure sending cancel macro playback trigger")
 
 
 async def handle_emergency_reset_trigger(manager: "SessionManager") -> None:
     try:
         await manager.client.send_command(Command(command=CommandType.EMERGENCY_RESET))
-    except Exception:
+    except OSError:
         log.debug("Failed to send emergency reset trigger", exc_info=True)
+    except Exception:
+        log.exception("Unexpected failure sending emergency reset trigger")
 
 
 async def handle_profile_trigger(manager: "SessionManager", data: JsonObject) -> None:
@@ -519,12 +525,19 @@ async def _track_runtime_profile_activation(
                 },
             )
         )
-    except Exception as exc:
+    except OSError as exc:
         log.warning(
             "Failed to track runtime profile activation profile=%s activation=%s: %s",
             activation.profile_name,
             activation.activation_id,
             exc,
+        )
+        return False
+    except Exception:
+        log.exception(
+            "Unexpected failure tracking runtime profile activation profile=%s activation=%s",
+            activation.profile_name,
+            activation.activation_id,
         )
         return False
     if response.status != "ok":
@@ -598,8 +611,10 @@ async def handle_exec_trigger(manager: "SessionManager", data: JsonObject) -> No
                     data={"wait_id": wait_id, "returncode": int(returncode)},
                 )
             )
-        except Exception:
+        except OSError:
             log.debug("Failed to report macro exec completion", exc_info=True)
+        except Exception:
+            log.exception("Unexpected failure reporting macro exec completion")
         return
 
     if is_async:
@@ -666,8 +681,14 @@ async def handle_runtime_reset_event(manager: "SessionManager", data: JsonObject
     manager.profile_state.runtime_profile_activations.clear()
     try:
         await runtime_profiles.reevaluate_profiles(manager, reason="runtime reset")
-    except Exception as exc:
+    except OSError as exc:
         log.warning("Failed to reapply profiles after runtime reset: %s", exc)
+        manager.send_notification(
+            "Keymasq: Reapply Failed",
+            "Emergency reset completed, but active profiles could not be reapplied.",
+        )
+    except Exception:
+        log.exception("Unexpected failure reapplying profiles after runtime reset")
         manager.send_notification(
             "Keymasq: Reapply Failed",
             "Emergency reset completed, but active profiles could not be reapplied.",

--- a/keymasq/session/manager/profiles.py
+++ b/keymasq/session/manager/profiles.py
@@ -1,7 +1,6 @@
 import asyncio
 import json
 import logging
-import traceback
 from datetime import datetime
 from typing import TYPE_CHECKING, cast
 
@@ -89,12 +88,18 @@ async def cancel_runtime_profile_activation(
                 },
             )
         )
-    except Exception as exc:
+    except OSError as exc:
         log.debug(
             "Failed to cancel runtime profile activation profile=%s activation=%s: %s",
             profile_name,
             activation.activation_id,
             exc,
+        )
+    except Exception:
+        log.exception(
+            "Unexpected failure cancelling runtime profile activation profile=%s activation=%s",
+            profile_name,
+            activation.activation_id,
         )
     if reevaluate:
         await reevaluate_profiles(
@@ -341,8 +346,11 @@ def schedule_topology_refresh(
                     return
                 except asyncio.CancelledError:
                     raise
-                except Exception as e:
-                    log.warning("Topology refresh failed: %s", e)
+                except OSError as exc:
+                    log.warning("Topology refresh failed: %s", exc)
+                    delay = retry_s
+                except Exception:
+                    log.exception("Unexpected topology refresh failure")
                     delay = retry_s
         except asyncio.CancelledError:
             raise
@@ -553,13 +561,21 @@ async def play_profile_lifecycle_macro(
                 data={"name": macro_name},
             )
         )
-    except Exception as exc:
+    except OSError as exc:
         log.warning(
             "Failed to play %s macro '%s' for profile '%s': %s",
             transition,
             macro_name,
             profile_name,
             exc,
+        )
+        return
+    except Exception:
+        log.exception(
+            "Unexpected failure playing %s macro '%s' for profile '%s'",
+            transition,
+            macro_name,
+            profile_name,
         )
         return
 
@@ -805,23 +821,32 @@ async def apply_resolved_device_profile(
             if "timed out waiting" in str(result.error or "").lower():
                 schedule_grab_retry(manager, hardware_id, delay_s=GRAB_RETRY_DELAY_S)
             return
-    except Exception as e:
+    except TimeoutError as exc:
         log.error(
             "keymasqd: Exception grabbing device %s: %s: %s",
             hardware_id,
-            type(e).__name__,
-            e,
+            type(exc).__name__,
+            exc,
         )
-        traceback.print_exc()
-        if isinstance(e, TimeoutError):
-            manager.send_notification(
-                "Keymasq: Grab Timed Out",
-                (
-                    f"{device_name_for_hardware(manager, hardware_id)}: grab timed out while "
-                    "waiting for keys to be released. Retrying automatically."
-                ),
-            )
-            schedule_grab_retry(manager, hardware_id, delay_s=GRAB_RETRY_DELAY_S)
+        manager.send_notification(
+            "Keymasq: Grab Timed Out",
+            (
+                f"{device_name_for_hardware(manager, hardware_id)}: grab timed out while "
+                "waiting for keys to be released. Retrying automatically."
+            ),
+        )
+        schedule_grab_retry(manager, hardware_id, delay_s=GRAB_RETRY_DELAY_S)
+        return
+    except OSError as exc:
+        log.error(
+            "keymasqd: Exception grabbing device %s: %s: %s",
+            hardware_id,
+            type(exc).__name__,
+            exc,
+        )
+        return
+    except Exception:
+        log.exception("Unexpected failure grabbing device %s", hardware_id)
         return
 
     log.info(
@@ -864,9 +889,10 @@ async def apply_resolved_device_profile(
         else:
             log.error("Failed to set mapping: %s", result.error)
 
-    except Exception as e:
-        log.error("Exception setting mapping: %s: %s", type(e).__name__, e)
-        traceback.print_exc()
+    except OSError as exc:
+        log.error("Exception setting mapping: %s: %s", type(exc).__name__, exc)
+    except Exception:
+        log.exception("Unexpected failure setting mapping for %s", hardware_id)
 
 
 def get_interfaces_to_grab(
@@ -1098,8 +1124,16 @@ async def update_grab_device_payload(
             return False
         manager.profile_state.last_sent_grab_signatures[hardware_id] = signature
         return True
-    except Exception as e:
-        log.error("Exception updating grab config for %s: %s: %s", hardware_id, type(e).__name__, e)
+    except OSError as exc:
+        log.error(
+            "Exception updating grab config for %s: %s: %s",
+            hardware_id,
+            type(exc).__name__,
+            exc,
+        )
+        return False
+    except Exception:
+        log.exception("Unexpected failure updating grab config for %s", hardware_id)
         return False
 
 
@@ -1137,8 +1171,10 @@ async def update_combos(
             return
         manager.profile_state.last_sent_combo_signature = signature
         manager.profile_state.resolved_combos = list(active_combos)
-    except Exception as e:
-        log.error("Exception updating combos: %s: %s", type(e).__name__, e)
+    except OSError as exc:
+        log.error("Exception updating combos: %s: %s", type(exc).__name__, exc)
+    except Exception:
+        log.exception("Unexpected failure updating combos")
 
 
 async def update_mapping(
@@ -1175,8 +1211,11 @@ async def update_mapping(
             return True
         log.error("Failed to update mapping: %s", result.error)
         return False
-    except Exception as e:
-        log.error("Exception updating mapping: %s: %s", type(e).__name__, e)
+    except OSError as exc:
+        log.error("Exception updating mapping: %s: %s", type(exc).__name__, exc)
+        return False
+    except Exception:
+        log.exception("Unexpected failure updating mapping for %s", hardware_id)
         return False
 
 
@@ -1205,8 +1244,11 @@ async def deactivate_profile(
             log.error("Failed to release device %s: %s", hardware_id, result.error)
             return False
         clear_hardware_runtime_state(manager, hardware_id)
-    except Exception as e:
-        log.error("Failed to release device %s: %s", hardware_id, e)
+    except OSError as exc:
+        log.error("Failed to release device %s: %s", hardware_id, exc)
+        return False
+    except Exception:
+        log.exception("Unexpected failure releasing device %s", hardware_id)
         return False
 
     runtime_payloads.clear_exec_refs(manager, hardware_id)

--- a/keymasq/session/manager/recording_capture.py
+++ b/keymasq/session/manager/recording_capture.py
@@ -93,9 +93,13 @@ async def capture_begin_for_paths(
                 },
             )
         )
-    except Exception:
+    except OSError:
         await _end_capture(manager, hardware_id)
         return {"status": "error", "message": "Daemon unavailable"}
+    except Exception:
+        log.exception("Unexpected failure beginning capture for hardware_id=%s", hardware_id)
+        await _end_capture(manager, hardware_id)
+        return {"status": "error", "message": "Failed to begin capture"}
 
     result_data = json_object(result.data)
     if result.status != "ok" or result_data is None:
@@ -129,8 +133,11 @@ async def capture_read(manager: "SessionManager", hardware_id: str) -> JsonObjec
         result = await manager.client.send_command(
             Command(command=CommandType.CAPTURE_READ, data={"token": token})
         )
-    except Exception:
+    except OSError:
         return {"status": "error", "message": "Daemon unavailable"}
+    except Exception:
+        log.exception("Unexpected failure reading capture for hardware_id=%s", hardware_id)
+        return {"status": "error", "message": "Failed to read capture"}
 
     result_data = json_object(result.data)
     if result.status == "ok" and result_data is not None:
@@ -145,9 +152,12 @@ async def capture_end(manager: "SessionManager", hardware_id: str) -> JsonObject
             result = await manager.client.send_command(
                 Command(command=CommandType.CAPTURE_END, data={"token": token})
             )
-        except Exception as exc:
+        except OSError as exc:
             log.debug("Failed to end capture for hardware_id=%s: %s", hardware_id, exc)
             return {"status": "error", "message": "Daemon unavailable"}
+        except Exception:
+            log.exception("Unexpected failure ending capture for hardware_id=%s", hardware_id)
+            return {"status": "error", "message": "Failed to end capture"}
         if result.status != "ok":
             return {"status": "error", "message": result.error or "Failed to end capture"}
         manager.capture_state.tokens.pop(hardware_id, None)
@@ -175,11 +185,16 @@ async def clear_captures_for_writer(
                 )
                 manager.capture_state.tokens.pop(hardware_id, None)
                 await _end_capture(manager, hardware_id)
-        except Exception as exc:
+        except OSError as exc:
             log.warning(
                 "Failed to end capture for disconnected owner hardware_id=%s: %s",
                 hardware_id,
                 exc,
+            )
+        except Exception:
+            log.exception(
+                "Unexpected failure ending capture for disconnected owner hardware_id=%s",
+                hardware_id,
             )
 
 
@@ -257,8 +272,11 @@ async def capture_combo(
                 },
             )
         )
-    except Exception:
+    except OSError:
         return {"status": "error", "message": "Daemon unavailable"}
+    except Exception:
+        log.exception("Unexpected failure capturing combo for profile '%s'", profile_name)
+        return {"status": "error", "message": "Combo capture failed"}
 
     result_data = json_object(result.data)
     if result.status != "ok" or result_data is None:

--- a/keymasq/session/manager/recording_device_selection.py
+++ b/keymasq/session/manager/recording_device_selection.py
@@ -170,8 +170,10 @@ async def refresh_recording_devices_cache(manager: "SessionManager") -> None:
         manager.recording_state.devices_cache = devices
         manager.recording_state.devices_cache_ready = True
         update_selected_recording_devices_cache(manager)
+    except OSError as exc:
+        log.debug("Failed to refresh recording devices cache: %s", exc)
     except Exception:
-        log.debug("Failed to refresh recording devices cache", exc_info=True)
+        log.exception("Unexpected failure refreshing recording devices cache")
 
 
 def update_selected_recording_devices_cache(manager: "SessionManager") -> None:
@@ -225,7 +227,11 @@ async def get_devices_for_recording(
 ) -> list[JsonObject]:
     try:
         result = await manager.client.send_command(Command(command=CommandType.LIST_DEVICES))
+    except OSError as exc:
+        log.debug("Failed to list devices for recording: %s", exc)
+        return []
     except Exception:
+        log.exception("Unexpected failure listing devices for recording")
         return []
     result_data = json_object(result.data)
     if result.status != "ok" or result_data is None:

--- a/keymasq/session/manager/recording_lifecycle.py
+++ b/keymasq/session/manager/recording_lifecycle.py
@@ -34,6 +34,15 @@ MACRO_RECORDING_DISABLED_MESSAGE = (
     "Macro recording is disabled. Enable macro recording in Keymasq before using "
     "recording triggers."
 )
+_RECORDING_MANAGER_ERRORS = (
+    OSError,
+    ConnectionError,
+    TimeoutError,
+    RuntimeError,
+    TypeError,
+    ValueError,
+    KeyError,
+)
 
 
 def _monotonic() -> float:
@@ -301,7 +310,7 @@ async def delete_pending_macro_slot(
                     data={"pending_recording_id": pending_recording_id},
                 )
             )
-        except Exception:
+        except _RECORDING_MANAGER_ERRORS:
             return False
         if result.status != "ok":
             return False
@@ -342,7 +351,7 @@ async def sync_pending_macro_slots_from_daemon(manager: "SessionManager") -> Non
         result = await manager.client.send_command(
             Command(command=CommandType.MACRO_LIST_RECORDINGS)
         )
-    except Exception:
+    except _RECORDING_MANAGER_ERRORS:
         return
     result_data = json_object(result.data)
     if result.status != "ok" or result_data is None:
@@ -437,7 +446,7 @@ async def stop_recording(
     slot = normalize_pending_macro_recording_slot(slot, default=1)
     try:
         result = await manager.client.send_command(Command(command=CommandType.STOP_RECORDING))
-    except Exception:
+    except _RECORDING_MANAGER_ERRORS:
         return {"status": "error", "message": "Daemon unavailable"}
 
     if result.status == "ok":
@@ -537,7 +546,7 @@ async def play_macro_slot_trigger(manager: "SessionManager", data: JsonObject) -
         result = await manager.client.send_command(
             Command(command=CommandType.MACRO_PLAY_RECORDING, data=payload)
         )
-    except Exception:
+    except _RECORDING_MANAGER_ERRORS:
         return {"status": "error", "message": "Daemon unavailable"}
     if result.status == "ok":
         response_data = json_object(result.data)
@@ -708,7 +717,7 @@ async def start_recording(
                     recording_data,
                     recording_slot=slot,
                 )
-        except Exception:
+        except _RECORDING_MANAGER_ERRORS:
             log.debug("Failed to stop active recording before starting a new one", exc_info=True)
         manager.recording_state.active = False
         manager.recording_state.active_slot = 0
@@ -754,7 +763,7 @@ async def start_recording(
                     )
                 else:
                     log.debug("Recording start: get_cursor_position returned None")
-            except Exception as e:
+            except _RECORDING_MANAGER_ERRORS as e:
                 log.debug("Failed to get cursor position for recording start: %s", e)
         else:
             log.debug("Recording start: no window listener available")
@@ -775,7 +784,7 @@ async def start_recording(
                 },
             )
         )
-    except Exception:
+    except _RECORDING_MANAGER_ERRORS:
         return {"status": "error", "message": "Daemon unavailable"}
 
     if result.status == "ok":
@@ -848,7 +857,7 @@ async def save_recording(
         result = await manager.client.send_command(
             Command(command=CommandType.MACRO_SAVE_RECORDING, data=macro)
         )
-    except Exception:
+    except _RECORDING_MANAGER_ERRORS:
         return {"status": "error", "message": "Daemon unavailable"}
 
     if result.status != "ok":

--- a/keymasq/session/manager/recording_lifecycle.py
+++ b/keymasq/session/manager/recording_lifecycle.py
@@ -38,10 +38,7 @@ _RECORDING_MANAGER_ERRORS = (
     OSError,
     ConnectionError,
     TimeoutError,
-    RuntimeError,
-    TypeError,
-    ValueError,
-    KeyError,
+    EOFError,
 )
 
 

--- a/keymasq/session/manager/recording_unlock.py
+++ b/keymasq/session/manager/recording_unlock.py
@@ -131,8 +131,10 @@ async def _resolve_unlock_status_async_impl(
                 Command(CommandType.RECORDING_UNLOCK_STATUS, data={"uid": int(uid)}),
                 timeout=3.0,
             )
-        except Exception as exc:
+        except OSError as exc:
             log.warning("Failed to query daemon recording unlock status: %s", exc)
+        except Exception:
+            log.exception("Unexpected failure querying daemon recording unlock status")
         else:
             if response.status == "ok" and isinstance(response.data, dict):
                 status = cast(RecordingStatus, response.data)
@@ -169,8 +171,10 @@ async def _resolve_macro_recording_status_async_impl(
                 Command(CommandType.MACRO_RECORDING_STATUS, data={"uid": int(uid)}),
                 timeout=3.0,
             )
-        except Exception as exc:
+        except OSError as exc:
             log.warning("Failed to query daemon macro recording status: %s", exc)
+        except Exception:
+            log.exception("Unexpected failure querying daemon macro recording status")
         else:
             if response.status == "ok" and isinstance(response.data, dict):
                 status = cast(RecordingStatus, response.data)
@@ -323,12 +327,18 @@ async def _cleanup_runtime_unlock_for_uid(
                 reason,
                 result.error,
             )
-    except Exception as e:
+    except OSError as exc:
         log.debug(
             "Runtime unlock cleanup failed uid=%s reason=%s error=%s",
             uid,
             reason,
-            e,
+            exc,
+        )
+    except Exception:
+        log.exception(
+            "Unexpected failure cleaning up runtime unlock uid=%s reason=%s",
+            uid,
+            reason,
         )
 
 
@@ -420,9 +430,13 @@ async def claim_recording_unlock_refresh(
                     },
                 )
             )
-        except Exception:
+        except OSError:
             manager.unlock_state.refresh_owner = None
             return {"status": "error", "message": "Daemon unavailable"}
+        except Exception:
+            log.exception("Unexpected failure establishing capture unlock lease")
+            manager.unlock_state.refresh_owner = None
+            return {"status": "error", "message": "Failed to establish capture unlock lease"}
 
         if refresh_result.status != "ok":
             manager.unlock_state.refresh_owner = None
@@ -494,8 +508,11 @@ async def refresh_recording_unlock(
                     },
                 )
             )
-        except Exception:
+        except OSError:
             return {"status": "error", "message": "Daemon unavailable"}
+        except Exception:
+            log.exception("Unexpected failure refreshing capture unlock")
+            return {"status": "error", "message": "Failed to refresh capture unlock"}
 
         if result.status != "ok":
             _clear_refresh_owner_for_uid(manager, int(peer.uid))
@@ -568,8 +585,11 @@ async def lock_recording_unlock(
                 data={"uid": int(peer.uid)},
             )
         )
-    except Exception:
+    except OSError:
         return {"status": "error", "message": "Daemon unavailable"}
+    except Exception:
+        log.exception("Unexpected failure locking capture unlock")
+        return {"status": "error", "message": "Failed to lock capture unlock"}
 
     if result.status != "ok":
         return {

--- a/keymasq/session/profiles.py
+++ b/keymasq/session/profiles.py
@@ -284,8 +284,10 @@ class ProfileManager:
         except RuntimeError:
             try:
                 self._repair_created_at_if_needed(created_at, path)
-            except Exception as exc:
+            except (OSError, tomllib.TOMLDecodeError) as exc:
                 log.error("Failed to repair created_at for %s: %s", path, exc)
+            except Exception:
+                log.exception("Unexpected failure repairing created_at for %s", path)
             return
 
         task = loop.create_task(self._repair_created_at_async(created_at, path))
@@ -299,8 +301,10 @@ class ProfileManager:
                 created_at,
                 path,
             )
-        except Exception as exc:
+        except (OSError, tomllib.TOMLDecodeError) as exc:
             log.error("Failed to repair created_at for %s: %s", path, exc)
+        except Exception:
+            log.exception("Unexpected failure repairing created_at for %s", path)
 
     def _repair_created_at_if_needed(self, created_at: datetime, path: Path) -> None:
         with self._profile_file_lock:
@@ -887,7 +891,12 @@ class ProfileManager:
         try:
             path.rename(trashed_path)
             log.warning("Moved deleted profile to trash: %s", trashed_path)
-        except Exception:
+        except OSError as exc:
+            log.warning(
+                "Failed to move deleted profile to trash %s; deleting permanently: %s",
+                path,
+                exc,
+            )
             path.unlink()
 
     def rename_profile(self, old_name: str, new_name: str) -> ProfileInfo:

--- a/keymasq/session/slurp.py
+++ b/keymasq/session/slurp.py
@@ -59,7 +59,12 @@ async def capture_slurp_cursor_position(
         )
         if result:
             return (result.x, result.y)
-    except Exception as exc:
+    except OSError as exc:
         if logger is not None:
             logger.debug("Slurp cursor capture failed: %s", exc)
+    except Exception:
+        if logger is not None:
+            logger.exception("Unexpected slurp cursor capture failure")
+        else:
+            log.exception("Unexpected slurp cursor capture failure")
     return None

--- a/keymasq/session/superkeys.py
+++ b/keymasq/session/superkeys.py
@@ -81,9 +81,20 @@ class SuperkeyManager:
                 if config:
                     loaded_superkeys[config.name] = config
                     loaded_paths[config.name] = superkey_file
-            except Exception as e:
-                log.error(f"Failed to load superkey {superkey_file}: {e}")
-                failures.append(ConfigLoadFailure(superkey_file, str(e)))
+            except tomllib.TOMLDecodeError as exc:
+                log.error("Failed to load superkey %s: %s", superkey_file, exc)
+                failures.append(ConfigLoadFailure(superkey_file, str(exc)))
+            except (OSError, ValueError, KeyError) as exc:
+                log.error("Failed to load superkey %s: %s", superkey_file, exc)
+                failures.append(ConfigLoadFailure(superkey_file, str(exc)))
+            except Exception as exc:
+                log.exception("Unexpected error while loading superkey %s", superkey_file)
+                failures.append(
+                    ConfigLoadFailure(
+                        superkey_file,
+                        str(exc) or type(exc).__name__,
+                    )
+                )
 
         if strict and failures:
             raise ConfigLoadError("superkey", failures)

--- a/keymasq/session/wayland_protocols/cosmic_toplevel_info_client.py
+++ b/keymasq/session/wayland_protocols/cosmic_toplevel_info_client.py
@@ -111,8 +111,13 @@ class CosmicToplevelInfoWaylandClient(ExtForeignToplevelListClientBase):
     async def _destroy_cosmic_handle(self, object_id: int) -> None:
         try:
             await self._send_request(object_id, 0, b"")
-        except Exception:
+        except (OSError, _transport.WaylandDisplayError):
             log.debug("Failed to destroy COSMIC toplevel info handle", exc_info=True)
+        except Exception:
+            log.exception(
+                "Unexpected failure destroying COSMIC toplevel info handle %s",
+                object_id,
+            )
         self._objects.pop(object_id, None)
         self._cosmic_handles.discard(object_id)
         ext_id = self._cosmic_to_ext.pop(object_id, None)

--- a/keymasq/session/wayland_protocols/ext_foreign_toplevel_list_client.py
+++ b/keymasq/session/wayland_protocols/ext_foreign_toplevel_list_client.py
@@ -45,8 +45,10 @@ class ExtForeignToplevelListClientBase(_transport.WaylandClientTransport):
                 await self._destroy_toplevel_handle(handle_id)
             try:
                 await self._send_request(self._list_id, 1, b"")
-            except Exception:
+            except (OSError, _transport.WaylandDisplayError):
                 log.debug("Failed to destroy ext foreign toplevel list", exc_info=True)
+            except Exception:
+                log.exception("Unexpected failure destroying ext foreign toplevel list")
             self._objects.pop(self._list_id, None)
             self._list_id = None
 
@@ -135,8 +137,13 @@ class ExtForeignToplevelListClientBase(_transport.WaylandClientTransport):
         await self._before_destroy_toplevel_handle(object_id)
         try:
             await self._send_request(object_id, 0, b"")
-        except Exception:
+        except (OSError, _transport.WaylandDisplayError):
             log.debug("Failed to destroy ext foreign toplevel handle", exc_info=True)
+        except Exception:
+            log.exception(
+                "Unexpected failure destroying ext foreign toplevel handle %s",
+                object_id,
+            )
         self._objects.pop(object_id, None)
         self._toplevel_handles.discard(object_id)
 

--- a/keymasq/session/wayland_protocols/registry_probe.py
+++ b/keymasq/session/wayland_protocols/registry_probe.py
@@ -1,7 +1,11 @@
 import asyncio
+import logging
+import struct
 from pathlib import Path
 
 from keymasq.session.wayland_protocols import client_transport as _transport
+
+log = logging.getLogger("keymasq-session.wayland.registry_probe")
 
 
 class _RegistryProbeTransport(_transport.WaylandClientTransport):
@@ -24,7 +28,8 @@ class _RegistryProbeTransport(_transport.WaylandClientTransport):
     async def _handle_registry_event(self, object_id: int, opcode: int, payload: bytes) -> None:
         try:
             await super()._handle_registry_event(object_id, opcode, payload)
-        except Exception:
+        except struct.error as exc:
+            log.debug("Ignoring malformed Wayland registry global: %s", exc)
             return
 
     async def _handle_registry_global(
@@ -63,5 +68,9 @@ async def list_registry_globals(socket_path: Path, timeout_s: float = 0.6) -> se
     transport = _RegistryProbeTransport(socket_path)
     try:
         return await asyncio.wait_for(transport.collect(timeout_s), timeout=timeout_s)
+    except (OSError, _transport.WaylandDisplayError) as exc:
+        log.debug("Wayland registry probe failed for %s: %s", socket_path, exc)
+        return set()
     except Exception:
+        log.exception("Unexpected Wayland registry probe failure for %s", socket_path)
         return set()

--- a/keymasq/session/wayland_protocols/registry_probe.py
+++ b/keymasq/session/wayland_protocols/registry_probe.py
@@ -68,6 +68,9 @@ async def list_registry_globals(socket_path: Path, timeout_s: float = 0.6) -> se
     transport = _RegistryProbeTransport(socket_path)
     try:
         return await asyncio.wait_for(transport.collect(timeout_s), timeout=timeout_s)
+    except TimeoutError as exc:
+        log.debug("Wayland registry probe timed out for %s: %s", socket_path, exc)
+        return set()
     except (OSError, _transport.WaylandDisplayError) as exc:
         log.debug("Wayland registry probe failed for %s: %s", socket_path, exc)
         return set()

--- a/keymasq/session/wayland_protocols/wlr_foreign_toplevel_client.py
+++ b/keymasq/session/wayland_protocols/wlr_foreign_toplevel_client.py
@@ -44,8 +44,10 @@ class WlrForeignToplevelWaylandClient(_transport.WaylandClientTransport):
                 self._toplevel_handles.clear()
                 try:
                     await self._send_request(self._manager_id, 0, b"")
-                except Exception:
+                except (OSError, _transport.WaylandDisplayError):
                     log.debug("Failed to destroy wlr foreign toplevel manager", exc_info=True)
+                except Exception:
+                    log.exception("Unexpected failure destroying wlr foreign toplevel manager")
                 self._objects.pop(self._manager_id, None)
                 self._manager_id = None
             self._close_socket()
@@ -103,8 +105,13 @@ class WlrForeignToplevelWaylandClient(_transport.WaylandClientTransport):
     async def _destroy_toplevel_handle(self, object_id: int) -> None:
         try:
             await self._send_request(object_id, 7, b"")
-        except Exception:
+        except (OSError, _transport.WaylandDisplayError):
             log.debug("Failed to destroy wlr foreign toplevel handle", exc_info=True)
+        except Exception:
+            log.exception(
+                "Unexpected failure destroying wlr foreign toplevel handle %s",
+                object_id,
+            )
         self._objects.pop(object_id, None)
         self._toplevel_handles.discard(object_id)
 

--- a/nix/daemon-session-integration-test/support.py
+++ b/nix/daemon-session-integration-test/support.py
@@ -898,7 +898,7 @@ type = "key"
         return f"{event_type}:{name}:{value}"
 
     def settle_udev(self) -> None:
-        try:
+        with contextlib.suppress(OSError, subprocess.SubprocessError):
             subprocess.run(
                 ["udevadm", "settle", "--timeout=5"],
                 check=False,
@@ -906,5 +906,3 @@ type = "key"
                 stderr=subprocess.DEVNULL,
                 timeout=6,
             )
-        except Exception:
-            pass

--- a/nix/listener-vm-matrix.nix
+++ b/nix/listener-vm-matrix.nix
@@ -932,7 +932,7 @@ EOF
   #          | xargs -I{} grep -n 'is_software' {}/src/backend/tty.rs
   #   3. If the guard moved or changed, update the sed pattern below.
   #   4. Run: nix build 'path:.#checks.x86_64-linux.listener-vm-niri'
-  niriExpectedVersion = "25.11";
+  niriExpectedVersion = "26.04";
 
   niriPatched = assert pkgs.niri.version == niriExpectedVersion; pkgs.niri.overrideAttrs (old: {
     postPatch = (old.postPatch or "") + ''

--- a/nix/listener-vms/gnome-bridge-probe.py
+++ b/nix/listener-vms/gnome-bridge-probe.py
@@ -2,10 +2,13 @@
 
 import argparse
 import json
+import logging
 import os
 import socket
 import time
 import traceback
+
+log = logging.getLogger("gnome-bridge-probe")
 
 
 def append_debug(path: str | None, message: str) -> None:
@@ -133,6 +136,7 @@ def main() -> int:
         if not all(title in result["focus_titles"] for title in args.expect_title):
             exit_code = 1
     except Exception:
+        log.exception("GNOME bridge probe failed")
         result["exception"] = traceback.format_exc()
         append_debug(args.debug_output, result["exception"])
         exit_code = 1

--- a/packaging/pacman/render.py
+++ b/packaging/pacman/render.py
@@ -14,7 +14,9 @@ COMMON_METADATA = {
     "maintainer": "nyrda <nyrda@keymasq.tools>",
     "pkgname": "keymasq",
     "pkgrel": "1",
-    "pkgdesc": "Keyboard and mouse remapper with GUI configuration, per-window profiles, and macros",
+    "pkgdesc": (
+        "Keyboard and mouse remapper with GUI configuration, per-window profiles, and macros"
+    ),
     "arch": ["any"],
     "url": "https://keymasq.tools",
     "license": ["MIT"],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,9 +83,11 @@ target-version = "py312"
 
 [tool.ruff.lint]
 select = ["E", "F", "W", "I", "N", "UP", "B"]
+extend-select = ["BLE", "S110", "S112"]
 
 [tool.ruff.lint.per-file-ignores]
 "**/__init__.py" = ["F401", "F403"]
+"benchmarks/*.py" = ["BLE001", "S110"]
 "keymasq/gui/**/*.py" = ["E402"]
 "keymasq/session/listeners/kde.py" = ["N802", "F821"]
 

--- a/scripts/release-version.py
+++ b/scripts/release-version.py
@@ -236,7 +236,6 @@ def main() -> int:
         parser.error("release date must use the form YYYY-MM-DD")
 
     root = repo_root()
-    current_version = _current_version(root)
     changed_paths = apply_rules(
         root,
         _build_rules(root, version, release_date),

--- a/tests/common/test_asyncio_runtime.py
+++ b/tests/common/test_asyncio_runtime.py
@@ -1,4 +1,5 @@
 import importlib
+import logging
 from types import SimpleNamespace
 from unittest.mock import Mock
 
@@ -53,3 +54,28 @@ def test_ensure_uvloop_logs_warning_once_when_unavailable(monkeypatch) -> None:
 
     first_logger.warning.assert_called_once()
     second_logger.warning.assert_not_called()
+
+
+def test_ensure_uvloop_logs_unexpected_setup_failure(monkeypatch, caplog) -> None:
+    import keymasq.common.asyncio_runtime as runtime
+
+    runtime = importlib.reload(runtime)
+
+    class _FakePolicy:
+        pass
+
+    def _raise_bad_policy(_policy: object) -> None:
+        raise ValueError("bad event loop policy")
+
+    monkeypatch.setattr(
+        runtime,
+        "_uvloop_module",
+        lambda: SimpleNamespace(EventLoopPolicy=_FakePolicy),
+    )
+    monkeypatch.setattr(runtime.asyncio, "get_event_loop_policy", lambda: object())
+    monkeypatch.setattr(runtime.asyncio, "set_event_loop_policy", _raise_bad_policy)
+
+    caplog.set_level(logging.ERROR, logger="keymasq.asyncio")
+
+    assert runtime.ensure_uvloop() is False
+    assert "Unexpected failure configuring uvloop" in caplog.text

--- a/tests/common/test_profile_manager.py
+++ b/tests/common/test_profile_manager.py
@@ -767,6 +767,41 @@ created_at = "not-a-date"
         assert 'created_at = "' in content
         assert 'created_at = "not-a-date"' not in content
 
+    def test_created_at_repair_logs_unexpected_failure(
+        self,
+        temp_config_dir,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        profile_path = Path(temp_config_dir) / "profiles" / "missing-created-at.toml"
+        profile_path.write_text(
+            """
+[profile]
+name = "Missing Created"
+enabled = true
+is_permanent = true
+priority = 1
+notify_on_activation = true
+""".strip(),
+            encoding="utf-8",
+        )
+
+        def fail_repair(
+            self: ProfileManager,
+            created_at: datetime,
+            path: Path,
+        ) -> None:
+            raise RuntimeError("repair bug")
+
+        monkeypatch.setattr(ProfileManager, "_repair_created_at_if_needed", fail_repair)
+
+        with caplog.at_level("ERROR", logger="keymasq-session.profiles"):
+            manager = ProfileManager()
+
+        assert manager.get_profile("Missing Created") is not None
+        assert f"Unexpected failure repairing created_at for {profile_path}" in caplog.text
+        assert "repair bug" in caplog.text
+
     def test_pending_created_at_repair_does_not_overwrite_newer_profile_save(
         self,
         temp_config_dir,
@@ -812,6 +847,59 @@ target = "key_1"
         mappings = saved.config.device_layers["1234:5678"].mappings
         assert mappings["btn_back"].target == "key_1"
         assert mappings["btn_forward"].target == "key_2"
+
+    def test_delete_profile_falls_back_to_unlink_when_trash_move_fails(
+        self,
+        temp_config_dir,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        manager = ProfileManager()
+        manager.save_profile(ProfileConfig(name="Delete Me"))
+        profile = manager.get_profile("Delete Me")
+        assert profile is not None
+        profile_path = profile.path
+        original_rename = Path.rename
+
+        def fail_profile_rename(self: Path, target: Path) -> Path:
+            if self == profile_path:
+                raise OSError("cross-device link")
+            return original_rename(self, target)
+
+        monkeypatch.setattr(Path, "rename", fail_profile_rename)
+
+        with caplog.at_level("WARNING", logger="keymasq-session.profiles"):
+            deleted = manager.delete_profile("Delete Me")
+
+        assert deleted is True
+        assert manager.get_profile("Delete Me") is None
+        assert not profile_path.exists()
+        assert "Failed to move deleted profile to trash" in caplog.text
+        assert "cross-device link" in caplog.text
+
+    def test_delete_profile_does_not_unlink_on_unexpected_trash_failure(
+        self,
+        temp_config_dir,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        manager = ProfileManager()
+        manager.save_profile(ProfileConfig(name="Delete Me"))
+        profile = manager.get_profile("Delete Me")
+        assert profile is not None
+        profile_path = profile.path
+
+        def fail_profile_rename(self: Path, target: Path) -> Path:
+            if self == profile_path:
+                raise RuntimeError("rename bug")
+            raise AssertionError("Unexpected rename call")
+
+        monkeypatch.setattr(Path, "rename", fail_profile_rename)
+
+        with pytest.raises(RuntimeError, match="rename bug"):
+            manager.delete_profile("Delete Me")
+
+        assert manager.get_profile("Delete Me") is profile
+        assert profile_path.exists()
 
     def test_remove_device_button_mappings_clears_matching_profile_entries(self, temp_config_dir):
         manager = ProfileManager()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,7 +36,7 @@ def _create_virtual_uinput(
             vendor=vendor,
             product=product,
         )
-    except Exception as exc:
+    except (OSError, RuntimeError, TypeError, ValueError) as exc:
         pytest.skip(f"Virtual uinput device unavailable: {exc}")
 
     backing_device = getattr(device, "device", None)

--- a/tests/gui/test_application_and_reload.py
+++ b/tests/gui/test_application_and_reload.py
@@ -1,4 +1,5 @@
 # ruff: noqa: I001
+import logging
 from types import SimpleNamespace
 
 import pytest
@@ -138,6 +139,16 @@ def test_gui_appearance_preference_round_trips(temp_config_dir) -> None:
     )
 
 
+def test_gui_preferences_warns_for_invalid_settings_toml(temp_config_dir, caplog) -> None:
+    from keymasq.gui.preferences import load_appearance_mode
+
+    (temp_config_dir / "gui_settings.toml").write_text("appearance = ", encoding="utf-8")
+    caplog.set_level(logging.WARNING, logger="keymasq.gui.preferences")
+
+    assert load_appearance_mode() == "system"
+    assert "Failed to load GUI settings" in caplog.text
+
+
 def test_gui_tab_layout_preference_round_trips_with_appearance(temp_config_dir) -> None:
     from keymasq.gui.preferences import (
         load_hidden_tabs,
@@ -166,7 +177,10 @@ def test_gui_tab_layout_preference_round_trips_with_appearance(temp_config_dir) 
     assert load_hidden_tabs() == {"combos"}
 
 
-def test_session_reload_reports_sync_and_async_status(monkeypatch) -> None:
+def test_session_reload_reports_sync_and_async_status(
+    caplog: pytest.LogCaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     import keymasq.gui.session_reload as session_reload_module
 
     monkeypatch.setattr(
@@ -179,8 +193,10 @@ def test_session_reload_reports_sync_and_async_status(monkeypatch) -> None:
     def raise_request(_payload, timeout=5.0):
         raise RuntimeError("daemon unavailable")
 
+    caplog.set_level(logging.ERROR, logger="keymasq.gui.session_reload")
     monkeypatch.setattr(session_reload_module, "session_request", raise_request)
     assert session_reload_module.notify_session_reload() is False
+    assert "Unexpected failure notifying session reload" in caplog.text
 
     callbacks: list[bool] = []
 

--- a/tests/gui/test_hardware_setup_dialog.py
+++ b/tests/gui/test_hardware_setup_dialog.py
@@ -981,6 +981,61 @@ class TestHardwareSetupDialog:
         assert dialog._detect_devices_via_session(detected_devices) is False
         assert detected_devices == {}
 
+    def test_detect_devices_locally_closes_opened_evdev_devices(self, monkeypatch):
+        gi.require_version("Gtk", "4.0")
+        from gi.repository import Gtk
+
+        from keymasq.gui.wizards import hardware_setup as hardware_setup_mod
+        from keymasq.gui.wizards.hardware_setup import HardwareSetupDialog
+
+        class FakeInputDevice:
+            def __init__(self, path: str) -> None:
+                self.path = path
+                self.name = "Test Device"
+                self.phys = "usb/input0"
+                self.info = SimpleNamespace(vendor=0x1234, product=0x5678)
+                self.closed = False
+
+            def close(self) -> None:
+                self.closed = True
+
+        devices: dict[str, FakeInputDevice] = {}
+
+        def input_device(path: str) -> FakeInputDevice:
+            device = FakeInputDevice(path)
+            devices[path] = device
+            return device
+
+        monkeypatch.setattr(HardwareSetupDialog, "_detect_devices", lambda self: None)
+        monkeypatch.setattr(
+            hardware_setup_mod.evdev,
+            "list_devices",
+            lambda: ["/dev/input/event1", "/dev/input/event2"],
+        )
+        monkeypatch.setattr(hardware_setup_mod.evdev, "InputDevice", input_device)
+        monkeypatch.setattr(hardware_setup_mod, "resolve_stable_path", lambda path: path)
+        monkeypatch.setattr(
+            hardware_setup_mod,
+            "detect_input_classes",
+            lambda _device: ["keyboard"],
+        )
+
+        dialog = HardwareSetupDialog(
+            Gtk.Window(),
+            SimpleNamespace(list_hardware=lambda: [], get_hardware=lambda _id: None),
+        )
+        dialog._should_skip_detected_device = lambda device: device.path.endswith("event1")  # type: ignore[method-assign]
+        dialog._should_include_detected_interface = lambda _device_types: False  # type: ignore[method-assign]
+        detected_devices: dict[str, dict] = {}
+
+        dialog._detect_devices_locally({}, detected_devices)
+
+        assert detected_devices == {}
+        assert {path: device.closed for path, device in devices.items()} == {
+            "/dev/input/event1": True,
+            "/dev/input/event2": True,
+        }
+
     def test_detect_devices_via_session_keeps_duplicate_gamepad_slots(self, monkeypatch):
         gi.require_version("Gtk", "4.0")
         from gi.repository import Gtk

--- a/tests/keymasqd/test_device_manager_core.py
+++ b/tests/keymasqd/test_device_manager_core.py
@@ -1064,6 +1064,54 @@ class TestListDevices:
             deps=dm._topology_runtime_deps(),
         )
 
+    def test_scan_live_interfaces_logs_snapshot_device_failures(
+        self,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        class _FakeDevice:
+            path = ""
+            name = "Test Device"
+            phys = ""
+            info = SimpleNamespace(vendor=0x1234, product=0x5678)
+
+            def capabilities(self) -> dict[int, list[int]]:
+                return {}
+
+        devices = {
+            "/dev/input/event0": _FakeDevice(),
+            "/dev/input/event1": _FakeDevice(),
+            "/dev/input/event2": _FakeDevice(),
+        }
+
+        def device_input(path: str) -> _FakeDevice:
+            return devices[path]
+
+        def resolve_stable_path(path: str) -> str:
+            if path.endswith("event0"):
+                raise OSError("stable path disappeared")
+            if path.endswith("event1"):
+                raise RuntimeError("stable resolver invalid")
+            return f"/dev/input/by-id/{path.rsplit('/', 1)[-1]}"
+
+        with caplog.at_level(logging.DEBUG, logger="keymasqd.devices"):
+            snapshot = tdm.scan_live_interfaces_sync(
+                clear_device_path_cache_fn=lambda: None,
+                device_paths_fn=lambda: list(devices),
+                device_input_fn=device_input,
+                detect_input_classes_fn=lambda _device: ["keyboard"],
+                primary_input_class_fn=lambda _classes: DeviceType.KEYBOARD,
+                resolve_stable_path_fn=resolve_stable_path,
+                get_interface_id_fn=lambda _stable_path: "kbd",
+                log=dm.log,
+            )
+
+        assert list(snapshot) == ["/dev/input/by-id/event2"]
+        assert snapshot["/dev/input/by-id/event2"].hardware_id == "1234:5678"
+        assert "Could not read live topology device /dev/input/event0" in caplog.text
+        assert "stable path disappeared" in caplog.text
+        assert "Unexpected failure reading live topology device /dev/input/event1" in caplog.text
+        assert "RuntimeError: stable resolver invalid" in caplog.text
+
     @pytest.mark.asyncio
     async def test_start_topology_watcher_reconciles_initial_snapshot_with_existing_grabs(
         self,

--- a/tests/keymasqd/test_device_manager_rapidfire.py
+++ b/tests/keymasqd/test_device_manager_rapidfire.py
@@ -298,7 +298,7 @@ class TestRapidfireRelease:
 
         class _FakeInputDevice:
             def active_keys(self) -> list[int]:
-                raise RuntimeError("broken active_keys")
+                raise OSError("broken active_keys")
 
         to_thread_calls: list[tuple[object, tuple[object, ...], dict[str, object]]] = []
 
@@ -332,6 +332,53 @@ class TestRapidfireRelease:
         assert [call[0] for call in to_thread_calls] == [device.device.active_keys]
         assert "failed to read active keys before grab: broken active_keys" in caplog.text
         assert "proceeding with grab" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_wait_for_active_keys_logs_unexpected_read_failure_and_proceeds(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        monkeypatch.setattr(gdm, "resolve_stable_path", lambda path: path)
+        monkeypatch.setattr(gdm, "get_interface_id", lambda _path: "kbd")
+
+        class _FakeInputDevice:
+            def active_keys(self) -> list[int]:
+                raise RuntimeError("broken active_keys")
+
+        to_thread_calls: list[tuple[object, tuple[object, ...], dict[str, object]]] = []
+
+        async def fake_to_thread(func, /, *args, **kwargs):
+            to_thread_calls.append((func, args, kwargs))
+            return func(*args, **kwargs)
+
+        monkeypatch.setattr(gdm.asyncio, "to_thread", fake_to_thread)
+
+        device = GrabbedDevice(
+            path="/dev/input/event-test",
+            hardware_id="1234:5678",
+            button_map={},
+            mapping_getter=lambda: {},
+            event_callback=AsyncMock(return_value=None),
+            device_type=DeviceType.KEYBOARD,
+            keyboard_uinput=FakeUInput(),  # type: ignore[arg-type]
+        )
+        device.device = _FakeInputDevice()  # type: ignore[assignment]
+
+        with caplog.at_level(logging.ERROR, logger="keymasqd.devices"):
+            await gdg.wait_for_active_keys_to_clear(
+                device,
+                asyncio_mod=gdm.ASYNCIO_RUNTIME,
+                time_mod=gdm.time,
+                log=gdm.log,
+                active_key_idle_max_wait_s=gdm.ACTIVE_KEY_IDLE_MAX_WAIT_S,
+                active_key_idle_log_interval_s=gdm.ACTIVE_KEY_IDLE_LOG_INTERVAL_S,
+            )
+
+        assert [call[0] for call in to_thread_calls] == [device.device.active_keys]
+        assert "unexpected failure reading active keys before grab" in caplog.text
+        assert "proceeding with grab" in caplog.text
+        assert "RuntimeError: broken active_keys" in caplog.text
 
     @pytest.mark.asyncio
     async def test_wait_for_active_keys_times_out_with_clear_error(

--- a/tests/keymasqd/test_device_manager_runtime_recovery.py
+++ b/tests/keymasqd/test_device_manager_runtime_recovery.py
@@ -195,6 +195,75 @@ class TestDeviceManagerHelpers:
         assert created[2].kwargs["vendor"] == 0x4B46
         assert created[2].kwargs["product"] == 0x1003
 
+    def test_configure_virtual_gamepads_logs_close_failures(
+        self,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        class _ClosingUInput:
+            def __init__(self, exc: Exception) -> None:
+                self.exc = exc
+
+            def close(self) -> None:
+                raise self.exc
+
+        manager = SimpleNamespace(
+            output_state=SimpleNamespace(
+                virtual_gamepad_uinputs={
+                    "virtual-gamepad-1": _ClosingUInput(OSError("device gone")),
+                    "virtual-gamepad-2": _ClosingUInput(RuntimeError("close state invalid")),
+                },
+                virtual_gamepad_count=2,
+            )
+        )
+        logger = logging.getLogger("keymasqd.devices")
+
+        with caplog.at_level(logging.DEBUG, logger="keymasqd.devices"):
+            count = ldm.runtime_outputs.configure_virtual_gamepads(
+                manager,
+                0,
+                evdev_mod=SimpleNamespace(ecodes=evdev.ecodes),
+                log=logger,
+                uinput_writer=lambda device: device,
+            )
+
+        assert count == 0
+        assert manager.output_state.virtual_gamepad_uinputs == {}
+        assert "Failed to close virtual gamepad virtual-gamepad-1: device gone" in caplog.text
+        assert "Unexpected failure closing virtual gamepad virtual-gamepad-2" in caplog.text
+        assert "RuntimeError: close state invalid" in caplog.text
+
+    def test_destroy_global_uinputs_logs_close_failures(
+        self,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        class _ClosingUInput:
+            def __init__(self, exc: Exception) -> None:
+                self.exc = exc
+
+            def close(self) -> None:
+                raise self.exc
+
+        manager = SimpleNamespace(
+            output_state=SimpleNamespace(
+                device_count=1,
+                keyboard_uinput=_ClosingUInput(OSError("keyboard gone")),
+                mouse_uinput=_ClosingUInput(RuntimeError("mouse close state invalid")),
+                virtual_gamepad_uinputs={},
+            )
+        )
+        logger = logging.getLogger("keymasqd.devices")
+
+        with caplog.at_level(logging.DEBUG, logger="keymasqd.devices"):
+            ldm.runtime_outputs.destroy_global_uinputs(manager, log=logger)
+
+        assert manager.output_state.device_count == 0
+        assert manager.output_state.keyboard_uinput is None
+        assert manager.output_state.mouse_uinput is None
+        assert manager.output_state.virtual_gamepad_uinputs == {}
+        assert "Failed to close global uinput device: keyboard gone" in caplog.text
+        assert "Unexpected failure closing global uinput device" in caplog.text
+        assert "RuntimeError: mouse close state invalid" in caplog.text
+
     @pytest.mark.asyncio
     async def test_grab_and_release_device_orchestrates_existing_and_removed_paths(
         self,

--- a/tests/keymasqd/test_grabbed_device_runtime_helpers.py
+++ b/tests/keymasqd/test_grabbed_device_runtime_helpers.py
@@ -58,6 +58,11 @@ class _FailingWriteUInput(FakeUInput):
         raise OSError("uinput disconnected")
 
 
+class _UnexpectedFailingWriteUInput(FakeUInput):
+    def write(self, event_type: int, code: int, value: int) -> None:
+        raise RuntimeError("writer state invalid")
+
+
 class _CountingUInput(FakeUInput):
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
@@ -68,6 +73,27 @@ class _CountingUInput(FakeUInput):
 
 
 class TestGrabbedDeviceHelpers:
+    def test_event_name_helpers_handle_missing_ecode_tables(self) -> None:
+        evdev_mod = SimpleNamespace(ecodes=SimpleNamespace(EV_KEY=evdev.ecodes.EV_KEY))
+        event = SimpleNamespace(type=evdev.ecodes.EV_KEY, code=evdev.ecodes.KEY_A, value=1)
+
+        assert gde.get_event_name(cast(gdt.InputEventLike, event), evdev_mod=evdev_mod) == str(
+            evdev.ecodes.KEY_A
+        )
+        assert gde.get_key_name(evdev.ecodes.KEY_A, evdev_mod=evdev_mod) is None
+
+    def test_event_name_helpers_use_available_ecode_tables(self) -> None:
+        evdev_mod = SimpleNamespace(
+            ecodes=SimpleNamespace(
+                EV_KEY=evdev.ecodes.EV_KEY,
+                bytype={evdev.ecodes.EV_KEY: {evdev.ecodes.KEY_A: ("KEY_A", "KEY_Q")}},
+            )
+        )
+        event = SimpleNamespace(type=evdev.ecodes.EV_KEY, code=evdev.ecodes.KEY_A, value=1)
+
+        assert gde.get_event_name(cast(gdt.InputEventLike, event), evdev_mod=evdev_mod) == "key_a"
+        assert gde.get_key_name(evdev.ecodes.KEY_A, evdev_mod=evdev_mod) == "key_a"
+
     @pytest.mark.asyncio
     async def test_device_release_ends_held_profile_trigger_state(
         self,
@@ -1185,6 +1211,32 @@ class TestGrabbedDeviceHelpers:
         assert "Failed to release output key" in caplog.text
         assert "Failed to release gamepad ABS axis" in caplog.text
 
+    def test_release_helpers_log_unexpected_uinput_release_failures(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        device = make_grabbed_device(monkeypatch)
+        keyboard = _UnexpectedFailingWriteUInput()
+        gamepad = _UnexpectedFailingWriteUInput()
+        device.keyboard_uinput = keyboard  # type: ignore[assignment]
+        device.gamepad_uinput = gamepad  # type: ignore[assignment]
+
+        with caplog.at_level(logging.ERROR, logger="keymasqd.devices"):
+            gdo.ensure_key_released(device, evdev.ecodes.KEY_A, device.keyboard_uinput)
+            gdo.ensure_abs_axis_released(
+                device,
+                evdev.ecodes.ABS_Z,
+                evdev_mod=evdev,
+                uinput_writer=lambda device: cast(
+                    runtime_adapters.WritableUInput | None, device
+                ),
+            )
+
+        assert "Unexpected failure releasing output key" in caplog.text
+        assert "Unexpected failure releasing gamepad ABS axis" in caplog.text
+        assert "RuntimeError: writer state invalid" in caplog.text
+
     def test_release_all_keys_keeps_tracking_after_failed_release(
         self,
         monkeypatch: pytest.MonkeyPatch,
@@ -1208,6 +1260,38 @@ class TestGrabbedDeviceHelpers:
         assert device.state.held_output_keys["keyboard"] == {evdev.ecodes.KEY_A}
         assert device.state.superkey_output_refcounts["keyboard"] == {evdev.ecodes.KEY_A: 1}
         assert "Failed to release held output keys" in caplog.text
+
+    def test_release_all_keys_logs_unexpected_release_failures(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        device = make_grabbed_device(monkeypatch)
+        keyboard = _UnexpectedFailingWriteUInput()
+        gamepad = _UnexpectedFailingWriteUInput()
+        device.keyboard_uinput = keyboard  # type: ignore[assignment]
+        device.gamepad_uinput = gamepad  # type: ignore[assignment]
+        device.state.held_output_keys["keyboard"].add(evdev.ecodes.KEY_A)
+        device.state.superkey_output_refcounts["keyboard"][evdev.ecodes.KEY_A] = 1
+        device.state.held_output_abs["gamepad"].add(evdev.ecodes.ABS_Z)
+        device.state.superkey_abs_refcounts["gamepad"][evdev.ecodes.ABS_Z] = 1
+
+        with caplog.at_level(logging.ERROR, logger="keymasqd.devices"):
+            gdo.release_all_keys(
+                device,
+                evdev_mod=evdev,
+                uinput_writer=lambda device: cast(
+                    runtime_adapters.WritableUInput | None, device
+                ),
+            )
+
+        assert device.state.held_output_keys["keyboard"] == {evdev.ecodes.KEY_A}
+        assert device.state.superkey_output_refcounts["keyboard"] == {evdev.ecodes.KEY_A: 1}
+        assert device.state.held_output_abs["gamepad"] == {evdev.ecodes.ABS_Z}
+        assert device.state.superkey_abs_refcounts["gamepad"] == {evdev.ecodes.ABS_Z: 1}
+        assert "Unexpected failure releasing held output keys" in caplog.text
+        assert "Unexpected failure releasing gamepad ABS axes" in caplog.text
+        assert "RuntimeError: writer state invalid" in caplog.text
 
     @pytest.mark.asyncio
     async def test_wait_for_active_key_activity_handles_timeouts_and_drain_errors(
@@ -1235,6 +1319,8 @@ class TestGrabbedDeviceHelpers:
                 self.calls += 1
                 if self.calls == 1:
                     raise OSError(errno.EIO, "drain failed")
+                if self.calls == 2:
+                    raise RuntimeError("broken read_one")
                 return None
 
         fake_input = _FakeInputDevice()
@@ -1242,7 +1328,7 @@ class TestGrabbedDeviceHelpers:
 
         monkeypatch.setattr(gdm.asyncio, "get_running_loop", lambda: _FakeLoop())
 
-        outcomes = iter([TimeoutError(), None])
+        outcomes = iter([TimeoutError(), None, None])
 
         async def fake_wait_for(awaitable, _timeout: float):
             close = getattr(awaitable, "close", None)
@@ -1279,6 +1365,22 @@ class TestGrabbedDeviceHelpers:
             )
 
         assert "failed to drain pending events before grab" in caplog.text
+
+        caplog.clear()
+        with caplog.at_level(logging.ERROR, logger="keymasqd.devices"):
+            assert (
+                await gdg.wait_for_active_key_activity(
+                    device,
+                    0.1,
+                    asyncio_mod=gdm.ASYNCIO_RUNTIME,
+                    errno_mod=errno,
+                    log=gdm.log,
+                )
+                is True
+            )
+
+        assert "unexpected failure draining pending events before grab" in caplog.text
+        assert "RuntimeError: broken read_one" in caplog.text
 
     @pytest.mark.asyncio
     async def test_broadcast_grab_status_and_startup_held_actions(
@@ -1327,6 +1429,35 @@ class TestGrabbedDeviceHelpers:
         assert device.state.held_source_actions["key_b"] == mapping_state["right"]
         assert keyboard.writes == [(evdev.ecodes.EV_KEY, evdev.ecodes.KEY_Z, 0)]
         assert mouse.writes == [(evdev.ecodes.EV_KEY, evdev.ecodes.BTN_LEFT, 0)]
+
+    def test_seed_startup_held_actions_logs_read_failures(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        device = make_grabbed_device(monkeypatch)
+
+        class _FailingInputDevice:
+            def __init__(self, exc: Exception) -> None:
+                self.exc = exc
+
+            def active_keys(self) -> list[int]:
+                raise self.exc
+
+        device.device = _FailingInputDevice(OSError("device gone"))  # type: ignore[assignment]
+        with caplog.at_level(logging.WARNING, logger="keymasqd.devices"):
+            gdg.seed_startup_held_actions(device)
+
+        assert "failed to read startup active keys" in caplog.text
+        assert "device gone" in caplog.text
+
+        caplog.clear()
+        device.device = _FailingInputDevice(RuntimeError("broken active_keys"))  # type: ignore[assignment]
+        with caplog.at_level(logging.ERROR, logger="keymasqd.devices"):
+            gdg.seed_startup_held_actions(device)
+
+        assert "unexpected failure reading startup active keys" in caplog.text
+        assert "RuntimeError: broken active_keys" in caplog.text
 
     def test_seed_startup_held_actions_matches_gamepad_alias_by_code(
         self,

--- a/tests/keymasqd/test_grabbed_device_runtime_helpers.py
+++ b/tests/keymasqd/test_grabbed_device_runtime_helpers.py
@@ -94,6 +94,17 @@ class TestGrabbedDeviceHelpers:
         assert gde.get_event_name(cast(gdt.InputEventLike, event), evdev_mod=evdev_mod) == "key_a"
         assert gde.get_key_name(evdev.ecodes.KEY_A, evdev_mod=evdev_mod) == "key_a"
 
+    def test_event_name_helpers_normalize_numeric_code_lookup(self) -> None:
+        evdev_mod = SimpleNamespace(
+            ecodes=SimpleNamespace(
+                EV_KEY=evdev.ecodes.EV_KEY,
+                bytype={evdev.ecodes.EV_KEY: {evdev.ecodes.KEY_A: "KEY_A"}},
+            )
+        )
+        event = SimpleNamespace(type=evdev.ecodes.EV_KEY, code=str(evdev.ecodes.KEY_A), value=1)
+
+        assert gde.get_event_name(cast(gdt.InputEventLike, event), evdev_mod=evdev_mod) == "key_a"
+
     @pytest.mark.asyncio
     async def test_device_release_ends_held_profile_trigger_state(
         self,

--- a/tests/keymasqd/test_macro_backend_recording.py
+++ b/tests/keymasqd/test_macro_backend_recording.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 from pathlib import Path
 from types import SimpleNamespace
 from typing import cast
@@ -1192,6 +1193,98 @@ def test_macro_cleanup_sync_uses_raw_uinput_with_non_identity_writer(
     writer.write.assert_called_once_with(evdev.ecodes.EV_KEY, evdev.ecodes.KEY_B, 0)
     assert sync_calls == [(raw_keyboard, writer)]
     assert manager.macro_state.held_refcount == {}
+
+
+def test_macro_cleanup_logs_expected_output_release_failures(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    manager = DeviceManager()
+    keyboard = MagicMock()
+    gamepad = MagicMock()
+    keyboard.write.side_effect = OSError("keyboard gone")
+    gamepad.write.side_effect = OSError("gamepad gone")
+    manager.output_state.keyboard_uinput = keyboard
+    manager.output_state.gamepad_uinput = gamepad
+    manager.macro_state.instance_held[1] = {("keyboard", evdev.ecodes.KEY_B)}
+    manager.macro_state.instance_held_abs[1] = {("gamepad", evdev.ecodes.ABS_Z)}
+    manager.macro_state.held_refcount[("keyboard", evdev.ecodes.KEY_B)] = 1
+    manager.macro_state.held_abs_refcount[("gamepad", evdev.ecodes.ABS_Z)] = 1
+
+    with caplog.at_level(logging.DEBUG, logger="keymasqd.devices"):
+        mdm.release_macro_held_for_instance(manager, 1, deps=dm._macro_runtime_deps())
+
+    assert manager.macro_state.held_refcount == {}
+    assert manager.macro_state.held_abs_refcount == {}
+    assert "Failed to release macro-held output key" in caplog.text
+    assert "Failed to release macro-held ABS output" in caplog.text
+
+
+def test_macro_cleanup_logs_unexpected_output_release_failures(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    manager = DeviceManager()
+    keyboard = MagicMock()
+    gamepad = MagicMock()
+    keyboard.write.side_effect = RuntimeError("keyboard writer invalid")
+    gamepad.write.side_effect = RuntimeError("gamepad writer invalid")
+    manager.output_state.keyboard_uinput = keyboard
+    manager.output_state.gamepad_uinput = gamepad
+    manager.macro_state.instance_held[1] = {("keyboard", evdev.ecodes.KEY_B)}
+    manager.macro_state.instance_held_abs[1] = {("gamepad", evdev.ecodes.ABS_Z)}
+    manager.macro_state.held_refcount[("keyboard", evdev.ecodes.KEY_B)] = 1
+    manager.macro_state.held_abs_refcount[("gamepad", evdev.ecodes.ABS_Z)] = 1
+
+    with caplog.at_level(logging.ERROR, logger="keymasqd.devices"):
+        mdm.release_macro_held_for_instance(manager, 1, deps=dm._macro_runtime_deps())
+
+    assert manager.macro_state.held_refcount == {}
+    assert manager.macro_state.held_abs_refcount == {}
+    assert "Unexpected failure releasing macro-held output key" in caplog.text
+    assert "Unexpected failure releasing macro-held ABS output" in caplog.text
+    assert "RuntimeError: keyboard writer invalid" in caplog.text
+    assert "RuntimeError: gamepad writer invalid" in caplog.text
+
+
+def test_macro_cleanup_logs_sync_failures(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    def make_manager() -> DeviceManager:
+        manager = DeviceManager()
+        manager.output_state.keyboard_uinput = MagicMock()
+        manager.macro_state.instance_held[1] = {("keyboard", evdev.ecodes.KEY_B)}
+        manager.macro_state.held_refcount[("keyboard", evdev.ecodes.KEY_B)] = 1
+        return manager
+
+    monkeypatch.setattr(
+        mdm,
+        "syn_if_passthrough_frame_closed",
+        MagicMock(side_effect=OSError("sync failed")),
+    )
+    with caplog.at_level(logging.DEBUG, logger="keymasqd.devices"):
+        mdm.release_macro_held_for_instance(
+            make_manager(),
+            1,
+            deps=dm._macro_runtime_deps(),
+        )
+
+    assert "Failed to synchronize macro cleanup outputs" in caplog.text
+
+    caplog.clear()
+    monkeypatch.setattr(
+        mdm,
+        "syn_if_passthrough_frame_closed",
+        MagicMock(side_effect=RuntimeError("sync state invalid")),
+    )
+    with caplog.at_level(logging.ERROR, logger="keymasqd.devices"):
+        mdm.release_macro_held_for_instance(
+            make_manager(),
+            1,
+            deps=dm._macro_runtime_deps(),
+        )
+
+    assert "Unexpected failure synchronizing macro cleanup outputs" in caplog.text
+    assert "RuntimeError: sync state invalid" in caplog.text
 
 
 @pytest.mark.asyncio

--- a/tests/session/test_dbus.py
+++ b/tests/session/test_dbus.py
@@ -1,5 +1,8 @@
+import logging
+
 import pytest
 from dbus_next.constants import MessageType
+from dbus_next.errors import DBusError
 from dbus_next.message import Message
 
 import keymasq.session.dbus as dbus_module
@@ -268,7 +271,7 @@ async def test_name_has_owner_helper_uses_supplied_or_temporary_dbus(
     assert await dbus_module.name_has_owner("org.example.Service", supplied, timeout=0.2) is True
     assert supplied.calls == [("org.example.Service", 0.2)]
 
-    failing = _SuppliedDBus(False, error=RuntimeError("no bus"))
+    failing = _SuppliedDBus(False, error=DBusError("org.example.Error", "no bus"))
     assert await dbus_module.name_has_owner("org.example.Service", failing) is False
 
     temporary_bus = _FakeBus()
@@ -279,3 +282,31 @@ async def test_name_has_owner_helper_uses_supplied_or_temporary_dbus(
     assert await dbus_module.name_has_owner("org.example.Temporary") is True
     assert temporary_iface.calls == ["org.example.Temporary"]
     assert temporary_bus.disconnect_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_name_has_owner_helper_logs_expected_dbus_failures(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    failing = _SuppliedDBus(
+        False,
+        error=DBusError("org.example.Error", "owner lookup failed"),
+    )
+
+    with caplog.at_level(logging.DEBUG, logger="keymasq-session.dbus"):
+        assert await dbus_module.name_has_owner("org.example.Service", failing) is False
+
+    assert "D-Bus owner lookup failed for org.example.Service: owner lookup failed" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_name_has_owner_helper_logs_unexpected_failures(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    failing = _SuppliedDBus(False, error=RuntimeError("probe bug"))
+
+    with caplog.at_level(logging.ERROR, logger="keymasq-session.dbus"):
+        assert await dbus_module.name_has_owner("org.example.Service", failing) is False
+
+    assert "Unexpected D-Bus owner lookup failure for org.example.Service" in caplog.text
+    assert "probe bug" in caplog.text

--- a/tests/session/test_session_manager_command_runtime.py
+++ b/tests/session/test_session_manager_command_runtime.py
@@ -1,5 +1,6 @@
 import asyncio
 import json
+import logging
 from types import SimpleNamespace
 from typing import cast
 from unittest.mock import AsyncMock, Mock
@@ -323,6 +324,32 @@ async def test_recording_unlock_status_prefers_daemon_when_connected() -> None:
     sent_command = manager.client.send_command.await_args.args[0]
     assert sent_command.command == CommandType.RECORDING_UNLOCK_STATUS
     assert sent_command.data == {"uid": 1000}
+
+
+@pytest.mark.asyncio
+async def test_recording_unlock_status_logs_unexpected_daemon_query_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    manager = SessionManager()
+    manager.connected = True
+    manager.client.send_command = AsyncMock(side_effect=RuntimeError("status bug"))
+    fallback_status = {"unlocked": False, "source": "none", "expires_at": 0}
+    monkeypatch.setattr(
+        session_recording_module,
+        "resolve_unlock_status",
+        lambda _uid: fallback_status,
+    )
+
+    with caplog.at_level(logging.ERROR, logger="keymasq-session"):
+        result = await session_recording_module.resolve_unlock_status_async(
+            manager,
+            1000,
+        )
+
+    assert result == fallback_status
+    assert "Unexpected failure querying daemon recording unlock status" in caplog.text
+    assert "status bug" in caplog.text
 
 
 @pytest.mark.asyncio
@@ -1421,8 +1448,34 @@ async def test_stop_device_inspector_preserves_state_on_daemon_error(
 
 
 @pytest.mark.asyncio
+async def test_device_inspector_reports_daemon_connection_errors() -> None:
+    manager = SessionManager()
+    manager.client.send_command = AsyncMock(side_effect=ConnectionError("daemon down"))
+
+    result = await session_device_inspector_module.disable_device_inspector_suppression(
+        manager,
+        "1234:5678",
+    )
+
+    assert result == {"status": "error", "message": "Daemon unavailable"}
+
+
+@pytest.mark.asyncio
+async def test_device_inspector_does_not_mask_runtime_errors() -> None:
+    manager = SessionManager()
+    manager.client.send_command = AsyncMock(side_effect=RuntimeError("request bug"))
+
+    with pytest.raises(RuntimeError, match="request bug"):
+        await session_device_inspector_module.disable_device_inspector_suppression(
+            manager,
+            "1234:5678",
+        )
+
+
+@pytest.mark.asyncio
 async def test_clear_device_inspectors_for_writer_continues_after_stop_failure(
     monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     manager = SessionManager()
     writer = object()
@@ -1448,13 +1501,18 @@ async def test_clear_device_inspectors_for_writer_continues_after_stop_failure(
 
     monkeypatch.setattr(session_device_inspector_module, "_stop_device_inspector_unlocked", stop)
 
-    await session_device_inspector_module.clear_device_inspectors_for_writer(
-        manager,
-        writer,  # type: ignore[arg-type]
-    )
+    with caplog.at_level("ERROR", logger="keymasq-session.device_inspector"):
+        await session_device_inspector_module.clear_device_inspectors_for_writer(
+            manager,
+            writer,  # type: ignore[arg-type]
+        )
 
     assert stopped == ["bad", "good"]
     assert manager.device_inspector_state.owners_by_hardware_id["bad"] == set()
+    assert (
+        "Failed to stop device inspector for disconnected owner hardware_id=bad" in caplog.text
+    )
+    assert "stop failed" in caplog.text
 
 
 @pytest.mark.asyncio
@@ -2000,13 +2058,33 @@ async def test_capture_end_keeps_token_when_daemon_end_fails() -> None:
     hardware_id = "2dc8:3106"
     manager.capture_state.tokens[hardware_id] = "token-1"
     manager.capture_state.locks.add(hardware_id)
-    manager.client.send_command = AsyncMock(side_effect=RuntimeError("daemon down"))
+    manager.client.send_command = AsyncMock(side_effect=OSError("daemon down"))
 
     result = await session_recording_module.capture_end(manager, hardware_id)
 
     assert result == {"status": "error", "message": "Daemon unavailable"}
     assert manager.capture_state.tokens[hardware_id] == "token-1"
     assert hardware_id in manager.capture_state.locks
+
+
+@pytest.mark.asyncio
+async def test_capture_end_logs_unexpected_failure(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    manager = SessionManager()
+    hardware_id = "2dc8:3106"
+    manager.capture_state.tokens[hardware_id] = "token-1"
+    manager.capture_state.locks.add(hardware_id)
+    manager.client.send_command = AsyncMock(side_effect=RuntimeError("capture bug"))
+
+    with caplog.at_level(logging.ERROR, logger="keymasq-session"):
+        result = await session_recording_module.capture_end(manager, hardware_id)
+
+    assert result == {"status": "error", "message": "Failed to end capture"}
+    assert manager.capture_state.tokens[hardware_id] == "token-1"
+    assert hardware_id in manager.capture_state.locks
+    assert "Unexpected failure ending capture for hardware_id=2dc8:3106" in caplog.text
+    assert "capture bug" in caplog.text
 
 
 @pytest.mark.asyncio
@@ -2020,7 +2098,7 @@ async def test_clear_captures_for_writer_forces_local_cleanup_on_daemon_failure(
     manager.capture_state.locks.add(hardware_id)
     manager.capture_state.owner_writer_ids[hardware_id] = id(writer)
     manager.capture_state.resume_profiles[hardware_id] = ["Default"]
-    manager.client.send_command = AsyncMock(side_effect=RuntimeError("daemon down"))
+    manager.client.send_command = AsyncMock(side_effect=OSError("daemon down"))
     reevaluate_profiles = AsyncMock()
     monkeypatch.setattr(session_profiles_module, "reevaluate_profiles", reevaluate_profiles)
 
@@ -2261,6 +2339,37 @@ async def test_handle_session_request_create_macro_broadcasts_saved_event(
     manager.broadcast_to_session_clients.assert_called_once_with(  # type: ignore[attr-defined]
         {"event": "macro_saved", "name": "Speedrun"}
     )
+
+
+@pytest.mark.asyncio
+async def test_handle_session_request_list_macros_reports_daemon_connection_errors() -> None:
+    manager = SessionManager()
+    manager.client.send_command = AsyncMock(side_effect=ConnectionError("daemon down"))
+    peer = PeerCredentials(pid=1, uid=1000, gid=1000)
+
+    result = await manager._handle_session_request(
+        {"command": "list_macros"},
+        "client",
+        peer,
+        object(),
+    )
+
+    assert result == {"status": "error", "message": "Daemon unavailable"}
+
+
+@pytest.mark.asyncio
+async def test_handle_session_request_list_macros_does_not_mask_runtime_errors() -> None:
+    manager = SessionManager()
+    manager.client.send_command = AsyncMock(side_effect=RuntimeError("request bug"))
+    peer = PeerCredentials(pid=1, uid=1000, gid=1000)
+
+    with pytest.raises(RuntimeError, match="request bug"):
+        await manager._handle_session_request(
+            {"command": "list_macros"},
+            "client",
+            peer,
+            object(),
+        )
 
 
 @pytest.mark.asyncio

--- a/tests/session/test_session_manager_command_runtime.py
+++ b/tests/session/test_session_manager_command_runtime.py
@@ -3,7 +3,7 @@ import json
 import logging
 from types import SimpleNamespace
 from typing import cast
-from unittest.mock import AsyncMock, Mock
+from unittest.mock import AsyncMock, Mock, call
 
 import pytest
 
@@ -2710,6 +2710,439 @@ async def test_handle_session_request_delete_macro_broadcasts_deleted_event(
     manager.broadcast_to_session_clients.assert_called_once_with(  # type: ignore[attr-defined]
         {"event": "macro_deleted", "name": "Speedrun"}
     )
+
+
+@pytest.mark.asyncio
+async def test_profile_commands_cover_simple_and_error_branches(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = SessionManager()
+    peer = PeerCredentials(pid=1, uid=1000, gid=1000)
+    set_profile_enabled = AsyncMock(return_value={"status": "ok", "enabled": True})
+    monkeypatch.setattr(
+        session_profiles_module,
+        "set_profile_enabled",
+        set_profile_enabled,
+    )
+    monkeypatch.setattr(
+        session_profiles_module,
+        "build_profile_overview",
+        lambda _manager: {"status": "ok", "profiles": [{"name": "Base"}]},
+    )
+
+    listed = await manager._handle_session_request(
+        {"command": "list_profiles"},
+        "client",
+        peer,
+        object(),
+    )
+    missing = await manager._handle_session_request(
+        {"command": "enable_profile"},
+        "client",
+        peer,
+        object(),
+    )
+    enabled = await manager._handle_session_request(
+        {"command": "enable_profile", "profile_name": "Base"},
+        "client",
+        peer,
+        object(),
+    )
+    toggled = await manager._handle_session_request(
+        {"command": "toggle_profile", "profile_name": "Base"},
+        "client",
+        peer,
+        object(),
+    )
+    ping = await manager._handle_session_request(
+        {"command": "ping"},
+        "client",
+        peer,
+        object(),
+    )
+
+    assert listed == {"status": "ok", "profiles": [{"name": "Base"}]}
+    assert missing == {"status": "error", "message": "missing profile_name"}
+    assert enabled == {"status": "ok", "enabled": True}
+    assert toggled == {"status": "ok", "enabled": True}
+    assert ping == {"status": "ok"}
+    assert [call.args for call in set_profile_enabled.await_args_list] == [
+        (manager, "Base", True),
+        (manager, "Base", None),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_profile_commands_report_reload_and_release_failures() -> None:
+    manager = SessionManager()
+    peer = PeerCredentials(pid=1, uid=1000, gid=1000)
+    manager.reload_profiles = AsyncMock(return_value=False)  # type: ignore[method-assign]
+
+    reload_result = await manager._handle_session_request(
+        {"command": "reload"},
+        "client",
+        peer,
+        object(),
+    )
+    missing_release = await manager._handle_session_request(
+        {"command": "release_device"},
+        "client",
+        peer,
+        object(),
+    )
+
+    manager.client.send_command = AsyncMock(side_effect=OSError("daemon down"))
+    unavailable_release = await manager._handle_session_request(
+        {"command": "release_device", "hardware_id": "1234:5678"},
+        "client",
+        peer,
+        object(),
+    )
+
+    manager.client.send_command = AsyncMock(
+        return_value=Response(status="error", error="still pressed")
+    )
+    rejected_release = await manager._handle_session_request(
+        {"command": "release_device", "hardware_id": "1234:5678", "immediate": False},
+        "client",
+        peer,
+        object(),
+    )
+
+    manager.reload_config_from_disk = Mock(side_effect=ValueError("bad config"))  # type: ignore[method-assign]
+    manager.send_notification = Mock()  # type: ignore[method-assign]
+    reevaluate = await manager._handle_session_request(
+        {"command": "reevaluate_profiles"},
+        "client",
+        peer,
+        object(),
+    )
+
+    assert reload_result["status"] == "error"
+    assert missing_release == {"status": "error", "message": "missing hardware_id"}
+    assert unavailable_release == {"status": "error", "message": "Daemon unavailable"}
+    assert rejected_release == {"status": "error", "message": "still pressed"}
+    assert reevaluate == {"status": "error", "message": "bad config"}
+    manager.send_notification.assert_called_once()  # type: ignore[attr-defined]
+    assert manager.client.send_command.await_args.args[0].data == {
+        "hardware_id": "1234:5678",
+        "immediate": False,
+    }
+
+
+@pytest.mark.asyncio
+async def test_settings_and_virtual_gamepad_commands_cover_success_and_unavailable(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(paths, "CONFIG_DIR", tmp_path / "keymasq")
+    session_settings.save_global_settings(GlobalSettings(virtual_gamepad_count=2))
+    manager = SessionManager()
+    peer = PeerCredentials(pid=1, uid=1000, gid=1000)
+    manager.broadcast_to_session_clients = Mock()  # type: ignore[method-assign]
+
+    virtuals = await manager._handle_session_request(
+        {"command": "get_virtual_gamepads"},
+        "client",
+        peer,
+        object(),
+    )
+    settings = await manager._handle_session_request(
+        {"command": "get_settings"},
+        "client",
+        peer,
+        object(),
+    )
+
+    manager.connected = True
+    manager.client.send_command = AsyncMock(side_effect=OSError("daemon down"))
+    virtual_unavailable = await manager._handle_session_request(
+        {"command": "set_virtual_gamepads", "count": 3},
+        "client",
+        peer,
+        object(),
+    )
+    settings_unavailable = await manager._handle_session_request(
+        {"command": "set_settings", "virtual_gamepad_count": 3},
+        "client",
+        peer,
+        object(),
+    )
+
+    manager.client.send_command = AsyncMock(
+        return_value=Response(status="ok", data={"count": 4})
+    )
+    settings_saved = await manager._handle_session_request(
+        {"command": "set_settings", "virtual_gamepad_count": 3},
+        "client",
+        peer,
+        object(),
+    )
+
+    assert virtuals["count"] == 2
+    assert settings["virtual_gamepad_count"] == 2
+    assert virtual_unavailable == {"status": "error", "message": "Daemon unavailable"}
+    assert settings_unavailable["status"] == "error"
+    assert settings_unavailable["message"] == "Daemon unavailable"
+    assert settings_saved["status"] == "ok"
+    assert settings_saved["virtual_gamepad_count"] == 4
+    manager.broadcast_to_session_clients.assert_called_once_with(  # type: ignore[attr-defined]
+        {"event": "settings_changed", "virtual_gamepad_count": 4}
+    )
+
+
+@pytest.mark.asyncio
+async def test_macro_commands_cover_remaining_daemon_variants(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = SessionManager()
+    peer = PeerCredentials(pid=1, uid=1000, gid=1000)
+    manager.broadcast_to_session_clients = Mock()  # type: ignore[method-assign]
+    refresh_macro_bindings = AsyncMock()
+    monkeypatch.setattr(
+        session_profiles_module,
+        "refresh_macro_bindings",
+        refresh_macro_bindings,
+    )
+
+    manager.client.send_command = AsyncMock(
+        side_effect=[
+            Response(status="error", error="empty list"),
+            Response(status="ok", data={"macro": {"name": "Demo"}}),
+            Response(status="error", error="missing"),
+            OSError("daemon down"),
+            Response(status="error", error="create failed"),
+            OSError("daemon down"),
+            Response(status="error", error="delete failed"),
+            Response(status="ok", data={"macro": {"name": "Renamed"}}),
+            Response(status="ok", data=None),
+            Response(status="error", error="rename failed"),
+            Response(status="ok", data={"status": "ok", "queued": True}),
+            Response(status="error", error="play failed"),
+            Response(status="ok", data={"cancelled": 2}),
+            Response(status="error", error="cancel failed"),
+        ]
+    )
+
+    requests = [
+        {"command": "list_macros"},
+        {"command": "get_macro", "name": "Demo"},
+        {"command": "get_macro", "name": "Missing"},
+        {"command": "get_macro", "name": "Missing"},
+        {"command": "create_macro", "macro": {"name": "Demo"}},
+        {"command": "update_macro", "name": "Demo", "macro": {"name": "Demo"}},
+        {"command": "delete_macro", "name": "Demo", "expected_revision": 3},
+        {"command": "rename_macro", "old": "Demo", "new": "Renamed"},
+        {"command": "rename_macro", "old": "Demo", "new": "Renamed"},
+        {"command": "rename_macro", "old": "Demo", "new": "Renamed"},
+        {
+            "command": "play_macro",
+            "name": "Demo",
+            "replay_mouse_movement": False,
+            "replay_mouse_clicks": False,
+            "speed": 1.5,
+        },
+        {"command": "play_macro", "name": "Demo"},
+        {"command": "cancel_macro_playback"},
+        {"command": "cancel_macro_playback"},
+    ]
+    results = [
+        await manager._handle_session_request(request, "client", peer, object())
+        for request in requests
+    ]
+
+    assert results == [
+        {"status": "error", "message": "empty list"},
+        {"status": "ok", "macro": {"name": "Demo"}},
+        {"status": "error", "message": "missing"},
+        {"status": "error", "message": "Daemon unavailable"},
+        {"status": "error", "message": "create failed"},
+        {"status": "error", "message": "Daemon unavailable"},
+        {"status": "error", "message": "delete failed"},
+        {"status": "ok", "macro": {"name": "Renamed"}},
+        {"status": "ok"},
+        {"status": "error", "message": "rename failed"},
+        {"status": "ok", "queued": True},
+        {"status": "error", "message": "play failed"},
+        {"cancelled": 2},
+        {"status": "error", "message": "cancel failed"},
+    ]
+    update_command = manager.client.send_command.await_args_list[5].args[0]
+    delete_command = manager.client.send_command.await_args_list[6].args[0]
+    play_command = manager.client.send_command.await_args_list[10].args[0]
+    assert update_command.command == CommandType.MACRO_UPDATE
+    assert delete_command.data == {"name": "Demo", "expected_revision": 3}
+    assert play_command.data == {
+        "name": "Demo",
+        "replay_mouse_movement": False,
+        "replay_mouse_clicks": False,
+        "speed": 1.5,
+    }
+    assert refresh_macro_bindings.await_count == 2
+    assert manager.broadcast_to_session_clients.call_args_list == [  # type: ignore[attr-defined]
+        call({"event": "macro_deleted", "name": "Demo"}),
+        call({"event": "macro_saved", "name": "Renamed"}),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_macro_commands_validate_payloads_and_compile_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = SessionManager()
+    peer = PeerCredentials(pid=1, uid=1000, gid=1000)
+
+    async def fake_to_thread(_func, /, *_args, **_kwargs):
+        raise ValueError("bad macro")
+
+    monkeypatch.setattr(session_commands_module.asyncio, "to_thread", fake_to_thread)
+
+    create_missing = await manager._handle_session_request(
+        {"command": "create_macro"},
+        "client",
+        peer,
+        object(),
+    )
+    update_missing = await manager._handle_session_request(
+        {"command": "update_macro", "name": "Demo"},
+        "client",
+        peer,
+        object(),
+    )
+    type_text_error = await manager._handle_session_request(
+        {"command": "type_text", "text": "Hi"},
+        "client",
+        peer,
+        object(),
+    )
+    compact_empty = await manager._handle_session_request(
+        {"command": "play_compact_macro", "tokens": []},
+        "client",
+        peer,
+        object(),
+    )
+    compact_error = await manager._handle_session_request(
+        {"command": "play_compact_macro", "tokens": ["key_a"]},
+        "client",
+        peer,
+        object(),
+    )
+
+    assert create_missing == {"status": "error", "message": "macro payload required"}
+    assert update_missing == {"status": "error", "message": "macro payload required"}
+    assert type_text_error == {"status": "error", "message": "bad macro"}
+    assert compact_empty == {"status": "error", "message": "tokens required"}
+    assert compact_error == {"status": "error", "message": "bad macro"}
+
+
+@pytest.mark.asyncio
+async def test_adhoc_macro_payload_reports_daemon_failures() -> None:
+    manager = SessionManager()
+    peer = PeerCredentials(pid=1, uid=1000, gid=1000)
+    payload = {
+        "command": "play_macro_payload",
+        "macro_events": [{"type": 1, "code": 30, "value": 1, "t_us": 0}],
+    }
+
+    manager.client.send_command = AsyncMock(side_effect=OSError("daemon down"))
+    unavailable = await manager._handle_session_request(payload, "client", peer, object())
+
+    manager.client.send_command = AsyncMock(
+        return_value=Response(status="error", error="play failed")
+    )
+    failed = await manager._handle_session_request(payload, "client", peer, object())
+
+    assert unavailable == {"status": "error", "message": "Daemon unavailable"}
+    assert failed == {"status": "error", "message": "play failed"}
+
+
+@pytest.mark.asyncio
+async def test_capture_and_diagnostics_commands_cover_remaining_branches(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = SessionManager()
+    manager.security_policy.recording_unlock_required = False
+    peer = PeerCredentials(pid=1, uid=1000, gid=1000)
+    writer = object()
+    get_devices = AsyncMock(return_value=[{"name": "Keyboard"}])
+    capture_read = AsyncMock(return_value={"status": "ok", "events": []})
+    update_selected = Mock()
+    monkeypatch.setattr(session_recording_module, "get_devices_for_recording", get_devices)
+    monkeypatch.setattr(session_recording_module, "capture_read", capture_read)
+    monkeypatch.setattr(
+        session_recording_module,
+        "update_selected_recording_devices_cache",
+        update_selected,
+    )
+
+    devices = await manager._handle_session_request(
+        {"command": "list_devices_for_recording", "include_other": True},
+        "client",
+        peer,
+        writer,
+    )
+    read = await manager._handle_session_request(
+        {"command": "capture_read", "hardware_id": "1234:5678"},
+        "client",
+        peer,
+        writer,
+    )
+    combo_missing = await manager._handle_session_request(
+        {"command": "capture_combo"},
+        "client",
+        peer,
+        writer,
+    )
+
+    manager.client.send_command = AsyncMock(side_effect=OSError("daemon down"))
+    diagnostics_unavailable = await manager._handle_session_request(
+        {"command": "set_diagnostics", "enabled": True},
+        "client",
+        peer,
+        writer,
+    )
+
+    manager.client.send_command = AsyncMock(
+        return_value=Response(status="ok", data={"enabled": True})
+    )
+    diagnostics_ok = await manager._handle_session_request(
+        {
+            "command": "set_diagnostics",
+            "enabled": True,
+            "interval": 2,
+            "categories": ["runtime", "", "devices"],
+        },
+        "client",
+        peer,
+        writer,
+    )
+
+    manager.client.send_command = AsyncMock(
+        return_value=Response(status="error", error="bad category")
+    )
+    diagnostics_error = await manager._handle_session_request(
+        {"command": "set_diagnostics"},
+        "client",
+        peer,
+        writer,
+    )
+
+    assert devices == {"status": "ok", "devices": [{"name": "Keyboard"}]}
+    assert read == {"status": "ok", "events": []}
+    assert combo_missing == {"error": "missing profile_name"}
+    assert diagnostics_unavailable == {"status": "error", "message": "Daemon unavailable"}
+    assert diagnostics_ok == {"status": "ok", "data": {"enabled": True}}
+    assert diagnostics_error == {"status": "error", "message": "bad category"}
+    get_devices.assert_awaited_once_with(
+        manager,
+        ["keyboard", "gamepad", "mouse", "touchpad", "pointstick", "other"],
+        include_grabbed=True,
+    )
+    assert manager.recording_state.devices_cache == [{"name": "Keyboard"}]
+    assert manager.recording_state.devices_cache_ready is True
+    update_selected.assert_called_once_with(manager)
+    sent = manager.client.send_command.await_args.args[0]
+    assert sent.command == CommandType.SET_DIAGNOSTICS
 
 
 @pytest.mark.asyncio

--- a/tests/session/test_session_manager_command_runtime.py
+++ b/tests/session/test_session_manager_command_runtime.py
@@ -1131,6 +1131,15 @@ async def test_list_macros_include_slots_syncs_slots_from_daemon() -> None:
 
 
 @pytest.mark.asyncio
+async def test_sync_pending_macro_slots_does_not_mask_runtime_errors() -> None:
+    manager = SessionManager()
+    manager.client.send_command = AsyncMock(side_effect=RuntimeError("local bug"))
+
+    with pytest.raises(RuntimeError, match="local bug"):
+        await session_recording_module.sync_pending_macro_slots_from_daemon(manager)
+
+
+@pytest.mark.asyncio
 async def test_play_macro_slot_trigger_rejects_empty_slot() -> None:
     manager = SessionManager()
     manager.client.send_command = AsyncMock(

--- a/tests/session/test_session_manager_connect_loop.py
+++ b/tests/session/test_session_manager_connect_loop.py
@@ -73,6 +73,9 @@ async def test_connect_loop_requests_session_restart_after_established_disconnec
         async def wait_disconnected(self) -> None:
             return None
 
+        async def send_command(self, _command: object) -> Response:
+            return Response(status="ok", data={"count": 1})
+
     manager = SessionManager()
     manager.running = True
     manager.restart_on_daemon_disconnect = True

--- a/tests/session/test_session_manager_profile_apply.py
+++ b/tests/session/test_session_manager_profile_apply.py
@@ -309,6 +309,38 @@ async def test_apply_resolved_device_profile_retries_after_grab_timeout(
 
 
 @pytest.mark.asyncio
+async def test_apply_resolved_device_profile_logs_unexpected_grab_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    manager = SessionManager()
+    hardware_id = "1234:5678"
+    resolved = ResolvedDeviceProfile(
+        hardware_id=hardware_id,
+        active_profile_names=["Desktop"],
+        mappings={"btn_side": MappingAction(action_type=ActionType.KEYBOARD, target="key_f13")},
+    )
+    manager.hardware.get_hardware = lambda _hardware_id: SimpleNamespace(  # type: ignore[assignment]
+        hardware_id=hardware_id,
+        name="Test Mouse",
+        evdev_devices=[SimpleNamespace(id="mouse", path="/dev/input/event10")],
+        buttons=[SimpleNamespace(id="btn_side", evdev="btn_side", source="mouse")],
+    )
+    manager.client.send_command = AsyncMock(side_effect=RuntimeError("grab bug"))
+    manager.send_notification = Mock()  # type: ignore[method-assign]
+    schedule_grab_retry = Mock()
+    monkeypatch.setattr(session_profiles_module, "schedule_grab_retry", schedule_grab_retry)
+
+    with caplog.at_level(logging.ERROR, logger="keymasq-session"):
+        await session_profiles_module.apply_resolved_device_profile(manager, hardware_id, resolved)
+
+    assert "Unexpected failure grabbing device 1234:5678" in caplog.text
+    assert "grab bug" in caplog.text
+    manager.send_notification.assert_not_called()  # type: ignore[attr-defined]
+    schedule_grab_retry.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_apply_resolved_device_profile_waits_when_daemon_reports_no_live_interfaces() -> None:
     manager = SessionManager()
     hardware_id = "1234:5678"

--- a/tests/session/test_session_manager_profile_resolution.py
+++ b/tests/session/test_session_manager_profile_resolution.py
@@ -217,7 +217,8 @@ async def test_topology_refresh_retries_after_reevaluate_failure(
         session_manager_module.TOPOLOGY_REFRESH_DEBOUNCE_S,
         session_manager_module.TOPOLOGY_REFRESH_RETRY_S,
     ]
-    assert "Topology refresh failed: refresh boom" in caplog.text
+    assert "Unexpected topology refresh failure" in caplog.text
+    assert "refresh boom" in caplog.text
     assert reevaluate_profiles.await_count == 2
     assert manager.profile_state.topology_refresh_task is None
 
@@ -619,3 +620,22 @@ async def test_reevaluate_profiles_plays_lifecycle_macros_once_per_transition(
         "gaming_enter",
         "gaming_leave",
     ]
+
+
+@pytest.mark.asyncio
+async def test_profile_lifecycle_macro_logs_unexpected_failure(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    manager = SessionManager()
+    manager.client.send_command = AsyncMock(side_effect=RuntimeError("macro bug"))
+
+    with caplog.at_level("ERROR", logger="keymasq-session"):
+        await session_profiles_module.play_profile_lifecycle_macro(
+            manager,
+            "desktop_enter",
+            profile_name="Desktop",
+            transition="activation",
+        )
+
+    assert "Unexpected failure playing activation macro 'desktop_enter'" in caplog.text
+    assert "macro bug" in caplog.text

--- a/tests/session/test_session_manager_recording_settings.py
+++ b/tests/session/test_session_manager_recording_settings.py
@@ -294,6 +294,24 @@ async def test_get_devices_for_recording_uses_daemon_grabbed_state_only() -> Non
 
 
 @pytest.mark.asyncio
+async def test_get_devices_for_recording_logs_unexpected_failure(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    manager = SessionManager()
+    manager.client.send_command = AsyncMock(side_effect=RuntimeError("list bug"))
+
+    with caplog.at_level(logging.ERROR, logger="keymasq-session"):
+        devices = await session_recording_module.get_devices_for_recording(
+            manager,
+            ["keyboard"],
+        )
+
+    assert devices == []
+    assert "Unexpected failure listing devices for recording" in caplog.text
+    assert "list bug" in caplog.text
+
+
+@pytest.mark.asyncio
 async def test_start_recording_defaults_to_recommended_sources_only() -> None:
     manager = SessionManager()
     sent_payloads: list[dict[str, object]] = []

--- a/tests/test_config_loading.py
+++ b/tests/test_config_loading.py
@@ -42,6 +42,34 @@ async def test_load_config_files_collects_failures_in_non_strict_mode(
 
 
 @pytest.mark.asyncio
+async def test_load_config_files_logs_unexpected_failures(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    config_dir = tmp_path / "configs"
+    config_dir.mkdir()
+    broken_path = config_dir / "broken.toml"
+    broken_path.write_text('name = "Broken"\n', encoding="utf-8")
+    logger = logging.getLogger("tests.config_loading")
+
+    def _raise_loader_bug(_path: Path) -> str:
+        raise RuntimeError("loader failed")
+
+    with caplog.at_level(logging.ERROR, logger=logger.name):
+        loaded = await load_config_files(
+            config_dir,
+            config_kind="test",
+            strict=False,
+            load_config=_raise_loader_bug,
+            logger=logger,
+        )
+
+    assert loaded == []
+    assert f"Unexpected error while loading test config {broken_path}" in caplog.text
+    assert "loader failed" in caplog.text
+
+
+@pytest.mark.asyncio
 async def test_load_config_files_raises_collected_failures_in_strict_mode(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -1,3 +1,4 @@
+import logging
 import os
 from pathlib import Path
 from types import SimpleNamespace
@@ -218,6 +219,38 @@ def test_find_all_interfaces_closes_devices_when_scan_raises(
 
     assert find_all_interfaces("1234", "5678") == []
     assert closed_paths == ["/dev/input/event1", "/dev/input/event2"]
+
+
+def test_find_all_interfaces_logs_unexpected_probe_failure(
+    caplog: pytest.LogCaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    closed_paths: list[str] = []
+
+    class _FakeInputDevice:
+        def __init__(self, path: str) -> None:
+            self.path = path
+            self.info = SimpleNamespace(vendor=0x1234, product=0x5678)
+            self.name = "Device"
+
+        def close(self) -> None:
+            closed_paths.append(self.path)
+
+    monkeypatch.setattr("evdev.list_devices", lambda: ["/dev/input/event1"])
+    monkeypatch.setattr("evdev.InputDevice", _FakeInputDevice)
+    monkeypatch.setattr(
+        "keymasq.common.devices.resolve_stable_path",
+        lambda _path: "/dev/input/by-id/bad-device",
+    )
+    monkeypatch.setattr(
+        "keymasq.common.devices.get_interface_id",
+        lambda _stable_path: (_ for _ in ()).throw(ValueError("bad interface id")),
+    )
+    caplog.set_level(logging.ERROR, logger="keymasq.common.devices")
+
+    assert find_all_interfaces("1234", "5678") == []
+    assert closed_paths == ["/dev/input/event1"]
+    assert "Unexpected failure probing evdev interface /dev/input/event1" in caplog.text
 
 
 def test_detect_input_classes_reports_combo_keyboard_mouse_pointstick() -> None:

--- a/tests/test_gnome_listener.py
+++ b/tests/test_gnome_listener.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 from unittest.mock import AsyncMock
 
 import pytest
@@ -28,6 +29,27 @@ class _FakeWriter:
 class _EofReader:
     async def readline(self) -> bytes:
         return b""
+
+
+class _ScriptedReader:
+    def __init__(self, chunks: list[bytes]) -> None:
+        self._chunks = chunks
+
+    async def readline(self) -> bytes:
+        if not self._chunks:
+            return b""
+        return self._chunks.pop(0)
+
+
+class _CloseFailWriter(_FakeWriter):
+    async def wait_closed(self) -> None:
+        raise RuntimeError("close bug")
+
+
+class _WriteFailWriter(_FakeWriter):
+    def write(self, data: bytes) -> None:
+        _ = data
+        raise RuntimeError("write bug")
 
 
 _UNSET = object()
@@ -321,6 +343,94 @@ async def test_gnome_stale_bridge_reader_does_not_clear_new_connection() -> None
 
 
 @pytest.mark.asyncio
+async def test_gnome_bridge_read_loop_logs_and_skips_malformed_frames(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    observed: list[tuple[str, str, list[str]]] = []
+
+    async def _callback(window_class: str, window_title: str, tags: list[str]) -> None:
+        observed.append((window_class, window_title, tags))
+
+    listener = GnomeListener(_callback)
+    listener.running = True
+    writer = _FakeWriter()
+    listener._writer = writer
+    listener._bridge_connected = True
+    reader = _ScriptedReader(
+        [
+            b"\xff\n",
+            b"{not-json\n",
+            b"[]\n",
+            gnome_module.json.dumps(
+                {
+                    "type": "focus_changed",
+                    "app_id": "org.gnome.Nautilus",
+                    "title": "Home",
+                }
+            ).encode("utf-8")
+            + b"\n",
+        ]
+    )
+
+    with caplog.at_level(logging.DEBUG, logger="keymasq-session.listeners.gnome"):
+        await listener._bridge_read_loop(reader, writer)
+
+    assert observed == [("org.gnome.Nautilus", "Home", [])]
+    assert "Ignoring GNOME bridge message with invalid UTF-8" in caplog.text
+    assert "Ignoring malformed GNOME bridge JSON message" in caplog.text
+    assert "Ignoring GNOME bridge JSON message that is not an object" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_gnome_bridge_read_loop_logs_unexpected_handler_errors(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    async def _callback(_window_class: str, _window_title: str, _tags: list[str]) -> None:
+        raise RuntimeError("callback bug")
+
+    listener = GnomeListener(_callback)
+    listener.running = True
+    writer = _FakeWriter()
+    listener._writer = writer
+    listener._bridge_connected = True
+    reader = _ScriptedReader(
+        [
+            gnome_module.json.dumps(
+                {
+                    "type": "focus_changed",
+                    "app_id": "org.gnome.Nautilus",
+                    "title": "Home",
+                }
+            ).encode("utf-8")
+            + b"\n",
+        ]
+    )
+
+    with caplog.at_level(logging.ERROR, logger="keymasq-session.listeners.gnome"):
+        await listener._bridge_read_loop(reader, writer)
+
+    assert "Unexpected GNOME bridge read loop error" in caplog.text
+    assert "callback bug" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_gnome_bridge_read_loop_logs_unexpected_close_errors(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    listener = GnomeListener(lambda *_args: asyncio.sleep(0))
+    listener.running = True
+    writer = _CloseFailWriter()
+    listener._writer = writer
+    listener._bridge_connected = True
+
+    with caplog.at_level(logging.ERROR, logger="keymasq-session.listeners.gnome"):
+        await listener._bridge_read_loop(_EofReader(), writer)
+
+    assert "Unexpected failure while closing GNOME bridge client writer" in caplog.text
+    assert "close bug" in caplog.text
+
+
+@pytest.mark.asyncio
 async def test_gnome_hello_reports_stale_bridge_protocol_warning() -> None:
     listener = GnomeListener(lambda *_args: asyncio.sleep(0))
     listener.running = True
@@ -395,6 +505,21 @@ async def test_gnome_get_active_window_queries_bridge_when_cache_empty() -> None
     assert await listener.get_active_window() == ("tools.keymasq.ListenerLab", "Alpha", [])
     assert observed == [("tools.keymasq.ListenerLab", "Alpha", [])]
     assert listener._writer.payloads == [{"type": "get_active_window", "request_id": 1}]
+
+
+@pytest.mark.asyncio
+async def test_gnome_send_request_logs_unexpected_writer_errors(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    listener = GnomeListener(lambda *_args: asyncio.sleep(0))
+    listener._writer = _WriteFailWriter()
+
+    with caplog.at_level(logging.ERROR, logger="keymasq-session.listeners.gnome"):
+        assert await listener._send_request({"type": "get_active_window"}, timeout=0.1) is None
+
+    assert "Unexpected GNOME bridge get_active_window request failure" in caplog.text
+    assert "write bug" in caplog.text
+    assert listener._pending_window == {}
 
 
 @pytest.mark.asyncio

--- a/tests/test_hyprland_listener.py
+++ b/tests/test_hyprland_listener.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 from unittest.mock import AsyncMock
 
 import pytest
@@ -49,6 +50,26 @@ async def test_hyprland_get_active_window_normalizes_tags() -> None:
     assert await listener.get_active_window() == ("term", "Shell", [])
 
 
+@pytest.mark.asyncio
+async def test_hyprland_active_window_logs_malformed_responses(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    listener = HyprlandListener(_noop_callback)
+    listener._send_cmd = AsyncMock(  # type: ignore[method-assign]
+        side_effect=[
+            b"{not-json",
+            b"[]",
+        ]
+    )
+
+    with caplog.at_level(logging.DEBUG, logger="keymasq-session.listeners.hyprland"):
+        assert await listener.get_active_window() == ("", "", [])
+        assert await listener._get_window_tags() == []
+
+    assert "Hyprland active window response was malformed JSON" in caplog.text
+    assert "Hyprland active window tags response was not a JSON object" in caplog.text
+
+
 class _FakeWriter:
     def __init__(self) -> None:
         self.closed = False
@@ -65,6 +86,11 @@ class _FakeWriter:
 
     async def wait_closed(self) -> None:
         return None
+
+
+class _CloseFailWriter(_FakeWriter):
+    async def wait_closed(self) -> None:
+        raise RuntimeError("close bug")
 
 
 class _FakeReader:
@@ -128,3 +154,54 @@ async def test_hyprland_send_cmd_times_out_stalled_read(monkeypatch) -> None:
 
     assert response is None
     assert writer.closed is True
+
+
+@pytest.mark.asyncio
+async def test_hyprland_send_cmd_logs_unexpected_command_errors(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    listener = HyprlandListener(_noop_callback)
+    listener.cmd_socket_path = "/tmp/hypr.sock"
+
+    async def fake_open_unix_connection(path: str) -> tuple[_FakeReader, _FakeWriter]:
+        assert path == "/tmp/hypr.sock"
+        raise RuntimeError("connect bug")
+
+    monkeypatch.setattr(
+        hyprland_module.asyncio,
+        "open_unix_connection",
+        fake_open_unix_connection,
+    )
+
+    with caplog.at_level(logging.ERROR, logger="keymasq-session.listeners.hyprland"):
+        assert await listener._send_cmd("cursorpos", read_size=256) is None
+
+    assert "Unexpected Hyprland command failure" in caplog.text
+    assert "connect bug" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_hyprland_send_cmd_logs_unexpected_close_errors(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    listener = HyprlandListener(_noop_callback)
+    writer = _CloseFailWriter()
+    listener.cmd_socket_path = "/tmp/hypr.sock"
+
+    async def fake_open_unix_connection(path: str) -> tuple[_FakeReader, _CloseFailWriter]:
+        assert path == "/tmp/hypr.sock"
+        return _FakeReader([b"100,200"]), writer
+
+    monkeypatch.setattr(
+        hyprland_module.asyncio,
+        "open_unix_connection",
+        fake_open_unix_connection,
+    )
+
+    with caplog.at_level(logging.ERROR, logger="keymasq-session.listeners.hyprland"):
+        assert await listener._send_cmd("cursorpos", read_size=256) == b"100,200"
+
+    assert "Unexpected failure while closing Hyprland command writer" in caplog.text
+    assert "close bug" in caplog.text

--- a/tests/test_kde_listener.py
+++ b/tests/test_kde_listener.py
@@ -293,7 +293,7 @@ async def _run_fake_ephemeral_kwin_script(
             result_future=future,
             timeout=timeout,
         )
-    except Exception as exc:
+    except (OSError, RuntimeError, TimeoutError, TypeError, ValueError) as exc:
         result = exc
 
     return result, calls, script_path.exists()

--- a/tests/test_kde_listener.py
+++ b/tests/test_kde_listener.py
@@ -44,6 +44,11 @@ def test_parse_kde_cursor_payload_accepts_wrapped_json_string() -> None:
     assert parse_kde_cursor_payload(payload) == ("abc123", 123, 456)
 
 
+def test_parse_kde_cursor_payload_rejects_overflowing_coordinates() -> None:
+    payload = '{"id":"abc123","x":"1e100000","y":456}'
+    assert parse_kde_cursor_payload(payload) is None
+
+
 def test_parse_kde_dispatch_payload_valid() -> None:
     payload = '{"id":"abc123","ok":true,"message":"ok"}'
     assert parse_kde_dispatch_payload(payload) == ("abc123", True, "ok")

--- a/tests/test_listener_slurp_cursor.py
+++ b/tests/test_listener_slurp_cursor.py
@@ -108,7 +108,7 @@ async def test_capture_slurp_cursor_position_returns_point_and_triggers_macro() 
 async def test_capture_slurp_cursor_position_returns_none_on_capture_exception(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    slurp = _FakeSlurp(error=RuntimeError("boom"))
+    slurp = _FakeSlurp(error=OSError("boom"))
     client = _FakeClient()
 
     with caplog.at_level(logging.DEBUG):
@@ -120,3 +120,22 @@ async def test_capture_slurp_cursor_position_returns_none_on_capture_exception(
 
     assert result is None
     assert "Slurp cursor capture failed: boom" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_capture_slurp_cursor_position_logs_unexpected_failure(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    slurp = _FakeSlurp(error=RuntimeError("capture bug"))
+    client = _FakeClient()
+
+    with caplog.at_level(logging.ERROR):
+        result = await capture_slurp_cursor_position(
+            slurp,
+            client,  # type: ignore[arg-type]
+            logging.getLogger("keymasq-test"),
+        )
+
+    assert result is None
+    assert "Unexpected slurp cursor capture failure" in caplog.text
+    assert "capture bug" in caplog.text

--- a/tests/test_listener_socket_helpers.py
+++ b/tests/test_listener_socket_helpers.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 import socket
 import tempfile
 from pathlib import Path
@@ -72,3 +73,49 @@ async def test_unix_socket_connectable_returns_false_for_missing_socket() -> Non
         assert (
             await unix_socket_connectable(Path(tmp_dir) / "missing.sock", timeout_s=0.01) is False
         )
+
+
+@pytest.mark.asyncio
+async def test_unix_socket_connectable_logs_unexpected_probe_errors(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    async def _raise_probe_error(*, path: str) -> tuple[object, object]:
+        _ = path
+        raise RuntimeError("probe bug")
+
+    monkeypatch.setattr(asyncio, "open_unix_connection", _raise_probe_error)
+
+    with caplog.at_level(logging.ERROR, logger="keymasq-session.listeners.socket_helpers"):
+        assert await unix_socket_connectable(Path("/tmp/keymasq-test.sock")) is False
+
+    assert "Unexpected error probing Unix socket /tmp/keymasq-test.sock" in caplog.text
+    assert "probe bug" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_unix_socket_connectable_logs_unexpected_close_errors(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    class _Writer:
+        def close(self) -> None:
+            return
+
+        async def wait_closed(self) -> None:
+            raise RuntimeError("close bug")
+
+    async def _connect(*, path: str) -> tuple[object, _Writer]:
+        _ = path
+        return object(), _Writer()
+
+    monkeypatch.setattr(asyncio, "open_unix_connection", _connect)
+
+    with caplog.at_level(logging.ERROR, logger="keymasq-session.listeners.socket_helpers"):
+        assert await unix_socket_connectable(Path("/tmp/keymasq-test.sock")) is True
+
+    assert (
+        "Unexpected error closing Unix socket probe connection /tmp/keymasq-test.sock"
+        in caplog.text
+    )
+    assert "close bug" in caplog.text

--- a/tests/test_macro_store.py
+++ b/tests/test_macro_store.py
@@ -1,6 +1,6 @@
 import logging
 import lzma
-from collections.abc import Callable, Iterable, Iterator
+from collections.abc import Callable, Generator, Iterable
 from contextlib import contextmanager
 from pathlib import Path
 
@@ -20,7 +20,7 @@ def _run_before_mutation_guard(
     callback_ran = False
 
     @contextmanager
-    def mutation_guard() -> Iterator[None]:
+    def mutation_guard() -> Generator[None, None, None]:
         nonlocal callback_ran
         if not callback_ran:
             callback_ran = True
@@ -379,5 +379,5 @@ def test_macro_store_list_meta_logs_unreadable_files(
     with caplog.at_level(logging.WARNING, logger="keymasqd.macros"):
         assert store.list_meta() == []
 
-    assert "Skipping unreadable macro file" in caplog.text
+    assert "Skipping corrupt compressed macro file" in caplog.text
     assert "broken.kmacro.xz" in caplog.text

--- a/tests/test_niri_listener.py
+++ b/tests/test_niri_listener.py
@@ -188,7 +188,7 @@ async def test_send_cmd_request_logs_malformed_replies(
 
 
 @pytest.mark.asyncio
-async def test_send_cmd_request_logs_unexpected_write_errors(
+async def test_send_cmd_request_resets_dropped_command_socket_errors(
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
@@ -201,15 +201,40 @@ async def test_send_cmd_request_logs_unexpected_write_errors(
 
     monkeypatch.setattr(listener, "_ensure_cmd_connection", fake_ensure)
 
-    with caplog.at_level(logging.ERROR, logger="keymasq-session.listeners.niri"):
+    with caplog.at_level(logging.DEBUG, logger="keymasq-session.listeners.niri"):
         ok, body = await listener._send_cmd_request({"Action": {}}, timeout_s=0.5)
 
     assert ok is False
     assert body is None
     assert listener._cmd_reader is None
     assert listener._cmd_writer is None
-    assert "Unexpected Niri command request failure" in caplog.text
+    assert "Niri command socket dropped" in caplog.text
     assert "write bug" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_send_cmd_request_resets_closed_command_socket(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    listener = NiriListener(_noop_callback)
+    listener._cmd_reader = _FakeReader([b""])  # type: ignore[assignment]
+    listener._cmd_writer = _FakeWriter()  # type: ignore[assignment]
+
+    async def fake_ensure() -> bool:
+        return True
+
+    monkeypatch.setattr(listener, "_ensure_cmd_connection", fake_ensure)
+
+    with caplog.at_level(logging.DEBUG, logger="keymasq-session.listeners.niri"):
+        ok, body = await listener._send_cmd_request({"Action": {}}, timeout_s=0.5)
+
+    assert ok is False
+    assert body is None
+    assert listener._cmd_reader is None
+    assert listener._cmd_writer is None
+    assert "Niri command socket dropped" in caplog.text
+    assert "Niri command socket closed" in caplog.text
 
 
 @pytest.mark.asyncio

--- a/tests/test_niri_listener.py
+++ b/tests/test_niri_listener.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 
 import pytest
 
@@ -33,6 +34,17 @@ class _FakeWriter:
 
     async def wait_closed(self) -> None:
         return None
+
+
+class _WriteFailWriter(_FakeWriter):
+    def write(self, data: bytes) -> None:
+        _ = data
+        raise RuntimeError("write bug")
+
+
+class _CloseFailWriter(_FakeWriter):
+    async def wait_closed(self) -> None:
+        raise RuntimeError("close bug")
 
 
 class _FakeReader:
@@ -146,6 +158,81 @@ async def test_send_cmd_request_retries_after_eof(monkeypatch) -> None:
 
     assert ok is True
     assert body == "Handled"
+
+
+@pytest.mark.asyncio
+async def test_send_cmd_request_logs_malformed_replies(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    listener = NiriListener(_noop_callback)
+    pairs = [
+        (_FakeReader([b"{not-json\n"]), _FakeWriter()),
+    ]
+
+    async def fake_ensure() -> bool:
+        if listener._cmd_reader is None or listener._cmd_writer is None:
+            if not pairs:
+                return False
+            listener._cmd_reader, listener._cmd_writer = pairs.pop(0)  # type: ignore[assignment]
+        return True
+
+    monkeypatch.setattr(listener, "_ensure_cmd_connection", fake_ensure)
+
+    with caplog.at_level(logging.DEBUG, logger="keymasq-session.listeners.niri"):
+        ok, body = await listener._send_cmd_request({"Action": {}}, timeout_s=0.5)
+
+    assert ok is False
+    assert body is None
+    assert "Niri command reply was invalid" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_send_cmd_request_logs_unexpected_write_errors(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    listener = NiriListener(_noop_callback)
+    listener._cmd_reader = _FakeReader([b'{"Ok":"Handled"}\n'])  # type: ignore[assignment]
+    listener._cmd_writer = _WriteFailWriter()  # type: ignore[assignment]
+
+    async def fake_ensure() -> bool:
+        return True
+
+    monkeypatch.setattr(listener, "_ensure_cmd_connection", fake_ensure)
+
+    with caplog.at_level(logging.ERROR, logger="keymasq-session.listeners.niri"):
+        ok, body = await listener._send_cmd_request({"Action": {}}, timeout_s=0.5)
+
+    assert ok is False
+    assert body is None
+    assert listener._cmd_reader is None
+    assert listener._cmd_writer is None
+    assert "Unexpected Niri command request failure" in caplog.text
+    assert "write bug" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_send_cmd_request_logs_unexpected_close_errors(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    listener = NiriListener(_noop_callback)
+    listener._cmd_reader = _FakeReader([b"{not-json\n"])  # type: ignore[assignment]
+    listener._cmd_writer = _CloseFailWriter()  # type: ignore[assignment]
+
+    async def fake_ensure() -> bool:
+        return True
+
+    monkeypatch.setattr(listener, "_ensure_cmd_connection", fake_ensure)
+
+    with caplog.at_level(logging.ERROR, logger="keymasq-session.listeners.niri"):
+        ok, body = await listener._send_cmd_request({"Action": {}}, timeout_s=0.5)
+
+    assert ok is False
+    assert body is None
+    assert "Unexpected failure while closing failed Niri command writer" in caplog.text
+    assert "close bug" in caplog.text
 
 
 @pytest.mark.asyncio

--- a/tests/test_output_helpers.py
+++ b/tests/test_output_helpers.py
@@ -1,3 +1,4 @@
+import logging
 from unittest.mock import MagicMock
 
 import evdev
@@ -38,7 +39,9 @@ def test_resolve_gamepad_axis_code_resolves_custom_abs_targets() -> None:
     assert output_helpers.resolve_gamepad_axis_code("abs_nope") is None
 
 
-def test_emit_mouse_move_supports_absolute_mode_and_swallows_errors() -> None:
+def test_emit_mouse_move_supports_absolute_mode_and_swallows_errors(
+    caplog,
+) -> None:
     uinput = MagicMock()
 
     output_helpers.emit_mouse_move(uinput, 12, -7, absolute=True)
@@ -52,6 +55,15 @@ def test_emit_mouse_move_supports_absolute_mode_and_swallows_errors() -> None:
     ]
     assert uinput.syn.call_count == 2
 
+    missing_device = MagicMock()
+    missing_device.write.side_effect = OSError("gone")
+    with caplog.at_level(logging.DEBUG, logger="keymasqd.output_helpers"):
+        output_helpers.emit_mouse_move(missing_device, 1, 2)
+    assert "Failed to emit mouse movement" in caplog.text
+
+    caplog.clear()
     broken = MagicMock()
     broken.write.side_effect = RuntimeError("boom")
-    output_helpers.emit_mouse_move(broken, 1, 2)
+    with caplog.at_level(logging.ERROR, logger="keymasqd.output_helpers"):
+        output_helpers.emit_mouse_move(broken, 1, 2)
+    assert "Unexpected failure emitting mouse movement" in caplog.text

--- a/tests/test_record_cli.py
+++ b/tests/test_record_cli.py
@@ -484,3 +484,28 @@ def test_main_error_emits_json_and_exits(
     payload = json.loads(capsys.readouterr().out.strip())
     assert payload["status"] == "error"
     assert "denied" in payload["message"]
+
+
+def test_main_unexpected_error_logs_exception(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    monkeypatch.setattr(sys, "argv", ["keymasq-record", "status", "--uid", "1000"])
+    monkeypatch.setattr(record, "_require_privileged_caller", lambda: None)
+
+    def _raise(_uid: int) -> dict[str, object]:
+        raise RuntimeError("resolver broke")
+
+    monkeypatch.setattr(record, "resolve_unlock_status", _raise)
+
+    with caplog.at_level("ERROR", logger="keymasq.record"):
+        with pytest.raises(SystemExit) as excinfo:
+            record.main()
+
+    assert excinfo.value.code == 1
+    payload = json.loads(capsys.readouterr().out.strip())
+    assert payload["status"] == "error"
+    assert "resolver broke" in payload["message"]
+    assert "Unexpected keymasq-record failure" in caplog.text
+    assert "RuntimeError: resolver broke" in caplog.text

--- a/tests/test_recording_extended.py
+++ b/tests/test_recording_extended.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 from pathlib import Path
 from unittest.mock import AsyncMock
 
@@ -143,6 +144,44 @@ async def test_recording_start_ignores_invalid_device_path(monkeypatch):
     stop_result = await recorder.stop()
 
     assert stop_result["event_count"] == 0
+
+
+@pytest.mark.asyncio
+async def test_recording_start_logs_expected_device_open_error(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    def _bad_device(_path: str):
+        raise OSError("bad path")
+
+    monkeypatch.setattr(evdev, "InputDevice", _bad_device)
+
+    recorder = RecordingManager()
+    with caplog.at_level(logging.DEBUG, logger="keymasqd.recording"):
+        result = await recorder.start([{"path": "/does/not/exist"}])
+
+    assert result == {"status": "ok"}
+    assert "Failed to open extra recording device /does/not/exist" in caplog.text
+    await recorder.stop()
+
+
+@pytest.mark.asyncio
+async def test_recording_start_logs_unexpected_device_open_error(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    def _broken_device(_path: str):
+        raise RuntimeError("driver bug")
+
+    monkeypatch.setattr(evdev, "InputDevice", _broken_device)
+
+    recorder = RecordingManager()
+    with caplog.at_level(logging.ERROR, logger="keymasqd.recording"):
+        result = await recorder.start([{"path": "/dev/input/event99"}])
+
+    assert result == {"status": "ok"}
+    assert "Unexpected failure opening extra recording device /dev/input/event99" in caplog.text
+    await recorder.stop()
 
 
 @pytest.mark.asyncio
@@ -322,6 +361,25 @@ async def test_recording_spool_finish_cleans_spool_file_on_fatal_error(
         await spool.finish()
 
     assert list(tmp_path.glob("recording-*.jsonl")) == []
+
+
+@pytest.mark.asyncio
+async def test_recording_spool_records_unexpected_flush_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    spool = RecordingSpool(tmp_path, memory_event_limit=1)
+
+    def fail_write(_chunk: list[dict[str, object]]) -> None:
+        raise AssertionError("bad recording event")
+
+    monkeypatch.setattr(spool, "_write_chunk", fail_write)
+    spool.append({"device_type": "keyboard", "t_us": 0})
+
+    with pytest.raises(RuntimeError, match="Recording spool failed"):
+        await spool.finish()
+
+    assert isinstance(spool.failed, AssertionError)
 
 
 @pytest.mark.asyncio

--- a/tests/test_recording_guard.py
+++ b/tests/test_recording_guard.py
@@ -33,6 +33,25 @@ def test_parse_unlock_expires_at_invalid_or_missing(tmp_path: Path) -> None:
     assert recording_guard.parse_unlock_expires_at(invalid) is None
 
 
+def test_parse_unlock_expires_at_logs_read_failure(
+    caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    lease = tmp_path / "lease"
+    lease.touch()
+    original_read_text = Path.read_text
+
+    def read_text(path: Path, *args: object, **kwargs: object) -> str:
+        if path == lease:
+            raise PermissionError("permission denied")
+        return original_read_text(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", read_text)
+    caplog.set_level(logging.WARNING, logger=recording_guard.__name__)
+
+    assert recording_guard.parse_unlock_expires_at(lease) is None
+    assert "Failed to read recording unlock file" in caplog.text
+
+
 def test_parse_unlock_expires_at_valid(tmp_path: Path) -> None:
     lease = tmp_path / "lease"
     lease.write_text("1234\n", encoding="utf-8")

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -1,6 +1,14 @@
+import logging
+import socket
+import struct
 from pathlib import Path
 
-from keymasq.common.security import command_allowed, load_security_policy, uid_allowed
+from keymasq.common.security import (
+    command_allowed,
+    get_peer_credentials,
+    load_security_policy,
+    uid_allowed,
+)
 
 
 def test_load_security_policy_defaults_when_missing(tmp_path: Path) -> None:
@@ -12,6 +20,33 @@ def test_load_security_policy_defaults_when_missing(tmp_path: Path) -> None:
     assert policy.recording_unlock_required is True
     assert policy.macro_edit_requires_unlock is False
     assert policy.emergency_cancel_combo_enabled is True
+
+
+def test_get_peer_credentials_reads_socket_peercred() -> None:
+    class _Socket:
+        def getsockopt(self, level: int, optname: int, buflen: int) -> bytes:
+            assert level == socket.SOL_SOCKET
+            assert optname == socket.SO_PEERCRED
+            assert buflen == struct.calcsize("3i")
+            return struct.pack("3i", 42, 1000, 1001)
+
+    credentials = get_peer_credentials(_Socket())
+
+    assert credentials is not None
+    assert credentials.pid == 42
+    assert credentials.uid == 1000
+    assert credentials.gid == 1001
+
+
+def test_get_peer_credentials_logs_unexpected_socket_error(caplog) -> None:
+    class _Socket:
+        def getsockopt(self, _level: int, _optname: int, _buflen: int) -> bytes:
+            raise RuntimeError("socket wrapper failed")
+
+    caplog.set_level(logging.ERROR, logger="keymasq.common.security")
+
+    assert get_peer_credentials(_Socket()) is None
+    assert "Unexpected failure reading peer credentials" in caplog.text
 
 
 def test_load_security_policy_overrides_acl(tmp_path: Path) -> None:

--- a/tests/test_session_clients.py
+++ b/tests/test_session_clients.py
@@ -340,8 +340,27 @@ def test_persistent_session_dispatch_event_falls_back_when_idle_add_fails(
 
     connection._dispatch_event({"event": "macro_saved", "name": "example"})
 
-    assert [call["name"] for call in calls] == ["example"]
+    assert calls == []
     assert "Failed to schedule session event callback with GLib" in caplog.text
+    assert "dropping event macro_saved" in caplog.text
+
+
+def test_persistent_session_dispatch_event_drops_when_idle_add_unavailable(
+    caplog: pytest.LogCaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    glib_module = _install_fake_glib(monkeypatch)
+    glib_module.idle_add = None
+    connection = gui_session_client._PersistentSessionConnection()
+    calls: list[dict[str, Any]] = []
+    connection.register_callback("macro_saved", lambda message: calls.append(message))
+    caplog.set_level(logging.WARNING, logger="keymasq.gui.session_client")
+
+    connection._dispatch_event({"event": "macro_saved", "name": "example"})
+
+    assert calls == []
+    assert "GLib.idle_add unavailable" in caplog.text
+    assert "dropping event macro_saved" in caplog.text
 
 
 def test_persistent_session_reader_loop_routes_events_and_response(

--- a/tests/test_session_clients.py
+++ b/tests/test_session_clients.py
@@ -1,23 +1,25 @@
 import asyncio
+import logging
 import queue
 import struct
 import sys
 import threading
 import types
 from collections.abc import Callable
-from typing import Any
+from typing import Any, cast
 
 import pytest
 
 from keymasq.common.ipc import Command, CommandType, Response, encode_response
 from keymasq.gui import session_client as gui_session_client
+from keymasq.session import client as session_client_module
 from keymasq.session.client import KeymasqdClient
 
 
 def test_keymasqd_client_send_command_requires_connection() -> None:
     async def _run() -> None:
         client = KeymasqdClient(event_handler=lambda _event, _data: None)
-        with pytest.raises(RuntimeError):
+        with pytest.raises(ConnectionError, match="Not connected to keymasqd"):
             await client.send_command(Command(command=CommandType.PING, data={}))
 
     asyncio.run(_run())
@@ -89,6 +91,55 @@ def test_keymasqd_client_listen_loop_skips_discarded_response_frame() -> None:
         await client._listen_loop()
 
         assert calls == [(CommandType.PING, {"ok": True})]
+
+    asyncio.run(_run())
+
+
+class _RaisingAsyncReader:
+    def __init__(self, error: Exception) -> None:
+        self.error = error
+
+    async def read(self, _size: int) -> bytes:
+        raise self.error
+
+
+def test_keymasqd_client_listen_loop_logs_read_errors(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    async def _run() -> None:
+        client = KeymasqdClient(event_handler=lambda _event, _data: None)
+        client.reader = cast(asyncio.StreamReader, _RaisingAsyncReader(OSError("read failed")))
+
+        with caplog.at_level(logging.WARNING, logger="keymasq-session.client"):
+            await client._listen_loop()
+
+        assert "Daemon client listen I/O error: read failed" in caplog.text
+        assert client.reader is None
+
+    asyncio.run(_run())
+
+
+def test_keymasqd_client_listen_loop_logs_unexpected_errors(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    async def _run() -> None:
+        def _raise_decode_error(_data: bytes) -> tuple[Response | None, bytes]:
+            raise RuntimeError("decoder failed")
+
+        client = KeymasqdClient(event_handler=lambda _event, _data: None)
+        reader = asyncio.StreamReader()
+        reader.feed_data(encode_response(Response(status="ok")))
+        reader.feed_eof()
+        client.reader = reader
+        monkeypatch.setattr(session_client_module, "decode_response", _raise_decode_error)
+
+        with caplog.at_level(logging.ERROR, logger="keymasq-session.client"):
+            await client._listen_loop()
+
+        assert "Unexpected daemon client listen error" in caplog.text
+        assert "decoder failed" in caplog.text
+        assert client.reader is None
 
     asyncio.run(_run())
 
@@ -274,6 +325,25 @@ def test_persistent_session_dispatch_event_callback_is_one_shot(
     assert idle_returns == [False]
 
 
+def test_persistent_session_dispatch_event_falls_back_when_idle_add_fails(
+    caplog: pytest.LogCaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _idle_add(_callback: Callable[..., Any], *_args: Any) -> bool:
+        raise RuntimeError("main loop unavailable")
+
+    _install_fake_glib(monkeypatch, idle_add=_idle_add)
+    connection = gui_session_client._PersistentSessionConnection()
+    calls: list[dict[str, Any]] = []
+    connection.register_callback("macro_saved", lambda message: calls.append(message))
+    caplog.set_level(logging.WARNING, logger="keymasq.gui.session_client")
+
+    connection._dispatch_event({"event": "macro_saved", "name": "example"})
+
+    assert [call["name"] for call in calls] == ["example"]
+    assert "Failed to schedule session event callback with GLib" in caplog.text
+
+
 def test_persistent_session_reader_loop_routes_events_and_response(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -352,7 +422,7 @@ def test_persistent_session_concurrent_first_connect_uses_one_socket(
             result = connection._ensure_connected(timeout=0.5)  # pyright: ignore[reportPrivateUsage]
             with results_lock:
                 results.append(result)
-        except BaseException as exc:
+        except (OSError, RuntimeError, TimeoutError, TypeError, ValueError, AssertionError) as exc:
             with results_lock:
                 errors.append(exc)
 

--- a/tests/test_session_hardware.py
+++ b/tests/test_session_hardware.py
@@ -334,6 +334,52 @@ def test_hardware_manager_delete_returns_false_for_only_stale_cached_path(
     assert manager.get_hardware("1234:5678") is None
 
 
+def test_hardware_manager_storage_path_match_logs_unexpected_load_errors(
+    temp_config_dir,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    manager = HardwareManager()
+    path = temp_config_dir / "hardware" / "1234_5678.toml"
+
+    def _raise_loader_bug(_path: Path) -> HardwareConfig:
+        raise RuntimeError("loader bug")
+
+    monkeypatch.setattr(manager, "_load_config", _raise_loader_bug)
+
+    with caplog.at_level(logging.ERROR, logger="keymasq-session.hardware"):
+        assert manager._storage_path_matches_hardware_id(path, "1234:5678") is False
+
+    assert f"Unexpected error while checking hardware storage path {path}" in caplog.text
+    assert "loader bug" in caplog.text
+
+
+def test_hardware_manager_delete_logs_unexpected_unlink_errors(
+    temp_config_dir,
+    sample_hardware_config: HardwareConfig,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    manager = HardwareManager()
+    manager.save_hardware(sample_hardware_config)
+    path = temp_config_dir / "hardware" / "1234_5678.toml"
+    path_type = type(path)
+    original_unlink = path_type.unlink
+
+    def _raise_unlink_bug(self: Path, missing_ok: bool = False) -> None:
+        if self == path:
+            raise RuntimeError("unlink bug")
+        original_unlink(self, missing_ok=missing_ok)
+
+    monkeypatch.setattr(path_type, "unlink", _raise_unlink_bug)
+
+    with caplog.at_level(logging.ERROR, logger="keymasq-session.hardware"):
+        assert manager.delete_hardware(sample_hardware_config.hardware_id) is False
+
+    assert f"Unexpected error deleting hardware config {path}" in caplog.text
+    assert "unlink bug" in caplog.text
+
+
 def test_hardware_manager_preserves_keymasq_logical_path(temp_config_dir) -> None:
     manager = HardwareManager()
     config = HardwareConfig(

--- a/tests/test_session_manager_core.py
+++ b/tests/test_session_manager_core.py
@@ -183,6 +183,24 @@ async def test_connect_loop_logs_unexpected_runtime_failures(
     assert manager.connected is False
 
 
+@pytest.mark.asyncio
+async def test_sync_virtual_gamepads_ignores_malformed_daemon_count(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    manager = SessionManager()
+    manager.connected = True
+    manager.virtual_gamepad_count = 2
+    manager.client.send_command = AsyncMock(
+        return_value=Response(status="ok", data={"count": "not-a-number"})
+    )
+
+    with caplog.at_level("WARNING", logger="keymasq-session"):
+        await manager._sync_virtual_gamepads_to_daemon()
+
+    assert manager.virtual_gamepad_count == 2
+    assert "Ignoring malformed virtual gamepad count from keymasqd" in caplog.text
+
+
 def test_signal_handler_only_sets_shutdown_state() -> None:
     manager = SessionManager()
     manager.running = True

--- a/tests/test_session_manager_core.py
+++ b/tests/test_session_manager_core.py
@@ -1,5 +1,7 @@
 import asyncio
 import json
+from types import SimpleNamespace
+from typing import cast
 from unittest.mock import AsyncMock, Mock
 
 import pytest
@@ -77,6 +79,31 @@ class _HangingSessionWriter(_FakeSessionWriter):
 
     def abort(self) -> None:
         self.abort_calls += 1
+
+
+class _FakeSessionServer:
+    def __init__(self) -> None:
+        self.closed = False
+        self.wait_closed_calls = 0
+
+    def close(self) -> None:
+        self.closed = True
+
+    async def wait_closed(self) -> None:
+        self.wait_closed_calls += 1
+
+
+def _inotify_event(wd: int, mask: int, name: str) -> bytes:
+    raw_name = name.encode() + b"\0"
+    return (
+        session_manager_core_module.INOTIFY_EVENT_STRUCT.pack(
+            wd,
+            mask,
+            0,
+            len(raw_name),
+        )
+        + raw_name
+    )
 
 
 @pytest.mark.asyncio
@@ -168,6 +195,50 @@ def test_signal_handler_only_sets_shutdown_state() -> None:
 
 
 @pytest.mark.asyncio
+async def test_start_wires_runtime_tasks_and_stops_on_shutdown(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = SessionManager()
+    added_signals = []
+
+    async def start_session_server() -> None:
+        asyncio.get_running_loop().call_soon(manager._shutdown_event.set)
+
+    async def connect_loop() -> None:
+        await asyncio.sleep(0)
+
+    async def compositor_supervisor_loop(_manager: SessionManager) -> None:
+        await asyncio.sleep(0)
+
+    monkeypatch.setattr(
+        session_manager_core_module.asyncio,
+        "get_event_loop",
+        lambda: SimpleNamespace(
+            add_signal_handler=lambda *args: added_signals.append(args),
+        ),
+    )
+    monkeypatch.setattr(
+        session_manager_core_module.runtime_compositor,
+        "compositor_supervisor_loop",
+        compositor_supervisor_loop,
+    )
+    manager._start_session_server = AsyncMock(side_effect=start_session_server)  # type: ignore[method-assign]
+    manager.connect_loop = connect_loop  # type: ignore[method-assign]
+    manager._start_config_watcher = Mock()  # type: ignore[method-assign]
+    manager.stop = AsyncMock()  # type: ignore[method-assign]
+
+    await manager.start()
+
+    assert manager.running is True
+    assert len(added_signals) == 3
+    manager._start_session_server.assert_awaited_once()  # type: ignore[attr-defined]
+    manager._start_config_watcher.assert_called_once()  # type: ignore[attr-defined]
+    manager.stop.assert_awaited_once()  # type: ignore[attr-defined]
+    assert manager.connect_task is not None
+    assert manager.compositor_state.supervisor_task is not None
+
+
+@pytest.mark.asyncio
 async def test_stop_cancels_tracked_event_tasks() -> None:
     manager = SessionManager()
     manager.running = True
@@ -198,6 +269,50 @@ async def test_stop_cancels_tracked_event_tasks() -> None:
     assert manager.event_state.tasks == set()
     manager.client.disconnect.assert_awaited_once()  # type: ignore[attr-defined]
     manager.dbus.disconnect.assert_awaited_once()  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_stop_cleans_runtime_tasks_server_capture_and_owned_socket(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = SessionManager()
+    manager.running = True
+    manager.client.disconnect = AsyncMock()  # type: ignore[method-assign]
+    manager.client.send_command = AsyncMock(return_value=Response(status="ok"))
+    manager.dbus.disconnect = AsyncMock()  # type: ignore[method-assign]
+    manager.action_handler = SimpleNamespace(cancel_background_tasks=AsyncMock())  # type: ignore[assignment]
+    manager.session_server = _FakeSessionServer()  # type: ignore[assignment]
+    manager.capture_state.tokens["1234:5678"] = "capture-token"
+    socket_path = tmp_path / "session.sock"
+    socket_path.write_text("")
+    manager._session_socket_owned = True
+    monkeypatch.setattr(session_manager_core_module, "SESSION_SOCKET_PATH", socket_path)
+
+    async def wait_forever() -> None:
+        await asyncio.Event().wait()
+
+    manager.compositor_state.supervisor_task = asyncio.create_task(wait_forever())
+    manager.profile_state.apply_task = asyncio.create_task(wait_forever())
+    manager.profile_state.topology_refresh_task = asyncio.create_task(wait_forever())
+    manager.recording_state.settings_save_task = asyncio.create_task(asyncio.sleep(0))
+    manager.connect_task = asyncio.create_task(wait_forever())
+
+    await manager.stop()
+
+    assert manager.compositor_state.supervisor_task is None
+    assert manager.profile_state.apply_task is None
+    assert manager.profile_state.topology_refresh_task is None
+    assert manager.recording_state.settings_save_task is None
+    assert manager.connect_task is None
+    assert manager.capture_state.tokens == {}
+    assert socket_path.exists() is False
+    assert manager._session_socket_owned is False
+    assert manager.session_server.closed is True  # type: ignore[union-attr]
+    assert manager.session_server.wait_closed_calls == 1  # type: ignore[union-attr]
+    manager.client.send_command.assert_awaited_once()  # type: ignore[attr-defined]
+    manager.client.disconnect.assert_awaited_once()  # type: ignore[attr-defined]
+    assert manager.action_handler.cancel_background_tasks.await_count == 2
 
 
 @pytest.mark.asyncio
@@ -443,6 +558,117 @@ async def test_session_client_request_error_keeps_connection_alive(
 
 
 @pytest.mark.asyncio
+async def test_session_client_rejects_missing_or_denied_peer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = SessionManager()
+    manager.running = True
+
+    missing_peer_writer = _FakeSessionWriter()
+    monkeypatch.setattr(
+        session_manager_core_module,
+        "get_peer_credentials",
+        lambda _sock: None,
+    )
+    await manager._handle_session_client(  # type: ignore[arg-type]
+        _FakeSessionReader([]),
+        missing_peer_writer,
+    )
+
+    denied_writer = _FakeSessionWriter()
+    manager.security_policy.session_allowed_uids = {1000}
+    monkeypatch.setattr(
+        session_manager_core_module,
+        "get_peer_credentials",
+        lambda _sock: PeerCredentials(pid=321, uid=2000, gid=2000),
+    )
+    await manager._handle_session_client(  # type: ignore[arg-type]
+        _FakeSessionReader([]),
+        denied_writer,
+    )
+
+    assert missing_peer_writer.closed is True
+    assert denied_writer.closed is True
+    assert denied_writer.writes == []
+
+
+@pytest.mark.asyncio
+async def test_session_client_handles_invalid_json_and_unexpected_request_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = SessionManager()
+    manager.running = True
+    reader = _FakeSessionReader(
+        [
+            b"{not-json}\n",
+            json.dumps({"command": "boom"}).encode() + b"\n",
+        ]
+    )
+    writer = _FakeSessionWriter()
+    manager._handle_session_request = AsyncMock(  # type: ignore[method-assign]
+        side_effect=RuntimeError("request failed")
+    )
+    monkeypatch.setattr(
+        session_manager_core_module,
+        "get_peer_credentials",
+        lambda _sock: PeerCredentials(pid=321, uid=1000, gid=1000),
+    )
+
+    await manager._handle_session_client(reader, writer)  # type: ignore[arg-type]
+
+    responses = [json.loads(payload) for payload in b"".join(writer.writes).splitlines()]
+    assert responses == [
+        {"error": "invalid json"},
+        {"status": "error", "message": "request failed"},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_broadcast_drain_and_close_error_paths() -> None:
+    manager = SessionManager()
+    ok_writer = _FakeSessionWriter()
+    skipped_writer = _FakeSessionWriter()
+    os_error_writer = _FakeSessionWriter()
+    generic_error_writer = _FakeSessionWriter()
+    os_error_writer.write = Mock(side_effect=OSError("closed"))  # type: ignore[method-assign]
+    generic_error_writer.write = Mock(side_effect=RuntimeError("broken"))  # type: ignore[method-assign]
+    manager.session_clients.update(
+        [ok_writer, skipped_writer, os_error_writer, generic_error_writer]  # type: ignore[list-item]
+    )
+    manager._close_session_writer = AsyncMock()  # type: ignore[method-assign]
+
+    manager.broadcast_to_session_client_ids(
+        {"event": "update"},
+        {id(ok_writer), id(os_error_writer), id(generic_error_writer)},
+    )
+    await asyncio.sleep(0)
+
+    assert ok_writer.writes == [b'{"event": "update"}\n']
+    assert skipped_writer.writes == []
+    assert os_error_writer not in manager.session_clients
+    assert generic_error_writer not in manager.session_clients
+    assert manager._close_session_writer.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_drain_session_writer_drops_clients_on_drain_errors() -> None:
+    manager = SessionManager()
+
+    for exc in (OSError("closed"), RuntimeError("broken")):
+        writer = _FakeSessionWriter()
+        writer.drain = AsyncMock(side_effect=exc)  # type: ignore[method-assign]
+        manager.session_clients.add(writer)  # type: ignore[arg-type]
+        manager.session_client_drain_tasks[writer] = asyncio.current_task()  # type: ignore[assignment]
+        manager._close_session_writer = AsyncMock()  # type: ignore[method-assign]
+
+        await manager._drain_session_writer(writer)  # type: ignore[arg-type]
+
+        assert writer not in manager.session_clients
+        manager._close_session_writer.assert_awaited_once()  # type: ignore[attr-defined]
+        assert writer not in manager.session_client_drain_tasks
+
+
+@pytest.mark.asyncio
 async def test_send_notification_logs_even_when_dbus_notification_fails(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
@@ -460,3 +686,202 @@ async def test_send_notification_logs_even_when_dbus_notification_fails(
         app_name="keymasq",
         timeout_ms=5000,
     )
+
+
+def test_send_notification_without_running_loop_returns(caplog: pytest.LogCaptureFixture) -> None:
+    manager = SessionManager()
+
+    with caplog.at_level("INFO", logger="keymasq-session"):
+        manager.send_notification("Title", "Message")
+
+    assert "Notification: Title: Message" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_config_watcher_lifecycle_and_registration_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = SessionManager()
+    added_readers = []
+    removed_readers = []
+    closed_fds = []
+
+    class FakeLoop:
+        def __init__(self) -> None:
+            self.add_reader_error: Exception | None = None
+
+        def add_reader(self, *args) -> None:
+            if self.add_reader_error is not None:
+                raise self.add_reader_error
+            added_readers.append(args)
+
+        def remove_reader(self, fd: int) -> None:
+            removed_readers.append(fd)
+
+    fake_loop = FakeLoop()
+    watch_ids = iter([101, 102, 103, 104, 105, 201, 202, 203, 204, 205])
+
+    def add_watch(_fd, path, _mask):
+        if path == session_manager_core_module.HARDWARE_DIR:
+            raise OSError("missing")
+        return next(watch_ids)
+
+    monkeypatch.setattr(
+        session_manager_core_module.asyncio,
+        "get_running_loop",
+        lambda: fake_loop,
+    )
+    monkeypatch.setattr(session_manager_core_module, "_inotify_init", lambda: 42)
+    monkeypatch.setattr(session_manager_core_module, "_inotify_add_watch", add_watch)
+    monkeypatch.setattr(session_manager_core_module.os, "close", lambda fd: closed_fds.append(fd))
+
+    manager._start_config_watcher()
+
+    assert manager.config_watch_fd == 42
+    assert added_readers == [(42, manager._handle_config_watch_events)]
+    assert session_manager_core_module.HARDWARE_DIR not in manager.config_watch_watches.values()
+    assert len(manager.config_watch_watches) == 4
+
+    manager._stop_config_watcher()
+
+    assert manager.config_watch_fd is None
+    assert manager.config_watch_watches == {}
+    assert removed_readers == [42]
+    assert closed_fds == [42]
+
+    fake_loop.add_reader_error = RuntimeError("unsupported")
+    manager._start_config_watcher()
+
+    assert manager.config_watch_fd is None
+    assert closed_fds[-1] == 42
+
+    monkeypatch.setattr(
+        session_manager_core_module,
+        "_inotify_init",
+        Mock(side_effect=OSError("no inotify")),
+    )
+    manager._start_config_watcher()
+
+    assert manager.config_watch_fd is None
+
+
+@pytest.mark.asyncio
+async def test_config_watch_event_parsing_and_reload_scheduling(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = SessionManager()
+    manager.config_watch_fd = 9
+    manager.config_watch_watches = {
+        1: session_manager_core_module.PROFILES_DIR,
+        2: session_manager_core_module.CONFIG_DIR,
+    }
+    manager._refresh_config_watches = Mock()  # type: ignore[method-assign]
+    manager._schedule_config_reload = Mock()  # type: ignore[method-assign]
+    data = b"".join(
+        [
+            _inotify_event(99, session_manager_core_module.IN_CLOSE_WRITE, "ignored.toml"),
+            _inotify_event(2, session_manager_core_module.IN_IGNORED, "profiles"),
+            _inotify_event(1, session_manager_core_module.IN_CLOSE_WRITE, "Base.toml"),
+        ]
+    )
+    monkeypatch.setattr(session_manager_core_module.os, "read", lambda _fd, _size: data)
+
+    manager._handle_config_watch_events()
+
+    assert 2 not in manager.config_watch_watches
+    manager._refresh_config_watches.assert_called_once()  # type: ignore[attr-defined]
+    manager._schedule_config_reload.assert_called_once()  # type: ignore[attr-defined]
+
+    manager.config_watch_fd = None
+    manager._handle_config_watch_events()
+
+    manager.config_watch_fd = 9
+    monkeypatch.setattr(
+        session_manager_core_module.os,
+        "read",
+        Mock(side_effect=BlockingIOError),
+    )
+    manager._handle_config_watch_events()
+
+    manager._stop_config_watcher = Mock()  # type: ignore[method-assign]
+    monkeypatch.setattr(
+        session_manager_core_module.os,
+        "read",
+        Mock(side_effect=OSError("dead fd")),
+    )
+    manager._handle_config_watch_events()
+
+    manager._stop_config_watcher.assert_called_once()  # type: ignore[attr-defined]
+
+
+def test_config_watch_relevance_rules() -> None:
+    manager = SessionManager()
+
+    assert manager._config_watch_event_is_relevant(
+        session_manager_core_module.CONFIG_DIR,
+        session_manager_core_module.SETTINGS_PATH.name,
+        0,
+    )
+    assert manager._config_watch_event_is_relevant(
+        session_manager_core_module.CONFIG_DIR,
+        session_manager_core_module.PROFILES_DIR.name,
+        session_manager_core_module.IN_ISDIR,
+    )
+    assert not manager._config_watch_event_is_relevant(
+        session_manager_core_module.CONFIG_DIR,
+        "notes.txt",
+        0,
+    )
+    assert manager._config_watch_event_is_relevant(
+        session_manager_core_module.PROFILES_DIR,
+        "Base.toml",
+        0,
+    )
+    assert not manager._config_watch_event_is_relevant(
+        session_manager_core_module.PROFILES_DIR,
+        "Base.txt",
+        0,
+    )
+    assert manager._config_watch_event_is_relevant(
+        session_manager_core_module.PROFILES_DIR,
+        "",
+        session_manager_core_module.IN_MOVE_SELF,
+    )
+
+
+@pytest.mark.asyncio
+async def test_scheduled_config_reload_branches() -> None:
+    manager = SessionManager()
+    manager.reload_profiles = AsyncMock(return_value=True)  # type: ignore[method-assign]
+
+    manager.running = False
+    manager._run_scheduled_config_reload()
+
+    assert manager.reload_task is None
+
+    manager.running = True
+    manager.reload_task = asyncio.create_task(asyncio.sleep(0.1))
+    manager._run_scheduled_config_reload()
+    running_task = manager.reload_task
+
+    assert running_task is not None
+    assert not running_task.done()
+    running_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await running_task
+
+    manager.reload_task = None
+    manager._schedule_config_reload()
+    first_timer = manager.config_reload_timer
+    manager._schedule_config_reload()
+
+    assert first_timer is not None
+    assert first_timer.cancelled()
+    assert manager.config_reload_timer is not first_timer
+    manager.config_reload_timer.cancel()
+
+    manager._run_scheduled_config_reload()
+    reload_task = manager.reload_task
+    assert reload_task is not None
+    await cast(asyncio.Task[object], reload_task)
+    manager.reload_profiles.assert_awaited_once()  # type: ignore[attr-defined]

--- a/tests/test_session_manager_core.py
+++ b/tests/test_session_manager_core.py
@@ -7,6 +7,7 @@ import pytest
 import keymasq.session.manager.core as session_manager_core_module
 import keymasq.session.manager.events as session_events_module
 import keymasq.session.manager.profiles as session_profiles_module
+from keymasq.common.ipc import Response
 from keymasq.common.models import ProfileConfig, SuperkeyConfig, SuperkeyMode
 from keymasq.common.security import PeerCredentials
 from keymasq.session.manager import SessionManager
@@ -25,6 +26,9 @@ class _FakeKeymasqdClient:
 
     async def disconnect(self) -> None:
         return
+
+    async def send_command(self, _command: object) -> Response:
+        return Response(status="ok", data={"count": 1})
 
 
 class _FakeSessionReader:
@@ -107,6 +111,49 @@ async def test_connect_loop_reconnect_reapplies_profiles_after_restart(
     assert status_events[:4] == [True, False, True, False]
     assert manager.profile_state.grabbed_devices == set()
     assert manager.profile_state.active_profile_names == []
+
+
+@pytest.mark.asyncio
+async def test_connect_loop_logs_unexpected_runtime_failures(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    class FakeClient:
+        async def connect(self) -> None:
+            return None
+
+        async def wait_disconnected(self) -> None:
+            return None
+
+        async def send_command(self, _command: object) -> Response:
+            return Response(status="ok", data={"count": 1})
+
+    manager = SessionManager()
+    manager.client = FakeClient()  # type: ignore[assignment]
+    manager.running = True
+    manager._broadcast_keymasqd_status = Mock()  # type: ignore[method-assign]
+
+    async def _sync_pending_macro_slots(_manager: SessionManager) -> None:
+        manager.running = False
+        raise RuntimeError("sync bug")
+
+    monkeypatch.setattr(
+        session_profiles_module,
+        "activate_initial_profiles",
+        AsyncMock(),
+    )
+    monkeypatch.setattr(
+        session_manager_core_module.runtime_recording,
+        "sync_pending_macro_slots_from_daemon",
+        _sync_pending_macro_slots,
+    )
+
+    with caplog.at_level("ERROR", logger="keymasq-session"):
+        await manager.connect_loop()
+
+    assert "Unexpected keymasqd connection loop failure" in caplog.text
+    assert "sync bug" in caplog.text
+    assert manager.connected is False
 
 
 def test_signal_handler_only_sets_shutdown_state() -> None:

--- a/tests/test_session_manager_events.py
+++ b/tests/test_session_manager_events.py
@@ -26,6 +26,129 @@ def _sent_daemon_commands(
 
 
 @pytest.mark.asyncio
+async def test_handle_event_dispatches_action_trigger_variants(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    manager = SessionManager(verbosity=1)
+    manager.exec_state.exec_refs[9] = ExecBinding(
+        cmd="echo hardware",
+        owner="combo",
+        hardware_id="1234:5678",
+    )
+    handlers = {
+        "start": AsyncMock(),
+        "stop": AsyncMock(),
+        "slot": AsyncMock(return_value={"status": "ok"}),
+        "cancel": AsyncMock(),
+        "reset": AsyncMock(),
+        "profile": AsyncMock(),
+    }
+    monkeypatch.setattr(session_events_module, "handle_start_macro_trigger", handlers["start"])
+    monkeypatch.setattr(session_events_module, "handle_stop_macro_trigger", handlers["stop"])
+    monkeypatch.setattr(
+        session_events_module.runtime_recording,
+        "play_macro_slot_trigger",
+        handlers["slot"],
+    )
+    monkeypatch.setattr(session_events_module, "handle_cancel_macro_trigger", handlers["cancel"])
+    monkeypatch.setattr(session_events_module, "handle_emergency_reset_trigger", handlers["reset"])
+    monkeypatch.setattr(session_events_module, "handle_profile_trigger", handlers["profile"])
+    manager.action_handler.execute_command = AsyncMock(return_value=0)
+
+    with caplog.at_level(logging.DEBUG, logger="keymasq-session"):
+        for action_type in (
+            "start_macro_recording",
+            "stop_macro_recording",
+            "play_macro_slot",
+            "cancel_macro_playback",
+            "emergency_reset",
+            "profile_enable",
+        ):
+            await session_events_module.handle_event(
+                manager,
+                CommandType.ACTION_TRIGGER,
+                {"action_type": action_type, "events": [{"type": 1}]},
+            )
+        await session_events_module.handle_event(
+            manager,
+            CommandType.ACTION_TRIGGER,
+            {"action_type": "exec", "exec_ref": 9},
+        )
+        await session_events_module.handle_event(
+            manager,
+            CommandType.ACTION_TRIGGER,
+            {"action_type": "exec", "exec_ref": 404},
+        )
+        await asyncio.sleep(0)
+
+    assert "Event: action_trigger ->" in caplog.text
+    assert "<1 events>" in caplog.text
+    for handler in handlers.values():
+        handler.assert_awaited()
+    manager.action_handler.execute_command.assert_awaited_once_with("echo hardware")
+    assert "Unknown exec_ref: 404" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_handle_event_dispatches_device_and_runtime_variants(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = SessionManager()
+    manager.broadcast_to_session_clients = Mock()  # type: ignore[method-assign]
+    connected = AsyncMock()
+    disconnected = AsyncMock()
+    grab_status = Mock()
+    runtime_reset = AsyncMock()
+    deactivate_requested = AsyncMock()
+    monkeypatch.setattr(session_events_module, "on_device_connected", connected)
+    monkeypatch.setattr(session_events_module, "on_device_disconnected", disconnected)
+    monkeypatch.setattr(session_events_module, "handle_device_grab_status_event", grab_status)
+    monkeypatch.setattr(session_events_module, "handle_runtime_reset_event", runtime_reset)
+    monkeypatch.setattr(
+        session_events_module,
+        "handle_profile_deactivate_requested",
+        deactivate_requested,
+    )
+
+    await session_events_module.handle_event(
+        manager,
+        CommandType.DEVICE_CONNECTED,
+        {"vendor_id": "1234", "product_id": "5678"},
+    )
+    await session_events_module.handle_event(
+        manager,
+        CommandType.DEVICE_DISCONNECTED,
+        {"hardware_id": "1234:5678"},
+    )
+    await session_events_module.handle_event(
+        manager,
+        CommandType.DEVICE_GRAB_STATUS,
+        {"hardware_id": "1234:5678", "state": "ready"},
+    )
+    await session_events_module.handle_event(
+        manager,
+        CommandType.RUNTIME_RESET,
+        {"reason": "test"},
+    )
+    await session_events_module.handle_event(
+        manager,
+        CommandType.PROFILE_DEACTIVATE_REQUESTED,
+        {"profile_name": "Nav"},
+    )
+    await asyncio.sleep(0)
+
+    connected.assert_awaited_once_with(manager, {"vendor_id": "1234", "product_id": "5678"})
+    disconnected.assert_awaited_once_with(manager, {"hardware_id": "1234:5678"})
+    grab_status.assert_called_once_with(
+        manager,
+        {"hardware_id": "1234:5678", "state": "ready"},
+    )
+    runtime_reset.assert_awaited_once_with(manager, {"reason": "test"})
+    deactivate_requested.assert_awaited_once_with(manager, {"profile_name": "Nav"})
+
+
+@pytest.mark.asyncio
 async def test_handle_event_compositor_dispatch_uses_listener() -> None:
     manager = SessionManager()
     manager.action_handler = AsyncMock()
@@ -135,6 +258,29 @@ async def test_cancel_event_tasks_cancels_tracked_background_task() -> None:
     assert cancelled.is_set()
     assert task.cancelled()
     assert manager.event_state.tasks == set()
+
+
+@pytest.mark.asyncio
+async def test_create_event_task_tracks_extra_task_set() -> None:
+    manager = SessionManager()
+    extra_tasks = set()
+
+    async def done() -> None:
+        return None
+
+    task = session_events_module.create_event_task(
+        manager,
+        done(),
+        name="extra",
+        extra_task_set=extra_tasks,
+    )
+
+    assert task in manager.event_state.tasks
+    assert task in extra_tasks
+    await task
+    await asyncio.sleep(0)
+    assert task not in manager.event_state.tasks
+    assert task not in extra_tasks
 
 
 @pytest.mark.asyncio
@@ -294,6 +440,40 @@ async def test_handle_event_macro_sync_exec_logs_unexpected_completion_report_fa
 
     assert "Unexpected failure reporting macro exec completion" in caplog.text
     assert "report bug" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_handle_exec_trigger_ignores_missing_command_or_handler() -> None:
+    manager = SessionManager()
+    manager.action_handler.execute_command = AsyncMock()
+
+    await session_events_module.handle_exec_trigger(manager, {"cmd": ""})
+
+    manager.action_handler.execute_command.assert_not_awaited()
+    manager.action_handler = None
+
+    await session_events_module.handle_exec_trigger(manager, {"cmd": "echo missing"})
+
+
+@pytest.mark.asyncio
+async def test_handle_event_macro_sync_exec_tolerates_daemon_os_errors() -> None:
+    manager = SessionManager()
+    manager.client.send_command = AsyncMock(side_effect=OSError("daemon down"))
+    manager.action_handler.execute_command = AsyncMock(return_value=0)
+
+    await session_events_module.handle_event(
+        manager,
+        CommandType.ACTION_TRIGGER,
+        {
+            "action_type": "exec",
+            "cmd": "echo macro",
+            "macro_exec_wait_id": "wait-1",
+        },
+    )
+    await asyncio.sleep(0)
+
+    manager.action_handler.execute_command.assert_awaited_once()
+    manager.client.send_command.assert_awaited_once()
 
 
 @pytest.mark.asyncio
@@ -633,6 +813,240 @@ async def test_runtime_activation_replacement_ignores_stale_expiry(
         {"profile_name": "Nav", "activation_id": new_id, "reason": "timeout"},
     )
     assert "Nav" not in manager.profile_state.runtime_profile_activations
+
+
+@pytest.mark.asyncio
+async def test_macro_recording_trigger_edge_branches(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = SessionManager()
+    manager.send_notification = Mock()  # type: ignore[method-assign]
+    manager.broadcast_to_session_clients = Mock()  # type: ignore[method-assign]
+
+    await session_events_module.handle_start_macro_trigger(manager, {})
+
+    manager.recording_state.active = True
+    manager.recording_state.active_slot = 2
+    stop_trigger = AsyncMock()
+    monkeypatch.setattr(session_events_module, "handle_stop_macro_trigger", stop_trigger)
+
+    await session_events_module.handle_start_macro_trigger(manager, {"recording_slot": 2})
+    await session_events_module.handle_start_macro_trigger(manager, {"recording_slot": 3})
+
+    manager.recording_state.active = False
+    monkeypatch.setattr(
+        session_events_module.runtime_recording,
+        "resolve_macro_recording_status_async",
+        AsyncMock(return_value={"unlocked": False, "source": "disabled"}),
+    )
+    notify_disabled = Mock()
+    monkeypatch.setattr(
+        session_events_module.runtime_recording,
+        "notify_macro_recording_disabled",
+        notify_disabled,
+    )
+
+    await session_events_module.handle_start_macro_trigger(manager, {"recording_slot": 1})
+
+    assert manager.send_notification.call_count == 2  # type: ignore[attr-defined]
+    stop_trigger.assert_awaited_once_with(manager, {"recording_slot": 2})
+    notify_disabled.assert_called_once_with(manager)
+    manager.broadcast_to_session_clients.assert_called_once_with(  # type: ignore[attr-defined]
+        {
+            "event": "macro_recording_disabled",
+            "macro_recording_enabled": False,
+            "macro_recording_source": "disabled",
+            "macro_recording_expires_at": 0,
+        }
+    )
+
+
+@pytest.mark.asyncio
+async def test_macro_recording_trigger_reports_failed_start_results(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = SessionManager()
+    manager.broadcast_to_session_clients = Mock()  # type: ignore[method-assign]
+    monkeypatch.setattr(
+        session_events_module.runtime_recording,
+        "resolve_macro_recording_status_async",
+        AsyncMock(return_value={"unlocked": True}),
+    )
+    start_recording = AsyncMock(
+        side_effect=[
+            {"status": "error", "error_code": "macro_recording_disabled"},
+            {"status": "error", "error_code": "sensitive_command_denied"},
+        ]
+    )
+    notify_disabled = Mock()
+    notify_unlock = Mock()
+    monkeypatch.setattr(session_events_module.runtime_recording, "start_recording", start_recording)
+    monkeypatch.setattr(
+        session_events_module.runtime_recording,
+        "notify_macro_recording_disabled",
+        notify_disabled,
+    )
+    monkeypatch.setattr(
+        session_events_module.runtime_recording,
+        "notify_recording_unlock_required",
+        notify_unlock,
+    )
+
+    await session_events_module.handle_start_macro_trigger(manager, {"recording_slot": 1})
+    await session_events_module.handle_start_macro_trigger(manager, {"recording_slot": 1})
+
+    notify_disabled.assert_called_once_with(manager)
+    notify_unlock.assert_called_once_with(
+        manager,
+        {"status": "error", "error_code": "sensitive_command_denied"},
+    )
+    assert manager.broadcast_to_session_clients.call_args_list == [  # type: ignore[attr-defined]
+        call({"event": "macro_recording_disabled"}),
+        call({"event": "recording_auth_requested"}),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_stop_macro_trigger_edge_and_error_branches(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = SessionManager()
+    stop_recording = AsyncMock(side_effect=[OSError("daemon down"), RuntimeError("bug")])
+    monkeypatch.setattr(
+        session_events_module.runtime_recording,
+        "stop_recording",
+        stop_recording,
+    )
+
+    await session_events_module.handle_stop_macro_trigger(manager, {"recording_slot": 1})
+
+    manager.recording_state.active = True
+    manager.recording_state.active_slot = 2
+    await session_events_module.handle_stop_macro_trigger(manager, {"recording_slot": 3})
+    await session_events_module.handle_stop_macro_trigger(manager, {"recording_slot": 2})
+    await session_events_module.handle_stop_macro_trigger(manager, {"recording_slot": 2})
+
+    assert stop_recording.await_count == 2
+    assert stop_recording.await_args_list[0].kwargs == {
+        "error_if_idle": False,
+        "recording_slot": 2,
+    }
+
+
+@pytest.mark.asyncio
+async def test_cancel_and_emergency_triggers_tolerate_daemon_failures() -> None:
+    manager = SessionManager()
+    manager.client.send_command = AsyncMock(
+        side_effect=[
+            OSError("daemon down"),
+            RuntimeError("bug"),
+            OSError("daemon down"),
+            RuntimeError("bug"),
+        ]
+    )
+
+    await session_events_module.handle_cancel_macro_trigger(manager)
+    await session_events_module.handle_cancel_macro_trigger(manager)
+    await session_events_module.handle_emergency_reset_trigger(manager)
+    await session_events_module.handle_emergency_reset_trigger(manager)
+
+    assert [
+        call_args.args[0].command
+        for call_args in manager.client.send_command.await_args_list
+    ] == [
+        CommandType.CANCEL_MACRO_PLAYBACK,
+        CommandType.CANCEL_MACRO_PLAYBACK,
+        CommandType.EMERGENCY_RESET,
+        CommandType.EMERGENCY_RESET,
+    ]
+
+
+@pytest.mark.asyncio
+async def test_runtime_reset_reports_reapply_failures(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = SessionManager()
+    manager.broadcast_to_session_clients = Mock()  # type: ignore[method-assign]
+    manager.send_notification = Mock()  # type: ignore[method-assign]
+    monkeypatch.setattr(
+        session_profiles_module,
+        "reevaluate_profiles",
+        AsyncMock(side_effect=OSError("daemon down")),
+    )
+
+    await session_events_module.handle_runtime_reset_event(manager, {"reason": "test"})
+
+    monkeypatch.setattr(
+        session_profiles_module,
+        "reevaluate_profiles",
+        AsyncMock(side_effect=RuntimeError("bug")),
+    )
+    await session_events_module.handle_runtime_reset_event(manager, {"reason": "test"})
+
+    assert manager.broadcast_to_session_clients.call_count == 2  # type: ignore[attr-defined]
+    assert manager.send_notification.call_args_list[-1] == call(  # type: ignore[attr-defined]
+        "Keymasq: Reapply Failed",
+        "Emergency reset completed, but active profiles could not be reapplied.",
+    )
+
+
+@pytest.mark.asyncio
+async def test_device_topology_events_schedule_known_hardware_refresh(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = SessionManager()
+    manager.hardware.get_hardware = Mock(  # type: ignore[method-assign]
+        side_effect=lambda hardware_id: (
+            SimpleNamespace(name="Keyboard") if hardware_id == "1234:5678" else None
+        )
+    )
+    manager.hardware.list_hardware = Mock(  # type: ignore[method-assign]
+        return_value=[SimpleNamespace(model_id="abcd:ef01")]
+    )
+    schedule_topology_refresh = Mock()
+    created_tasks = []
+
+    def create_event_task(_manager, coro, **kwargs):
+        coro.close()
+        created_tasks.append(kwargs)
+        return Mock()
+
+    monkeypatch.setattr(
+        session_profiles_module,
+        "schedule_topology_refresh",
+        schedule_topology_refresh,
+    )
+    monkeypatch.setattr(session_events_module, "create_event_task", create_event_task)
+
+    await session_events_module.on_device_connected(
+        manager,
+        {"vendor_id": "1234", "product_id": "5678"},
+    )
+    await session_events_module.on_device_disconnected(
+        manager,
+        {"vendor_id": "abcd", "product_id": "ef01"},
+    )
+    await session_events_module.on_device_connected(
+        manager,
+        {"vendor_id": "0000", "product_id": "0000"},
+    )
+    await session_events_module.on_device_disconnected(manager, {})
+
+    assert schedule_topology_refresh.call_count == 2
+    assert [task["name"] for task in created_tasks] == [
+        "recording_devices_refresh",
+        "recording_devices_refresh",
+    ]
+    assert session_events_module.device_name_for_hardware(manager, "missing:id") == "missing:id"
+    assert session_events_module._hardware_or_model_known(manager, "abcd:ef01") is True
+    assert session_events_module.event_log_view({"events": [1, 2]}) == {
+        "events": "<2 events>",
+        "event_count": 2,
+    }
+    assert session_events_module.event_log_view({"events": [1], "event_count": 9}) == {
+        "events": "<1 events>",
+        "event_count": 9,
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/test_session_manager_events.py
+++ b/tests/test_session_manager_events.py
@@ -273,6 +273,30 @@ async def test_handle_event_macro_sync_exec_clamps_timeout_to_session_policy() -
 
 
 @pytest.mark.asyncio
+async def test_handle_event_macro_sync_exec_logs_unexpected_completion_report_failure(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    manager = SessionManager()
+    manager.client.send_command = AsyncMock(side_effect=RuntimeError("report bug"))
+    manager.action_handler.execute_command = AsyncMock(return_value=0)
+
+    with caplog.at_level(logging.ERROR, logger="keymasq-session"):
+        await session_events_module.handle_event(
+            manager,
+            CommandType.ACTION_TRIGGER,
+            {
+                "action_type": "exec",
+                "cmd": "echo macro",
+                "macro_exec_wait_id": "wait-1",
+            },
+        )
+        await asyncio.sleep(0)
+
+    assert "Unexpected failure reporting macro exec completion" in caplog.text
+    assert "report bug" in caplog.text
+
+
+@pytest.mark.asyncio
 async def test_handle_event_macro_trigger_forwards_full_playback_payload() -> None:
     manager = SessionManager()
     manager.client.send_command = AsyncMock(
@@ -399,7 +423,7 @@ async def test_lifetime_profile_enable_rolls_back_when_daemon_tracking_fails(
     temp_config_dir,
 ) -> None:
     manager = SessionManager()
-    manager.client.send_command = AsyncMock(side_effect=RuntimeError("daemon unavailable"))
+    manager.client.send_command = AsyncMock(side_effect=ConnectionError("daemon unavailable"))
     manager.profiles.save_profile(ProfileConfig(name="Nav", enabled=False, is_permanent=True))
 
     await session_events_module.handle_profile_trigger(
@@ -411,6 +435,32 @@ async def test_lifetime_profile_enable_rolls_back_when_daemon_tracking_fails(
         },
     )
 
+    assert "Nav" not in manager.profile_state.runtime_profile_activations
+    assert "Nav" not in manager.profile_state.active_profile_names
+    assert manager.profiles.get_profile("Nav").config.enabled is False
+
+
+@pytest.mark.asyncio
+async def test_lifetime_profile_enable_logs_unexpected_tracking_failures(
+    temp_config_dir,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    manager = SessionManager()
+    manager.client.send_command = AsyncMock(side_effect=RuntimeError("tracking bug"))
+    manager.profiles.save_profile(ProfileConfig(name="Nav", enabled=False, is_permanent=True))
+
+    with caplog.at_level(logging.ERROR, logger="keymasq-session"):
+        await session_events_module.handle_profile_trigger(
+            manager,
+            {
+                "action_type": "profile_enable",
+                "profile_name": "Nav",
+                "deactivation": {"after_actions": 1},
+            },
+        )
+
+    assert "Unexpected failure tracking runtime profile activation" in caplog.text
+    assert "tracking bug" in caplog.text
     assert "Nav" not in manager.profile_state.runtime_profile_activations
     assert "Nav" not in manager.profile_state.active_profile_names
     assert manager.profiles.get_profile("Nav").config.enabled is False

--- a/tests/test_slurp.py
+++ b/tests/test_slurp.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 from collections.abc import Awaitable, Callable
 from typing import Any
 
@@ -439,4 +440,48 @@ def test_cancel_async_kills_and_waits_again_when_terminate_wait_times_out(
     assert process.terminated is True
     assert process.killed is True
     assert process.wait_calls == 2
+    assert capture._process is None
+
+
+def test_cancel_async_warns_when_process_survives_kill(
+    caplog: pytest.LogCaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    capture = SlurpCapture()
+    process = _FakeSlurpProcess()
+    capture._process = process  # type: ignore[assignment]
+
+    async def _wait_for(awaitable: Awaitable[object], timeout: float) -> object:
+        awaitable.close()
+        raise TimeoutError
+
+    monkeypatch.setattr(asyncio, "wait_for", _wait_for)
+    caplog.set_level(logging.WARNING, logger="keymasq.slurp")
+
+    asyncio.run(capture.cancel_async())
+
+    assert process.terminated is True
+    assert process.killed is True
+    assert process.wait_calls == 2
+    assert "slurp process did not exit after kill" in caplog.text
+    assert capture._process is None
+
+
+def test_cancel_async_logs_unexpected_terminate_failure(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    capture = SlurpCapture()
+
+    class _BrokenProcess(_FakeSlurpProcess):
+        def terminate(self) -> None:
+            raise RuntimeError("terminate failed")
+
+    process = _BrokenProcess()
+    capture._process = process  # type: ignore[assignment]
+    caplog.set_level(logging.ERROR, logger="keymasq.slurp")
+
+    asyncio.run(capture.cancel_async())
+
+    assert "Unexpected failure terminating slurp process" in caplog.text
+    assert process.killed is False
     assert capture._process is None

--- a/tests/test_socket_server.py
+++ b/tests/test_socket_server.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 import os
 import struct
 
@@ -561,7 +562,11 @@ class TestSocketServer:
         await writer.wait_closed()
         await server.stop()
 
-    async def test_broadcast_event_does_not_block_on_slow_client(self, temp_socket_dir):
+    async def test_broadcast_event_does_not_block_on_slow_client(
+        self,
+        temp_socket_dir,
+        caplog,
+    ):
         server = SocketServer(
             str(paths.SOCKET_PATH),
             _ok_handler,
@@ -571,10 +576,11 @@ class TestSocketServer:
         fast_writer = _BroadcastWriter()
         server.clients = {slow_writer, fast_writer}  # type: ignore[assignment]
 
-        await asyncio.wait_for(
-            server.broadcast_event(CommandType.PING, {"pong": True}),
-            timeout=1.0,
-        )
+        with caplog.at_level(logging.WARNING, logger="keymasqd.socket"):
+            await asyncio.wait_for(
+                server.broadcast_event(CommandType.PING, {"pong": True}),
+                timeout=1.0,
+            )
 
         assert len(fast_writer.writes) == 1
         assert fast_writer.drain_calls == 1
@@ -582,10 +588,12 @@ class TestSocketServer:
         assert slow_writer.wait_closed_calls == 1
         assert slow_writer not in server.clients  # type: ignore[operator]
         assert fast_writer in server.clients  # type: ignore[operator]
+        assert "Timed out sending event to client" in caplog.text
 
     async def test_broadcast_event_removes_failed_last_client_and_fires_disconnect_handler(
         self,
         temp_socket_dir,
+        caplog,
     ):
         disconnects: list[str] = []
 
@@ -601,12 +609,36 @@ class TestSocketServer:
         failed_writer = _BroadcastWriter(drain_error=ConnectionError("broken pipe"))
         server.clients = {failed_writer}  # type: ignore[assignment]
 
-        await server.broadcast_event(CommandType.PING, {"pong": True})
+        with caplog.at_level(logging.WARNING, logger="keymasqd.socket"):
+            await server.broadcast_event(CommandType.PING, {"pong": True})
 
         assert failed_writer.closed is True
         assert failed_writer.wait_closed_calls == 1
         assert not server.clients
         assert disconnects == ["done"]
+        assert "Failed to send event to client: broken pipe" in caplog.text
+
+    async def test_broadcast_event_logs_unexpected_send_failure(
+        self,
+        temp_socket_dir,
+        caplog,
+    ):
+        server = SocketServer(
+            str(paths.SOCKET_PATH),
+            _ok_handler,
+            broadcast_drain_timeout_s=0.01,
+        )
+        failed_writer = _BroadcastWriter(drain_error=RuntimeError("writer state invalid"))
+        server.clients = {failed_writer}  # type: ignore[assignment]
+
+        with caplog.at_level(logging.ERROR, logger="keymasqd.socket"):
+            await server.broadcast_event(CommandType.PING, {"pong": True})
+
+        assert failed_writer.closed is True
+        assert failed_writer.wait_closed_calls == 1
+        assert not server.clients
+        assert "Unexpected failure sending event to client" in caplog.text
+        assert "RuntimeError: writer state invalid" in caplog.text
 
     async def test_server_stop_times_out_stuck_client_close(self, temp_socket_dir):
         server = SocketServer(

--- a/tests/test_superkey_state.py
+++ b/tests/test_superkey_state.py
@@ -774,6 +774,90 @@ async def test_mouse_wheel_rapidfire_repeats_without_key_up() -> None:
 
 
 @pytest.mark.asyncio
+async def test_rapidfire_loop_logs_expected_output_failure(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    machine = SuperkeyMachine(
+        config=SuperkeyConfig(name="rapidfire_error_test"),
+        event_name="btn_side",
+        keyboard_uinput=MagicMock(),
+        mouse_uinput=MagicMock(),
+        gamepad_uinput=MagicMock(),
+    )
+    machine._rapidfire_active = True
+    action = SuperkeyActionData(
+        action_type="keyboard",
+        target="key_a",
+        rapidfire_enabled=True,
+    )
+    machine._execute_action_down = AsyncMock(side_effect=OSError("uinput disconnected"))  # type: ignore[method-assign]
+    machine._execute_action_up = AsyncMock()  # type: ignore[method-assign]
+
+    with caplog.at_level(logging.DEBUG, logger="keymasqd.superkey"):
+        await machine._rapidfire_loop(action)
+
+    assert "Rapidfire loop stopped after error" in caplog.text
+    assert "uinput disconnected" in caplog.text
+    machine._execute_action_up.assert_awaited_once_with(action)
+
+
+@pytest.mark.asyncio
+async def test_rapidfire_loop_logs_unexpected_failure(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    machine = SuperkeyMachine(
+        config=SuperkeyConfig(name="rapidfire_error_test"),
+        event_name="btn_side",
+        keyboard_uinput=MagicMock(),
+        mouse_uinput=MagicMock(),
+        gamepad_uinput=MagicMock(),
+    )
+    machine._rapidfire_active = True
+    action = SuperkeyActionData(
+        action_type="keyboard",
+        target="key_a",
+        rapidfire_enabled=True,
+    )
+    machine._execute_action_down = AsyncMock(side_effect=RuntimeError("action state invalid"))  # type: ignore[method-assign]
+    machine._execute_action_up = AsyncMock()  # type: ignore[method-assign]
+
+    with caplog.at_level(logging.ERROR, logger="keymasqd.superkey"):
+        await machine._rapidfire_loop(action)
+
+    assert "Rapidfire loop stopped after unexpected error" in caplog.text
+    assert "RuntimeError: action state invalid" in caplog.text
+    machine._execute_action_up.assert_awaited_once_with(action)
+
+
+@pytest.mark.asyncio
+async def test_rapidfire_loop_logs_final_release_failure(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    machine = SuperkeyMachine(
+        config=SuperkeyConfig(name="rapidfire_release_error_test"),
+        event_name="btn_side",
+        keyboard_uinput=MagicMock(),
+        mouse_uinput=MagicMock(),
+        gamepad_uinput=MagicMock(),
+    )
+    machine._rapidfire_active = True
+    action = SuperkeyActionData(
+        action_type="keyboard",
+        target="key_a",
+        rapidfire_enabled=True,
+    )
+    machine._execute_action_down = AsyncMock(side_effect=RuntimeError("action state invalid"))  # type: ignore[method-assign]
+    machine._execute_action_up = AsyncMock(side_effect=RuntimeError("release state invalid"))  # type: ignore[method-assign]
+
+    with caplog.at_level(logging.ERROR, logger="keymasqd.superkey"):
+        await machine._rapidfire_loop(action)
+
+    assert "Rapidfire loop stopped after unexpected error" in caplog.text
+    assert "Unexpected failure releasing rapidfire action after loop stop" in caplog.text
+    assert "RuntimeError: release state invalid" in caplog.text
+
+
+@pytest.mark.asyncio
 async def test_tap_action_fires_after_double_tap_window_expires() -> None:
     keyboard_uinput = MagicMock()
     keyboard_uinput.write = MagicMock()

--- a/tests/test_superkeys.py
+++ b/tests/test_superkeys.py
@@ -93,6 +93,32 @@ tap = [{ action = "keyboard", target = "key_a" }]
     assert config is None
 
 
+def test_superkey_manager_logs_unexpected_load_failure(
+    temp_config_dir,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    superkeys_dir = temp_config_dir / "superkeys"
+    superkeys_dir.mkdir()
+    monkeypatch.setattr(paths, "SUPERKEYS_DIR", superkeys_dir)
+    (superkeys_dir / "broken.toml").write_text(
+        'name = "broken"\nmode = "pattern"\n',
+        encoding="utf-8",
+    )
+
+    def fail_load(_self: SuperkeyManager, _path: object) -> SuperkeyConfig | None:
+        raise RuntimeError("loader bug")
+
+    monkeypatch.setattr(SuperkeyManager, "_load_superkey", fail_load)
+
+    with caplog.at_level("ERROR", logger="keymasq-session.superkeys"):
+        manager = SuperkeyManager()
+
+    assert manager.list_superkeys() == []
+    assert "Unexpected error while loading superkey" in caplog.text
+    assert "loader bug" in caplog.text
+
+
 def test_superkey_manager_rejects_single_table_pattern_slots(
     temp_config_dir,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_wayland_protocol_trackers.py
+++ b/tests/test_wayland_protocol_trackers.py
@@ -394,6 +394,26 @@ def test_registry_probe_logs_unexpected_collect_failure(
     assert "probe bug" in caplog.text
 
 
+def test_registry_probe_logs_timeout_as_expected_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    async def timeout_collect(_self: object, _timeout_s: float) -> set[str]:
+        await asyncio.sleep(1)
+        return {"wl_compositor"}
+
+    monkeypatch.setattr(registry_probe._RegistryProbeTransport, "collect", timeout_collect)
+
+    with caplog.at_level("DEBUG", logger="keymasq-session.wayland.registry_probe"):
+        result = asyncio.run(
+            registry_probe.list_registry_globals(Path("/tmp/wayland-test"), timeout_s=0.01)
+        )
+
+    assert result == set()
+    assert "Wayland registry probe timed out" in caplog.text
+    assert "Unexpected Wayland registry probe failure" not in caplog.text
+
+
 def test_wayland_clients_send_requests_with_loop_sock_sendall() -> None:
     async def send_requests() -> None:
         clients = (

--- a/tests/test_wayland_protocol_trackers.py
+++ b/tests/test_wayland_protocol_trackers.py
@@ -3,7 +3,7 @@ import socket
 import struct
 import tempfile
 import threading
-from collections.abc import Iterator
+from collections.abc import Generator
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Any, cast
@@ -133,7 +133,7 @@ def test_wayland_transport_display_error_raises_protocol_error() -> None:
 
 
 @contextmanager
-def _short_socket_path(name: str) -> Iterator[Path]:
+def _short_socket_path(name: str) -> Generator[Path, None, None]:
     with tempfile.TemporaryDirectory(prefix="kmq-", dir="/tmp") as temp_dir:
         yield Path(temp_dir) / name
 
@@ -243,7 +243,7 @@ def _serve_registry_probe_response(
                     conn.recv(4096)
                     conn.sendall(response)
                     conn.recv(4096)
-        except BaseException as exc:
+        except (OSError, RuntimeError, TimeoutError, TypeError, ValueError, AssertionError) as exc:
             errors.append(exc)
             ready.set()
 
@@ -377,6 +377,23 @@ def test_registry_probe_ignores_truncated_global_interface_async() -> None:
     assert asyncio.run(run_probe()) == {EXT_FOREIGN_TOPLEVEL_LIST_INTERFACE}
 
 
+def test_registry_probe_logs_unexpected_collect_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    async def fail_collect(_self: object, _timeout_s: float) -> set[str]:
+        raise RuntimeError("probe bug")
+
+    monkeypatch.setattr(registry_probe._RegistryProbeTransport, "collect", fail_collect)
+
+    with caplog.at_level("ERROR", logger="keymasq-session.wayland.registry_probe"):
+        result = asyncio.run(registry_probe.list_registry_globals(Path("/tmp/wayland-test")))
+
+    assert result == set()
+    assert "Unexpected Wayland registry probe failure" in caplog.text
+    assert "probe bug" in caplog.text
+
+
 def test_wayland_clients_send_requests_with_loop_sock_sendall() -> None:
     async def send_requests() -> None:
         clients = (
@@ -465,6 +482,39 @@ def test_ext_wayland_client_stop_destroys_handles_before_list() -> None:
     assert fake_socket.closed is True
 
 
+def test_ext_wayland_client_stop_logs_unexpected_destroy_failure(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    tracker = ExtForeignToplevelListTracker()
+    client = ExtForeignToplevelListWaylandClient(tracker)
+    fake_socket = _FakeWaylandSocket()
+    client._socket = fake_socket
+
+    list_id = client._allocate_object_id(EXT_FOREIGN_TOPLEVEL_LIST_INTERFACE)
+    handle_id = client._allocate_object_id("ext_foreign_toplevel_handle_v1")
+    client._list_id = list_id
+    client._toplevel_handles.add(handle_id)
+
+    async def fail_send_request(
+        _object_id: int,
+        _opcode: int,
+        _payload: bytes,
+    ) -> None:
+        raise RuntimeError("destroy bug")
+
+    client._send_request = fail_send_request
+
+    with caplog.at_level("ERROR", logger="keymasq-session.wayland.ext_foreign_toplevel"):
+        asyncio.run(client.stop())
+
+    assert fake_socket.closed is True
+    assert client._list_id is None
+    assert client._toplevel_handles == set()
+    assert "Unexpected failure destroying ext foreign toplevel handle" in caplog.text
+    assert "Unexpected failure destroying ext foreign toplevel list" in caplog.text
+    assert "destroy bug" in caplog.text
+
+
 def test_wlr_wayland_client_dispatches_manager_and_toplevel_events() -> None:
     tracker = WlrForeignToplevelManagerTracker()
     client = wlr_client_module.WlrForeignToplevelWaylandClient(tracker)
@@ -528,6 +578,43 @@ def test_wlr_wayland_client_stop_removes_tracker_handles() -> None:
     assert tracker.get_active_window() == ("", "")
     assert client._toplevel_handles == set()
     assert fake_socket.closed is True
+
+
+def test_wlr_wayland_client_stop_logs_unexpected_destroy_failure(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    tracker = WlrForeignToplevelManagerTracker()
+    client = wlr_client_module.WlrForeignToplevelWaylandClient(tracker)
+    fake_socket = _FakeWaylandSocket()
+    client._socket = fake_socket
+
+    manager_id = client._allocate_object_id(
+        wlr_client_module.WLR_FOREIGN_TOPLEVEL_MANAGER_INTERFACE
+    )
+    handle_id = client._allocate_object_id("zwlr_foreign_toplevel_handle_v1")
+    client._manager_id = manager_id
+    client._toplevel_handles.add(handle_id)
+    tracker.add_toplevel(str(handle_id))
+
+    async def fail_send_request(
+        _object_id: int,
+        _opcode: int,
+        _payload: bytes,
+    ) -> None:
+        raise RuntimeError("destroy bug")
+
+    client._send_request = fail_send_request
+
+    with caplog.at_level("ERROR", logger="keymasq-session.wayland.wlr_foreign_toplevel"):
+        asyncio.run(client.stop())
+
+    assert fake_socket.closed is True
+    assert client._manager_id is None
+    assert client._toplevel_handles == set()
+    assert str(handle_id) not in tracker._windows
+    assert "Unexpected failure destroying wlr foreign toplevel handle" in caplog.text
+    assert "Unexpected failure destroying wlr foreign toplevel manager" in caplog.text
+    assert "destroy bug" in caplog.text
 
 
 def test_cosmic_wayland_client_links_ext_handles_to_cosmic_state() -> None:
@@ -628,6 +715,40 @@ def test_cosmic_wayland_client_stop_destroys_handles_before_list() -> None:
         (list_id, 1),
     ]
     assert fake_socket.closed is True
+
+
+def test_cosmic_wayland_client_logs_unexpected_cosmic_handle_destroy_failure(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    tracker = ExtForeignToplevelListTracker()
+    client = cosmic_client_module.CosmicToplevelInfoWaylandClient(tracker)
+    cosmic_handle_id = client._allocate_object_id("zcosmic_toplevel_handle_v1")
+    ext_handle_id = client._allocate_object_id("ext_foreign_toplevel_handle_v1")
+    client._cosmic_handles.add(cosmic_handle_id)
+    client._ext_to_cosmic[ext_handle_id] = cosmic_handle_id
+    client._cosmic_to_ext[cosmic_handle_id] = ext_handle_id
+
+    async def fail_send_request(
+        _object_id: int,
+        _opcode: int,
+        _payload: bytes,
+    ) -> None:
+        raise RuntimeError("destroy bug")
+
+    client._send_request = fail_send_request
+
+    with caplog.at_level(
+        "ERROR",
+        logger="keymasq-session.wayland.cosmic_toplevel_info",
+    ):
+        asyncio.run(client._destroy_cosmic_handle(cosmic_handle_id))
+
+    assert cosmic_handle_id not in client._cosmic_handles
+    assert cosmic_handle_id not in client._objects
+    assert ext_handle_id not in client._ext_to_cosmic
+    assert cosmic_handle_id not in client._cosmic_to_ext
+    assert "Unexpected failure destroying COSMIC toplevel info handle" in caplog.text
+    assert "destroy bug" in caplog.text
 
 
 def test_cosmic_wayland_client_skips_unsupported_registry_version() -> None:

--- a/tests/test_x11_listener.py
+++ b/tests/test_x11_listener.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 from types import SimpleNamespace
 
 from keymasq.session.listeners import x11 as x11_listener_module
@@ -75,6 +76,62 @@ def test_x11_probe_available_requires_openable_display(monkeypatch) -> None:
     )
 
     assert asyncio.run(X11Listener.probe_available()) is False
+
+
+def test_x11_can_open_display_logs_expected_failures(monkeypatch, caplog) -> None:
+    class _DisplayModule:
+        def Display(self, _display: str) -> object:  # noqa: N802 - Xlib API
+            raise OSError("display unavailable")
+
+    monkeypatch.setattr(x11_listener_module, "xdisplay", _DisplayModule())
+
+    with caplog.at_level(logging.DEBUG, logger="keymasq-session.listeners.x11"):
+        assert X11Listener._can_open_display(":99") is False
+
+    assert "Could not open X11 display :99: display unavailable" in caplog.text
+
+
+def test_x11_can_open_display_logs_unexpected_failures(monkeypatch, caplog) -> None:
+    class _DisplayModule:
+        def Display(self, _display: str) -> object:  # noqa: N802 - Xlib API
+            raise RuntimeError("display bug")
+
+    monkeypatch.setattr(x11_listener_module, "xdisplay", _DisplayModule())
+
+    with caplog.at_level(logging.ERROR, logger="keymasq-session.listeners.x11"):
+        assert X11Listener._can_open_display(":99") is False
+
+    assert "Could not open X11 display :99" in caplog.text
+    assert "display bug" in caplog.text
+
+
+def test_x11_get_active_window_logs_unexpected_query_failures(caplog) -> None:
+    async def run() -> None:
+        listener = X11Listener(_cb)
+
+        def _raise_query() -> tuple[str, str, list[str]]:
+            raise RuntimeError("query bug")
+
+        listener._query_active_window = _raise_query
+
+        with caplog.at_level(logging.ERROR, logger="keymasq-session.listeners.x11"):
+            assert await listener.get_active_window() == ("", "", [])
+
+        assert "X11 active window query failed" in caplog.text
+        assert "query bug" in caplog.text
+
+    asyncio.run(run())
+
+
+def test_x11_query_active_window_id_ignores_malformed_property(monkeypatch) -> None:
+    listener = X11Listener(_cb)
+    listener._root = SimpleNamespace(
+        get_full_property=lambda *_args: SimpleNamespace(value=["not-int"])
+    )
+    listener._atom_active = 1
+    monkeypatch.setattr(x11_listener_module, "X", SimpleNamespace(AnyPropertyType=0))
+
+    assert listener._query_active_window_id_unlocked() is None
 
 
 def test_x11_listener_waits_for_fd_event_before_draining(monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- Added and extended tests across session-manager execution paths (`command`, `core`, and `events`) plus related runtime/profile/manager flows.
- Replaced broad `except Exception` handlers with targeted exceptions in daemon, session, GUI, common utilities, and capture/runtime paths while preserving behavior with safe fallbacks.
- Improved failure logging for unexpected paths (`log.exception`/`log.warning`) and made cleanup/reporting for sockets, devices, and processes more deterministic.
- Tightened parsing/IO resilience for settings, recording unlock state, peer credentials, and hardware/probe operations to fail safely without masking all errors.
- Updated supporting files and lock/runtime metadata (`flake.lock`) alongside minor test/config/helper adjustments.

## Testing
- Not run: `./scripts/check.sh` was not executed in this PR content generation context.
- Not run: `nix develop -c pytest` for the full suite was not executed in this PR content generation context.
- Added/updated tests relevant to this change:
  - `tests/session/test_session_manager_command_runtime.py`
  - `tests/session/test_session_manager_core.py`
  - `tests/session/test_session_manager_events.py`
  - `tests/session/test_session_manager_profile_apply.py`
  - `tests/test_session_manager_profile_resolution.py`
  - `tests/test_session_manager_connect_loop.py`
  - `tests/test_config_loading.py`
  - `tests/test_session_clients.py`
  - `tests/test_session_manager_recording_settings.py`
  - `tests/test_session_manager_profile_resolution.py`
  - `tests/keymasqd/test_device_manager_core.py`
  - `tests/keymasqd/test_device_manager_runtime_recovery.py`