### PR TITLE
Defer selector commits and coalesce config watcher reloads

### DIFF
--- a/keymasq/gui/widgets/device_tab/tab.py
+++ b/keymasq/gui/widgets/device_tab/tab.py
@@ -8,7 +8,7 @@ import gi
 gi.require_version("Gtk", "4.0")
 gi.require_version("Adw", "1")
 
-from gi.repository import Adw, Gdk, Gtk, Pango  # pyright: ignore[reportAttributeAccessIssue]
+from gi.repository import Adw, Gdk, GLib, Gtk, Pango  # pyright: ignore[reportAttributeAccessIssue]
 
 from keymasq.common.devices import (
     is_by_id_path,
@@ -62,6 +62,7 @@ from keymasq.session.profiles import ProfileInfo, ProfileManager
 log = logging.getLogger(__name__)
 session_request_async = _default_session_request_async
 SessionCallback = Callable[[JsonDict | None], bool]
+SELECTOR_COMMIT_AFTER_CLOSE_DELAY_MS = 500
 
 
 def _session_request_async(payload: JsonDict, callback: SessionCallback) -> object:
@@ -95,6 +96,9 @@ class DeviceTab(ProfileManagedTab):
         self._user_interacting = False
         self._keyboard_layout_mode = False
         self._highlight_timeout_ids: list[int] = []
+        self._selector_commit_source_id = 0
+        self._pending_selector_commit: Callable[[], None] | None = None
+        self.connect("destroy", self._on_device_tab_destroy)
         self._setup_header()
         self._setup_profile_selector()
         self._setup_button_grid()
@@ -1337,20 +1341,25 @@ class DeviceTab(ProfileManagedTab):
         if layer:
             current_action = layer.mappings.get(button.id)
 
-        def on_key_selected(dialog, action):
-            layer = self._selected_layer(create=True)
-            if layer is None:
-                return
-            if action is None:
-                if button.id in layer.mappings:
-                    del layer.mappings[button.id]
-            else:
-                layer.mappings[button.id] = action
-            self._save_profile()
-            self._update_button_display(button.id)
-            self._update_header_caption()
-
         dialog = KeySelectorDialog(self, button.label, current_action)
+        defer_commit = self._defer_selector_commit_until_dialog_closed(dialog)
+
+        def on_key_selected(dialog, action):
+            def commit_selection() -> None:
+                layer = self._selected_layer(create=True)
+                if layer is None:
+                    return
+                if action is None:
+                    if button.id in layer.mappings:
+                        del layer.mappings[button.id]
+                else:
+                    layer.mappings[button.id] = action
+                self._update_button_display(button.id)
+                self._update_header_caption()
+                self._save_profile()
+
+            defer_commit(commit_selection)
+
         dialog.connect("key-selected", on_key_selected)
         dialog.present(self.get_root())
 
@@ -1359,18 +1368,6 @@ class DeviceTab(ProfileManagedTab):
         layer = self._selected_layer()
         if layer:
             current_action = layer.mappings.get(analog.id)
-
-        def on_key_selected(dialog, action):
-            layer = self._selected_layer(create=True)
-            if layer is None:
-                return
-            if action is None:
-                layer.mappings.pop(analog.id, None)
-            else:
-                layer.mappings[analog.id] = action
-            self._save_profile()
-            self._update_button_display(analog.id)
-            self._update_header_caption()
 
         dialog = KeySelectorDialog(
             self,
@@ -1382,8 +1379,65 @@ class DeviceTab(ProfileManagedTab):
             source_type="analog",
             analog_input_type=analog.type,
         )
+        defer_commit = self._defer_selector_commit_until_dialog_closed(dialog)
+
+        def on_key_selected(dialog, action):
+            def commit_selection() -> None:
+                layer = self._selected_layer(create=True)
+                if layer is None:
+                    return
+                if action is None:
+                    layer.mappings.pop(analog.id, None)
+                else:
+                    layer.mappings[analog.id] = action
+                self._update_button_display(analog.id)
+                self._update_header_caption()
+                self._save_profile()
+
+            defer_commit(commit_selection)
+
         dialog.connect("key-selected", on_key_selected)
         dialog.present(self.get_root())
+
+    def _defer_selector_commit_until_dialog_closed(
+        self,
+        dialog: Adw.Dialog,
+    ) -> Callable[[Callable[[], None]], None]:
+        pending_commit: Callable[[], None] | None = None
+
+        def set_pending_commit(commit: Callable[[], None]) -> None:
+            nonlocal pending_commit
+            pending_commit = commit
+
+        def on_dialog_closed(_dialog: Adw.Dialog) -> None:
+            if pending_commit is not None:
+                self._queue_selector_commit_after_close(pending_commit)
+
+        dialog.connect("closed", on_dialog_closed)
+        return set_pending_commit
+
+    def _queue_selector_commit_after_close(self, commit: Callable[[], None]) -> None:
+        if self._selector_commit_source_id:
+            GLib.source_remove(self._selector_commit_source_id)
+        self._pending_selector_commit = commit
+        self._selector_commit_source_id = GLib.timeout_add(
+            SELECTOR_COMMIT_AFTER_CLOSE_DELAY_MS,
+            self._run_pending_selector_commit,
+        )
+
+    def _run_pending_selector_commit(self) -> bool:
+        self._selector_commit_source_id = 0
+        commit = self._pending_selector_commit
+        self._pending_selector_commit = None
+        if commit is not None:
+            commit()
+        return False
+
+    def _on_device_tab_destroy(self, _widget) -> None:
+        if self._selector_commit_source_id:
+            GLib.source_remove(self._selector_commit_source_id)
+            self._selector_commit_source_id = 0
+        self._pending_selector_commit = None
 
     def _profile_info_by_name(self, profile_name: str) -> ProfileInfo | None:
         return mapping_display.profile_info_by_name(

--- a/keymasq/gui/widgets/device_tab/tab.py
+++ b/keymasq/gui/widgets/device_tab/tab.py
@@ -1437,7 +1437,16 @@ class DeviceTab(ProfileManagedTab):
     def _queue_selector_commit_after_close(self, commit: Callable[[], None]) -> None:
         if self._selector_commit_source_id:
             GLib.source_remove(self._selector_commit_source_id)
-        self._pending_selector_commit = commit
+        previous_commit = self._pending_selector_commit
+        if previous_commit is not None:
+
+            def combined_commit() -> None:
+                previous_commit()
+                commit()
+
+            self._pending_selector_commit = combined_commit
+        else:
+            self._pending_selector_commit = commit
         self._selector_commit_source_id = GLib.timeout_add(
             SELECTOR_COMMIT_AFTER_CLOSE_DELAY_MS,
             self._run_pending_selector_commit,

--- a/keymasq/gui/widgets/device_tab/tab.py
+++ b/keymasq/gui/widgets/device_tab/tab.py
@@ -117,6 +117,20 @@ class DeviceTab(ProfileManagedTab):
             return self._selected_profile.config.ensure_layer(self.device.hardware_id)
         return self._selected_profile.config.get_layer(self.device.hardware_id)
 
+    def _device_layer_for_profile(self, profile: ProfileInfo | None, create: bool = False):
+        if profile is None:
+            return None
+        if create:
+            return profile.config.ensure_layer(self.device.hardware_id)
+        return profile.config.get_layer(self.device.hardware_id)
+
+    def _profile_is_selected(self, profile: ProfileInfo | None) -> bool:
+        return (
+            profile is not None
+            and self._selected_profile is not None
+            and self._selected_profile.config.name == profile.config.name
+        )
+
     def _append_profile_settings_groups(self, container: Gtk.Box) -> None:
         self.always_grab_checks: dict[str, Adw.SwitchRow] = {}
 
@@ -1336,8 +1350,9 @@ class DeviceTab(ProfileManagedTab):
         dialog.present(self.get_root())
 
     def _show_function_editor(self, button: ButtonDefinition) -> None:
+        target_profile = self._selected_profile
         current_action = None
-        layer = self._selected_layer()
+        layer = self._device_layer_for_profile(target_profile)
         if layer:
             current_action = layer.mappings.get(button.id)
 
@@ -1346,7 +1361,7 @@ class DeviceTab(ProfileManagedTab):
 
         def on_key_selected(dialog, action):
             def commit_selection() -> None:
-                layer = self._selected_layer(create=True)
+                layer = self._device_layer_for_profile(target_profile, create=True)
                 if layer is None:
                     return
                 if action is None:
@@ -1354,9 +1369,10 @@ class DeviceTab(ProfileManagedTab):
                         del layer.mappings[button.id]
                 else:
                     layer.mappings[button.id] = action
-                self._update_button_display(button.id)
-                self._update_header_caption()
-                self._save_profile()
+                if self._profile_is_selected(target_profile):
+                    self._update_button_display(button.id)
+                    self._update_header_caption()
+                self._save_specific_profile(target_profile)
 
             defer_commit(commit_selection)
 
@@ -1364,8 +1380,9 @@ class DeviceTab(ProfileManagedTab):
         dialog.present(self.get_root())
 
     def _show_analog_editor(self, analog: AnalogInputDefinition) -> None:
+        target_profile = self._selected_profile
         current_action = None
-        layer = self._selected_layer()
+        layer = self._device_layer_for_profile(target_profile)
         if layer:
             current_action = layer.mappings.get(analog.id)
 
@@ -1383,16 +1400,17 @@ class DeviceTab(ProfileManagedTab):
 
         def on_key_selected(dialog, action):
             def commit_selection() -> None:
-                layer = self._selected_layer(create=True)
+                layer = self._device_layer_for_profile(target_profile, create=True)
                 if layer is None:
                     return
                 if action is None:
                     layer.mappings.pop(analog.id, None)
                 else:
                     layer.mappings[analog.id] = action
-                self._update_button_display(analog.id)
-                self._update_header_caption()
-                self._save_profile()
+                if self._profile_is_selected(target_profile):
+                    self._update_button_display(analog.id)
+                    self._update_header_caption()
+                self._save_specific_profile(target_profile)
 
             defer_commit(commit_selection)
 
@@ -1437,7 +1455,7 @@ class DeviceTab(ProfileManagedTab):
         if self._selector_commit_source_id:
             GLib.source_remove(self._selector_commit_source_id)
             self._selector_commit_source_id = 0
-        self._pending_selector_commit = None
+        self._run_pending_selector_commit()
 
     def _profile_info_by_name(self, profile_name: str) -> ProfileInfo | None:
         return mapping_display.profile_info_by_name(

--- a/keymasq/gui/widgets/key_selector/analog_tab.py
+++ b/keymasq/gui/widgets/key_selector/analog_tab.py
@@ -140,8 +140,7 @@ class AnalogTabMixin:
             action_type=ActionType.ANALOG_CONTROL,
             analog_control_names=[name],
         )
-        self.emit("key-selected", action)
-        self.close()
+        self._emit_selected_action(action)
 
     def _show_analog_preset_save_error(self, name: str, exc: Exception) -> None:
         dialog = Adw.AlertDialog()
@@ -359,5 +358,4 @@ class AnalogTabMixin:
             action_type=ActionType.ANALOG_CONTROL,
             analog_control_names=list(self._selected_analog_controls),
         )
-        self.emit("key-selected", action)
-        self.close()
+        self._emit_selected_action(action)

--- a/keymasq/gui/widgets/key_selector/dialog.py
+++ b/keymasq/gui/widgets/key_selector/dialog.py
@@ -60,6 +60,7 @@ class KeySelectorDialog(
     _include_tap_options = True
     _gamepad_output_selector_mode = "title"
     _rapidfire_warning_context = "key selector"
+    _selection_emit_closes_dialog = True
 
     def _build_selected_action(
         self,
@@ -70,6 +71,7 @@ class KeySelectorDialog(
 
     def _emit_selected_action(self, action: MappingAction | None) -> None:
         self.emit("key-selected", action)
+        self.close()
 
     def __init__(
         self,
@@ -516,20 +518,21 @@ class KeySelectorDialog(
 
     def _on_special_clicked(self, btn, action_type: str):
         if action_type == "clear_mapping":
-            self.emit("key-selected", None)
+            self._emit_selected_action(None)
         elif action_type == "explicit_passthrough":
             self._warn_and_clear_unsupported_rapidfire(ActionType.PASSTHROUGH)
             action = MappingAction(action_type=ActionType.PASSTHROUGH)
-            self.emit("key-selected", action)
+            self._emit_selected_action(action)
         elif action_type == "suppress":
             self._warn_and_clear_unsupported_rapidfire(ActionType.SUPPRESS)
             action = MappingAction(action_type=ActionType.SUPPRESS)
-            self.emit("key-selected", action)
+            self._emit_selected_action(action)
         elif action_type == "cancel_macro_playback":
             self._warn_and_clear_unsupported_rapidfire(ActionType.CANCEL_MACRO_PLAYBACK)
             action = MappingAction(action_type=ActionType.CANCEL_MACRO_PLAYBACK)
-            self.emit("key-selected", action)
-        self.close()
+            self._emit_selected_action(action)
+        else:
+            self.close()
 
     def _on_tab_changed(self, stack, param):
         child_name = self.stack.get_visible_child_name()
@@ -592,13 +595,11 @@ class KeySelectorDialog(
             return
         self._warn_and_clear_unsupported_rapidfire(ActionType.EXEC)
         action = MappingAction(action_type=ActionType.EXEC, cmd=cmd)
-        self.emit("key-selected", action)
-        self.close()
+        self._emit_selected_action(action)
 
     def _on_compositor_action_selected(self, action: MappingAction) -> None:
         self._warn_and_clear_unsupported_rapidfire(ActionType.COMPOSITOR_DISPATCH)
-        self.emit("key-selected", action)
-        self.close()
+        self._emit_selected_action(action)
 
     def _on_mouse_move_map_clicked(self, btn) -> None:
         x = int(self.mouse_move_x_spin.get_value())
@@ -627,8 +628,7 @@ class KeySelectorDialog(
                 if hasattr(self, "mouse_move_stop_on_failure_check")
                 else False,
             )
-            self.emit("key-selected", action)
-            self.close()
+            self._emit_selected_action(action)
             return
         if self.mouse_move_abs_check.get_active():
             action_type = ActionType.MOUSE_MOVE_ABS
@@ -644,8 +644,7 @@ class KeySelectorDialog(
             tap_enabled=self._tap_enabled,
             tap_hold_ms=int(self.tap_spin.get_value()),
         )
-        self.emit("key-selected", action)
-        self.close()
+        self._emit_selected_action(action)
 
     def _on_mouse_move_mode_changed(self, check: Gtk.CheckButton) -> None:
         self._update_mouse_move_mode_visibility()

--- a/keymasq/gui/widgets/key_selector/macro_tab.py
+++ b/keymasq/gui/widgets/key_selector/macro_tab.py
@@ -468,8 +468,7 @@ class MacroTabMixin:
             action = MappingAction(action_type=ActionType.CANCEL_MACRO_PLAYBACK)
         else:
             return
-        self.emit("key-selected", action)
-        self.close()
+        self._emit_selected_action(action)
 
     def _on_macro_recording_slot_clicked(self, _btn, slot: int) -> None:
         self._warn_and_clear_unsupported_rapidfire(ActionType.START_MACRO_RECORDING)
@@ -477,8 +476,7 @@ class MacroTabMixin:
             action_type=ActionType.START_MACRO_RECORDING,
             macro_recording_slot=slot,
         )
-        self.emit("key-selected", action)
-        self.close()
+        self._emit_selected_action(action)
 
     def _on_macro_play_slot_clicked(self, _btn, slot: int) -> None:
         self._warn_and_clear_unsupported_rapidfire(ActionType.PLAY_MACRO_SLOT)
@@ -486,8 +484,7 @@ class MacroTabMixin:
             action_type=ActionType.PLAY_MACRO_SLOT,
             macro_recording_slot=slot,
         )
-        self.emit("key-selected", action)
-        self.close()
+        self._emit_selected_action(action)
 
     def _on_macro_map_clicked(self, btn) -> None:
         if not self._selected_macro:
@@ -500,8 +497,7 @@ class MacroTabMixin:
             macro_replay_mouse_clicks=self._macro_replay_clicks,
             macro_speed=self._macro_speed,
         )
-        self.emit("key-selected", action)
-        self.close()
+        self._emit_selected_action(action)
 
 
 class SuperkeyMacroTabMixin:

--- a/keymasq/gui/widgets/key_selector/options_panel.py
+++ b/keymasq/gui/widgets/key_selector/options_panel.py
@@ -292,8 +292,7 @@ class MappingOptionsPanelMixin(RapidfireWarningMixin):
             rapidfire_hold_ms=int(self.repeat_hold_spin.get_value()),
             rapidfire_wait_ms=int(self.repeat_wait_spin.get_value()),
         )
-        self.emit("key-selected", action)
-        self.close()
+        self._emit_selected_action(action)
 
 
 class SuperkeyOptionsPanelMixin(RapidfireWarningMixin):

--- a/keymasq/gui/widgets/key_selector/profile_tab.py
+++ b/keymasq/gui/widgets/key_selector/profile_tab.py
@@ -491,8 +491,7 @@ class ProfileTabMixin:
             profile_name=self._selected_profile_name,
             profile_deactivation=self._profile_deactivation_policy(action_type),
         )
-        self.emit("key-selected", action)
-        self.close()
+        self._emit_selected_action(action)
 
     def _profile_deactivation_policy(
         self,

--- a/keymasq/gui/widgets/key_selector/superkey_tab.py
+++ b/keymasq/gui/widgets/key_selector/superkey_tab.py
@@ -189,5 +189,4 @@ class SuperkeyTabMixin:
             action_type=ActionType.SUPERKEY,
             superkey_name=self._selected_superkey,
         )
-        self.emit("key-selected", action)
-        self.close()
+        self._emit_selected_action(action)

--- a/keymasq/gui/widgets/key_selector/tabs.py
+++ b/keymasq/gui/widgets/key_selector/tabs.py
@@ -112,6 +112,7 @@ def _ensure_compact_tabs_css() -> None:
 
 
 class SharedInputTabsMixin:
+    _selection_emit_closes_dialog = False
     _include_keyboard_capture_controls = False
     _include_mpris_controls = True
     _include_mouse_button_controls = True
@@ -121,6 +122,10 @@ class SharedInputTabsMixin:
     _mouse_move_commit_label = "Map Move"
     _include_tap_options = False
     _gamepad_output_selector_mode = "inline"
+
+    def _close_after_selection_emit(self) -> None:
+        if not self._selection_emit_closes_dialog:
+            self.close()
 
     def _create_key_button(
         self, label: str, evdev: str, width: float = 1, large: bool = False, protected: bool = False
@@ -680,7 +685,7 @@ class SharedInputTabsMixin:
             mpris_command=command,
         )
         self._emit_selected_action(action)
-        self.close()
+        self._close_after_selection_emit()
 
     def _on_keyboard_clicked(self, btn, evdev_name: str):
         use_rapidfire = _keyboard_target_allows_rapidfire(evdev_name)
@@ -694,7 +699,7 @@ class SharedInputTabsMixin:
             ),
         )
         self._emit_selected_action(action)
-        self.close()
+        self._close_after_selection_emit()
 
     def _on_f_key_selected(self, btn):
         idx = self.f_dropdown.get_selected()
@@ -710,7 +715,7 @@ class SharedInputTabsMixin:
             **self._input_option_fields(),
         )
         self._emit_selected_action(action)
