### PR TITLE
Block deleting last profile; move default profile seeding to session

### DIFF
--- a/docs/PROFILES.md
+++ b/docs/PROFILES.md
@@ -93,8 +93,9 @@ Profiles are stored in:
 
 The visible profile name can contain arbitrary characters. The on-disk filename is derived from that name by replacing unsafe filename characters so the file always stays inside `profiles/`.
 
-On first start, Keymasq seeds an editable permanent profile named `Default` so
-new devices can be remapped immediately without creating a profile first.
+Keymasq keeps at least one editable profile. On first start, and whenever the
+session reloads an empty profiles directory, `keymasq-session` seeds a permanent
+profile named `Default` so new devices can be remapped immediately.
 
 Hardware definitions are still separate:
 

--- a/keymasq/gui/widgets/profile_managed_tab.py
+++ b/keymasq/gui/widgets/profile_managed_tab.py
@@ -485,6 +485,9 @@ class ProfileManagedTab(Gtk.Box):
     ) -> None:
         if not self._selected_profile or self.demo_mode:
             return
+        if not self._can_delete_selected_profile():
+            self._show_last_profile_error()
+            return
 
         profile_name = self._selected_profile.config.name
         dialog = Adw.Dialog(title="Delete Profile", content_width=360, content_height=-1)
@@ -530,6 +533,10 @@ class ProfileManagedTab(Gtk.Box):
         if not self._selected_profile or self.profile_manager is None:
             dialog.close()
             return
+        if not self._can_delete_selected_profile():
+            dialog.close()
+            self._show_last_profile_error()
+            return
 
         self.profile_manager.delete_profile(self._selected_profile.config.name)
         self._refresh_other_profile_tabs()
@@ -538,6 +545,16 @@ class ProfileManagedTab(Gtk.Box):
         if close_after_delete is not None:
             close_after_delete.close()
         notify_session_reload_async()
+
+    def _can_delete_selected_profile(self) -> bool:
+        if self.profile_manager is None:
+            return False
+        return len(self.profile_manager.list_profiles()) > 1
+
+    def _show_last_profile_error(self) -> None:
+        self._show_profile_error_dialog(
+            "At least one profile is required. Create another profile before deleting this one."
+        )
 
     def _on_priority_changed(self, spin: Gtk.SpinButton) -> None:
         if not self._selected_profile:

--- a/keymasq/gui/window/connection.py
+++ b/keymasq/gui/window/connection.py
@@ -131,6 +131,7 @@ def _on_status_response(window, data: dict | None, query_id: int) -> bool:
         )
         if isinstance(data, dict) and data.get("status") == "ok":
             profiles._apply_profile_runtime_state(window, data)
+            _queue_initial_status_profile_reload(window)
             compositor_id = data.get("compositor_id")
             if compositor_id is not None:
                 window._compositor_id = compositor_id
@@ -159,6 +160,13 @@ def _on_status_response(window, data: dict | None, query_id: int) -> bool:
         _update_status_disconnected(window)
 
     return False
+
+
+def _queue_initial_status_profile_reload(window) -> None:
+    if window.demo_mode or window._initial_status_profile_reload_done:
+        return
+    window._initial_status_profile_reload_done = True
+    profiles._queue_profile_reload(window)
 
 
 def _update_status_disconnected(window) -> None:

--- a/keymasq/gui/window/core.py
+++ b/keymasq/gui/window/core.py
@@ -34,7 +34,7 @@ class MainWindow(_runtime.Adw.ApplicationWindow):
 
         self.demo_mode = demo_mode
         self.hardware_manager = HardwareManager()
-        self.profile_manager = ProfileManager(auto_create_default_if_empty=True)
+        self.profile_manager = ProfileManager()
         self._session_connected: bool | None = None
         self._keymasqd_via_session: bool | None = None
         self._compositor_id: str | None = None

