### PR TITLE
Extend type macro compiler with named key controls, shortcuts, and mouse actions

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -37,6 +37,10 @@ keymasq type --speed 1.5 "hello"
 keymasq type "café"
 keymasq type "user<tab>password<enter>"
 keymasq type "user<tab><wait:100:250>password<enter>"
+keymasq type "<shortcut:ctrl+l><delete>query<enter>"
+keymasq type "<down:5><enter>"
+keymasq type "<move:420:180><click>"
+keymasq type "<click:420:180><doubleclick>"
 keymasq type --no-unicode "café"
 keymasq type --print-json "hello"
 ```
@@ -59,8 +63,31 @@ The type compiler supports a small set of inline controls:
 |---|---|
 | `<tab>` | Press Tab |
 | `<enter>` | Press Enter |
+| `<space>` | Press Space |
+| `<esc>` | Press Escape |
+| `<backspace>` | Press Backspace |
+| `<delete>` | Press Delete |
+| `<up>` / `<down>` / `<left>` / `<right>` | Press an arrow key |
+| `<home>` / `<end>` | Press Home or End |
+| `<pageup>` / `<pagedown>` | Press Page Up or Page Down |
+| `<KEY:COUNT>` | Repeat a named key control; for example, `<tab:3>` or `<down:5>` |
+| `<shortcut:MOD+KEY>` | Press a keyboard shortcut; for example, `<shortcut:ctrl+l>` or `<shortcut:ctrl+shift+v>` |
+| `<move:X:Y>` | Move the pointer to absolute coordinates using the fast natural-move defaults |
+| `<click>` / `<lclick>` / `<leftclick>` | Left click |
+| `<rclick>` / `<rightclick>` | Right click |
+| `<doubleclick>` | Double left click |
+| `<click:X:Y>` / `<rclick:X:Y>` / `<doubleclick:X:Y>` | Move to absolute coordinates, then click |
+| `<settle>` | Wait 300 ms |
 | `<wait:MS>` | Wait a fixed number of milliseconds |
 | `<wait:MIN:MAX>` | Wait a random number of milliseconds in the inclusive range |
+
+Shortcut modifiers are `ctrl`, `shift`, `alt`, and `super`, with `control`,
+`meta`, and `win` accepted as modifier aliases.
+
+`<move:X:Y>` uses the same natural cursor movement as the compact `play`
+`move:X:Y` token with the fast defaults: `100000` px/s, zero jitter, linear
+curve, `2` px tolerance, `3000` ms timeout, and `stop_on_failure=false`. The
+type syntax does not expose tuning arguments for this control.
 
 Use `\<` to type a literal `<`. Backslashes are otherwise treated as normal
 text, so `\\<tab>` types `\<tab>`.

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -70,13 +70,13 @@ The type compiler supports a small set of inline controls:
 | `<up>` / `<down>` / `<left>` / `<right>` | Press an arrow key |
 | `<home>` / `<end>` | Press Home or End |
 | `<pageup>` / `<pagedown>` | Press Page Up or Page Down |
-| `<KEY:COUNT>` | Repeat a named key control; for example, `<tab:3>` or `<down:5>` |
+| `<KEY:COUNT>` | Repeat a named key control up to 100 times; for example, `<tab:3>` or `<down:5>` |
 | `<shortcut:MOD+KEY>` | Press a keyboard shortcut; for example, `<shortcut:ctrl+l>` or `<shortcut:ctrl+shift+v>` |
 | `<move:X:Y>` | Move the pointer to absolute coordinates using the fast natural-move defaults |
 | `<click>` / `<lclick>` / `<leftclick>` | Left click |
 | `<rclick>` / `<rightclick>` | Right click |
 | `<doubleclick>` | Double left click |
-| `<click:X:Y>` / `<rclick:X:Y>` / `<doubleclick:X:Y>` | Move to absolute coordinates, then click |
+| `<click:X:Y>` / `<rclick:X:Y>` / `<doubleclick:X:Y>` | Move to absolute coordinates, then click if the move succeeds |
 | `<settle>` | Wait 300 ms |
 | `<wait:MS>` | Wait a fixed number of milliseconds |
 | `<wait:MIN:MAX>` | Wait a random number of milliseconds in the inclusive range |

--- a/docs/agents/macros.txt
+++ b/docs/agents/macros.txt
@@ -64,7 +64,7 @@ keymasq play btn_left wait:10 btn_left --print-json \
 <end>
 <pageup>
 <pagedown>
-<KEY:COUNT>          repeat a named key, e.g. <tab:3>
+<KEY:COUNT>          repeat a named key up to 100 times, e.g. <tab:3>
 <shortcut:MOD+KEY>   press a shortcut, e.g. <shortcut:ctrl+shift+v>
 <move:X:Y>           natural absolute mouse move with fast defaults
 <click>              left click

--- a/docs/agents/macros.txt
+++ b/docs/agents/macros.txt
@@ -52,6 +52,29 @@ keymasq play btn_left wait:10 btn_left --print-json \
 ```text
 <tab>
 <enter>
