### PR TITLE
Add analog control presets for one-click stick and trigger setup

### DIFF
--- a/docs/ACTIONS.md
+++ b/docs/ACTIONS.md
@@ -363,6 +363,10 @@ so only a small allowlisted set of actions is available.
 Assign a [super key](SUPERKEYS.md) to this button. Select one from the Super
 Keys tab, then click **Map**.
 
+Use **Open Super Keys…** to create or edit reusable super keys. Right-click a
+saved super key in the selector to open the Super Keys dialog with that super
+key selected.
+
 Super keys have two modes:
 
 - **Pattern**: Tap, Double Tap, Hold, and Tap + Hold choose one slot, and each
@@ -376,6 +380,9 @@ Super keys have two modes:
 
 Trigger temporary macro recording slots, play temporary slots, cancel macro
 playback, or play a saved macro.
+
+Right-click a saved macro in the selector's Macro Library to open it in the
+macro editor.
 
 ### Macro Controls
 

--- a/docs/ANALOG_CONTROLS.md
+++ b/docs/ANALOG_CONTROLS.md
@@ -151,6 +151,14 @@ output     = clamp((normalized ^ response_curve) * sensitivity, 0, 1)
 
 The curve mirrors for negative stick directions and for `output_direction = "both"`.
 
+## Presets
+
+For new users, the mapping dialog's **Presets** tab offers one-click starting
+points (Mouse Move, Mouse Area, Scroll Wheel, WASD for sticks; Trigger Left
+Click, Trigger Right Click, Trigger Scroll Up, Trigger Scroll Down for
+triggers). A preset saves a normal, fully editable config and maps it to the
+input — see [Game Controller Support](GAMEPAD.md) for the GUI workflow.
+
 ## Templates
 
 The GUI provides templates for stick digital actions. Templates append
@@ -160,7 +168,7 @@ thresholds to the existing list; the result is fully editable.
 |----------|-----------|---------|
 | WASD | 4 (±X, ±Y at 0.65) | `key_w`, `key_s`, `key_a`, `key_d` |
 | Arrow Keys | 4 (±X, ±Y at 0.65) | `key_up`, `key_down`, `key_left`, `key_right` |
-| Mouse Wheel | 2 (±Y at 0.55) | Scroll up/down with rapidfire (hold 20ms, wait 60ms) |
+| Mouse Wheel | 4 (±X, ±Y at 0.55) | Scroll up/down (Y) and side-scroll left/right (X) with rapidfire (hold 20ms, wait 60ms) |
 
 ## Full Example
 

--- a/docs/GAMEPAD.md
+++ b/docs/GAMEPAD.md
@@ -80,12 +80,19 @@ delete it.
 
 ### Assigning an Analog Control
 
-Once you have a learned analog input and a saved analog control config:
+Open the **Device** tab and select the analog input. The mapping dialog opens
+on the **Presets** tab when no analog controls exist yet.
 
