### PR TITLE
Extract compat module for analog control dialog

### DIFF
--- a/keymasq/gui/widgets/analog_control/compat.py
+++ b/keymasq/gui/widgets/analog_control/compat.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import sys
+from typing import Any
+
+from keymasq import __version__ as _package_version
+from keymasq.common.slurp import get_slurp_capture as _get_slurp_capture
+from keymasq.gui.widgets.docs_links import actions_docs_url as _actions_docs_url
+from keymasq.gui.widgets.gamepad_output_choices import (
+    virtual_gamepad_count as _virtual_gamepad_count,
+)
+from keymasq.session.compositor import detect_compositor_sync as _detect_compositor_sync
+from keymasq.session.hardware import HardwareManager as _HardwareManager
+
+_SHIM_MODULE = "keymasq.gui.widgets.analog_control_dialog"
+
+
+def _shim_attr[T](name: str, default: T) -> T:
+    module = sys.modules.get(_SHIM_MODULE)
+    if module is None:
+        return default
+    return getattr(module, name, default)
+
+
+def package_version() -> str:
+    return str(_shim_attr("__version__", _package_version))
+
+
+def get_slurp_capture() -> Any:
+    func = _shim_attr("get_slurp_capture", _get_slurp_capture)
+    return func()
+
+
+def detect_compositor_sync() -> str | None:
+    func = _shim_attr("detect_compositor_sync", _detect_compositor_sync)
+    return func()
+
+
+def virtual_gamepad_count() -> int:
+    func = _shim_attr("virtual_gamepad_count", _virtual_gamepad_count)
+    return int(func())
+
+
+def hardware_manager() -> Any:
+    factory = _shim_attr("HardwareManager", _HardwareManager)
+    return factory()
+
+
+def analog_controls_docs_url() -> str:
+    return _actions_docs_url("analog-controls", version=package_version())

--- a/keymasq/gui/widgets/analog_control/dialog.py
+++ b/keymasq/gui/widgets/analog_control/dialog.py
@@ -21,8 +21,16 @@ from keymasq.common.models import (
     AnalogGamepadOutputConfig,
     AnalogMouseMotionConfig,
 )
-from keymasq.common.slurp import get_slurp_capture
 from keymasq.common.virtual_devices import is_virtual_gamepad_output_id
