### PR TITLE
Extract compositor-vm-lib for shared desktop/VM test infrastructure

### DIFF
--- a/docs/LISTENER_VM_TESTS.md
+++ b/docs/LISTENER_VM_TESTS.md
@@ -112,8 +112,8 @@ These tests are heavy. A Linux host with KVM acceleration is strongly recommende
 The VM environments install:
 
 - `keymasq-session-query` — sends commands to the session socket and prints the JSON response.
-- `keymasq-listener-window-lab` — small GTK4 app controlled over a Unix socket.
-- `keymasq-listener-window-labctl` — CLI client for `window-lab`.
+- `keymasq-listener-window-lab` — the shared GTK4 window lab wrapped with a listener-specific command name.
+- `keymasq-listener-window-labctl` — shared CLI client for `window-lab` wrapped with a listener-specific command name.
 
 `window-lab` gives the test real desktop windows to observe without depending on compositor-specific tooling:
 

--- a/flake.nix
+++ b/flake.nix
@@ -140,9 +140,10 @@
       listenerVmMatrix =
         let
           pkgs = mkPkgs "x86_64-linux";
+          compositorVmLib = self.lib.compositorVmLib { inherit pkgs; };
         in
         import ./nix/listener-vm-matrix.nix {
-          inherit pkgs;
+          inherit pkgs compositorVmLib;
           system = "x86_64-linux";
           keymasqPackage = packagesFor.x86_64-linux.default;
           keymasqModule = self.nixosModules.default;
@@ -196,6 +197,8 @@
           program = "${self.packages.${system}.default}/bin/keymasq";
         };
       });
+
+      lib.compositorVmLib = { pkgs }: import ./nix/compositor-vm-lib.nix { inherit pkgs; };
 
       checks = {
         x86_64-linux =

--- a/nix/compositor-vm-lib.nix
+++ b/nix/compositor-vm-lib.nix
@@ -443,12 +443,18 @@ EOF
           probe_cmd: str | None = None,
       ) -> None:
           deadline = time.time() + timeout
+          socket_seen = False
+          last_probe_status = None
+          last_probe_output = ""
           while time.time() < deadline:
               status, _ = machine.execute(as_user(f"test -S {socket_path}"), timeout=20)
               if status == 0:
+                  socket_seen = True
                   if probe_cmd is None:
                       return
-                  ready_status, _ = machine.execute(as_user(probe_cmd), timeout=20)
+                  ready_status, ready_output = machine.execute(as_user(probe_cmd), timeout=20)
+                  last_probe_status = ready_status
+                  last_probe_output = ready_output
                   if ready_status == 0:
                       return
 
@@ -465,6 +471,12 @@ EOF
               time.sleep(1)
 
           ${dumpFunctionName}(f"Timed out waiting for {description}")
+          if socket_seen:
+              raise AssertionError(
+                  f"{description} socket was created by {unit_name}, "
+                  f"but readiness probe did not succeed "
+                  f"(exit={last_probe_status}): {last_probe_output}"
+              )
           raise AssertionError(f"{description} was not created by {unit_name}")
     '';
 }

