### PR TITLE
Refactor action normalization and payload serialization to eliminate duplication

### DIFF
--- a/keymasq/common/models.py
+++ b/keymasq/common/models.py
@@ -1,5 +1,5 @@
 import logging
-from dataclasses import dataclass, field, replace
+from dataclasses import dataclass, field, fields, replace
 from datetime import datetime
 from enum import Enum
 from typing import TYPE_CHECKING, Any, Protocol, cast, overload
@@ -527,7 +527,6 @@ class MappingAction:
         self.source_profile_name = (
             str(self.source_profile_name).strip() if self.source_profile_name else None
         ) or None
-        self.output_id = normalize_gamepad_output_id(self.action_type, self.output_id)
         if self.analog_control_name and not self.analog_control_names:
             self.analog_control_names = [self.analog_control_name]
         else:
@@ -540,45 +539,11 @@ class MappingAction:
             self.analog_control_configs = [self.analog_control_config]
         elif self.analog_control_configs:
             self.analog_control_config = self.analog_control_configs[0]
-        if self.action_type == ActionType.GAMEPAD_AXIS:
-            self.target = normalize_gamepad_axis_target(self.target)
-            self.axis_value = clamp_gamepad_axis_value(self.target, self.axis_value)
-        rapidfire_enabled, rapidfire_hold_ms, rapidfire_wait_ms = normalize_rapidfire_fields(
-            self.action_type,
-            rapidfire_enabled=bool(self.rapidfire_enabled),
-            rapidfire_hold_ms=int(self.rapidfire_hold_ms),
-            rapidfire_wait_ms=int(self.rapidfire_wait_ms),
-        )
-        self.rapidfire_enabled = rapidfire_enabled
-        self.rapidfire_hold_ms = rapidfire_hold_ms
-        self.rapidfire_wait_ms = rapidfire_wait_ms
-        self.profile_deactivation = normalize_profile_deactivation_policy(
-            self.action_type,
-            self.profile_deactivation,
-        )
-        if self.action_type == ActionType.MPRIS:
-            self.mpris_command = normalize_mpris_command(self.mpris_command)
-        else:
-            self.mpris_command = None
-        if self.action_type in {
-            ActionType.START_MACRO_RECORDING,
-            ActionType.STOP_MACRO_RECORDING,
-            ActionType.PLAY_MACRO_SLOT,
-        }:
-            self.macro_recording_slot = normalize_macro_recording_slot(self.macro_recording_slot)
-        else:
-            self.macro_recording_slot = 0
+        _normalize_common_action_fields(self)
         if self.action_type == ActionType.REPEAT:
             self.repeat_categories = normalize_repeat_categories(self.repeat_categories)
         else:
             self.repeat_categories = None