+<space>
+<esc>
+<backspace>
+<delete>
+<up>
+<down>
+<left>
+<right>
+<home>
+<end>
+<pageup>
+<pagedown>
+<KEY:COUNT>          repeat a named key, e.g. <tab:3>
+<shortcut:MOD+KEY>   press a shortcut, e.g. <shortcut:ctrl+shift+v>
+<move:X:Y>           natural absolute mouse move with fast defaults
+<click>              left click
+<lclick>             left click
+<rclick>             right click
+<doubleclick>        double left click
+<click:X:Y>          move to absolute coordinates, then left click
+<rclick:X:Y>         move to absolute coordinates, then right click
+<doubleclick:X:Y>    move to absolute coordinates, then double left click
+<settle>             fixed 300ms wait
 <wait:MS>
 <wait:MIN:MAX>
 ```

--- a/docs/agents/macros.txt
+++ b/docs/agents/macros.txt
@@ -69,7 +69,9 @@ keymasq play btn_left wait:10 btn_left --print-json \
 <move:X:Y>           natural absolute mouse move with fast defaults
 <click>              left click
 <lclick>             left click
+<leftclick>          left click
 <rclick>             right click
+<rightclick>         right click
 <doubleclick>        double left click
 <click:X:Y>          move to absolute coordinates, then left click
 <rclick:X:Y>         move to absolute coordinates, then right click

--- a/keymasq/cli/__main__.py
+++ b/keymasq/cli/__main__.py
@@ -64,9 +64,13 @@ def main() -> None:
         help="Type text using an ad-hoc macro",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog=(
-            "Inline controls: <tab>, <enter>, <wait:MS>, <wait:MIN:MAX>\n"
+            "Inline controls: <tab>, <enter>, <space>, <esc>, <backspace>, <delete>,\n"
+            "<up>, <down>, <left>, <right>, <home>, <end>, <pageup>, <pagedown>,\n"
+            "<KEY:COUNT>, <shortcut:MOD+KEY>, <move:X:Y>, <click[:X:Y]>,\n"
+            "<doubleclick[:X:Y]>, <rclick[:X:Y]>, <settle>, <wait:MS>, <wait:MIN:MAX>\n"
             r"Use \< to type a literal <." "\n"
             'Example: keymasq type "user<tab><wait:100:250>password<enter>"\n'
+            'Example: keymasq type "<move:420:180><click>"\n'
             f"Full reference: {_docs_url()}"
         ),
     )

--- a/keymasq/cli/commands.py
+++ b/keymasq/cli/commands.py
@@ -472,7 +472,7 @@ def type_cli(
         except ValueError as exc:
             print(f"Error: {exc}")
             sys.exit(1)
-        _print_json(macro_definition_from_events(events, device_types=["keyboard"]))
+        _print_json(macro_definition_from_events(events))
         return
 
     result = _request_or_error(

--- a/keymasq/common/macro_compile.py
+++ b/keymasq/common/macro_compile.py
@@ -14,10 +14,12 @@ from keymasq.common.models import (
 from keymasq.common.types import JsonObject
 
 IntLike = int | float | str | bytes
+TypeMacroToken = tuple[str, str]
 _COMPACT_NATURAL_MOUSE_MOVE_DEFAULT_SPEED = 100_000.0
 _COMPACT_NATURAL_MOUSE_MOVE_DEFAULT_JITTER = 0.0
 _COMPACT_NATURAL_MOUSE_MOVE_FAST_CURVE = "linear"
 _COMPACT_NATURAL_MOUSE_MOVE_SLOW_CURVE = "natural"
+_TYPE_MACRO_SETTLE_WAIT_MS = 300
 
 _TYPE_MACRO_TEXT_TRANSLATION = str.maketrans(
     {
@@ -47,6 +49,41 @@ _TYPE_MACRO_TEXT_TRANSLATION = str.maketrans(
         "\ufeff": "",
     }
 )
+
+_TYPE_MACRO_NAMED_KEY_CODES = {
+    "space": evdev.ecodes.KEY_SPACE,
+    "enter": evdev.ecodes.KEY_ENTER,
+    "tab": evdev.ecodes.KEY_TAB,
+    "esc": evdev.ecodes.KEY_ESC,
+    "backspace": evdev.ecodes.KEY_BACKSPACE,
+    "delete": evdev.ecodes.KEY_DELETE,
+    "up": evdev.ecodes.KEY_UP,
+    "down": evdev.ecodes.KEY_DOWN,
+    "left": evdev.ecodes.KEY_LEFT,
+    "right": evdev.ecodes.KEY_RIGHT,
+    "home": evdev.ecodes.KEY_HOME,
+    "end": evdev.ecodes.KEY_END,
+    "pageup": evdev.ecodes.KEY_PAGEUP,
+    "pagedown": evdev.ecodes.KEY_PAGEDOWN,
+}
+
+_TYPE_MACRO_SHORTCUT_MODIFIER_CODES = {
+    "ctrl": evdev.ecodes.KEY_LEFTCTRL,
+    "control": evdev.ecodes.KEY_LEFTCTRL,
+    "shift": evdev.ecodes.KEY_LEFTSHIFT,
+    "alt": evdev.ecodes.KEY_LEFTALT,
+    "super": evdev.ecodes.KEY_LEFTMETA,
+    "meta": evdev.ecodes.KEY_LEFTMETA,
+    "win": evdev.ecodes.KEY_LEFTMETA,
+}
+
+_TYPE_MACRO_CLICK_BUTTON_CODES = {
+    "click": evdev.ecodes.BTN_LEFT,
+    "lclick": evdev.ecodes.BTN_LEFT,
+    "leftclick": evdev.ecodes.BTN_LEFT,
+    "rclick": evdev.ecodes.BTN_RIGHT,
+    "rightclick": evdev.ecodes.BTN_RIGHT,
+}
 
 
 def normalize_type_macro_text(text: str) -> str:
@@ -83,38 +120,51 @@ def build_type_macro_events(
             _append_wait_event(events, value.split(":"), t_us)
             continue
 
-        if kind == "key":
-            code, needs_shift = char_to_key(value)
+        if kind == "mouse_move":
+            t_us = _append_type_macro_mouse_move_event(events, value, t_us)
+        elif kind == "mouse_click":
+            t_us = _append_type_macro_mouse_click_events(events, value, t_us, down_ms)
+        elif kind == "shortcut":
+            t_us = _append_type_macro_shortcut_events(
+                events,
+                value,
+                t_us,
+                down_ms,
+                modifier_settle_us,
+            )
         else:
-            ch = value
-            try:
-                code, needs_shift = char_to_key(ch)
-            except ValueError as exc:
-                if use_unicode_input:
-                    t_us = _append_unicode_char_events(
-                        events,
-                        ch,
-                        t_us,
-                        down_ms,
-                        modifier_settle_us,
-                    )
-                    if _should_add_type_pause(tokens, i, pause_ms):
-                        t_us += pause_ms * 1000
-                    continue
+            if kind == "key":
+                code, needs_shift = _resolve_type_macro_key(value)
+            else:
+                ch = value
+                try:
+                    code, needs_shift = char_to_key(ch)
+                except ValueError as exc:
+                    if use_unicode_input:
+                        t_us = _append_unicode_char_events(
+                            events,
+                            ch,
+                            t_us,
+                            down_ms,
+                            modifier_settle_us,
+                        )
+                        if _should_add_type_pause(tokens, i, pause_ms):
+                            t_us += pause_ms * 1000
+                        continue
 
-                char_name = unicodedata.name(ch, "UNKNOWN")
-                raise ValueError(
-                    f"Unsupported character at position {i + 1}: {ch!r} ({char_name})"
-                ) from exc
+                    char_name = unicodedata.name(ch, "UNKNOWN")
+                    raise ValueError(
+                        f"Unsupported character at position {i + 1}: {ch!r} ({char_name})"
+                    ) from exc
 
-        t_us = _append_direct_key_events(
-            events,
-            code,
-            needs_shift,
-            t_us,
-            down_ms,
-            modifier_settle_us,
-        )
+            t_us = _append_direct_key_events(
+                events,
+                code,
+                needs_shift,
+                t_us,
+                down_ms,
+                modifier_settle_us,
+            )
 
         if _should_add_type_pause(tokens, i, pause_ms):
             t_us += pause_ms * 1000
@@ -122,8 +172,8 @@ def build_type_macro_events(
     return events
 
 
-def _type_macro_tokens(text: str) -> list[tuple[str, str]]:
-    tokens: list[tuple[str, str]] = []
+def _type_macro_tokens(text: str) -> list[TypeMacroToken]:
+    tokens: list[TypeMacroToken] = []
     index = 0
     while index < len(text):
         if text.startswith(r"\<", index):
@@ -144,16 +194,9 @@ def _type_macro_tokens(text: str) -> list[tuple[str, str]]:
 
         raw_tag = text[index + 1 : end]
         tag = raw_tag.strip().lower()
-        if tag == "enter":
-            tokens.append(("key", "\n"))
-            index = end + 1
-            continue
-        if tag == "tab":
-            tokens.append(("key", "\t"))
-            index = end + 1
-            continue
-        if tag.startswith("wait:"):
-            tokens.append(("wait", tag.removeprefix("wait:")))
+        control_tokens = _type_macro_control_tokens(tag)
+        if control_tokens is not None:
+            tokens.extend(control_tokens)
             index = end + 1
             continue
 
@@ -163,7 +206,107 @@ def _type_macro_tokens(text: str) -> list[tuple[str, str]]:
     return tokens
 
 
-def _should_add_type_pause(tokens: list[tuple[str, str]], index: int, pause_ms: int) -> bool:
+def _type_macro_control_tokens(tag: str) -> list[TypeMacroToken] | None:
+    if tag == "settle":
+        return [("wait", str(_TYPE_MACRO_SETTLE_WAIT_MS))]
+
+    if tag.startswith("wait:"):
+        return [("wait", tag.removeprefix("wait:"))]
+
+    if tag.startswith("shortcut:"):
+        shortcut = tag.removeprefix("shortcut:").strip()
+        if not shortcut:
+            raise ValueError("shortcut requires modifiers and a key")
+        return [("shortcut", shortcut)]
+
+    move_token = _parse_type_macro_mouse_move_control(tag)
+    if move_token is not None:
+        return [move_token]
+
+    click_tokens = _parse_type_macro_click_control(tag)
+    if click_tokens is not None:
+        return click_tokens
+
+    named_key = _parse_type_macro_named_key_control(tag)
+    if named_key is None:
+        return None
+
+    name, repeat_count = named_key
+    return [("key", name) for _ in range(repeat_count)]
+
+
+def _parse_type_macro_mouse_move_control(tag: str) -> TypeMacroToken | None:
+    if not tag.startswith("move:"):
+        return None
+
+    args = [part.strip() for part in tag.removeprefix("move:").split(":")]
+    if len(args) != 2 or any(not arg for arg in args):
+        raise ValueError("move control requires x and y arguments")
+
+    x = _parse_int(args[0], "move x")
+    y = _parse_int(args[1], "move y")
+    return "mouse_move", f"{x}:{y}"
+
+
+def _parse_type_macro_click_control(tag: str) -> list[TypeMacroToken] | None:
+    parts = [part.strip() for part in tag.split(":")]
+    name = parts[0]
+    if name == "doubleclick":
+        button_code = evdev.ecodes.BTN_LEFT
+        click_args = parts[1:]
+        first_click = _type_macro_mouse_click_token(button_code, click_args, name)
+        return [first_click, _format_type_macro_mouse_click_token(button_code)]
+
+    button_code = _TYPE_MACRO_CLICK_BUTTON_CODES.get(name)
+    if button_code is None:
+        return None
+
+    return [_type_macro_mouse_click_token(button_code, parts[1:], name)]
+
+
+def _type_macro_mouse_click_token(
+    button_code: int,
+    args: list[str],
+    name: str,
+) -> TypeMacroToken:
+    if not args:
+        return _format_type_macro_mouse_click_token(button_code)
+    if len(args) != 2 or any(not arg for arg in args):
+        raise ValueError(f"{name} control accepts optional x and y arguments")
+
+    x = _parse_int(args[0], f"{name} x")
+    y = _parse_int(args[1], f"{name} y")
+    return _format_type_macro_mouse_click_token(button_code, x, y)
+
+
+def _format_type_macro_mouse_click_token(
+    button_code: int,
+    x: int | None = None,
+    y: int | None = None,
+) -> TypeMacroToken:
+    if x is None or y is None:
+        return "mouse_click", str(button_code)
+    return "mouse_click", f"{button_code}:{x}:{y}"
+
+
+def _parse_type_macro_named_key_control(tag: str) -> tuple[str, int] | None:
+    if ":" not in tag:
+        if tag not in _TYPE_MACRO_NAMED_KEY_CODES:
+            return None
+        return tag, 1
+
+    parts = [part.strip() for part in tag.split(":")]
+    name = parts[0]
+    if name not in _TYPE_MACRO_NAMED_KEY_CODES:
+        return None
+    if len(parts) != 2:
+        raise ValueError(f"{name} repeat control accepts one count argument")
+
+    repeat_count = _parse_positive_int(parts[1], f"{name} repeat count")
+    return name, repeat_count
+
+
+def _should_add_type_pause(tokens: list[TypeMacroToken], index: int, pause_ms: int) -> bool:
     return pause_ms > 0 and index < len(tokens) - 1 and tokens[index + 1][0] != "wait"
 
 
@@ -236,6 +379,12 @@ def char_to_key(ch: str) -> tuple[int, bool]:
         return specials[ch]
 
     raise ValueError(f"Unsupported character for typing macro: {ch!r}")
+
+
+def _resolve_type_macro_key(value: str) -> tuple[int, bool]:
+    if value in _TYPE_MACRO_NAMED_KEY_CODES:
+        return _TYPE_MACRO_NAMED_KEY_CODES[value], False
+    return char_to_key(value)
 
 
 def build_compact_macro_events(tokens: list[str]) -> list[JsonObject]:
@@ -492,6 +641,132 @@ def _append_direct_key_events(
         _append_key_event(events, "keyboard", evdev.ecodes.KEY_LEFTSHIFT, 0, t_us)
 
     return t_us
+
+
+def _append_type_macro_shortcut_events(
+    events: list[JsonObject],
+    shortcut: str,
+    t_us: int,
+    down_ms: int,
+    modifier_settle_us: int,
+) -> int:
+    modifier_codes, key_code = _parse_type_macro_shortcut(shortcut)
+
+    for modifier_code in modifier_codes:
+        _append_key_event(events, "keyboard", modifier_code, 1, t_us)
+        t_us += modifier_settle_us
+
+    _append_key_event(events, "keyboard", key_code, 1, t_us)
+    t_us += down_ms * 1000
+    _append_key_event(events, "keyboard", key_code, 0, t_us)
+
+    for modifier_code in reversed(modifier_codes):
+        t_us += modifier_settle_us
+        _append_key_event(events, "keyboard", modifier_code, 0, t_us)
+
+    return t_us
+
+
+def _parse_type_macro_shortcut(shortcut: str) -> tuple[list[int], int]:
+    parts = [part.strip() for part in shortcut.split("+")]
+    if len(parts) < 2 or any(not part for part in parts):
+        raise ValueError("shortcut requires modifiers and a key")
+
+    key_part = parts[-1]
+    if key_part in _TYPE_MACRO_SHORTCUT_MODIFIER_CODES:
+        raise ValueError("shortcut requires one non-modifier key")
+
+    modifier_codes: list[int] = []
+    for modifier_name in parts[:-1]:
+        modifier_code = _TYPE_MACRO_SHORTCUT_MODIFIER_CODES.get(modifier_name)
+        if modifier_code is None:
+            raise ValueError(f"unknown shortcut modifier: {modifier_name}")
+        if modifier_code in modifier_codes:
+            raise ValueError(f"duplicate shortcut modifier: {modifier_name}")
+        modifier_codes.append(modifier_code)
+
+    key_code, needs_shift = _resolve_type_macro_shortcut_key(key_part)
+    shift_code = evdev.ecodes.KEY_LEFTSHIFT
+    if needs_shift and shift_code not in modifier_codes:
+        modifier_codes.append(shift_code)
+    return modifier_codes, key_code
+
+
+def _resolve_type_macro_shortcut_key(value: str) -> tuple[int, bool]:
+    if value in _TYPE_MACRO_NAMED_KEY_CODES:
+        return _TYPE_MACRO_NAMED_KEY_CODES[value], False
+    if len(value) == 1:
+        return char_to_key(value)
+
+    try:
+        device_type, code = resolve_key_or_button(value)
+    except ValueError as exc:
+        raise ValueError(f"unknown shortcut key: {value}") from exc
+    if device_type != "keyboard":
+        raise ValueError(f"shortcut key must be a keyboard key: {value}")
+    return code, False
+
+
+def _append_type_macro_mouse_move_event(
+    events: list[JsonObject],
+    value: str,
+    t_us: int,
+) -> int:
+    x, y = _parse_type_macro_coordinate_value(value)
+    _append_type_macro_natural_move_event(events, x, y, t_us)
+    return t_us + 1
+
+
+def _append_type_macro_mouse_click_events(
+    events: list[JsonObject],
+    value: str,
+    t_us: int,
+    down_ms: int,
+) -> int:
+    parts = value.split(":")
+    button_code = _parse_int(parts[0], "click button")
+    if len(parts) == 3:
+        x = _parse_int(parts[1], "click x")
+        y = _parse_int(parts[2], "click y")
+        _append_type_macro_natural_move_event(events, x, y, t_us)
+        t_us += 1
+    elif len(parts) != 1:
+        raise ValueError("click control accepts optional x and y arguments")
+
+    _append_key_event(events, "mouse", button_code, 1, t_us)
+    t_us += down_ms * 1000
+    _append_key_event(events, "mouse", button_code, 0, t_us)
+    return t_us
+
+
+def _append_type_macro_natural_move_event(
+    events: list[JsonObject],
+    x: int,
+    y: int,
+    t_us: int,
+) -> None:
+    _append_mouse_move_event(
+        events,
+        "mouse_move_natural_abs",
+        x,
+        y,
+        t_us,
+        options={
+            "speed": _COMPACT_NATURAL_MOUSE_MOVE_DEFAULT_SPEED,
+            "jitter": _COMPACT_NATURAL_MOUSE_MOVE_DEFAULT_JITTER,
+            "curve": _COMPACT_NATURAL_MOUSE_MOVE_FAST_CURVE,
+            "tolerance": DEFAULT_NATURAL_MOUSE_MOVE_TOLERANCE,
+            "max_duration_ms": DEFAULT_NATURAL_MOUSE_MOVE_MAX_DURATION_MS,
+            "stop_on_failure": False,
+        },
+    )
+
+
+def _parse_type_macro_coordinate_value(value: str) -> tuple[int, int]:
+    parts = value.split(":")
+    if len(parts) != 2:
+        raise ValueError("move control requires x and y arguments")
+    return _parse_int(parts[0], "move x"), _parse_int(parts[1], "move y")
 
 
 def _append_unicode_char_events(

--- a/keymasq/common/macro_compile.py
+++ b/keymasq/common/macro_compile.py
@@ -20,6 +20,7 @@ _COMPACT_NATURAL_MOUSE_MOVE_DEFAULT_JITTER = 0.0
 _COMPACT_NATURAL_MOUSE_MOVE_FAST_CURVE = "linear"
 _COMPACT_NATURAL_MOUSE_MOVE_SLOW_CURVE = "natural"
 _TYPE_MACRO_SETTLE_WAIT_MS = 300
+_TYPE_MACRO_MAX_REPEAT_COUNT = 100
 
 _TYPE_MACRO_TEXT_TRANSLATION = str.maketrans(
     {
@@ -303,6 +304,11 @@ def _parse_type_macro_named_key_control(tag: str) -> tuple[str, int] | None:
         raise ValueError(f"{name} repeat control accepts one count argument")
 
     repeat_count = _parse_positive_int(parts[1], f"{name} repeat count")
+    if repeat_count > _TYPE_MACRO_MAX_REPEAT_COUNT:
+        raise ValueError(
+            f"{name} repeat count must be less than or equal to "
+            f"{_TYPE_MACRO_MAX_REPEAT_COUNT}"
+        )
     return name, repeat_count
 
 
@@ -713,7 +719,7 @@ def _append_type_macro_mouse_move_event(
     t_us: int,
 ) -> int:
     x, y = _parse_type_macro_coordinate_value(value)
-    _append_type_macro_natural_move_event(events, x, y, t_us)
+    _append_type_macro_natural_move_event(events, x, y, t_us, stop_on_failure=False)
     return t_us + 1
 
 
@@ -728,7 +734,7 @@ def _append_type_macro_mouse_click_events(
     if len(parts) == 3:
         x = _parse_int(parts[1], "click x")
         y = _parse_int(parts[2], "click y")
-        _append_type_macro_natural_move_event(events, x, y, t_us)
+        _append_type_macro_natural_move_event(events, x, y, t_us, stop_on_failure=True)
         t_us += 1
     elif len(parts) != 1:
         raise ValueError("click control accepts optional x and y arguments")
@@ -744,6 +750,8 @@ def _append_type_macro_natural_move_event(
     x: int,
     y: int,
     t_us: int,
+    *,
+    stop_on_failure: bool,
 ) -> None:
     _append_mouse_move_event(
         events,
@@ -757,7 +765,7 @@ def _append_type_macro_natural_move_event(
             "curve": _COMPACT_NATURAL_MOUSE_MOVE_FAST_CURVE,
             "tolerance": DEFAULT_NATURAL_MOUSE_MOVE_TOLERANCE,
             "max_duration_ms": DEFAULT_NATURAL_MOUSE_MOVE_MAX_DURATION_MS,
-            "stop_on_failure": False,
+            "stop_on_failure": stop_on_failure,
         },
     )
 

--- a/tests/common/test_macro_compile.py
+++ b/tests/common/test_macro_compile.py
@@ -240,6 +240,154 @@ def test_type_macro_builder_expands_enter_and_tab_controls() -> None:
     ]
 
 
+def test_type_macro_builder_expands_named_key_controls() -> None:
+    events = build_type_macro_events(
+        "<space><esc><backspace><delete><up><down><left><right><home><end>"
+        "<pageup><pagedown>",
+        10,
+        0,
+    )
+
+    assert _press_codes(events) == [
+        evdev.ecodes.KEY_SPACE,
+        evdev.ecodes.KEY_ESC,
+        evdev.ecodes.KEY_BACKSPACE,
+        evdev.ecodes.KEY_DELETE,
+        evdev.ecodes.KEY_UP,
+        evdev.ecodes.KEY_DOWN,
+        evdev.ecodes.KEY_LEFT,
+        evdev.ecodes.KEY_RIGHT,
+        evdev.ecodes.KEY_HOME,
+        evdev.ecodes.KEY_END,
+        evdev.ecodes.KEY_PAGEUP,
+        evdev.ecodes.KEY_PAGEDOWN,
+    ]
+
+
+def test_type_macro_builder_repeats_named_key_controls() -> None:
+    events = build_type_macro_events("<tab:3><backspace:2><down:5>", 10, 0)
+
+    assert _press_codes(events) == [
+        evdev.ecodes.KEY_TAB,
+        evdev.ecodes.KEY_TAB,
+        evdev.ecodes.KEY_TAB,
+        evdev.ecodes.KEY_BACKSPACE,
+        evdev.ecodes.KEY_BACKSPACE,
+        evdev.ecodes.KEY_DOWN,
+        evdev.ecodes.KEY_DOWN,
+        evdev.ecodes.KEY_DOWN,
+        evdev.ecodes.KEY_DOWN,
+        evdev.ecodes.KEY_DOWN,
+    ]
+
+
+def test_type_macro_builder_expands_shortcut_controls() -> None:
+    events = build_type_macro_events(
+        "<shortcut:ctrl+l><shortcut:ctrl+a><shortcut:ctrl+shift+v>",
+        10,
+        0,
+    )
+
+    assert [
+        (event["code"], event["value"])
+        for event in events
+        if event["type"] == evdev.ecodes.EV_KEY
+    ] == [
+        (evdev.ecodes.KEY_LEFTCTRL, 1),
+        (evdev.ecodes.KEY_L, 1),
+        (evdev.ecodes.KEY_L, 0),
+        (evdev.ecodes.KEY_LEFTCTRL, 0),
+        (evdev.ecodes.KEY_LEFTCTRL, 1),
+        (evdev.ecodes.KEY_A, 1),
+        (evdev.ecodes.KEY_A, 0),
+        (evdev.ecodes.KEY_LEFTCTRL, 0),
+        (evdev.ecodes.KEY_LEFTCTRL, 1),
+        (evdev.ecodes.KEY_LEFTSHIFT, 1),
+        (evdev.ecodes.KEY_V, 1),
+        (evdev.ecodes.KEY_V, 0),
+        (evdev.ecodes.KEY_LEFTSHIFT, 0),
+        (evdev.ecodes.KEY_LEFTCTRL, 0),
+    ]
+
+
+def test_type_macro_builder_expands_mouse_move_control() -> None:
+    events = build_type_macro_events("<move:420:180>", 10, 0)
+
+    assert events == [
+        {
+            "device_type": "macro",
+            "type": 0,
+            "code": 0,
+            "value": 0,
+            "t_us": 0,
+            "macro_action": "mouse_move_natural_abs",
+            "x": 420,
+            "y": 180,
+            "speed": 100000.0,
+            "jitter": 0.0,
+            "curve": "linear",
+            "tolerance": 2,
+            "max_duration_ms": 3000,
+            "stop_on_failure": False,
+        }
+    ]
+
+
+def test_type_macro_builder_expands_mouse_click_controls() -> None:
+    events = build_type_macro_events("<click><lclick><leftclick><rclick><rightclick>", 10, 0)
+
+    assert _key_values(events, evdev.ecodes.BTN_LEFT) == [1, 0, 1, 0, 1, 0]
+    assert _key_values(events, evdev.ecodes.BTN_RIGHT) == [1, 0, 1, 0]
+    assert all(event["device_type"] == "mouse" for event in events)
+
+
+def test_type_macro_builder_expands_coordinate_click_control() -> None:
+    events = build_type_macro_events("<click:420:180>", 10, 0)
+
+    assert events[0]["macro_action"] == "mouse_move_natural_abs"
+    assert events[0]["x"] == 420
+    assert events[0]["y"] == 180
+    assert [
+        (event["device_type"], event["code"], event["value"], event["t_us"])
+        for event in events[1:]
+    ] == [
+        ("mouse", evdev.ecodes.BTN_LEFT, 1, 1),
+        ("mouse", evdev.ecodes.BTN_LEFT, 0, 10001),
+    ]
+
+
+def test_type_macro_builder_expands_doubleclick_control_with_pause() -> None:
+    events = build_type_macro_events("<doubleclick>", 10, 20)
+
+    assert [
+        (event["code"], event["value"], event["t_us"])
+        for event in events
+        if event["type"] == evdev.ecodes.EV_KEY
+    ] == [
+        (evdev.ecodes.BTN_LEFT, 1, 0),
+        (evdev.ecodes.BTN_LEFT, 0, 10000),
+        (evdev.ecodes.BTN_LEFT, 1, 30000),
+        (evdev.ecodes.BTN_LEFT, 0, 40000),
+    ]
+
+
+def test_type_macro_builder_expands_coordinate_doubleclick_control() -> None:
+    events = build_type_macro_events("<doubleclick:420:180>", 10, 20)
+
+    assert events[0]["macro_action"] == "mouse_move_natural_abs"
+    assert events[0]["x"] == 420
+    assert events[0]["y"] == 180
+    assert [
+        (event["device_type"], event["code"], event["value"], event["t_us"])
+        for event in events[1:]
+    ] == [
+        ("mouse", evdev.ecodes.BTN_LEFT, 1, 1),
+        ("mouse", evdev.ecodes.BTN_LEFT, 0, 10001),
+        ("mouse", evdev.ecodes.BTN_LEFT, 1, 30001),
+        ("mouse", evdev.ecodes.BTN_LEFT, 0, 40001),
+    ]
+
+
 def test_type_macro_builder_adds_fixed_and_random_wait_controls() -> None:
     events = build_type_macro_events("a<wait:10>b<wait:20:30>c", 10, 0)
 
@@ -264,6 +412,23 @@ def test_type_macro_builder_adds_fixed_and_random_wait_controls() -> None:
             "min_us": 20_000,
             "max_us": 30_000,
         },
+    ]
+
+
+def test_type_macro_builder_adds_settle_control() -> None:
+    events = build_type_macro_events("a<settle>b", 10, 0)
+
+    waits = [event for event in events if event.get("macro_action")]
+    assert waits == [
+        {
+            "device_type": "macro",
+            "type": 0,
+            "code": 0,
+            "value": 0,
+            "t_us": 10_000,
+            "macro_action": "wait",
+            "duration_us": 300_000,
+        }
     ]
 
 
@@ -326,6 +491,31 @@ def test_type_macro_builder_escapes_literal_less_than_before_control() -> None:
 def test_type_macro_builder_rejects_invalid_wait_control() -> None:
     with pytest.raises(ValueError, match="wait duration must be an integer"):
         build_type_macro_events("a<wait:soon>b", 10, 0)
+
+
+@pytest.mark.parametrize(
+    ("text", "match"),
+    [
+        ("<tab:0>", "tab repeat count must be greater than 0"),
+        ("<tab:soon>", "tab repeat count must be an integer"),
+        ("<tab:1:2>", "tab repeat control accepts one count argument"),
+        ("<shortcut:l>", "shortcut requires modifiers and a key"),
+        ("<shortcut:ctrl+bogus>", "unknown shortcut key: bogus"),
+        ("<shortcut:ctrl+shift>", "shortcut requires one non-modifier key"),
+        ("<move:1>", "move control requires x and y arguments"),
+        ("<move:1:2:3>", "move control requires x and y arguments"),
+        ("<move:soon:2>", "move x must be an integer"),
+        ("<click:1>", "click control accepts optional x and y arguments"),
+        ("<click:1:2:3>", "click control accepts optional x and y arguments"),
+        ("<rclick:1:soon>", "rclick y must be an integer"),
+    ],
+)
+def test_type_macro_builder_rejects_invalid_extended_controls(
+    text: str,
+    match: str,
+) -> None:
+    with pytest.raises(ValueError, match=match):
+        build_type_macro_events(text, 10, 0)
 
 
 def test_type_macro_builder_reports_unsupported_character_position() -> None:

--- a/tests/common/test_macro_compile.py
+++ b/tests/common/test_macro_compile.py
@@ -281,6 +281,12 @@ def test_type_macro_builder_repeats_named_key_controls() -> None:
     ]
 
 
+def test_type_macro_builder_allows_repeat_count_limit() -> None:
+    events = build_type_macro_events("<tab:100>", 10, 0)
+
+    assert _press_codes(events) == [evdev.ecodes.KEY_TAB] * 100
+
+
 def test_type_macro_builder_expands_shortcut_controls() -> None:
     events = build_type_macro_events(
         "<shortcut:ctrl+l><shortcut:ctrl+a><shortcut:ctrl+shift+v>",
@@ -347,6 +353,7 @@ def test_type_macro_builder_expands_coordinate_click_control() -> None:
     assert events[0]["macro_action"] == "mouse_move_natural_abs"
     assert events[0]["x"] == 420
     assert events[0]["y"] == 180
+    assert events[0]["stop_on_failure"] is True
     assert [
         (event["device_type"], event["code"], event["value"], event["t_us"])
         for event in events[1:]
@@ -377,6 +384,7 @@ def test_type_macro_builder_expands_coordinate_doubleclick_control() -> None:
     assert events[0]["macro_action"] == "mouse_move_natural_abs"
     assert events[0]["x"] == 420
     assert events[0]["y"] == 180
+    assert events[0]["stop_on_failure"] is True
     assert [
         (event["device_type"], event["code"], event["value"], event["t_us"])
         for event in events[1:]
@@ -499,6 +507,7 @@ def test_type_macro_builder_rejects_invalid_wait_control() -> None:
         ("<tab:0>", "tab repeat count must be greater than 0"),
         ("<tab:soon>", "tab repeat count must be an integer"),
         ("<tab:1:2>", "tab repeat control accepts one count argument"),
+        ("<tab:101>", "tab repeat count must be less than or equal to 100"),
         ("<shortcut:l>", "shortcut requires modifiers and a key"),
         ("<shortcut:ctrl+bogus>", "unknown shortcut key: bogus"),
         ("<shortcut:ctrl+shift>", "shortcut requires one non-modifier key"),

--- a/tests/test_cli_commands_helpers.py
+++ b/tests/test_cli_commands_helpers.py
@@ -547,6 +547,18 @@ def test_type_cli_print_json_does_not_send(
     assert len(payload["events"]) > 0
 
 
+def test_type_cli_print_json_infers_mouse_device_type(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr(commands, "_session_request", lambda payload: pytest.fail("sent request"))
+
+    commands.type_cli(["<move:200:100>test"], print_json=True)
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["device_types"] == ["mouse", "keyboard"]
+
+
 def test_play_adhoc_cli_compiles_compact_tokens(monkeypatch: pytest.MonkeyPatch) -> None:
     sent: list[dict[str, object]] = []
 

--- a/tests/test_entrypoints_and_cli.py
+++ b/tests/test_entrypoints_and_cli.py
@@ -108,7 +108,9 @@ def test_cli_main_type_help_includes_inline_controls_and_docs(
 
     assert excinfo.value.code == 0
     out = capsys.readouterr().out
-    assert "<tab>, <enter>, <wait:MS>, <wait:MIN:MAX>" in out
+    assert "<tab>, <enter>, <space>, <esc>, <backspace>, <delete>" in out
+    assert "<KEY:COUNT>, <shortcut:MOD+KEY>, <move:X:Y>, <click[:X:Y]>" in out
+    assert "<doubleclick[:X:Y]>, <rclick[:X:Y]>, <settle>, <wait:MS>, <wait:MIN:MAX>" in out
     assert "https://keymasq.tools/docs/v1.2.3/CLI.md" in out
 
 


### PR DESCRIPTION
## Summary

- Add `<space>`, `<esc>`, `<backspace>`, `<delete>`, arrow keys, `<home>`, `<end>`, `<pageup>`, `<pagedown>` inline controls
- Add repeat count syntax `<KEY:COUNT>` for any named key (e.g., `<tab:3>`, `<down:5>`)
- Add `<shortcut:MOD+KEY>` to press a keyboard shortcut with modifier aliases (`control`, `meta`, `win`)
- Add `<move:X:Y>` for natural cursor movement with fast defaults
- Add `<click>`, `<lclick>`, `<leftclick>`, `<rclick>`, `<rightclick>`, `<doubleclick>` mouse button controls
- Add coordinate-click variants: `<click:X:Y>`, `<rclick:X:Y>`, `<doubleclick:X:Y>`
- Add `<settle>` as a fixed 300 ms wait
- Update `--help` epilog, `docs/CLI.md`, and `docs/agents/macros.txt`
- Infer `mouse` device type in `--print-json` when mouse events are present
- Add 15 new test cases covering all new controls and edge-case validation

## Testing

- All existing type macro tests continue to pass
- `test_type_macro_builder_expands_named_key_controls` — verifies each named key emits the correct evdev code
- `test_type_macro_builder_repeats_named_key_controls` — verifies `<tab:3>` produces three tab events
- `test_type_macro_builder_expands_shortcut_controls` — checks modifier down/key press/key up/modifier up order
- `test_type_macro_builder_expands_mouse_move_control` — asserts natural move event shape with defaults
- `test_type_macro_builder_expands_mouse_click_controls` — verifies left/right click press/release pairs
- `test_type_macro_builder_expands_coordinate_click_control` — confirms move event precedes click events
- `test_type_macro_builder_expands_doubleclick_control_with_pause` — double click separated by inter-event pause
- `test_type_macro_builder_expands_coordinate_doubleclick_control` — move then double click
- `test_type_macro_builder_adds_settle_control` — settle produces 300 ms wait
- `test_type_macro_builder_rejects_invalid_extended_controls` — 10 parametrized rejection cases
- `test_type_cli_print_json_infers_mouse_device_type` — `--print-json` includes `mouse` in device_types
- `test_cli_main_type_help_includes_inline_controls_and_docs` — updated to expect new controls in help output
- `ruff`, `basedpyright`, and full pytest suite pass via `scripts/check.sh`