+from keymasq.gui.widgets.analog_control.compat import (
+    analog_controls_docs_url as _analog_controls_docs_url,
+)
+from keymasq.gui.widgets.analog_control.compat import (
+    detect_compositor_sync,
+    get_slurp_capture,
+    hardware_manager,
+    virtual_gamepad_count,
+)
 from keymasq.gui.widgets.analog_control.groups import (
     build_digital_group,
     build_gamepad_output_group,
@@ -32,7 +40,6 @@ from keymasq.gui.widgets.analog_control.groups import (
 from keymasq.gui.widgets.analog_control.options import (
     _INPUT_TYPE_OPTIONS,
     _analog_control_search_text,
-    _analog_controls_docs_url,
     _gamepad_output_target_label_for_input_type,
     _gamepad_output_target_options_for_input_type,
     _group_analog_control_names,
@@ -49,7 +56,6 @@ from keymasq.gui.widgets.gamepad_output_choices import (
     load_gamepad_output_choices,
     selected_gamepad_output_id,
     update_gamepad_output_warning_label,
-    virtual_gamepad_count,
 )
 from keymasq.gui.widgets.position_capture import (
     PositionCallback,
@@ -75,8 +81,6 @@ from keymasq.gui.widgets.superkey_dialog import ActionListDialog
 from keymasq.session.analog_controls import (
     AnalogControlManager,
 )
-from keymasq.session.compositor import detect_compositor_sync
-from keymasq.session.hardware import HardwareManager
 from keymasq.session.profiles import ProfileManager
 
 log = logging.getLogger("keymasq.gui.widgets.analog_control_dialog")
@@ -1000,7 +1004,7 @@ class AnalogControlDialog(Adw.Dialog):
         choice_set = load_gamepad_output_choices(
             helper_selected_id,
             count_loader=virtual_gamepad_count,
-            hardware_manager_factory=HardwareManager,
+            hardware_manager_factory=hardware_manager,
         )
         self._hardware_output_configs = {
             str(getattr(config, "hardware_id", "") or ""): config

--- a/keymasq/gui/widgets/analog_control/options.py
+++ b/keymasq/gui/widgets/analog_control/options.py
@@ -2,7 +2,6 @@
 
 from dataclasses import dataclass
 
-from keymasq import __version__
 from keymasq.common.models import (
     AnalogActionThreshold,
     AnalogControlConfig,
@@ -67,19 +66,6 @@ _GAMEPAD_OUTPUT_TARGET_OPTIONS = (
 _MOUSE_DEADZONE_DEFAULT = 0.15
 _CONTROL_GROUPS = (("axis", "1D Axes / Triggers"), ("stick", "Sticks"))
 _AXIS_ITEMS = ("x", "y")
-
-
-def _docs_version() -> str:
-    version = __version__.strip()
-    if not version:
-        return "master"
-    if "dev" in version:
-        return "master"
-    return f"v{version.removeprefix('v')}"
-
-
-def _analog_controls_docs_url() -> str:
-    return f"https://keymasq.tools/docs/{_docs_version()}/ANALOG_CONTROLS/"
 
 
 def _compute_hysteresis(threshold: AnalogActionThreshold) -> float:

--- a/keymasq/gui/widgets/analog_control_dialog.py
+++ b/keymasq/gui/widgets/analog_control_dialog.py
@@ -1,7 +1,10 @@
 from keymasq import __version__
 from keymasq.common.slurp import get_slurp_capture
 from keymasq.gui.widgets.analog_control import dialog as _dialog
-from keymasq.gui.widgets.analog_control.dialog import AnalogControlDialog as _AnalogControlDialog
+from keymasq.gui.widgets.analog_control.compat import (
+    analog_controls_docs_url as _analog_controls_docs_url,
+)
+from keymasq.gui.widgets.analog_control.dialog import AnalogControlDialog
 from keymasq.gui.widgets.analog_control.options import (
     _analog_control_search_text,
     _clamp_threshold_value,
@@ -32,36 +35,13 @@ GLib = _dialog.GLib
 GObject = _dialog.GObject
 Gtk = _dialog.Gtk
 
-
-def _docs_version() -> str:
-    version = __version__.strip()
-    if not version:
-        return "master"
-    if "dev" in version:
-        return "master"
-    return f"v{version.removeprefix('v')}"
-
-
-def _analog_controls_docs_url() -> str:
-    return f"https://keymasq.tools/docs/{_docs_version()}/ANALOG_CONTROLS/"
-
-
-def _sync_compat_overrides() -> None:
-    _dialog.get_slurp_capture = get_slurp_capture
-    _dialog.detect_compositor_sync = detect_compositor_sync
-    _dialog.virtual_gamepad_count = virtual_gamepad_count
-    _dialog.HardwareManager = HardwareManager
-    _dialog._analog_controls_docs_url = _analog_controls_docs_url
-
-
-class AnalogControlDialog(_AnalogControlDialog):
-    def __init__(self, *args, **kwargs):
-        _sync_compat_overrides()
-        super().__init__(*args, **kwargs)
-
-
 __all__ = [
     "AnalogControlDialog",
+    "Adw",
+    "Gdk",
+    "GLib",
+    "GObject",
+    "Gtk",
     "_SelectOption",
     "_analog_control_search_text",
     "_analog_controls_docs_url",
@@ -81,4 +61,9 @@ __all__ = [
     "_option_labels",
     "_options_for_input_type",
     "_to_percent",
+    "get_slurp_capture",
+    "detect_compositor_sync",
+    "HardwareManager",
+    "virtual_gamepad_count",
+    "__version__",
 ]


### PR DESCRIPTION
## Summary

- Extracts runtime compat shims from `analog_control_dialog.py` into a new dedicated `compat.py` module.
- Removes the monkey-patch pattern (`_sync_compat_overrides`) and the subclass override.
- Moves URL version logic out of `options.py` into `compat`.
- Re-exports all forwarded symbols in `analog_control_dialog.__all__` for backward compatibility.

## Testing

- Verified imports resolve correctly through both the legacy module path and the new `compat` module.
- Lint, type-check, and pytest suite pass via `./scripts/check.sh`.
- Not run: manual GUI interaction.