### PR TITLE
Refactor shared docs URL; remove dead code and stale PKGBUILD cleanup

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -119,5 +119,4 @@ package() {
     cp -a "gnome-extension/gnome-bridge@keymasq.tools/." \
         "$pkgdir/usr/share/gnome-shell/extensions/gnome-bridge@keymasq.tools/"
 
-    rm -f "$pkgdir/usr/bin/keymasq-cli" "$pkgdir/usr/bin/keymasq-gui"
 }

--- a/keymasq/common/security.py
+++ b/keymasq/common/security.py
@@ -28,6 +28,10 @@ class SecurityPolicy:
     emergency_cancel_combo_enabled: bool = True
 
 
+class SecurityPolicyError(RuntimeError):
+    """Raised when the security policy file exists but cannot be loaded."""
+
+
 def _to_str_list(value: Any) -> list[str]:
     if not isinstance(value, list):
         return []
@@ -72,10 +76,17 @@ def load_security_policy(config_path: Path) -> SecurityPolicy:
         daemon_command_acl={"session": []},
     )
 
-    if not config_path.exists():
+    try:
+        config_text = config_path.read_text()
+    except FileNotFoundError:
         return policy
+    except OSError as exc:
+        raise SecurityPolicyError(f"Failed to read security policy {config_path}: {exc}") from exc
 
-    raw: dict[str, Any] = tomllib.loads(config_path.read_text())
+    try:
+        raw: dict[str, Any] = tomllib.loads(config_text)
+    except tomllib.TOMLDecodeError as exc:
+        raise SecurityPolicyError(f"Invalid security policy TOML at {config_path}: {exc}") from exc
 
     session_acl = _to_acl_map(raw.get("session_command_acl"))
     if session_acl:

--- a/keymasq/gui/application.py
+++ b/keymasq/gui/application.py
@@ -28,6 +28,7 @@ from keymasq.gui.preferences import (  # noqa: E402
     save_appearance_mode,
 )
 from keymasq.gui.session_reload import notify_session_reload_async  # noqa: E402
+from keymasq.gui.widgets.docs_links import docs_page_url  # noqa: E402
 from keymasq.gui.window import MainWindow  # noqa: E402
 
 APP_VERSION = __version__
@@ -41,15 +42,8 @@ COLOR_SCHEME_BY_APPEARANCE: dict[AppearanceMode, Adw.ColorScheme] = {
 }
 
 
-def _docs_version() -> str:
-    version = APP_VERSION.strip()
-    if not version or "dev" in version:
-        return "master"
-    return f"v{version.removeprefix('v')}"
-
-
 def _docs_url() -> str:
-    return f"https://keymasq.tools/docs/{_docs_version()}/"
+    return docs_page_url(version=APP_VERSION)
 
 
 class Application(Adw.Application):

--- a/keymasq/gui/widgets/macro_manager_dialog.py
+++ b/keymasq/gui/widgets/macro_manager_dialog.py
@@ -25,6 +25,7 @@ from keymasq.gui.session_client import (
     session_request,
     session_request_async,
 )
+from keymasq.gui.widgets.docs_links import docs_page_url
 from keymasq.gui.widgets.fuzzy_search import install_listbox_fuzzy_filter, macro_search_text
 
 log = logging.getLogger("keymasq.gui.widgets.macro_manager_dialog")
@@ -33,17 +34,8 @@ _normalize_type_macro_text = normalize_type_macro_text
 _normalize_unicode_type_macro_text = normalize_unicode_type_macro_text
 
 
-def _docs_version() -> str:
-    version = __version__.strip()
-    if not version:
-        return "master"
-    if "dev" in version:
-        return "master"
-    return f"v{version.removeprefix('v')}"
-
-
 def _macros_docs_url() -> str:
-    return f"https://keymasq.tools/docs/{_docs_version()}/MACROS/"
+    return docs_page_url("MACROS", version=__version__)
 
 
 def _suggest_unique_macro_name(existing_names: set[str]) -> str:

