### PR TITLE
Handle session and listener edge cases safely

### DIFF
--- a/keymasq/gui/session_client.py
+++ b/keymasq/gui/session_client.py
@@ -201,21 +201,26 @@ class _PersistentSessionConnection:
             if callable(raw_idle_add):
                 idle_add = raw_idle_add
             else:
-                log.warning("GLib.idle_add unavailable; dispatching session callbacks directly")
+                log.warning("GLib.idle_add unavailable; dropping session event callback")
 
         for callback in callbacks:
             if idle_add is None:
-                self._dispatch_event_callback_once(callback, message)
+                log.warning(
+                    "Cannot marshal session event callback to GTK main loop; dropping event %s",
+                    event,
+                )
                 continue
 
             try:
                 idle_add(self._dispatch_event_callback_once, callback, message)
             except (RuntimeError, TypeError) as exc:
-                log.warning("Failed to schedule session event callback with GLib: %s", exc)
-                self._dispatch_event_callback_once(callback, message)
+                log.warning(
+                    "Failed to schedule session event callback with GLib: %s; dropping event %s",
+                    exc,
+                    event,
+                )
             except Exception:
                 log.exception("Unexpected failure scheduling session event callback")
-                self._dispatch_event_callback_once(callback, message)
 
     @staticmethod
     def _dispatch_event_callback_once(

--- a/keymasq/gui/wizards/hardware_setup.py
+++ b/keymasq/gui/wizards/hardware_setup.py
@@ -786,65 +786,80 @@ class HardwareSetupDialog(Adw.Dialog):
         for path in sorted(evdev.list_devices(), key=local_sort_key):
             try:
                 device = evdev.InputDevice(path)
-                if self._should_skip_detected_device(device):
-                    continue
-                info = device.info
-                vendor_id = f"{info.vendor:04x}"
-                product_id = f"{info.product:04x}"
-                vid_pid = f"{vendor_id}:{product_id}"
-                device_types = detect_input_classes(device)
-                if not self._should_include_detected_interface(device_types):
-                    continue
-                stable_path = resolve_stable_path(path)
-                phys = str(getattr(device, "phys", "") or "")
-                identity_key = self._detected_identity_key(
-                    model_id=vid_pid,
-                    device_types=device_types,
-                    stable_path=stable_path,
-                    phys=phys,
-                    path=path,
-                )
-                configured_hardware_id = configured_identity_hardware_ids.get(identity_key, "")
-                if not self._show_raw_evdev_devices and (
-                    configured_hardware_id
-                    or (not has_config_inventory and self._hardware_config_exists(vid_pid))
-                ):
-                    continue
-                if self._show_raw_evdev_devices and configured_hardware_id:
-                    hardware_id = configured_hardware_id
-                    device_key = _in_use_row_key(hardware_id, path, stable_path)
-                    configured_fields = {"configured_hardware_id": hardware_id}
-                elif self._show_raw_evdev_devices:
-                    hardware_id = vid_pid
-                    device_key = _raw_row_key(path, stable_path)
-                    configured_fields = {}
-                else:
-                    hardware_id = pending_identity_hardware_ids.get(identity_key)
-                    if hardware_id is None:
-                        hardware_id = self._allocate_hardware_id(vid_pid, used_hardware_ids)
-                        used_hardware_ids.add(hardware_id)
-                        pending_identity_hardware_ids[identity_key] = hardware_id
-                    device_key = hardware_id
-                    configured_fields = {}
-                device_type = primary_input_class(device_types)
-                lsusb_entry = lsusb_map.get(vid_pid)
-                display_name = (
-                    lsusb_entry["name"] if lsusb_entry and lsusb_entry["name"] else device.name
-                )
-                human_name = (
-                    lsusb_entry["name"] if lsusb_entry and lsusb_entry["name"] else device.name
-                )
+                try:
+                    if self._should_skip_detected_device(device):
+                        continue
+                    info = device.info
+                    vendor_id = f"{info.vendor:04x}"
+                    product_id = f"{info.product:04x}"
+                    vid_pid = f"{vendor_id}:{product_id}"
+                    device_types = detect_input_classes(device)
+                    if not self._should_include_detected_interface(device_types):
+                        continue
+                    stable_path = resolve_stable_path(path)
+                    phys = str(getattr(device, "phys", "") or "")
+                    identity_key = self._detected_identity_key(
+                        model_id=vid_pid,
+                        device_types=device_types,
+                        stable_path=stable_path,
+                        phys=phys,
+                        path=path,
+                    )
+                    configured_hardware_id = configured_identity_hardware_ids.get(identity_key, "")
+                    if not self._show_raw_evdev_devices and (
+                        configured_hardware_id
+                        or (not has_config_inventory and self._hardware_config_exists(vid_pid))
+                    ):
+                        continue
+                    if self._show_raw_evdev_devices and configured_hardware_id:
+                        hardware_id = configured_hardware_id
+                        device_key = _in_use_row_key(hardware_id, path, stable_path)
+                        configured_fields = {"configured_hardware_id": hardware_id}
+                    elif self._show_raw_evdev_devices:
+                        hardware_id = vid_pid
+                        device_key = _raw_row_key(path, stable_path)
+                        configured_fields = {}
+                    else:
+                        hardware_id = pending_identity_hardware_ids.get(identity_key)
+                        if hardware_id is None:
+                            hardware_id = self._allocate_hardware_id(vid_pid, used_hardware_ids)
+                            used_hardware_ids.add(hardware_id)
+                            pending_identity_hardware_ids[identity_key] = hardware_id
+                        device_key = hardware_id
+                        configured_fields = {}
+                    device_type = primary_input_class(device_types)
+                    lsusb_entry = lsusb_map.get(vid_pid)
+                    display_name = (
+                        lsusb_entry["name"] if lsusb_entry and lsusb_entry["name"] else device.name
+                    )
+                    human_name = (
+                        lsusb_entry["name"] if lsusb_entry and lsusb_entry["name"] else device.name
+                    )
 
-                if device_key not in detected_devices:
-                    detected_devices[device_key] = {
-                        "name": human_name,
-                        "display_name": display_name,
-                        "hardware_id": hardware_id,
-                        "model_id": vid_pid,
-                        "vendor_id": vendor_id,
-                        "product_id": product_id,
-                        "paths": [path],
-                        "interfaces": [
+                    if device_key not in detected_devices:
+                        detected_devices[device_key] = {
+                            "name": human_name,
+                            "display_name": display_name,
+                            "hardware_id": hardware_id,
+                            "model_id": vid_pid,
+                            "vendor_id": vendor_id,
+                            "product_id": product_id,
+                            "paths": [path],
+                            "interfaces": [
+                                {
+                                    "path": path,
+                                    "stable_path": stable_path,
+                                    "name": device.name,
+                                    "phys": phys,
+                                    "device_type": device_type,
+                                    "device_types": device_types,
+                                    **configured_fields,
+                                }
+                            ],
+                        }
+                    else:
+                        detected_devices[device_key]["paths"].append(path)
+                        detected_devices[device_key]["interfaces"].append(
                             {
                                 "path": path,
                                 "stable_path": stable_path,
@@ -854,21 +869,9 @@ class HardwareSetupDialog(Adw.Dialog):
                                 "device_types": device_types,
                                 **configured_fields,
                             }
-                        ],
-                    }
-                else:
-                    detected_devices[device_key]["paths"].append(path)
-                    detected_devices[device_key]["interfaces"].append(
-                        {
-                            "path": path,
-                            "stable_path": stable_path,
-                            "name": device.name,
-                            "phys": phys,
-                            "device_type": device_type,
-                            "device_types": device_types,
-                            **configured_fields,
-                        }
-                    )
+                        )
+                finally:
+                    device.close()
 
             except Exception:
                 log.exception("Skipping local input device %s", path)

--- a/keymasq/keymasqd/runtime/grabbed_device_events.py
+++ b/keymasq/keymasqd/runtime/grabbed_device_events.py
@@ -343,7 +343,7 @@ def get_event_name(event: InputEventLike, *, evdev_mod: EvdevModule) -> str:
     names = _evdev_code_names(event.type, evdev_mod=evdev_mod)
     if names is None:
         return str(event.code)
-    raw_code_name = names.get(raw_code, str(raw_code))
+    raw_code_name = names.get(code, str(raw_code))
     return _evdev_code_name(raw_code_name, code)
 
 

--- a/keymasq/session/listeners/kde.py
+++ b/keymasq/session/listeners/kde.py
@@ -101,7 +101,7 @@ def parse_kde_cursor_payload(payload: str) -> tuple[str, int, int] | None:
     try:
         x = int(float(str(x_raw)))
         y = int(float(str(y_raw)))
-    except (TypeError, ValueError):
+    except (TypeError, ValueError, OverflowError):
         return None
 
     return request_id, x, y

--- a/keymasq/session/listeners/niri.py
+++ b/keymasq/session/listeners/niri.py
@@ -26,6 +26,8 @@ NIRI_DISPATCH_TIMEOUT_SECONDS = 1.5
 NIRI_FOCUSED_WINDOW_TIMEOUT_SECONDS = 0.6
 NIRI_ACTIVATE_TIMEOUT_SECONDS = 2.0
 NIRI_CLI_DISPATCH_TIMEOUT_SECONDS = 3.0
+_READ_ONLY_NIRI_REQUESTS = {"FocusedWindow", "Windows"}
+
 
 def _normalize_string(value: object) -> str:
     if isinstance(value, str):
@@ -33,6 +35,19 @@ def _normalize_string(value: object) -> str:
     if value is None:
         return ""
     return str(value)
+
+
+def _niri_request_name(request: object) -> str:
+    if isinstance(request, str):
+        return request
+    request_object = _json_object(request)
+    if request_object is not None and len(request_object) == 1:
+        return str(next(iter(request_object)))
+    return ""
+
+
+def _niri_request_is_read_only(request: object) -> bool:
+    return _niri_request_name(request) in _READ_ONLY_NIRI_REQUESTS
 
 
 def _parse_workspace_reference(args: str) -> tuple[bool, str, JsonObject | None]:
@@ -716,8 +731,11 @@ class NiriListener(WindowListener):
         request: object,
         timeout_s: float,
     ) -> tuple[bool, object | None]:
+        request_name = _niri_request_name(request)
+        request_read_only = _niri_request_is_read_only(request)
         async with self._cmd_lock:
             for _ in range(2):
+                request_sent = False
                 if not await self._ensure_cmd_connection():
                     return False, None
                 try:
@@ -728,6 +746,7 @@ class NiriListener(WindowListener):
 
                     cmd_writer.write((json.dumps(request) + "\n").encode("utf-8"))
                     await cmd_writer.drain()
+                    request_sent = True
                     reply = await asyncio.wait_for(cmd_reader.readline(), timeout=timeout_s)
                     if not reply:
                         raise ConnectionError("Niri command socket closed")
@@ -739,14 +758,47 @@ class NiriListener(WindowListener):
                     return False, body
                 except TimeoutError as exc:
                     log.debug("Niri command request timed out: %s", exc)
-                    await self._reset_failed_cmd_connection()
-                except OSError as exc:
-                    log.debug("Niri command request failed: %s", exc)
-                    await self._reset_failed_cmd_connection()
+                    if not await self._reset_cmd_connection_for_retry(
+                        request_sent, request_read_only, request_name
+                    ):
+                        return False, None
+                except (ConnectionError, RuntimeError) as exc:
+                    log.debug("Niri command socket dropped: %s", exc)
+                    if not await self._reset_cmd_connection_for_retry(
+                        request_sent, request_read_only, request_name
+                    ):
+                        return False, None
                 except (json.JSONDecodeError, ValueError) as exc:
                     log.debug("Niri command reply was invalid: %s", exc)