-1. Open the **Device** tab and select the analog input.
-2. In the mapping dialog, choose a saved analog control by name.
-3. One input can fan out to multiple configs — each receives the same
-   normalized input and handles its output independently:
+**Quick start (presets):** Click a preset card — for sticks: Mouse Move, Mouse
+Area, Scroll Wheel, or WASD Keys; for triggers: Trigger Left Click, Trigger
+Right Click, Trigger Scroll Up, or Trigger Scroll Down. The preset is saved as a
+normal analog control, mapped to the input, and the dialog closes. Reopen the
+input later to fine-tune it or pick others.
+
+**From saved controls:** On the **Analog Controls** tab, select one or more
+saved configs by name. Right-click a config (or use **Open Analog Controls…**)
+to edit it in the manager. One input can fan out to multiple configs — each
+receives the same normalized input and handles its output independently:
 
 ```toml
 [devices."045e:028e".mapping.right_stick]
@@ -166,7 +173,8 @@ thresholds can overlap — they are evaluated independently.
 **Templates** (stick only):
 - **WASD** — maps stick to W/A/S/D keys
 - **Arrow Keys** — maps stick to arrow keys
-- **Mouse Wheel** — maps stick Y to scroll up/down with rapidfire
+- **Mouse Wheel** — maps stick Y to scroll up/down and stick X to side-scroll
+  left/right, all with rapidfire
 
 Templates append thresholds to the existing list and are fully editable
 after applying.

--- a/keymasq/gui/widgets/analog_control_dialog.py
+++ b/keymasq/gui/widgets/analog_control_dialog.py
@@ -2567,6 +2567,10 @@ class AnalogControlDialog(Adw.Dialog):
         dialog.set_close_response("ok")
         dialog.present(self)
 
+    def select_control_by_name(self, name: str) -> None:
+        """Select a saved analog control by name, e.g. when opened to edit one."""
+        self._select_control(name)
+
     def _select_control(self, name: str) -> None:
         idx = 0
         while True:

--- a/keymasq/gui/widgets/key_selector_dialog.py
+++ b/keymasq/gui/widgets/key_selector_dialog.py
@@ -44,6 +44,7 @@ from keymasq.common.models import (
 )
 from keymasq.common.slurp import get_slurp_capture
 from keymasq.gui.session_client import session_request_async
+from keymasq.gui.session_reload import notify_session_reload_async
 from keymasq.gui.widgets.action_labels import describe_mapping_action_verbose
 from keymasq.gui.widgets.compositor_actions import (
     build_compositor_action_pages,
@@ -79,7 +80,11 @@ from keymasq.gui.widgets.input_picker_shared import (
 from keymasq.gui.widgets.input_picker_shared import (
     build_navigation_tab as build_shared_navigation_tab,
 )
-from keymasq.session.analog_controls import AnalogControlManager
+from keymasq.session.analog_controls import (
+    AnalogControlManager,
+    AnalogControlPreset,
+    analog_control_presets,
+)
 from keymasq.session.compositor import detect_compositor_sync
 from keymasq.session.hardware import HardwareManager
 from keymasq.session.superkeys import SuperkeyManager
@@ -340,6 +345,7 @@ MEDIA_KEY_TARGETS = {
 }
 
 ACTION_DOC_LINKS = {
+    "analog_presets": ("analog-controls", "Analog Controls"),
     "analog_control": ("analog-controls", "Analog Controls"),
     "special": ("special", "Special"),
     "keyboard": ("keyboard", "Keyboard"),
@@ -831,6 +837,11 @@ class KeySelectorDialog(Adw.Dialog, _GamepadAxisControlsMixin):
         self.stack.set_vexpand(True)
         if self._source_type == "analog":
             self.stack.add_titled(
+                self._build_analog_presets_tab(),
+                "analog_presets",
+                "Presets",
+            )
+            self.stack.add_titled(
                 self._build_analog_control_tab(),
                 "analog_control",
                 "Analog Controls",
@@ -1220,6 +1231,144 @@ class KeySelectorDialog(Adw.Dialog, _GamepadAxisControlsMixin):
         self._load_superkey_list()
         return outer
 
+    def _set_initial_analog_tab(self) -> None:
+        action = self._current_action
+        if action is not None and action.action_type == ActionType.ANALOG_CONTROL:
+            self.stack.set_visible_child_name("analog_control")
+            return
+        if action is not None and action.action_type in (
+            ActionType.SUPPRESS,
+            ActionType.PASSTHROUGH,
+        ):
+            self.stack.set_visible_child_name("special")
+            return
+        if self._analog_control_list:
+            self.stack.set_visible_child_name("analog_control")
+        else:
+            self.stack.set_visible_child_name("analog_presets")
+
+    def _build_analog_presets_tab(self) -> Gtk.Widget:
+        outer = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=0)
+
+        intro = Gtk.Label(
+            label="Pick what this control does — one click sets it up. "
+            "Fine-tune it any time under Analog Controls."
+        )
+        intro.add_css_class("dim-label")
+        intro.set_wrap(True)
+        intro.set_justify(Gtk.Justification.CENTER)
+        intro.set_halign(Gtk.Align.CENTER)
+        intro.set_margin_top(16)
+        intro.set_margin_start(16)
+        intro.set_margin_end(16)
+        intro.set_margin_bottom(12)
+        outer.append(intro)
+
+        scrolled = Gtk.ScrolledWindow()
+        scrolled.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
+        scrolled.set_vexpand(True)
+
+        flow = Gtk.FlowBox()
+        flow.set_selection_mode(Gtk.SelectionMode.NONE)
+        flow.set_max_children_per_line(2)
+        flow.set_min_children_per_line(2)
+        flow.set_homogeneous(True)
+        flow.set_column_spacing(12)
+        flow.set_row_spacing(12)
+        flow.set_margin_start(16)
+        flow.set_margin_end(16)
+        flow.set_margin_bottom(16)
+        flow.set_valign(Gtk.Align.START)
+
+        for preset in analog_control_presets(self._analog_input_type):
+            flow.append(self._build_analog_preset_card(preset))
+
+        scrolled.set_child(flow)
+        outer.append(scrolled)
+
+        link_row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=8)
+        link_row.set_halign(Gtk.Align.CENTER)
+        link_row.set_margin_top(4)
+        link_row.set_margin_bottom(12)
+        manage_btn = Gtk.Button(label="Open Analog Controls…")
+        manage_btn.add_css_class("flat")
+        manage_btn.set_tooltip_text("Create or fine-tune analog controls")
+        manage_btn.connect("clicked", self._on_open_analog_manager_clicked)
+        link_row.append(manage_btn)
+        outer.append(link_row)
+
+        return outer
+
+    def _build_analog_preset_card(self, preset: AnalogControlPreset) -> Gtk.Widget:
+        button = Gtk.Button()
+        button.add_css_class("card")
+        button.set_hexpand(True)
+        button.set_tooltip_text(preset.description)
+        button.connect("clicked", self._on_analog_preset_clicked, preset)
+
+        content = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=12)
+        content.set_margin_top(12)
+        content.set_margin_bottom(12)
+        content.set_margin_start(12)
+        content.set_margin_end(12)
+
+        icon = Gtk.Image.new_from_icon_name(preset.icon_name)
+        icon.set_pixel_size(28)
+        content.append(icon)
+
+        text_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=2)
+        text_box.set_valign(Gtk.Align.CENTER)
+        title = Gtk.Label(label=preset.label)
+        title.set_halign(Gtk.Align.START)
+        title.add_css_class("heading")
+        text_box.append(title)
+        subtitle = Gtk.Label(label=preset.description)
+        subtitle.set_halign(Gtk.Align.START)
+        subtitle.set_wrap(True)
+        subtitle.add_css_class("dim-label")
+        subtitle.add_css_class("caption")
+        text_box.append(subtitle)
+        content.append(text_box)
+
+        button.set_child(content)
+        return button
+
+    def _on_analog_preset_clicked(self, _button: Gtk.Button, preset: AnalogControlPreset) -> None:
+        manager = AnalogControlManager()
+        name = manager.unique_analog_control_name(preset.default_name)
+        config = preset.build(name)
+        try:
+            manager.save_analog_control(config)
+        except (OSError, ValueError):
+            log.exception("Could not save preset analog control %s", name)
+            return
+        notify_session_reload_async()
+        action = MappingAction(
+            action_type=ActionType.ANALOG_CONTROL,
+            analog_control_names=[name],
+        )
+        self.emit("key-selected", action)
+        self.close()
+
+    def _on_open_analog_manager_clicked(self, _button: Gtk.Button) -> None:
+        self._open_analog_control_manager()
+
+    def _open_analog_control_manager(self, select_name: str | None = None) -> None:
+        from keymasq.gui.widgets.analog_control_dialog import AnalogControlDialog
+
+        root = self.get_root()
+        profile_manager = getattr(self._parent, "profile_manager", None)
+        dialog = AnalogControlDialog(root, profile_manager)
+        dialog.connect("analog-control-saved", self._on_analog_control_manager_changed)
+        dialog.connect("analog-control-deleted", self._on_analog_control_manager_changed)
+        dialog.present(root)
+        if select_name:
+            dialog.select_control_by_name(select_name)
+
+    def _on_analog_control_manager_changed(self, _dialog, _name: str) -> None:
+        notify_session_reload_async()
+        self._load_analog_control_list()
+
     def _build_analog_control_tab(self) -> Gtk.Widget:
         outer = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=0)
 
@@ -1230,12 +1379,15 @@ class KeySelectorDialog(Adw.Dialog, _GamepadAxisControlsMixin):
         toolbar_row.set_margin_end(12)
         toolbar_row.set_halign(Gtk.Align.START)
 
-        refresh_btn = Gtk.Button(label="Refresh")
-        refresh_btn.add_css_class("flat")
-        refresh_btn.connect("clicked", self._on_analog_control_refresh)
-        toolbar_row.append(refresh_btn)
+        manage_btn = Gtk.Button(label="Open Analog Controls…")
+        manage_btn.add_css_class("flat")
+        manage_btn.set_tooltip_text("Create or fine-tune analog controls")
+        manage_btn.connect("clicked", self._on_open_analog_manager_clicked)
+        toolbar_row.append(manage_btn)
 
-        selection_hint = Gtk.Label(label="Select one or multiple analog controls")
+        selection_hint = Gtk.Label(
+            label="Select one or multiple · right-click to edit"
+        )
         selection_hint.add_css_class("dim-label")
         selection_hint.add_css_class("caption")
         selection_hint.set_halign(Gtk.Align.START)
@@ -2910,6 +3062,13 @@ class KeySelectorDialog(Adw.Dialog, _GamepadAxisControlsMixin):
             click.connect("pressed", self._on_analog_control_row_pressed, row)
             row.add_controller(click)
 
+            right_click = Gtk.GestureClick()
+            right_click.set_button(3)
+            right_click.connect(
+                "pressed", self._on_analog_control_row_right_pressed, config.name
+            )
+            row.add_controller(right_click)
+
             row_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=12)
             row_box.set_margin_top(8)
             row_box.set_margin_bottom(8)
@@ -2944,8 +3103,16 @@ class KeySelectorDialog(Adw.Dialog, _GamepadAxisControlsMixin):
             parts.append(f"{count} range{'s' if count != 1 else ''}")
         return " · ".join(parts)
 
-    def _on_analog_control_refresh(self, btn) -> None:
-        self._load_analog_control_list()
+    def _on_analog_control_row_right_pressed(
+        self,
+        gesture: Gtk.GestureClick,
+        _n_press: int,
+        _x: float,
+        _y: float,
+        name: str,
+    ) -> None:
+        gesture.set_state(Gtk.EventSequenceState.CLAIMED)
+        self._open_analog_control_manager(name)
 
     def _on_analog_control_row_pressed(
         self,
@@ -3222,6 +3389,9 @@ class KeySelectorDialog(Adw.Dialog, _GamepadAxisControlsMixin):
         return policy if policy.has_condition else None
 
     def _set_initial_tab(self):
+        if self._source_type == "analog":
+            self._set_initial_analog_tab()
+            return
         if not self._current_action:
             return
         compositor_tab = compositor_action_tab_name(

--- a/keymasq/gui/widgets/key_selector_dialog.py
+++ b/keymasq/gui/widgets/key_selector_dialog.py
@@ -1,5 +1,6 @@
 import logging
 from collections.abc import Callable
+from typing import cast
 
 import evdev
 import gi
@@ -87,6 +88,7 @@ from keymasq.session.analog_controls import (
 )
 from keymasq.session.compositor import detect_compositor_sync
 from keymasq.session.hardware import HardwareManager
+from keymasq.session.profiles import ProfileManager
 from keymasq.session.superkeys import SuperkeyManager
 
 log = logging.getLogger("keymasq.gui.widgets.key_selector_dialog")
@@ -1007,6 +1009,13 @@ class KeySelectorDialog(Adw.Dialog, _GamepadAxisControlsMixin):
                     queue.append(root)
         return candidates
 
+    def _profile_manager_for_child_dialog(self) -> ProfileManager | None:
+        for candidate in self._macro_parent_candidates():
+            profile_manager = getattr(candidate, "profile_manager", None)
+            if profile_manager is not None:
+                return cast(ProfileManager, profile_manager)
+        return None
+
     def _resolve_macro_recording_enabled(self, *, default: bool) -> bool:
         for candidate in self._macro_parent_candidates():
             enabled = getattr(candidate, "macro_recording_enabled", None)
@@ -1208,10 +1217,17 @@ class KeySelectorDialog(Adw.Dialog, _GamepadAxisControlsMixin):
         toolbar_row.set_margin_end(12)
         toolbar_row.set_halign(Gtk.Align.START)
 
-        refresh_btn = Gtk.Button(label="Refresh")
-        refresh_btn.add_css_class("flat")
-        refresh_btn.connect("clicked", self._on_superkey_refresh)
-        toolbar_row.append(refresh_btn)
+        manage_btn = Gtk.Button(label="Open Super Keys…")
+        manage_btn.add_css_class("flat")
+        manage_btn.set_tooltip_text("Create or edit super keys")
+        manage_btn.connect("clicked", self._on_open_superkey_manager_clicked)
+        toolbar_row.append(manage_btn)
+
+        selection_hint = Gtk.Label(label="Select one · right-click to edit")
+        selection_hint.add_css_class("dim-label")
+        selection_hint.add_css_class("caption")
+        selection_hint.set_halign(Gtk.Align.START)
+        toolbar_row.append(selection_hint)
         outer.append(toolbar_row)
 
         scrolled = Gtk.ScrolledWindow()
@@ -1230,6 +1246,25 @@ class KeySelectorDialog(Adw.Dialog, _GamepadAxisControlsMixin):
 
         self._load_superkey_list()
         return outer
+
+    def _on_open_superkey_manager_clicked(self, _button: Gtk.Button) -> None:
+        self._open_superkey_manager()
+
+    def _open_superkey_manager(self, select_name: str | None = None) -> None:
+        from keymasq.gui.widgets.superkey_dialog import SuperkeyDialog
+
+        root = self.get_root()
+        profile_manager = self._profile_manager_for_child_dialog()
+        dialog = SuperkeyDialog(root, profile_manager)
+        dialog.connect("superkey-saved", self._on_superkey_manager_changed)
+        dialog.connect("superkey-deleted", self._on_superkey_manager_changed)
+        dialog.present(root)
+        if select_name:
+            dialog.select_superkey_by_name(select_name)
+
+    def _on_superkey_manager_changed(self, _dialog, _name: str) -> None:
+        notify_session_reload_async()
+        self._load_superkey_list()
 
     def _set_initial_analog_tab(self) -> None:
         action = self._current_action
@@ -1357,7 +1392,7 @@ class KeySelectorDialog(Adw.Dialog, _GamepadAxisControlsMixin):
         from keymasq.gui.widgets.analog_control_dialog import AnalogControlDialog
 
         root = self.get_root()
-        profile_manager = getattr(self._parent, "profile_manager", None)
+        profile_manager = self._profile_manager_for_child_dialog()
         dialog = AnalogControlDialog(root, profile_manager)
         dialog.connect("analog-control-saved", self._on_analog_control_manager_changed)
         dialog.connect("analog-control-deleted", self._on_analog_control_manager_changed)
@@ -1368,6 +1403,9 @@ class KeySelectorDialog(Adw.Dialog, _GamepadAxisControlsMixin):
     def _on_analog_control_manager_changed(self, _dialog, _name: str) -> None:
         notify_session_reload_async()
         self._load_analog_control_list()
+        if self.stack.get_visible_child_name() == "analog_presets":
+            self.stack.set_visible_child_name("analog_control")
+        self._on_tab_changed(self.stack, None)
 
     def _build_analog_control_tab(self) -> Gtk.Widget:
         outer = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=0)
@@ -1856,6 +1894,8 @@ class KeySelectorDialog(Adw.Dialog, _GamepadAxisControlsMixin):
         is_special = child_name == "special"
         is_superkey = child_name == "superkey"
         is_analog_control = child_name == "analog_control"
+        is_analog_presets = child_name == "analog_presets"
+        is_analog_only = is_analog_control or is_analog_presets
         is_macro = child_name == "macro"
         is_profile = child_name == "profile"
         is_exec = child_name == "exec"
@@ -1867,7 +1907,7 @@ class KeySelectorDialog(Adw.Dialog, _GamepadAxisControlsMixin):
         show_options = has_options and not (
             is_special
             or is_superkey
-            or is_analog_control
+            or is_analog_only
             or is_macro
             or is_profile
             or is_exec
@@ -2948,6 +2988,10 @@ class KeySelectorDialog(Adw.Dialog, _GamepadAxisControlsMixin):
         for config in self._superkey_list:
             row = Gtk.ListBoxRow()
             row._superkey_name = config.name
+            right_click = Gtk.GestureClick()
+            right_click.set_button(3)
+            right_click.connect("pressed", self._on_superkey_row_right_pressed, config.name)
+            row.add_controller(right_click)
 
             row_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=12)
             row_box.set_margin_top(8)
@@ -3004,8 +3048,16 @@ class KeySelectorDialog(Adw.Dialog, _GamepadAxisControlsMixin):
         noun = "slot" if slots == 1 else "slots"
         return f"Pattern · {slots} {noun}"
 
-    def _on_superkey_refresh(self, btn) -> None:
-        self._load_superkey_list()
+    def _on_superkey_row_right_pressed(
+        self,
+        gesture: Gtk.GestureClick,
+        _n_press: int,
+        _x: float,
+        _y: float,
+        name: str,
+    ) -> None:
+        gesture.set_state(Gtk.EventSequenceState.CLAIMED)
+        self._open_superkey_manager(name)
 
     def _on_superkey_row_selected(self, listbox, row) -> None:
         if row and hasattr(row, "_superkey_name"):
@@ -3176,6 +3228,10 @@ class KeySelectorDialog(Adw.Dialog, _GamepadAxisControlsMixin):
             row = Gtk.ListBoxRow()
             row._macro_name = macro["name"]
             row._search_text = macro_search_text(macro)
+            right_click = Gtk.GestureClick()
+            right_click.set_button(3)
+            right_click.connect("pressed", self._on_macro_row_right_pressed, macro["name"])
+            row.add_controller(right_click)
 
             row_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=12)
             row_box.set_margin_top(8)
@@ -3242,6 +3298,29 @@ class KeySelectorDialog(Adw.Dialog, _GamepadAxisControlsMixin):
         else:
             self._clear_macro_selection()
         self.map_btn.set_sensitive(self._selected_macro is not None)
+
+    def _on_macro_row_right_pressed(
+        self,
+        gesture: Gtk.GestureClick,
+        _n_press: int,
+        _x: float,
+        _y: float,
+        name: str,
+    ) -> None:
+        gesture.set_state(Gtk.EventSequenceState.CLAIMED)
+        self._open_macro_editor(name)
+
+    def _open_macro_editor(self, name: str) -> None:
+        from keymasq.gui.widgets.macro_editor_dialog import MacroEditorDialog
+
+        root = self.get_root()
+        parent = root if root is not None else self._parent
+        dialog = MacroEditorDialog(parent, name)
+        dialog.connect("closed", self._on_macro_editor_closed)
+        dialog.present(parent)
+
+    def _on_macro_editor_closed(self, _dialog: Adw.Dialog) -> None:
+        self._load_macro_list()
 
     def _on_macro_movement_toggled(self, check) -> None:
         self._macro_replay_movement = check.get_active()

--- a/keymasq/gui/widgets/superkey_dialog.py
+++ b/keymasq/gui/widgets/superkey_dialog.py
@@ -1209,6 +1209,21 @@ class SuperkeyDialog(Adw.Dialog):
         dialog.set_close_response("ok")
         dialog.present(self)
 
+    def select_superkey_by_name(self, name: str) -> None:
+        """Select a saved super key by name, e.g. when opened to edit one."""
+        self._select_superkey(name)
+
+    def _select_superkey(self, name: str) -> None:
+        idx = 0
+        while True:
+            row = self.list_box.get_row_at_index(idx)
+            if row is None:
+                return
+            if getattr(row, "_superkey_name", None) == name:
+                self.list_box.select_row(row)
+                return
+            idx += 1
+
     def _on_save_clicked(self, _button) -> None:
         self._save_current_superkey()
 

--- a/keymasq/session/analog_controls.py
+++ b/keymasq/session/analog_controls.py
@@ -1,5 +1,6 @@
 import logging
 import tomllib
+from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
 from typing import BinaryIO, cast
@@ -218,6 +219,25 @@ class AnalogControlManager:
     def get_all_analog_controls(self) -> dict[str, AnalogControlConfig]:
         return {name: entry.config for name, entry in self._analog_controls.items()}
 
+    def unique_analog_control_name(self, base: str) -> str:
+        """Return a new display name that will not collide with storage paths."""
+        base_name = str(base or "").strip() or "Analog Control"
+        name = base_name
+        index = 2
+        while not self._can_create_analog_control_named(name):
+            name = f"{base_name} {index}"
+            index += 1
+        return name
+
+    def _can_create_analog_control_named(self, name: str) -> bool:
+        if name in self._analog_controls:
+            return False
+        try:
+            self._ensure_storage_path_available(name, self._path_for_name(name))
+        except ValueError:
+            return False
+        return True
+
     def snapshot_analog_controls(self) -> dict[str, _AnalogControlEntry]:
         return self._analog_controls.copy()
 
@@ -434,40 +454,41 @@ def analog_control_arrow_template() -> list[AnalogActionThreshold]:
     )
 
 
+def _scroll_action(target: str) -> MappingAction:
+    return MappingAction(
+        action_type=ActionType.MOUSE,
+        target=target,
+        rapidfire_enabled=True,
+        rapidfire_hold_ms=20,
+        rapidfire_wait_ms=60,
+    )
+
+
+def _scroll_threshold(
+    axis: str,
+    trigger_min: float,
+    trigger_max: float,
+    release_min: float,
+    release_max: float,
+    target: str,
+) -> AnalogActionThreshold:
+    return AnalogActionThreshold(
+        axis=axis,
+        trigger_min=trigger_min,
+        trigger_max=trigger_max,
+        release_min=release_min,
+        release_max=release_max,
+        actions=[_scroll_action(target)],
+    )
+
+
 def analog_control_mouse_wheel_template() -> list[AnalogActionThreshold]:
+    # Vertical (Y) scrolls up/down; horizontal (X) scrolls left/right.
     return [
-        AnalogActionThreshold(
-            axis="y",
-            trigger_min=-1.0,
-            trigger_max=-0.55,
-            release_min=-1.0,
-            release_max=-0.45,
-            actions=[
-                MappingAction(
-                    action_type=ActionType.MOUSE,
-                    target="rel_wheel:1",
-                    rapidfire_enabled=True,
-                    rapidfire_hold_ms=20,
-                    rapidfire_wait_ms=60,
-                )
-            ],
-        ),
-        AnalogActionThreshold(
-            axis="y",
-            trigger_min=0.55,
-            trigger_max=1.0,
-            release_min=0.45,
-            release_max=1.0,
-            actions=[
-                MappingAction(
-                    action_type=ActionType.MOUSE,
-                    target="rel_wheel:-1",
-                    rapidfire_enabled=True,
-                    rapidfire_hold_ms=20,
-                    rapidfire_wait_ms=60,
-                )
-            ],
-        ),
+        _scroll_threshold("y", -1.0, -0.55, -1.0, -0.45, "rel_wheel:1"),
+        _scroll_threshold("y", 0.55, 1.0, 0.45, 1.0, "rel_wheel:-1"),
+        _scroll_threshold("x", -1.0, -0.55, -1.0, -0.45, "rel_hwheel:-1"),
+        _scroll_threshold("x", 0.55, 1.0, 0.45, 1.0, "rel_hwheel:1"),
     ]
 
 
@@ -489,3 +510,218 @@ def _direction_template(targets: dict[str, str]) -> list[AnalogActionThreshold]:
         )
         for axis, trigger_min, trigger_max, release_min, release_max, target in specs
     ]
+
+
+@dataclass(frozen=True)
+class AnalogControlPreset:
+    """A ready-to-use analog control starting point offered in the GUI.
+
+    Presets give new users a one-click way to make a stick or trigger do
+    something useful without first understanding reusable analog controls.
+    ``build`` returns a full, editable config saved like any other.
+    """
+
+    preset_id: str
+    label: str
+    description: str
+    icon_name: str
+    input_type: str
+    default_name: str
+    build: Callable[[str], AnalogControlConfig]
+
+
+def analog_control_mouse_move_preset(name: str) -> AnalogControlConfig:
+    return AnalogControlConfig(
+        name=name,
+        description="Move the mouse with the stick",
+        input_type="stick",
+        mouse_motion=AnalogMouseMotionConfig(
+            enabled=True,
+            mode="velocity",
+            speed=1000.0,
+            deadzone=0.18,
+            sensitivity=1.0,
+            response_curve=2.0,
+        ),
+    )
+
+
+def analog_control_mouse_area_preset(name: str) -> AnalogControlConfig:
+    return AnalogControlConfig(
+        name=name,
+        description="Map the stick position to a cursor area",
+        input_type="stick",
+        mouse_motion=AnalogMouseMotionConfig(
+            enabled=True,
+            mode="area",
+            area_radius_x=400.0,
+            area_radius_y=400.0,
+            deadzone=0.12,
+            sensitivity=1.0,
+            response_curve=1.0,
+        ),
+    )
+
+
+def analog_control_scroll_wheel_preset(name: str) -> AnalogControlConfig:
+    return AnalogControlConfig(
+        name=name,
+        description="Scroll up/down and side-scroll with the stick",
+        input_type="stick",
+        thresholds=analog_control_mouse_wheel_template(),
+    )
+
+
+def analog_control_wasd_preset(name: str) -> AnalogControlConfig:
+    return AnalogControlConfig(
+        name=name,
+        description="Map the stick to W/A/S/D",
+        input_type="stick",
+        thresholds=analog_control_wasd_template(),
+    )
+
+
+def _axis_action_threshold(action: MappingAction) -> AnalogActionThreshold:
+    return AnalogActionThreshold(
+        axis="x",
+        trigger_min=0.5,
+        trigger_max=1.0,
+        release_min=0.45,
+        release_max=1.0,
+        actions=[action],
+    )
+
+
+def _trigger_action_preset(
+    name: str, description: str, action: MappingAction
+) -> AnalogControlConfig:
+    return AnalogControlConfig(
+        name=name,
+        description=description,
+        input_type="axis",
+        thresholds=[_axis_action_threshold(action)],
+    )
+
+
+def analog_control_trigger_left_click_preset(name: str) -> AnalogControlConfig:
+    return _trigger_action_preset(
+        name,
+        "Left-click when the trigger is pulled",
+        MappingAction(action_type=ActionType.MOUSE, target="btn_left"),
+    )
+
+
+def analog_control_trigger_right_click_preset(name: str) -> AnalogControlConfig:
+    return _trigger_action_preset(
+        name,
+        "Right-click when the trigger is pulled",
+        MappingAction(action_type=ActionType.MOUSE, target="btn_right"),
+    )
+
+
+def analog_control_trigger_scroll_up_preset(name: str) -> AnalogControlConfig:
+    return _trigger_action_preset(
+        name,
+        "Scroll up while the trigger is pulled",
+        _scroll_action("rel_wheel:1"),
+    )
+
+
+def analog_control_trigger_scroll_down_preset(name: str) -> AnalogControlConfig:
+    return _trigger_action_preset(
+        name,
+        "Scroll down while the trigger is pulled",
+        _scroll_action("rel_wheel:-1"),
+    )
+
+
+_STICK_PRESETS: tuple[AnalogControlPreset, ...] = (
+    AnalogControlPreset(
+        preset_id="mouse_move",
+        label="Mouse Move",
+        description="Move the cursor with the stick",
+        icon_name="input-mouse-symbolic",
+        input_type="stick",
+        default_name="Mouse Move",
+        build=analog_control_mouse_move_preset,
+    ),
+    AnalogControlPreset(
+        preset_id="mouse_area",
+        label="Mouse Area",
+        description="Stick position controls cursor position",
+        icon_name="view-restore-symbolic",
+        input_type="stick",
+        default_name="Mouse Area",
+        build=analog_control_mouse_area_preset,
+    ),
+    AnalogControlPreset(
+        preset_id="scroll_wheel",
+        label="Scroll Wheel",
+        description="Scroll up/down and side-scroll with the stick",
+        icon_name="go-up-symbolic",
+        input_type="stick",
+        default_name="Scroll Wheel",
+        build=analog_control_scroll_wheel_preset,
+    ),
+    AnalogControlPreset(
+        preset_id="wasd",
+        label="WASD Keys",
+        description="Map the stick to W/A/S/D",
+        icon_name="input-keyboard-symbolic",
+        input_type="stick",
+        default_name="WASD",
+        build=analog_control_wasd_preset,
+    ),
+)
+
+_AXIS_PRESETS: tuple[AnalogControlPreset, ...] = (
+    AnalogControlPreset(
+        preset_id="trigger_left_click",
+        label="Trigger Left Click",
+        description="Left-click when the trigger is pulled",
+        icon_name="input-mouse-symbolic",
+        input_type="axis",
+        default_name="Trigger Left Click",
+        build=analog_control_trigger_left_click_preset,
+    ),
+    AnalogControlPreset(
+        preset_id="trigger_right_click",
+        label="Trigger Right Click",
+        description="Right-click when the trigger is pulled",
+        icon_name="input-mouse-symbolic",
+        input_type="axis",
+        default_name="Trigger Right Click",
+        build=analog_control_trigger_right_click_preset,
+    ),
+    AnalogControlPreset(
+        preset_id="trigger_scroll_up",
+        label="Trigger Scroll Up",
+        description="Scroll up while the trigger is pulled",
+        icon_name="go-up-symbolic",
+        input_type="axis",
+        default_name="Trigger Scroll Up",
+        build=analog_control_trigger_scroll_up_preset,
+    ),
+    AnalogControlPreset(
+        preset_id="trigger_scroll_down",
+        label="Trigger Scroll Down",
+        description="Scroll down while the trigger is pulled",
+        icon_name="go-down-symbolic",
+        input_type="axis",
+        default_name="Trigger Scroll Down",
+        build=analog_control_trigger_scroll_down_preset,
+    ),
+)
+
+
+def analog_control_presets(input_type: str | None) -> tuple[AnalogControlPreset, ...]:
+    """Return the presets that apply to a given analog input type.
+
+    ``None`` returns every preset (useful for tests and discovery).
+    """
+    normalized = str(input_type or "").lower()
+    if normalized == "stick":
+        return _STICK_PRESETS
+    if normalized == "axis":
+        return _AXIS_PRESETS
+    return _STICK_PRESETS + _AXIS_PRESETS

--- a/tests/gui/test_analog_control_dialog.py
+++ b/tests/gui/test_analog_control_dialog.py
@@ -1312,6 +1312,113 @@ def test_analog_selector_clicking_selected_control_deselects_it(temp_config_dir)
     assert dialog.map_btn.get_sensitive() is False
 
 
+def test_analog_control_dialog_select_control_by_name_selects_saved_control(
+    temp_config_dir,
+) -> None:
+    gi.require_version("Gtk", "4.0")
+    from gi.repository import Gtk
+
+    from keymasq.common.models import AnalogControlConfig
+    from keymasq.gui.widgets.analog_control_dialog import AnalogControlDialog
+    from keymasq.session.analog_controls import AnalogControlManager
+
+    manager = AnalogControlManager()
+    manager.save_analog_control(AnalogControlConfig(name="Alpha"))
+    manager.save_analog_control(AnalogControlConfig(name="Beta"))
+
+    dialog = AnalogControlDialog(Gtk.Window())
+
+    dialog.select_control_by_name("Beta")
+
+    assert dialog._current_name == "Beta"
+    assert dialog.name_entry.get_text() == "Beta"
+
+
+def test_analog_selector_right_click_opens_manager_for_control(
+    temp_config_dir,
+    monkeypatch,
+) -> None:
+    gi.require_version("Gtk", "4.0")
+    from gi.repository import Gtk
+
+    from keymasq.common.models import AnalogControlConfig
+    from keymasq.gui.widgets.key_selector_dialog import KeySelectorDialog
+    from keymasq.session.analog_controls import AnalogControlManager
+
+    AnalogControlManager().save_analog_control(AnalogControlConfig(name="Mouse"))
+    dialog = KeySelectorDialog(
+        Gtk.Window(),
+        "Left Stick",
+        source_type="analog",
+        analog_input_type="stick",
+    )
+    opened: list[str | None] = []
+    monkeypatch.setattr(dialog, "_open_analog_control_manager", opened.append)
+
+    dialog._on_analog_control_row_right_pressed(
+        Gtk.GestureClick(),
+        1,
+        0.0,
+        0.0,
+        "Mouse",
+    )
+
+    assert opened == ["Mouse"]
+
+
+def test_analog_selector_open_manager_presents_and_selects_requested_control(
+    monkeypatch,
+) -> None:
+    gi.require_version("Gtk", "4.0")
+    from gi.repository import Gtk
+
+    import keymasq.gui.widgets.analog_control_dialog as analog_dialog_module
+    from keymasq.gui.widgets.key_selector_dialog import KeySelectorDialog
+
+    captured: dict[str, object] = {}
+    parent = Gtk.Window()
+    profile_manager = object()
+    parent.profile_manager = profile_manager
+
+    class DummyAnalogControlDialog:
+        def __init__(self, root, profile_manager_arg):
+            captured["root"] = root
+            captured["profile_manager"] = profile_manager_arg
+            captured["signals"] = []
+
+        def connect(self, signal_name, callback):
+            captured["signals"].append(signal_name)
+            captured[signal_name] = callback
+
+        def present(self, root):
+            captured["present_root"] = root
+
+        def select_control_by_name(self, name):
+            captured["selected_name"] = name
+
+    monkeypatch.setattr(
+        analog_dialog_module,
+        "AnalogControlDialog",
+        DummyAnalogControlDialog,
+    )
+
+    dialog = KeySelectorDialog(
+        parent,
+        "Left Stick",
+        source_type="analog",
+        analog_input_type="stick",
+    )
+    monkeypatch.setattr(dialog, "get_root", lambda: parent)
+
+    dialog._open_analog_control_manager("Mouse")
+
+    assert captured["root"] is parent
+    assert captured["profile_manager"] is profile_manager
+    assert captured["present_root"] is parent
+    assert captured["signals"] == ["analog-control-saved", "analog-control-deleted"]
+    assert captured["selected_name"] == "Mouse"
+
+
 def test_analog_selector_docs_button_links_to_analog_controls_docs(
     temp_config_dir,
     monkeypatch,
@@ -1326,7 +1433,9 @@ def test_analog_selector_docs_button_links_to_analog_controls_docs(
 
     dialog = KeySelectorDialog(Gtk.Window(), "Left Stick", source_type="analog")
 
-    assert dialog.stack.get_visible_child_name() == "analog_control"
+    # With no saved controls the dialog opens on the Presets tab, which still
+    # links to the Analog Controls docs.
+    assert dialog.stack.get_visible_child_name() == "analog_presets"
     assert dialog.actions_docs_btn.get_visible() is True
     assert (
         dialog.actions_docs_btn.get_tooltip_text()

--- a/tests/gui/test_analog_control_dialog.py
+++ b/tests/gui/test_analog_control_dialog.py
@@ -1312,6 +1312,82 @@ def test_analog_selector_clicking_selected_control_deselects_it(temp_config_dir)
     assert dialog.map_btn.get_sensitive() is False
 
 
+def test_analog_selector_presets_tab_hides_rapidfire_tap_footer(
+    temp_config_dir,
+) -> None:
+    gi.require_version("Gtk", "4.0")
+    from gi.repository import Gtk
+
+    from keymasq.gui.widgets.key_selector_dialog import KeySelectorDialog
+
+    dialog = KeySelectorDialog(Gtk.Window(), "Left Stick", source_type="analog")
+
+    assert dialog.stack.get_visible_child_name() == "analog_presets"
+    assert dialog.options_box.get_visible() is False
+
+
+def test_analog_manager_changed_switches_presets_to_control_picker(
+    temp_config_dir,
+    monkeypatch,
+) -> None:
+    gi.require_version("Gtk", "4.0")
+    from gi.repository import Gtk
+
+    from keymasq.common.models import AnalogControlConfig
+    from keymasq.gui.widgets import key_selector_dialog as dialog_module
+    from keymasq.gui.widgets.key_selector_dialog import KeySelectorDialog
+    from keymasq.session.analog_controls import AnalogControlManager
+
+    monkeypatch.setattr(dialog_module, "notify_session_reload_async", lambda: None)
+
+    dialog = KeySelectorDialog(Gtk.Window(), "Left Stick", source_type="analog")
+    assert dialog.stack.get_visible_child_name() == "analog_presets"
+
+    AnalogControlManager().save_analog_control(AnalogControlConfig(name="Mouse"))
+    dialog._on_analog_control_manager_changed(dialog, "Mouse")
+
+    assert dialog.stack.get_visible_child_name() == "analog_control"
+    assert dialog.map_btn.get_sensitive() is False
+
+
+def test_analog_manager_changed_clears_deleted_control_selection(
+    temp_config_dir,
+    monkeypatch,
+) -> None:
+    gi.require_version("Gtk", "4.0")
+    from gi.repository import Gtk
+
+    from keymasq.common.models import ActionType, AnalogControlConfig, MappingAction
+    from keymasq.gui.widgets import key_selector_dialog as dialog_module
+    from keymasq.gui.widgets.key_selector_dialog import KeySelectorDialog
+    from keymasq.session.analog_controls import AnalogControlManager
+
+    monkeypatch.setattr(dialog_module, "notify_session_reload_async", lambda: None)
+
+    manager = AnalogControlManager()
+    manager.save_analog_control(AnalogControlConfig(name="Mouse"))
+    dialog = KeySelectorDialog(
+        Gtk.Window(),
+        "Left Stick",
+        current_action=MappingAction(
+            action_type=ActionType.ANALOG_CONTROL,
+            analog_control_names=["Mouse"],
+        ),
+        source_type="analog",
+        analog_input_type="stick",
+    )
+
+    assert dialog.stack.get_visible_child_name() == "analog_control"
+    assert dialog.map_btn.get_sensitive() is True
+
+    manager.delete_analog_control("Mouse")
+    dialog._on_analog_control_manager_changed(dialog, "Mouse")
+
+    assert dialog._selected_analog_controls == []
+    assert dialog._selected_analog_control is None
+    assert dialog.map_btn.get_sensitive() is False
+
+
 def test_analog_control_dialog_select_control_by_name_selects_saved_control(
     temp_config_dir,
 ) -> None:
@@ -1367,6 +1443,7 @@ def test_analog_selector_right_click_opens_manager_for_control(
 
 
 def test_analog_selector_open_manager_presents_and_selects_requested_control(
+    temp_config_dir,
     monkeypatch,
 ) -> None:
     gi.require_version("Gtk", "4.0")

--- a/tests/gui/test_gui_demo_and_dialogs.py
+++ b/tests/gui/test_gui_demo_and_dialogs.py
@@ -1241,6 +1241,28 @@ class TestDialogConstruction:
         assert dialog._current_config.name == "Beta"
         assert dialog._modified is False
 
+    def test_superkey_dialog_select_superkey_by_name_selects_saved_superkey(
+        self, temp_config_dir
+    ):
+        gi.require_version("Gtk", "4.0")
+        from gi.repository import Gtk
+
+        from keymasq.common.models import SuperkeyConfig
+        from keymasq.gui.widgets.superkey_dialog import SuperkeyDialog
+        from keymasq.session.superkeys import SuperkeyManager
+
+        manager = SuperkeyManager()
+        manager.save_superkey(SuperkeyConfig(name="Alpha"))
+        manager.save_superkey(SuperkeyConfig(name="Beta"))
+
+        dialog = SuperkeyDialog(Gtk.Window())
+
+        dialog.select_superkey_by_name("Beta")
+
+        assert dialog._current_config is not None
+        assert dialog._current_config.name == "Beta"
+        assert dialog.name_entry.get_text() == "Beta"
+
     def test_superkey_dialog_docs_button_links_to_superkeys_docs(
         self, temp_config_dir, monkeypatch
     ):

--- a/tests/gui/test_gui_demo_and_dialogs.py
+++ b/tests/gui/test_gui_demo_and_dialogs.py
@@ -1257,8 +1257,18 @@ class TestDialogConstruction:
 
         dialog = SuperkeyDialog(Gtk.Window())
 
+        def row_for(name: str):
+            idx = 0
+            while row := dialog.list_box.get_row_at_index(idx):
+                if getattr(row, "_superkey_name", None) == name:
+                    return row
+                idx += 1
+            raise AssertionError(f"missing row {name}")
+
         dialog.select_superkey_by_name("Beta")
 
+        beta_row = row_for("Beta")
+        assert dialog.list_box.get_selected_row() is beta_row
         assert dialog._current_config is not None
         assert dialog._current_config.name == "Beta"
         assert dialog.name_entry.get_text() == "Beta"

--- a/tests/gui/test_gui_device_tab_misc.py
+++ b/tests/gui/test_gui_device_tab_misc.py
@@ -1,4 +1,5 @@
 # ruff: noqa: I001
+from collections.abc import Callable
 from types import SimpleNamespace
 
 import pytest
@@ -1212,6 +1213,16 @@ def test_key_selector_dialog_uses_dedicated_superkey_tab(temp_config_dir, monkey
     from keymasq.gui.widgets.key_selector_dialog import KeySelectorDialog
     from keymasq.session.superkeys import SuperkeyManager
 
+    def collect_buttons(widget):
+        buttons = []
+        child = widget.get_first_child()
+        while child is not None:
+            if isinstance(child, Gtk.Button):
+                buttons.append(child)
+            buttons.extend(collect_buttons(child))
+            child = child.get_next_sibling()
+        return buttons
+
     superkeys_dir = temp_config_dir / "superkeys"
     monkeypatch.setattr(paths, "SUPERKEYS_DIR", superkeys_dir)
     SuperkeyManager().save_superkey(
@@ -1235,6 +1246,11 @@ def test_key_selector_dialog_uses_dedicated_superkey_tab(temp_config_dir, monkey
 
     assert dialog.stack.get_visible_child_name() == "superkey"
     assert dialog._superkey_names == ["volume_rocker"]
+    superkey_tab = dialog.stack.get_child_by_name("superkey")
+    assert superkey_tab is not None
+    button_labels = {button.get_label() for button in collect_buttons(superkey_tab)}
+    assert "Open Super Keys…" in button_labels
+    assert "Refresh" not in button_labels
     assert dialog.map_btn.get_visible() is True
     assert dialog.map_btn.get_sensitive() is True
 
@@ -1243,6 +1259,140 @@ def test_key_selector_dialog_uses_dedicated_superkey_tab(temp_config_dir, monkey
     assert len(results) == 1
     assert results[0].action_type == ActionType.SUPERKEY
     assert results[0].superkey_name == "volume_rocker"
+
+
+def test_key_selector_superkey_right_click_opens_manager_for_superkey(
+    temp_config_dir,
+    monkeypatch,
+):
+    from gi.repository import Gtk
+
+    from keymasq.common.models import SuperkeyConfig
+    from keymasq.gui.widgets.key_selector_dialog import KeySelectorDialog
+    from keymasq.session.superkeys import SuperkeyManager
+
+    SuperkeyManager().save_superkey(SuperkeyConfig(name="volume_rocker"))
+    dialog = KeySelectorDialog(Gtk.Window(), "Back")
+    opened: list[str | None] = []
+    monkeypatch.setattr(dialog, "_open_superkey_manager", opened.append)
+
+    dialog._on_superkey_row_right_pressed(
+        Gtk.GestureClick(),
+        1,
+        0.0,
+        0.0,
+        "volume_rocker",
+    )
+
+    assert opened == ["volume_rocker"]
+
+
+def test_key_selector_open_superkey_manager_uses_root_profile_manager(
+    monkeypatch,
+):
+    from gi.repository import Gtk
+
+    import keymasq.gui.widgets.superkey_dialog as superkey_dialog_module
+    from keymasq.gui.widgets.key_selector_dialog import KeySelectorDialog
+
+    captured: dict[str, object] = {}
+    parent = Gtk.Box()
+    root = Gtk.Window()
+    profile_manager = object()
+    root.profile_manager = profile_manager
+    parent.main_window = root
+
+    class DummySuperkeyDialog:
+        def __init__(self, root, profile_manager_arg):
+            captured["root"] = root
+            captured["profile_manager"] = profile_manager_arg
+            captured["signals"] = []
+
+        def connect(self, signal_name, callback):
+            captured["signals"].append(signal_name)
+            captured[signal_name] = callback
+
+        def present(self, root):
+            captured["present_root"] = root
+
+        def select_superkey_by_name(self, name):
+            captured["selected_name"] = name
+
+    monkeypatch.setattr(superkey_dialog_module, "SuperkeyDialog", DummySuperkeyDialog)
+
+    dialog = KeySelectorDialog(parent, "Back")
+    monkeypatch.setattr(dialog, "get_root", lambda: root)
+
+    dialog._open_superkey_manager("volume_rocker")
+
+    assert captured["root"] is root
+    assert captured["profile_manager"] is profile_manager
+    assert captured["present_root"] is root
+    assert captured["signals"] == ["superkey-saved", "superkey-deleted"]
+    assert captured["selected_name"] == "volume_rocker"
+
+
+def test_key_selector_macro_right_click_opens_macro_editor(monkeypatch):
+    from gi.repository import Gtk
+
+    from keymasq.gui.widgets.key_selector_dialog import KeySelectorDialog
+
+    dialog = KeySelectorDialog(Gtk.Window(), "Back")
+    opened: list[str] = []
+    monkeypatch.setattr(dialog, "_open_macro_editor", opened.append)
+
+    dialog._on_macro_row_right_pressed(
+        Gtk.GestureClick(),
+        1,
+        0.0,
+        0.0,
+        "demo_macro",
+    )
+
+    assert opened == ["demo_macro"]
+
+
+def test_key_selector_open_macro_editor_presents_and_reloads_on_close(monkeypatch):
+    from gi.repository import Gtk
+
+    import keymasq.gui.widgets.macro_editor_dialog as macro_editor_dialog_module
+    from keymasq.gui.widgets.key_selector_dialog import KeySelectorDialog
+
+    captured: dict[str, object] = {}
+    callbacks: list[Callable[[object], object]] = []
+    parent = Gtk.Window()
+
+    class DummyMacroEditorDialog:
+        def __init__(self, root, macro_name):
+            captured["root"] = root
+            captured["macro_name"] = macro_name
+
+        def connect(self, signal_name, callback):
+            captured["signal_name"] = signal_name
+            callbacks.append(callback)
+
+        def present(self, root):
+            captured["present_root"] = root
+
+    monkeypatch.setattr(
+        macro_editor_dialog_module,
+        "MacroEditorDialog",
+        DummyMacroEditorDialog,
+    )
+
+    dialog = KeySelectorDialog(parent, "Back")
+    monkeypatch.setattr(dialog, "get_root", lambda: parent)
+    reloaded: list[bool] = []
+    monkeypatch.setattr(dialog, "_load_macro_list", lambda: reloaded.append(True) or False)
+
+    dialog._open_macro_editor("demo_macro")
+    callbacks[0](captured["root"])
+
+    assert captured["root"] is parent
+    assert captured["macro_name"] == "demo_macro"
+    assert captured["present_root"] is parent
+    assert captured["signal_name"] == "closed"
+    assert reloaded == [True]
 
 
 def test_key_selector_dialog_keyboard_mapping_uses_rapidfire_or_tap_state():

--- a/tests/gui/test_gui_device_tab_misc.py
+++ b/tests/gui/test_gui_device_tab_misc.py
@@ -1019,10 +1019,12 @@ def test_key_selector_dialog_passthrough_clears_current_profile_mapping():
     assert results == [None]
 
 
-def test_analog_key_selector_opens_controls_first_and_special_has_no_passthrough():
+def test_analog_key_selector_default_tab_and_special_has_no_passthrough(temp_config_dir):
     from gi.repository import Gtk
 
+    from keymasq.common.models import AnalogControlConfig
     from keymasq.gui.widgets.key_selector_dialog import KeySelectorDialog
+    from keymasq.session.analog_controls import AnalogControlManager
 
     def collect_buttons(widget):
         buttons = []
@@ -1034,27 +1036,19 @@ def test_analog_key_selector_opens_controls_first_and_special_has_no_passthrough
             child = child.get_next_sibling()
         return buttons
 
-    def collect_labels(widget):
-        labels = []
-        child = widget.get_first_child()
-        while child is not None:
-            if isinstance(child, Gtk.Label):
-                labels.append(child)
-            labels.extend(collect_labels(child))
-            child = child.get_next_sibling()
-        return labels
-
+    # New users have no saved controls, so the dialog opens on the Presets tab
+    # with a link through to the full Analog Controls manager.
     dialog = KeySelectorDialog(Gtk.Box(), "Left Stick", source_type="analog")
+    assert dialog.stack.get_visible_child_name() == "analog_presets"
+    presets_tab = dialog.stack.get_child_by_name("analog_presets")
+    assert presets_tab is not None
+    presets_labels = {button.get_label() for button in collect_buttons(presets_tab)}
+    assert "Open Analog Controls…" in presets_labels
 
-    assert dialog.stack.get_visible_child_name() == "analog_control"
-    analog_tab = dialog.stack.get_child_by_name("analog_control")
-    assert analog_tab is not None
-    hint = next(
-        label
-        for label in collect_labels(analog_tab)
-        if label.get_text() == "Select one or multiple analog controls"
-    )
-    assert "dim-label" in hint.get_css_classes()
+    # Once a control exists, the dialog opens on the picker instead.
+    AnalogControlManager().save_analog_control(AnalogControlConfig(name="My Stick"))
+    populated = KeySelectorDialog(Gtk.Box(), "Left Stick", source_type="analog")
+    assert populated.stack.get_visible_child_name() == "analog_control"
 
     special_tab = dialog._build_special_tab()
     button_labels = {button.get_label() for button in collect_buttons(special_tab)}
@@ -1062,6 +1056,46 @@ def test_analog_key_selector_opens_controls_first_and_special_has_no_passthrough
     assert "Clear Mapping" in button_labels
     assert "Suppress" in button_labels
     assert "Passthrough" not in button_labels
+
+
+def test_analog_key_selector_preset_uses_suffixed_name_for_storage_collision(
+    temp_config_dir,
+    monkeypatch,
+):
+    from gi.repository import Gtk
+
+    from keymasq.common.models import ActionType, AnalogControlConfig, MappingAction
+    from keymasq.gui.widgets import key_selector_dialog as dialog_module
+    from keymasq.gui.widgets.key_selector_dialog import KeySelectorDialog
+    from keymasq.session.analog_controls import (
+        AnalogControlManager,
+        analog_control_presets,
+    )
+
+    monkeypatch.setattr(dialog_module, "notify_session_reload_async", lambda: None)
+
+    manager = AnalogControlManager()
+    manager.save_analog_control(AnalogControlConfig(name="Mouse_Move"))
+
+    results: list[MappingAction] = []
+    dialog = KeySelectorDialog(
+        Gtk.Box(),
+        "Left Stick",
+        source_type="analog",
+        analog_input_type="stick",
+    )
+    dialog.connect("key-selected", lambda _dialog, action: results.append(action))
+    preset = next(
+        preset
+        for preset in analog_control_presets("stick")
+        if preset.preset_id == "mouse_move"
+    )
+
+    dialog._on_analog_preset_clicked(Gtk.Button(), preset)
+
+    assert results[0].action_type == ActionType.ANALOG_CONTROL
+    assert results[0].analog_control_names == ["Mouse Move 2"]
+    assert AnalogControlManager().get_analog_control("Mouse Move 2") is not None
 
 
 def test_key_selector_dialog_repeat_uses_special_toggle_buttons_and_inline_rapidfire():

--- a/tests/test_analog_controls.py
+++ b/tests/test_analog_controls.py
@@ -12,10 +12,12 @@ from keymasq.common.models import (
     AnalogGamepadOutputConfig,
     AnalogMouseMotionConfig,
     MappingAction,
+    validate_analog_control_config,
 )
 from keymasq.session.analog_controls import (
     AnalogControlManager,
     analog_control_mouse_wheel_template,
+    analog_control_presets,
     analog_control_wasd_template,
 )
 
@@ -523,3 +525,103 @@ def test_analog_control_templates_produce_threshold_actions() -> None:
     assert wheel[0].actions[0].rapidfire_enabled is True
     assert wheel[0].actions[0].rapidfire_hold_ms == 20
     assert wheel[0].actions[0].rapidfire_wait_ms == 60
+    # Vertical (Y) up/down plus horizontal (X) left/right side-scrolling.
+    assert [(t.axis, t.actions[0].target) for t in wheel] == [
+        ("y", "rel_wheel:1"),
+        ("y", "rel_wheel:-1"),
+        ("x", "rel_hwheel:-1"),
+        ("x", "rel_hwheel:1"),
+    ]
+    assert all(t.actions[0].rapidfire_enabled for t in wheel)
+
+
+def test_analog_control_presets_filtered_by_input_type() -> None:
+    stick = analog_control_presets("stick")
+    axis = analog_control_presets("axis")
+    assert {p.preset_id for p in stick} == {
+        "mouse_move",
+        "mouse_area",
+        "scroll_wheel",
+        "wasd",
+    }
+    assert {p.preset_id for p in axis} == {
+        "trigger_left_click",
+        "trigger_right_click",
+        "trigger_scroll_up",
+        "trigger_scroll_down",
+    }
+    assert all(p.input_type == "stick" for p in stick)
+    assert all(p.input_type == "axis" for p in axis)
+
+
+def test_analog_control_presets_none_returns_all() -> None:
+    every = analog_control_presets(None)
+    assert {p.preset_id for p in every} == {
+        "mouse_move",
+        "mouse_area",
+        "scroll_wheel",
+        "wasd",
+        "trigger_left_click",
+        "trigger_right_click",
+        "trigger_scroll_up",
+        "trigger_scroll_down",
+    }
+
+
+def test_analog_control_presets_build_valid_configs() -> None:
+    for preset in analog_control_presets(None):
+        config = preset.build(preset.default_name)
+        assert config.name == preset.default_name
+        assert config.input_type == preset.input_type
+        # Should not raise — every preset is a valid, ready-to-use config.
+        validate_analog_control_config(config)
+
+
+def test_analog_control_mouse_move_preset_uses_velocity_mouse_motion() -> None:
+    preset = next(p for p in analog_control_presets("stick") if p.preset_id == "mouse_move")
+    config = preset.build("Mouse Move")
+    assert config.mouse_motion.enabled is True
+    assert config.mouse_motion.mode == "velocity"
+
+
+def test_analog_control_mouse_area_preset_uses_area_mode() -> None:
+    preset = next(p for p in analog_control_presets("stick") if p.preset_id == "mouse_area")
+    config = preset.build("Mouse Area")
+    assert config.mouse_motion.enabled is True
+    assert config.mouse_motion.mode == "area"
+
+
+def test_analog_control_trigger_presets_cover_clicks_and_scroll() -> None:
+    targets = {}
+    for preset in analog_control_presets("axis"):
+        config = preset.build(preset.default_name)
+        assert config.input_type == "axis"
+        assert len(config.thresholds) == 1
+        action = config.thresholds[0].actions[0]
+        assert action.action_type == ActionType.MOUSE
+        targets[preset.preset_id] = action.target
+    assert targets == {
+        "trigger_left_click": "btn_left",
+        "trigger_right_click": "btn_right",
+        "trigger_scroll_up": "rel_wheel:1",
+        "trigger_scroll_down": "rel_wheel:-1",
+    }
+
+
+def test_analog_control_presets_round_trip_through_manager(temp_config_dir) -> None:
+    manager = AnalogControlManager()
+    for preset in analog_control_presets(None):
+        config = preset.build(preset.default_name)
+        manager.save_analog_control(config)
+    saved = set(manager.list_analog_controls())
+    assert {p.default_name for p in analog_control_presets(None)} <= saved
+
+
+def test_analog_control_unique_name_accounts_for_storage_filename_collisions(
+    temp_config_dir,
+) -> None:
+    manager = AnalogControlManager()
+    manager.save_analog_control(AnalogControlConfig(name="Mouse_Move"))
+    manager.save_analog_control(AnalogControlConfig(name="Mouse Move 2"))
+
+    assert manager.unique_analog_control_name("Mouse Move") == "Mouse Move 3"


### PR DESCRIPTION
## Summary

- Add preset cards in the mapping dialog for quick analog control setup (Mouse Move, Mouse Area, Scroll Wheel, WASD for sticks; Trigger Left Click, Trigger Right Click, Trigger Scroll Up/Down for triggers)
- Show Presets tab by default when no analog controls exist; fall back to control picker once saved
- Extend mouse wheel template to include horizontal side-scroll (rel_hwheel) in addition to vertical scroll
- Add right-click on analog control rows to open the manager directly editing that control
- Add `unique_analog_control_name` to avoid storage filename collisions when saving presets
- Add `select_control_by_name` to `AnalogControlDialog` for external navigation
- Add right-click gesture on superkey and macro rows to open editor
- Add select_superkey_by_name() to SuperkeyDialog for external navigation

## Testing

- `test_analog_control_presets_filtered_by_input_type` — verifies stick/axis preset filtering
- `test_analog_control_presets_build_valid_configs` — all presets produce valid configs
- `test_analog_control_trigger_presets_cover_clicks_and_scroll` — trigger presets map to correct mouse targets
- `test_analog_control_presets_round_trip_through_manager` — presets survive save/load cycle
- `test_analog_control_mouse_wheel_template` — wheel template now covers Y and X axes with rapidfire
- `test_analog_key_selector_default_tab_and_special_has_no_passthrough` — Presets tab shown for new users
- `test_analog_key_selector_preset_uses_suffixed_name_for_storage_collision` — collision-safe naming
- `test_analog_selector_right_click_opens_manager_for_control` — right-click opens manager
- `test_analog_control_dialog_select_control_by_name_selects_saved_control` — programmatic selection
- Run `./scripts/check.sh` (ruff, basedpyright, pytest)