-        if self.action_type == ActionType.MOUSE_MOVE_NATURAL_ABS:
-            self.move_speed = max(1.0, float(self.move_speed))
-            self.move_jitter = max(0.0, float(self.move_jitter))
-            self.move_curve = normalize_natural_mouse_move_curve(self.move_curve)
-            self.move_tolerance = max(0, int(self.move_tolerance))
-            self.move_max_duration_ms = max(1, int(self.move_max_duration_ms))
-            self.move_stop_on_failure = bool_value(self.move_stop_on_failure)
 
 
 ANALOG_THRESHOLD_ACTION_TYPES = frozenset(
@@ -853,79 +818,54 @@ class SuperkeyAction:
         return self.action_type in SUPERKEY_ACTION_TYPES
 
     def __post_init__(self) -> None:
-        self.output_id = normalize_gamepad_output_id(self.action_type, self.output_id)
-        if self.action_type == ActionType.GAMEPAD_AXIS:
-            self.target = normalize_gamepad_axis_target(self.target)
-            self.axis_value = clamp_gamepad_axis_value(self.target, self.axis_value)
-        rapidfire_enabled, rapidfire_hold_ms, rapidfire_wait_ms = normalize_rapidfire_fields(
-            self.action_type,
-            rapidfire_enabled=bool(self.rapidfire_enabled),
-            rapidfire_hold_ms=int(self.rapidfire_hold_ms),
-            rapidfire_wait_ms=int(self.rapidfire_wait_ms),
-        )
-        self.rapidfire_enabled = rapidfire_enabled
-        self.rapidfire_hold_ms = rapidfire_hold_ms
-        self.rapidfire_wait_ms = rapidfire_wait_ms
-        self.profile_deactivation = normalize_profile_deactivation_policy(
-            self.action_type,
-            self.profile_deactivation,
-        )
-        if self.action_type == ActionType.MPRIS:
-            self.mpris_command = normalize_mpris_command(self.mpris_command)
-        else:
-            self.mpris_command = None
-        if self.action_type in {
-            ActionType.START_MACRO_RECORDING,
-            ActionType.STOP_MACRO_RECORDING,
-            ActionType.PLAY_MACRO_SLOT,
-        }:
-            self.macro_recording_slot = normalize_macro_recording_slot(self.macro_recording_slot)
-        else:
-            self.macro_recording_slot = 0
-        if self.action_type == ActionType.MOUSE_MOVE_NATURAL_ABS:
-            self.move_speed = max(1.0, float(self.move_speed))
-            self.move_jitter = max(0.0, float(self.move_jitter))
-            self.move_curve = normalize_natural_mouse_move_curve(self.move_curve)
-            self.move_tolerance = max(0, int(self.move_tolerance))
-            self.move_max_duration_ms = max(1, int(self.move_max_duration_ms))
-            self.move_stop_on_failure = bool_value(self.move_stop_on_failure)
+        _normalize_common_action_fields(self)
 
 
-SUPERKEY_ACTION_SHARED_FIELDS = (
-    "target",
-    "output_id",
-    "cmd",
-    "exec_ref",
-    "macro_name",
-    "macro_replay_mouse_movement",
-    "macro_replay_mouse_clicks",
-    "macro_speed",
-    "macro_loop_mode",
-    "macro_loop_count",
-    "macro_loop_stop_behavior",
-    "macro_move_to_start",
-    "macro_start_x",
-    "macro_start_y",
-    "macro_block_mouse_movement",
-    "macro_recording_slot",
-    "profile_name",
-    "profile_deactivation",
-    "compositor_id",
-    "compositor_dispatcher",
-    "compositor_args",
-    "mpris_command",
-    "move_x",
-    "move_y",
-    "axis_value",
-    "move_speed",
-    "move_jitter",
-    "move_curve",
-    "move_tolerance",
-    "move_max_duration_ms",
-    "move_stop_on_failure",
-    "rapidfire_enabled",
-    "rapidfire_hold_ms",
-    "rapidfire_wait_ms",
+def _normalize_common_action_fields(action: MappingAction | SuperkeyAction) -> None:
+    action.output_id = normalize_gamepad_output_id(action.action_type, action.output_id)
+    if action.action_type == ActionType.GAMEPAD_AXIS:
+        action.target = normalize_gamepad_axis_target(action.target)
+        action.axis_value = clamp_gamepad_axis_value(action.target, action.axis_value)
+    rapidfire_enabled, rapidfire_hold_ms, rapidfire_wait_ms = normalize_rapidfire_fields(
+        action.action_type,
+        rapidfire_enabled=bool(action.rapidfire_enabled),
+        rapidfire_hold_ms=int(action.rapidfire_hold_ms),
+        rapidfire_wait_ms=int(action.rapidfire_wait_ms),
+    )
+    action.rapidfire_enabled = rapidfire_enabled
+    action.rapidfire_hold_ms = rapidfire_hold_ms
+    action.rapidfire_wait_ms = rapidfire_wait_ms
+    action.profile_deactivation = normalize_profile_deactivation_policy(
+        action.action_type,
+        action.profile_deactivation,
+    )
+    if action.action_type == ActionType.MPRIS:
+        action.mpris_command = normalize_mpris_command(action.mpris_command)
+    else:
+        action.mpris_command = None
+    if action.action_type in {
+        ActionType.START_MACRO_RECORDING,
+        ActionType.STOP_MACRO_RECORDING,
+        ActionType.PLAY_MACRO_SLOT,
+    }:
+        action.macro_recording_slot = normalize_macro_recording_slot(
+            action.macro_recording_slot
+        )
+    else:
+        action.macro_recording_slot = 0
+    if action.action_type == ActionType.MOUSE_MOVE_NATURAL_ABS:
+        action.move_speed = max(1.0, float(action.move_speed))
+        action.move_jitter = max(0.0, float(action.move_jitter))
+        action.move_curve = normalize_natural_mouse_move_curve(action.move_curve)
+        action.move_tolerance = max(0, int(action.move_tolerance))
+        action.move_max_duration_ms = max(1, int(action.move_max_duration_ms))
+        action.move_stop_on_failure = bool_value(action.move_stop_on_failure)
+
+
+SUPERKEY_ACTION_SHARED_FIELDS = tuple(
+    dataclass_field.name
+    for dataclass_field in fields(SuperkeyAction)
+    if dataclass_field.name != "action_type"
 )
 
 

--- a/keymasq/session/manager/payloads.py
+++ b/keymasq/session/manager/payloads.py
@@ -765,94 +765,161 @@ def serialize_superkey(
     *,
     track_combo_refs: bool = False,
 ) -> JsonObject:
+    return _serialize_superkey_payload(
+        manager,
+        config,
+        hardware_id,
+        signature=False,
+        track_combo_refs=track_combo_refs,
+    )
+
+
+def _serialize_superkey_payload(
+    manager: "SessionManager",
+    config: SuperkeyConfig,
+    hardware_id: str,
+    *,
+    signature: bool,
+    track_combo_refs: bool = False,
+) -> JsonObject:
     data: JsonObject = {
         "name": config.name,
         "mode": config.mode.value,
-        "tap_timeout_ms": config.tap_timeout_ms,
-        "double_tap_window_ms": config.double_tap_window_ms,
-        "hold_threshold_ms": config.hold_threshold_ms,
+        "tap_timeout_ms": int(config.tap_timeout_ms) if signature else config.tap_timeout_ms,
+        "double_tap_window_ms": (
+            int(config.double_tap_window_ms) if signature else config.double_tap_window_ms
+        ),
+        "hold_threshold_ms": int(config.hold_threshold_ms)
+        if signature
+        else config.hold_threshold_ms,
     }
 
     if config.mode == SuperkeyMode.PATTERN:
         if config.tap_actions:
-            data["tap_actions"] = [
-                serialize_superkey_action(
-                    manager,
-                    action,
-                    hardware_id,
-                    track_combo_refs=track_combo_refs,
-                )
-                for action in config.tap_actions
-            ]
-        if config.double_tap_actions:
-            data["double_tap_actions"] = [
-                serialize_superkey_action(
-                    manager,
-                    action,
-                    hardware_id,
-                    track_combo_refs=track_combo_refs,
-                )
-                for action in config.double_tap_actions
-            ]
-        if config.hold_actions:
-            data["hold_actions"] = [
-                serialize_superkey_action(
-                    manager,
-                    action,
-                    hardware_id,
-                    track_combo_refs=track_combo_refs,
-                )
-                for action in config.hold_actions
-            ]
-        if config.tap_hold_actions:
-            data["tap_hold_actions"] = [
-                serialize_superkey_action(
-                    manager,
-                    action,
-                    hardware_id,
-                    track_combo_refs=track_combo_refs,
-                )
-                for action in config.tap_hold_actions
-            ]
-    elif config.overload_actions:
-        data["overload_actions"] = [
-            serialize_superkey_overload_action(
+            data["tap_actions"] = _serialize_superkey_pattern_actions(
                 manager,
-                action,
+                config.tap_actions,
                 hardware_id,
+                signature=signature,
                 track_combo_refs=track_combo_refs,
             )
-            for action in config.overload_actions
-        ]
+        if config.double_tap_actions:
+            data["double_tap_actions"] = _serialize_superkey_pattern_actions(
+                manager,
+                config.double_tap_actions,
+                hardware_id,
+                signature=signature,
+                track_combo_refs=track_combo_refs,
+            )
+        if config.hold_actions:
+            data["hold_actions"] = _serialize_superkey_pattern_actions(
+                manager,
+                config.hold_actions,
+                hardware_id,
+                signature=signature,
+                track_combo_refs=track_combo_refs,
+            )
+        if config.tap_hold_actions:
+            data["tap_hold_actions"] = _serialize_superkey_pattern_actions(
+                manager,
+                config.tap_hold_actions,
+                hardware_id,
+                signature=signature,
+                track_combo_refs=track_combo_refs,
+            )
+    elif config.overload_actions:
+        data["overload_actions"] = _serialize_superkey_overload_actions(
+            manager,
+            config.overload_actions,
+            hardware_id,
+            signature=signature,
+            track_combo_refs=track_combo_refs,
+        )
     if config.mode == SuperkeyMode.OVERLOAD:
         if config.overload_down_actions:
-            data["overload_down_actions"] = [
-                serialize_superkey_overload_action(
-                    manager,
-                    action,
-                    hardware_id,
-                    track_combo_refs=track_combo_refs,
-                )
-                for action in config.overload_down_actions
-            ]
+            data["overload_down_actions"] = _serialize_superkey_overload_actions(
+                manager,
+                config.overload_down_actions,
+                hardware_id,
+                signature=signature,
+                track_combo_refs=track_combo_refs,
+            )
         if config.overload_up_actions:
-            data["overload_up_actions"] = [
-                serialize_superkey_overload_action(
-                    manager,
-                    action,
-                    hardware_id,
-                    track_combo_refs=track_combo_refs,
-                )
-                for action in config.overload_up_actions
-            ]
+            data["overload_up_actions"] = _serialize_superkey_overload_actions(
+                manager,
+                config.overload_up_actions,
+                hardware_id,
+                signature=signature,
+                track_combo_refs=track_combo_refs,
+            )
 
     return data
+
+
+def _serialize_superkey_pattern_actions(
+    manager: "SessionManager",
+    actions: list[SuperkeyAction],
+    hardware_id: str,
+    *,
+    signature: bool,
+    track_combo_refs: bool,
+) -> list[JsonObject]:
+    if signature:
+        return [
+            serialize_superkey_action_signature(manager, action, hardware_id)
+            for action in actions
+        ]
+    return [
+        serialize_superkey_action(
+            manager,
+            action,
+            hardware_id,
+            track_combo_refs=track_combo_refs,
+        )
+        for action in actions
+    ]
+
+
+def _serialize_superkey_overload_actions(
+    manager: "SessionManager",
+    actions: list[MappingAction],
+    hardware_id: str,
+    *,
+    signature: bool,
+    track_combo_refs: bool,
+) -> list[JsonObject]:
+    if signature:
+        return [action_signature_payload(manager, action, hardware_id) for action in actions]
+    return [
+        serialize_superkey_overload_action(
+            manager,
+            action,
+            hardware_id,
+            track_combo_refs=track_combo_refs,
+        )
+        for action in actions
+    ]
 
 
 def serialize_analog_control(
     manager: "SessionManager",
     config: AnalogControlConfig,
     hardware_id: str,
+) -> JsonObject:
+    return _serialize_analog_control_payload(
+        manager,
+        config,
+        hardware_id,
+        signature=False,
+    )
+
+
+def _serialize_analog_control_payload(
+    manager: "SessionManager",
+    config: AnalogControlConfig,
+    hardware_id: str,
+    *,
+    signature: bool,
 ) -> JsonObject:
     config = normalize_analog_control_features(config)
     return {
@@ -900,7 +967,12 @@ def serialize_analog_control(
             "response_curve": float(config.gamepad_output.response_curve),
         },
         "thresholds": [
-            serialize_analog_threshold(manager, threshold, hardware_id)
+            _serialize_analog_threshold_payload(
+                manager,
+                threshold,
+                hardware_id,
+                signature=signature,
+            )
             for threshold in config.thresholds
         ],
     }
@@ -911,6 +983,21 @@ def serialize_analog_threshold(
     threshold: AnalogActionThreshold,
     hardware_id: str,
 ) -> JsonObject:
+    return _serialize_analog_threshold_payload(
+        manager,
+        threshold,
+        hardware_id,
+        signature=False,
+    )
+
+
+def _serialize_analog_threshold_payload(
+    manager: "SessionManager",
+    threshold: AnalogActionThreshold,
+    hardware_id: str,
+    *,
+    signature: bool,
+) -> JsonObject:
     return {
         "axis": threshold.axis,
         "trigger_min": float(threshold.trigger_min),
@@ -918,7 +1005,9 @@ def serialize_analog_threshold(
         "release_min": float(threshold.release_min),
         "release_max": float(threshold.release_max),
         "actions": [
-            serialize_overload_action(manager, action, hardware_id)
+            action_signature_payload(manager, action, hardware_id)
+            if signature
+            else serialize_overload_action(manager, action, hardware_id)
             for action in threshold.actions
         ],
     }
@@ -929,56 +1018,12 @@ def serialize_analog_control_signature(
     config: AnalogControlConfig,
     hardware_id: str,
 ) -> JsonObject:
-    config = normalize_analog_control_features(config)
-    return {
-        "name": config.name,
-        "input_type": config.input_type,
-        "mouse_motion": {
-            "enabled": bool(config.mouse_motion.enabled),
-            "mode": config.mouse_motion.mode,
-            "speed": float(config.mouse_motion.speed),
-            "speed_x": float(
-                config.mouse_motion.speed_x
-                if config.mouse_motion.speed_x is not None
-                else config.mouse_motion.speed
-            ),
-            "speed_y": float(
-                config.mouse_motion.speed_y
-                if config.mouse_motion.speed_y is not None
-                else config.mouse_motion.speed
-            ),
-            "area_radius_x": float(config.mouse_motion.area_radius_x),
-            "area_radius_y": float(config.mouse_motion.area_radius_y),
-            "area_start_enabled": bool(config.mouse_motion.area_start_enabled),
-            "area_start_x": int(config.mouse_motion.area_start_x),
-            "area_start_y": int(config.mouse_motion.area_start_y),
-            "deadzone": float(config.mouse_motion.deadzone),
-            "sensitivity": float(config.mouse_motion.sensitivity),
-            "response_curve": float(config.mouse_motion.response_curve),
-            "direction": config.mouse_motion.direction,
-            "invert_x": bool(config.mouse_motion.invert_x),
-            "invert_y": bool(config.mouse_motion.invert_y),
-            "tick_ms": int(config.mouse_motion.tick_ms),
-        },
-        "gamepad_output": {
-            "enabled": bool(config.gamepad_output.enabled),
-            "output_id": config.gamepad_output.output_id,
-            "deadzone": float(config.gamepad_output.deadzone),
-            "target": config.gamepad_output.target,
-            "target_analog_id": config.gamepad_output.target_analog_id,
-            "output_rest": config.gamepad_output.output_rest,
-            "output_direction": config.gamepad_output.output_direction,
-            "output_invert": bool(config.gamepad_output.output_invert),
-            "output_invert_x": bool(config.gamepad_output.output_invert_x),
-            "output_invert_y": bool(config.gamepad_output.output_invert_y),
-            "sensitivity": float(config.gamepad_output.sensitivity),
-            "response_curve": float(config.gamepad_output.response_curve),
-        },
-        "thresholds": [
-            serialize_analog_threshold_signature(manager, threshold, hardware_id)
-            for threshold in config.thresholds
-        ],
-    }
+    return _serialize_analog_control_payload(
+        manager,
+        config,
+        hardware_id,
+        signature=True,
+    )
 
 
 def serialize_analog_threshold_signature(
@@ -986,17 +1031,12 @@ def serialize_analog_threshold_signature(
     threshold: AnalogActionThreshold,
     hardware_id: str,
 ) -> JsonObject:
-    return {
-        "axis": threshold.axis,
-        "trigger_min": float(threshold.trigger_min),
-        "trigger_max": float(threshold.trigger_max),
-        "release_min": float(threshold.release_min),
-        "release_max": float(threshold.release_max),
-        "actions": [
-            action_signature_payload(manager, action, hardware_id)
-            for action in threshold.actions
-        ],
-    }
+    return _serialize_analog_threshold_payload(
+        manager,
+        threshold,
+        hardware_id,
+        signature=True,
+    )
 
 
 def serialize_superkey_signature(
@@ -1004,53 +1044,12 @@ def serialize_superkey_signature(
     config: SuperkeyConfig,
     hardware_id: str,
 ) -> JsonObject:
-    data: JsonObject = {
-        "name": config.name,
-        "mode": config.mode.value,
-        "tap_timeout_ms": int(config.tap_timeout_ms),
-        "double_tap_window_ms": int(config.double_tap_window_ms),
-        "hold_threshold_ms": int(config.hold_threshold_ms),
-    }
-
-    if config.mode == SuperkeyMode.PATTERN:
-        if config.tap_actions:
-            data["tap_actions"] = [
-                serialize_superkey_action_signature(manager, action, hardware_id)
-                for action in config.tap_actions
-            ]
-        if config.double_tap_actions:
-            data["double_tap_actions"] = [
-                serialize_superkey_action_signature(manager, action, hardware_id)
-                for action in config.double_tap_actions
-            ]
-        if config.hold_actions:
-            data["hold_actions"] = [
-                serialize_superkey_action_signature(manager, action, hardware_id)
-                for action in config.hold_actions
-            ]
-        if config.tap_hold_actions:
-            data["tap_hold_actions"] = [
-                serialize_superkey_action_signature(manager, action, hardware_id)
-                for action in config.tap_hold_actions
-            ]
-    elif config.overload_actions:
-        data["overload_actions"] = [
-            action_signature_payload(manager, action, hardware_id)
-            for action in config.overload_actions
-        ]
-    if config.mode == SuperkeyMode.OVERLOAD:
-        if config.overload_down_actions:
-            data["overload_down_actions"] = [
-                action_signature_payload(manager, action, hardware_id)
-                for action in config.overload_down_actions
-            ]
-        if config.overload_up_actions:
-            data["overload_up_actions"] = [
-                action_signature_payload(manager, action, hardware_id)
-                for action in config.overload_up_actions
-            ]
-
-    return data
+    return _serialize_superkey_payload(
+        manager,
+        config,
+        hardware_id,
+        signature=True,
+    )
 
 
 def serialize_superkey_action(


### PR DESCRIPTION
## Summary

- Extracted `_normalize_common_action_fields()` from `MappingAction.__post_init__()` and `SuperkeyAction.__post_init__()` to avoid duplicated normalization logic
- Replaced the hardcoded `SUPERKEY_ACTION_SHARED_FIELDS` tuple with a dynamic `fields()`-driven derivation, reducing maintenance burden when fields change
- Unified `serialize_superkey` / `serialize_superkey_signature` and `serialize_analog_control` / `serialize_analog_control_signature` (and their threshold equivalents) under shared `_serialize_*_payload` implementations with a `signature` flag, removing large blocks of near-identical code

## Testing

- `./scripts/check.sh` passes (ruff, basedpyright, pytest)
- Verified existing serialization signatures produce identical JSON for both call paths
- Manual smoke test on a running session to confirm profile apply/unapply flow works