--- a/keymasq/gui/window/core.py
+++ b/keymasq/gui/window/core.py
@@ -94,6 +94,7 @@ class MainWindow(_runtime.Adw.ApplicationWindow):
         }
         self._profile_reload_inflight = False
         self._profile_reload_pending = False
+        self._initial_status_profile_reload_done = False
         self._destroyed = False
         self._tab_order = load_tab_order()
         self._hidden_tabs = load_hidden_tabs()

--- a/keymasq/gui/window/profiles.py
+++ b/keymasq/gui/window/profiles.py
@@ -63,7 +63,7 @@ def _queue_profile_reload(window) -> None:
 
 
 def _load_profile_manager_snapshot(window) -> ProfileManager:
-    return ProfileManager(auto_create_default_if_empty=True)
+    return ProfileManager()
 
 
 def _on_profile_reload_finished(window, result: _runtime.GuiTaskResult[ProfileManager]) -> bool:

--- a/tests/gui/test_main_window.py
+++ b/tests/gui/test_main_window.py
@@ -1258,7 +1258,7 @@ class TestMainWindow:
         window._status_query_inflight = True
         finished = connection._on_status_response(
             window,
-            {"status": "ok", "keymasqd_connected": True},
+            {"status": "ok", "keymasqd_connected": False},
             1,
         )
 

