### PR TITLE
Add session manager command, core, and event coverage

### DIFF
--- a/tests/session/test_session_manager_command_runtime.py
+++ b/tests/session/test_session_manager_command_runtime.py
@@ -3,7 +3,7 @@ import json
 import logging
 from types import SimpleNamespace
 from typing import cast
-from unittest.mock import AsyncMock, Mock
+from unittest.mock import AsyncMock, Mock, call
 
 import pytest
 
@@ -2774,6 +2774,445 @@ async def test_handle_session_request_delete_macro_broadcasts_deleted_event(
     manager.broadcast_to_session_clients.assert_called_once_with(  # type: ignore[attr-defined]
         {"event": "macro_deleted", "name": "Speedrun"}
     )
+
+
+@pytest.mark.asyncio
+async def test_profile_commands_cover_simple_and_error_branches(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = SessionManager()
+    peer = PeerCredentials(pid=1, uid=1000, gid=1000)
+    set_profile_enabled = AsyncMock(return_value={"status": "ok", "enabled": True})
+    monkeypatch.setattr(
+        session_profiles_module,
+        "set_profile_enabled",
+        set_profile_enabled,
+    )
+    monkeypatch.setattr(
+        session_profiles_module,
+        "build_profile_overview",
+        lambda _manager: {"status": "ok", "profiles": [{"name": "Base"}]},
+    )
+
+    listed = await manager._handle_session_request(
+        {"command": "list_profiles"},
+        "client",
+        peer,
+        object(),
+    )
+    missing = await manager._handle_session_request(
+        {"command": "enable_profile"},
+        "client",
+        peer,
+        object(),
+    )
+    enabled = await manager._handle_session_request(
+        {"command": "enable_profile", "profile_name": "Base"},
+        "client",
+        peer,
+        object(),
+    )
+    toggled = await manager._handle_session_request(
+        {"command": "toggle_profile", "profile_name": "Base"},
+        "client",
+        peer,
+        object(),
+    )
+    ping = await manager._handle_session_request(
+        {"command": "ping"},
+        "client",
+        peer,
+        object(),
+    )
+
+    assert listed == {"status": "ok", "profiles": [{"name": "Base"}]}
+    assert missing == {"status": "error", "message": "missing profile_name"}
+    assert enabled == {"status": "ok", "enabled": True}
+    assert toggled == {"status": "ok", "enabled": True}
+    assert ping == {"status": "ok"}
+    assert [call.args for call in set_profile_enabled.await_args_list] == [
+        (manager, "Base", True),
+        (manager, "Base", None),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_profile_commands_report_reload_and_release_failures() -> None:
+    manager = SessionManager()
+    peer = PeerCredentials(pid=1, uid=1000, gid=1000)
+    manager.reload_profiles = AsyncMock(return_value=False)  # type: ignore[method-assign]
+
+    reload_result = await manager._handle_session_request(
+        {"command": "reload"},
+        "client",
+        peer,
+        object(),
+    )
+    missing_release = await manager._handle_session_request(
+        {"command": "release_device"},
+        "client",
+        peer,
+        object(),
+    )
+
+    manager.client.send_command = AsyncMock(side_effect=OSError("daemon down"))
+    unavailable_release = await manager._handle_session_request(
+        {"command": "release_device", "hardware_id": "1234:5678"},
+        "client",
+        peer,
+        object(),
+    )
+
+    manager.client.send_command = AsyncMock(
+        return_value=Response(status="error", error="still pressed")
+    )
+    rejected_release = await manager._handle_session_request(
+        {"command": "release_device", "hardware_id": "1234:5678", "immediate": False},
+        "client",
+        peer,
+        object(),
+    )
+
+    manager.reload_config_from_disk = Mock(side_effect=ValueError("bad config"))  # type: ignore[method-assign]
+    manager.send_notification = Mock()  # type: ignore[method-assign]
+    reevaluate = await manager._handle_session_request(
+        {"command": "reevaluate_profiles"},
+        "client",
+        peer,
+        object(),
+    )
+
+    assert reload_result["status"] == "error"
+    assert missing_release == {"status": "error", "message": "missing hardware_id"}
+    assert unavailable_release == {"status": "error", "message": "Daemon unavailable"}
+    assert rejected_release == {"status": "error", "message": "still pressed"}
+    assert reevaluate == {"status": "error", "message": "bad config"}
+    manager.send_notification.assert_called_once()  # type: ignore[attr-defined]
+    assert manager.client.send_command.await_args.args[0].data == {
+        "hardware_id": "1234:5678",
+        "immediate": False,
+    }
+
+
+@pytest.mark.asyncio
+async def test_settings_and_virtual_gamepad_commands_cover_success_and_unavailable(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(paths, "CONFIG_DIR", tmp_path / "keymasq")
+    session_settings.save_global_settings(GlobalSettings(virtual_gamepad_count=2))
+    manager = SessionManager()
+    peer = PeerCredentials(pid=1, uid=1000, gid=1000)
+    manager.broadcast_to_session_clients = Mock()  # type: ignore[method-assign]
+
+    virtuals = await manager._handle_session_request(
+        {"command": "get_virtual_gamepads"},
+        "client",
+        peer,
+        object(),
+    )
+    settings = await manager._handle_session_request(
+        {"command": "get_settings"},
+        "client",
+        peer,
+        object(),
+    )
+
+    manager.connected = True
+    manager.client.send_command = AsyncMock(side_effect=OSError("daemon down"))
+    virtual_unavailable = await manager._handle_session_request(
+        {"command": "set_virtual_gamepads", "count": 3},
+        "client",
+        peer,
+        object(),
+    )
+    settings_unavailable = await manager._handle_session_request(
+        {"command": "set_settings", "virtual_gamepad_count": 3},
+        "client",
+        peer,
+        object(),
+    )
+
+    manager.client.send_command = AsyncMock(
+        return_value=Response(status="ok", data={"count": 4})
+    )
+    settings_saved = await manager._handle_session_request(
+        {"command": "set_settings", "virtual_gamepad_count": 3},
+        "client",
+        peer,
+        object(),
+    )
+
+    assert virtuals["count"] == 2
+    assert settings["virtual_gamepad_count"] == 2
+    assert virtual_unavailable == {"status": "error", "message": "Daemon unavailable"}
+    assert settings_unavailable["status"] == "error"
+    assert settings_unavailable["message"] == "Daemon unavailable"
+    assert settings_saved["status"] == "ok"
+    assert settings_saved["virtual_gamepad_count"] == 4
+    manager.broadcast_to_session_clients.assert_called_once_with(  # type: ignore[attr-defined]
+        {"event": "settings_changed", "virtual_gamepad_count": 4}
+    )
+
+
+@pytest.mark.asyncio
+async def test_macro_commands_cover_remaining_daemon_variants(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = SessionManager()
+    peer = PeerCredentials(pid=1, uid=1000, gid=1000)
+    manager.broadcast_to_session_clients = Mock()  # type: ignore[method-assign]
+    refresh_macro_bindings = AsyncMock()
+    monkeypatch.setattr(
+        session_profiles_module,
+        "refresh_macro_bindings",
+        refresh_macro_bindings,
+    )
+
+    manager.client.send_command = AsyncMock(
+        side_effect=[
+            Response(status="error", error="empty list"),
+            Response(status="ok", data={"macro": {"name": "Demo"}}),
+            Response(status="error", error="missing"),
+            OSError("daemon down"),
+            Response(status="error", error="create failed"),
+            OSError("daemon down"),
+            Response(status="error", error="delete failed"),
+            Response(status="ok", data={"macro": {"name": "Renamed"}}),
+            Response(status="ok", data=None),
+            Response(status="error", error="rename failed"),
+            Response(status="ok", data={"status": "ok", "queued": True}),
+            Response(status="error", error="play failed"),
+            Response(status="ok", data={"cancelled": 2}),
+            Response(status="error", error="cancel failed"),
+        ]
+    )
+
+    requests = [
+        {"command": "list_macros"},
+        {"command": "get_macro", "name": "Demo"},
+        {"command": "get_macro", "name": "Missing"},
+        {"command": "get_macro", "name": "Missing"},
+        {"command": "create_macro", "macro": {"name": "Demo"}},
+        {"command": "update_macro", "name": "Demo", "macro": {"name": "Demo"}},
+        {"command": "delete_macro", "name": "Demo", "expected_revision": 3},
+        {"command": "rename_macro", "old": "Demo", "new": "Renamed"},
+        {"command": "rename_macro", "old": "Demo", "new": "Renamed"},
+        {"command": "rename_macro", "old": "Demo", "new": "Renamed"},
+        {
+            "command": "play_macro",
+            "name": "Demo",
+            "replay_mouse_movement": False,
+            "replay_mouse_clicks": False,
+            "speed": 1.5,
+        },
+        {"command": "play_macro", "name": "Demo"},
+        {"command": "cancel_macro_playback"},
+        {"command": "cancel_macro_playback"},
+    ]
+    results = [
+        await manager._handle_session_request(request, "client", peer, object())
+        for request in requests
+    ]
+
+    assert results == [
+        {"status": "error", "message": "empty list"},
+        {"status": "ok", "macro": {"name": "Demo"}},
+        {"status": "error", "message": "missing"},
+        {"status": "error", "message": "Daemon unavailable"},
+        {"status": "error", "message": "create failed"},
+        {"status": "error", "message": "Daemon unavailable"},
+        {"status": "error", "message": "delete failed"},
+        {"status": "ok", "macro": {"name": "Renamed"}},
+        {"status": "ok"},
+        {"status": "error", "message": "rename failed"},
+        {"status": "ok", "queued": True},
+        {"status": "error", "message": "play failed"},
+        {"cancelled": 2},
+        {"status": "error", "message": "cancel failed"},
+    ]
+    update_command = manager.client.send_command.await_args_list[5].args[0]
+    delete_command = manager.client.send_command.await_args_list[6].args[0]
+    play_command = manager.client.send_command.await_args_list[10].args[0]
+    assert update_command.command == CommandType.MACRO_UPDATE
+    assert delete_command.data == {"name": "Demo", "expected_revision": 3}
+    assert play_command.data == {
+        "name": "Demo",
+        "replay_mouse_movement": False,
+        "replay_mouse_clicks": False,
+        "speed": 1.5,
+    }
+    assert refresh_macro_bindings.await_count == 2
+    assert manager.broadcast_to_session_clients.call_args_list == [  # type: ignore[attr-defined]
+        call({"event": "macro_deleted", "name": "Demo"}),
+        call({"event": "macro_saved", "name": "Renamed"}),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_macro_commands_validate_payloads_and_compile_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = SessionManager()
+    peer = PeerCredentials(pid=1, uid=1000, gid=1000)
+
+    async def fake_to_thread(_func, /, *_args, **_kwargs):
+        raise ValueError("bad macro")
+
+    monkeypatch.setattr(session_commands_module.asyncio, "to_thread", fake_to_thread)
+
+    create_missing = await manager._handle_session_request(
+        {"command": "create_macro"},
+        "client",
+        peer,
+        object(),
+    )
+    update_missing = await manager._handle_session_request(
+        {"command": "update_macro", "name": "Demo"},
+        "client",
+        peer,
+        object(),
+    )
+    type_text_error = await manager._handle_session_request(
+        {"command": "type_text", "text": "Hi"},
+        "client",
+        peer,
+        object(),
+    )
+    compact_empty = await manager._handle_session_request(
+        {"command": "play_compact_macro", "tokens": []},
+        "client",
+        peer,
+        object(),
+    )
+    compact_error = await manager._handle_session_request(
+        {"command": "play_compact_macro", "tokens": ["key_a"]},
+        "client",
+        peer,
+        object(),
+    )
+
+    assert create_missing == {"status": "error", "message": "macro payload required"}
+    assert update_missing == {"status": "error", "message": "macro payload required"}
+    assert type_text_error == {"status": "error", "message": "bad macro"}
+    assert compact_empty == {"status": "error", "message": "tokens required"}
+    assert compact_error == {"status": "error", "message": "bad macro"}
+
+
+@pytest.mark.asyncio
+async def test_adhoc_macro_payload_reports_daemon_failures() -> None:
+    manager = SessionManager()
+    peer = PeerCredentials(pid=1, uid=1000, gid=1000)
+    payload = {
+        "command": "play_macro_payload",
+        "macro_events": [{"type": 1, "code": 30, "value": 1, "t_us": 0}],
+    }
+
+    manager.client.send_command = AsyncMock(side_effect=OSError("daemon down"))
+    unavailable = await manager._handle_session_request(payload, "client", peer, object())
+
+    manager.client.send_command = AsyncMock(
+        return_value=Response(status="error", error="play failed")
+    )
+    failed = await manager._handle_session_request(payload, "client", peer, object())
+
+    assert unavailable == {"status": "error", "message": "Daemon unavailable"}
+    assert failed == {"status": "error", "message": "play failed"}
+
+
+@pytest.mark.asyncio
+async def test_capture_and_diagnostics_commands_cover_remaining_branches(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = SessionManager()
+    manager.security_policy.recording_unlock_required = False
+    peer = PeerCredentials(pid=1, uid=1000, gid=1000)
+    writer = object()
+    get_devices = AsyncMock(return_value=[{"name": "Keyboard"}])
+    capture_read = AsyncMock(return_value={"status": "ok", "events": []})
+    update_selected = Mock()
+    monkeypatch.setattr(session_recording_module, "get_devices_for_recording", get_devices)
+    monkeypatch.setattr(session_recording_module, "capture_read", capture_read)
+    monkeypatch.setattr(
+        session_recording_module,
+        "update_selected_recording_devices_cache",
+        update_selected,
+    )
+
+    devices = await manager._handle_session_request(
+        {"command": "list_devices_for_recording", "include_other": True},
+        "client",
+        peer,
+        writer,
+    )
+    read = await manager._handle_session_request(
+        {"command": "capture_read", "hardware_id": "1234:5678"},
+        "client",
+        peer,
+        writer,
+    )
+    combo_missing = await manager._handle_session_request(
+        {"command": "capture_combo"},
+        "client",
+        peer,
+        writer,
+    )
+
+    manager.client.send_command = AsyncMock(side_effect=OSError("daemon down"))
+    diagnostics_unavailable = await manager._handle_session_request(
+        {"command": "set_diagnostics", "enabled": True},
+        "client",
+        peer,
+        writer,
+    )
+
+    manager.client.send_command = AsyncMock(
+        return_value=Response(status="ok", data={"enabled": True})
+    )
+    diagnostics_ok = await manager._handle_session_request(
+        {
+            "command": "set_diagnostics",
+            "enabled": True,
+            "interval": 2,
+            "categories": ["runtime", "", "devices"],
+        },
+        "client",
+        peer,
+        writer,
+    )
+
+    sent = manager.client.send_command.await_args.args[0]
+    assert sent.command == CommandType.SET_DIAGNOSTICS
+    assert sent.data == {
+        "enabled": True,
+        "interval": 2.0,
+        "categories": ["runtime", "devices"],
+    }
+
+    manager.client.send_command = AsyncMock(
+        return_value=Response(status="error", error="bad category")
+    )
+    diagnostics_error = await manager._handle_session_request(
+        {"command": "set_diagnostics"},
+        "client",
+        peer,
+        writer,
+    )
+
+    assert devices == {"status": "ok", "devices": [{"name": "Keyboard"}]}
+    assert read == {"status": "ok", "events": []}
+    assert combo_missing == {"error": "missing profile_name"}
+    assert diagnostics_unavailable == {"status": "error", "message": "Daemon unavailable"}
+    assert diagnostics_ok == {"status": "ok", "data": {"enabled": True}}
+    assert diagnostics_error == {"status": "error", "message": "bad category"}
+    get_devices.assert_awaited_once_with(
+        manager,
+        ["keyboard", "gamepad", "mouse", "touchpad", "pointstick", "other"],
+        include_grabbed=True,
+    )
+    assert manager.recording_state.devices_cache == [{"name": "Keyboard"}]
+    assert manager.recording_state.devices_cache_ready is True
+    update_selected.assert_called_once_with(manager)
 
 
 @pytest.mark.asyncio

--- a/tests/test_session_manager_core.py
+++ b/tests/test_session_manager_core.py
@@ -1,5 +1,7 @@
 import asyncio
 import json
+from types import SimpleNamespace
+from typing import cast
 from unittest.mock import AsyncMock, Mock
 
 import pytest
@@ -8,7 +10,7 @@ import keymasq.session.manager.core as session_manager_core_module
 import keymasq.session.manager.events as session_events_module
 import keymasq.session.manager.profiles as session_profiles_module
 from keymasq.common.ipc import Response
-from keymasq.common.models import ProfileConfig, SuperkeyConfig, SuperkeyMode
+from keymasq.common.models import ButtonDefinition, ProfileConfig, SuperkeyConfig, SuperkeyMode
 from keymasq.common.security import PeerCredentials
 from keymasq.session.manager import SessionManager
 from keymasq.session.profiles import ProfileInfo
@@ -77,6 +79,31 @@ class _HangingSessionWriter(_FakeSessionWriter):
 
     def abort(self) -> None:
         self.abort_calls += 1
+
+
+class _FakeSessionServer:
+    def __init__(self) -> None:
+        self.closed = False
+        self.wait_closed_calls = 0
+
+    def close(self) -> None:
+        self.closed = True
+
+    async def wait_closed(self) -> None:
+        self.wait_closed_calls += 1
+
+
+def _inotify_event(wd: int, mask: int, name: str) -> bytes:
+    raw_name = name.encode() + b"\0"
+    return (
+        session_manager_core_module.INOTIFY_EVENT_STRUCT.pack(
+            wd,
+            mask,
+            0,
+            len(raw_name),
+        )
+        + raw_name
+    )
 
 
 @pytest.mark.asyncio
@@ -168,6 +195,50 @@ def test_signal_handler_only_sets_shutdown_state() -> None:
 
 
 @pytest.mark.asyncio
+async def test_start_wires_runtime_tasks_and_stops_on_shutdown(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = SessionManager()
+    added_signals = []
+
+    async def start_session_server() -> None:
+        asyncio.get_running_loop().call_soon(manager._shutdown_event.set)
+
+    async def connect_loop() -> None:
+        await asyncio.sleep(0)
+
+    async def compositor_supervisor_loop(_manager: SessionManager) -> None:
+        await asyncio.sleep(0)
+
+    monkeypatch.setattr(
+        session_manager_core_module.asyncio,
+        "get_event_loop",
+        lambda: SimpleNamespace(
+            add_signal_handler=lambda *args: added_signals.append(args),
+        ),
+    )
+    monkeypatch.setattr(
+        session_manager_core_module.runtime_compositor,
+        "compositor_supervisor_loop",
+        compositor_supervisor_loop,
+    )
+    manager._start_session_server = AsyncMock(side_effect=start_session_server)  # type: ignore[method-assign]
+    manager.connect_loop = connect_loop  # type: ignore[method-assign]
+    manager._start_config_watcher = Mock()  # type: ignore[method-assign]
+    manager.stop = AsyncMock()  # type: ignore[method-assign]
+
+    await manager.start()
+
+    assert manager.running is True
+    assert len(added_signals) == 3
+    manager._start_session_server.assert_awaited_once()  # type: ignore[attr-defined]
+    manager._start_config_watcher.assert_called_once()  # type: ignore[attr-defined]
+    manager.stop.assert_awaited_once()  # type: ignore[attr-defined]
+    assert manager.connect_task is not None
+    assert manager.compositor_state.supervisor_task is not None
+
+
+@pytest.mark.asyncio
 async def test_stop_cancels_tracked_event_tasks() -> None:
     manager = SessionManager()
     manager.running = True
@@ -198,6 +269,62 @@ async def test_stop_cancels_tracked_event_tasks() -> None:
     assert manager.event_state.tasks == set()
     manager.client.disconnect.assert_awaited_once()  # type: ignore[attr-defined]
     manager.dbus.disconnect.assert_awaited_once()  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_stop_cleans_runtime_tasks_server_capture_and_owned_socket(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = SessionManager()
+    manager.running = True
+    manager.client.disconnect = AsyncMock()  # type: ignore[method-assign]
+    manager.client.send_command = AsyncMock(return_value=Response(status="ok"))
+    manager.dbus.disconnect = AsyncMock()  # type: ignore[method-assign]
+    manager.action_handler = SimpleNamespace(cancel_background_tasks=AsyncMock())  # type: ignore[assignment]
+    manager.session_server = _FakeSessionServer()  # type: ignore[assignment]
+    manager.capture_state.tokens["1234:5678"] = "capture-token"
+
+    class FakeSocketPath:
+        def __init__(self) -> None:
+            self.exists_called = False
+            self.unlinked = False
+
+        def exists(self) -> bool:
+            self.exists_called = True
+            return not self.unlinked
+
+        def unlink(self) -> None:
+            self.unlinked = True
+
+    socket_path = FakeSocketPath()
+    manager._session_socket_owned = True
+    monkeypatch.setattr(session_manager_core_module, "SESSION_SOCKET_PATH", socket_path)
+
+    async def wait_forever() -> None:
+        await asyncio.Event().wait()
+
+    manager.compositor_state.supervisor_task = asyncio.create_task(wait_forever())
+    manager.profile_state.apply_task = asyncio.create_task(wait_forever())
+    manager.profile_state.topology_refresh_task = asyncio.create_task(wait_forever())
+    manager.recording_state.settings_save_task = asyncio.create_task(asyncio.sleep(0))
+    manager.connect_task = asyncio.create_task(wait_forever())
+
+    await manager.stop()
+
+    assert manager.compositor_state.supervisor_task is None
+    assert manager.profile_state.apply_task is None
+    assert manager.profile_state.topology_refresh_task is None
+    assert manager.recording_state.settings_save_task is None
+    assert manager.connect_task is None
+    assert manager.capture_state.tokens == {}
+    assert socket_path.exists_called is True
+    assert socket_path.unlinked is True
+    assert manager._session_socket_owned is False
+    assert manager.session_server.closed is True  # type: ignore[union-attr]
+    assert manager.session_server.wait_closed_calls == 1  # type: ignore[union-attr]
+    manager.client.send_command.assert_awaited_once()  # type: ignore[attr-defined]
+    manager.client.disconnect.assert_awaited_once()  # type: ignore[attr-defined]
+    assert manager.action_handler.cancel_background_tasks.await_count == 2
 
 
 @pytest.mark.asyncio
@@ -443,6 +570,119 @@ async def test_session_client_request_error_keeps_connection_alive(
 
 
 @pytest.mark.asyncio
+async def test_session_client_rejects_missing_or_denied_peer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = SessionManager()
+    manager.running = True
+
+    missing_peer_writer = _FakeSessionWriter()
+    monkeypatch.setattr(
+        session_manager_core_module,
+        "get_peer_credentials",
+        lambda _sock: None,
+    )
+    await manager._handle_session_client(  # type: ignore[arg-type]
+        _FakeSessionReader([]),
+        missing_peer_writer,
+    )
+
+    denied_writer = _FakeSessionWriter()
+    manager.security_policy.session_allowed_uids = {1000}
+    monkeypatch.setattr(
+        session_manager_core_module,
+        "get_peer_credentials",
+        lambda _sock: PeerCredentials(pid=321, uid=2000, gid=2000),
+    )
+    await manager._handle_session_client(  # type: ignore[arg-type]
+        _FakeSessionReader([]),
+        denied_writer,
+    )
+
+    assert missing_peer_writer.closed is True
+    assert denied_writer.closed is True
+    assert denied_writer.writes == []
+
+
+@pytest.mark.asyncio
+async def test_session_client_handles_invalid_json_and_unexpected_request_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = SessionManager()
+    manager.running = True
+    reader = _FakeSessionReader(
+        [
+            b"{not-json}\n",
+            json.dumps({"command": "boom"}).encode() + b"\n",
+        ]
+    )
+    writer = _FakeSessionWriter()
+    manager._handle_session_request = AsyncMock(  # type: ignore[method-assign]
+        side_effect=RuntimeError("request failed")
+    )
+    monkeypatch.setattr(
+        session_manager_core_module,
+        "get_peer_credentials",
+        lambda _sock: PeerCredentials(pid=321, uid=1000, gid=1000),
+    )
+
+    await manager._handle_session_client(reader, writer)  # type: ignore[arg-type]
+
+    responses = [json.loads(payload) for payload in b"".join(writer.writes).splitlines()]
+    assert responses == [
+        {"error": "invalid json"},
+        {"status": "error", "message": "request failed"},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_broadcast_drain_and_close_error_paths() -> None:
+    manager = SessionManager()
+    ok_writer = _FakeSessionWriter()
+    skipped_writer = _FakeSessionWriter()
+    os_error_writer = _FakeSessionWriter()
+    generic_error_writer = _FakeSessionWriter()
+    os_error_writer.write = Mock(side_effect=OSError("closed"))  # type: ignore[method-assign]
+    generic_error_writer.write = Mock(side_effect=RuntimeError("broken"))  # type: ignore[method-assign]
+    manager.session_clients.update(
+        [ok_writer, skipped_writer, os_error_writer, generic_error_writer]  # type: ignore[list-item]
+    )
+    manager._close_session_writer = AsyncMock()  # type: ignore[method-assign]
+
+    manager.broadcast_to_session_client_ids(
+        {"event": "update"},
+        {id(ok_writer), id(os_error_writer), id(generic_error_writer)},
+    )
+    await asyncio.sleep(0)
+
+    assert ok_writer.writes == [b'{"event": "update"}\n']
+    assert skipped_writer.writes == []
+    assert os_error_writer not in manager.session_clients
+    assert generic_error_writer not in manager.session_clients
+    assert manager._close_session_writer.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_drain_session_writer_drops_clients_on_drain_errors() -> None:
+    manager = SessionManager()
+
+    for exc in (OSError("closed"), RuntimeError("broken")):
+        writer = _FakeSessionWriter()
+        writer.drain = AsyncMock(side_effect=exc)  # type: ignore[method-assign]
+        manager.session_clients.add(writer)  # type: ignore[arg-type]
+        manager._close_session_writer = AsyncMock()  # type: ignore[method-assign]
+
+        manager.broadcast_to_session_clients({"event": "update"})
+        drain_task = manager.session_client_drain_tasks[writer]  # type: ignore[index]
+        await asyncio.gather(drain_task, return_exceptions=True)
+
+        assert writer not in manager.session_clients
+        assert drain_task.done()
+        manager._close_session_writer.assert_awaited_once()  # type: ignore[attr-defined]
+        assert writer not in manager.session_client_drain_tasks
+
+
+@pytest.mark.asyncio
 async def test_send_notification_logs_even_when_dbus_notification_fails(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
@@ -460,3 +700,638 @@ async def test_send_notification_logs_even_when_dbus_notification_fails(
         app_name="keymasq",
         timeout_ms=5000,
     )
+
+
+def test_send_notification_without_running_loop_returns(caplog: pytest.LogCaptureFixture) -> None:
+    manager = SessionManager()
+
+    with caplog.at_level("INFO", logger="keymasq-session"):
+        manager.send_notification("Title", "Message")
+
+    assert "Notification: Title: Message" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_config_watcher_lifecycle_and_registration_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = SessionManager()
+    added_readers = []
+    removed_readers = []
+    closed_fds = []
+
+    class FakeLoop:
+        def __init__(self) -> None:
+            self.add_reader_error: Exception | None = None
+
+        def add_reader(self, *args) -> None:
+            if self.add_reader_error is not None:
+                raise self.add_reader_error
+            added_readers.append(args)
+
+        def remove_reader(self, fd: int) -> None:
+            removed_readers.append(fd)
+
+    fake_loop = FakeLoop()
+    watch_ids = iter([101, 102, 103, 104, 105, 201, 202, 203, 204, 205])
+
+    def add_watch(_fd, path, _mask):
+        if path == session_manager_core_module.HARDWARE_DIR:
+            raise OSError("missing")
+        return next(watch_ids)
+
+    monkeypatch.setattr(
+        session_manager_core_module.asyncio,
+        "get_running_loop",
+        lambda: fake_loop,
+    )
+    monkeypatch.setattr(session_manager_core_module, "_inotify_init", lambda: 42)
+    monkeypatch.setattr(session_manager_core_module, "_inotify_add_watch", add_watch)
+    monkeypatch.setattr(session_manager_core_module.os, "close", lambda fd: closed_fds.append(fd))
+
+    manager._start_config_watcher()
+
+    assert manager.config_watch_fd == 42
+    assert added_readers == [(42, manager._handle_config_watch_events)]
+    assert session_manager_core_module.HARDWARE_DIR not in manager.config_watch_watches.values()
+    assert len(manager.config_watch_watches) == 4
+
+    manager._stop_config_watcher()
+
+    assert manager.config_watch_fd is None
+    assert manager.config_watch_watches == {}
+    assert removed_readers == [42]
+    assert closed_fds == [42]
+
+    fake_loop.add_reader_error = RuntimeError("unsupported")
+    manager._start_config_watcher()
+
+    assert manager.config_watch_fd is None
+    assert closed_fds[-1] == 42
+
+    monkeypatch.setattr(
+        session_manager_core_module,
+        "_inotify_init",
+        Mock(side_effect=OSError("no inotify")),
+    )
+    manager._start_config_watcher()
+
+    assert manager.config_watch_fd is None
+
+
+@pytest.mark.asyncio
+async def test_config_watch_event_parsing_and_reload_scheduling(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = SessionManager()
+    manager.config_watch_fd = 9
+    manager.config_watch_watches = {
+        1: session_manager_core_module.PROFILES_DIR,
+        2: session_manager_core_module.CONFIG_DIR,
+    }
+    manager._refresh_config_watches = Mock()  # type: ignore[method-assign]
+    manager._schedule_config_reload = Mock()  # type: ignore[method-assign]
+    data = b"".join(
+        [
+            _inotify_event(99, session_manager_core_module.IN_CLOSE_WRITE, "ignored.toml"),
+            _inotify_event(2, session_manager_core_module.IN_IGNORED, "profiles"),
+            _inotify_event(1, session_manager_core_module.IN_CLOSE_WRITE, "Base.toml"),
+        ]
+    )
+    monkeypatch.setattr(session_manager_core_module.os, "read", lambda _fd, _size: data)
+
+    manager._handle_config_watch_events()
+
+    assert 2 not in manager.config_watch_watches
+    manager._refresh_config_watches.assert_called_once()  # type: ignore[attr-defined]
+    manager._schedule_config_reload.assert_called_once()  # type: ignore[attr-defined]
+
+    manager.config_watch_fd = None
+    manager._handle_config_watch_events()
+
+    manager.config_watch_fd = 9
+    monkeypatch.setattr(
+        session_manager_core_module.os,
+        "read",
+        Mock(side_effect=BlockingIOError),
+    )
+    manager._handle_config_watch_events()
+
+    manager._stop_config_watcher = Mock()  # type: ignore[method-assign]
+    monkeypatch.setattr(
+        session_manager_core_module.os,
+        "read",
+        Mock(side_effect=OSError("dead fd")),
+    )
+    manager._handle_config_watch_events()
+
+    manager._stop_config_watcher.assert_called_once()  # type: ignore[attr-defined]
+
+
+def test_config_watch_relevance_rules() -> None:
+    manager = SessionManager()
+
+    assert manager._config_watch_event_is_relevant(
+        session_manager_core_module.CONFIG_DIR,
+        session_manager_core_module.SETTINGS_PATH.name,
+        0,
+    )
+    assert manager._config_watch_event_is_relevant(
+        session_manager_core_module.CONFIG_DIR,
+        session_manager_core_module.PROFILES_DIR.name,
+        session_manager_core_module.IN_ISDIR,
+    )
+    assert not manager._config_watch_event_is_relevant(
+        session_manager_core_module.CONFIG_DIR,
+        "notes.txt",
+        0,
+    )
+    assert manager._config_watch_event_is_relevant(
+        session_manager_core_module.PROFILES_DIR,
+        "Base.toml",
+        0,
+    )
+    assert not manager._config_watch_event_is_relevant(
+        session_manager_core_module.PROFILES_DIR,
+        "Base.txt",
+        0,
+    )
+    assert manager._config_watch_event_is_relevant(
+        session_manager_core_module.PROFILES_DIR,
+        "",
+        session_manager_core_module.IN_MOVE_SELF,
+    )
+
+
+@pytest.mark.asyncio
+async def test_scheduled_config_reload_branches() -> None:
+    manager = SessionManager()
+    manager.reload_profiles = AsyncMock(return_value=True)  # type: ignore[method-assign]
+
+    manager.running = False
+    manager._run_scheduled_config_reload()
+
+    assert manager.reload_task is None
+
+    manager.running = True
+    manager.reload_task = asyncio.create_task(asyncio.sleep(0.1))
+    manager._run_scheduled_config_reload()
+    running_task = manager.reload_task
+
+    assert running_task is not None
+    assert not running_task.done()
+    running_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await running_task
+
+    manager.reload_task = None
+    manager._schedule_config_reload()
+    first_timer = manager.config_reload_timer
+    manager._schedule_config_reload()
+
+    assert first_timer is not None
+    assert first_timer.cancelled()
+    assert manager.config_reload_timer is not first_timer
+    manager.config_reload_timer.cancel()
+
+    manager._run_scheduled_config_reload()
+    reload_task = manager.reload_task
+    assert reload_task is not None
+    await cast(asyncio.Task[object], reload_task)
+    manager.reload_profiles.assert_awaited_once()  # type: ignore[attr-defined]
+
+
+def test_resolved_button_codes_skips_unresolved_buttons(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = SessionManager()
+    buttons = [
+        SimpleNamespace(id="", evdev_code=1, evdev=None),
+        SimpleNamespace(id="explicit", evdev_code=42, evdev=None),
+        SimpleNamespace(id="resolved", evdev_code=None, evdev="KEY_A"),
+        SimpleNamespace(id="missing", evdev_code=None, evdev="KEY_UNKNOWN"),
+    ]
+
+    monkeypatch.setattr(
+        session_manager_core_module,
+        "resolve_evdev_code",
+        lambda evdev: 30 if evdev == "KEY_A" else None,
+    )
+
+    assert manager.resolved_button_codes(cast(list[ButtonDefinition], buttons)) == {
+        "explicit": 42,
+        "resolved": 30,
+    }
+
+
+@pytest.mark.asyncio
+async def test_stop_returns_when_already_stopped() -> None:
+    manager = SessionManager()
+    manager.client.disconnect = AsyncMock()  # type: ignore[method-assign]
+
+    await manager.stop()
+
+    manager.client.disconnect.assert_not_awaited()  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_stop_cancels_drain_tasks_and_ignores_capture_shutdown_errors() -> None:
+    manager = SessionManager()
+    manager.running = True
+    manager.client.disconnect = AsyncMock()  # type: ignore[method-assign]
+    manager.client.send_command = AsyncMock(  # type: ignore[method-assign]
+        side_effect=[OSError("daemon closed"), RuntimeError("daemon bug")]
+    )
+    manager.dbus.disconnect = AsyncMock()  # type: ignore[method-assign]
+    manager.capture_state.tokens = {"keyboard": "token-a", "mouse": "token-b"}
+
+    async def wait_forever() -> None:
+        await asyncio.Event().wait()
+
+    writer_a = _FakeSessionWriter()
+    writer_b = _FakeSessionWriter()
+    task_a = asyncio.create_task(wait_forever())
+    task_b = asyncio.create_task(wait_forever())
+    manager.session_client_drain_tasks = {
+        writer_a: task_a,  # type: ignore[dict-item]
+        writer_b: task_b,  # type: ignore[dict-item]
+    }
+
+    await manager.stop()
+    await asyncio.sleep(0)
+
+    assert task_a.cancelled()
+    assert task_b.cancelled()
+    assert manager.session_client_drain_tasks == {}
+    assert manager.capture_state.tokens == {}
+    assert manager.client.send_command.await_count == 2  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_stop_marks_owned_socket_unowned_when_unlink_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = SessionManager()
+    manager.running = True
+    manager.client.disconnect = AsyncMock()  # type: ignore[method-assign]
+    manager.dbus.disconnect = AsyncMock()  # type: ignore[method-assign]
+    manager._session_socket_owned = True
+
+    class FakeSocketPath:
+        def exists(self) -> bool:
+            return True
+
+        def unlink(self) -> None:
+            raise OSError("permission denied")
+
+    monkeypatch.setattr(session_manager_core_module, "SESSION_SOCKET_PATH", FakeSocketPath())
+
+    await manager.stop()
+
+    assert manager._session_socket_owned is False
+
+
+@pytest.mark.asyncio
+async def test_start_session_server_creates_owned_socket_and_warns_on_chmod_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = SessionManager()
+    calls: list[object] = []
+    server = _FakeSessionServer()
+
+    class FakeSocketPath:
+        def exists(self) -> bool:
+            return False
+
+        def __str__(self) -> str:
+            return "/tmp/keymasq-session-test.sock"
+
+    async def start_unix_server(handler, path: str):
+        calls.append((handler, path))
+        return server
+
+    monkeypatch.setattr(
+        session_manager_core_module,
+        "ensure_session_socket_dir",
+        lambda: calls.append("ensure-dir"),
+    )
+    monkeypatch.setattr(session_manager_core_module, "SESSION_SOCKET_PATH", FakeSocketPath())
+    monkeypatch.setattr(session_manager_core_module.asyncio, "start_unix_server", start_unix_server)
+    monkeypatch.setattr(
+        session_manager_core_module.os,
+        "chmod",
+        Mock(side_effect=OSError("chmod failed")),
+    )
+
+    await manager._start_session_server()
+
+    assert calls == [
+        "ensure-dir",
+        (manager._handle_session_client, "/tmp/keymasq-session-test.sock"),
+    ]
+    assert manager.session_server is server
+    assert manager._session_socket_owned is True
+
+
+@pytest.mark.asyncio
+async def test_start_session_server_rejects_existing_live_socket(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = SessionManager()
+
+    class FakeSocketPath:
+        def exists(self) -> bool:
+            return True
+
+        def __str__(self) -> str:
+            return "/tmp/keymasq-session-live.sock"
+
+    monkeypatch.setattr(session_manager_core_module, "ensure_session_socket_dir", lambda: None)
+    monkeypatch.setattr(session_manager_core_module, "SESSION_SOCKET_PATH", FakeSocketPath())
+    monkeypatch.setattr(
+        session_manager_core_module,
+        "_session_socket_accepts_connections",
+        AsyncMock(return_value=True),
+    )
+
+    with pytest.raises(RuntimeError, match="already listening"):
+        await manager._start_session_server()
+
+
+@pytest.mark.asyncio
+async def test_close_session_writer_error_branches() -> None:
+    manager = SessionManager()
+    manager.SESSION_CLIENT_CLOSE_TIMEOUT_S = 0.01
+
+    timeout_writer = _HangingSessionWriter()
+    timeout_writer.abort = Mock(side_effect=RuntimeError("abort failed"))  # type: ignore[method-assign]
+    await manager._close_session_writer(timeout_writer)  # type: ignore[arg-type]
+
+    os_error_writer = _FakeSessionWriter()
+    os_error_writer.wait_closed = AsyncMock(side_effect=OSError("closed"))  # type: ignore[method-assign]
+    await manager._close_session_writer(os_error_writer)  # type: ignore[arg-type]
+
+    runtime_error_writer = _FakeSessionWriter()
+    runtime_error_writer.wait_closed = AsyncMock(side_effect=RuntimeError("bug"))  # type: ignore[method-assign]
+    await manager._close_session_writer(runtime_error_writer)  # type: ignore[arg-type]
+
+    assert timeout_writer.abort.called  # type: ignore[attr-defined]
+    os_error_writer.wait_closed.assert_awaited_once()  # type: ignore[attr-defined]
+    runtime_error_writer.wait_closed.assert_awaited_once()  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_drop_session_client_writer_cancels_pending_drain_task() -> None:
+    manager = SessionManager()
+    writer = _FakeSessionWriter()
+    task = asyncio.create_task(asyncio.Event().wait())
+    manager.session_clients.add(writer)  # type: ignore[arg-type]
+    manager.session_client_peers[writer] = PeerCredentials(pid=1, uid=2, gid=3)  # type: ignore[index]
+    manager.session_client_drain_tasks[writer] = task  # type: ignore[index]
+
+    manager._drop_session_client_writer(writer)  # type: ignore[arg-type]
+    await asyncio.sleep(0)
+
+    assert writer not in manager.session_clients
+    assert writer not in manager.session_client_peers
+    assert writer not in manager.session_client_drain_tasks
+    assert task.cancelled()
+
+
+@pytest.mark.asyncio
+async def test_wait_for_session_clients_to_close_logs_timeout(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    manager = SessionManager()
+    manager.session_clients.add(_FakeSessionWriter())  # type: ignore[arg-type]
+
+    with caplog.at_level("DEBUG", logger="keymasq-session"):
+        await manager._wait_for_session_clients_to_close(timeout_s=0.01)
+
+    assert "Timed out waiting for 1 session client(s) to close" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_reload_handler_defers_when_existing_reload_task_is_running() -> None:
+    manager = SessionManager()
+    running_task = asyncio.create_task(asyncio.sleep(1))
+    manager.reload_task = running_task
+
+    manager._reload_handler()
+
+    assert manager.reload_pending is True
+    assert manager.reload_task is running_task
+    running_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await running_task
+
+
+@pytest.mark.asyncio
+async def test_reload_profiles_deactivates_removed_hardware(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = SessionManager()
+    manager.profile_state.grabbed_devices = {"present", "stale"}
+    manager.profile_state.resolved_devices = {"stale": SimpleNamespace()}
+    manager.hardware.list_hardware_ids = Mock(return_value=["present"])  # type: ignore[method-assign]
+    manager.broadcast_to_session_clients = Mock()  # type: ignore[method-assign]
+    manager._sync_virtual_gamepads_to_daemon = AsyncMock()  # type: ignore[method-assign]
+    deactivate_profile = AsyncMock()
+    reevaluate_profiles = AsyncMock()
+
+    monkeypatch.setattr(manager, "reload_config_from_disk", lambda: None)
+    monkeypatch.setattr(session_profiles_module, "deactivate_profile", deactivate_profile)
+    monkeypatch.setattr(session_profiles_module, "reevaluate_profiles", reevaluate_profiles)
+
+    assert await manager.reload_profiles() is True
+
+    deactivate_profile.assert_awaited_once_with(manager, "stale", immediate=True)
+    assert "stale" not in manager.profile_state.resolved_devices
+    reevaluate_profiles.assert_awaited_once_with(manager, reason="config reload")
+
+
+def test_reload_config_from_disk_success_updates_virtual_gamepad_count(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = SessionManager()
+    manager.virtual_gamepad_count = 1
+
+    monkeypatch.setattr(manager.superkeys, "reload", Mock())
+    monkeypatch.setattr(manager.analog_controls, "reload", Mock())
+    monkeypatch.setattr(manager.profiles, "reload", Mock())
+    monkeypatch.setattr(manager.hardware, "reload", Mock())
+    monkeypatch.setattr(
+        session_manager_core_module,
+        "load_global_settings",
+        Mock(return_value=SimpleNamespace(virtual_gamepad_count=4)),
+    )
+
+    manager.reload_config_from_disk()
+
+    assert manager.virtual_gamepad_count == 4
+
+
+def test_stop_config_watcher_cancels_pending_timer() -> None:
+    manager = SessionManager()
+    timer = Mock()
+    manager.config_reload_timer = timer
+
+    manager._stop_config_watcher()
+
+    timer.cancel.assert_called_once()
+    assert manager.config_reload_timer is None
+
+
+def test_refresh_config_watches_skips_missing_fd_and_existing_paths(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = SessionManager()
+
+    manager._refresh_config_watches()
+
+    manager.config_watch_fd = 10
+    manager.config_watch_watches = {1: session_manager_core_module.CONFIG_DIR}
+    watched: list[object] = []
+
+    def add_watch(_fd: int, path: object, _mask: int) -> int:
+        watched.append(path)
+        return len(watched) + 1
+
+    monkeypatch.setattr(session_manager_core_module, "_inotify_add_watch", add_watch)
+
+    manager._refresh_config_watches()
+
+    assert session_manager_core_module.CONFIG_DIR not in watched
+    assert session_manager_core_module.PROFILES_DIR in watched
+
+
+@pytest.mark.asyncio
+async def test_sync_virtual_gamepads_logs_daemon_transport_failure(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    manager = SessionManager()
+    manager.connected = True
+    manager.virtual_gamepad_count = 3
+    manager.client.send_command = AsyncMock(side_effect=OSError("daemon closed"))  # type: ignore[method-assign]
+
+    with caplog.at_level("WARNING", logger="keymasq-session"):
+        await manager._sync_virtual_gamepads_to_daemon()
+
+    assert "Failed to configure virtual gamepads in keymasqd" in caplog.text
+    assert manager.virtual_gamepad_count == 3
+
+
+@pytest.mark.asyncio
+async def test_handle_keymasqd_disconnect_clears_runtime_state_and_cancels_grab_retries() -> None:
+    manager = SessionManager()
+    manager.connected = True
+    manager.profile_state.grabbed_devices = {"hardware"}
+    manager.profile_state.active_profile_names = ["Base"]
+    retry_task = asyncio.create_task(asyncio.Event().wait())
+    manager.profile_state.grab_retry_tasks = {"hardware": retry_task}
+    manager._broadcast_keymasqd_status = Mock()  # type: ignore[method-assign]
+
+    manager._handle_keymasqd_disconnect()
+    await asyncio.sleep(0)
+
+    assert retry_task.cancelled()
+    assert manager.connected is False
+    assert manager.profile_state.grabbed_devices == set()
+    assert manager.profile_state.active_profile_names == []
+    manager._broadcast_keymasqd_status.assert_called_once_with(False)  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_on_window_change_delegates_to_compositor_runtime(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = SessionManager()
+    on_window_change = AsyncMock()
+    monkeypatch.setattr(
+        session_manager_core_module.runtime_compositor,
+        "on_window_change",
+        on_window_change,
+    )
+
+    await manager.on_window_change("app", "title", ["tag"])
+
+    on_window_change.assert_awaited_once_with(manager, "app", "title", ["tag"])
+
+
+@pytest.mark.asyncio
+async def test_session_socket_probe_timeout_and_os_error_paths(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class FakeSocket:
+        def __init__(self) -> None:
+            self.closed = False
+
+        def setblocking(self, _blocking: bool) -> None:
+            return None
+
+        def close(self) -> None:
+            self.closed = True
+
+    class TimeoutLoop:
+        async def sock_connect(self, _sock: FakeSocket, _path: str) -> None:
+            await asyncio.sleep(1)
+
+    class ErrorLoop:
+        async def sock_connect(self, _sock: FakeSocket, _path: str) -> None:
+            raise OSError("missing")
+
+    created: list[FakeSocket] = []
+
+    def make_socket(*_args, **_kwargs) -> FakeSocket:
+        sock = FakeSocket()
+        created.append(sock)
+        return sock
+
+    monkeypatch.setattr(session_manager_core_module.socket, "socket", make_socket)
+    monkeypatch.setattr(
+        session_manager_core_module.asyncio,
+        "get_running_loop",
+        lambda: TimeoutLoop(),
+    )
+    assert await session_manager_core_module._session_socket_accepts_connections(0.001)
+
+    monkeypatch.setattr(
+        session_manager_core_module.asyncio,
+        "get_running_loop",
+        lambda: ErrorLoop(),
+    )
+    assert not await session_manager_core_module._session_socket_accepts_connections()
+    assert all(sock.closed for sock in created)
+
+
+def test_inotify_wrappers_return_fd_and_raise_os_errors(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    class FakeFunction:
+        def __init__(self, results: list[int]) -> None:
+            self.results = results
+
+        def __call__(self, *_args) -> int:
+            return self.results.pop(0)
+
+    class FakeLibc:
+        def __init__(self) -> None:
+            self.inotify_init1 = FakeFunction([7, -1])
+            self.inotify_add_watch = FakeFunction([11, -1])
+
+    fake_libc = FakeLibc()
+    monkeypatch.setattr(
+        session_manager_core_module.ctypes,
+        "CDLL",
+        lambda *_args, **_kwargs: fake_libc,
+    )
+    monkeypatch.setattr(session_manager_core_module.ctypes, "get_errno", lambda: 24)
+
+    assert session_manager_core_module._inotify_init() == 7
+    with pytest.raises(OSError):
+        session_manager_core_module._inotify_init()
+
+    assert session_manager_core_module._inotify_add_watch(7, tmp_path, 0) == 11
+    with pytest.raises(OSError):
+        session_manager_core_module._inotify_add_watch(7, tmp_path, 0)

--- a/tests/test_session_manager_events.py
+++ b/tests/test_session_manager_events.py
@@ -26,6 +26,129 @@ def _sent_daemon_commands(
 
 
 @pytest.mark.asyncio
+async def test_handle_event_dispatches_action_trigger_variants(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    manager = SessionManager(verbosity=1)
+    manager.exec_state.exec_refs[9] = ExecBinding(
+        cmd="echo hardware",
+        owner="combo",
+        hardware_id="1234:5678",
+    )
+    handlers = {
+        "start": AsyncMock(),
+        "stop": AsyncMock(),
+        "slot": AsyncMock(return_value={"status": "ok"}),
+        "cancel": AsyncMock(),
+        "reset": AsyncMock(),
+        "profile": AsyncMock(),
+    }
+    monkeypatch.setattr(session_events_module, "handle_start_macro_trigger", handlers["start"])
+    monkeypatch.setattr(session_events_module, "handle_stop_macro_trigger", handlers["stop"])
+    monkeypatch.setattr(
+        session_events_module.runtime_recording,
+        "play_macro_slot_trigger",
+        handlers["slot"],
+    )
+    monkeypatch.setattr(session_events_module, "handle_cancel_macro_trigger", handlers["cancel"])
+    monkeypatch.setattr(session_events_module, "handle_emergency_reset_trigger", handlers["reset"])
+    monkeypatch.setattr(session_events_module, "handle_profile_trigger", handlers["profile"])
+    manager.action_handler.execute_command = AsyncMock(return_value=0)
+
+    with caplog.at_level(logging.DEBUG, logger="keymasq-session"):
+        for action_type in (
+            "start_macro_recording",
+            "stop_macro_recording",
+            "play_macro_slot",
+            "cancel_macro_playback",
+            "emergency_reset",
+            "profile_enable",
+        ):
+            await session_events_module.handle_event(
+                manager,
+                CommandType.ACTION_TRIGGER,
+                {"action_type": action_type, "events": [{"type": 1}]},
+            )
+        await session_events_module.handle_event(
+            manager,
+            CommandType.ACTION_TRIGGER,
+            {"action_type": "exec", "exec_ref": 9},
+        )
+        await session_events_module.handle_event(
+            manager,
+            CommandType.ACTION_TRIGGER,
+            {"action_type": "exec", "exec_ref": 404},
+        )
+        await asyncio.sleep(0)
+
+    assert "Event: action_trigger ->" in caplog.text
+    assert "<1 events>" in caplog.text
+    for handler in handlers.values():
+        handler.assert_awaited()
+    manager.action_handler.execute_command.assert_awaited_once_with("echo hardware")
+    assert "Unknown exec_ref: 404" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_handle_event_dispatches_device_and_runtime_variants(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = SessionManager()
+    manager.broadcast_to_session_clients = Mock()  # type: ignore[method-assign]
+    connected = AsyncMock()
+    disconnected = AsyncMock()
+    grab_status = Mock()
+    runtime_reset = AsyncMock()
+    deactivate_requested = AsyncMock()
+    monkeypatch.setattr(session_events_module, "on_device_connected", connected)
+    monkeypatch.setattr(session_events_module, "on_device_disconnected", disconnected)
+    monkeypatch.setattr(session_events_module, "handle_device_grab_status_event", grab_status)
+    monkeypatch.setattr(session_events_module, "handle_runtime_reset_event", runtime_reset)
+    monkeypatch.setattr(
+        session_events_module,
+        "handle_profile_deactivate_requested",
+        deactivate_requested,
+    )
+
+    await session_events_module.handle_event(
+        manager,
+        CommandType.DEVICE_CONNECTED,
+        {"vendor_id": "1234", "product_id": "5678"},
+    )
+    await session_events_module.handle_event(
+        manager,
+        CommandType.DEVICE_DISCONNECTED,
+        {"hardware_id": "1234:5678"},
+    )
+    await session_events_module.handle_event(
+        manager,
+        CommandType.DEVICE_GRAB_STATUS,
+        {"hardware_id": "1234:5678", "state": "ready"},
+    )
+    await session_events_module.handle_event(
+        manager,
+        CommandType.RUNTIME_RESET,
+        {"reason": "test"},
+    )
+    await session_events_module.handle_event(
+        manager,
+        CommandType.PROFILE_DEACTIVATE_REQUESTED,
+        {"profile_name": "Nav"},
+    )
+    await asyncio.sleep(0)
+
+    connected.assert_awaited_once_with(manager, {"vendor_id": "1234", "product_id": "5678"})
+    disconnected.assert_awaited_once_with(manager, {"hardware_id": "1234:5678"})
+    grab_status.assert_called_once_with(
+        manager,
+        {"hardware_id": "1234:5678", "state": "ready"},
+    )
+    runtime_reset.assert_awaited_once_with(manager, {"reason": "test"})
+    deactivate_requested.assert_awaited_once_with(manager, {"profile_name": "Nav"})
+
+
+@pytest.mark.asyncio
 async def test_handle_event_compositor_dispatch_uses_listener() -> None:
     manager = SessionManager()
     manager.action_handler = AsyncMock()
@@ -135,6 +258,29 @@ async def test_cancel_event_tasks_cancels_tracked_background_task() -> None:
     assert cancelled.is_set()
     assert task.cancelled()
     assert manager.event_state.tasks == set()
+
+
+@pytest.mark.asyncio
+async def test_create_event_task_tracks_extra_task_set() -> None:
+    manager = SessionManager()
+    extra_tasks = set()
+
+    async def done() -> None:
+        return None
+
+    task = session_events_module.create_event_task(
+        manager,
+        done(),
+        name="extra",
+        extra_task_set=extra_tasks,
+    )
+
+    assert task in manager.event_state.tasks
+    assert task in extra_tasks
+    await task
+    await asyncio.sleep(0)
+    assert task not in manager.event_state.tasks
+    assert task not in extra_tasks
 
 
 @pytest.mark.asyncio
@@ -294,6 +440,40 @@ async def test_handle_event_macro_sync_exec_logs_unexpected_completion_report_fa
 
     assert "Unexpected failure reporting macro exec completion" in caplog.text
     assert "report bug" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_handle_exec_trigger_ignores_missing_command_or_handler() -> None:
+    manager = SessionManager()
+    manager.action_handler.execute_command = AsyncMock()
+
+    await session_events_module.handle_exec_trigger(manager, {"cmd": ""})
+
+    manager.action_handler.execute_command.assert_not_awaited()
+    manager.action_handler = None
+
+    await session_events_module.handle_exec_trigger(manager, {"cmd": "echo missing"})
+
+
+@pytest.mark.asyncio
+async def test_handle_event_macro_sync_exec_tolerates_daemon_os_errors() -> None:
+    manager = SessionManager()
+    manager.client.send_command = AsyncMock(side_effect=OSError("daemon down"))
+    manager.action_handler.execute_command = AsyncMock(return_value=0)
+
+    await session_events_module.handle_event(
+        manager,
+        CommandType.ACTION_TRIGGER,
+        {
+            "action_type": "exec",
+            "cmd": "echo macro",
+            "macro_exec_wait_id": "wait-1",
+        },
+    )
+    await asyncio.sleep(0)
+
+    manager.action_handler.execute_command.assert_awaited_once()
+    manager.client.send_command.assert_awaited_once()
 
 
 @pytest.mark.asyncio
@@ -633,6 +813,240 @@ async def test_runtime_activation_replacement_ignores_stale_expiry(
         {"profile_name": "Nav", "activation_id": new_id, "reason": "timeout"},
     )
     assert "Nav" not in manager.profile_state.runtime_profile_activations
+
+
+@pytest.mark.asyncio
+async def test_macro_recording_trigger_edge_branches(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = SessionManager()
+    manager.send_notification = Mock()  # type: ignore[method-assign]
+    manager.broadcast_to_session_clients = Mock()  # type: ignore[method-assign]
+
+    await session_events_module.handle_start_macro_trigger(manager, {})
+
+    manager.recording_state.active = True
+    manager.recording_state.active_slot = 2
+    stop_trigger = AsyncMock()
+    monkeypatch.setattr(session_events_module, "handle_stop_macro_trigger", stop_trigger)
+
+    await session_events_module.handle_start_macro_trigger(manager, {"recording_slot": 2})
+    await session_events_module.handle_start_macro_trigger(manager, {"recording_slot": 3})
+
+    manager.recording_state.active = False
+    monkeypatch.setattr(
+        session_events_module.runtime_recording,
+        "resolve_macro_recording_status_async",
+        AsyncMock(return_value={"unlocked": False, "source": "disabled"}),
+    )
+    notify_disabled = Mock()
+    monkeypatch.setattr(
+        session_events_module.runtime_recording,
+        "notify_macro_recording_disabled",
+        notify_disabled,
+    )
+
+    await session_events_module.handle_start_macro_trigger(manager, {"recording_slot": 1})
+
+    assert manager.send_notification.call_count == 2  # type: ignore[attr-defined]
+    stop_trigger.assert_awaited_once_with(manager, {"recording_slot": 2})
+    notify_disabled.assert_called_once_with(manager)
+    manager.broadcast_to_session_clients.assert_called_once_with(  # type: ignore[attr-defined]
+        {
+            "event": "macro_recording_disabled",
+            "macro_recording_enabled": False,
+            "macro_recording_source": "disabled",
+            "macro_recording_expires_at": 0,
+        }
+    )
+
+
+@pytest.mark.asyncio
+async def test_macro_recording_trigger_reports_failed_start_results(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = SessionManager()
+    manager.broadcast_to_session_clients = Mock()  # type: ignore[method-assign]
+    monkeypatch.setattr(
+        session_events_module.runtime_recording,
+        "resolve_macro_recording_status_async",
+        AsyncMock(return_value={"unlocked": True}),
+    )
+    start_recording = AsyncMock(
+        side_effect=[
+            {"status": "error", "error_code": "macro_recording_disabled"},
+            {"status": "error", "error_code": "sensitive_command_denied"},
+        ]
+    )
+    notify_disabled = Mock()
+    notify_unlock = Mock()
+    monkeypatch.setattr(session_events_module.runtime_recording, "start_recording", start_recording)
+    monkeypatch.setattr(
+        session_events_module.runtime_recording,
+        "notify_macro_recording_disabled",
+        notify_disabled,
+    )
+    monkeypatch.setattr(
+        session_events_module.runtime_recording,
+        "notify_recording_unlock_required",
+        notify_unlock,
+    )
+
+    await session_events_module.handle_start_macro_trigger(manager, {"recording_slot": 1})
+    await session_events_module.handle_start_macro_trigger(manager, {"recording_slot": 1})
+
+    notify_disabled.assert_called_once_with(manager)
+    notify_unlock.assert_called_once_with(
+        manager,
+        {"status": "error", "error_code": "sensitive_command_denied"},
+    )
+    assert manager.broadcast_to_session_clients.call_args_list == [  # type: ignore[attr-defined]
+        call({"event": "macro_recording_disabled"}),
+        call({"event": "recording_auth_requested"}),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_stop_macro_trigger_edge_and_error_branches(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = SessionManager()
+    stop_recording = AsyncMock(side_effect=[OSError("daemon down"), RuntimeError("bug")])
+    monkeypatch.setattr(
+        session_events_module.runtime_recording,
+        "stop_recording",
+        stop_recording,
+    )
+
+    await session_events_module.handle_stop_macro_trigger(manager, {"recording_slot": 1})
+
+    manager.recording_state.active = True
+    manager.recording_state.active_slot = 2
+    await session_events_module.handle_stop_macro_trigger(manager, {"recording_slot": 3})
+    await session_events_module.handle_stop_macro_trigger(manager, {"recording_slot": 2})
+    await session_events_module.handle_stop_macro_trigger(manager, {"recording_slot": 2})
+
+    assert stop_recording.await_count == 2
+    assert stop_recording.await_args_list[0].kwargs == {
+        "error_if_idle": False,
+        "recording_slot": 2,
+    }
+
+
+@pytest.mark.asyncio
+async def test_cancel_and_emergency_triggers_tolerate_daemon_failures() -> None:
+    manager = SessionManager()
+    manager.client.send_command = AsyncMock(
+        side_effect=[
+            OSError("daemon down"),
+            RuntimeError("bug"),
+            OSError("daemon down"),
+            RuntimeError("bug"),
+        ]
+    )
+
+    await session_events_module.handle_cancel_macro_trigger(manager)
+    await session_events_module.handle_cancel_macro_trigger(manager)
+    await session_events_module.handle_emergency_reset_trigger(manager)
+    await session_events_module.handle_emergency_reset_trigger(manager)
+
+    assert [
+        call_args.args[0].command
+        for call_args in manager.client.send_command.await_args_list
+    ] == [
+        CommandType.CANCEL_MACRO_PLAYBACK,
+        CommandType.CANCEL_MACRO_PLAYBACK,
+        CommandType.EMERGENCY_RESET,
+        CommandType.EMERGENCY_RESET,
+    ]
+
+
+@pytest.mark.asyncio
+async def test_runtime_reset_reports_reapply_failures(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = SessionManager()
+    manager.broadcast_to_session_clients = Mock()  # type: ignore[method-assign]
+    manager.send_notification = Mock()  # type: ignore[method-assign]
+    monkeypatch.setattr(
+        session_profiles_module,
+        "reevaluate_profiles",
+        AsyncMock(side_effect=OSError("daemon down")),
+    )
+
+    await session_events_module.handle_runtime_reset_event(manager, {"reason": "test"})
+
+    monkeypatch.setattr(
+        session_profiles_module,
+        "reevaluate_profiles",
+        AsyncMock(side_effect=RuntimeError("bug")),
+    )
+    await session_events_module.handle_runtime_reset_event(manager, {"reason": "test"})
+
+    assert manager.broadcast_to_session_clients.call_count == 2  # type: ignore[attr-defined]
+    assert manager.send_notification.call_args_list[-1] == call(  # type: ignore[attr-defined]
+        "Keymasq: Reapply Failed",
+        "Emergency reset completed, but active profiles could not be reapplied.",
+    )
+
+
+@pytest.mark.asyncio
+async def test_device_topology_events_schedule_known_hardware_refresh(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = SessionManager()
+    manager.hardware.get_hardware = Mock(  # type: ignore[method-assign]
+        side_effect=lambda hardware_id: (
+            SimpleNamespace(name="Keyboard") if hardware_id == "1234:5678" else None
+        )
+    )
+    manager.hardware.list_hardware = Mock(  # type: ignore[method-assign]
+        return_value=[SimpleNamespace(model_id="abcd:ef01")]
+    )
+    schedule_topology_refresh = Mock()
+    created_tasks = []
+
+    def create_event_task(_manager, coro, **kwargs):
+        coro.close()
+        created_tasks.append(kwargs)
+        return Mock()
+
+    monkeypatch.setattr(
+        session_profiles_module,
+        "schedule_topology_refresh",
+        schedule_topology_refresh,
+    )
+    monkeypatch.setattr(session_events_module, "create_event_task", create_event_task)
+
+    await session_events_module.on_device_connected(
+        manager,
+        {"vendor_id": "1234", "product_id": "5678"},
+    )
+    await session_events_module.on_device_disconnected(
+        manager,
+        {"vendor_id": "abcd", "product_id": "ef01"},
+    )
+    await session_events_module.on_device_connected(
+        manager,
+        {"vendor_id": "0000", "product_id": "0000"},
+    )
+    await session_events_module.on_device_disconnected(manager, {})
+
+    assert schedule_topology_refresh.call_count == 2
+    assert [task["name"] for task in created_tasks] == [
+        "recording_devices_refresh",
+        "recording_devices_refresh",
+    ]
+    assert session_events_module.device_name_for_hardware(manager, "missing:id") == "missing:id"
+    assert session_events_module._hardware_or_model_known(manager, "abcd:ef01") is True
+    assert session_events_module.event_log_view({"events": [1, 2]}) == {
+        "events": "<2 events>",
+        "event_count": 2,
+    }
+    assert session_events_module.event_log_view({"events": [1], "event_count": 9}) == {
+        "events": "<1 events>",
+        "event_count": 9,
+    }
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Add focused command dispatcher coverage in `tests/session/test_session_manager_command_runtime.py` for profile, settings/virtual gamepad, macro/recording, diagnostics, capture/relay, and error variants.
- Extend `tests/test_session_manager_core.py` for startup/shutdown cleanup, reconnect handling, session client I/O, config watcher/reload paths, virtual gamepad sync, disconnect cleanup, and small socket/inotify helpers.
- Extend `tests/test_session_manager_events.py` for action, device, runtime, recording/status, capture, and event task dispatch branches.

## Coverage
Focused coverage for the requested modules now reports:
- `keymasq/session/manager/commands.py`: 91%
- `keymasq/session/manager/core.py`: 92%
- `keymasq/session/manager/events.py`: 92%

## Testing
- `./scripts/check.sh full`