### PR TITLE
Add `move` compact macro token for natural-abs cursor movement

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -72,7 +72,7 @@ Compile compact event tokens into a temporary macro and play it immediately.
 ```bash
 keymasq play key_a
 keymasq play key_leftctrl:1 wait:20 key_c wait:20 key_leftctrl:0
-keymasq play move_abs:100:200 wait:10 btn_left
+keymasq play move:100:200 wait:10 btn_left
 keymasq play key_a wait:10:20 key_b
 keymasq play --speed 0.5 key_a wait:20 key_b
 keymasq play --print-json key_a wait:20 key_b
@@ -90,8 +90,22 @@ The compact grammar uses `:` for all parameters:
 | `btn_left:0` / `btn_left:up` | Release a held button |
 | `move_abs:X:Y` | Move the pointer to absolute coordinates |
 | `move_rel:DX:DY` | Move the pointer relative to the current position |
+| `move:X:Y` | Move the pointer to absolute coordinates using realtime cursor feedback |
+| `move:X:Y:SPEED[:JITTER[:CURVE[:TOLERANCE[:MAX_DURATION_MS[:STOP_ON_FAILURE]]]]]` | Natural move with tuning options; `SPEED` is pixels per second, so `100000` is 100 kpx/s |
 | `wait:MS` | Wait a fixed number of milliseconds |
 | `wait:MIN:MAX` | Wait a random number of milliseconds in the inclusive range |
+
+`move_nat`, `move_natural`, and `move_natural_abs` are accepted as aliases for
+`move`. The default compact natural move is `100000` px/s, zero jitter, linear
+curve, `2` px tolerance, `3000` ms timeout, and `stop_on_failure=false`. If you
+provide a `SPEED` lower than `100000` and omit `CURVE`, the curve defaults to
+`natural`; otherwise the omitted curve defaults to `linear`.
+
+Natural movement uses the same runtime as `mouse_move_natural_abs` profile and
+macro actions, and macro playback waits for the move to finish before later
+events run. `move_abs` remains available as the compatibility absolute-move
+token; it is not silently rewritten because existing scripts may rely on its
+immediate behavior. Use `key_move` if you need the Linux `KEY_MOVE` key token.
 
 The compact compiler automatically releases any held keys/buttons at the end of
 the macro, in reverse press order. It rejects duplicate explicit presses and
@@ -107,7 +121,8 @@ keymasq --json play --json < macro.json
 
 `play --json` accepts either an event list or a macro object with an `events`
 field. JSON playback uses the existing macro runtime and supports the full macro
-event schema. Pointer moves compiled from `move_abs` and `move_rel` are semantic
+event schema. Pointer moves compiled from `move_abs`, `move_rel`, and
+`move` are semantic
 macro actions, for example `{"macro_action":"mouse_move_abs","x":100,"y":200}`.
 The compact token grammar intentionally does not support `exec`.
 

--- a/docs/agents/macros.txt
+++ b/docs/agents/macros.txt
@@ -67,9 +67,17 @@ btn_left:down      press button
 btn_left:up        release button
 move_abs:X:Y       absolute mouse move
 move_rel:DX:DY     relative mouse move
+move:X:Y           natural absolute mouse move
+move:X:Y:SPEED[:JITTER[:CURVE[:TOLERANCE[:MAX_DURATION_MS[:STOP_ON_FAILURE]]]]]
+                   natural absolute mouse move with tuning; SPEED is px/s
 wait:MS            fixed wait
 wait:MIN:MAX       random wait
 ```
+
+Prefer `move:X:Y` for reliable absolute cursor positioning. It uses the natural
+mouse movement runtime, which sends relative motion in a feedback loop and
+checks realtime cursor position until the cursor lands.
+`move` defaults to 100000 px/s, zero jitter, and linear curve.
 
 ## Macro JSON
 