--- a/tests/gui/test_main_window.py
+++ b/tests/gui/test_main_window.py
@@ -18,7 +18,7 @@ from keymasq.gui.window import (
 
 
 class TestMainWindow:
-    def test_main_window_seeds_default_profile_for_first_device(self, temp_config_dir):
+    def test_main_window_does_not_seed_default_profile_for_first_device(self, temp_config_dir):
         from keymasq.common.models import ButtonDefinition, HardwareConfig
         from keymasq.gui.window import MainWindow
 
@@ -36,10 +36,16 @@ class TestMainWindow:
 
         tab = tab_layout._child_for_hardware_id(window, device.hardware_id)
 
-        assert window.profile_manager.get_profile("Default") is not None
-        assert tab._selected_profile is not None
-        assert tab._selected_profile.config.name == "Default"
-        assert tab.settings_frame.get_sensitive() is True
+        assert window.profile_manager.get_profile("Default") is None
+        assert not (temp_config_dir / "profiles" / "Default.toml").exists()
+        assert tab._selected_profile is None
+        assert tab.settings_frame.get_sensitive() is False
+
+    def test_gui_profile_reload_snapshot_does_not_seed_default(self, temp_config_dir):
+        manager = profiles._load_profile_manager_snapshot(object())
+
+        assert manager.list_profiles() == []
+        assert not (temp_config_dir / "profiles" / "Default.toml").exists()
 
     def test_main_window_demo_mode(self, temp_config_dir):
         from keymasq.common.models import (
@@ -452,7 +458,7 @@ class TestMainWindow:
         )
         device_tabs._add_device_tab(window, device)
         original_profile_manager = window.profile_manager
-        profiles._set_profile_manager(window, ProfileManager(auto_create_default_if_empty=True))
+        profiles._set_profile_manager(window, ProfileManager())
         assert window.profile_manager.get_profile("Gaming") is None
         original_profile_manager.save_profile(
             ProfileConfig(name="Gaming", enabled=True, is_permanent=True)
@@ -1048,7 +1054,7 @@ class TestMainWindow:
         )
 
         device_tabs._add_device_tab(window, device)
-        external_profiles = ProfileManager(auto_create_default_if_empty=True)
+        external_profiles = ProfileManager()
         external_profiles.save_profile(
             ProfileConfig(
                 name="Gaming",

--- a/tests/gui/test_main_window.py
+++ b/tests/gui/test_main_window.py
@@ -1238,6 +1238,44 @@ class TestMainWindow:
         assert window._profile_runtime_state["devices"] == {"2234:6678": {"profiles": ["Desktop"]}}
         assert window._profile_runtime_state["window"] == {"class": "steam"}
 
+    def test_main_window_successful_initial_status_queues_profile_reload_once(
+        self,
+        temp_config_dir,
+        monkeypatch,
+    ):
+        from keymasq.gui.window import MainWindow
+
+        window = MainWindow(demo_mode=True)
+        window.demo_mode = False
+        reloads: list[object] = []
+        monkeypatch.setattr(
+            profiles,
+            "_queue_profile_reload",
+            lambda target: reloads.append(target),
+        )
+
+        window._status_query_id = 1
+        window._status_query_inflight = True
+        finished = connection._on_status_response(
+            window,
+            {"status": "ok", "keymasqd_connected": True},
+            1,
+        )
+
+        assert finished is False
+        assert reloads == [window]
+        assert window._initial_status_profile_reload_done is True
+
+        window._status_query_id = 2
+        window._status_query_inflight = True
+        connection._on_status_response(
+            window,
+            {"status": "ok", "keymasqd_connected": True},
+            2,
+        )
+
+        assert reloads == [window]
+
     def test_main_window_recording_auth_event_opens_locked_recording_dialog(self, monkeypatch):
         from keymasq.gui.window import MainWindow
 

--- a/tests/gui/test_profile_dialogs_and_actions.py
+++ b/tests/gui/test_profile_dialogs_and_actions.py
@@ -133,6 +133,57 @@ class TestProfileManagedTab:
         assert copy_config is not None
         assert copy_config.name == "Project_2"
 
+    def test_delete_last_profile_is_blocked(self, monkeypatch):
+        from pathlib import Path
+
+        from keymasq.common.models import ProfileConfig
+        from keymasq.gui.widgets import profile_managed_tab as profile_managed_tab_module
+        from keymasq.gui.widgets.profile_managed_tab import ProfileManagedTab
+        from keymasq.session.profiles import ProfileInfo
+
+        only_profile = ProfileInfo(Path("base.toml"), ProfileConfig(name="Base"))
+
+        class ProfileManagerStub:
+            def __init__(self):
+                self.deleted: list[str] = []
+
+            def list_profiles(self):
+                return [only_profile]
+
+            def delete_profile(self, name: str):
+                self.deleted.append(name)
+                return True
+
+        class DialogStub:
+            def __init__(self):
+                self.closed = False
+
+            def close(self):
+                self.closed = True
+
+        manager = ProfileManagerStub()
+        reloads: list[bool] = []
+        monkeypatch.setattr(
+            profile_managed_tab_module,
+            "notify_session_reload_async",
+            lambda: reloads.append(True),
+        )
+
+        tab = ProfileManagedTab(manager)
+        tab._selected_profile = only_profile
+        errors: list[str] = []
+        tab._show_profile_error_dialog = errors.append
+        dialog = DialogStub()
+
+        tab._on_confirm_delete_profile(None, dialog)
+
+        assert dialog.closed is True
+        assert manager.deleted == []
+        assert reloads == []
+        assert errors == [
+            "At least one profile is required. Create another profile before deleting this one."
+        ]
+
 
 class TestProfileActions:
     def test_action_types(self):


### PR DESCRIPTION
## Summary

- Prevent deletion of the last remaining profile in the GUI; show an error dialog instead.
- Move `auto_create_default_if_empty` seeding from GUI `ProfileManager` instantiation to the session side.
- Update `docs/PROFILES.md` to reflect session-side default seeding.
- Update existing tests for the new behavior and add `test_delete_last_profile_is_blocked`.

## Testing

- `test_delete_last_profile_is_blocked` — unit test confirms deletion is blocked and error dialog shown.
- `test_main_window_does_not_seed_default_profile_for_first_device` — passes.
- `test_gui_profile_reload_snapshot_does_not_seed_default` — passes.
- All other existing tests adapted to not depend on automatic default seeding.
- `ruff`, `basedpyright`, and pytest suite pass via `./scripts/check.sh`.