### PR TITLE
Add permission hints to input and uinput failures

### DIFF
--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -183,6 +183,8 @@ Symptoms:
 - `keymasqd` fails to start
 - remaps do not activate
 - logs mention permission errors for `/dev/uinput` or `/dev/input/event*`
+- device discovery or capture says no devices/interfaces were found even though
+  the hardware is connected
 
 Checks:
 

--- a/keymasq/keymasqd/capture_manager.py
+++ b/keymasq/keymasqd/capture_manager.py
@@ -21,7 +21,10 @@ from keymasq.common.devices import (
     wheel_button_id,
 )
 from keymasq.common.types import JsonObject
-from keymasq.keymasqd.permission_hints import input_device_permission_message
+from keymasq.keymasqd.permission_hints import (
+    input_device_permission_message,
+    is_permission_error,
+)
 from keymasq.keymasqd.runtime import device_path_resolver
 from keymasq.keymasqd.runtime.adapters import DeviceInfo
 
@@ -118,6 +121,7 @@ class CaptureManager:
 
         grabbed: list[_CaptureInputDevice] = []
         warnings: list[str] = []
+        permission_error_seen = False
         for device in matched:
             try:
                 device.grab()
@@ -125,7 +129,8 @@ class CaptureManager:
             except OSError as e:
                 if e.errno == errno.EBUSY:
                     warnings.append(f"{device.path}: busy")
-                elif e.errno == errno.EACCES:
+                elif is_permission_error(e):
+                    permission_error_seen = True
                     warnings.append(f"{device.path}: permission denied")
                 else:
                     warnings.append(f"{device.path}: {e}")
@@ -135,7 +140,7 @@ class CaptureManager:
             message = "No readable/grabbable interfaces found"
             if warnings:
                 message = f"{message}: {', '.join(warnings)}"
-            if any("permission denied" in warning for warning in warnings):
+            if permission_error_seen:
                 message = input_device_permission_message(message)
             raise RuntimeError(message)
 

--- a/keymasq/keymasqd/capture_manager.py
+++ b/keymasq/keymasqd/capture_manager.py
@@ -21,6 +21,7 @@ from keymasq.common.devices import (
     wheel_button_id,
 )
 from keymasq.common.types import JsonObject
+from keymasq.keymasqd.permission_hints import input_device_permission_message
 from keymasq.keymasqd.runtime import device_path_resolver
 from keymasq.keymasqd.runtime.adapters import DeviceInfo
 
@@ -111,7 +112,9 @@ class CaptureManager:
         else:
             matched = self._find_devices(*self._parse_hardware_id(hardware_id))
         if not matched:
-            raise ValueError(f"No devices found for {hardware_id}")
+            raise ValueError(
+                input_device_permission_message(f"No devices found for {hardware_id}")
+            )
 
         grabbed: list[_CaptureInputDevice] = []
         warnings: list[str] = []
@@ -129,7 +132,12 @@ class CaptureManager:
                 _close_device(device)
 
         if not grabbed:
-            raise RuntimeError("No readable/grabbable interfaces found")
+            message = "No readable/grabbable interfaces found"
+            if warnings:
+                message = f"{message}: {', '.join(warnings)}"
+            if any("permission denied" in warning for warning in warnings):
+                message = input_device_permission_message(message)
+            raise RuntimeError(message)
 
         token = str(uuid.uuid4())
         self._sessions[token] = CaptureSession(
@@ -190,7 +198,11 @@ class CaptureManager:
             path_hardware_ids=path_hardware_ids,
         )
         if not matched and not allow_empty:
-            raise ValueError("No keyboard devices found for combo capture")
+            raise ValueError(
+                input_device_permission_message(
+                    "No keyboard devices found for combo capture"
+                )
+            )
 
         devices = list(matched)
         warnings: list[str] = []

--- a/keymasq/keymasqd/device_manager.py
+++ b/keymasq/keymasqd/device_manager.py
@@ -50,6 +50,10 @@ from keymasq.keymasqd.combo_engine import (
     RuntimeComboStep,
 )
 from keymasq.keymasqd.output_helpers import emit_mouse_move, resolve_output_code
+from keymasq.keymasqd.permission_hints import (
+    input_device_permission_message,
+    is_permission_error,
+)
 from keymasq.keymasqd.recording import RecordingManager
 from keymasq.keymasqd.runtime import actions as runtime_actions
 from keymasq.keymasqd.runtime import adapters as runtime_adapters
@@ -1332,6 +1336,15 @@ class DeviceManager:
                     }
                 )
             except OSError as exc:
+                if is_permission_error(exc):
+                    log.warning(
+                        input_device_permission_message(
+                            "Skipping unreadable device %s: %s"
+                        ),
+                        path,
+                        exc,
+                    )
+                    continue
                 log.debug("Skipping unreadable device %s: %s", path, exc)
             except Exception:
                 log.exception("Could not read device %s", path)

--- a/keymasq/keymasqd/permission_hints.py
+++ b/keymasq/keymasqd/permission_hints.py
@@ -11,12 +11,29 @@ UINPUT_PERMISSION_HINT = (
     "Check that keymasqd can write /dev/uinput; see "
     f"{PERMISSION_TROUBLESHOOTING_REF}."
 )
+UINPUT_PERMISSION_ERROR_MARKERS = (
+    "cannot be opened for writing",
+    "permission",
+    "not permitted",
+    "access denied",
+)
 
 
 def is_permission_error(exc: BaseException) -> bool:
     if isinstance(exc, PermissionError):
         return True
     return isinstance(exc, OSError) and exc.errno in {errno.EACCES, errno.EPERM}
+
+
+def is_uinput_permission_error(exc: BaseException) -> bool:
+    if is_permission_error(exc):
+        return True
+    if exc.__class__.__name__ != "UInputError":
+        return False
+    message = str(exc).lower()
+    return "/dev/uinput" in message and any(
+        marker in message for marker in UINPUT_PERMISSION_ERROR_MARKERS
+    )
 
 
 def has_permission_hint(message: object) -> bool:

--- a/keymasq/keymasqd/permission_hints.py
+++ b/keymasq/keymasqd/permission_hints.py
@@ -38,7 +38,7 @@ def is_uinput_permission_error(exc: BaseException) -> bool:
 
 def has_permission_hint(message: object) -> bool:
     text = str(message)
-    return "/dev/input/event*" in text or "/dev/uinput" in text
+    return PERMISSION_TROUBLESHOOTING_REF in text
 
 
 def input_device_permission_message(message: str) -> str:

--- a/keymasq/keymasqd/permission_hints.py
+++ b/keymasq/keymasqd/permission_hints.py
@@ -1,0 +1,38 @@
+import errno
+
+PERMISSION_TROUBLESHOOTING_REF = (
+    "docs/TROUBLESHOOTING.md#uinput-or-input-device-access-problems"
+)
+INPUT_DEVICE_PERMISSION_HINT = (
+    "Check that keymasqd can read /dev/input/event*; see "
+    f"{PERMISSION_TROUBLESHOOTING_REF}."
+)
+UINPUT_PERMISSION_HINT = (
+    "Check that keymasqd can write /dev/uinput; see "
+    f"{PERMISSION_TROUBLESHOOTING_REF}."
+)
+
+
+def is_permission_error(exc: BaseException) -> bool:
+    if isinstance(exc, PermissionError):
+        return True
+    return isinstance(exc, OSError) and exc.errno in {errno.EACCES, errno.EPERM}
+
+
+def has_permission_hint(message: object) -> bool:
+    text = str(message)
+    return "/dev/input/event*" in text or "/dev/uinput" in text
+
+
+def input_device_permission_message(message: str) -> str:
+    return _append_hint(message, INPUT_DEVICE_PERMISSION_HINT)
+
+
+def uinput_permission_message(message: str) -> str:
+    return _append_hint(message, UINPUT_PERMISSION_HINT)
+
+
+def _append_hint(message: str, hint: str) -> str:
+    if has_permission_hint(message):
+        return message
+    return f"{message}. {hint}"

--- a/keymasq/keymasqd/runtime/device_path_resolver.py
+++ b/keymasq/keymasqd/runtime/device_path_resolver.py
@@ -20,6 +20,10 @@ from keymasq.common.devices import (
 )
 from keymasq.common.models import DeviceType
 from keymasq.common.types import JsonObject
+from keymasq.keymasqd.permission_hints import (
+    input_device_permission_message,
+    is_permission_error,
+)
 from keymasq.keymasqd.runtime.adapters import DeviceInfo, close_device
 
 log = logging.getLogger("keymasqd.device_path_resolver")
@@ -158,6 +162,9 @@ def _probe_cached_device_info(
             is_virtual=_is_keymasq_virtual_device(device),
         )
     except OSError as exc:
+        if is_permission_error(exc):
+            log.warning(input_device_permission_message(skip_log_message), path, exc)
+            return None
         log.debug(skip_log_message, path, exc)
         return None
     except Exception:

--- a/keymasq/keymasqd/runtime/grab_lifecycle.py
+++ b/keymasq/keymasqd/runtime/grab_lifecycle.py
@@ -16,6 +16,11 @@ from keymasq.common.models import MappingAction
 from keymasq.common.types import JsonObject
 from keymasq.keymasqd.combo_engine import ComboDecision
 from keymasq.keymasqd.output_helpers import resolve_output_code