--- a/nix/compositor-vm-lib.nix
+++ b/nix/compositor-vm-lib.nix
@@ -1,0 +1,470 @@
+{ pkgs }:
+
+let
+  lib = pkgs.lib;
+
+  indent =
+    prefix: text:
+    lib.concatMapStringsSep "\n" (line: prefix + line) (
+      lib.splitString "\n" (lib.removeSuffix "\n" text)
+    );
+
+  giTypelibPath = lib.makeSearchPath "lib/girepository-1.0" [
+    pkgs.cairo
+    pkgs.gdk-pixbuf
+    pkgs.glib
+    pkgs.graphene
+    pkgs.gtk4
+    pkgs.pango
+  ];
+
+  gtkPython = pkgs.python3.withPackages (ps: [ ps.pygobject3 ]);
+
+  defaultNiriConfig = ''
+    input {
+        focus-follows-mouse
+        warp-mouse-to-focus mode="center-xy-always"
+    }
+
+    debug {
+        honor-xdg-activation-with-invalid-serial
+    }
+  '';
+in
+rec {
+  mkGtkScript =
+    name: script:
+    pkgs.stdenvNoCC.mkDerivation {
+      pname = name;
+      version = "1";
+      dontUnpack = true;
+
+      nativeBuildInputs = [
+        pkgs.gobject-introspection
+        pkgs.wrapGAppsHook4
+      ];
+      buildInputs = [
+        gtkPython
+        pkgs.adwaita-icon-theme
+        pkgs.cairo
+        pkgs.gdk-pixbuf
+        pkgs.glib
+        pkgs.graphene
+        pkgs.gtk4
+        pkgs.hicolor-icon-theme
+        pkgs.pango
+      ];
+
+      preFixup = ''
+        gappsWrapperArgs+=(
+          --prefix GI_TYPELIB_PATH : "${giTypelibPath}"
+        )
+      '';
+
+      installPhase = ''
+        mkdir -p "$out/bin"
+        install -m755 ${script} "$out/bin/${name}"
+        sed -i '1s|.*|#!${gtkPython}/bin/python|' "$out/bin/${name}"
+      '';
+    };
+
+  mkWindowLabTools =
+    {
+      commandPrefix,
+      packageName,
+      includeWaylandLauncher ? false,
+      extraPaths ? [ ],
+    }:
+    let
+      windowLabName = "${commandPrefix}-window-lab";
+      windowLabCtlName = "${commandPrefix}-window-labctl";
+      windowLab = mkGtkScript windowLabName ./compositor-vm-tools/window-lab.py;
+      windowLabCtl = pkgs.writeShellApplication {
+        name = windowLabCtlName;
+        runtimeInputs = [ pkgs.python3 ];
+        text = ''
+          exec ${pkgs.python3}/bin/python ${./compositor-vm-tools/window-labctl.py} "$@"
+        '';
+      };
+      windowLabWayland = pkgs.writeShellApplication {
+        name = "${windowLabName}-wayland";
+        runtimeInputs = [ windowLab ];
+        text = ''
+          export GDK_BACKEND=wayland
+          export GSK_RENDERER=cairo
+          export LIBGL_ALWAYS_SOFTWARE=1
+          exec ${windowLabName} "$@"
+        '';
+      };
+      paths =
+        [
+          windowLab
+          windowLabCtl
+        ]
+        ++ lib.optionals includeWaylandLauncher [ windowLabWayland ]
+        ++ extraPaths;
+    in
+    {
+      inherit
+        paths
+        windowLab
+        windowLabCtl
+        windowLabName
+        windowLabCtlName
+        ;
+      tools = pkgs.symlinkJoin {
+        name = packageName;
+        inherit paths;
+      };
+    }
+    // lib.optionalAttrs includeWaylandLauncher {
+      inherit windowLabWayland;
+      windowLabWaylandName = "${windowLabName}-wayland";
+    };
+
+  mkBaseDesktopModule =
+    {
+      name,
+      vmUser,
+      vmUid,
+      userDescription,
+      memorySize ? 3072,
+      cores ? 4,
+      extraGroups ? [
+        "video"
+        "input"
+      ],
+      imports ? [ ],
+      systemPackages ? [ ],
+      extraConfig ? { },
+    }:
+    { ... }:
+    {
+      inherit imports;
+      config = lib.mkMerge [
+        {
+          documentation.nixos.enable = false;
+
+          virtualisation = {
+            graphics = true;
+            memorySize = memorySize;
+            cores = cores;
+          };
+
+          networking.hostName = name;
+          time.timeZone = "UTC";
+          i18n.defaultLocale = "en_US.UTF-8";
+
+          users.users.${vmUser} = {
+            isNormalUser = true;
+            uid = vmUid;
+            description = userDescription;
+            createHome = true;
+            home = "/home/${vmUser}";
+            inherit extraGroups;
+          };
+
+          services.displayManager.autoLogin = {
+            enable = true;
+            user = vmUser;
+          };
+
+          hardware.graphics.enable = true;
+          services.dbus.enable = true;
+          security.polkit.enable = true;
+          services.libinput.enable = true;
+          programs.dconf.enable = true;
+
+          environment.systemPackages = systemPackages;
+        }
+        extraConfig
+      ];
+    };
+
+  desktopModules = rec {
+    sway = {
+      services.displayManager.defaultSession = "sway";
+      services.displayManager.sddm = {
+        enable = true;
+        wayland.enable = true;
+      };
+      programs.sway.enable = true;
+    };
+
+    xfce = {
+      services.xserver.enable = true;
+      services.displayManager.defaultSession = "xfce";
+      services.xserver.displayManager.lightdm.enable = true;
+      services.xserver.desktopManager.xfce.enable = true;
+    };
+
+    gnome =
+      {
+        enableXserver ? false,
+        sessionPath ? [ ],
+        extraGSettingsOverrides ? "",
+        dconfExtensions ? [ ],
+      }:
+      lib.mkMerge [
+        (lib.optionalAttrs enableXserver {
+          services.xserver.enable = true;
+        })
+        {
+          services.displayManager.defaultSession = "gnome";
+          services.displayManager.gdm.enable = true;
+          services.desktopManager.gnome =
+            {
+              enable = true;
+            }
+            // lib.optionalAttrs (sessionPath != [ ]) {
+              inherit sessionPath;
+            }
+            // lib.optionalAttrs (extraGSettingsOverrides != "") {
+              inherit extraGSettingsOverrides;
+            };
+        }
+        (lib.optionalAttrs (dconfExtensions != [ ]) {
+          programs.dconf.profiles.user.databases = [
+            {
+              settings = {
+                "org/gnome/shell" = {
+                  disable-user-extensions = false;
+                  enabled-extensions = dconfExtensions;
+                };
+              };
+            }
+          ];
+        })
+      ];
+
+    kde =
+      { enableXserver ? false }:
+      lib.mkMerge [
+        (lib.optionalAttrs enableXserver {
+          services.xserver.enable = true;
+        })
+        {
+          services.displayManager.defaultSession = "plasma";
+          services.displayManager.sddm = {
+            enable = true;
+            wayland.enable = true;
+          };
+          services.desktopManager.plasma6.enable = true;
+        }
+      ];
+
+    hyprland =
+      { withUWSM ? false }:
+      {
+        services.displayManager.defaultSession = if withUWSM then "hyprland-uwsm" else "hyprland";
+        services.displayManager.sddm = {
+          enable = true;
+          wayland.enable = true;
+        };
+        programs.hyprland =
+          {
+            enable = true;
+          }
+          // lib.optionalAttrs withUWSM {
+            withUWSM = true;
+          };
+      };
+
+    cosmic =
+      { sessionPackage ? cosmicMinimalSessionPackage }:
+      {
+        services.xserver.enable = true;
+        services.displayManager.defaultSession = "cosmic-minimal";
+        services.displayManager.sessionPackages = [ sessionPackage ];
+        services.displayManager.sddm = {
+          enable = true;
+          wayland.enable = true;
+        };
+        environment.systemPackages = [ pkgs.cosmic-comp ];
+      };
+
+    niri =
+      {
+        package ? niriPatched,
+        configText ? defaultNiriConfig,
+      }:
+      {
+        services.displayManager.defaultSession = "niri";
+        services.displayManager.sddm = {
+          enable = true;
+          wayland.enable = true;
+        };
+        programs.niri = {
+          enable = true;
+          package = package;
+        };
+        environment.etc."niri/config.kdl".text = configText;
+      };
+  };
+
+  cosmicMinimalSessionPackage = pkgs.stdenvNoCC.mkDerivation {
+    pname = "keymasq-cosmic-minimal-session";
+    version = "1";
+    dontUnpack = true;
+    passthru.providedSessions = [ "cosmic-minimal" ];
+    installPhase = ''
+      mkdir -p "$out/bin" "$out/share/wayland-sessions"
+      cat > "$out/bin/cosmic-minimal-session" <<'EOF'
+#!${pkgs.bash}/bin/bash
+set -euo pipefail
+export XDG_CURRENT_DESKTOP=COSMIC
+export DESKTOP_SESSION=cosmic
+export XDG_SESSION_TYPE=wayland
+exec ${pkgs.cosmic-comp}/bin/cosmic-comp
+EOF
+      chmod +x "$out/bin/cosmic-minimal-session"
+      cat > "$out/share/wayland-sessions/cosmic-minimal.desktop" <<EOF
+[Desktop Entry]
+Name=COSMIC Minimal
+Comment=Minimal COSMIC compositor session for Keymasq compositor VM tests
+Exec=$out/bin/cosmic-minimal-session
+Type=Application
+DesktopNames=COSMIC
+EOF
+    '';
+  };
+
+  niriExpectedVersion = "26.04";
+
+  niriPatched = assert pkgs.niri.version == niriExpectedVersion; pkgs.niri.overrideAttrs (old: {
+    postPatch = (old.postPatch or "") + ''
+      # Allow software EGL renderers (llvmpipe) for VM testing.
+      sed -i 's/!egl_device\.is_software()/true/' src/backend/tty.rs
+
+      if grep -q 'egl_device\.is_software()' src/backend/tty.rs; then
+        echo "ERROR: niri software-renderer patch did not apply - see niriPatched in compositor-vm-lib.nix"
+        exit 1
+      fi
+    '';
+  });
+
+  testScriptPrelude =
+    {
+      vmUser,
+      vmUid,
+      dumpFunctionName ? "dump_debug",
+      extraDebugScript ? "",
+    }:
+    ''
+      import base64
+      import json
+      import shlex
+      import time
+
+      runtime_dir = "/run/user/${toString vmUid}"
+
+      def as_user(cmd: str) -> str:
+          return (
+              "runuser -u ${vmUser} -- env "
+              f"HOME=/home/${vmUser} "
+              f"XDG_RUNTIME_DIR={runtime_dir} "
+              f"DBUS_SESSION_BUS_ADDRESS=unix:path={runtime_dir}/bus "
+              "sh -lc "
+              + shlex.quote(cmd)
+          )
+
+      def user_env(name: str) -> str:
+          return machine.succeed(
+              as_user(f"systemctl --user show-environment | sed -n 's/^{name}=//p'")
+          ).strip()
+
+      def as_user_with_env(env: dict[str, str], cmd: str) -> str:
+          env_args = " ".join(f"{key}={shlex.quote(value)}" for key, value in env.items())
+          return (
+              "runuser -u ${vmUser} -- env "
+              f"HOME=/home/${vmUser} "
+              f"XDG_RUNTIME_DIR={runtime_dir} "
+              f"DBUS_SESSION_BUS_ADDRESS=unix:path={runtime_dir}/bus "
+              f"{env_args} sh -lc "
+              + shlex.quote(cmd)
+          )
+
+      def process_env_value(process_pattern: str, variable: str) -> str:
+          script = (
+              f"pid=$(pgrep -u ${toString vmUid} -f {shlex.quote(process_pattern)} | head -n1); "
+              "test -n \"$pid\"; "
+              f"tr '\\0' '\\n' < /proc/$pid/environ | sed -n 's/^{variable}=//p' | head -n1"
+          )
+          return machine.succeed(script).strip()
+
+      def set_user_environment(env: dict[str, str]) -> None:
+          env_args = " ".join(f"{key}={shlex.quote(value)}" for key, value in env.items())
+          machine.succeed(as_user(f"systemctl --user set-environment {env_args}"))
+
+      def log_command_output(label: str, cmd: str) -> None:
+          status, output = machine.execute(cmd, timeout=30)
+          machine.log(f"{label} (exit={status})\n{output}")
+
+      def ${dumpFunctionName}(label: str) -> None:
+          machine.log(f"==== {label} ====")
+          log_command_output("loginctl sessions", "loginctl list-sessions --no-legend || true")
+          log_command_output(
+              "display manager",
+              "systemctl status display-manager.service --no-pager || true",
+          )
+          log_command_output(
+              "user manager",
+              "systemctl status user@${toString vmUid}.service --no-pager || true",
+          )
+          log_command_output("runtime dir", f"ls -la {runtime_dir} || true")
+          log_command_output("user environment", as_user("systemctl --user show-environment || true"))
+      ${indent "    " extraDebugScript}
+
+      def wait_for_command(description: str, cmd: str, timeout: int = 180) -> str:
+          machine.log(f"Waiting for {description}: {cmd}")
+          deadline = time.time() + timeout
+          last_status = None
+          last_output = ""
+          while time.time() < deadline:
+              status, output = machine.execute(cmd, timeout=20)
+              last_status = status
+              last_output = output
+              if status == 0:
+                  return output
+              time.sleep(1)
+          ${dumpFunctionName}(f"Timed out waiting for {description}")
+          raise AssertionError(
+              f"{description} did not become ready (exit={last_status}): {last_output}"
+          )
+
+      def wait_for_user_command(description: str, cmd: str, timeout: int = 180) -> str:
+          return wait_for_command(description, as_user(cmd), timeout=timeout)
+
+      def wait_for_user_socket(
+          description: str,
+          socket_path: str,
+          unit_name: str,
+          timeout: int = 60,
+          probe_cmd: str | None = None,
+      ) -> None:
+          deadline = time.time() + timeout
+          while time.time() < deadline:
+              status, _ = machine.execute(as_user(f"test -S {socket_path}"), timeout=20)
+              if status == 0:
+                  if probe_cmd is None:
+                      return
+                  ready_status, _ = machine.execute(as_user(probe_cmd), timeout=20)
+                  if ready_status == 0:
+                      return
+
+              unit_status, _ = machine.execute(
+                  as_user(f"systemctl --user is-failed {unit_name}"), timeout=20
+              )
+              if unit_status == 0:
+                  ${dumpFunctionName}(f"{unit_name} failed while waiting for {description}")
+                  raise AssertionError(
+                      machine.succeed(
+                          as_user(f"journalctl --user -u {unit_name} --no-pager -n 80 || true")
+                      )
+                  )
+              time.sleep(1)
+
+          ${dumpFunctionName}(f"Timed out waiting for {description}")
+          raise AssertionError(f"{description} was not created by {unit_name}")
+    '';
+}