-        self.close()
+        self._close_after_selection_emit()
 
     def _on_gamepad_clicked(self, btn, evdev_name: str):
         action = self._build_selected_action(
@@ -720,7 +725,7 @@ class SharedInputTabsMixin:
             **self._input_option_fields(),
         )
         self._emit_selected_action(action)
-        self.close()
+        self._close_after_selection_emit()
 
     def _on_gamepad_axis_clicked(self, btn, axis_target: str, axis_value: int):
         action = self._build_selected_action(
@@ -731,7 +736,7 @@ class SharedInputTabsMixin:
             **self._input_option_fields(),
         )
         self._emit_selected_action(action)
-        self.close()
+        self._close_after_selection_emit()
 
     def _on_gamepad_code_clicked(self, widget) -> None:
         evdev_name = _resolve_gamepad_button_target(self.gamepad_code_entry.get_text())

--- a/keymasq/session/manager/commands.py
+++ b/keymasq/session/manager/commands.py
@@ -41,6 +41,26 @@ def _daemon_unavailable_response() -> JsonObject:
     return {"status": "error", "message": "Daemon unavailable"}
 
 
+def _config_reload_failed_response() -> JsonObject:
+    return {
+        "status": "error",
+        "message": "Failed to reload config; keeping previous active config",
+    }
+
+
+async def _suppress_or_join_config_watcher_reload(
+    manager: "SessionManager",
+) -> JsonObject | None:
+    manager.suppress_config_watcher_reload()
+    running_reload_result = await manager.wait_for_running_config_reload()
+    if running_reload_result is True:
+        manager.suppress_config_watcher_reload()
+        return {"status": "ok"}
+    if running_reload_result is False:
+        return _config_reload_failed_response()
+    return None
+
+
 async def _send_daemon_request(
     manager: "SessionManager",
     command: Command,
@@ -170,12 +190,12 @@ async def _handle_profile_commands(
         return await runtime_profiles.set_profile_enabled(manager, profile_name, enabled)
 
     if command == "reload":
+        if response := await _suppress_or_join_config_watcher_reload(manager):
+            return response
         if await manager.reload_profiles():
+            manager.suppress_config_watcher_reload()
             return {"status": "ok"}
-        return {
-            "status": "error",
-            "message": "Failed to reload config; keeping previous active config",
-        }
+        return _config_reload_failed_response()
 
     if command == "release_device":
         hardware_id = coerce_str(request.get("hardware_id"), "").strip()
@@ -204,6 +224,8 @@ async def _handle_profile_commands(
 
     if command in {"reevaluate_profiles", "reevaluate_hardware"}:
         log.info("Global profile reevaluate requested")
+        if response := await _suppress_or_join_config_watcher_reload(manager):
+            return response
         try:
             await asyncio.to_thread(manager.reload_config_from_disk)
         except Exception as exc:
@@ -213,6 +235,7 @@ async def _handle_profile_commands(
                 "Failed to reload config; keeping the previous active config. See logs.",
             )
             return {"status": "error", "message": str(exc)}
+        manager.suppress_config_watcher_reload()
         runtime_profiles.invalidate_runtime_payload_signatures(manager)
         await runtime_profiles.reevaluate_profiles(manager, reason="session command reevaluate")
         return {"status": "ok"}

--- a/keymasq/session/manager/commands.py
+++ b/keymasq/session/manager/commands.py
@@ -53,11 +53,8 @@ async def _suppress_or_join_config_watcher_reload(
 ) -> JsonObject | None:
     manager.suppress_config_watcher_reload()
     running_reload_result = await manager.wait_for_running_config_reload()
-    if running_reload_result is True:
+    if running_reload_result is not None:
         manager.suppress_config_watcher_reload()
-        return None
-    if running_reload_result is False:
-        return _config_reload_failed_response()
     return None
 
 

--- a/keymasq/session/manager/commands.py
+++ b/keymasq/session/manager/commands.py
@@ -55,7 +55,7 @@ async def _suppress_or_join_config_watcher_reload(
     running_reload_result = await manager.wait_for_running_config_reload()
     if running_reload_result is True:
         manager.suppress_config_watcher_reload()
-        return {"status": "ok"}
+        return None
     if running_reload_result is False:
         return _config_reload_failed_response()
     return None

--- a/keymasq/session/manager/core.py
+++ b/keymasq/session/manager/core.py
@@ -73,6 +73,9 @@ GRAB_RETRY_DELAY_S = manager_constants.GRAB_RETRY_DELAY_S
 TOPOLOGY_REFRESH_DEBOUNCE_S = manager_constants.TOPOLOGY_REFRESH_DEBOUNCE_S
 TOPOLOGY_REFRESH_RETRY_S = manager_constants.TOPOLOGY_REFRESH_RETRY_S
 CONFIG_RELOAD_DEBOUNCE_S = 0.5
+# Longer than the watcher debounce so explicit saves suppress both already-scheduled
+# and slightly delayed inotify events.
+CONFIG_RELOAD_EXPLICIT_COALESCE_S = CONFIG_RELOAD_DEBOUNCE_S + 1.0
 IN_ACCESS = 0x00000001
 IN_ATTRIB = 0x00000004
 IN_CLOSE_WRITE = 0x00000008
@@ -131,6 +134,7 @@ class SessionManager:
         self.reload_task: asyncio.Task[bool] | None = None
         self.reload_pending = False
         self.config_reload_timer: asyncio.TimerHandle | None = None
+        self._config_reload_coalesce_until = 0.0
         self.config_watch_fd: int | None = None
         self.config_watch_watches: dict[int, Path] = {}
         self.verbosity = verbosity
@@ -736,17 +740,50 @@ class SessionManager:
         return bool(mask & (IN_DELETE_SELF | IN_MOVE_SELF | IN_ATTRIB))
 
     def _schedule_config_reload(self) -> None:
+        loop = asyncio.get_running_loop()
+        if self._config_reload_is_coalesced(loop):
+            log.debug("Skipping config watcher reload after explicit reload request")
+            return
+
         timer = self.config_reload_timer
         if timer is not None:
             timer.cancel()
-        self.config_reload_timer = asyncio.get_running_loop().call_later(
+        self.config_reload_timer = loop.call_later(
             CONFIG_RELOAD_DEBOUNCE_S,
             self._run_scheduled_config_reload,
         )
 
+    def _config_reload_is_coalesced(self, loop: asyncio.AbstractEventLoop) -> bool:
+        return loop.time() <= self._config_reload_coalesce_until
+
+    def suppress_config_watcher_reload(self) -> None:
+        timer = self.config_reload_timer
+        if timer is not None:
+            timer.cancel()
+            self.config_reload_timer = None
+        loop = asyncio.get_running_loop()
+        self._config_reload_coalesce_until = max(
+            self._config_reload_coalesce_until,
+            loop.time() + CONFIG_RELOAD_EXPLICIT_COALESCE_S,
+        )
+
+    async def wait_for_running_config_reload(self) -> bool | None:
+        task = self.reload_task
+        if task is None or task.done():
+            return None
+        log.debug("Waiting for running config reload before handling explicit reload request")
+        try:
+            return await task
+        except Exception:
+            log.exception("Running config reload failed")
+            return False
+
     def _run_scheduled_config_reload(self) -> None:
         self.config_reload_timer = None
         if not self.running:
+            return
+        if self._config_reload_is_coalesced(asyncio.get_running_loop()):
+            log.debug("Skipping scheduled config reload after explicit reload request")
             return
         if self.reload_task is not None and not self.reload_task.done():
             log.debug("Config reload already running; skipping scheduled reload")

--- a/tests/gui/test_device_tab_widget.py
+++ b/tests/gui/test_device_tab_widget.py
@@ -911,6 +911,47 @@ class TestDeviceTabWidget:
         assert tab._pending_selector_commit is None
         assert tab._selector_commit_source_id == 0
 
+    def test_device_tab_selector_pending_commits_chain_in_order(
+        self,
+        monkeypatch,
+    ):
+        from collections.abc import Callable
+
+        from keymasq.common.models import ButtonDefinition, HardwareConfig
+        import keymasq.gui.widgets.device_tab.tab as device_tab_module
+        from keymasq.gui.widgets.device_tab import DeviceTab
+
+        scheduled: list[Callable[[], bool]] = []
+        removed: list[int] = []
+        monkeypatch.setattr(
+            device_tab_module.GLib,
+            "timeout_add",
+            lambda _delay_ms, callback: scheduled.append(callback) or 123,
+        )
+        monkeypatch.setattr(device_tab_module.GLib, "source_remove", removed.append)
+
+        device = HardwareConfig(
+            vendor_id="1234",
+            product_id="5678",
+            name="Test Mouse",
+            evdev_devices=[],
+            buttons=[ButtonDefinition(id="btn_back", label="Back", evdev="btn_side")],
+        )
+        tab = DeviceTab(device=device, profile_manager=None, demo_mode=False)
+        commits: list[str] = []
+
+        tab._queue_selector_commit_after_close(lambda: commits.append("first"))
+        tab._queue_selector_commit_after_close(lambda: commits.append("second"))
+
+        assert len(scheduled) == 2
+        assert removed == [123]
+
+        assert scheduled[-1]() is False
+
+        assert commits == ["first", "second"]
+        assert tab._pending_selector_commit is None
+        assert tab._selector_commit_source_id == 0
+
     def test_device_tab_profile_settings_lists_all_devices_for_grab_mode(self, temp_config_dir):
         from keymasq.common.models import ButtonDefinition, HardwareConfig, ProfileConfig
         from keymasq.gui.window import MainWindow

--- a/tests/gui/test_device_tab_widget.py
+++ b/tests/gui/test_device_tab_widget.py
@@ -825,10 +825,19 @@ class TestDeviceTabWidget:
                 device_layers={"1234:5678": DeviceProfileLayer(hardware_id="1234:5678")},
             )
         )
+        profile_manager.save_profile(
+            ProfileConfig(
+                name="Work",
+                enabled=True,
+                is_permanent=True,
+            )
+        )
         tab = DeviceTab(device=device, profile_manager=profile_manager, demo_mode=False)
         tab.refresh_profiles(preferred_profile_name="Gaming", publish_selection=False)
-        save_calls: list[bool] = []
-        tab._save_profile = lambda: save_calls.append(True) or True  # type: ignore[method-assign]
+        save_calls: list[str | None] = []
+        tab._save_specific_profile = (  # type: ignore[method-assign]
+            lambda profile: save_calls.append(profile.config.name if profile else None) or True
+        )
 
         tab._show_function_editor(device.buttons[0])
         action = MappingAction(action_type=ActionType.SUPPRESS)
@@ -850,10 +859,57 @@ class TestDeviceTabWidget:
             )
         ]
 
+        tab.refresh_profiles(preferred_profile_name="Work", publish_selection=False)
+        assert tab.selected_profile_name() == "Work"
+
         assert scheduled[0][1]() is False
 
-        assert layer.mappings["btn_back"] == action
-        assert save_calls == [True]
+        gaming = profile_manager.get_profile("Gaming")
+        work = profile_manager.get_profile("Work")
+        assert gaming is not None
+        assert work is not None
+        assert gaming.config.get_layer("1234:5678").mappings["btn_back"] == action
+        work_layer = work.config.get_layer("1234:5678")
+        assert work_layer is None or "btn_back" not in work_layer.mappings
+        assert save_calls == ["Gaming"]
+
+    def test_device_tab_selector_pending_commit_flushes_on_destroy(
+        self,
+        monkeypatch,
+    ):
+        from collections.abc import Callable
+
+        from keymasq.common.models import ButtonDefinition, HardwareConfig
+        import keymasq.gui.widgets.device_tab.tab as device_tab_module
+        from keymasq.gui.widgets.device_tab import DeviceTab
+
+        scheduled: list[Callable[[], bool]] = []
+        removed: list[int] = []
+        monkeypatch.setattr(
+            device_tab_module.GLib,
+            "timeout_add",
+            lambda _delay_ms, callback: scheduled.append(callback) or 123,
+        )
+        monkeypatch.setattr(device_tab_module.GLib, "source_remove", removed.append)
+
+        device = HardwareConfig(
+            vendor_id="1234",
+            product_id="5678",
+            name="Test Mouse",
+            evdev_devices=[],
+            buttons=[ButtonDefinition(id="btn_back", label="Back", evdev="btn_side")],
+        )
+        tab = DeviceTab(device=device, profile_manager=None, demo_mode=False)
+        commits: list[bool] = []
+
+        tab._queue_selector_commit_after_close(lambda: commits.append(True))
+        tab._on_device_tab_destroy(tab)
+
+        assert scheduled == [tab._run_pending_selector_commit]
+        assert removed == [123]
+        assert commits == [True]
+        assert tab._pending_selector_commit is None
+        assert tab._selector_commit_source_id == 0
 
     def test_device_tab_profile_settings_lists_all_devices_for_grab_mode(self, temp_config_dir):
         from keymasq.common.models import ButtonDefinition, HardwareConfig, ProfileConfig

--- a/tests/gui/test_device_tab_widget.py
+++ b/tests/gui/test_device_tab_widget.py
@@ -712,6 +712,149 @@ class TestDeviceTabWidget:
         assert layer.always_grab_all is True
         assert save_calls == [True]
 
+    def test_device_tab_profile_save_requests_explicit_reevaluate(
+        self,
+        temp_config_dir,
+        monkeypatch,
+    ):
+        from keymasq.common.models import (
+            ActionType,
+            ButtonDefinition,
+            DeviceProfileLayer,
+            HardwareConfig,
+            MappingAction,
+            ProfileConfig,
+        )
+        import keymasq.gui.widgets.profile_managed_tab as profile_managed_tab_module
+        from keymasq.gui.widgets.device_tab import DeviceTab
+        from keymasq.session.profiles import ProfileManager
+
+        requests: list[dict] = []
+        monkeypatch.setattr(
+            profile_managed_tab_module,
+            "session_request_async",
+            lambda payload, _callback: requests.append(payload),
+        )
+
+        profile_manager = ProfileManager()
+        profile_manager.save_profile(
+            ProfileConfig(
+                name="Gaming",
+                enabled=True,
+                is_permanent=True,
+                device_layers={"1234:5678": DeviceProfileLayer(hardware_id="1234:5678")},
+            )
+        )
+
+        device = HardwareConfig(
+            vendor_id="1234",
+            product_id="5678",
+            name="Test Mouse",
+            evdev_devices=[],
+            buttons=[ButtonDefinition(id="btn_back", label="Back", evdev="btn_side")],
+        )
+
+        tab = DeviceTab(device=device, profile_manager=profile_manager, demo_mode=False)
+        tab.refresh_profiles(preferred_profile_name="Gaming", publish_selection=False)
+        layer = tab._selected_layer(create=True)
+        assert layer is not None
+        layer.mappings["btn_back"] = MappingAction(action_type=ActionType.SUPPRESS)
+
+        assert tab._save_profile() is True
+
+        assert requests.count({"command": "reevaluate_profiles"}) == 1
+        assert {"command": "reload"} not in requests
+
+    def test_device_tab_selector_profile_save_waits_for_dialog_closed(
+        self,
+        temp_config_dir,
+        monkeypatch,
+    ):
+        from collections.abc import Callable
+        from typing import cast
+
+        from keymasq.common.models import (
+            ActionType,
+            ButtonDefinition,
+            DeviceProfileLayer,
+            HardwareConfig,
+            MappingAction,
+            ProfileConfig,
+        )
+        import keymasq.gui.widgets.device_tab.tab as device_tab_module
+        from keymasq.gui.widgets.device_tab import DeviceTab
+        from keymasq.session.profiles import ProfileManager
+
+        dialogs: list[object] = []
+        scheduled: list[tuple[int, Callable[[], bool]]] = []
+
+        class DummyDialog:
+            callbacks: dict[str, Callable[..., object]]
+            present_root: object
+
+            def __init__(self, *args, **kwargs):
+                self.callbacks = {}
+                dialogs.append(self)
+
+            def connect(self, signal_name, callback):
+                self.callbacks[signal_name] = callback
+
+            def present(self, root):
+                self.present_root = root
+
+        monkeypatch.setattr(device_tab_module, "KeySelectorDialog", DummyDialog)
+        monkeypatch.setattr(
+            device_tab_module.GLib,
+            "timeout_add",
+            lambda delay_ms, callback: scheduled.append((delay_ms, callback)) or 123,
+        )
+
+        device = HardwareConfig(
+            vendor_id="1234",
+            product_id="5678",
+            name="Test Mouse",
+            evdev_devices=[],
+            buttons=[ButtonDefinition(id="btn_back", label="Back", evdev="btn_side")],
+        )
+        profile_manager = ProfileManager()
+        profile_manager.save_profile(
+            ProfileConfig(
+                name="Gaming",
+                enabled=True,
+                is_permanent=True,
+                device_layers={"1234:5678": DeviceProfileLayer(hardware_id="1234:5678")},
+            )
+        )
+        tab = DeviceTab(device=device, profile_manager=profile_manager, demo_mode=False)
+        tab.refresh_profiles(preferred_profile_name="Gaming", publish_selection=False)
+        save_calls: list[bool] = []
+        tab._save_profile = lambda: save_calls.append(True) or True  # type: ignore[method-assign]
+
+        tab._show_function_editor(device.buttons[0])
+        action = MappingAction(action_type=ActionType.SUPPRESS)
+        dialog = cast(DummyDialog, dialogs[0])
+        dialog.callbacks["key-selected"](dialog, action)
+
+        assert save_calls == []
+        layer = tab._selected_layer()
+        assert layer is not None
+        assert "btn_back" not in layer.mappings
+
+        dialog.callbacks["closed"](dialog)
+
+        assert save_calls == []
+        assert scheduled == [
+            (
+                device_tab_module.SELECTOR_COMMIT_AFTER_CLOSE_DELAY_MS,
+                tab._run_pending_selector_commit,
+            )
+        ]
+
+        assert scheduled[0][1]() is False
+
+        assert layer.mappings["btn_back"] == action
+        assert save_calls == [True]
+
     def test_device_tab_profile_settings_lists_all_devices_for_grab_mode(self, temp_config_dir):
         from keymasq.common.models import ButtonDefinition, HardwareConfig, ProfileConfig
         from keymasq.gui.window import MainWindow

--- a/tests/gui/test_gui_device_tab_misc.py
+++ b/tests/gui/test_gui_device_tab_misc.py
@@ -1326,6 +1326,27 @@ def test_key_selector_dialog_keyboard_mapping_uses_rapidfire_or_tap_state():
     assert tap_results[0].tap_hold_ms == 70
 
 
+def test_key_selector_dialog_selection_emits_and_closes(monkeypatch):
+    from gi.repository import Gtk
+
+    from keymasq.common.models import ActionType, MappingAction
+    from keymasq.gui.widgets.key_selector_dialog import KeySelectorDialog
+
+    dialog = KeySelectorDialog(Gtk.Box(), "Back")
+    results: list[MappingAction | None] = []
+    close_calls: list[bool] = []
+    dialog.connect("key-selected", lambda _dialog, selected: results.append(selected))
+    monkeypatch.setattr(dialog, "close", lambda: close_calls.append(True))
+
+    dialog._on_keyboard_clicked(None, "key_f5")
+
+    assert close_calls == [True]
+    assert len(results) == 1
+    assert results[0] is not None
+    assert results[0].action_type == ActionType.KEYBOARD
+    assert results[0].target == "key_f5"
+
+
 def test_key_selector_dialog_media_tab_hides_options_and_raw_keys_ignore_them():
     from gi.repository import Gtk
 

--- a/tests/session/test_session_manager_command_runtime.py
+++ b/tests/session/test_session_manager_command_runtime.py
@@ -1424,6 +1424,34 @@ async def test_reevaluate_profiles_command_invalidates_runtime_payload_signature
 
 
 @pytest.mark.asyncio
+async def test_reevaluate_profiles_command_uses_running_config_reload(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = SessionManager()
+    manager.reload_config_from_disk = Mock()  # type: ignore[method-assign]
+    reevaluate_profiles = AsyncMock()
+    monkeypatch.setattr(session_profiles_module, "reevaluate_profiles", reevaluate_profiles)
+    peer = PeerCredentials(pid=1, uid=1000, gid=1000)
+
+    async def running_reload() -> bool:
+        await asyncio.sleep(0)
+        return True
+
+    manager.reload_task = asyncio.create_task(running_reload())
+
+    result = await manager._handle_session_request(
+        {"command": "reevaluate_profiles"},
+        "client",
+        peer,
+        object(),
+    )
+
+    assert result == {"status": "ok"}
+    manager.reload_config_from_disk.assert_not_called()  # type: ignore[attr-defined]
+    reevaluate_profiles.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_diagnostics_snapshot_event_forwards_to_gui_clients() -> None:
     manager = SessionManager()
     manager.broadcast_to_session_clients = Mock()  # type: ignore[method-assign]

--- a/tests/session/test_session_manager_command_runtime.py
+++ b/tests/session/test_session_manager_command_runtime.py
@@ -1424,7 +1424,7 @@ async def test_reevaluate_profiles_command_invalidates_runtime_payload_signature
 
 
 @pytest.mark.asyncio
-async def test_reevaluate_profiles_command_uses_running_config_reload(
+async def test_reevaluate_profiles_command_runs_fresh_reload_after_running_config_reload(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     manager = SessionManager()
@@ -1447,8 +1447,11 @@ async def test_reevaluate_profiles_command_uses_running_config_reload(
     )
 
     assert result == {"status": "ok"}
-    manager.reload_config_from_disk.assert_not_called()  # type: ignore[attr-defined]
-    reevaluate_profiles.assert_not_awaited()
+    manager.reload_config_from_disk.assert_called_once_with()  # type: ignore[attr-defined]
+    reevaluate_profiles.assert_awaited_once_with(
+        manager,
+        reason="session command reevaluate",
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/session/test_session_manager_command_runtime.py
+++ b/tests/session/test_session_manager_command_runtime.py
@@ -1455,6 +1455,37 @@ async def test_reevaluate_profiles_command_runs_fresh_reload_after_running_confi
 
 
 @pytest.mark.asyncio
+async def test_reevaluate_profiles_command_runs_fresh_reload_after_failed_running_reload(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = SessionManager()
+    manager.reload_config_from_disk = Mock()  # type: ignore[method-assign]
+    reevaluate_profiles = AsyncMock()
+    monkeypatch.setattr(session_profiles_module, "reevaluate_profiles", reevaluate_profiles)
+    peer = PeerCredentials(pid=1, uid=1000, gid=1000)
+
+    async def running_reload() -> bool:
+        await asyncio.sleep(0)
+        return False
+
+    manager.reload_task = asyncio.create_task(running_reload())
+
+    result = await manager._handle_session_request(
+        {"command": "reevaluate_profiles"},
+        "client",
+        peer,
+        object(),
+    )
+
+    assert result == {"status": "ok"}
+    manager.reload_config_from_disk.assert_called_once_with()  # type: ignore[attr-defined]
+    reevaluate_profiles.assert_awaited_once_with(
+        manager,
+        reason="session command reevaluate",
+    )
+
+
+@pytest.mark.asyncio
 async def test_diagnostics_snapshot_event_forwards_to_gui_clients() -> None:
     manager = SessionManager()
     manager.broadcast_to_session_clients = Mock()  # type: ignore[method-assign]

--- a/tests/test_session_manager_core.py
+++ b/tests/test_session_manager_core.py
@@ -897,6 +897,41 @@ async def test_scheduled_config_reload_branches() -> None:
     manager.reload_profiles.assert_awaited_once()  # type: ignore[attr-defined]
 
 
+@pytest.mark.asyncio
+async def test_explicit_reload_coalesces_config_watcher_reload() -> None:
+    manager = SessionManager()
+    manager.reload_profiles = AsyncMock(return_value=True)  # type: ignore[method-assign]
+
+    manager._schedule_config_reload()
+    first_timer = manager.config_reload_timer
+
+    assert first_timer is not None
+
+    manager.suppress_config_watcher_reload()
+
+    assert first_timer.cancelled()
+    assert manager.config_reload_timer is None
+
+    manager._schedule_config_reload()
+
+    assert manager.config_reload_timer is None
+
+    manager._schedule_config_reload()
+
+    assert manager.config_reload_timer is None
+
+    manager.running = True
+    manager._run_scheduled_config_reload()
+
+    manager.reload_profiles.assert_not_awaited()  # type: ignore[attr-defined]
+
+    manager._config_reload_coalesce_until = 0.0
+    manager._schedule_config_reload()
+
+    assert manager.config_reload_timer is not None
+    manager.config_reload_timer.cancel()
+
+
 def test_resolved_button_codes_skips_unresolved_buttons(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary
- Defer mapping commits from the key selector until after the dialog is closed, preventing stale-state races
- Unify emit-then-close pattern into `_emit_selected_action()` across all selector dialogs
- Introduce a 500 ms post-close delay (`SELECTOR_COMMIT_AFTER_CLOSE_DELAY_MS`) before writing the mapping
- Coalesce config-watcher-triggered reloads with explicit `reload` / `reevaluate_profiles` commands: suppress scheduled watcher timers and join any in-flight reload task
- Add `suppress_config_watcher_reload()` and `wait_for_running_config_reload()` to the session manager

## Testing
- `test_device_tab_profile_save_requests_explicit_reevaluate` — confirms `_save_profile()` emits `reevaluate_profiles` (not `reload`)
- `test_device_tab_selector_profile_save_waits_for_dialog_closed` — confirms deferred commit fires only after `closed` signal + timer expiry
- `test_key_selector_dialog_selection_emits_and_closes` — confirms each selection call both emits and closes
- `test_reevaluate_profiles_command_uses_running_config_reload` — confirms the command joins a running reload instead of starting a second one
- `test_explicit_reload_coalesces_config_watcher_reload` — confirms `suppress_config_watcher_reload` cancels the timer and blocks subsequent scheduled reloads
- Not run: end-to-end GUI interaction tests; all other existing tests pass via `./scripts/check.sh`