-                    await self._reset_failed_cmd_connection()
+                    if not await self._reset_cmd_connection_for_retry(
+                        request_sent, request_read_only, request_name
+                    ):
+                        return False, None
+                except OSError as exc:
+                    log.debug("Niri command request failed: %s", exc)
+                    if not await self._reset_cmd_connection_for_retry(
+                        request_sent, request_read_only, request_name
+                    ):
+                        return False, None
                 except Exception:
                     log.exception("Unexpected Niri command request failure")
-                    await self._reset_failed_cmd_connection()
+                    if not await self._reset_cmd_connection_for_retry(
+                        request_sent, request_read_only, request_name
+                    ):
+                        return False, None
             return False, None
+
+    async def _reset_cmd_connection_for_retry(
+        self,
+        request_sent: bool,
+        request_read_only: bool,
+        request_name: str,
+    ) -> bool:
+        if request_sent and not request_read_only:
+            log.debug(
+                "Not retrying sent non-read-only Niri command request: %s",
+                request_name or "<unknown>",
+            )
+            return False
+        await self._reset_failed_cmd_connection()
+        return True

--- a/keymasq/session/manager/core.py
+++ b/keymasq/session/manager/core.py
@@ -760,7 +760,13 @@ class SessionManager:
                 data = cast(JsonObject, response.data)
                 raw_count = data.get("count", self.virtual_gamepad_count)
                 if isinstance(raw_count, (int, float, str)):