--- a/nix/compositor-vm-tools/window-lab.py
+++ b/nix/compositor-vm-tools/window-lab.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+from __future__ import annotations
 
 import argparse
 import json
@@ -14,7 +15,7 @@ gi.require_version("Gtk", "4.0")
 from gi.repository import GLib, Gtk  # noqa: E402
 
 
-@dataclass
+@dataclass(slots=True)
 class WindowState:
     window_id: str
     window: Gtk.ApplicationWindow
@@ -23,19 +24,18 @@ class WindowState:
 class WindowLab(Gtk.Application):
     def __init__(
         self,
+        *,
         socket_path: str,
         app_id: str,
         initial_window_id: str = "",
         initial_title: str = "",
     ) -> None:
         super().__init__(application_id=app_id)
-        # Keep the application alive until the harness explicitly sends `quit`.
         self.hold()
         self._socket_path = socket_path
         self._initial_window_id = initial_window_id
         self._initial_title = initial_title
         self._server: socket.socket | None = None
-        self._server_thread: threading.Thread | None = None
         self._windows: dict[str, WindowState] = {}
         self._opened_initial_window = False
 
@@ -56,9 +56,7 @@ class WindowLab(Gtk.Application):
         self._server = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
         self._server.bind(self._socket_path)
         self._server.listen(16)
