### PR TITLE
fix: prevent duplicate-profile errors after key selector updates

### DIFF
--- a/keymasq/gui/widgets/device_tab/tab.py
+++ b/keymasq/gui/widgets/device_tab/tab.py
@@ -124,6 +124,17 @@ class DeviceTab(ProfileManagedTab):
             return profile.config.ensure_layer(self.device.hardware_id)
         return profile.config.get_layer(self.device.hardware_id)
 
+    def _resolve_mapping_target_profile(
+        self,
+        target_profile: ProfileInfo | None,
+    ) -> ProfileInfo | None:
+        target_profile = target_profile or self._selected_profile
+        if target_profile is None:
+            return None
+        if self.profile_manager is None or self.demo_mode:
+            return target_profile
+        return self.profile_manager.get_profile(target_profile.config.name)
+
     def _profile_is_selected(self, profile: ProfileInfo | None) -> bool:
         return (
             profile is not None
@@ -1361,7 +1372,8 @@ class DeviceTab(ProfileManagedTab):
 
         def on_key_selected(dialog, action):
             def commit_selection() -> None:
-                layer = self._device_layer_for_profile(target_profile, create=True)
+                current_profile = self._resolve_mapping_target_profile(target_profile)
+                layer = self._device_layer_for_profile(current_profile, create=True)
                 if layer is None:
                     return
                 if action is None:
@@ -1369,10 +1381,11 @@ class DeviceTab(ProfileManagedTab):
                         del layer.mappings[button.id]
                 else:
                     layer.mappings[button.id] = action
-                if self._profile_is_selected(target_profile):
+                if self._profile_is_selected(current_profile):
+                    self._selected_profile = current_profile
                     self._update_button_display(button.id)
                     self._update_header_caption()
-                self._save_specific_profile(target_profile)
+                self._save_specific_profile(current_profile)
 
             defer_commit(commit_selection)
 
@@ -1400,17 +1413,19 @@ class DeviceTab(ProfileManagedTab):
 
         def on_key_selected(dialog, action):
             def commit_selection() -> None:
-                layer = self._device_layer_for_profile(target_profile, create=True)
+                current_profile = self._resolve_mapping_target_profile(target_profile)
+                layer = self._device_layer_for_profile(current_profile, create=True)
                 if layer is None:
                     return
                 if action is None:
                     layer.mappings.pop(analog.id, None)
                 else:
                     layer.mappings[analog.id] = action
-                if self._profile_is_selected(target_profile):
+                if self._profile_is_selected(current_profile):
+                    self._selected_profile = current_profile
                     self._update_button_display(analog.id)
                     self._update_header_caption()
-                self._save_specific_profile(target_profile)
+                self._save_specific_profile(current_profile)
 
             defer_commit(commit_selection)
 

--- a/tests/gui/test_device_tab_widget.py
+++ b/tests/gui/test_device_tab_widget.py
@@ -873,6 +873,97 @@ class TestDeviceTabWidget:
         assert work_layer is None or "btn_back" not in work_layer.mappings
         assert save_calls == ["Gaming"]
 
+    def test_device_tab_selector_pending_commit_survives_profile_reload(
+        self,
+        temp_config_dir,
+        monkeypatch,
+    ):
+        from collections.abc import Callable
+        from typing import cast
+
+        from keymasq.common.models import (
+            ActionType,
+            ButtonDefinition,
+            DeviceProfileLayer,
+            HardwareConfig,
+            MappingAction,
+            ProfileConfig,
+        )
+        import keymasq.gui.widgets.device_tab.tab as device_tab_module
+        import keymasq.gui.widgets.profile_managed_tab as profile_managed_tab_module
+        from keymasq.gui.widgets.device_tab import DeviceTab
+        from keymasq.session.profiles import ProfileManager
+
+        dialogs: list[object] = []
+        scheduled: list[tuple[int, Callable[[], bool]]] = []
+        requests: list[dict] = []
+
+        class DummyDialog:
+            callbacks: dict[str, Callable[..., object]]
+            present_root: object
+
+            def __init__(self, *args, **kwargs):
+                self.callbacks = {}
+                dialogs.append(self)
+
+            def connect(self, signal_name, callback):
+                self.callbacks[signal_name] = callback
+
+            def present(self, root):
+                self.present_root = root
+
+        monkeypatch.setattr(device_tab_module, "KeySelectorDialog", DummyDialog)
+        monkeypatch.setattr(
+            device_tab_module.GLib,
+            "timeout_add",
+            lambda delay_ms, callback: scheduled.append((delay_ms, callback)) or 123,
+        )
+        monkeypatch.setattr(
+            profile_managed_tab_module,
+            "session_request_async",
+            lambda payload, _callback: requests.append(payload),
+        )
+
+        device = HardwareConfig(
+            vendor_id="1234",
+            product_id="5678",
+            name="Test Mouse",
+            evdev_devices=[],
+            buttons=[ButtonDefinition(id="btn_back", label="Back", evdev="btn_side")],
+        )
+        profile_manager = ProfileManager()
+        profile_manager.save_profile(
+            ProfileConfig(
+                name="Desktop",
+                enabled=True,
+                is_permanent=True,
+                device_layers={"1234:5678": DeviceProfileLayer(hardware_id="1234:5678")},
+            )
+        )
+        tab = DeviceTab(device=device, profile_manager=profile_manager, demo_mode=False)
+        tab.refresh_profiles(preferred_profile_name="Desktop", publish_selection=False)
+        errors: list[str] = []
+        tab._show_profile_error_dialog = errors.append  # type: ignore[method-assign]
+
+        tab._show_function_editor(device.buttons[0])
+        action = MappingAction(action_type=ActionType.SUPPRESS)
+        dialog = cast(DummyDialog, dialogs[0])
+        dialog.callbacks["key-selected"](dialog, action)
+        dialog.callbacks["closed"](dialog)
+
+        profile_manager.reload()
+        assert scheduled[0][1]() is False
+
+        current_profile = profile_manager.get_profile("Desktop")
+        assert current_profile is not None
+        layer = current_profile.config.get_layer("1234:5678")
+        assert layer is not None
+        assert layer.mappings["btn_back"] == action
+        assert tab._selected_profile is not None
+        assert tab._selected_profile.config is current_profile.config
+        assert errors == []
+        assert requests.count({"command": "reevaluate_profiles"}) == 1
+
     def test_device_tab_selector_pending_commit_flushes_on_destroy(
         self,
         monkeypatch,


### PR DESCRIPTION
## Summary

- Fix the fast-update key selector path that could show `Profile '<name>' already exists` after a profile reload
- Re-resolve the button or analog mapping target profile by name immediately before the delayed selector commit runs
- Keep the device tab selection pointed at the live profile object before refreshing the mapping UI and saving
- Add a regression test that reloads profiles between selector close and the delayed commit, then verifies the mapping saves without an error dialog

## Testing

- `nix develop -c pytest tests/gui/test_device_tab_widget.py`
- `nix develop -c ./scripts/check.sh`