+from keymasq.keymasqd.permission_hints import (
+    has_permission_hint,
+    input_device_permission_message,
+    is_permission_error,
+)
 from keymasq.keymasqd.runtime import actions as runtime_actions
 from keymasq.keymasqd.runtime import adapters as runtime_adapters
 from keymasq.keymasqd.runtime import combos as runtime_combos
@@ -278,8 +283,9 @@ async def grab_device_unlocked(
     ) -> None:
         await release_interface(manager, disconnected_hardware_id, disconnected_path)
 
-    async def rollback_failed_grab(path: str, exc: BaseException) -> None:
-        log.error("Failed to grab %s: %s", path, exc)
+    async def rollback_failed_grab(path: str, exc: BaseException) -> BaseException:
+        reported_exc = _permission_aware_grab_exception(path, exc)
+        log.error("Failed to grab %s: %s", path, reported_exc)
         for device in list(devices):
             if any(device is existing for existing in existing_devices):
                 continue
@@ -295,6 +301,7 @@ async def grab_device_unlocked(
                 previous_desired_paths,
                 previous_desired_config,
             )
+        return reported_exc
 
     for path in sorted(requested_paths):
         if path in existing_by_claim_path:
@@ -423,14 +430,14 @@ async def grab_device_unlocked(
             if exc.errno in {errno_mod.ENOENT, errno_mod.ENODEV}:
                 log.info("Skipping unavailable interface for %s: %s", hardware_id, path)
                 continue
-            await rollback_failed_grab(path, exc)
-            raise
+            reported_exc = await rollback_failed_grab(path, exc)
+            raise reported_exc from exc
         except Exception as exc:
             if raw_device is not None:
                 runtime_adapters.close_device(raw_device)
                 raw_device = None
-            await rollback_failed_grab(path, exc)
-            raise
+            reported_exc = await rollback_failed_grab(path, exc)
+            raise reported_exc from exc
         finally:
             if raw_device is not None:
                 runtime_adapters.close_device(raw_device)
@@ -481,6 +488,16 @@ async def grab_device_unlocked(
         "skipped_count": skipped_count,
         "waiting_for_device": waiting_for_device,
     }
+
+
+def _permission_aware_grab_exception(path: str, exc: BaseException) -> BaseException:
+    if not is_permission_error(exc) or has_permission_hint(exc):
+        return exc
+    return PermissionError(
+        input_device_permission_message(
+            f"Permission denied while opening or grabbing {path}: {exc}"
+        )
+    )
 
 
 def grabbed_paths_for_other_hardware(

--- a/keymasq/keymasqd/runtime/grabbed_device.py
+++ b/keymasq/keymasqd/runtime/grabbed_device.py
@@ -51,7 +51,10 @@ from keymasq.keymasqd.runtime.grabbed_device_types import (
 from keymasq.keymasqd.runtime.grabbed_device_types import (
     ManagedInputDevice as _ManagedInputDevice,
 )
-from keymasq.keymasqd.runtime.outputs import uinput_identity
+from keymasq.keymasqd.runtime.outputs import (
+    create_uinput_with_permission_hint,
+    uinput_identity,
+)
 from keymasq.keymasqd.runtime.repeat import RepeatRuntimeState
 
 log = logging.getLogger("keymasqd.devices")
@@ -535,17 +538,20 @@ class GrabbedDevice:
                 passthrough_input_props = None
 
             def make_passthrough_uinput(max_effects: int) -> evdev.UInput:
-                return evdev.UInput(
-                    **_passthrough_uinput_kwargs(
-                        caps=caps,
-                        passthrough_name=passthrough_name,
-                        passthrough_vendor=passthrough_vendor,
-                        passthrough_product=passthrough_product,
-                        passthrough_version=passthrough_version,
-                        passthrough_bustype=passthrough_bustype,
-                        passthrough_input_props=passthrough_input_props,
-                        ff_max_effects=max_effects,
-                    )
+                return create_uinput_with_permission_hint(
+                    "passthrough",
+                    lambda: evdev.UInput(
+                        **_passthrough_uinput_kwargs(
+                            caps=caps,
+                            passthrough_name=passthrough_name,
+                            passthrough_vendor=passthrough_vendor,
+                            passthrough_product=passthrough_product,
+                            passthrough_version=passthrough_version,
+                            passthrough_bustype=passthrough_bustype,
+                            passthrough_input_props=passthrough_input_props,
+                            ff_max_effects=max_effects,
+                        )
+                    ),
                 )
 
             self.uinput = make_passthrough_uinput(ff_max_effects)

--- a/keymasq/keymasqd/runtime/outputs.py
+++ b/keymasq/keymasqd/runtime/outputs.py
@@ -5,9 +5,11 @@ from collections.abc import Callable, Mapping, Sequence
 from hashlib import blake2b
 from typing import Any, Final, Protocol, cast
 
+from evdev.uinput import UInputError
+
 from keymasq.common.virtual_devices import clamp_virtual_gamepad_count, virtual_gamepad_output_id
 from keymasq.keymasqd.permission_hints import (
-    is_permission_error,
+    is_uinput_permission_error,
     uinput_permission_message,
 )
 from keymasq.keymasqd.runtime.adapters import (
@@ -220,8 +222,8 @@ class _EvdevModule(Protocol):
 def create_uinput_with_permission_hint[T](context: str, create: Callable[[], T]) -> T:
     try:
         return create()
-    except OSError as exc:
-        if is_permission_error(exc):
+    except (OSError, UInputError) as exc:
+        if is_uinput_permission_error(exc):
             raise PermissionError(
                 uinput_permission_message(
                     f"Failed to create {context} uinput device: {exc}"

--- a/keymasq/keymasqd/runtime/outputs.py
+++ b/keymasq/keymasqd/runtime/outputs.py
@@ -1,11 +1,15 @@
 import logging
 import os
 import re
-from collections.abc import Mapping, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from hashlib import blake2b
 from typing import Any, Final, Protocol, cast
 
 from keymasq.common.virtual_devices import clamp_virtual_gamepad_count, virtual_gamepad_output_id
+from keymasq.keymasqd.permission_hints import (
+    is_permission_error,
+    uinput_permission_message,
+)
 from keymasq.keymasqd.runtime.adapters import (
     ClosableUInput,
     UInputWriter,
@@ -213,6 +217,19 @@ class _EvdevModule(Protocol):
     AbsInfo: Final[_AbsInfoFactory]
 
 
+def create_uinput_with_permission_hint[T](context: str, create: Callable[[], T]) -> T:
+    try:
+        return create()
+    except OSError as exc:
+        if is_permission_error(exc):
+            raise PermissionError(
+                uinput_permission_message(
+                    f"Failed to create {context} uinput device: {exc}"
+                )
+            ) from exc
+        raise
+
+
 def _test_uinput_enabled() -> bool:
     value = str(os.environ.get(TEST_UINPUT_ENV, "")).strip().lower()
     return value not in {"", "0", "false", "no"}
@@ -348,13 +365,16 @@ def create_virtual_gamepad(
         "gamepad",
         test_name="gamepad" if index == 1 else f"gamepad-{index}",
     )
-    uinput_dev = evdev_mod.UInput(
-        events=cast(dict[int, Sequence[int]], gamepad_caps(evdev_mod)),
-        name=gamepad_name,
-        vendor=0x045E if gamepad_vendor is None else gamepad_vendor,
-        product=0x028E if gamepad_product is None else gamepad_product,
-        version=0x0110,
-        bustype=0x0003,
+    uinput_dev = create_uinput_with_permission_hint(
+        "virtual gamepad",
+        lambda: evdev_mod.UInput(
+            events=cast(dict[int, Sequence[int]], gamepad_caps(evdev_mod)),
+            name=gamepad_name,
+            vendor=0x045E if gamepad_vendor is None else gamepad_vendor,
+            product=0x028E if gamepad_product is None else gamepad_product,
+            version=0x0110,
+            bustype=0x0003,
+        ),
     )
     _initialize_gamepad_axes(uinput_writer(uinput_dev), evdev_mod)
     return uinput_dev
@@ -527,16 +547,22 @@ def create_global_uinputs(
             "keyboard",
         )
         if keyboard_vendor is None or keyboard_product is None:
-            manager.output_state.keyboard_uinput = evdev_mod.UInput(
-                events=cast(dict[int, Sequence[int]], keyboard_caps),
-                name=keyboard_name,
+            manager.output_state.keyboard_uinput = create_uinput_with_permission_hint(
+                "keyboard",
+                lambda: evdev_mod.UInput(
+                    events=cast(dict[int, Sequence[int]], keyboard_caps),
+                    name=keyboard_name,
+                ),
             )
         else:
-            manager.output_state.keyboard_uinput = evdev_mod.UInput(
-                events=cast(dict[int, Sequence[int]], keyboard_caps),
-                name=keyboard_name,
-                vendor=keyboard_vendor,
-                product=keyboard_product,
+            manager.output_state.keyboard_uinput = create_uinput_with_permission_hint(
+                "keyboard",
+                lambda: evdev_mod.UInput(
+                    events=cast(dict[int, Sequence[int]], keyboard_caps),
+                    name=keyboard_name,
+                    vendor=keyboard_vendor,
+                    product=keyboard_product,
+                ),
             )
 
         mouse_caps = {
@@ -570,16 +596,22 @@ def create_global_uinputs(
             "mouse",
         )
         if mouse_vendor is None or mouse_product is None:
-            manager.output_state.mouse_uinput = evdev_mod.UInput(
-                events=cast(dict[int, Sequence[int]], mouse_caps),
-                name=mouse_name,
+            manager.output_state.mouse_uinput = create_uinput_with_permission_hint(
+                "mouse",
+                lambda: evdev_mod.UInput(
+                    events=cast(dict[int, Sequence[int]], mouse_caps),
+                    name=mouse_name,
+                ),
             )
         else:
-            manager.output_state.mouse_uinput = evdev_mod.UInput(
-                events=cast(dict[int, Sequence[int]], mouse_caps),
-                name=mouse_name,
-                vendor=mouse_vendor,
-                product=mouse_product,
+            manager.output_state.mouse_uinput = create_uinput_with_permission_hint(
+                "mouse",
+                lambda: evdev_mod.UInput(
+                    events=cast(dict[int, Sequence[int]], mouse_caps),
+                    name=mouse_name,
+                    vendor=mouse_vendor,
+                    product=mouse_product,
+                ),
             )
 
         configure_virtual_gamepads(

--- a/tests/keymasqd/test_device_manager_core.py
+++ b/tests/keymasqd/test_device_manager_core.py
@@ -49,6 +49,29 @@ async def test_set_cursor_position_reports_missing_mouse_uinput() -> None:
 
 
 @pytest.mark.asyncio
+async def test_grab_device_permission_denied_mentions_input_permissions(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = DeviceManager()
+
+    def fake_input_device(_path: str):
+        raise PermissionError(errno.EACCES, "denied")
+
+    monkeypatch.setattr(dm.evdev, "InputDevice", fake_input_device)
+
+    with pytest.raises(PermissionError) as excinfo:
+        await manager.grab_device(
+            "1234:5678",
+            ["/dev/input/event0"],
+            {"a": "key_a"},
+        )
+
+    message = str(excinfo.value)
+    assert "/dev/input/event0" in message
+    assert "/dev/input/event*" in message
+
+
+@pytest.mark.asyncio
 async def test_get_cursor_position_uses_broadcast_request_response() -> None:
     broadcast = AsyncMock()
     manager = DeviceManager(broadcast_callback=broadcast)
@@ -1923,6 +1946,26 @@ class TestListDevices:
         assert closed_paths == ["/dev/input/event0"]
         assert "Skipping unreadable device /dev/input/event0" in caplog.text
         assert "Could not read device /dev/input/event0" not in caplog.text
+
+    def test_list_devices_permission_error_logs_hint(
+        self,
+        caplog: pytest.LogCaptureFixture,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        manager = DeviceManager()
+
+        def fake_input_device(_path: str):
+            raise PermissionError(errno.EACCES, "denied")
+
+        monkeypatch.setattr(dm, "_device_paths", lambda: ["/dev/input/event0"])
+        monkeypatch.setattr(dm.evdev, "InputDevice", fake_input_device)
+        caplog.set_level(logging.WARNING, logger="keymasqd.devices")
+
+        result = manager._list_devices_sync()
+
+        assert result == {"devices": []}
+        assert "Skipping unreadable device /dev/input/event0" in caplog.text
+        assert "/dev/input/event*" in caplog.text
 
     def test_list_devices_marks_physical_recording_identity(
         self,

--- a/tests/keymasqd/test_device_manager_core.py
+++ b/tests/keymasqd/test_device_manager_core.py
@@ -58,6 +58,7 @@ async def test_grab_device_permission_denied_mentions_input_permissions(
         raise PermissionError(errno.EACCES, "denied")
 
     monkeypatch.setattr(dm.evdev, "InputDevice", fake_input_device)
+    monkeypatch.setattr(dm, "resolve_stable_path", lambda path: path)
 
     with pytest.raises(PermissionError) as excinfo:
         await manager.grab_device(

--- a/tests/keymasqd/test_device_manager_runtime_recovery.py
+++ b/tests/keymasqd/test_device_manager_runtime_recovery.py
@@ -11,6 +11,7 @@ from evdev.uinput import UInputError
 from keymasq.common.models import ActionType, DeviceType, SuperkeyMode
 from keymasq.keymasqd import device_manager as dm
 from keymasq.keymasqd.device_manager import DeviceManager
+from keymasq.keymasqd.permission_hints import UINPUT_PERMISSION_HINT
 from keymasq.keymasqd.runtime import actions as adm
 from keymasq.keymasqd.runtime import adapters as runtime_adapters
 from keymasq.keymasqd.runtime import combos as cdm
@@ -305,7 +306,7 @@ class TestDeviceManagerHelpers:
 
         message = str(excinfo.value)
         assert "keyboard uinput device" in message
-        assert "/dev/uinput" in message
+        assert UINPUT_PERMISSION_HINT in message
         assert manager.output_state.device_count == 0
 
     def test_create_global_uinputs_uinput_error_mentions_uinput(self) -> None:
@@ -335,7 +336,7 @@ class TestDeviceManagerHelpers:
 
         message = str(excinfo.value)
         assert "keyboard uinput device" in message
-        assert "/dev/uinput" in message
+        assert UINPUT_PERMISSION_HINT in message
         assert manager.output_state.device_count == 0
 
     def test_configure_virtual_gamepads_logs_close_failures(

--- a/tests/keymasqd/test_device_manager_runtime_recovery.py
+++ b/tests/keymasqd/test_device_manager_runtime_recovery.py
@@ -277,6 +277,36 @@ class TestDeviceManagerHelpers:
         assert created[2].kwargs["vendor"] == 0x4B46
         assert created[2].kwargs["product"] == 0x1003
 
+    def test_create_global_uinputs_permission_error_mentions_uinput(self) -> None:
+        manager = SimpleNamespace(
+            output_state=SimpleNamespace(
+                device_count=0,
+                keyboard_uinput=None,
+                mouse_uinput=None,
+                gamepad_uinput=None,
+            )
+        )
+
+        def fail_uinput(**_kwargs) -> FakeUInput:
+            raise PermissionError(errno.EACCES, "denied")
+
+        with pytest.raises(PermissionError) as excinfo:
+            ldm.runtime_outputs.create_global_uinputs(
+                manager,
+                evdev_mod=SimpleNamespace(
+                    ecodes=evdev.ecodes,
+                    UInput=fail_uinput,
+                    AbsInfo=evdev.AbsInfo,
+                ),
+                log=logging.getLogger("test"),
+                uinput_writer=lambda device: device,
+            )
+
+        message = str(excinfo.value)
+        assert "keyboard uinput device" in message
+        assert "/dev/uinput" in message
+        assert manager.output_state.device_count == 0
+
     def test_configure_virtual_gamepads_logs_close_failures(
         self,
         caplog: pytest.LogCaptureFixture,

--- a/tests/keymasqd/test_device_manager_runtime_recovery.py
+++ b/tests/keymasqd/test_device_manager_runtime_recovery.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, Mock
 
 import evdev
 import pytest
+from evdev.uinput import UInputError
 
 from keymasq.common.models import ActionType, DeviceType, SuperkeyMode
 from keymasq.keymasqd import device_manager as dm
@@ -289,6 +290,36 @@ class TestDeviceManagerHelpers:
 
         def fail_uinput(**_kwargs) -> FakeUInput:
             raise PermissionError(errno.EACCES, "denied")
+
+        with pytest.raises(PermissionError) as excinfo:
+            ldm.runtime_outputs.create_global_uinputs(
+                manager,
+                evdev_mod=SimpleNamespace(
+                    ecodes=evdev.ecodes,
+                    UInput=fail_uinput,
+                    AbsInfo=evdev.AbsInfo,
+                ),
+                log=logging.getLogger("test"),
+                uinput_writer=lambda device: device,
+            )
+
+        message = str(excinfo.value)
+        assert "keyboard uinput device" in message
+        assert "/dev/uinput" in message
+        assert manager.output_state.device_count == 0
+
+    def test_create_global_uinputs_uinput_error_mentions_uinput(self) -> None:
+        manager = SimpleNamespace(
+            output_state=SimpleNamespace(
+                device_count=0,
+                keyboard_uinput=None,
+                mouse_uinput=None,
+                gamepad_uinput=None,
+            )
+        )
+
+        def fail_uinput(**_kwargs) -> FakeUInput:
+            raise UInputError('"/dev/uinput" cannot be opened for writing')
 
         with pytest.raises(PermissionError) as excinfo:
             ldm.runtime_outputs.create_global_uinputs(

--- a/tests/keymasqd/test_permission_hints.py
+++ b/tests/keymasqd/test_permission_hints.py
@@ -1,0 +1,21 @@
+from keymasq.keymasqd.permission_hints import (
+    UINPUT_PERMISSION_HINT,
+    uinput_permission_message,
+)
+
+
+def test_uinput_permission_message_appends_hint_when_error_mentions_devnode() -> None:
+    message = uinput_permission_message(
+        'Failed to create keyboard uinput device: "/dev/uinput" '
+        "cannot be opened for writing"
+    )
+
+    assert UINPUT_PERMISSION_HINT in message
+
+
+def test_uinput_permission_message_does_not_duplicate_existing_hint() -> None:
+    message = uinput_permission_message(
+        f"Failed to create keyboard uinput device. {UINPUT_PERMISSION_HINT}"
+    )
+
+    assert message.count(UINPUT_PERMISSION_HINT) == 1

--- a/tests/test_capture_manager.py
+++ b/tests/test_capture_manager.py
@@ -373,6 +373,30 @@ def test_capture_manager_begin_reports_grab_warnings(monkeypatch) -> None:
     assert denied.close_count == 1
 
 
+def test_capture_manager_begin_reports_eperm_grab_warning_with_hint(
+    monkeypatch,
+) -> None:
+    denied = _FakeDevice("/dev/input/event2", 0x1234, 0x5678, [])
+
+    def _grab_denied() -> None:
+        raise OSError(errno.EPERM, "not permitted")
+
+    denied.grab = _grab_denied
+
+    monkeypatch.setattr(evdev, "list_devices", lambda: [denied.path])
+    monkeypatch.setattr(evdev, "InputDevice", lambda _path: denied)
+
+    manager = CaptureManager()
+    with pytest.raises(RuntimeError, match="No readable/grabbable interfaces found") as excinfo:
+        manager.begin("1234:5678")
+
+    message = str(excinfo.value)
+    assert "/dev/input/event2: permission denied" in message
+    assert "/dev/input/event*" in message
+    assert denied.closed is True
+    assert denied.close_count == 1
+
+
 def test_capture_manager_begin_combo_no_devices_mentions_input_permissions(
     monkeypatch,
 ) -> None:

--- a/tests/test_capture_manager.py
+++ b/tests/test_capture_manager.py
@@ -1,3 +1,4 @@
+import errno
 import threading
 from typing import cast
 from unittest.mock import Mock
@@ -121,6 +122,35 @@ def test_capture_manager_begin_can_target_explicit_paths(monkeypatch) -> None:
             manager.end(token)
     assert wanted.grabbed is False
     assert wanted.closed is True
+
+
+def test_capture_manager_begin_no_devices_mentions_input_permissions(monkeypatch) -> None:
+    monkeypatch.setattr(evdev, "list_devices", lambda: [])
+
+    manager = CaptureManager()
+    with pytest.raises(ValueError) as excinfo:
+        manager.begin("1234:5678")
+
+    message = str(excinfo.value)
+    assert "No devices found for 1234:5678" in message
+    assert "/dev/input/event*" in message
+
+
+def test_capture_manager_begin_unreadable_devices_mentions_input_permissions(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(evdev, "list_devices", lambda: ["/dev/input/event1"])
+
+    def fake_input_device(_path: str):
+        raise PermissionError(errno.EACCES, "denied")
+
+    monkeypatch.setattr(evdev, "InputDevice", fake_input_device)
+
+    manager = CaptureManager()
+    with pytest.raises(ValueError) as excinfo:
+        manager.begin("1234:5678")
+
+    assert "/dev/input/event*" in str(excinfo.value)
 
 
 def test_capture_manager_resolves_keymasq_paths(monkeypatch) -> None:
@@ -331,13 +361,30 @@ def test_capture_manager_begin_reports_grab_warnings(monkeypatch) -> None:
     monkeypatch.setattr(evdev, "InputDevice", lambda path: devices[path])
 
     manager = CaptureManager()
-    with pytest.raises(RuntimeError, match="No readable/grabbable interfaces found"):
+    with pytest.raises(RuntimeError, match="No readable/grabbable interfaces found") as excinfo:
         manager.begin("1234:5678")
 
+    message = str(excinfo.value)
+    assert "/dev/input/event2: permission denied" in message
+    assert "/dev/input/event*" in message
     assert busy.closed is True
     assert denied.closed is True
     assert busy.close_count == 1
     assert denied.close_count == 1
+
+
+def test_capture_manager_begin_combo_no_devices_mentions_input_permissions(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(evdev, "list_devices", lambda: [])
+    manager = CaptureManager()
+
+    with pytest.raises(ValueError) as excinfo:
+        manager.begin_combo(authorization=manager.authorize_combo_capture())
+
+    message = str(excinfo.value)
+    assert "No keyboard devices found for combo capture" in message
+    assert "/dev/input/event*" in message
 
 
 def test_capture_manager_begin_closes_failed_grab_devices_with_partial_success(

--- a/tests/test_grabbed_device.py
+++ b/tests/test_grabbed_device.py
@@ -171,6 +171,49 @@ async def test_grab_failure_closes_input_device_when_passthrough_creation_fails(
     assert grabbed.uinput is None
 
 
+@pytest.mark.asyncio
+async def test_grab_permission_error_mentions_uinput_when_passthrough_creation_fails(
+    monkeypatch,
+):
+    fake_device = SimpleNamespace(
+        name="fake input",
+        info=SimpleNamespace(vendor=None, product=None, version=None, bustype=None),
+        capabilities=MagicMock(
+            return_value={
+                evdev.ecodes.EV_SYN: [],
+                evdev.ecodes.EV_KEY: [evdev.ecodes.BTN_LEFT],
+            }
+        ),
+        close=MagicMock(),
+        grab=MagicMock(),
+    )
+
+    def fail_uinput_creation(**kwargs):
+        raise PermissionError(13, "denied")
+
+    monkeypatch.setattr(gdm, "_device_input", lambda path: fake_device)
+    monkeypatch.setattr(gdm.evdev, "UInput", fail_uinput_creation)
+
+    grabbed = GrabbedDevice(
+        path="/dev/input/event-test",
+        hardware_id="test:device",
+        button_map={},
+        mapping_getter=lambda: {},
+        event_callback=AsyncMock(),
+    )
+
+    with pytest.raises(PermissionError) as excinfo:
+        await grabbed.grab()
+
+    message = str(excinfo.value)
+    assert "passthrough uinput device" in message
+    assert "/dev/uinput" in message
+    fake_device.close.assert_called_once_with()
+    fake_device.grab.assert_not_called()
+    assert grabbed.device is None
+    assert grabbed.uinput is None
+
+
 class TestActionExecution:
     def test_resolve_code_btn_left(self):
         code = resolve_output_code("btn_left")

--- a/tests/test_grabbed_device.py
+++ b/tests/test_grabbed_device.py
@@ -8,6 +8,7 @@ import pytest
 from evdev.uinput import UInputError
 
 from keymasq.keymasqd.output_helpers import resolve_output_code
+from keymasq.keymasqd.permission_hints import UINPUT_PERMISSION_HINT
 from keymasq.keymasqd.runtime import grabbed_device as gdm
 from keymasq.keymasqd.runtime import grabbed_device_outputs as gdo
 from keymasq.keymasqd.runtime import grabbed_device_repeat as gdr
@@ -208,7 +209,7 @@ async def test_grab_uinput_error_mentions_uinput_when_passthrough_creation_fails
 
     message = str(excinfo.value)
     assert "passthrough uinput device" in message
-    assert "/dev/uinput" in message
+    assert UINPUT_PERMISSION_HINT in message
     fake_device.close.assert_called_once_with()
     fake_device.grab.assert_not_called()
     assert grabbed.device is None

--- a/tests/test_grabbed_device.py
+++ b/tests/test_grabbed_device.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import evdev
 import pytest
+from evdev.uinput import UInputError
 
 from keymasq.keymasqd.output_helpers import resolve_output_code
 from keymasq.keymasqd.runtime import grabbed_device as gdm
@@ -172,7 +173,7 @@ async def test_grab_failure_closes_input_device_when_passthrough_creation_fails(
 
 
 @pytest.mark.asyncio
-async def test_grab_permission_error_mentions_uinput_when_passthrough_creation_fails(
+async def test_grab_uinput_error_mentions_uinput_when_passthrough_creation_fails(
     monkeypatch,
 ):
     fake_device = SimpleNamespace(
@@ -189,7 +190,7 @@ async def test_grab_permission_error_mentions_uinput_when_passthrough_creation_f
     )
 
     def fail_uinput_creation(**kwargs):
-        raise PermissionError(13, "denied")
+        raise UInputError('"/dev/uinput" cannot be opened for writing')
 
     monkeypatch.setattr(gdm, "_device_input", lambda path: fake_device)
     monkeypatch.setattr(gdm.evdev, "UInput", fail_uinput_creation)


### PR DESCRIPTION
## Summary
- Add permission-aware error hints for device discovery, grab, and uinput creation paths.
- Improve log messages when unreadable devices are skipped or grabs fail due to `EACCES`/`EPERM`.
- Extend troubleshooting docs to point users at the new permission guidance.
- Cover the new diagnostics with targeted tests for capture, device listing, grab recovery, and passthrough/global uinput setup.

## Testing
- Added unit tests for permission-denied device discovery, grab failures, and uinput creation failures.
- Added log assertions to verify permission hints are surfaced in unreadable-device paths.