--- a/keymasq/cli/__main__.py
+++ b/keymasq/cli/__main__.py
@@ -91,7 +91,8 @@ def main() -> None:
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog=(
             "Compact tokens: key_a, key_a:1, key_a:0, btn_left,\n"
-            "move_abs:X:Y, move_rel:DX:DY, wait:MS, wait:MIN:MAX\n"
+            "move_abs:X:Y, move_rel:DX:DY, move:X:Y[:SPEED],\n"
+            "wait:MS, wait:MIN:MAX\n"
             'Example: keymasq play key_leftctrl:1 wait:20 key_c wait:20 key_leftctrl:0\n'
             f"Full reference: {_docs_url()}"
         ),

--- a/keymasq/common/macro_compile.py
+++ b/keymasq/common/macro_compile.py
@@ -1,12 +1,23 @@
 import json
 import unicodedata
+from math import isfinite
 from typing import cast
 
 import evdev
 
+from keymasq.common.coercion import coerce_bool
+from keymasq.common.models import (
+    DEFAULT_NATURAL_MOUSE_MOVE_MAX_DURATION_MS,
+    DEFAULT_NATURAL_MOUSE_MOVE_TOLERANCE,
+    NATURAL_MOUSE_MOVE_CURVES,
+)
 from keymasq.common.types import JsonObject
 
 IntLike = int | float | str | bytes