-
-        self._server_thread = threading.Thread(target=self._serve_forever, daemon=True)
-        self._server_thread.start()
+        threading.Thread(target=self._serve_forever, daemon=True).start()
 
     def _serve_forever(self) -> None:
         assert self._server is not None
@@ -74,29 +72,31 @@ class WindowLab(Gtk.Application):
                 if not data:
                     continue
                 request = json.loads(data.decode("utf-8"))
-                result = self._invoke_on_main_thread(request)
-                conn.sendall(json.dumps(result).encode("utf-8") + b"\n")
+                response = self._invoke_on_main_thread(request)
+                conn.sendall(json.dumps(response).encode("utf-8") + b"\n")
 
-    def _invoke_on_main_thread(self, request: dict) -> dict:
-        loop = GLib.MainLoop()
-        result: dict[str, object] = {}
+    def _invoke_on_main_thread(self, request: dict[str, object]) -> dict[str, object]:
+        done = threading.Event()
+        response: dict[str, object] = {}
 
-        def _dispatch() -> bool:
-            nonlocal result
-            result = self._handle_request(request)
-            loop.quit()
+        def dispatch() -> bool:
+            nonlocal response
+            response = self._handle_request(request)
+            done.set()
             return False
 
-        GLib.idle_add(_dispatch)
-        loop.run()
-        return result
+        GLib.idle_add(dispatch)
+        done.wait()
+        return response
 
-    def _handle_request(self, request: dict) -> dict:
+    def _handle_request(self, request: dict[str, object]) -> dict[str, object]:
         command = str(request.get("command", "") or "")
         window_id = str(request.get("window_id", "") or "")
         title = str(request.get("title", "") or "")
 
         if command == "open":
+            if not window_id:
+                return {"status": "error", "message": "window_id is required"}
             self._open_window(window_id, title)
             return {"status": "ok"}
         if command == "focus":
@@ -119,29 +119,29 @@ class WindowLab(Gtk.Application):
             state.window.close()
             return {"status": "ok"}
         if command == "snapshot":
-            return {"status": "ok", "windows": sorted(self._windows.keys())}
+            return {"status": "ok", "windows": sorted(self._windows)}
         if command == "quit":
             self.quit()
             return {"status": "ok"}
         return {"status": "error", "message": f"unknown command: {command}"}
 
     def _open_window(self, window_id: str, title: str) -> None:
-        state = self._windows.get(window_id)
-        if state is not None:
-            state.window.set_title(title)
-            state.window.present()
+        existing = self._windows.get(window_id)
+        if existing is not None:
+            existing.window.set_title(title)
+            existing.window.present()
             return
 
         window = Gtk.ApplicationWindow(application=self)
         window.set_title(title)
-        window.set_default_size(480, 240)
+        window.set_default_size(480, 260)
         window.set_child(Gtk.Label(label=title))
 
-        def _on_close_request(_window: Gtk.ApplicationWindow) -> bool:
+        def on_close_request(_window: Gtk.ApplicationWindow) -> bool:
             self._windows.pop(window_id, None)
             return False
 
-        window.connect("close-request", _on_close_request)
+        window.connect("close-request", on_close_request)
         self._windows[window_id] = WindowState(window_id=window_id, window=window)
         window.present()
 

