### PR TITLE
Add gi-cairo dependencies

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -23,6 +23,7 @@ depends=(
     'python-uvloop'
     'python-xlib>=0.33'
     'python-gobject>=3.42.0'
+    'python-cairo'
     'gtk4'
     'libadwaita'
     'polkit'

--- a/debian/control
+++ b/debian/control
@@ -27,6 +27,7 @@ Depends:
  python3-dbus-next,
  python3-evdev,
  python3-gi,
+ python3-gi-cairo,
  python3-tomli-w,
   python3-uvloop,
  python3-xlib,

--- a/docs/DEPENDENCIES.md
+++ b/docs/DEPENDENCIES.md
@@ -166,6 +166,7 @@ Defined in `PKGBUILD` under `depends`:
 - `python-dbus-next>=0.2.3`
 - `python-evdev>=1.6.0`
 - `python-gobject>=3.42.0`
+- `python-cairo`
 - `python-uvloop`
 - `python-tomli-w>=1.0.0`
 - `python-xlib>=0.33`
@@ -185,6 +186,7 @@ Defined in `debian/control`:
 - `python3-dbus-next`
 - `python3-evdev`
 - `python3-gi`
+- `python3-gi-cairo`
 - `python3-tomli-w`
 - `python3-uvloop`
 - `python3-xlib`
@@ -213,6 +215,7 @@ is built per Fedora release rather than as one cross-release RPM:
   - `dbus-next`
   - `python-xlib`
   - `PyGObject`
+  - PyGObject Cairo bindings where split from `PyGObject`
 - distro-specific GTK4 and libadwaita package names
 - `polkit`
 - `systemd`

--- a/packaging/aur/.SRCINFO
+++ b/packaging/aur/.SRCINFO
@@ -18,6 +18,7 @@ pkgbase = keymasq
 	depends = python-uvloop
 	depends = python-xlib>=0.33
 	depends = python-gobject>=3.42.0
+	depends = python-cairo
 	depends = gtk4
 	depends = libadwaita
 	depends = polkit

--- a/packaging/aur/PKGBUILD
+++ b/packaging/aur/PKGBUILD
@@ -23,6 +23,7 @@ depends=(
     'python-uvloop'
     'python-xlib>=0.33'
     'python-gobject>=3.42.0'
+    'python-cairo'
     'gtk4'
     'libadwaita'
     'polkit'

--- a/packaging/pacman/render.py
+++ b/packaging/pacman/render.py
@@ -30,6 +30,7 @@ COMMON_METADATA = {
         "python-uvloop",
         "python-xlib>=0.33",
         "python-gobject>=3.42.0",
+        "python-cairo",
         "gtk4",
         "libadwaita",
         "polkit",

--- a/packaging/rpm/build-opensuse-rpm.sh
+++ b/packaging/rpm/build-opensuse-rpm.sh
@@ -23,6 +23,7 @@ for var_name in \
     RPM_UVLOOP_DEP \
     RPM_XLIB_DEP \
     RPM_PYGOBJECT_DEP \
+    RPM_PYGOBJECT_CAIRO_DEP \
     RPM_GTK_DEP \
     RPM_ADW_DEP
 do
@@ -71,6 +72,7 @@ Requires: ${RPM_TOMLI_W_DEP}
 Requires: ${RPM_DBUS_NEXT_DEP}
 Requires: ${RPM_XLIB_DEP}
 Requires: ${RPM_PYGOBJECT_DEP}
+Requires: ${RPM_PYGOBJECT_CAIRO_DEP}
 Requires: ${RPM_GTK_DEP}
 Requires: ${RPM_ADW_DEP}
 Requires: polkit

--- a/scripts/build-packages.sh
+++ b/scripts/build-packages.sh
@@ -95,6 +95,7 @@ configure_opensuse_dependencies() {
     export RPM_UVLOOP_DEP="${python_prefix}-uvloop"
     export RPM_XLIB_DEP="${python_prefix}-python-xlib"
     export RPM_PYGOBJECT_DEP="${python_prefix}-gobject"
+    export RPM_PYGOBJECT_CAIRO_DEP="${python_prefix}-gobject-cairo"
     export RPM_GTK_DEP='typelib(Gtk) = 4.0'
     export RPM_ADW_DEP='typelib(Adw) = 1'
 }


### PR DESCRIPTION
## Summary

- Add `python-cairo` / `python3-gi-cairo` runtime dependency across all packaging formats (PKGBUILD, Debian, Nix, docs)
- 
## Testing
- installed packages on all supported distros in local VMs and verified working