+_COMPACT_NATURAL_MOUSE_MOVE_DEFAULT_SPEED = 100_000.0
+_COMPACT_NATURAL_MOUSE_MOVE_DEFAULT_JITTER = 0.0
+_COMPACT_NATURAL_MOUSE_MOVE_FAST_CURVE = "linear"
+_COMPACT_NATURAL_MOUSE_MOVE_SLOW_CURVE = "natural"
 
 _TYPE_MACRO_TEXT_TRANSLATION = str.maketrans(
     {
@@ -266,6 +277,60 @@ def build_compact_macro_events(tokens: list[str]) -> list[JsonObject]:
             advance_sequence()
             continue
 
+        if name in {"move", "move_nat", "move_natural", "move_natural_abs"}:
+            if len(args) < 2 or len(args) > 8:
+                raise ValueError(
+                    f"{name} requires x and y arguments, with optional speed, jitter, "
+                    "curve, tolerance, max_duration_ms, and stop_on_failure"
+                )
+            x = _parse_int(args[0], f"{name} x")
+            y = _parse_int(args[1], f"{name} y")
+            speed = (
+                _COMPACT_NATURAL_MOUSE_MOVE_DEFAULT_SPEED
+                if len(args) < 3
+                else _parse_positive_float(args[2], f"{name} speed")
+            )
+            jitter = (
+                _COMPACT_NATURAL_MOUSE_MOVE_DEFAULT_JITTER
+                if len(args) < 4
+                else _parse_non_negative_float(args[3], f"{name} jitter")
+            )
+            curve = (
+                _default_compact_natural_mouse_curve(speed)
+                if len(args) < 5
+                else _parse_natural_mouse_curve(args[4], f"{name} curve")
+            )
+            tolerance = (
+                DEFAULT_NATURAL_MOUSE_MOVE_TOLERANCE
+                if len(args) < 6
+                else _parse_non_negative_int(args[5], f"{name} tolerance")
+            )
+            max_duration_ms = (
+                DEFAULT_NATURAL_MOUSE_MOVE_MAX_DURATION_MS
+                if len(args) < 7
+                else _parse_positive_int(args[6], f"{name} max_duration_ms")
+            )
+            stop_on_failure = (
+                False if len(args) < 8 else _parse_bool(args[7], f"{name} stop_on_failure")
+            )
+            _append_mouse_move_event(
+                events,
+                "mouse_move_natural_abs",
+                x,
+                y,
+                t_us,
+                options={
+                    "speed": speed,
+                    "jitter": jitter,
+                    "curve": curve,
+                    "tolerance": tolerance,
+                    "max_duration_ms": max_duration_ms,
+                    "stop_on_failure": stop_on_failure,
+                },
+            )
+            advance_sequence()
+            continue
+
         device_type, code = resolve_key_or_button(name)
         if len(args) > 1:
             raise ValueError(f"{name} accepts at most one state argument")
@@ -520,19 +585,22 @@ def _append_mouse_move_event(
     x: int,
     y: int,
     t_us: int,
+    *,
+    options: JsonObject | None = None,
 ) -> None:
-    events.append(
-        {
-            "device_type": "macro",
-            "type": 0,
-            "code": 0,
-            "value": 0,
-            "t_us": int(t_us),
-            "macro_action": action,
-            "x": int(x),
-            "y": int(y),
-        }
-    )
+    event: JsonObject = {
+        "device_type": "macro",
+        "type": 0,
+        "code": 0,
+        "value": 0,
+        "t_us": int(t_us),
+        "macro_action": action,
+        "x": int(x),
+        "y": int(y),
+    }
+    if options:
+        event.update(options)
+    events.append(event)
 
 
 def _parse_int(value: str, label: str) -> int:
@@ -547,6 +615,58 @@ def _parse_non_negative_int(value: str, label: str) -> int:
     if parsed < 0:
         raise ValueError(f"{label} must be non-negative")
     return parsed
+
+
+def _parse_positive_int(value: str, label: str) -> int:
+    parsed = _parse_int(value, label)
+    if parsed <= 0:
+        raise ValueError(f"{label} must be greater than 0")
+    return parsed
+
+
+def _parse_float(value: str, label: str) -> float:
+    try:
+        parsed = float(value)
+    except ValueError as exc:
+        raise ValueError(f"{label} must be a number") from exc
+    if not isfinite(parsed):
+        raise ValueError(f"{label} must be finite")
+    return parsed
+
+
+def _parse_positive_float(value: str, label: str) -> float:
+    parsed = _parse_float(value, label)
+    if parsed <= 0:
+        raise ValueError(f"{label} must be greater than 0")
+    return parsed
+
+
+def _parse_non_negative_float(value: str, label: str) -> float:
+    parsed = _parse_float(value, label)
+    if parsed < 0:
+        raise ValueError(f"{label} must be non-negative")
+    return parsed
+
+
+def _parse_natural_mouse_curve(value: str, label: str) -> str:
+    curve = value.strip().lower()
+    if curve not in NATURAL_MOUSE_MOVE_CURVES:
+        expected = ", ".join(sorted(NATURAL_MOUSE_MOVE_CURVES))
+        raise ValueError(f"{label} must be one of: {expected}")
+    return curve
+
+
+def _default_compact_natural_mouse_curve(speed: float) -> str:
+    if speed < _COMPACT_NATURAL_MOUSE_MOVE_DEFAULT_SPEED:
+        return _COMPACT_NATURAL_MOUSE_MOVE_SLOW_CURVE
+    return _COMPACT_NATURAL_MOUSE_MOVE_FAST_CURVE
+
+
+def _parse_bool(value: str, label: str) -> bool:
+    try:
+        return coerce_bool(value, strict=True)
+    except ValueError as exc:
+        raise ValueError(f"{label} must be a boolean") from exc
 
 
 def _infer_device_types(events: list[JsonObject]) -> list[str]:

--- a/tests/common/test_macro_compile.py
+++ b/tests/common/test_macro_compile.py
@@ -87,6 +87,101 @@ def test_compact_move_events_use_macro_action_shape() -> None:
     ]
 
 
+def test_compact_natural_move_event_uses_default_options() -> None:
+    events = build_compact_macro_events(["move:100:200"])
+
+    assert events == [
+        {
+            "device_type": "macro",
+            "type": 0,
+            "code": 0,
+            "value": 0,
+            "t_us": 0,
+            "macro_action": "mouse_move_natural_abs",
+            "x": 100,
+            "y": 200,
+            "speed": 100000.0,
+            "jitter": 0.0,
+            "curve": "linear",
+            "tolerance": 2,
+            "max_duration_ms": 3000,
+            "stop_on_failure": False,
+        }
+    ]
+
+
+def test_compact_natural_move_event_accepts_aliases() -> None:
+    for name in ("move", "move_nat", "move_natural", "move_natural_abs"):
+        events = build_compact_macro_events([f"{name}:100:200"])
+
+        assert events[0]["macro_action"] == "mouse_move_natural_abs"
+        assert events[0]["x"] == 100
+        assert events[0]["y"] == 200
+
+
+def test_compact_natural_move_uses_natural_curve_for_lower_custom_speed() -> None:
+    events = build_compact_macro_events(["move:100:200:99999"])
+
+    assert events[0]["speed"] == 99999.0
+    assert events[0]["jitter"] == 0.0
+    assert events[0]["curve"] == "natural"
+
+
+def test_compact_natural_move_allows_explicit_curve_for_lower_custom_speed() -> None:
+    events = build_compact_macro_events(["move:100:200:12000:0:linear"])
+
+    assert events[0]["speed"] == 12000.0
+    assert events[0]["curve"] == "linear"
+
+
+def test_compact_natural_move_event_accepts_tuning_options() -> None:
+    events = build_compact_macro_events(
+        ["move:300:400:100000:0:linear:1:500:true"]
+    )
+
+    assert events == [
+        {
+            "device_type": "macro",
+            "type": 0,
+            "code": 0,
+            "value": 0,
+            "t_us": 0,
+            "macro_action": "mouse_move_natural_abs",
+            "x": 300,
+            "y": 400,
+            "speed": 100000.0,
+            "jitter": 0.0,
+            "curve": "linear",
+            "tolerance": 1,
+            "max_duration_ms": 500,
+            "stop_on_failure": True,
+        }
+    ]
+
+
+def test_compact_explicit_key_move_still_taps_evdev_key_move() -> None:
+    events = build_compact_macro_events(["key_move"])
+
+    assert _key_values(events, evdev.ecodes.KEY_MOVE) == [1, 0]
+
+
+@pytest.mark.parametrize(
+    "token, match",
+    [
+        ("move:1", "requires x and y"),
+        ("move:1:2:0", "speed must be greater than 0"),
+        ("move:1:2:100:nan", "jitter must be finite"),
+        ("move:1:2:100:0:ease", "curve must be one of"),
+        ("move:1:2:100:0:linear:-1", "tolerance must be non-negative"),
+        ("move:1:2:100:0:linear:1:0", "max_duration_ms must be greater than 0"),
+        ("move:1:2:100:0:linear:1:500:maybe", "stop_on_failure must be a boolean"),
+    ],
+)
+def test_compact_natural_move_rejects_invalid_options(token: str, match: str) -> None:
+    with pytest.raises(ValueError, match=match):
+        build_compact_macro_events([token])
+
+
 def test_compact_releases_held_keys_at_end_in_reverse_order() -> None:
     events = build_compact_macro_events(["key_leftctrl:1", "key_leftshift:1"])
 

--- a/tests/test_entrypoints_and_cli.py
+++ b/tests/test_entrypoints_and_cli.py
@@ -124,7 +124,8 @@ def test_cli_main_play_help_includes_compact_tokens_and_docs(
 
     assert excinfo.value.code == 0
     out = capsys.readouterr().out
-    assert "move_abs:X:Y, move_rel:DX:DY, wait:MS, wait:MIN:MAX" in out
+    assert "move_abs:X:Y, move_rel:DX:DY, move:X:Y[:SPEED]," in out
+    assert "wait:MS, wait:MIN:MAX" in out
     assert "https://keymasq.tools/docs/v1.2.3/CLI.md" in out
 
 


### PR DESCRIPTION
## Summary

- Adds `move:X:Y` compact macro token (aliases: `move_nat`, `move_natural`, `move_natural_abs`) that compiles to `mouse_move_natural_abs` macro actions
- Supports optional tuning parameters: speed, jitter, curve, tolerance, max_duration_ms, stop_on_failure
- Speed < 100000 defaults curve to `natural`; otherwise defaults to `linear`
- `move_abs` is preserved unchanged for existing users who need immediate absolute moves
- `key_move` continues to emit the evdev `KEY_MOVE` key token (no collision)
- Updates CLI help text, docs, agent reference, and tests

## Testing

- `tests/common/test_macro_compile.py` — tests for default options, aliases, curve inference, full tuning options, and invalid option rejection
- `tests/test_entrypoints_and_cli.py` — CLI help text updated to include `move:X:Y[:SPEED]`
- `./scripts/check.sh` — ruff, basedpyright, and pytest all pass