### PR TITLE
Fix concurrent access races in combo, force-feedback, and device release paths

### DIFF
--- a/keymasq/keymasqd/device_manager.py
+++ b/keymasq/keymasqd/device_manager.py
@@ -969,25 +969,28 @@ class DeviceManager:
                 self,
                 deps=_combo_runtime_deps(),
             )
-            self.combo_state.engine.set_combos(active_combos)
         else:
             await runtime_combos.clear_combo_runtime_except(
                 self,
                 preserve_combo_ids,
                 deps=_combo_runtime_deps(),
             )
-            self.combo_state.engine.set_combos(
-                active_combos,
-                preserve_candidate_ids=preserve_combo_ids,
+        async with self.combo_state.runtime_lock:
+            if preserve_combo_ids is None:
+                self.combo_state.engine.set_combos(active_combos)
+            else:
+                self.combo_state.engine.set_combos(
+                    active_combos,
+                    preserve_candidate_ids=preserve_combo_ids,
+                )
+            runtime_combos.prime_combo_engine_with_held_bindings(
+                self,
             )
-        runtime_combos.prime_combo_engine_with_held_bindings(
-            self,
-        )
-        runtime_combos.refresh_combo_timeout_watchdog(
-            self,
-            deps=_combo_runtime_deps(),
-        )
-        return active_combos
+            runtime_combos.refresh_combo_timeout_watchdog(
+                self,
+                deps=_combo_runtime_deps(),
+            )
+            return active_combos
 
     async def _refresh_combo_runtime_preserving_unchanged(self) -> list[RuntimeCombo]:
         unchanged_ids = unchanged_combo_ids(

--- a/keymasq/keymasqd/runtime/combos.py
+++ b/keymasq/keymasqd/runtime/combos.py
@@ -98,6 +98,7 @@ class ComboRuntimeState:
     capture_queues: dict[str, ComboCaptureQueueState] = field(default_factory=dict)
     active_combos: list[RuntimeCombo] = field(default_factory=list)
     engine: ComboEngine = field(default_factory=ComboEngine)
+    runtime_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
     timeout_task: asyncio.Task[None] | None = None
     active_actions: dict[str, ComboActionState] = field(default_factory=dict)
     superkey_machines: dict[str, SuperkeyMachine] = field(default_factory=dict)
@@ -234,15 +235,17 @@ async def on_device_event(
     if not event_source:
         resolved_path = stable_path or resolve_stable_path_fn(evdev_path)
         event_source = str(get_interface_id_fn(resolved_path) or "").lower()
-    if should_suppress_high_res_combo_wheel_event(
-        manager,
-        hardware_id,
-        event_type,
-        event_code,
-        event_value,
-        event_source,
-        evdev_mod=deps.evdev_mod,
-    ):
+    async with manager.combo_state.runtime_lock:
+        suppress_high_res = should_suppress_high_res_combo_wheel_event(
+            manager,
+            hardware_id,
+            event_type,
+            event_code,
+            event_value,
+            event_source,
+            evdev_mod=deps.evdev_mod,
+        )
+    if suppress_high_res:
         return True
     combo_payload = build_combo_event_payload(
         hardware_id,
@@ -414,21 +417,22 @@ async def process_runtime_combo_event(
         evdev=str_value_fn(payload.get("evdev"), ""),
         source=str_value_fn(payload.get("source"), ""),
     )
-    if value == 1 and not is_combo_pulse_evdev(binding.evdev):
-        held_modifiers = held_combo_modifier_bindings_for_scope(
-            manager,
-            binding.hardware_id,
-            binding.source,
+    async with manager.combo_state.runtime_lock:
+        if value == 1 and not is_combo_pulse_evdev(binding.evdev):
+            held_modifiers = held_combo_modifier_bindings_for_scope(
+                manager,
+                binding.hardware_id,
+                binding.source,
+            )
+            if binding in held_modifiers:
+                held_modifiers.discard(binding)
+            manager.combo_state.engine.prime_held_bindings(held_modifiers)
+        decision = manager.combo_state.engine.handle_event(
+            ComboInputEvent(binding=binding, value=value),
+            time.monotonic(),
         )
-        if binding in held_modifiers:
-            held_modifiers.discard(binding)
-        manager.combo_state.engine.prime_held_bindings(held_modifiers)
-    decision = manager.combo_state.engine.handle_event(
-        ComboInputEvent(binding=binding, value=value),
-        time.monotonic(),
-    )
-    if decision.recall_events:
-        emit_combo_recalls(manager, decision.recall_events)
+        if decision.recall_events:
+            emit_combo_recalls(manager, decision.recall_events)
     if decision.action_transition is not None:
         await apply_combo_action_transition(
             manager,
@@ -441,10 +445,11 @@ async def process_runtime_combo_event(
             transition,
             deps=deps,
         )
-    refresh_combo_timeout_watchdog(
-        manager,
-        deps=deps,
-    )
+    async with manager.combo_state.runtime_lock:
+        refresh_combo_timeout_watchdog(
+            manager,
+            deps=deps,
+        )
     if (
         decision.consume_current_event
         or decision.passthrough_current_event
@@ -1241,27 +1246,61 @@ async def _start_combo_action_instance(
             deps=combo_deps,
         )
 
-    await shared_action_runner.execute_action(
-        runtime,
-        action,
-        _combo_synthetic_event(trigger_binding, 1),
-        trigger_name,
-        deps=_action_execution_deps(deps),
-        execution_handle=handle,
-        cancel_macro_playback=manager.cancel_macro_playback,
-        repeat_superkey_executor=repeat_superkey_executor,
-        resolve_code_fn=deps.resolve_code_fn,
-        record_repeat=record_repeat,
-    )
-    await started.wait()
+    needs_release = _combo_action_needs_release(action)
+    preregistered = False
+    if needs_release and action.action_type != ActionType.REPEAT:
+        manager.combo_state.active_actions[combo_id] = ComboActionState(
+            kind="executor",
+            action=action,
+            trigger_binding=trigger_binding,
+            source_device=runtime.hardware_id,
+            source_button=trigger_name,
+            started=handle.started,
+            action_runtime=runtime,
+            execution_handle=handle,
+        )
+        preregistered = True
+
+    try:
+        await shared_action_runner.execute_action(
+            runtime,
+            action,
+            _combo_synthetic_event(trigger_binding, 1),
+            trigger_name,
+            deps=_action_execution_deps(deps),
+            execution_handle=handle,
+            cancel_macro_playback=manager.cancel_macro_playback,
+            repeat_superkey_executor=repeat_superkey_executor,
+            resolve_code_fn=deps.resolve_code_fn,
+            record_repeat=record_repeat,
+        )
+        await started.wait()
+    except asyncio.CancelledError:
+        if preregistered:
+            manager.combo_state.active_actions.pop(combo_id, None)
+            runtime.stop()
+        raise
+    except Exception:
+        if preregistered:
+            manager.combo_state.active_actions.pop(combo_id, None)
+            runtime.stop()
+        raise
 
     if is_hold_macro_action(action):
         await shared_action_runner.drain_action_tasks(handle)
 
-    needs_release = _combo_action_needs_release(action)
     if action.action_type == ActionType.REPEAT and not runtime.state.repeat_active_actions:
         needs_release = False
     if needs_release:
+        if preregistered:
+            state = manager.combo_state.active_actions.get(combo_id)
+            if state is None:
+                runtime.stop()
+                return
+            state.trigger_binding = trigger_binding
+            state.source_device = runtime.hardware_id
+            state.source_button = trigger_name
+            return
         manager.combo_state.active_actions[combo_id] = ComboActionState(
             kind="executor",
             action=action,
@@ -1397,6 +1436,18 @@ async def clear_combo_runtime(
     *,
     deps: ComboRuntimeDeps,
 ) -> None:
+    async with manager.combo_state.runtime_lock:
+        await clear_combo_runtime_unlocked(
+            manager,
+            deps=deps,
+        )
+
+
+async def clear_combo_runtime_unlocked(
+    manager: _ComboManager,
+    *,
+    deps: ComboRuntimeDeps,
+) -> None:
     manager.combo_state.engine.reset()
     for combo_id in list(manager.combo_state.active_actions):
         await stop_combo_action(
@@ -1424,6 +1475,20 @@ async def clear_combo_runtime(
 
 
 async def clear_combo_runtime_except(
+    manager: _ComboManager,
+    preserve_combo_ids: set[str],
+    *,
+    deps: ComboRuntimeDeps,
+) -> None:
+    async with manager.combo_state.runtime_lock:
+        await clear_combo_runtime_except_unlocked(
+            manager,
+            preserve_combo_ids,
+            deps=deps,
+        )
+
+
+async def clear_combo_runtime_except_unlocked(
     manager: _ComboManager,
     preserve_combo_ids: set[str],
     *,
@@ -1464,6 +1529,22 @@ async def clear_combo_runtime_except(
 
 
 async def clear_combo_runtime_for_binding_scope(
+    manager: _ComboManager,
+    hardware_id: str,
+    source: str | None,
+    *,
+    deps: ComboRuntimeDeps,
+) -> None:
+    async with manager.combo_state.runtime_lock:
+        await clear_combo_runtime_for_binding_scope_unlocked(
+            manager,
+            hardware_id,
+            source,
+            deps=deps,
+        )
+
+
+async def clear_combo_runtime_for_binding_scope_unlocked(
     manager: _ComboManager,
     hardware_id: str,
     source: str | None,
@@ -1536,16 +1617,16 @@ async def combo_timeout_watchdog(
 ) -> None:
     try:
         await deps.asyncio_mod.sleep(max(0.0, deadline - time.monotonic()))
-        manager.combo_state.engine.expire_timeouts(time.monotonic())
+        async with manager.combo_state.runtime_lock:
+            manager.combo_state.engine.expire_timeouts(time.monotonic())
+            if manager.combo_state.timeout_task is deps.asyncio_mod.current_task():
+                manager.combo_state.timeout_task = None
+            refresh_combo_timeout_watchdog(
+                manager,
+                deps=deps,
+            )
     except deps.asyncio_mod.CancelledError:
         raise
-    finally:
-        if manager.combo_state.timeout_task is deps.asyncio_mod.current_task():
-            manager.combo_state.timeout_task = None
-        refresh_combo_timeout_watchdog(
-            manager,
-            deps=deps,
-        )
 
 
 def begin_combo_capture(

--- a/keymasq/keymasqd/runtime/force_feedback.py
+++ b/keymasq/keymasqd/runtime/force_feedback.py
@@ -2,6 +2,7 @@ import asyncio
 import ctypes
 import errno
 import logging
+import threading
 from collections.abc import Callable, Iterable, Mapping, Sequence
 from dataclasses import dataclass
 from typing import Final, Literal, Protocol, cast
@@ -173,13 +174,17 @@ class PassthroughForceFeedbackProxy:
         self._fd: int | None = None
         self._running = False
         self._effects: dict[int, EffectMapping] = {}
+        self._effects_lock = threading.RLock()
+        self._pending_uploads: set[int] = set()
+        self._queued_upload_plays: dict[int, list[int]] = {}
         self._request_queue: asyncio.Queue[_WorkerRequest] | None = None
         self._worker_task: asyncio.Task[None] | None = None
         self._write_tasks: set[asyncio.Task[None]] = set()
 
     @property
     def effect_mappings(self) -> Mapping[int, EffectMapping]:
-        return dict(self._effects)
+        with self._effects_lock:
+            return dict(self._effects)
 
     def start(self) -> None:
         if self._running:
@@ -271,7 +276,9 @@ class PassthroughForceFeedbackProxy:
             self._schedule_physical_ff(event_code, event_value)
             return
 
-        mapping = self._effects.get(event_code)
+        mapping, queued = self._effect_mapping_for_play(event_code, event_value)
+        if queued:
+            return
         if mapping is None:
             self.log.debug(
                 "Dropping force-feedback play for unknown virtual effect %s on %s",
@@ -280,6 +287,20 @@ class PassthroughForceFeedbackProxy:
             )
             return
         self._schedule_physical_ff(mapping.physical_id, event_value)
+
+    def _effect_mapping_for_play(
+        self,
+        virtual_id: int,
+        event_value: int,
+    ) -> tuple[EffectMapping | None, bool]:
+        with self._effects_lock:
+            mapping = self._effects.get(virtual_id)
+            if mapping is not None:
+                return mapping, False
+            if virtual_id not in self._pending_uploads:
+                return None, False
+            self._queued_upload_plays.setdefault(virtual_id, []).append(int(event_value))
+            return None, True
 
     async def _request_worker(self, queue: asyncio.Queue[_WorkerRequest]) -> None:
         while True:
@@ -324,11 +345,14 @@ class PassthroughForceFeedbackProxy:
         previous_mapping: EffectMapping | None = None
         physical_id: int | None = None
         published_mapping = False
+        queued_plays: list[int] = []
         try:
             upload = _begin_upload(self.uinput, request_id)
             effect = cast(_UploadLike, upload).effect
             virtual_id = _effect_id(effect)
-            previous_mapping = self._effects.get(virtual_id)
+            with self._effects_lock:
+                self._pending_uploads.add(virtual_id)
+                previous_mapping = self._effects.get(virtual_id)
             physical_upload_id = (
                 previous_mapping.physical_id if previous_mapping is not None else -1
             )
@@ -337,9 +361,15 @@ class PassthroughForceFeedbackProxy:
                 physical_id = int(self.physical_device.upload_effect(effect))
             finally:
                 _set_effect_id(effect, virtual_id)
-            self._effects[virtual_id] = EffectMapping(physical_id=physical_id)
+            with self._effects_lock:
+                self._effects[virtual_id] = EffectMapping(physical_id=physical_id)
+                self._pending_uploads.discard(virtual_id)
+                queued_plays = self._queued_upload_plays.pop(virtual_id, [])
             published_mapping = True
+            for queued_value in queued_plays:
+                self._schedule_physical_ff(physical_id, queued_value)
         except Exception as exc:  # noqa: BLE001 - request must be acked on upload failure.
+            self._discard_pending_upload(virtual_id)
             retval = _negative_errno(exc)
             self.log.warning(
                 "Failed to proxy force-feedback upload for %s: %s",
@@ -373,11 +403,16 @@ class PassthroughForceFeedbackProxy:
         try:
             erase = _begin_erase(self.uinput, request_id)
             virtual_id = _erase_effect_id(erase)
-            mapping = self._effects.get(virtual_id)
+            with self._effects_lock:
+                mapping = self._effects.pop(virtual_id, None)
             if mapping is None:
                 raise OSError(errno.EINVAL, "unknown force-feedback effect")
-            self.physical_device.erase_effect(mapping.physical_id)
-            self._effects.pop(virtual_id, None)
+            try:
+                self.physical_device.erase_effect(mapping.physical_id)
+            except Exception:
+                with self._effects_lock:
+                    self._effects[virtual_id] = mapping
+                raise
         except Exception as exc:  # noqa: BLE001 - request must be acked on erase failure.
             retval = _negative_errno(exc, default_errno=errno.EINVAL)
             self.log.warning(
@@ -395,7 +430,14 @@ class PassthroughForceFeedbackProxy:
                     self.log.exception(
                         "Failed to finish force-feedback erase request for %s",
                         self.label,
-                    )
+                )
+
+    def _discard_pending_upload(self, virtual_id: int | None) -> None:
+        if virtual_id is None:
+            return
+        with self._effects_lock:
+            self._pending_uploads.discard(virtual_id)
+            self._queued_upload_plays.pop(virtual_id, None)
 
     def _rollback_uploaded_effect(
         self,
@@ -432,10 +474,11 @@ class PassthroughForceFeedbackProxy:
     ) -> None:
         if not published_mapping or virtual_id is None:
             return
-        if previous_mapping is None:
-            self._effects.pop(virtual_id, None)
-            return
-        self._effects[virtual_id] = previous_mapping
+        with self._effects_lock:
+            if previous_mapping is None:
+                self._effects.pop(virtual_id, None)
+                return
+            self._effects[virtual_id] = previous_mapping
 
     async def _wait_for_write_tasks(self) -> None:
         tasks = set(self._write_tasks)

--- a/keymasq/keymasqd/runtime/grab_lifecycle.py
+++ b/keymasq/keymasqd/runtime/grab_lifecycle.py
@@ -1,4 +1,5 @@
 import asyncio
+import inspect
 import logging
 from collections.abc import Awaitable, Callable, Sequence
 from typing import Any, cast
@@ -67,6 +68,33 @@ def combo_runtime_deps(
         resolve_code_fn=resolve_code_fn,
         fire_and_observe_fn=fire_and_observe_fn,
     )
+
+
+async def stop_device_event_loop(device: object) -> None:
+    stopper = getattr(device, "stop_event_loop", None)
+    if callable(stopper):
+        result = cast(Callable[[], object], stopper)()
+        if inspect.isawaitable(result):
+            await cast(Awaitable[None], result)
+        return
+
+    if hasattr(device, "_running"):
+        cast(Any, device)._running = False
+    task = getattr(device, "task", None)
+    if task is None or task is asyncio.current_task():
+        return
+    cancel = getattr(task, "cancel", None)
+    if callable(cancel):
+        cancel()
+    try:
+        await asyncio.wait_for(cast(Awaitable[object], task), timeout=1.0)
+    except (TimeoutError, asyncio.CancelledError):
+        pass
+
+
+async def stop_device_event_loops(devices: Sequence[object]) -> None:
+    for device in devices:
+        await stop_device_event_loop(device)
 
 
 async def grab_device_unlocked(
@@ -813,6 +841,7 @@ async def release_device_unlocked(
 ) -> dict[str, object]:
     cancel_pending_hardware_release(manager, hardware_id)
     cancel_pending_interface_releases_for_hardware(manager, hardware_id)
+    await stop_device_event_loops(manager.grabbed_devices.get(hardware_id, []))
     await runtime_combos.clear_combo_runtime_for_binding_scope(
         manager,
         hardware_id,
@@ -1007,6 +1036,7 @@ async def release_interface_unlocked(
     if removed is None:
         return
 
+    await stop_device_event_loop(removed)
     await runtime_combos.clear_combo_runtime_for_binding_scope(
         manager,
         hardware_id,
@@ -1044,6 +1074,8 @@ async def release_all_devices(
 ) -> None:
     async with manager._op_lock:
         await manager.cancel_macro_playback()
+        for devices in list(manager.grabbed_devices.values()):
+            await stop_device_event_loops(devices)
         await runtime_combos.clear_combo_runtime(
             manager,
             deps=combo_runtime_deps(fire_and_observe_fn=fire_and_observe_fn),

--- a/keymasq/keymasqd/runtime/grabbed_device.py
+++ b/keymasq/keymasqd/runtime/grabbed_device.py
@@ -631,8 +631,20 @@ class GrabbedDevice:
 
         log.info("Grabbed %s for %s", self.path, self.hardware_id)
 
-    async def release(self) -> None:
+    async def stop_event_loop(self) -> None:
         self._running = False
+        if self.task:
+            task = self.task
+            self.task = None
+            if task is not asyncio.current_task():
+                task.cancel()
+                try:
+                    await asyncio.wait_for(task, timeout=1.0)
+                except (TimeoutError, asyncio.CancelledError):
+                    pass
+
+    async def release(self) -> None:
+        await self.stop_event_loop()
         await self.reset_analog_controls()
         await self.reset_superkeys()
         runtime_events.observe_profile_trigger_end_for_held_sources(self)
@@ -645,16 +657,6 @@ class GrabbedDevice:
         self.state.held_source_actions.clear()
         self.state.combo_passthrough_held.clear()
         self.state.combo_recalled_bindings.clear()
-
-        if self.task:
-            task = self.task
-            self.task = None
-            if task is not asyncio.current_task():
-                task.cancel()
-                try:
-                    await asyncio.wait_for(task, timeout=1.0)
-                except (TimeoutError, asyncio.CancelledError):
-                    pass
 
         await self._stop_force_feedback_proxy()
 

--- a/tests/keymasqd/test_device_manager_combo_runtime.py
+++ b/tests/keymasqd/test_device_manager_combo_runtime.py
@@ -497,6 +497,127 @@ class TestCombos:
         await asyncio.sleep(0)
 
     @pytest.mark.asyncio
+    async def test_runtime_combo_release_during_action_start_does_not_leave_stale_action(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        manager = DeviceManager()
+        keyboard = FakeUInput()
+        manager.output_state.keyboard_uinput = keyboard
+        await manager.set_combos(
+            [
+                {
+                    "id": "combo-cross-device",
+                    "name": "Cross Device",
+                    "steps": [
+                        {
+                            "events": [
+                                {
+                                    "hardware_id": "1234:5678",
+                                    "source": "kbd-a",
+                                    "evdev": "key_leftalt",
+                                },
+                                {
+                                    "hardware_id": "1234:5678",
+                                    "source": "kbd-b",
+                                    "evdev": "key_b",
+                                },
+                            ]
+                        }
+                    ],
+                    "action": {
+                        "action": "keyboard",
+                        "target": "key_f5",
+                        "tap_enabled": True,
+                        "tap_hold_ms": 10,
+                    },
+                }
+            ]
+        )
+
+        monkeypatch.setattr(dm, "resolve_stable_path", lambda path: path)
+        monkeypatch.setattr(dm, "get_interface_id", lambda _path: "")
+
+        action_task_waiting = asyncio.Event()
+        release_action_task = asyncio.Event()
+        action_tasks: list[asyncio.Task[object]] = []
+
+        def delayed_fire_and_observe(coro, _label):
+            async def runner():
+                try:
+                    action_task_waiting.set()
+                    await release_action_task.wait()
+                    return await coro
+                finally:
+                    if not release_action_task.is_set():
+                        close = getattr(coro, "close", None)
+                        if callable(close):
+                            close()
+
+            task = asyncio.create_task(runner())
+            action_tasks.append(task)
+            return task
+
+        kwargs = combo_event_runtime_kwargs()
+        kwargs["deps"] = combo_runtime_deps(
+            fire_and_observe_fn=delayed_fire_and_observe,
+        )
+        press_b_task = None
+        try:
+            await cdm.on_device_event(
+                manager,
+                "1234:5678",
+                "/dev/input/by-id/test-kbd-a",
+                evdev.ecodes.EV_KEY,
+                evdev.ecodes.KEY_LEFTALT,
+                1,
+                None,
+                "kbd-a",
+                **kwargs,
+            )
+            press_b_task = asyncio.create_task(
+                cdm.on_device_event(
+                    manager,
+                    "1234:5678",
+                    "/dev/input/by-id/test-kbd-b",
+                    evdev.ecodes.EV_KEY,
+                    evdev.ecodes.KEY_B,
+                    1,
+                    None,
+                    "kbd-b",
+                    **kwargs,
+                )
+            )
+            await asyncio.wait_for(action_task_waiting.wait(), timeout=1.0)
+
+            await cdm.on_device_event(
+                manager,
+                "1234:5678",
+                "/dev/input/by-id/test-kbd-b",
+                evdev.ecodes.EV_KEY,
+                evdev.ecodes.KEY_B,
+                0,
+                None,
+                "kbd-b",
+                **kwargs,
+            )
+            release_action_task.set()
+            await asyncio.wait_for(press_b_task, timeout=1.0)
+            await asyncio.gather(*action_tasks, return_exceptions=True)
+
+            assert manager.combo_state.active_actions == {}
+        finally:
+            release_action_task.set()
+            if press_b_task is not None and not press_b_task.done():
+                press_b_task.cancel()
+                await asyncio.gather(press_b_task, return_exceptions=True)
+            await cdm.clear_combo_runtime(manager, deps=combo_runtime_deps())
+            for task in action_tasks:
+                if not task.done():
+                    task.cancel()
+                await asyncio.gather(task, return_exceptions=True)
+
+    @pytest.mark.asyncio
     async def test_runtime_combo_keyboard_action_mirrors_press_and_release(self, monkeypatch):
         manager = DeviceManager()
         manager.output_state.keyboard_uinput = Mock()

--- a/tests/keymasqd/test_device_manager_core.py
+++ b/tests/keymasqd/test_device_manager_core.py
@@ -1795,6 +1795,48 @@ class TestDeviceManager:
 
         assert len(manager.grabbed_devices) == 0
 
+    @pytest.mark.asyncio
+    async def test_release_interface_stops_event_loop_before_clearing_combo_runtime(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        manager = DeviceManager()
+        pending = asyncio.Event()
+        read_task = asyncio.create_task(pending.wait())
+
+        class _Device:
+            path = "/dev/input/event0"
+            interface_id = "kbd"
+
+            def __init__(self) -> None:
+                self.task = read_task
+                self.release_tracked_outputs = Mock()
+
+            async def release(self) -> None:
+                self.task.cancel()
+                await asyncio.gather(self.task, return_exceptions=True)
+
+        device = _Device()
+        manager.grabbed_devices["hw"] = [device]
+        manager.grab_state.desired_paths["hw"] = {device.path}
+
+        async def clear_combo_runtime_for_binding_scope(*_args, **_kwargs) -> None:
+            assert device.task.done()
+
+        monkeypatch.setattr(
+            ldm.runtime_combos,
+            "clear_combo_runtime_for_binding_scope",
+            clear_combo_runtime_for_binding_scope,
+        )
+        monkeypatch.setattr(ldm.runtime_outputs, "destroy_global_uinputs", Mock())
+
+        try:
+            await ldm.release_interface_unlocked(manager, "hw", device.path)
+        finally:
+            if not read_task.done():
+                read_task.cancel()
+                await asyncio.gather(read_task, return_exceptions=True)
+
 
 class TestDeviceDetection:
     @pytest.mark.asyncio

--- a/tests/keymasqd/test_force_feedback.py
+++ b/tests/keymasqd/test_force_feedback.py
@@ -1,6 +1,7 @@
 import asyncio
 import ctypes
 import errno
+import threading
 from collections.abc import Callable
 from types import SimpleNamespace
 from typing import cast
@@ -403,6 +404,33 @@ async def test_stop_and_wait_drains_inflight_worker_before_returning() -> None:
 
     assert physical.upload_ids == [-1]
     assert proxy.effect_mappings[7].physical_id == 23
+
+
+@pytest.mark.asyncio
+async def test_force_feedback_play_during_inflight_upload_is_not_dropped() -> None:
+    uinput = _FakeUInput()
+    entered_upload = threading.Event()
+    finish_upload = threading.Event()
+
+    class _BlockingPhysicalDevice(_FakePhysicalDevice):
+        def upload_effect(self, effect: object) -> int:
+            entered_upload.set()
+            if not finish_upload.wait(timeout=1.0):
+                raise TimeoutError("timed out waiting to finish force-feedback upload")
+            return super().upload_effect(effect)
+
+    physical = _BlockingPhysicalDevice()
+    proxy = PassthroughForceFeedbackProxy(uinput, physical, label="test")
+    uinput.uploads[100] = _Upload(effect_id=7)
+
+    upload_task = asyncio.create_task(asyncio.to_thread(proxy._handle_upload, 100))
+    assert await asyncio.to_thread(entered_upload.wait, 1.0)
+
+    proxy.handle_event(_event(evdev.ecodes.EV_FF, 7, 1))
+    finish_upload.set()
+    await upload_task
+
+    assert physical.writes == [(evdev.ecodes.EV_FF, 23, 1)]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Serialize combo runtime mutations under `combo_state.runtime_lock` to prevent races between event handlers and engine updates
- Preregister combo actions before async execution so cancellation / errors don't leave stale state
- Protect force-feedback effect mappings with a threading lock; queue play events that arrive while an upload is in-flight
- Stop device event loops before releasing grabbed devices/interfaces to prevent concurrent event processing during teardown

## Testing
- `test_runtime_combo_release_during_action_start_does_not_leave_stale_action` – verifies action cleanup under concurrent release
- `test_release_interface_stops_event_loop_before_clearing_combo_runtime` – confirms event loop stop precedes combo teardown
- `test_force_feedback_play_during_inflight_upload_is_not_dropped` – verifies FF plays are queued during upload and replayed after
- Existing test suite: pytest: ok - 2319 passed in 18.56s; ./scripts/integration.sh daemon-session passes.