-                    self.virtual_gamepad_count = int(raw_count)
+                    try:
+                        self.virtual_gamepad_count = max(0, int(raw_count))
+                    except (TypeError, ValueError, OverflowError):
+                        log.warning(
+                            "Ignoring malformed virtual gamepad count from keymasqd: %r",
+                            raw_count,
+                        )
         except OSError as exc:
             log.warning("Failed to configure virtual gamepads in keymasqd: %s", exc)
 

--- a/keymasq/session/manager/recording_lifecycle.py
+++ b/keymasq/session/manager/recording_lifecycle.py
@@ -35,15 +35,6 @@ MACRO_RECORDING_DISABLED_MESSAGE = (
     "Macro recording is disabled. Enable macro recording in Keymasq before using "
     "recording triggers."
 )
-_RECORDING_MANAGER_ERRORS = (
-    OSError,
-    ConnectionError,
-    TimeoutError,
-    RuntimeError,
-    TypeError,
-    ValueError,
-    KeyError,
-)
 
 
 def _monotonic() -> float:
@@ -299,7 +290,7 @@ async def delete_pending_macro_slot(
                     data={"pending_recording_id": pending_recording_id},
                 )
             )
-        except _RECORDING_MANAGER_ERRORS:
+        except (OSError, TimeoutError, EOFError):
             return False
         if result.status != "ok":
             return False
@@ -340,7 +331,7 @@ async def sync_pending_macro_slots_from_daemon(manager: "SessionManager") -> Non
         result = await manager.client.send_command(
             Command(command=CommandType.MACRO_LIST_RECORDINGS)
         )
-    except _RECORDING_MANAGER_ERRORS:
+    except (OSError, TimeoutError, EOFError):
         return
     result_data = json_object(result.data)
     if result.status != "ok" or result_data is None:
@@ -429,7 +420,7 @@ async def stop_recording(
     slot = normalize_pending_macro_recording_slot(slot, default=1)
     try:
         result = await manager.client.send_command(Command(command=CommandType.STOP_RECORDING))
-    except _RECORDING_MANAGER_ERRORS:
+    except (OSError, TimeoutError, EOFError):
         return {"status": "error", "message": "Daemon unavailable"}
 
     if result.status == "ok":
@@ -530,7 +521,7 @@ async def play_macro_slot_trigger(manager: "SessionManager", data: JsonObject) -
         result = await manager.client.send_command(
             Command(command=CommandType.MACRO_PLAY_RECORDING, data=payload)
         )
-    except _RECORDING_MANAGER_ERRORS:
+    except (OSError, TimeoutError, EOFError):
         return {"status": "error", "message": "Daemon unavailable"}
     if result.status == "ok":
         response_data = json_object(result.data)
@@ -701,7 +692,7 @@ async def start_recording(
                     recording_data,
                     recording_slot=slot,
                 )
-        except _RECORDING_MANAGER_ERRORS:
+        except (OSError, TimeoutError, EOFError):
             log.debug("Failed to stop active recording before starting a new one", exc_info=True)
         manager.recording_state.active = False
         manager.recording_state.active_slot = 0
@@ -747,7 +738,7 @@ async def start_recording(
                     )
                 else:
                     log.debug("Recording start: get_cursor_position returned None")
-            except _RECORDING_MANAGER_ERRORS as e:
+            except (OSError, TimeoutError, EOFError) as e:
                 log.debug("Failed to get cursor position for recording start: %s", e)
         else:
             log.debug("Recording start: no window listener available")
@@ -768,7 +759,7 @@ async def start_recording(
                 },
             )
         )
