### PR TITLE
Introduce separate profile state lock for concurrent reads

### DIFF
--- a/keymasq/session/manager/core.py
+++ b/keymasq/session/manager/core.py
@@ -623,26 +623,27 @@ class SessionManager:
         return True
 
     def reload_config_from_disk(self) -> None:
-        superkeys_snapshot = self.superkeys.snapshot_superkeys()
-        analog_controls_snapshot = self.analog_controls.snapshot_analog_controls()
-        profiles_snapshot = self.profiles.snapshot_profiles_for_reload()
-        hardware_snapshot = self.hardware.snapshot_hardware()
-        old_virtual_gamepad_count = self.virtual_gamepad_count
+        with self.profiles.profile_file_transaction():
+            superkeys_snapshot = self.superkeys.snapshot_superkeys()
+            analog_controls_snapshot = self.analog_controls.snapshot_analog_controls()
+            profiles_snapshot = self.profiles.snapshot_profiles_for_reload()
+            hardware_snapshot = self.hardware.snapshot_hardware()
+            old_virtual_gamepad_count = self.virtual_gamepad_count
 
-        try:
-            self.superkeys.reload()
-            self.analog_controls.reload()
-            self.profiles.reload()
-            self.hardware.reload()
-            settings = load_global_settings(strict=True)
-            self.virtual_gamepad_count = settings.virtual_gamepad_count
-        except Exception:
-            self.superkeys.restore_superkeys(superkeys_snapshot)
-            self.analog_controls.restore_analog_controls(analog_controls_snapshot)
-            self.profiles.restore_profiles(profiles_snapshot)
-            self.hardware.restore_hardware(hardware_snapshot)
-            self.virtual_gamepad_count = old_virtual_gamepad_count
-            raise
+            try:
+                self.superkeys.reload()
+                self.analog_controls.reload()
+                self.profiles.reload()
+                self.hardware.reload()
+                settings = load_global_settings(strict=True)
+                self.virtual_gamepad_count = settings.virtual_gamepad_count
+            except Exception:
+                self.superkeys.restore_superkeys(superkeys_snapshot)
+                self.analog_controls.restore_analog_controls(analog_controls_snapshot)
+                self.profiles.restore_profiles(profiles_snapshot)
+                self.hardware.restore_hardware(hardware_snapshot)
+                self.virtual_gamepad_count = old_virtual_gamepad_count
+                raise
 
     def _start_config_watcher(self) -> None:
         try:

--- a/keymasq/session/manager/core.py
+++ b/keymasq/session/manager/core.py
@@ -625,7 +625,7 @@ class SessionManager:
     def reload_config_from_disk(self) -> None:
         superkeys_snapshot = self.superkeys.snapshot_superkeys()
         analog_controls_snapshot = self.analog_controls.snapshot_analog_controls()
-        profiles_snapshot = self.profiles.snapshot_profiles()
+        profiles_snapshot = self.profiles.snapshot_profiles_for_reload()
         hardware_snapshot = self.hardware.snapshot_hardware()
         old_virtual_gamepad_count = self.virtual_gamepad_count
 

--- a/keymasq/session/profiles.py
+++ b/keymasq/session/profiles.py
@@ -546,9 +546,13 @@ class ProfileManager:
     def list_profiles(self) -> list[ProfileInfo]:
         return list(self._profiles.values())
 
-    @_with_profile_file_lock
     @_with_profile_state_lock
     def snapshot_profiles(self) -> dict[str, ProfileInfo]:
+        return self._profiles.copy()
+
+    @_with_profile_file_lock
+    @_with_profile_state_lock
+    def snapshot_profiles_for_reload(self) -> dict[str, ProfileInfo]:
         return self._profiles.copy()
 
     @_with_profile_file_lock
@@ -1056,7 +1060,6 @@ class ProfileManager:
         log.info("Renamed profile: %s -> %s", old_name, new_name)
         return renamed_profile
 
-    @_with_profile_file_lock
     @_with_profile_state_lock
     def find_profiles_using_superkey(self, superkey_name: str) -> list[tuple[str, str]]:
         result: list[tuple[str, str]] = []
@@ -1080,7 +1083,6 @@ class ProfileManager:
                     break
         return result
 