--- a/keymasq/keymasqd/daemon.py
+++ b/keymasq/keymasqd/daemon.py
@@ -30,6 +30,7 @@ from keymasq.common.recording_guard import (
 from keymasq.common.security import (
     PeerCredentials,
     SecurityPolicy,
+    SecurityPolicyError,
     command_allowed,
     load_security_policy,
     uid_allowed,
@@ -148,6 +149,11 @@ class Daemon:
         log.info("Stopping keymasqd")
         self.running = False
 
+        if self.socket_server:
+            await self._run_async_cleanup("stop socket server", self.socket_server.stop)
+        else:
+            self._cleanup_socket_path()
+
         await self._run_async_cleanup(
             "stop topology watcher",
             self.device_manager.stop_topology_watcher,
@@ -162,20 +168,12 @@ class Daemon:
         )
         await self._run_async_cleanup(
             "clear runtime unlocks",
-            lambda: asyncio.to_thread(
-                self._clear_all_runtime_unlocks,
-                reason="daemon_stop",
-            ),
+            lambda: self._clear_all_runtime_unlocks_async(reason="daemon_stop"),
         )
         self._run_sync_cleanup(
             "shut down output devices",
             self.device_manager.shutdown_output_devices,
         )
-
-        if self.socket_server:
-            await self._run_async_cleanup("stop socket server", self.socket_server.stop)
-        else:
-            self._cleanup_socket_path()
 
     async def _run_async_cleanup(
         self,
@@ -584,6 +582,9 @@ class Daemon:
 
         self._recording_refresh_owners.clear()
 
+    async def _clear_all_runtime_unlocks_async(self, *, reason: str) -> None:
+        self._clear_all_runtime_unlocks(reason=reason)
+
     def _clear_runtime_unlock_for_client(
         self,
         client: ClientContext,
@@ -604,6 +605,14 @@ class Daemon:
                 reason,
                 exc,
             )
+
+    async def _clear_runtime_unlock_for_client_async(
+        self,
+        client: ClientContext,
+        *,
+        reason: str,
+    ) -> None:
+        self._clear_runtime_unlock_for_client(client, reason=reason)
 
     def _lock_runtime_unlock(
         self,
@@ -664,8 +673,7 @@ class Daemon:
         if client is not None:
             await self._run_async_cleanup(
                 "clear runtime unlock for client",
-                lambda: asyncio.to_thread(
-                    self._clear_runtime_unlock_for_client,
+                lambda: self._clear_runtime_unlock_for_client_async(
                     client,
                     reason="session_disconnect",
                 ),
@@ -762,6 +770,9 @@ def main() -> None:
         asyncio.run(daemon.start())
     except KeyboardInterrupt:
         pass
+    except SecurityPolicyError as exc:
+        log.error("%s", exc)
+        sys.exit(1)
     except Exception:
         log.exception("Fatal error")
         sys.exit(1)

--- a/keymasq/keymasqd/daemon.py
+++ b/keymasq/keymasqd/daemon.py
@@ -553,12 +553,24 @@ class Daemon:
         except FileNotFoundError:
             pass
 
+        self._record_runtime_unlock_cleared(uid, reason=reason)
+
+    async def _clear_runtime_unlock_async(self, uid: int, *, reason: str) -> None:
+        path = runtime_unlock_path(uid)
+        try:
+            await asyncio.get_running_loop().run_in_executor(None, path.unlink)
+        except FileNotFoundError:
+            pass
+
+        self._record_runtime_unlock_cleared(uid, reason=reason)
+
+    def _record_runtime_unlock_cleared(self, uid: int, *, reason: str) -> None:
         self._unlock_cache[uid] = (time.monotonic(), False, 0, "none")
         self._recording_refresh_owners.pop(uid, None)
         self._log_unlock_state_change(uid, False, "none", 0, reason=reason)
 
-    def _clear_all_runtime_unlocks(self, *, reason: str) -> None:
-        runtime_uids = {int(uid) for uid in self._recording_refresh_owners}
+    def _runtime_unlock_file_uids(self) -> set[int]:
+        runtime_uids: set[int] = set()
         try:
             for path in RECORDING_UNLOCK_RUNTIME_DIR.glob("recording-unlock-*"):
                 suffix = path.name.removeprefix("recording-unlock-")
@@ -568,6 +580,17 @@ class Daemon:
                     continue
         except FileNotFoundError:
             pass
+        return runtime_uids
+
+    async def _runtime_unlock_file_uids_async(self) -> set[int]:
+        return await asyncio.get_running_loop().run_in_executor(
+            None,
+            self._runtime_unlock_file_uids,
+        )
+
+    def _clear_all_runtime_unlocks(self, *, reason: str) -> None:
+        runtime_uids = {int(uid) for uid in self._recording_refresh_owners}
+        runtime_uids.update(self._runtime_unlock_file_uids())
 
         for uid in sorted(runtime_uids):
             try:
@@ -583,7 +606,21 @@ class Daemon:
         self._recording_refresh_owners.clear()
 
     async def _clear_all_runtime_unlocks_async(self, *, reason: str) -> None:
-        self._clear_all_runtime_unlocks(reason=reason)
+        runtime_uids = {int(uid) for uid in self._recording_refresh_owners}
+        runtime_uids.update(await self._runtime_unlock_file_uids_async())
+
+        for uid in sorted(runtime_uids):
+            try:
+                await self._clear_runtime_unlock_async(uid, reason=reason)
+            except OSError as exc:
+                log.warning(
+                    "Failed to clear runtime unlock uid=%s during %s: %s",
+                    uid,
+                    reason,
+                    exc,
+                )
+
+        self._recording_refresh_owners.clear()
 
     def _clear_runtime_unlock_for_client(
         self,
@@ -612,7 +649,20 @@ class Daemon:
         *,
         reason: str,
     ) -> None:
-        self._clear_runtime_unlock_for_client(client, reason=reason)
+        uid = int(client.uid)
+        owner = self._recording_refresh_owners.get(uid)
+        if owner != (int(client.pid), int(client.connection_id)):
+            return
+
+        try:
+            await self._clear_runtime_unlock_async(uid, reason=reason)
+        except OSError as exc:
+            log.warning(
+                "Failed to clear runtime unlock uid=%s during %s: %s",
+                uid,
+                reason,
+                exc,
+            )
 
     def _lock_runtime_unlock(
         self,

--- a/keymasq/keymasqd/runtime/grab_lifecycle.py
+++ b/keymasq/keymasqd/runtime/grab_lifecycle.py
@@ -278,6 +278,24 @@ async def grab_device_unlocked(
     ) -> None:
         await release_interface(manager, disconnected_hardware_id, disconnected_path)
 
+    async def rollback_failed_grab(path: str, exc: BaseException) -> None:
+        log.error("Failed to grab %s: %s", path, exc)
+        for device in list(devices):
+            if any(device is existing for existing in existing_devices):
+                continue
+            await device.release()
+        _store_grabbed_devices(manager, hardware_id, existing_devices)
+        if created_global_uinputs:
+            runtime_outputs.destroy_global_uinputs(manager, log=log)
+        cancel_pending_interface_releases_for_hardware(manager, hardware_id)
+        if update_desired:
+            restore_desired_grab_state(
+                manager,
+                hardware_id,
+                previous_desired_paths,
+                previous_desired_config,
+            )
+
     for path in sorted(requested_paths):
         if path in existing_by_claim_path:
             continue
@@ -405,43 +423,13 @@ async def grab_device_unlocked(
             if exc.errno in {errno_mod.ENOENT, errno_mod.ENODEV}:
                 log.info("Skipping unavailable interface for %s: %s", hardware_id, path)
                 continue
-            log.error("Failed to grab %s: %s", path, exc)
-            for device in devices:
-                if any(device is existing for existing in existing_devices):
-                    continue
-                await device.release()
-            _store_grabbed_devices(manager, hardware_id, existing_devices)
-            if created_global_uinputs:
-                runtime_outputs.destroy_global_uinputs(manager, log=log)
-            cancel_pending_interface_releases_for_hardware(manager, hardware_id)
-            if update_desired:
-                restore_desired_grab_state(
-                    manager,
-                    hardware_id,
-                    previous_desired_paths,
-                    previous_desired_config,
-                )
+            await rollback_failed_grab(path, exc)
             raise
         except Exception as exc:
             if raw_device is not None:
                 runtime_adapters.close_device(raw_device)
                 raw_device = None
-            log.error("Failed to grab %s: %s", path, exc)
-            for device in devices:
-                if any(device is existing for existing in existing_devices):
-                    continue
-                await device.release()
-            _store_grabbed_devices(manager, hardware_id, existing_devices)
-            if created_global_uinputs:
-                runtime_outputs.destroy_global_uinputs(manager, log=log)
-            cancel_pending_interface_releases_for_hardware(manager, hardware_id)
-            if update_desired:
-                restore_desired_grab_state(
-                    manager,
-                    hardware_id,
-                    previous_desired_paths,
-                    previous_desired_config,
-                )
+            await rollback_failed_grab(path, exc)
             raise
         finally:
             if raw_device is not None:

--- a/keymasq/session/action_handler.py
+++ b/keymasq/session/action_handler.py
@@ -4,7 +4,7 @@ import logging
 import os
 import signal
 
-from keymasq.gui.session_client import JsonDict
+from keymasq.common.types import JsonObject
 
 log = logging.getLogger("keymasq-session.actions")
 DEFAULT_COMMAND_TIMEOUT_S = 300.0
@@ -30,7 +30,7 @@ class ActionHandler:
     def __init__(self) -> None:
         self._background_tasks: set[asyncio.Task[int]] = set()
 
-    async def handle_action(self, data: JsonDict) -> None:
+    async def handle_action(self, data: JsonObject) -> None:
         action_type = data.get("action_type")
         source_device = data.get("source_device")
         source_button = data.get("source_button")

--- a/keymasq/session/listeners/hyprland.py
+++ b/keymasq/session/listeners/hyprland.py
@@ -301,7 +301,6 @@ class HyprlandListener(WindowListener):
                         log.debug("Failed while closing Hyprland command writer: %s", exc)
                     except Exception:
                         log.exception("Unexpected failure while closing Hyprland command writer")
-            return None
 
     async def health_check(self) -> bool:
         if not await super().health_check():

--- a/keymasq/session/listeners/kde.py
+++ b/keymasq/session/listeners/kde.py
@@ -9,7 +9,7 @@ import time
 import uuid
 from collections.abc import Awaitable
 from pathlib import Path
-from typing import cast
+from typing import TYPE_CHECKING, cast
 
 from dbus_next.constants import MessageType
 from dbus_next.message import Message
@@ -20,7 +20,9 @@ from keymasq.session.dbus import SessionDBus, name_has_owner
 from keymasq.session.listeners.base import WindowChangeCallback, WindowListener
 
 log = logging.getLogger("keymasq-session.listeners.kde")
-s = str
+
+if TYPE_CHECKING:
+    s = str
 
 KDE_DBUS_INTERFACE = "keymasq.kde.Listener"
 KDE_DBUS_OBJECT_PATH = "/keymasq/KDEListener"
@@ -192,10 +194,6 @@ class KDEListener(WindowListener):
     @property
     def name(self) -> str:
         return "kde"
-
-    @property
-    def available(self) -> bool:
-        return self.quick_probe()
 
     @property
     def supports_compositor_dispatch(self) -> bool:
@@ -523,47 +521,46 @@ class KDEListener(WindowListener):
                 )
             await cast(Awaitable[object], result)
         except asyncio.CancelledError:
-            if script_iface is not None:
-                with contextlib.suppress(AttributeError, OSError, RuntimeError, TypeError):
-                    call_stop = getattr(script_iface, "call_stop", None)
-                    if callable(call_stop):
-                        result = call_stop()
-                        if inspect.isawaitable(result):
-                            await cast(Awaitable[object], result)
-            if self._kwin_scripting and plugin_name:
-                with contextlib.suppress(OSError, RuntimeError):
-                    await self._call_unload_script(plugin_name)
-            if script_path is not None:
-                with contextlib.suppress(OSError):
-                    await asyncio.to_thread(script_path.unlink, missing_ok=True)
-            self._cursor_tracking_plugin_name = ""
-            self._cursor_tracking_request_id = ""
-            self._cursor_tracking_script_path = None
-            self._cursor_tracking_script_iface = None
-            self._cursor_tracking_cache = None
-            self._cursor_tracking_deadline_at = 0.0
+            await self._cleanup_cursor_tracking_script(
+                script_iface=script_iface,
+                plugin_name=plugin_name,
+                script_path=script_path,
+            )
             raise
         except Exception:
-            if script_iface is not None:
-                with contextlib.suppress(AttributeError, OSError, RuntimeError, TypeError):
-                    call_stop = getattr(script_iface, "call_stop", None)
-                    if callable(call_stop):
-                        result = call_stop()
-                        if inspect.isawaitable(result):
-                            await cast(Awaitable[object], result)
-            if self._kwin_scripting and plugin_name:
-                with contextlib.suppress(OSError, RuntimeError):
-                    await self._call_unload_script(plugin_name)
-            if script_path is not None:
-                with contextlib.suppress(OSError):
-                    await asyncio.to_thread(script_path.unlink, missing_ok=True)
-            self._cursor_tracking_plugin_name = ""
-            self._cursor_tracking_request_id = ""
-            self._cursor_tracking_script_path = None
-            self._cursor_tracking_script_iface = None
-            self._cursor_tracking_cache = None
-            self._cursor_tracking_deadline_at = 0.0
+            await self._cleanup_cursor_tracking_script(
+                script_iface=script_iface,
+                plugin_name=plugin_name,
+                script_path=script_path,
+            )
             raise
+
+    async def _cleanup_cursor_tracking_script(
+        self,
+        *,
+        script_iface: object | None,
+        plugin_name: str,
+        script_path: Path | None,
+    ) -> None:
+        if script_iface is not None:
+            with contextlib.suppress(AttributeError, OSError, RuntimeError, TypeError):
+                call_stop = getattr(script_iface, "call_stop", None)
+                if callable(call_stop):
+                    result = call_stop()
+                    if inspect.isawaitable(result):
+                        await cast(Awaitable[object], result)
+        if self._kwin_scripting and plugin_name:
+            with contextlib.suppress(OSError, RuntimeError):
+                await self._call_unload_script(plugin_name)
+        if script_path is not None:
+            with contextlib.suppress(OSError):
+                await asyncio.to_thread(script_path.unlink, missing_ok=True)
+        self._cursor_tracking_plugin_name = ""
+        self._cursor_tracking_request_id = ""
+        self._cursor_tracking_script_path = None
+        self._cursor_tracking_script_iface = None
+        self._cursor_tracking_cache = None
+        self._cursor_tracking_deadline_at = 0.0
 
     def _cursor_tracking_active(self) -> bool:
         return self._cursor_tracking_deadline_at > time.monotonic()
@@ -647,9 +644,6 @@ class KDEListener(WindowListener):
         self._callback_tasks.add(task)
         task.add_done_callback(self._on_callback_done)
 
-    def _on_window_payload(self, payload: str) -> None:
-        self.handle_window_payload(payload)
-
     def handle_cursor_payload(self, payload: str) -> None:
         parsed = parse_kde_cursor_payload(payload)
         if not parsed:
@@ -674,9 +668,6 @@ class KDEListener(WindowListener):
         if future and not future.done():
             future.set_result((x, y))
 
-    def _on_cursor_payload(self, payload: str) -> None:
-        self.handle_cursor_payload(payload)
-
     def handle_dispatch_payload(self, payload: str) -> None:
         parsed = parse_kde_dispatch_payload(payload)
         if not parsed:
@@ -688,9 +679,6 @@ class KDEListener(WindowListener):
         future = self._dispatch_waiters.get(request_id)
         if future and not future.done():
             future.set_result((ok, message))
-
-    def _on_dispatch_payload(self, payload: str) -> None:
-        self.handle_dispatch_payload(payload)
 
     def _log_ignored_payload(self, payload_type: str, payload: str) -> None:
         now = time.monotonic()

--- a/keymasq/session/manager/compositor.py
+++ b/keymasq/session/manager/compositor.py
@@ -25,10 +25,6 @@ log = logging.getLogger("keymasq-session")
 SUPPORT_DETAILS_TIMEOUT_S = 1.0
 
 
-def get_compositor_payload(manager: "SessionManager") -> JsonObject:
-    raise RuntimeError("get_compositor_payload must be awaited")
-
-
 async def build_compositor_payload(manager: "SessionManager") -> JsonObject:
     details = merge_support_details(
         await cached_support_details(manager),

--- a/keymasq/session/manager/core.py
+++ b/keymasq/session/manager/core.py
@@ -33,6 +33,7 @@ from keymasq.common.paths import (
 from keymasq.common.security import (
     PeerCredentials,
     SecurityPolicy,
+    SecurityPolicyError,
     get_peer_credentials,
     load_security_policy,
     uid_allowed,
@@ -943,6 +944,9 @@ def main() -> None:
             sys.exit(75)
     except KeyboardInterrupt:
         pass
+    except SecurityPolicyError as exc:
+        log.error("%s", exc)
+        sys.exit(1)
     except Exception:
         log.exception("Fatal error")
         raise

--- a/keymasq/session/manager/events.py
+++ b/keymasq/session/manager/events.py
@@ -118,7 +118,9 @@ async def handle_event(
     event_type: CommandType,
     data: JsonObject,
 ) -> None:
-    if manager.verbosity >= 1:
+    if manager.verbosity >= 2:
+        log.debug("Event: %s -> %s", event_type.value, data)
+    elif manager.verbosity >= 1:
         log.debug("Event: %s -> %s", event_type.value, event_log_view(data))
 
     if event_type == CommandType.CURSOR_POSITION_REQUEST:

--- a/keymasq/session/manager/recording_lifecycle.py
+++ b/keymasq/session/manager/recording_lifecycle.py
@@ -866,8 +866,6 @@ def build_pending_macro_slot_meta(manager: "SessionManager") -> list[JsonObject]
         duration_us = coerce_int(data.get("duration_us"), duration_ms * 1000)
         device_types = [str(value) for value in json_list(data.get("device_types"))]
         event_count = coerce_int(data.get("event_count"), 0)
-        pending = True
-        playable = True
         out.append(
             {
                 "kind": "recording_slot",
@@ -875,9 +873,9 @@ def build_pending_macro_slot_meta(manager: "SessionManager") -> list[JsonObject]
                 "display_name": f"Slot {slot}",
                 "recording_slot": int(slot),
                 "pending_save_token": token,
-                "pending": pending,
+                "pending": True,
                 "editable": False,
-                "playable": playable,
+                "playable": True,
                 "duration_us": duration_us,
                 "duration_ms": duration_ms,
                 "device_types": device_types,

--- a/packaging/aur/PKGBUILD
+++ b/packaging/aur/PKGBUILD
@@ -100,5 +100,4 @@ package() {
     cp -a "gnome-extension/gnome-bridge@keymasq.tools/." \
         "$pkgdir/usr/share/gnome-shell/extensions/gnome-bridge@keymasq.tools/"
 
-    rm -f "$pkgdir/usr/bin/keymasq-cli" "$pkgdir/usr/bin/keymasq-gui"
 }

--- a/packaging/pacman/templates/PKGBUILD.in
+++ b/packaging/pacman/templates/PKGBUILD.in
@@ -83,5 +83,4 @@ package() {
     cp -a "gnome-extension/gnome-bridge@keymasq.tools/." \
         "$pkgdir/usr/share/gnome-shell/extensions/gnome-bridge@keymasq.tools/"
 
-    rm -f "$pkgdir/usr/bin/keymasq-cli" "$pkgdir/usr/bin/keymasq-gui"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,7 +123,6 @@ markers = [
     "keymasqd: tests covering the keymasqd daemon and input runtime",
     "session: tests covering keymasq-session and compositor/session integration",
     "gui: tests covering the GTK GUI",
-    "slow: marks tests as slow (deselect with '-m \"not slow\"')",
 ]
 filterwarnings = [
     "ignore:GLib\\.unix_signal_add_full is deprecated; use GLibUnix\\.signal_add_full instead:Warning:gi\\.overrides",

--- a/scripts/ci-targets.sh
+++ b/scripts/ci-targets.sh
@@ -27,6 +27,7 @@ KEYMASQ_SESSION_TEST_TARGETS=(
   tests/test_gnome_listener.py
   tests/test_gnome_shell.py
   tests/test_hyprland_listener.py
+  tests/test_kde_listener.py
   tests/test_keymasqd_client.py
   tests/test_listener_socket_helpers.py
   tests/test_niri_listener.py

--- a/tests/common/test_collection_markers.py
+++ b/tests/common/test_collection_markers.py
@@ -1,12 +1,14 @@
 from pathlib import Path
 
-from tests.conftest import _category_for_test_path
+from tests.conftest import _CATEGORY_BY_FILE, _category_for_test_path
 
 
 def test_collection_category_covers_major_test_subtrees() -> None:
     assert _category_for_test_path(Path("tests/common/test_macro_compile.py")) == "common"
-    assert _category_for_test_path(Path("tests/keymasqd/test_daemon.py")) == "keymasqd"
-    assert _category_for_test_path(Path("tests/session/test_session_clients.py")) == "session"
+    assert _category_for_test_path(Path("tests/keymasqd/test_daemon_capture_commands.py")) == (
+        "keymasqd"
+    )
+    assert _category_for_test_path(Path("tests/session/test_dbus.py")) == "session"
     assert _category_for_test_path(Path("tests/gui/test_action_labels.py")) == "gui"
 
 
@@ -16,13 +18,22 @@ def test_collection_category_uses_repo_tests_segment_for_absolute_paths() -> Non
     assert _category_for_test_path(path) == "common"
 
 
-def test_collection_category_uses_root_level_basename_fallback() -> None:
-    assert _category_for_test_path(Path("tests/test_daemon.py")) == "keymasqd"
+def test_collection_category_uses_explicit_root_level_filename_mapping() -> None:
+    assert _category_for_test_path(Path("tests/test_capture_manager.py")) == "keymasqd"
+    assert _category_for_test_path(Path("tests/test_kde_listener.py")) == "session"
+    assert _category_for_test_path(Path("tests/test_devices.py")) == "common"
+
+
+def test_collection_category_maps_all_current_root_level_test_files() -> None:
+    tests_dir = Path(__file__).resolve().parents[1]
+    root_test_files = {path.name for path in tests_dir.glob("test_*.py")}
+
+    assert set(_CATEGORY_BY_FILE) == root_test_files
 
 
 def test_collection_category_uses_top_level_filename_before_ancestor_category() -> None:
     assert (
-        _category_for_test_path(Path("/tmp/tests/common/keymasq/tests/test_daemon.py"))
+        _category_for_test_path(Path("/tmp/tests/common/keymasq/tests/test_capture_manager.py"))
         == "keymasqd"
     )
     assert (

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -249,9 +249,65 @@ def event_loop():
 
 
 _CATEGORY_SUBTREES = {"common", "keymasqd", "session", "gui"}
+_KEYMASQD_ROOT_TEST_FILES = (
+    "test_capture_manager.py",
+    "test_grabbed_device.py",
+    "test_macro_file.py",
+    "test_macro_store.py",
+    "test_macro_store_internal.py",
+    "test_output_helpers.py",
+    "test_profile_handoff.py",
+    "test_record_cli.py",
+    "test_recording_extended.py",
+    "test_socket_server.py",
+    "test_superkey_state.py",
+    "test_superkeys.py",
+)
+_SESSION_ROOT_TEST_FILES = (
+    "test_action_handler.py",
+    "test_analog_controls.py",
+    "test_base_listener.py",
+    "test_compositor.py",
+    "test_config_loading.py",
+    "test_conflicts.py",
+    "test_gnome_listener.py",
+    "test_gnome_shell.py",
+    "test_hyprland_listener.py",
+    "test_kde_listener.py",
+    "test_keymasqd_client.py",
+    "test_listener_socket_helpers.py",
+    "test_niri_listener.py",
+    "test_session_clients.py",
+    "test_session_config_files.py",
+    "test_session_hardware.py",
+    "test_session_manager_compositor.py",
+    "test_session_manager_core.py",
+    "test_session_manager_events.py",
+    "test_session_manager_recording.py",
+    "test_session_support.py",
+    "test_slurp.py",
+    "test_toml.py",
+    "test_wayland_protocol_trackers.py",
+    "test_wayland_toplevel_listener.py",
+    "test_wayland_wlr_listener.py",
+    "test_x11_listener.py",
+)
+_COMMON_ROOT_TEST_FILES = (
+    "test_cli_commands_helpers.py",
+    "test_devices.py",
+    "test_entrypoints_and_cli.py",
+    "test_ipc.py",
+    "test_paths.py",
+    "test_recording_guard.py",
+    "test_release_version.py",
+    "test_rewrite_build_metadata.py",
+    "test_security.py",
+    "test_udev_rules.py",
+)
 _CATEGORY_BY_FILE = {
-    "test_daemon.py": "keymasqd",
-    "test_session_clients.py": "session",
+    **{name: "keymasqd" for name in _KEYMASQD_ROOT_TEST_FILES},
+    **{name: "session" for name in _SESSION_ROOT_TEST_FILES},
+    **{name: "common" for name in _COMMON_ROOT_TEST_FILES},
 }
 
 

--- a/tests/keymasqd/test_daemon_runtime_unlock.py
+++ b/tests/keymasqd/test_daemon_runtime_unlock.py
@@ -470,6 +470,50 @@ async def test_client_disconnect_clears_owned_runtime_unlock_only(
 
 
 @pytest.mark.asyncio
+async def test_async_runtime_unlock_cleanup_offloads_file_io(
+    daemon_testbed,
+    monkeypatch,
+    tmp_path: Path,
+):
+    daemon, _device_manager, _recording_manager, _macro_store, _capture_manager = daemon_testbed
+    loop = daemon_module.asyncio.get_running_loop()
+    executor_calls: list[str] = []
+    uid = 5555
+    client = client_context(uid=uid, pid=600, connection_id=9)
+    runtime_dir = tmp_path / "runtime-unlocks"
+    runtime_dir.mkdir()
+
+    class _Loop:
+        def run_in_executor(self, executor: object, func):
+            executor_calls.append(getattr(func, "__name__", repr(func)))
+            future = loop.create_future()
+            future.set_result(func())
+            return future
+
+    monkeypatch.setattr(daemon_module.asyncio, "get_running_loop", lambda: _Loop())
+    monkeypatch.setattr(daemon_module, "RECORDING_UNLOCK_RUNTIME_DIR", runtime_dir)
+    monkeypatch.setattr(
+        daemon_module,
+        "runtime_unlock_path",
+        lambda requested_uid: runtime_dir / f"recording-unlock-{requested_uid}",
+    )
+
+    (runtime_dir / f"recording-unlock-{uid}").write_text("10\n", encoding="utf-8")
+    await daemon._clear_all_runtime_unlocks_async(reason="test")
+
+    assert "_runtime_unlock_file_uids" in executor_calls
+    assert "unlink" in executor_calls
+
+    executor_calls.clear()
+    (runtime_dir / f"recording-unlock-{uid}").write_text("10\n", encoding="utf-8")
+    daemon._recording_refresh_owners[uid] = (600, 9)
+
+    await daemon._clear_runtime_unlock_for_client_async(client, reason="test")
+
+    assert executor_calls == ["unlink"]
+
+
+@pytest.mark.asyncio
 async def test_client_disconnect_releases_devices_after_recording_discard_fails(daemon_testbed):
     daemon, device_manager, recording_manager, _macro_store, _capture_manager = daemon_testbed
     recording_manager.discard_all_pending_recordings.side_effect = RuntimeError(

--- a/tests/test_entrypoints_and_cli.py
+++ b/tests/test_entrypoints_and_cli.py
@@ -5,6 +5,8 @@ from collections.abc import Callable
 
 import pytest
 
+from keymasq.common.security import SecurityPolicyError
+
 
 def _module_with_main(fn: Callable[[], None]) -> types.ModuleType:
     module = types.ModuleType("stub_module")
@@ -163,6 +165,56 @@ def test_session_entrypoint_delegates_help_to_manager(monkeypatch: pytest.Monkey
 
     runpy.run_module("keymasq.session.__main__", run_name="__main__")
     assert called == ["manager"]
+
+
+def test_keymasqd_main_exits_on_security_policy_error(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    from keymasq.keymasqd import daemon as daemon_module
+
+    class _Daemon:
+        def __init__(self, *, verbosity: int = 0) -> None:
+            self.verbosity = verbosity
+
+        async def start(self) -> None:
+            raise SecurityPolicyError("Invalid security policy TOML at /tmp/security.toml: bad")
+
+    monkeypatch.setattr(sys, "argv", ["keymasqd"])
+    monkeypatch.setattr(daemon_module, "Daemon", _Daemon)
+    monkeypatch.setattr(daemon_module.os, "geteuid", lambda: 1000)
+    monkeypatch.setattr(daemon_module, "ensure_uvloop", lambda _log: None)
+    monkeypatch.setattr(daemon_module, "set_timer_slack_ns", lambda *, logger: None)
+
+    with caplog.at_level("ERROR", logger="keymasqd"):
+        with pytest.raises(SystemExit) as excinfo:
+            daemon_module.main()
+
+    assert excinfo.value.code == 1
+    assert "Invalid security policy TOML at /tmp/security.toml: bad" in caplog.text
+
+
+def test_session_main_exits_on_security_policy_error(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    from keymasq.session.manager import core as manager_module
+
+    class _SessionManager:
+        def __init__(self, *, verbosity: int = 0) -> None:
+            self.verbosity = verbosity
+            raise SecurityPolicyError("Invalid security policy TOML at /tmp/security.toml: bad")
+
+    monkeypatch.setattr(sys, "argv", ["keymasq-session"])
+    monkeypatch.setattr(manager_module, "SessionManager", _SessionManager)
+    monkeypatch.setattr(manager_module, "ensure_uvloop", lambda _log: None)
+
+    with caplog.at_level("ERROR", logger="keymasq-session"):
+        with pytest.raises(SystemExit) as excinfo:
+            manager_module.main()
+
+    assert excinfo.value.code == 1
+    assert "Invalid security policy TOML at /tmp/security.toml: bad" in caplog.text
 
 
 def test_cli_main_profiles_toggle_routes_to_helper(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_kde_listener.py
+++ b/tests/test_kde_listener.py
@@ -454,7 +454,9 @@ def test_dispatch_runs_one_shot_kwin_script(monkeypatch, tmp_path) -> None:
 
     class _ScriptIface:
         async def call_run(self) -> None:
-            listener._on_dispatch_payload('{"id":"abc12345def67890","ok":true,"message":"ok"}')
+            listener.handle_dispatch_payload(
+                '{"id":"abc12345def67890","ok":true,"message":"ok"}'
+            )
 
         async def call_stop(self) -> None:
             return

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -3,7 +3,10 @@ import socket
 import struct
 from pathlib import Path
 
+import pytest
+
 from keymasq.common.security import (
+    SecurityPolicyError,
     command_allowed,
     get_peer_credentials,
     load_security_policy,
@@ -20,6 +23,14 @@ def test_load_security_policy_defaults_when_missing(tmp_path: Path) -> None:
     assert policy.recording_unlock_required is True
     assert policy.macro_edit_requires_unlock is False
     assert policy.emergency_cancel_combo_enabled is True
+
+
+def test_load_security_policy_rejects_malformed_toml(tmp_path: Path) -> None:
+    policy_path = tmp_path / "security.toml"
+    policy_path.write_text("[macro\n")
+
+    with pytest.raises(SecurityPolicyError, match="Invalid security policy TOML"):
+        load_security_policy(policy_path)
 
 
 def test_get_peer_credentials_reads_socket_peercred() -> None:

--- a/tests/test_session_manager_events.py
+++ b/tests/test_session_manager_events.py
@@ -170,6 +170,38 @@ async def test_handle_event_dispatches_action_trigger_variants(
 
 
 @pytest.mark.asyncio
+async def test_handle_event_double_verbose_logs_full_event_payload(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    manager = SessionManager(verbosity=1)
+    manager.broadcast_to_session_clients = Mock()  # type: ignore[method-assign]
+
+    with caplog.at_level(logging.DEBUG, logger="keymasq-session"):
+        await session_events_module.handle_event(
+            manager,
+            CommandType.DIAGNOSTICS_SNAPSHOT,
+            {"events": [{"type": 1}]},
+        )
+
+    assert "Event: diagnostics_snapshot ->" in caplog.text
+    assert "<1 events>" in caplog.text
+    assert "{'type': 1}" not in caplog.text
+
+    caplog.clear()
+    manager.verbosity = 2
+    with caplog.at_level(logging.DEBUG, logger="keymasq-session"):
+        await session_events_module.handle_event(
+            manager,
+            CommandType.DIAGNOSTICS_SNAPSHOT,
+            {"events": [{"type": 1}]},
+        )
+
+    assert "Event: diagnostics_snapshot ->" in caplog.text
+    assert "<1 events>" not in caplog.text
+    assert "{'type': 1}" in caplog.text
+
+
+@pytest.mark.asyncio
 async def test_handle_event_dispatches_device_and_runtime_variants(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary

- Centralize docs URL generation into `docs_page_url` from `keymasq.gui.widgets.docs_links`, removing duplicated `_docs_version()` in `application.py` and `macro_manager_dialog.py`.
- **Dead code removal:**
  - `kde.py`: Removed unused private methods (`_on_window_payload`, `_on_cursor_payload`, `_on_dispatch_payload`) and the `available` property.
  - `kde.py`: Extracted duplicate cleanup logic in `_start_cursor_tracking` into `_cleanup_cursor_tracking_script`.
  - `hyprland.py`: Removed unreachable `return None`.
  - `compositor.py`: Removed sync stub `get_compositor_payload`.
  - `recording_lifecycle.py`: Inlined trivial local variables.
  - `pyproject.toml`: Removed unused `slow` test marker definition.
- **Packaging:** Removed stale `rm -f keymasq-cli keymasq-gui` from all PKGBUILD files (root, AUR, Pacman template) since these wrapper scripts no longer exist.
- **Testing:** Updated `test_kde_listener.py` to call public `handle_dispatch_payload` instead of the removed private method.

## Testing

- `ruff` and `basedpyright` pass.
- Existing pytest suite passes via `./scripts/check.sh`.
- Manual verification of docs links in the GUI opens correct versioned URLs.
- KDE window/cursor tracking smoke tests pass.
- `makepkg` dry-run on PKGBUILD succeeds without warnings.