--- a/nix/compositor-vm-tools/window-lab.py
+++ b/nix/compositor-vm-tools/window-lab.py
@@ -81,12 +81,17 @@ class WindowLab(Gtk.Application):
 
         def dispatch() -> bool:
             nonlocal response
-            response = self._handle_request(request)
-            done.set()
+            try:
+                response = self._handle_request(request)
+            except Exception as exc:  # noqa: BLE001 - callback boundary must answer the client.
+                response = {"status": "error", "message": f"request failed: {exc}"}
+            finally:
+                done.set()
             return False
 
         GLib.idle_add(dispatch)
-        done.wait()
+        if not done.wait(timeout=10):
+            return {"status": "error", "message": "request timed out"}
         return response
 
     def _handle_request(self, request: dict[str, object]) -> dict[str, object]:

--- a/nix/compositor-vm-tools/window-labctl.py
+++ b/nix/compositor-vm-tools/window-labctl.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+from __future__ import annotations
 
 import argparse
 import json
@@ -11,7 +12,14 @@ def main() -> int:
     parser.add_argument("--socket", required=True)
     parser.add_argument(
         "command",
-        choices=["open", "focus", "retitle", "close", "quit", "snapshot"],
+        choices=[
+            "open",
+            "focus",
+            "retitle",
+            "close",
+            "snapshot",
+            "quit",
+        ],
     )
     parser.add_argument("window_id", nargs="?")
     parser.add_argument("title", nargs="?")
@@ -36,7 +44,6 @@ def main() -> int:
 
     if data:
         sys.stdout.write(data.decode("utf-8"))
-
     return 0
 
 

--- a/nix/listener-vm-matrix.nix
+++ b/nix/listener-vm-matrix.nix
@@ -1,4 +1,10 @@
-{ pkgs, system, keymasqPackage, keymasqModule }:
+{
+  pkgs,
+  system,
+  keymasqPackage,
+  keymasqModule,
+  compositorVmLib,
+}:
 
 let
   lib = pkgs.lib;
@@ -6,54 +12,7 @@ let
 
   vmUser = "keymasqvm";
   vmUid = 1000;
-  giTypelibPath = lib.makeSearchPath "lib/girepository-1.0" [
-    pkgs.cairo
-    pkgs.gdk-pixbuf
-    pkgs.glib
-    pkgs.graphene
-    pkgs.gtk4
-    pkgs.pango
-  ];
 
-  gtkPython = pkgs.python3.withPackages (ps: [ ps.pygobject3 ]);
-
-  mkGtkScript =
-    name: script:
-    pkgs.stdenvNoCC.mkDerivation {
-      pname = name;
-      version = "1";
-      dontUnpack = true;
-
-      nativeBuildInputs = [
-        pkgs.gobject-introspection
-        pkgs.wrapGAppsHook4
-      ];
-      buildInputs = [
-        gtkPython
-        pkgs.cairo
-        pkgs.gdk-pixbuf
-        pkgs.glib
-        pkgs.graphene
-        pkgs.gtk4
-        pkgs.adwaita-icon-theme
-        pkgs.hicolor-icon-theme
-        pkgs.pango
-      ];
-
-      preFixup = ''
-        gappsWrapperArgs+=(
-          --prefix GI_TYPELIB_PATH : "${giTypelibPath}"
-        )
-      '';
-
-      installPhase = ''
-        mkdir -p "$out/bin"
-        install -m755 ${script} "$out/bin/${name}"
-        sed -i '1s|.*|#!${gtkPython}/bin/python|' "$out/bin/${name}"
-      '';
-    };
-
-  windowLab = mkGtkScript "keymasq-listener-window-lab" ./listener-vms/window-lab.py;
   gnomeBridge = pkgs.runCommand "keymasq-gnome-bridge" { } ''
     mkdir -p "$out/share/gnome-shell/extensions/gnome-bridge@keymasq.tools"
     cp ${gnomeBridgeSource + "/extension.js"} \
@@ -78,52 +37,15 @@ let
     '';
   };
 