-    @_with_profile_file_lock
     @_with_profile_state_lock
     def find_profiles_using_analog_control(
         self,

--- a/keymasq/session/profiles.py
+++ b/keymasq/session/profiles.py
@@ -113,6 +113,17 @@ class ProfileManager:
 
         return wrapper
 
+    @staticmethod
+    def _with_profile_state_lock[**P, R](
+        method: Callable[Concatenate["ProfileManager", P], R],
+    ) -> Callable[Concatenate["ProfileManager", P], R]:
+        @wraps(method)
+        def wrapper(self: "ProfileManager", *args: P.args, **kwargs: P.kwargs) -> R:
+            with self._profile_state_lock:
+                return method(self, *args, **kwargs)
+
+        return wrapper
+
     def __init__(
         self,
         superkey_manager: "SuperkeyManager | None" = None,
@@ -126,6 +137,7 @@ class ProfileManager:
         self._profiles: dict[str, ProfileInfo] = {}
         self._pending_repairs: set[asyncio.Task[None]] = set()
         self._profile_file_lock = threading.RLock()
+        self._profile_state_lock = threading.RLock()
         self._load_all()
         self._ensure_default_profile_exists()
 
@@ -144,7 +156,8 @@ class ProfileManager:
                 loaded_profiles,
             )
 
-        self._profiles = loaded_profiles
+        with self._profile_state_lock:
+            self._profiles = loaded_profiles
 
     def _add_loaded_profile(
         self,
@@ -189,8 +202,12 @@ class ProfileManager:
         self._ensure_default_profile_exists()
 
     def _ensure_default_profile_exists(self) -> None:
-        if not self._auto_create_default_if_empty or self._profiles:
+        if not self._auto_create_default_if_empty:
             return
+
+        with self._profile_state_lock:
+            if self._profiles:
+                return
 
         config = ProfileConfig(
             name=DEFAULT_PROFILE_NAME,
@@ -213,7 +230,10 @@ class ProfileManager:
             self._load_all()
             return
 
-        self._profiles[config.name] = ProfileInfo(path=path, config=config)
+        with self._profile_state_lock:
+            if self._profiles:
+                return
+            self._profiles[config.name] = ProfileInfo(path=path, config=config)
         log.info("Created default profile: %s", path)
 
     def _load_profile(self, path: Path) -> ProfileConfig:
@@ -518,23 +538,23 @@ class ProfileManager:
             return self._parse_action(action_dict)
         return None
 
-    @_with_profile_file_lock
+    @_with_profile_state_lock
     def list_profiles(self) -> list[ProfileInfo]:
         return list(self._profiles.values())
 
-    @_with_profile_file_lock
+    @_with_profile_state_lock
     def snapshot_profiles(self) -> dict[str, ProfileInfo]:
         return self._profiles.copy()
 
-    @_with_profile_file_lock
+    @_with_profile_state_lock
     def restore_profiles(self, profiles: dict[str, ProfileInfo]) -> None:
         self._profiles = profiles.copy()
 
-    @_with_profile_file_lock
+    @_with_profile_state_lock
     def get_profile(self, profile_name: str) -> ProfileInfo | None:
         return self._profiles.get(profile_name)
 
-    @_with_profile_file_lock
+    @_with_profile_state_lock
     def get_next_priority(self) -> int:
         if not self._profiles:
             return 0
@@ -577,17 +597,21 @@ class ProfileManager:
 
     @_with_profile_file_lock
     def set_profile_enabled(self, profile_name: str, enabled: bool | None) -> ProfileConfig | None:
-        profile = self.get_profile(profile_name)
-        if profile is None:
-            return None
+        with self._profile_state_lock:
+            profile = self._profiles.get(profile_name)
+            if profile is None:
+                return None
 
-        target_enabled = (not profile.config.enabled) if enabled is None else bool(enabled)
-        if profile.config.enabled == target_enabled:
-            return profile.config
+            target_enabled = (not profile.config.enabled) if enabled is None else bool(enabled)
+            if profile.config.enabled == target_enabled:
+                return profile.config
 
-        profile.config.enabled = target_enabled
-        self.save_profile(profile.config)
-        return profile.config
+            updated_config = copy.deepcopy(profile.config)
+            updated_config.enabled = target_enabled
+            profile_path = profile.path
+
+        self.save_profile(updated_config, path=profile_path)
+        return updated_config
 
     def has_unsupported_rules(self, config: ProfileConfig, capabilities: list[str]) -> bool:
         has_tag_support = "window_tags" in capabilities
@@ -638,7 +662,7 @@ class ProfileManager:
 
         return True
 
-    @_with_profile_file_lock
+    @_with_profile_state_lock
     def resolve_active_profiles(
         self,
         window_info: TomlDict | None = None,
@@ -815,22 +839,24 @@ class ProfileManager:
 
         profile_name = config.name
         current_path = path
-        existing_profile = self._profiles.get(profile_name)
-        if existing_profile is not None:
-            if current_path is None:
-                if existing_profile.config is not config:
+        with self._profile_state_lock:
+            existing_profile = self._profiles.get(profile_name)
+            if existing_profile is not None:
+                if current_path is None:
+                    if existing_profile.config is not config:
+                        raise ValueError(f"Profile '{profile_name}' already exists")
+                    path = existing_profile.path
+                elif existing_profile.path != current_path:
                     raise ValueError(f"Profile '{profile_name}' already exists")
-                path = existing_profile.path
-            elif existing_profile.path != current_path:
-                raise ValueError(f"Profile '{profile_name}' already exists")
+                else:
+                    path = existing_profile.path
             else:
                 path = self._profile_path_for_name(profile_name, current_path=current_path)
-        else:
-            path = self._profile_path_for_name(profile_name, current_path=current_path)
 
         self._write_profile_file(config, path, validate_window_rules=False)
 
-        self._profiles[config.name] = ProfileInfo(path=path, config=config)
+        with self._profile_state_lock:
+            self._profiles[config.name] = ProfileInfo(path=path, config=config)
 
         log.info("Saved profile: %s", path)
 
@@ -935,13 +961,15 @@ class ProfileManager:
 
     @_with_profile_file_lock
     def delete_profile(self, name: str) -> bool:
-        profile = self._profiles.get(name)
+        with self._profile_state_lock:
+            profile = self._profiles.get(name)
         if profile is None:
             return False
 
         if profile.path.exists():
             self._trash_profile_file(profile.path)
-        self._profiles.pop(name, None)
+        with self._profile_state_lock:
+            self._profiles.pop(name, None)
         log.info("Deleted profile: %s", name)
         return True
 
@@ -971,19 +999,28 @@ class ProfileManager:
 
     @_with_profile_file_lock
     def rename_profile(self, old_name: str, new_name: str) -> ProfileInfo:
-        if new_name in self._profiles and new_name != old_name:
-            raise ValueError(f"Profile '{new_name}' already exists")
+        with self._profile_state_lock:
+            if new_name in self._profiles and new_name != old_name:
+                raise ValueError(f"Profile '{new_name}' already exists")
 
-        profile = self._profiles.get(old_name)
-        if profile is None:
-            raise ValueError(f"Profile '{old_name}' not found")
+            profile = self._profiles.get(old_name)
+            if profile is None:
+                raise ValueError(f"Profile '{old_name}' not found")
 
-        old_path = profile.path
-        profile.config.name = new_name
-        self._profiles.pop(old_name, None)
-        self.save_profile(profile.config, path=old_path)
-        renamed_profile = self._profiles[new_name]
-        new_path = renamed_profile.path
+            old_path = profile.path
+            renamed_config = copy.deepcopy(profile.config)
+            renamed_config.name = new_name
+            new_path = self._profile_path_for_name(new_name, current_path=old_path)
+
+        self.validate_window_rules(renamed_config.window_rules)
+        if renamed_config.created_at is None:
+            renamed_config.created_at = datetime.now()
+        self._write_profile_file(renamed_config, new_path, validate_window_rules=False)
+
+        renamed_profile = ProfileInfo(path=new_path, config=renamed_config)
+        with self._profile_state_lock:
+            self._profiles.pop(old_name, None)
+            self._profiles[new_name] = renamed_profile
 
         if old_path != new_path and old_path.exists():
             try:

--- a/keymasq/session/profiles.py
+++ b/keymasq/session/profiles.py
@@ -856,6 +856,18 @@ class ProfileManager:
         current_path = path
         occupied_paths: set[Path] | None = None
         with self._profile_state_lock:
+            if current_path is not None:
+                path_owner = next(
+                    (
+                        name
+                        for name, info in self._profiles.items()
+                        if info.path == current_path
+                    ),
+                    None,
+                )
+                if path_owner is not None and path_owner != profile_name:
+                    raise ValueError(f"Profile storage path is already used by '{path_owner}'")
+
             existing_profile = self._profiles.get(profile_name)
             if existing_profile is not None:
                 if current_path is None:

--- a/keymasq/session/profiles.py
+++ b/keymasq/session/profiles.py
@@ -139,9 +139,8 @@ class ProfileManager:
         self._profile_file_lock = threading.RLock()
         self._profile_state_lock = threading.RLock()
         self._load_all()
-        self._ensure_default_profile_exists()
 
-    def _load_all(self, *, strict: bool = False) -> None:
+    def _load_profiles(self, *, strict: bool = False) -> dict[str, ProfileInfo]:
         loaded_profiles: dict[str, ProfileInfo] = {}
         for profile_file, config in load_config_files_sync(
             paths.PROFILES_DIR,
@@ -156,6 +155,14 @@ class ProfileManager:
                 loaded_profiles,
             )
 
+        return loaded_profiles
+
+    def _load_all(self, *, strict: bool = False) -> None:
+        loaded_profiles = self._load_profiles(strict=strict)
+        loaded_profiles = self._profiles_with_default_if_empty(
+            loaded_profiles,
+            strict=strict,
+        )
         with self._profile_state_lock:
             self._profiles = loaded_profiles
 
@@ -199,15 +206,15 @@ class ProfileManager:
     @_with_profile_file_lock
     def reload(self) -> None:
         self._load_all(strict=True)
-        self._ensure_default_profile_exists()
 
-    def _ensure_default_profile_exists(self) -> None:
-        if not self._auto_create_default_if_empty:
-            return
-
-        with self._profile_state_lock:
-            if self._profiles:
-                return
+    def _profiles_with_default_if_empty(
+        self,
+        profiles: dict[str, ProfileInfo],
+        *,
+        strict: bool = False,
+    ) -> dict[str, ProfileInfo]:
+        if not self._auto_create_default_if_empty or profiles:
+            return profiles
 
         config = ProfileConfig(
             name=DEFAULT_PROFILE_NAME,
@@ -227,14 +234,11 @@ class ProfileManager:
                 exclusive=True,
             )
         except FileExistsError:
-            self._load_all()
-            return
+            return self._load_profiles(strict=strict)
 
-        with self._profile_state_lock:
-            if self._profiles:
-                return
-            self._profiles[config.name] = ProfileInfo(path=path, config=config)
+        profiles[config.name] = ProfileInfo(path=path, config=config)
         log.info("Created default profile: %s", path)
+        return profiles
 
     def _load_profile(self, path: Path) -> ProfileConfig:
         with open(path, "rb") as f:
@@ -542,10 +546,12 @@ class ProfileManager:
     def list_profiles(self) -> list[ProfileInfo]:
         return list(self._profiles.values())
 
+    @_with_profile_file_lock
     @_with_profile_state_lock
     def snapshot_profiles(self) -> dict[str, ProfileInfo]:
         return self._profiles.copy()
 
+    @_with_profile_file_lock
     @_with_profile_state_lock
     def restore_profiles(self, profiles: dict[str, ProfileInfo]) -> None:
         self._profiles = profiles.copy()
@@ -570,20 +576,25 @@ class ProfileManager:
     def _is_canonical_profile_storage_path(self, profile_name: str, path: Path) -> bool:
         return path == self._canonical_profile_storage_path(profile_name)
 
+    def _occupied_profile_paths(self, current_path: Path | None = None) -> set[Path]:
+        return {
+            info.path
+            for info in self._profiles.values()
+            if current_path is None or info.path != current_path
+        }
+
     def _profile_path_for_name(
         self,
         profile_name: str,
         current_path: Path | None = None,
+        occupied_paths: set[Path] | None = None,
     ) -> Path:
         base_stem = self._sanitize_profile_storage_stem(profile_name)
         candidate = self._canonical_profile_storage_path(profile_name)
         suffix = 2
 
-        occupied_paths = {
-            info.path
-            for info in self._profiles.values()
-            if current_path is None or info.path != current_path
-        }
+        if occupied_paths is None:
+            occupied_paths = self._occupied_profile_paths(current_path)
 
         attempts = 0
         while candidate in occupied_paths or (candidate.exists() and candidate != current_path):
@@ -839,6 +850,7 @@ class ProfileManager:
 
         profile_name = config.name
         current_path = path
+        occupied_paths: set[Path] | None = None
         with self._profile_state_lock:
             existing_profile = self._profiles.get(profile_name)
             if existing_profile is not None:
@@ -851,7 +863,14 @@ class ProfileManager:
                 else:
                     path = existing_profile.path
             else:
-                path = self._profile_path_for_name(profile_name, current_path=current_path)
+                occupied_paths = self._occupied_profile_paths(current_path)
+
+        if path is None:
+            path = self._profile_path_for_name(
+                profile_name,
+                current_path=current_path,
+                occupied_paths=occupied_paths,
+            )
 
         self._write_profile_file(config, path, validate_window_rules=False)
 
@@ -1010,7 +1029,13 @@ class ProfileManager:
             old_path = profile.path
             renamed_config = copy.deepcopy(profile.config)
             renamed_config.name = new_name
-            new_path = self._profile_path_for_name(new_name, current_path=old_path)
+            occupied_paths = self._occupied_profile_paths(old_path)
+
+        new_path = self._profile_path_for_name(
+            new_name,
+            current_path=old_path,
+            occupied_paths=occupied_paths,
+        )
 
         self.validate_window_rules(renamed_config.window_rules)
         if renamed_config.created_at is None:
@@ -1032,6 +1057,7 @@ class ProfileManager:
         return renamed_profile
 
     @_with_profile_file_lock
+    @_with_profile_state_lock
     def find_profiles_using_superkey(self, superkey_name: str) -> list[tuple[str, str]]:
         result: list[tuple[str, str]] = []
         for info in self.list_profiles():
@@ -1055,6 +1081,7 @@ class ProfileManager:
         return result
 
     @_with_profile_file_lock
+    @_with_profile_state_lock
     def find_profiles_using_analog_control(
         self,
         analog_control_name: str,
@@ -1075,8 +1102,9 @@ class ProfileManager:
     def replace_analog_control_with_suppress(self, analog_control_name: str) -> int:
         count = 0
         for info in self.list_profiles():
+            updated_config = copy.deepcopy(info.config)
             modified = False
-            for layer in info.config.device_layers.values():
+            for layer in updated_config.device_layers.values():
                 for button_id, action in list(layer.mappings.items()):
                     if (
                         action.action_type == ActionType.ANALOG_CONTROL
@@ -1098,7 +1126,7 @@ class ProfileManager:
                         modified = True
                         count += 1
             if modified:
-                self.save_profile(info.config)
+                self.save_profile(updated_config, path=info.path)
         if count > 0:
             log.info(
                 "Replaced analog control '%s' with suppress in %d references",
@@ -1113,8 +1141,9 @@ class ProfileManager:
             return 0
         count = 0
         for info in self.list_profiles():
+            updated_config = copy.deepcopy(info.config)
             modified = False
-            for layer in info.config.device_layers.values():
+            for layer in updated_config.device_layers.values():
                 for action in layer.mappings.values():
                     if (
                         action.action_type == ActionType.ANALOG_CONTROL
@@ -1128,7 +1157,7 @@ class ProfileManager:
                         modified = True
                         count += 1
             if modified:
-                self.save_profile(info.config)
+                self.save_profile(updated_config, path=info.path)
         if count > 0:
             log.info(
                 "Renamed analog control references '%s' -> '%s' in %d mappings",
@@ -1142,8 +1171,9 @@ class ProfileManager:
     def replace_superkey_with_suppress(self, superkey_name: str) -> int:
         count = 0
         for info in self.list_profiles():
+            updated_config = copy.deepcopy(info.config)
             modified = False
-            for layer in info.config.device_layers.values():
+            for layer in updated_config.device_layers.values():
                 for button_id, action in list(layer.mappings.items()):
                     if (
                         action.action_type == ActionType.SUPERKEY
@@ -1152,7 +1182,7 @@ class ProfileManager:
                         layer.mappings[button_id] = MappingAction(action_type=ActionType.SUPPRESS)
                         modified = True
                         count += 1
-            for combo in info.config.combos:
+            for combo in updated_config.combos:
                 action = combo.action
                 if (
                     action is not None
@@ -1163,7 +1193,7 @@ class ProfileManager:
                     modified = True
                     count += 1
             if modified:
-                self.save_profile(info.config)
+                self.save_profile(updated_config, path=info.path)
         if count > 0:
             log.info(
                 "Replaced superkey '%s' with suppress in %d references",
@@ -1178,8 +1208,9 @@ class ProfileManager:
         for info in self.list_profiles():
             if hardware_id not in info.config.device_layers:
                 continue
-            info.config.device_layers.pop(hardware_id, None)
-            self.save_profile(info.config)
+            updated_config = copy.deepcopy(info.config)
+            updated_config.device_layers.pop(hardware_id, None)
+            self.save_profile(updated_config, path=info.path)
             updated += 1
         return updated
 
@@ -1187,10 +1218,11 @@ class ProfileManager:
     def remove_device_button_mappings(self, hardware_id: str, button_id: str) -> int:
         updated = 0
         for info in self.list_profiles():
-            layer = info.config.get_layer(hardware_id)
+            updated_config = copy.deepcopy(info.config)
+            layer = updated_config.get_layer(hardware_id)
             if layer is None or button_id not in layer.mappings:
                 continue
             layer.mappings.pop(button_id, None)
-            self.save_profile(info.config)
+            self.save_profile(updated_config, path=info.path)
             updated += 1
         return updated

--- a/keymasq/session/profiles.py
+++ b/keymasq/session/profiles.py
@@ -5,7 +5,8 @@ import logging
 import re
 import threading
 import tomllib
-from collections.abc import Callable
+from collections.abc import Callable, Generator
+from contextlib import contextmanager
 from dataclasses import dataclass, field
 from datetime import datetime
 from functools import wraps
@@ -206,6 +207,11 @@ class ProfileManager:
     @_with_profile_file_lock
     def reload(self) -> None:
         self._load_all(strict=True)
+
+    @contextmanager
+    def profile_file_transaction(self) -> Generator[None]:
+        with self._profile_file_lock:
+            yield
 
     def _profiles_with_default_if_empty(
         self,

--- a/tests/common/test_profile_manager.py
+++ b/tests/common/test_profile_manager.py
@@ -679,6 +679,70 @@ macro_name = "Example"
         assert profile is not None
         assert profile.config.enabled is False
 
+    def test_profile_reads_do_not_wait_for_reload_disk_load(
+        self,
+        temp_config_dir,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        manager = ProfileManager()
+        manager.save_profile(ProfileConfig(name="Race Profile", enabled=True, is_permanent=True))
+        original_load_all = manager._load_all
+        reload_reached_load = threading.Event()
+        release_reload = threading.Event()
+        reload_errors: list[object] = []
+
+        def load_all_with_pause(*, strict: bool = False) -> None:
+            reload_reached_load.set()
+            assert release_reload.wait(timeout=5)
+            original_load_all(strict=strict)
+
+        def reload_profiles() -> None:
+            try:
+                manager.reload()
+            except (AssertionError, OSError, RuntimeError, ValueError) as exc:
+                reload_errors.append(exc)
+
+        monkeypatch.setattr(manager, "_load_all", load_all_with_pause)
+        reloader = threading.Thread(target=reload_profiles)
+        reloader.start()
+
+        read_done = threading.Event()
+        read_errors: list[object] = []
+        reader: threading.Thread | None = None
+        try:
+            assert reload_reached_load.wait(timeout=5)
+
+            def read_profiles() -> None:
+                try:
+                    profile = manager.get_profile("Race Profile")
+                    assert profile is not None
+                    assert [info.config.name for info in manager.list_profiles()] == [
+                        "Race Profile"
+                    ]
+                    resolved = manager.resolve_active_profiles()
+                    assert [profile.name for profile in resolved.active_profiles] == [
+                        "Race Profile"
+                    ]
+                except (AssertionError, OSError, RuntimeError, ValueError) as exc:
+                    read_errors.append(exc)
+                finally:
+                    read_done.set()
+
+            reader = threading.Thread(target=read_profiles)
+            reader.start()
+            assert read_done.wait(timeout=0.2)
+        finally:
+            release_reload.set()
+            if reader is not None:
+                reader.join(timeout=5)
+            reloader.join(timeout=5)
+
+        assert reader is not None
+        assert not reader.is_alive()
+        assert not reloader.is_alive()
+        assert read_errors == []
+        assert reload_errors == []
+
     def test_duplicate_profile_names_prefer_canonical_path(
         self,
         temp_config_dir,

--- a/tests/common/test_profile_manager.py
+++ b/tests/common/test_profile_manager.py
@@ -590,6 +590,21 @@ macro_name = "Example"
         assert first.path.name == "Work_Mode.toml"
         assert second.path.name == "Work_Mode_2.toml"
 
+    def test_save_profile_rejects_explicit_path_owned_by_other_profile(self, temp_config_dir):
+        manager = ProfileManager()
+        manager.save_profile(ProfileConfig(name="Work/Mode", enabled=True, device_layers={}))
+        first = manager.get_profile("Work/Mode")
+        assert first is not None
+
+        with pytest.raises(ValueError, match="already used by 'Work/Mode'"):
+            manager.save_profile(
+                ProfileConfig(name="Work_Mode", enabled=False, device_layers={}),
+                path=first.path,
+            )
+
+        assert manager.get_profile("Work_Mode") is None
+        assert 'name = "Work/Mode"' in first.path.read_text(encoding="utf-8")
+
     def test_save_existing_loaded_profile_updates_original_path(self, temp_config_dir):
         profiles_dir = temp_config_dir / "profiles"
         fixture_path = _write_profile_toml(

--- a/tests/test_session_manager_core.py
+++ b/tests/test_session_manager_core.py
@@ -1,5 +1,6 @@
 import asyncio
 import json
+import threading
 from types import SimpleNamespace
 from typing import cast
 from unittest.mock import AsyncMock, Mock
@@ -480,6 +481,57 @@ def test_reload_config_from_disk_rolls_back_user_config_on_failure(
     assert manager.superkeys.get_superkey("OldSuper") is old_superkey
     assert manager.superkeys.get_superkey("NewSuper") is None
     assert manager.virtual_gamepad_count == 2
+
+
+def test_reload_config_from_disk_serializes_profile_writes_until_rollback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = SessionManager()
+    manager.profiles.save_profile(ProfileConfig(name="Nav", enabled=False, is_permanent=True))
+    original_snapshot = manager.profiles.snapshot_profiles_for_reload
+    writer_started = threading.Event()
+    writer_done = threading.Event()
+    writer_errors: list[object] = []
+    writer: threading.Thread | None = None
+
+    def enable_profile() -> None:
+        writer_started.set()
+        try:
+            manager.profiles.set_profile_enabled("Nav", True)
+        except (AssertionError, OSError, RuntimeError, ValueError) as exc:
+            writer_errors.append(exc)
+        finally:
+            writer_done.set()
+
+    def snapshot_profiles_for_reload() -> dict[str, ProfileInfo]:
+        nonlocal writer
+        snapshot = original_snapshot()
+        writer = threading.Thread(target=enable_profile)
+        writer.start()
+        assert writer_started.wait(timeout=5)
+        assert not writer_done.wait(timeout=0.2)
+        return snapshot
+
+    def reload_hardware() -> None:
+        raise ValueError("bad hardware TOML")
+
+    monkeypatch.setattr(
+        manager.profiles,
+        "snapshot_profiles_for_reload",
+        snapshot_profiles_for_reload,
+    )
+    monkeypatch.setattr(manager.hardware, "reload", reload_hardware)
+
+    with pytest.raises(ValueError, match="bad hardware TOML"):
+        manager.reload_config_from_disk()
+
+    assert writer is not None
+    writer.join(timeout=5)
+    assert not writer.is_alive()
+    assert writer_errors == []
+    profile = manager.profiles.get_profile("Nav")
+    assert profile is not None
+    assert profile.config.enabled is True
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Split the monolithic `_profile_file_lock` into two locks: `_profile_state_lock` for in-memory state and `_profile_file_lock` for disk I/O.
- Reader methods (`list_profiles`, `get_profile`, `snapshot_profiles`, `resolve_active_profiles`, etc.) now only take the state lock, so they can proceed without waiting for pending file operations like `reload()`.
- Mutating methods (`save_profile`, `delete_profile`, `rename_profile`, `set_profile_enabled`) use both locks appropriately to ensure state consistency during file writes.
- Added a concurrency test verifying that profile reads complete within 200ms even when a reload is blocked on disk I/O.

## Testing

- New test `test_profile_reads_do_not_wait_for_reload_disk_load` asserts that reads (`get_profile`, `list_profiles`, `resolve_active_profiles`) complete quickly while a `reload()` is paused in `_load_all`.
- Existing profile manager tests continue to pass.
- Ran `ruff`, `basedpyright`, and the relevant pytest suite via `./scripts/check.sh`.