-    except _RECORDING_MANAGER_ERRORS:
+    except (OSError, TimeoutError, EOFError):
         return {"status": "error", "message": "Daemon unavailable"}
 
     if result.status == "ok":
@@ -842,7 +833,7 @@ async def save_recording(
         result = await manager.client.send_command(
             Command(command=CommandType.MACRO_SAVE_RECORDING, data=macro)
         )
-    except _RECORDING_MANAGER_ERRORS:
+    except (OSError, TimeoutError, EOFError):
         return {"status": "error", "message": "Daemon unavailable"}
 
     if result.status != "ok":

--- a/keymasq/session/wayland_protocols/registry_probe.py
+++ b/keymasq/session/wayland_protocols/registry_probe.py
@@ -68,6 +68,9 @@ async def list_registry_globals(socket_path: Path, timeout_s: float = 0.6) -> se
     transport = _RegistryProbeTransport(socket_path)
     try:
         return await asyncio.wait_for(transport.collect(timeout_s), timeout=timeout_s)
+    except TimeoutError as exc:
+        log.debug("Wayland registry probe timed out for %s: %s", socket_path, exc)
+        return set()
     except (OSError, _transport.WaylandDisplayError) as exc:
         log.debug("Wayland registry probe failed for %s: %s", socket_path, exc)
         return set()

--- a/tests/gui/test_hardware_setup_dialog.py
+++ b/tests/gui/test_hardware_setup_dialog.py
@@ -981,6 +981,61 @@ class TestHardwareSetupDialog:
         assert dialog._detect_devices_via_session(detected_devices) is False
         assert detected_devices == {}
 
+    def test_detect_devices_locally_closes_opened_evdev_devices(self, monkeypatch):
+        gi.require_version("Gtk", "4.0")
+        from gi.repository import Gtk
+
+        from keymasq.gui.wizards import hardware_setup as hardware_setup_mod
+        from keymasq.gui.wizards.hardware_setup import HardwareSetupDialog
+
+        class FakeInputDevice:
+            def __init__(self, path: str) -> None:
+                self.path = path
+                self.name = "Test Device"
+                self.phys = "usb/input0"
+                self.info = SimpleNamespace(vendor=0x1234, product=0x5678)
+                self.closed = False
+
+            def close(self) -> None:
+                self.closed = True
+
+        devices: dict[str, FakeInputDevice] = {}
+
+        def input_device(path: str) -> FakeInputDevice:
+            device = FakeInputDevice(path)
+            devices[path] = device
+            return device
+
+        monkeypatch.setattr(HardwareSetupDialog, "_detect_devices", lambda self: None)
+        monkeypatch.setattr(
+            hardware_setup_mod.evdev,
+            "list_devices",
+            lambda: ["/dev/input/event1", "/dev/input/event2"],
+        )
+        monkeypatch.setattr(hardware_setup_mod.evdev, "InputDevice", input_device)
+        monkeypatch.setattr(hardware_setup_mod, "resolve_stable_path", lambda path: path)
+        monkeypatch.setattr(
+            hardware_setup_mod,
+            "detect_input_classes",
+            lambda _device: ["keyboard"],
+        )
+
+        dialog = HardwareSetupDialog(
+            Gtk.Window(),
+            SimpleNamespace(list_hardware=lambda: [], get_hardware=lambda _id: None),
+        )
+        dialog._should_skip_detected_device = lambda device: device.path.endswith("event1")  # type: ignore[method-assign]
+        dialog._should_include_detected_interface = lambda _device_types: False  # type: ignore[method-assign]
+        detected_devices: dict[str, dict] = {}
+
+        dialog._detect_devices_locally({}, detected_devices)
+
+        assert detected_devices == {}
+        assert {path: device.closed for path, device in devices.items()} == {
+            "/dev/input/event1": True,
+            "/dev/input/event2": True,
+        }
+
     def test_detect_devices_via_session_keeps_duplicate_gamepad_slots(self, monkeypatch):
         gi.require_version("Gtk", "4.0")
         from gi.repository import Gtk

--- a/tests/keymasqd/test_grabbed_device_runtime_helpers.py
+++ b/tests/keymasqd/test_grabbed_device_runtime_helpers.py
@@ -94,6 +94,17 @@ class TestGrabbedDeviceHelpers:
         assert gde.get_event_name(cast(gdt.InputEventLike, event), evdev_mod=evdev_mod) == "key_a"
         assert gde.get_key_name(evdev.ecodes.KEY_A, evdev_mod=evdev_mod) == "key_a"
 
+    def test_event_name_helpers_normalize_numeric_code_lookup(self) -> None:
+        evdev_mod = SimpleNamespace(
+            ecodes=SimpleNamespace(
+                EV_KEY=evdev.ecodes.EV_KEY,
+                bytype={evdev.ecodes.EV_KEY: {evdev.ecodes.KEY_A: "KEY_A"}},
+            )
+        )
+        event = SimpleNamespace(type=evdev.ecodes.EV_KEY, code=str(evdev.ecodes.KEY_A), value=1)
+
+        assert gde.get_event_name(cast(gdt.InputEventLike, event), evdev_mod=evdev_mod) == "key_a"
+
     @pytest.mark.asyncio
     async def test_device_release_ends_held_profile_trigger_state(
         self,

--- a/tests/session/test_session_manager_command_runtime.py
+++ b/tests/session/test_session_manager_command_runtime.py
@@ -1169,6 +1169,15 @@ async def test_list_macros_include_slots_syncs_slots_from_daemon() -> None:
 
 
 @pytest.mark.asyncio
+async def test_sync_pending_macro_slots_does_not_mask_runtime_errors() -> None:
+    manager = SessionManager()
+    manager.client.send_command = AsyncMock(side_effect=RuntimeError("local bug"))
+
+    with pytest.raises(RuntimeError, match="local bug"):
+        await session_recording_module.sync_pending_macro_slots_from_daemon(manager)
+
+
+@pytest.mark.asyncio
 async def test_play_macro_slot_trigger_rejects_empty_slot() -> None:
     manager = SessionManager()
     manager.client.send_command = AsyncMock(

--- a/tests/test_kde_listener.py
+++ b/tests/test_kde_listener.py
@@ -44,6 +44,11 @@ def test_parse_kde_cursor_payload_accepts_wrapped_json_string() -> None:
     assert parse_kde_cursor_payload(payload) == ("abc123", 123, 456)
 
 
+def test_parse_kde_cursor_payload_rejects_overflowing_coordinates() -> None:
+    payload = '{"id":"abc123","x":"1e100000","y":456}'
+    assert parse_kde_cursor_payload(payload) is None
+
+
 def test_parse_kde_dispatch_payload_valid() -> None:
     payload = '{"id":"abc123","ok":true,"message":"ok"}'
     assert parse_kde_dispatch_payload(payload) == ("abc123", True, "ok")

--- a/tests/test_niri_listener.py
+++ b/tests/test_niri_listener.py
@@ -154,7 +154,7 @@ async def test_send_cmd_request_retries_after_eof(monkeypatch) -> None:
 
     monkeypatch.setattr(listener, "_ensure_cmd_connection", fake_ensure)
 
-    ok, body = await listener._send_cmd_request({"Action": {}}, timeout_s=0.5)
+    ok, body = await listener._send_cmd_request("Windows", timeout_s=0.5)
 
     assert ok is True
     assert body == "Handled"
@@ -188,7 +188,41 @@ async def test_send_cmd_request_logs_malformed_replies(
 
 
 @pytest.mark.asyncio
-async def test_send_cmd_request_logs_unexpected_write_errors(
+async def test_send_cmd_request_does_not_retry_sent_action_after_eof(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    listener = NiriListener(_noop_callback)
+    first_writer = _FakeWriter()
+    second_writer = _FakeWriter()
+    pairs = [
+        (_FakeReader([b""]), first_writer),
+        (_FakeReader([b'{"Ok":"Handled"}\n']), second_writer),
+    ]
+
+    async def fake_ensure() -> bool:
+        if listener._cmd_reader is None or listener._cmd_writer is None:
+            if not pairs:
+                return False
+            listener._cmd_reader, listener._cmd_writer = pairs.pop(0)  # type: ignore[assignment]
+        return True
+
+    monkeypatch.setattr(listener, "_ensure_cmd_connection", fake_ensure)
+
+    with caplog.at_level(logging.DEBUG, logger="keymasq-session.listeners.niri"):
+        ok, body = await listener._send_cmd_request({"Action": {}}, timeout_s=0.5)
+
+    assert ok is False
+    assert body is None
+    assert first_writer.payloads == ['{"Action": {}}\n']
+    assert second_writer.payloads == []
+    assert listener._cmd_writer is first_writer
+    assert first_writer.closed is False
+    assert "Not retrying sent non-read-only Niri command request: Action" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_send_cmd_request_resets_dropped_command_socket_errors(
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
@@ -201,15 +235,40 @@ async def test_send_cmd_request_logs_unexpected_write_errors(
 
     monkeypatch.setattr(listener, "_ensure_cmd_connection", fake_ensure)
 
-    with caplog.at_level(logging.ERROR, logger="keymasq-session.listeners.niri"):
+    with caplog.at_level(logging.DEBUG, logger="keymasq-session.listeners.niri"):
         ok, body = await listener._send_cmd_request({"Action": {}}, timeout_s=0.5)
 
     assert ok is False
     assert body is None
     assert listener._cmd_reader is None
     assert listener._cmd_writer is None
-    assert "Unexpected Niri command request failure" in caplog.text
+    assert "Niri command socket dropped" in caplog.text
     assert "write bug" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_send_cmd_request_resets_closed_command_socket(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    listener = NiriListener(_noop_callback)
+    listener._cmd_reader = _FakeReader([b""])  # type: ignore[assignment]
+    listener._cmd_writer = _FakeWriter()  # type: ignore[assignment]
+
+    async def fake_ensure() -> bool:
+        return True
+
+    monkeypatch.setattr(listener, "_ensure_cmd_connection", fake_ensure)
+
+    with caplog.at_level(logging.DEBUG, logger="keymasq-session.listeners.niri"):
+        ok, body = await listener._send_cmd_request("Windows", timeout_s=0.5)
+
+    assert ok is False
+    assert body is None
+    assert listener._cmd_reader is None
+    assert listener._cmd_writer is None
+    assert "Niri command socket dropped" in caplog.text
+    assert "Niri command socket closed" in caplog.text
 
 
 @pytest.mark.asyncio
@@ -227,7 +286,7 @@ async def test_send_cmd_request_logs_unexpected_close_errors(
     monkeypatch.setattr(listener, "_ensure_cmd_connection", fake_ensure)
 
     with caplog.at_level(logging.ERROR, logger="keymasq-session.listeners.niri"):
-        ok, body = await listener._send_cmd_request({"Action": {}}, timeout_s=0.5)
+        ok, body = await listener._send_cmd_request("Windows", timeout_s=0.5)
 
     assert ok is False
     assert body is None

--- a/tests/test_session_clients.py
+++ b/tests/test_session_clients.py
@@ -340,8 +340,27 @@ def test_persistent_session_dispatch_event_falls_back_when_idle_add_fails(
 
     connection._dispatch_event({"event": "macro_saved", "name": "example"})
 
-    assert [call["name"] for call in calls] == ["example"]
+    assert calls == []
     assert "Failed to schedule session event callback with GLib" in caplog.text
+    assert "dropping event macro_saved" in caplog.text
+
+
+def test_persistent_session_dispatch_event_drops_when_idle_add_unavailable(
+    caplog: pytest.LogCaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    glib_module = _install_fake_glib(monkeypatch)
+    glib_module.idle_add = None
+    connection = gui_session_client._PersistentSessionConnection()
+    calls: list[dict[str, Any]] = []
+    connection.register_callback("macro_saved", lambda message: calls.append(message))
+    caplog.set_level(logging.WARNING, logger="keymasq.gui.session_client")
+
+    connection._dispatch_event({"event": "macro_saved", "name": "example"})
+
+    assert calls == []
+    assert "GLib.idle_add unavailable" in caplog.text
+    assert "dropping event macro_saved" in caplog.text
 
 
 def test_persistent_session_reader_loop_routes_events_and_response(

--- a/tests/test_session_manager_core.py
+++ b/tests/test_session_manager_core.py
@@ -156,6 +156,38 @@ async def test_connect_loop_logs_unexpected_runtime_failures(
     assert manager.connected is False
 
 
+@pytest.mark.asyncio
+async def test_sync_virtual_gamepads_ignores_malformed_daemon_count(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    manager = SessionManager()
+    manager.connected = True
+    manager.virtual_gamepad_count = 2
+    manager.client.send_command = AsyncMock(
+        return_value=Response(status="ok", data={"count": "not-a-number"})
+    )
+
+    with caplog.at_level("WARNING", logger="keymasq-session"):
+        await manager._sync_virtual_gamepads_to_daemon()
+
+    assert manager.virtual_gamepad_count == 2
+    assert "Ignoring malformed virtual gamepad count from keymasqd" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_sync_virtual_gamepads_clamps_negative_daemon_count() -> None:
+    manager = SessionManager()
+    manager.connected = True
+    manager.virtual_gamepad_count = 2
+    manager.client.send_command = AsyncMock(
+        return_value=Response(status="ok", data={"count": -3})
+    )
+
+    await manager._sync_virtual_gamepads_to_daemon()
+
+    assert manager.virtual_gamepad_count == 0
+
+
 def test_signal_handler_only_sets_shutdown_state() -> None:
     manager = SessionManager()
     manager.running = True

--- a/tests/test_wayland_protocol_trackers.py
+++ b/tests/test_wayland_protocol_trackers.py
@@ -403,6 +403,26 @@ def test_registry_probe_logs_unexpected_collect_failure(
     assert "probe bug" in caplog.text
 
 
+def test_registry_probe_logs_timeout_as_expected_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    async def timeout_collect(_self: object, _timeout_s: float) -> set[str]:
+        await asyncio.sleep(1)
+        return {"wl_compositor"}
+
+    monkeypatch.setattr(registry_probe._RegistryProbeTransport, "collect", timeout_collect)
+
+    with caplog.at_level("DEBUG", logger="keymasq-session.wayland.registry_probe"):
+        result = asyncio.run(
+            registry_probe.list_registry_globals(Path("/tmp/wayland-test"), timeout_s=0.01)
+        )
+
+    assert result == set()
+    assert "Wayland registry probe timed out" in caplog.text
+    assert "Unexpected Wayland registry probe failure" not in caplog.text
+
+
 def test_wayland_clients_send_requests_with_loop_sock_sendall() -> None:
     async def send_requests() -> None:
         clients = (


### PR DESCRIPTION
Summary:
- Keep session client callbacks off the reader thread when GTK main-loop marshaling is unavailable
- Handle remaining listener, Wayland probe, evdev-name, hardware scan, virtual gamepad, and recording IPC edge cases
- Remove _RECORDING_MANAGER_ERRORS and catch explicit transport failures in recording lifecycle flows

Origin/master status before this branch:
- None of the 8 reviewed findings were already addressed in origin/master.

Validation:
- ./scripts/check.sh full: ruff ok, basedpyright ok, stylelint ok, pytest ok - 1887 passed, 25 skipped, 2 warnings