-  windowCtl = pkgs.writeShellApplication {
-    name = "keymasq-listener-window-labctl";
-    runtimeInputs = [ pkgs.python3 ];
-    text = ''
-      exec ${pkgs.python3}/bin/python ${./listener-vms/window-labctl.py} "$@"
-    '';
+  listenerWindowLabTools = compositorVmLib.mkWindowLabTools {
+    commandPrefix = "keymasq-listener";
+    packageName = "keymasq-listener-vm-tools";
+    extraPaths = [
+      sessionQuery
+      gnomeBridgeProbe
+    ];
   };
-
-  listenerVmTools = pkgs.symlinkJoin {
-    name = "keymasq-listener-vm-tools";
-    paths = [ windowLab sessionQuery windowCtl gnomeBridgeProbe ];
-  };
-
-  cosmicMinimalSession = pkgs.stdenvNoCC.mkDerivation {
-    pname = "keymasq-cosmic-minimal-session";
-    version = "1";
-    dontUnpack = true;
-    passthru.providedSessions = [ "cosmic-minimal" ];
-    installPhase = ''
-      mkdir -p "$out/bin" "$out/share/wayland-sessions"
-      cat > "$out/bin/cosmic-minimal-session" <<'EOF'
-#!${pkgs.bash}/bin/bash
-set -euo pipefail
-export XDG_CURRENT_DESKTOP=COSMIC
-export DESKTOP_SESSION=cosmic
-export XDG_SESSION_TYPE=wayland
-exec ${pkgs.cosmic-comp}/bin/cosmic-comp
-EOF
-      chmod +x "$out/bin/cosmic-minimal-session"
-      cat > "$out/share/wayland-sessions/cosmic-minimal.desktop" <<EOF
-[Desktop Entry]
-Name=COSMIC Minimal
-Comment=Minimal COSMIC compositor session for Keymasq listener tests
-Exec=$out/bin/cosmic-minimal-session
-Type=Application
-DesktopNames=COSMIC
-EOF
-    '';
-  };
-
-  userCommand =
-    cmd:
-    let
-      runtimeDir = "/run/user/${toString vmUid}";
-    in
-    "runuser -u ${vmUser} -- sh -lc 'export XDG_RUNTIME_DIR=${runtimeDir}; export DBUS_SESSION_BUS_ADDRESS=unix:path=${runtimeDir}/bus; ${cmd}'";
+  listenerVmTools = listenerWindowLabTools.tools;
 
   mkDesktopTest =
     {
@@ -140,83 +62,90 @@ EOF
     pkgs.testers.runNixOSTest {
       inherit name;
 
-      nodes.machine =
-        {
-          pkgs,
-          ...
-        }:
-        {
-          imports = [
-            keymasqModule
-            extraModule
-          ];
-
-          documentation.nixos.enable = false;
-
-          virtualisation = {
-            graphics = true;
-            memorySize = memorySize;
-            cores = 4;
-          };
-
-          networking.hostName = name;
-          time.timeZone = "UTC";
-          i18n.defaultLocale = "en_US.UTF-8";
-
-          services.keymasq = {
-            enable = true;
-            securityConfig = {
-              daemon_allowed_uids = [ vmUid ];
-              session_allowed_uids = [ vmUid ];
-              recording_guard = {
-                unlock_required = false;
-                macro_edit_requires_unlock = false;
+      nodes.machine = compositorVmLib.mkBaseDesktopModule {
+        inherit
+          name
+          vmUser
+          vmUid
+          memorySize
+          ;
+        userDescription = "Listener VM test user";
+        imports = [ keymasqModule ];
+        extraGroups = [
+          "wheel"
+          "video"
+          "input"
+        ];
+        systemPackages = [
+          keymasqPackage
+          listenerVmTools
+          gnomeBridge
+          pkgs.jq
+          pkgs.wmctrl
+          pkgs.xdotool
+          pkgs.slurp
+        ];
+        extraConfig = lib.mkMerge [
+          extraModule
+          {
+            services.keymasq = {
+              enable = true;
+              securityConfig = {
+                daemon_allowed_uids = [ vmUid ];
+                session_allowed_uids = [ vmUid ];
+                recording_guard = {
+                  unlock_required = false;
+                  macro_edit_requires_unlock = false;
+                };
               };
             };
-          };
-
-          users.users.${vmUser} = {
-            isNormalUser = true;
-            uid = vmUid;
-            description = "Listener VM test user";
-            createHome = true;
-            home = "/home/${vmUser}";
-            extraGroups = [ "wheel" "video" "input" ];
-          };
-
-          services.displayManager.autoLogin = {
-            enable = true;
-            user = vmUser;
-          };
-
-          hardware.graphics.enable = true;
-          services.dbus.enable = true;
-          security.polkit.enable = true;
-          services.libinput.enable = true;
-          programs.dconf.enable = true;
-
-          environment.systemPackages = [
-            keymasqPackage
-            listenerVmTools
-            gnomeBridge
-            pkgs.jq
-            pkgs.wmctrl
-            pkgs.xdotool
-            pkgs.slurp
-          ];
-        };
+          }
+        ];
+      };
 
       testScript = ''
-        import json
-        import shlex
-        import time
+        ${compositorVmLib.testScriptPrelude {
+          inherit vmUser vmUid;
+          dumpFunctionName = "dump_session_debug";
+          extraDebugScript = ''
+            log_command_output("loginctl user-status", "loginctl user-status ${vmUser} || true")
+            log_command_output(
+                "journalctl display-manager",
+                "journalctl -b -u display-manager.service --no-pager -n 200 || true",
+            )
+            log_command_output(
+                "journalctl user@${toString vmUid}",
+                "journalctl -b -u user@${toString vmUid}.service --no-pager -n 200 || true",
+            )
+            log_command_output(
+                "user systemctl failed units",
+                as_user("systemctl --user --failed --no-pager || true"),
+            )
+            log_command_output(
+                "user default target",
+                as_user("systemctl --user status default.target --no-pager || true"),
+            )
+            log_command_output(
+                "keymasq-session user service",
+                as_user("systemctl --user status keymasq-session.service --no-pager || true"),
+            )
+            log_command_output(
+                "keymasq-session journal",
+                as_user("journalctl --user -u keymasq-session.service --no-pager -n 200 || true"),
+            )
+            log_command_output(
+                "gnome-bridge-probe user service",
+                as_user("systemctl --user status gnome-bridge-probe.service --no-pager || true"),
+            )
+            log_command_output(
+                "gnome-bridge-probe journal",
+                as_user("journalctl --user -u gnome-bridge-probe.service --no-pager -n 200 || true"),
+            )
+          '';
+        }}
 
-        runtime_dir = "/run/user/${toString vmUid}"
         listener_socket = f"{runtime_dir}/listener-lab.sock"
         lab_prestarted = False
-
-        def as_user(cmd: str) -> str:
-            return "${userCommand "{cmd}"}".replace("{cmd}", cmd)
 
         def session_query(command: str) -> dict:
             raw = machine.succeed(
@@ -375,113 +304,6 @@ EOF
         def niri_window_by_title(title: str) -> dict | None:
             return next((window for window in niri_windows() if window.get("title") == title), None)
 
-        def log_command_output(label: str, cmd: str) -> None:
-            status, output = machine.execute(cmd)
-            machine.log(f"{label} (exit={status})\n{output}")
-
-        def dump_session_debug(label: str) -> None:
-            machine.log(f"==== {label} ====")
-            log_command_output("loginctl list-sessions", "loginctl list-sessions --no-legend")
-            log_command_output("loginctl user-status", "loginctl user-status ${vmUser}")
-            log_command_output(
-                "systemctl status display-manager.service",
-                "systemctl status display-manager.service --no-pager",
-            )
-            log_command_output(
-                "systemctl status user@${toString vmUid}.service",
-                "systemctl status user@${toString vmUid}.service --no-pager",
-            )
-            log_command_output(
-                "journalctl display-manager",
-                "journalctl -b -u display-manager.service --no-pager -n 200",
-            )
-            log_command_output(
-                "journalctl user@${toString vmUid}",
-                "journalctl -b -u user@${toString vmUid}.service --no-pager -n 200",
-            )
-            log_command_output("runtime directory contents", f"ls -la {runtime_dir} || true")
-            log_command_output(
-                "user systemctl failed units",
-                as_user("systemctl --user --failed --no-pager || true"),
-            )
-            log_command_output(
-                "user default target",
-                as_user("systemctl --user status default.target --no-pager || true"),
-            )
-            log_command_output(
-                "keymasq-session user service",
-                as_user("systemctl --user status keymasq-session.service --no-pager || true"),
-            )
-            log_command_output(
-                "keymasq-session journal",
-                as_user("journalctl --user -u keymasq-session.service --no-pager -n 200 || true"),
-            )
-            log_command_output(
-                "gnome-bridge-probe user service",
-                as_user("systemctl --user status gnome-bridge-probe.service --no-pager || true"),
-            )
-            log_command_output(
-                "gnome-bridge-probe journal",
-                as_user("journalctl --user -u gnome-bridge-probe.service --no-pager -n 200 || true"),
-            )
-
-        def wait_for_command(description: str, cmd: str, timeout: int = 180) -> str:
-            machine.log(f"Waiting for {description}: {cmd}")
-            deadline = time.time() + timeout
-            last_output = ""
-            last_status = None
-            while time.time() < deadline:
-                status, output = machine.execute(cmd, timeout=20)
-                last_status = status
-                last_output = output
-                if status == 0:
-                    return output
-                time.sleep(1)
-            dump_session_debug(f"Timed out waiting for {description}")
-            raise AssertionError(
-                f"{description} did not become ready (exit={last_status}): {last_output}"
-            )
-
-        def wait_for_user_command(description: str, cmd: str, timeout: int = 180) -> str:
-            return wait_for_command(description, as_user(cmd), timeout=timeout)
-
-        def wait_for_user_socket(
-            description: str, socket_path: str, unit_name: str, timeout: int = 60
-        ) -> None:
-            deadline = time.time() + timeout
-            while time.time() < deadline:
-                status, _ = machine.execute(as_user(f"test -S {socket_path}"), timeout=20)
-                if status == 0:
-                    if socket_path == listener_socket:
-                        ready_status, _ = machine.execute(
-                            as_user(
-                                "keymasq-listener-window-labctl "
-                                f"--socket {socket_path} snapshot >/dev/null"
-                            ),
-                            timeout=20,
-                        )
-                        if ready_status == 0:
-                            return
-                    else:
-                        return
-
-                unit_status, _ = machine.execute(
-                    as_user(f"systemctl --user is-failed {unit_name}"), timeout=20
-                )
-                if unit_status == 0:
-                    dump_session_debug(f"{unit_name} failed while waiting for {description}")
-                    raise AssertionError(
-                        machine.succeed(
-                            as_user(
-                                f"journalctl --user -u {unit_name} --no-pager -n 80 || true"
-                            )
-                        )
-                    )
-                time.sleep(1)
-
-            dump_session_debug(f"Timed out waiting for {description}")
-            raise AssertionError(f"{description} was not created by {unit_name}")
-
         def wait_for_listener() -> None:
             machine.log("Waiting for keymasq-session listener readiness")
             deadline = time.time() + 120
@@ -547,8 +369,8 @@ EOF
         ${desktopReadyScript}
         ${preflightScript}
         if ${if runListenerAssertions then "True" else "False"}:
-            machine.succeed("${userCommand "systemctl --user stop keymasq-session.service || true"}")
-            machine.succeed("${userCommand "systemctl --user start keymasq-session.service || true"}")
+            machine.succeed(as_user("systemctl --user stop keymasq-session.service || true"))
+            machine.succeed(as_user("systemctl --user start keymasq-session.service || true"))
             wait_for_user_command("keymasq-session user service", "systemctl --user is-active keymasq-session.service")
             wait_for_user_socket(
                 "keymasq-session socket",
@@ -586,6 +408,10 @@ EOF
                         "window lab socket",
                         listener_socket,
                         "keymasq-window-lab.service",
+                        probe_cmd=(
+                            "keymasq-listener-window-labctl "
+                            f"--socket {listener_socket} snapshot >/dev/null"
+                        ),
                     )
 
                 machine.succeed(
@@ -837,141 +663,28 @@ EOF
       '';
     };
 
-  gnomeModule = {
-    services.xserver.enable = true;
-    services.displayManager.defaultSession = "gnome";
-    services.displayManager.gdm.enable = true;
-    services.desktopManager.gnome.enable = true;
+  gnomeModule = lib.mkMerge [
+    (compositorVmLib.desktopModules.gnome {
+      enableXserver = true;
+      dconfExtensions = [ "gnome-bridge@keymasq.tools" ];
+    })
+    {
+      systemd.user.services.keymasq-session = {
+        wantedBy = lib.mkForce [ ];
+        partOf = lib.mkForce [ ];
+        after = lib.mkForce [ ];
+      };
 
-    systemd.user.services.keymasq-session = {
-      wantedBy = lib.mkForce [ ];
-      partOf = lib.mkForce [ ];
-      after = lib.mkForce [ ];
-    };
+      services.gnome.gnome-initial-setup.enable = false;
+    }
+  ];
 
-    services.gnome.gnome-initial-setup.enable = false;
-    programs.dconf.profiles.user.databases = [
-      {
-        settings = {
-          "org/gnome/shell" = {
-            disable-user-extensions = false;
-            enabled-extensions = [ "gnome-bridge@keymasq.tools" ];
-          };
-        };
-      }
-    ];
-  };
-
-  kdeModule = {
-    services.xserver.enable = true;
-    services.displayManager.defaultSession = "plasma";
-    services.displayManager.sddm = {
-      enable = true;
-      wayland.enable = true;
-    };
-    services.desktopManager.plasma6.enable = true;
-  };
-
-  hyprlandModule = {
-    services.displayManager.defaultSession = "hyprland-uwsm";
-    services.displayManager.sddm = {
-      enable = true;
-      wayland.enable = true;
-    };
-    programs.hyprland = {
-      enable = true;
-      withUWSM = true;
-    };
-  };
-
-  xfceModule = {
-    services.xserver.enable = true;
-    services.displayManager.defaultSession = "xfce";
-    services.xserver.displayManager.lightdm.enable = true;
-    services.xserver.desktopManager.xfce.enable = true;
-  };
-
-  cosmicModule = {
-    services.displayManager.defaultSession = "cosmic-minimal";
-    services.displayManager.sessionPackages = [ cosmicMinimalSession ];
-    services.xserver.enable = true;
-    services.displayManager.sddm = {
-      enable = true;
-      wayland.enable = true;
-    };
-    environment.systemPackages = [ pkgs.cosmic-comp ];
-  };
-
-  swayModule = {
-    services.displayManager.defaultSession = "sway";
-    services.displayManager.sddm = {
-      enable = true;
-      wayland.enable = true;
-    };
-    programs.sway.enable = true;
-  };
-
-  # -- Patched niri for VM testing ----------------------------------------
-  #
-  # Niri (Smithay) refuses software EGL renderers (llvmpipe) in
-  # src/backend/tty.rs via `ensure!(!egl_device.is_software(), ...)`.
-  # NixOS VM tests only have software EGL (no real GPU), so niri starts
-  # with zero wl_output objects and slurp fails with "no wl_output".
-  #
-  # Fix: patch the check to `ensure!(true, ...)` so llvmpipe is accepted.
-  # The default QEMU bochs-drm VGA then provides a working DRM/GBM/EGL
-  # pipeline, which is sufficient for compositor integration testing.
-  #
-  # The version assertion and grep guard ensure the build fails loudly
-  # if a nixpkgs bump changes niri underneath the patch.
-  #
-  # To update after a nixpkgs bump:
-  #   1. Set niriExpectedVersion to the new niri version in nixpkgs.
-  #   2. Check the new source for the is_software guard:
-  #        nix build --print-out-paths 'nixpkgs#niri.src' \
-  #          | xargs -I{} grep -n 'is_software' {}/src/backend/tty.rs
-  #   3. If the guard moved or changed, update the sed pattern below.
-  #   4. Run: nix build 'path:.#checks.x86_64-linux.listener-vm-niri'
-  niriExpectedVersion = "26.04";
-
-  niriPatched = assert pkgs.niri.version == niriExpectedVersion; pkgs.niri.overrideAttrs (old: {
-    postPatch = (old.postPatch or "") + ''
-      # Allow software EGL renderers (llvmpipe) for VM testing.
-      # The ensure!(!is_software(), ...) check becomes ensure!(true, ...)
-      # which is a no-op, letting niri initialise its renderer via llvmpipe.
-      sed -i 's/!egl_device\.is_software()/true/' src/backend/tty.rs
-
-      # Guard: fail the build if the sed didn't match.  The patched source
-      # must contain "true," (the replacement) and must NOT contain the
-      # original "is_software()" call in tty.rs.
-      if grep -q 'egl_device\.is_software()' src/backend/tty.rs; then
-        echo "ERROR: niri software-renderer patch did not apply — see niriPatched in listener-vm-matrix.nix"
-        exit 1
-      fi
-    '';
-  });
-
-  niriModule = {
-    services.displayManager.defaultSession = "niri";
-    services.displayManager.sddm = {
-      enable = true;
-      wayland.enable = true;
-    };
-    programs.niri = {
-      enable = true;
-      package = niriPatched;
-    };
-    environment.etc."niri/config.kdl".text = ''
-      input {
-          focus-follows-mouse
-          warp-mouse-to-focus mode="center-xy-always"
-      }
-
-      debug {
-          honor-xdg-activation-with-invalid-serial
-      }
-    '';
-  };
+  kdeModule = compositorVmLib.desktopModules.kde { enableXserver = true; };
+  hyprlandModule = compositorVmLib.desktopModules.hyprland { withUWSM = true; };
+  xfceModule = compositorVmLib.desktopModules.xfce;
+  cosmicModule = compositorVmLib.desktopModules.cosmic { };
+  swayModule = compositorVmLib.desktopModules.sway;
+  niriModule = compositorVmLib.desktopModules.niri { };
 
 in
 {


### PR DESCRIPTION
## Summary
- Extract `compositor-vm-lib.nix` as a reusable Nix library for building desktop VM test configurations
- Move `window-lab.py` and `window-labctl.py` to `nix/compositor-vm-tools/` for sharing across listener and compositor tests
- Refactor `listener-vm-matrix.nix` to use `compositor-vm-lib`, removing ~440 lines of duplicated code
- Clean up Python scripts (dataclass slots, threading, typing annotations)
- Expose `compositorVmLib` via flake `lib` for external consumers

## Testing
- Verified listener VM test matrices still build and run correctly for all compositors (sway, xfce, gnome, kde, hyprland, niri, cosmic)
- Ran `nix flake check` successfully on x86_64-linux