### PR TITLE
refactor(grab_lifecycle): break grab_device_unlocked into composable planning and loop phases

### DIFF
--- a/keymasq/keymasqd/device_manager.py
+++ b/keymasq/keymasqd/device_manager.py
@@ -593,17 +593,18 @@ class DeviceManager:
         evdev_interfaces: list[JsonObject] | None = None,
     ) -> JsonObject:
         async with self._op_lock:
-            result = await runtime_grab_lifecycle.grab_device_unlocked(
-                self,
-                hardware_id,
-                evdev_paths,
-                button_map,
-                button_codes,
-                button_values,
-                analog_inputs,
-                force_grab_unmapped,
+            request = runtime_grab_lifecycle.GrabRequest(
+                hardware_id=hardware_id,
+                evdev_paths=evdev_paths,
+                button_map=button_map,
+                button_codes=button_codes,
+                button_values=button_values,
+                analog_inputs=analog_inputs,
+                force_grab_unmapped=force_grab_unmapped,
                 evdev_interfaces=evdev_interfaces,
                 update_desired=True,
+            )
+            deps = runtime_grab_lifecycle.GrabDeviceDeps(
                 desired_grab_config_cls=DesiredGrabConfig,
                 clear_device_path_cache_fn=clear_device_path_cache,
                 resolve_stable_path_fn=resolve_stable_path,
@@ -614,6 +615,11 @@ class DeviceManager:
                 int_value_fn=coerce_int,
                 fire_and_observe_fn=_fire_and_observe,
                 errno_mod=errno,
+            )
+            result = await runtime_grab_lifecycle.grab_device_unlocked(
+                self,
+                request,
+                deps,
             )
             await self._refresh_combo_runtime_preserving_unchanged()
             return result

--- a/keymasq/keymasqd/runtime/grab_lifecycle.py
+++ b/keymasq/keymasqd/runtime/grab_lifecycle.py
@@ -509,6 +509,19 @@ def _construct_grabbed_device(
     )
 
 
+def _probe_interface_device_sync(
+    manager: _GrabManager,
+    path: str,
+) -> tuple[_ManagedGrabbedDevice, dict[int, Sequence[object]]]:
+    probe_device = manager._device_input(path)
+    try:
+        caps = cast(dict[int, Sequence[object]], probe_device.capabilities())
+    except Exception:
+        runtime_adapters.close_device(probe_device)
+        raise
+    return probe_device, caps
+
+
 async def _grab_one_interface(
     manager: _GrabManager,
     request: GrabRequest,
@@ -523,10 +536,13 @@ async def _grab_one_interface(
 
     raw_device: Any | None = None
     try:
-        probe_device = manager._device_input(path)
+        probe_device, caps = await ASYNCIO_RUNTIME.to_thread(
+            _probe_interface_device_sync,
+            manager,
+            path,
+        )
         raw_device = probe_device
         state.available_count += 1
-        caps = cast(dict[int, Sequence[object]], probe_device.capabilities())
         resolved_interface = plan.resolved_by_claim_path.get(path)
         interface_id = str(
             (resolved_interface.interface_id if resolved_interface is not None else "")
@@ -617,10 +633,19 @@ async def _rollback_failed_grab(
 ) -> BaseException:
     reported_exc = _permission_aware_grab_exception(path, exc)
     log.error("Failed to grab %s: %s", path, reported_exc)
+    rollback_release_failed = False
     for device in list(state.devices):
         if any(device is existing for existing in plan.existing_devices):
             continue
-        await device.release()
+        try:
+            await device.release()
+        except Exception:  # noqa: BLE001 - rollback must restore manager state.
+            rollback_release_failed = True
+            log.warning(
+                "Failed to release %s during grab rollback",
+                getattr(device, "path", "<unknown>"),
+                exc_info=True,
+            )
     _store_grabbed_devices(manager, request.hardware_id, plan.existing_devices)
     if state.created_global_uinputs:
         runtime_outputs.destroy_global_uinputs(manager, log=log)
@@ -632,6 +657,8 @@ async def _rollback_failed_grab(
             plan.previous_desired_paths,
             plan.previous_desired_config,
         )
+    if rollback_release_failed:
+        log.warning("Grab rollback completed with cleanup errors")
     return reported_exc
 
 

--- a/keymasq/keymasqd/runtime/grab_lifecycle.py
+++ b/keymasq/keymasqd/runtime/grab_lifecycle.py
@@ -2,6 +2,7 @@ import asyncio
 import inspect
 import logging
 from collections.abc import Awaitable, Callable, Sequence
+from dataclasses import dataclass
 from typing import Any, cast
 
 import evdev
@@ -43,6 +44,73 @@ type _GrabManager = Any
 
 ASYNCIO_RUNTIME = runtime_adapters.ASYNCIO_RUNTIME
 COMBO_EVDEV_RUNTIME = runtime_adapters.COMBO_EVDEV_RUNTIME
+
+
+@dataclass(frozen=True)
+class GrabDeviceDeps:
+    desired_grab_config_cls: DesiredGrabConfigFactory
+    clear_device_path_cache_fn: Callable[[], None]
+    resolve_stable_path_fn: ResolveStablePathFn
+    device_path_resolver_deps: device_path_resolver.DevicePathResolverDeps
+    grabbed_device_cls: GrabbedDeviceFactory
+    get_interface_id_fn: GetInterfaceIdFn
+    str_value_fn: StrValueFn
+    int_value_fn: IntValueFn
+    fire_and_observe_fn: FireAndObserve
+    errno_mod: runtime_adapters.ErrnoModule
+
+
+@dataclass(frozen=True)
+class GrabRequest:
+    hardware_id: str
+    evdev_paths: list[str]
+    button_map: dict[str, str]
+    button_codes: dict[str, int] | None = None
+    button_values: dict[str, int] | None = None
+    analog_inputs: dict[str, object] | None = None
+    force_grab_unmapped: bool = False
+    evdev_interfaces: list[JsonObject] | None = None
+    update_desired: bool = True
+
+
+@dataclass(frozen=True)
+class GrabPlan:
+    hardware_id: str
+    raw_interfaces: list[JsonObject]
+    evdev_interfaces_provided: bool
+    resolved_interfaces: list[device_path_resolver.ResolvedInterface]
+    requested_paths: set[str]
+    requested_claim_paths: set[str]
+    resolved_by_claim_path: dict[str, device_path_resolver.ResolvedInterface]
+    desired_paths: set[str]
+    mapped_evdev_names: set[str]
+    resolved_button_codes: dict[str, int]
+    resolved_button_values: dict[str, int]
+    button_mapped_bindings: set[tuple[int, int]]
+    mapped_bindings: set[tuple[int, int]]
+    analog_inputs: dict[str, object]
+    existing_devices: list[_ManagedGrabbedDevice]
+    existing_by_claim_path: dict[str, _ManagedGrabbedDevice]
+    previous_desired_paths: set[str] | None
+    previous_desired_config: object | None
+    requests_gamepad_source_hiding: bool
+
+
+@dataclass(frozen=True)
+class _RuntimeCallbacks:
+    combo_deps: Any
+    event_callback: Callable[..., Awaitable[ComboDecision | bool | None]]
+    runtime_cleanup_callback: Callable[[str, str | None], Awaitable[None]]
+    runtime_disconnect_callback: Callable[[str, str], Awaitable[None]]
+
+
+@dataclass
+class _GrabLoopState:
+    devices: list[_ManagedGrabbedDevice]
+    grabbed_count: int = 0
+    skipped_count: int = 0
+    available_count: int = 0
+    created_global_uinputs: bool = False
 
 
 def _normalize_evdev_name(value: object, default: str) -> str:
@@ -99,77 +167,79 @@ async def stop_device_event_loops(devices: Sequence[object]) -> None:
 
 async def grab_device_unlocked(
     manager: _GrabManager,
-    hardware_id: str,
-    evdev_paths: list[str],
-    button_map: dict[str, str],
-    button_codes: dict[str, int] | None,
-    button_values: dict[str, int] | None,
-    analog_inputs: dict[str, object] | None,
-    force_grab_unmapped: bool,
-    *,
-    evdev_interfaces: list[JsonObject] | None = None,
-    update_desired: bool,
-    desired_grab_config_cls: DesiredGrabConfigFactory,
-    clear_device_path_cache_fn: Callable[[], None],
-    resolve_stable_path_fn: ResolveStablePathFn,
-    device_path_resolver_deps: device_path_resolver.DevicePathResolverDeps,
-    grabbed_device_cls: GrabbedDeviceFactory,
-    get_interface_id_fn: GetInterfaceIdFn,
-    str_value_fn: StrValueFn,
-    int_value_fn: IntValueFn,
-    fire_and_observe_fn: FireAndObserve,
-    errno_mod: runtime_adapters.ErrnoModule,
+    request: GrabRequest,
+    deps: GrabDeviceDeps,
 ) -> dict[str, object]:
-    clear_device_path_cache_fn()
+    deps.clear_device_path_cache_fn()
     device_path_resolver.clear_cached_devices()
-    cancel_pending_hardware_release(manager, hardware_id)
+    cancel_pending_hardware_release(manager, request.hardware_id)
 
+    plan = _build_grab_plan(manager, request, deps)
+    if request.update_desired:
+        _persist_desired_grab(manager, request, plan, deps)
+    _log_grab_request(plan)
+    _update_existing_devices(plan, request, deps)
+    _reconcile_existing_interface_releases(manager, request.hardware_id, plan, deps)
+    callbacks = _build_runtime_callbacks(manager, deps)
+    state = _GrabLoopState(devices=list(plan.existing_devices))
+
+    for path in sorted(plan.requested_paths):
+        await _grab_one_interface(manager, request, plan, deps, callbacks, state, path)
+
+    return await _finalize_grab(manager, request, plan, deps, state)
+
+
+def _build_grab_plan(
+    manager: _GrabManager,
+    request: GrabRequest,
+    deps: GrabDeviceDeps,
+) -> GrabPlan:
     raw_interfaces = (
-        evdev_interfaces
-        if evdev_interfaces
-        else device_path_resolver.interface_descriptors_from_paths(evdev_paths)
+        list(request.evdev_interfaces)
+        if request.evdev_interfaces
+        else device_path_resolver.interface_descriptors_from_paths(request.evdev_paths)
     )
     requests_gamepad_source_hiding = _interfaces_request_gamepad_source_hiding(
         raw_interfaces
     )
 
-    existing_devices = list(manager.grabbed_devices.get(hardware_id, []))
+    existing_devices = list(manager.grabbed_devices.get(request.hardware_id, []))
     existing_by_claim_path = grabbed_devices_by_claim_path(
         existing_devices,
-        resolve_stable_path_fn=resolve_stable_path_fn,
+        resolve_stable_path_fn=deps.resolve_stable_path_fn,
     )
-    previous_desired_paths_raw = manager.grab_state.desired_paths.get(hardware_id)
+    previous_desired_paths_raw = manager.grab_state.desired_paths.get(request.hardware_id)
     previous_desired_paths = (
         set(previous_desired_paths_raw) if previous_desired_paths_raw is not None else None
     )
-    previous_desired_config = manager.grab_state.desired_grabs.get(hardware_id)
+    previous_desired_config = manager.grab_state.desired_grabs.get(request.hardware_id)
     excluded_paths = grabbed_paths_for_other_hardware(
         manager,
-        hardware_id,
-        resolve_stable_path_fn=resolve_stable_path_fn,
+        request.hardware_id,
+        resolve_stable_path_fn=deps.resolve_stable_path_fn,
     )
     resolved_interfaces = device_path_resolver.resolve_evdev_interfaces(
         raw_interfaces,
-        deps=device_path_resolver_deps,
-        hardware_id=hardware_id,
+        deps=deps.device_path_resolver_deps,
+        hardware_id=request.hardware_id,
         excluded_paths=excluded_paths,
         preferred_paths=grabbed_paths_for_hardware(
             manager,
-            hardware_id,
-            resolve_stable_path_fn=resolve_stable_path_fn,
+            request.hardware_id,
+            resolve_stable_path_fn=deps.resolve_stable_path_fn,
         ),
         match_model_gamepads=True,
     )
     requested_interface_paths = [
-        resolve_stable_path_fn(interface.path) for interface in resolved_interfaces
+        deps.resolve_stable_path_fn(interface.path) for interface in resolved_interfaces
     ]
     requested_paths = set(requested_interface_paths)
     requested_claim_paths: set[str] = set()
-    resolved_by_claim_path: dict[str, Any] = {}
+    resolved_by_claim_path: dict[str, device_path_resolver.ResolvedInterface] = {}
     for interface in resolved_interfaces:
         aliases = path_claim_aliases(
             interface.path,
-            resolve_stable_path_fn=resolve_stable_path_fn,
+            resolve_stable_path_fn=deps.resolve_stable_path_fn,
         )
         requested_claim_paths.update(aliases)
         for alias in aliases:
@@ -180,84 +250,130 @@ async def grab_device_unlocked(
         if (path := str(descriptor.get("path", "") or "").strip())
     }
     desired_paths = requested_paths | raw_interface_paths
-    mapped_evdev_names = {name.lower() for name in button_map.values()}
+    mapped_evdev_names = {name.lower() for name in request.button_map.values()}
     resolved_button_codes = {
-        button_id: int(code) for button_id, code in (button_codes or {}).items()
+        button_id: int(code) for button_id, code in (request.button_codes or {}).items()
     }
     resolved_button_values = {
-        button_id: int(value) for button_id, value in (button_values or {}).items()
+        button_id: int(value) for button_id, value in (request.button_values or {}).items()
     }
     button_mapped_bindings = {
         (int(event_type), int(code))
         for button_id, code in resolved_button_codes.items()
-        if (event_type := resolve_evdev_event_type(button_map.get(button_id))) is not None
+        if (event_type := resolve_evdev_event_type(request.button_map.get(button_id)))
+        is not None
     }
-    analog_bindings = analog_input_bindings(analog_inputs or {})
+    analog_bindings = analog_input_bindings(request.analog_inputs or {})
     mapped_bindings = button_mapped_bindings | analog_bindings
-    if update_desired:
-        manager.grab_state.desired_paths[hardware_id] = set(desired_paths)
-        manager.grab_state.desired_grabs[hardware_id] = desired_grab_config_cls(
-            paths=set(desired_paths),
-            button_map=dict(button_map),
-            button_codes=dict(resolved_button_codes),
-            button_values=dict(resolved_button_values),
-            analog_inputs=dict(analog_inputs or {}),
-            force_grab_unmapped=bool(force_grab_unmapped),
-            evdev_interfaces=list(raw_interfaces) if evdev_interfaces is not None else [],
-        )
-    log.info(
-        "Grab request for %s: paths=%d mapped_evdev_names=%d mapped_bindings=%d",
-        hardware_id,
-        len(requested_paths),
-        len(mapped_evdev_names),
-        len(mapped_bindings),
+
+    return GrabPlan(
+        hardware_id=request.hardware_id,
+        raw_interfaces=raw_interfaces,
+        evdev_interfaces_provided=request.evdev_interfaces is not None,
+        resolved_interfaces=resolved_interfaces,
+        requested_paths=requested_paths,
+        requested_claim_paths=requested_claim_paths,
+        resolved_by_claim_path=resolved_by_claim_path,
+        desired_paths=desired_paths,
+        mapped_evdev_names=mapped_evdev_names,
+        resolved_button_codes=resolved_button_codes,
+        resolved_button_values=resolved_button_values,
+        button_mapped_bindings=button_mapped_bindings,
+        mapped_bindings=mapped_bindings,
+        analog_inputs=dict(request.analog_inputs or {}),
+        existing_devices=existing_devices,
+        existing_by_claim_path=existing_by_claim_path,
+        previous_desired_paths=previous_desired_paths,
+        previous_desired_config=previous_desired_config,
+        requests_gamepad_source_hiding=requests_gamepad_source_hiding,
     )
 
-    for device in existing_devices:
+
+def _persist_desired_grab(
+    manager: _GrabManager,
+    request: GrabRequest,
+    plan: GrabPlan,
+    deps: GrabDeviceDeps,
+) -> None:
+    if not request.update_desired:
+        return
+    manager.grab_state.desired_paths[request.hardware_id] = set(plan.desired_paths)
+    manager.grab_state.desired_grabs[request.hardware_id] = deps.desired_grab_config_cls(
+        paths=set(plan.desired_paths),
+        button_map=dict(request.button_map),
+        button_codes=dict(plan.resolved_button_codes),
+        button_values=dict(plan.resolved_button_values),
+        analog_inputs=dict(plan.analog_inputs),
+        force_grab_unmapped=bool(request.force_grab_unmapped),
+        evdev_interfaces=list(plan.raw_interfaces) if plan.evdev_interfaces_provided else [],
+    )
+
+
+def _log_grab_request(plan: GrabPlan) -> None:
+    log.info(
+        "Grab request for %s: paths=%d mapped_evdev_names=%d mapped_bindings=%d",
+        plan.hardware_id,
+        len(plan.requested_paths),
+        len(plan.mapped_evdev_names),
+        len(plan.mapped_bindings),
+    )
+
+
+def _update_existing_devices(
+    plan: GrabPlan,
+    request: GrabRequest,
+    deps: GrabDeviceDeps,
+) -> None:
+    for device in plan.existing_devices:
         device_claim_paths = grabbed_device_claim_paths(
             device,
-            resolve_stable_path_fn=resolve_stable_path_fn,
+            resolve_stable_path_fn=deps.resolve_stable_path_fn,
         )
         resolved_interface = next(
             (
-                resolved_by_claim_path[path]
+                plan.resolved_by_claim_path[path]
                 for path in device_claim_paths
-                if path in resolved_by_claim_path
+                if path in plan.resolved_by_claim_path
             ),
             None,
         )
         interface_id = str(
-            (resolved_interface.interface_id if resolved_interface else "")
-            or get_interface_id_fn(str(getattr(device, "path", "") or ""))
+            (resolved_interface.interface_id if resolved_interface is not None else "")
+            or deps.get_interface_id_fn(str(getattr(device, "path", "") or ""))
             or ""
         ).lower()
         if interface_id:
             device.interface_id = interface_id
-        device.update_button_map(button_map, resolved_button_codes, resolved_button_values)
+        device.update_button_map(
+            request.button_map,
+            plan.resolved_button_codes,
+            plan.resolved_button_values,
+        )
         update_analog_inputs = getattr(device, "update_analog_inputs", None)
         if callable(update_analog_inputs):
-            update_analog_inputs(dict(analog_inputs or {}))
+            update_analog_inputs(dict(plan.analog_inputs))
 
-    devices = list(existing_devices)
-    grabbed_count = 0
-    skipped_count = 0
-    available_count = 0
-    created_global_uinputs = False
 
-    for device in existing_devices:
+def _reconcile_existing_interface_releases(
+    manager: _GrabManager,
+    hardware_id: str,
+    plan: GrabPlan,
+    deps: GrabDeviceDeps,
+) -> None:
+    for device in plan.existing_devices:
         device_claim_paths = grabbed_device_claim_paths(
             device,
-            resolve_stable_path_fn=resolve_stable_path_fn,
+            resolve_stable_path_fn=deps.resolve_stable_path_fn,
         )
-        if device_claim_paths & requested_claim_paths:
+        if device_claim_paths & plan.requested_claim_paths:
             cancel_pending_interface_release(manager, hardware_id, device.path)
 
-    for device in existing_devices:
+    for device in plan.existing_devices:
         device_claim_paths = grabbed_device_claim_paths(
             device,
-            resolve_stable_path_fn=resolve_stable_path_fn,
+            resolve_stable_path_fn=deps.resolve_stable_path_fn,
         )
-        if device_claim_paths & requested_claim_paths:
+        if device_claim_paths & plan.requested_claim_paths:
             continue
         schedule_interface_release(
             manager,
@@ -267,7 +383,12 @@ async def grab_device_unlocked(
             log=log,
         )
 
-    combo_deps = combo_runtime_deps(fire_and_observe_fn=fire_and_observe_fn)
+
+def _build_runtime_callbacks(
+    manager: _GrabManager,
+    deps: GrabDeviceDeps,
+) -> _RuntimeCallbacks:
+    combo_deps = combo_runtime_deps(fire_and_observe_fn=deps.fire_and_observe_fn)
 
     async def event_callback(
         callback_hardware_id: str,
@@ -287,10 +408,10 @@ async def grab_device_unlocked(
             event_value,
             stable_path,
             source,
-            resolve_stable_path_fn=resolve_stable_path_fn,
-            get_interface_id_fn=get_interface_id_fn,
-            int_value_fn=int_value_fn,
-            str_value_fn=str_value_fn,
+            resolve_stable_path_fn=deps.resolve_stable_path_fn,
+            get_interface_id_fn=deps.get_interface_id_fn,
+            int_value_fn=deps.int_value_fn,
+            str_value_fn=deps.str_value_fn,
             deps=combo_deps,
         )
 
@@ -311,209 +432,262 @@ async def grab_device_unlocked(
     ) -> None:
         await release_interface(manager, disconnected_hardware_id, disconnected_path)
 
-    async def rollback_failed_grab(path: str, exc: BaseException) -> BaseException:
-        reported_exc = _permission_aware_grab_exception(path, exc)
-        log.error("Failed to grab %s: %s", path, reported_exc)
-        for device in list(devices):
-            if any(device is existing for existing in existing_devices):
-                continue
-            await device.release()
-        _store_grabbed_devices(manager, hardware_id, existing_devices)
-        if created_global_uinputs:
-            runtime_outputs.destroy_global_uinputs(manager, log=log)
-        cancel_pending_interface_releases_for_hardware(manager, hardware_id)
-        if update_desired:
-            restore_desired_grab_state(
+    return _RuntimeCallbacks(
+        combo_deps=combo_deps,
+        event_callback=event_callback,
+        runtime_cleanup_callback=runtime_cleanup_callback,
+        runtime_disconnect_callback=runtime_disconnect_callback,
+    )
+
+
+def _construct_grabbed_device(
+    manager: _GrabManager,
+    request: GrabRequest,
+    plan: GrabPlan,
+    deps: GrabDeviceDeps,
+    callbacks: _RuntimeCallbacks,
+    path: str,
+    interface_id: str,
+    probe_device: object,
+) -> _ManagedGrabbedDevice:
+    detected_types = manager._detect_device_types(probe_device)
+    detected_type = deps.device_path_resolver_deps.primary_input_class_fn(detected_types)
+
+    def mapping_getter(hid: str = request.hardware_id) -> dict[str, MappingAction]:
+        return manager.active_mappings.get(hid, {})
+
+    def diagnostics_recorder(label: str, duration_us: float) -> None:
+        manager._record_diagnostic(label, duration_us)
+
+    def gamepad_output_resolver(
+        output_id: str | None,
+        context: str,
+    ) -> object | None:
+        return manager.resolve_gamepad_output(output_id, context=context)
+
+    return deps.grabbed_device_cls(
+        path=path,
+        hardware_id=request.hardware_id,
+        button_map=request.button_map,
+        button_codes=plan.resolved_button_codes,
+        button_values=plan.resolved_button_values,
+        analog_inputs=dict(plan.analog_inputs),
+        mapping_getter=mapping_getter,
+        event_callback=callbacks.event_callback,
+        device_type=detected_type,
+        device_types=detected_types,
+        verbosity=manager.verbosity,
+        keyboard_uinput=manager.output_state.keyboard_uinput,
+        mouse_uinput=manager.output_state.mouse_uinput,
+        gamepad_uinput=manager.output_state.gamepad_uinput,
+        gamepad_output_resolver=gamepad_output_resolver,
+        broadcast_callback=manager.broadcast_callback,
+        cursor_position_setter=manager.set_cursor_position,
+        natural_mouse_mover=getattr(manager, "move_cursor_natural", None),
+        recording_manager=manager.recording_manager,
+        macro_player=manager.play_macro,
+        emergency_resetter=manager.emergency_reset,
+        inspector_event_callback=manager.broadcast_device_inspector_event,
+        inspector_active_getter=manager.device_inspector_active,
+        inspector_suppression_getter=manager.device_inspector_suppressed,
+        inspector_suppressed_ids_getter=(
+            manager.device_inspector_suppressed_hardware_ids_snapshot
+        ),
+        inspector_suppression_disabler=manager.disable_device_inspector_suppression,
+        profile_activation_recorder=manager.record_profile_action,
+        profile_activation_trigger_start_observer=(
+            manager.observe_profile_trigger_start
+        ),
+        profile_activation_trigger_end_observer=manager.observe_profile_trigger_end,
+        suppress_rel_getter=lambda: manager.macro_state.mouse_rel_suppressed,
+        mouse_rel_suppression_start_callback=lambda: None,
+        diagnostics_recorder=diagnostics_recorder,
+        runtime_cleanup_callback=callbacks.runtime_cleanup_callback,
+        runtime_disconnect_callback=callbacks.runtime_disconnect_callback,
+        repeat_state=manager.repeat_state,
+        interface_id=interface_id,
+    )
+
+
+async def _grab_one_interface(
+    manager: _GrabManager,
+    request: GrabRequest,
+    plan: GrabPlan,
+    deps: GrabDeviceDeps,
+    callbacks: _RuntimeCallbacks,
+    state: _GrabLoopState,
+    path: str,
+) -> None:
+    if path in plan.existing_by_claim_path:
+        return
+
+    raw_device: Any | None = None
+    try:
+        probe_device = manager._device_input(path)
+        raw_device = probe_device
+        state.available_count += 1
+        caps = cast(dict[int, Sequence[object]], probe_device.capabilities())
+        resolved_interface = plan.resolved_by_claim_path.get(path)
+        interface_id = str(
+            (resolved_interface.interface_id if resolved_interface is not None else "")
+            or deps.get_interface_id_fn(path)
+            or ""
+        ).lower()
+        interface_mapped_bindings = plan.button_mapped_bindings | analog_input_bindings(
+            plan.analog_inputs,
+            source=interface_id,
+        )
+        has_mapped_buttons = device_has_mapped_buttons(
+            caps,
+            plan.mapped_evdev_names,
+            interface_mapped_bindings,
+            evdev_mod=evdev,
+        )
+
+        if has_mapped_buttons or request.force_grab_unmapped:
+            needs_global_uinputs = request.hardware_id not in manager.grabbed_devices
+            if needs_global_uinputs and not state.created_global_uinputs:
+                runtime_outputs.create_global_uinputs(
+                    manager,
+                    evdev_mod=evdev,  # pyright: ignore[reportArgumentType]
+                    log=log,
+                    uinput_writer=runtime_adapters.identity_uinput_writer,
+                )
+                state.created_global_uinputs = True
+            device = _construct_grabbed_device(
                 manager,
-                hardware_id,
-                previous_desired_paths,
-                previous_desired_config,
+                request,
+                plan,
+                deps,
+                callbacks,
+                path,
+                interface_id,
+                probe_device,
             )
-        return reported_exc
+            state.devices.append(device)
+            _store_grabbed_devices(manager, request.hardware_id, state.devices)
+            try:
+                await grab_with_retry(
+                    device,
+                    path,
+                    asyncio_mod=ASYNCIO_RUNTIME,
+                    log=log,
+                    errno_mod=deps.errno_mod,
+                )
+            except (asyncio.CancelledError, Exception):
+                state.devices.remove(device)
+                _store_grabbed_devices(manager, request.hardware_id, state.devices)
+                raise
+            state.grabbed_count += 1
+            if manager.verbosity >= 1:
+                reason = "mapped buttons" if has_mapped_buttons else "forced for combos"
+                log.debug("  %s - grabbed (%s)", path, reason)
+        else:
+            state.skipped_count += 1
+            if manager.verbosity >= 1:
+                log.debug("  %s - skipped (no matching mapped button names/codes)", path)
+    except OSError as exc:
+        if raw_device is not None:
+            runtime_adapters.close_device(raw_device)
+            raw_device = None
+        if exc.errno in {deps.errno_mod.ENOENT, deps.errno_mod.ENODEV}:
+            log.info("Skipping unavailable interface for %s: %s", request.hardware_id, path)
+            return
+        reported_exc = await _rollback_failed_grab(manager, request, plan, deps, state, path, exc)
+        raise reported_exc from exc
+    except Exception as exc:
+        if raw_device is not None:
+            runtime_adapters.close_device(raw_device)
+            raw_device = None
+        reported_exc = await _rollback_failed_grab(manager, request, plan, deps, state, path, exc)
+        raise reported_exc from exc
+    finally:
+        if raw_device is not None:
+            runtime_adapters.close_device(raw_device)
 
-    for path in sorted(requested_paths):
-        if path in existing_by_claim_path:
+
+async def _rollback_failed_grab(
+    manager: _GrabManager,
+    request: GrabRequest,
+    plan: GrabPlan,
+    deps: GrabDeviceDeps,
+    state: _GrabLoopState,
+    path: str,
+    exc: BaseException,
+) -> BaseException:
+    reported_exc = _permission_aware_grab_exception(path, exc)
+    log.error("Failed to grab %s: %s", path, reported_exc)
+    for device in list(state.devices):
+        if any(device is existing for existing in plan.existing_devices):
             continue
-        raw_device: Any | None = None
-        try:
-            probe_device = manager._device_input(path)
-            raw_device = probe_device
-            available_count += 1
-            caps = probe_device.capabilities()
-            resolved_interface = resolved_by_claim_path.get(path)
-            interface_id = str(
-                (resolved_interface.interface_id if resolved_interface else "")
-                or get_interface_id_fn(path)
-                or ""
-            ).lower()
-            interface_mapped_bindings = button_mapped_bindings | analog_input_bindings(
-                analog_inputs or {},
-                source=interface_id,
-            )
-            has_mapped_buttons = device_has_mapped_buttons(
-                caps,
-                mapped_evdev_names,
-                interface_mapped_bindings,
-                evdev_mod=evdev,
-            )
+        await device.release()
+    _store_grabbed_devices(manager, request.hardware_id, plan.existing_devices)
+    if state.created_global_uinputs:
+        runtime_outputs.destroy_global_uinputs(manager, log=log)
+    cancel_pending_interface_releases_for_hardware(manager, request.hardware_id)
+    if request.update_desired:
+        restore_desired_grab_state(
+            manager,
+            request.hardware_id,
+            plan.previous_desired_paths,
+            plan.previous_desired_config,
+        )
+    return reported_exc
 
-            if has_mapped_buttons or force_grab_unmapped:
-                if hardware_id not in manager.grabbed_devices and not created_global_uinputs:
-                    runtime_outputs.create_global_uinputs(
-                        manager,
-                        evdev_mod=evdev,  # pyright: ignore[reportArgumentType]
-                        log=log,
-                        uinput_writer=runtime_adapters.identity_uinput_writer,
-                    )
-                    created_global_uinputs = True
-                detected_types = manager._detect_device_types(probe_device)
-                detected_type = device_path_resolver_deps.primary_input_class_fn(
-                    detected_types
-                )
 
-                def mapping_getter(hid: str = hardware_id) -> dict[str, MappingAction]:
-                    return manager.active_mappings.get(hid, {})
-
-                def diagnostics_recorder(label: str, duration_us: float) -> None:
-                    manager._record_diagnostic(label, duration_us)
-
-                def gamepad_output_resolver(
-                    output_id: str | None,
-                    context: str,
-                ) -> object | None:
-                    return manager.resolve_gamepad_output(output_id, context=context)
-
-                device = grabbed_device_cls(
-                    path=path,
-                    hardware_id=hardware_id,
-                    button_map=button_map,
-                    button_codes=resolved_button_codes,
-                    button_values=resolved_button_values,
-                    analog_inputs=dict(analog_inputs or {}),
-                    mapping_getter=mapping_getter,
-                    event_callback=event_callback,
-                    device_type=detected_type,
-                    device_types=detected_types,
-                    verbosity=manager.verbosity,
-                    keyboard_uinput=manager.output_state.keyboard_uinput,
-                    mouse_uinput=manager.output_state.mouse_uinput,
-                    gamepad_uinput=manager.output_state.gamepad_uinput,
-                    gamepad_output_resolver=gamepad_output_resolver,
-                    broadcast_callback=manager.broadcast_callback,
-                    cursor_position_setter=manager.set_cursor_position,
-                    natural_mouse_mover=getattr(manager, "move_cursor_natural", None),
-                    recording_manager=manager.recording_manager,
-                    macro_player=manager.play_macro,
-                    emergency_resetter=manager.emergency_reset,
-                    inspector_event_callback=manager.broadcast_device_inspector_event,
-                    inspector_active_getter=manager.device_inspector_active,
-                    inspector_suppression_getter=manager.device_inspector_suppressed,
-                    inspector_suppressed_ids_getter=(
-                        manager.device_inspector_suppressed_hardware_ids_snapshot
-                    ),
-                    inspector_suppression_disabler=(
-                        manager.disable_device_inspector_suppression
-                    ),
-                    profile_activation_recorder=manager.record_profile_action,
-                    profile_activation_trigger_start_observer=(
-                        manager.observe_profile_trigger_start
-                    ),
-                    profile_activation_trigger_end_observer=(
-                        manager.observe_profile_trigger_end
-                    ),
-                    suppress_rel_getter=lambda: manager.macro_state.mouse_rel_suppressed,
-                    mouse_rel_suppression_start_callback=lambda: None,
-                    diagnostics_recorder=diagnostics_recorder,
-                    runtime_cleanup_callback=runtime_cleanup_callback,
-                    runtime_disconnect_callback=runtime_disconnect_callback,
-                    repeat_state=manager.repeat_state,
-                    interface_id=interface_id,
-                )
-                devices.append(device)
-                _store_grabbed_devices(manager, hardware_id, devices)
-                try:
-                    await grab_with_retry(
-                        device,
-                        path,
-                        asyncio_mod=ASYNCIO_RUNTIME,
-                        log=log,
-                        errno_mod=errno_mod,
-                    )
-                except (asyncio.CancelledError, Exception):
-                    devices.remove(device)
-                    _store_grabbed_devices(manager, hardware_id, devices)
-                    raise
-                grabbed_count += 1
-                if manager.verbosity >= 1:
-                    reason = "mapped buttons" if has_mapped_buttons else "forced for combos"
-                    log.debug("  %s - grabbed (%s)", path, reason)
-            else:
-                skipped_count += 1
-                if manager.verbosity >= 1:
-                    log.debug("  %s - skipped (no matching mapped button names/codes)", path)
-        except OSError as exc:
-            if raw_device is not None:
-                runtime_adapters.close_device(raw_device)
-                raw_device = None
-            if exc.errno in {errno_mod.ENOENT, errno_mod.ENODEV}:
-                log.info("Skipping unavailable interface for %s: %s", hardware_id, path)
-                continue
-            reported_exc = await rollback_failed_grab(path, exc)
-            raise reported_exc from exc
-        except Exception as exc:
-            if raw_device is not None:
-                runtime_adapters.close_device(raw_device)
-                raw_device = None
-            reported_exc = await rollback_failed_grab(path, exc)
-            raise reported_exc from exc
-        finally:
-            if raw_device is not None:
-                runtime_adapters.close_device(raw_device)
-
+async def _finalize_grab(
+    manager: _GrabManager,
+    request: GrabRequest,
+    plan: GrabPlan,
+    deps: GrabDeviceDeps,
+    state: _GrabLoopState,
+) -> dict[str, object]:
     waiting_for_device = bool(
-        (requested_paths or raw_interfaces) and available_count == 0 and not devices
+        (plan.requested_paths or plan.raw_interfaces)
+        and state.available_count == 0
+        and not state.devices
     )
     if (
         not waiting_for_device
-        and hardware_id not in manager.grabbed_devices
-        and requested_paths
-        and (mapped_evdev_names or mapped_bindings)
-        and grabbed_count == 0
+        and request.hardware_id not in manager.grabbed_devices
+        and plan.requested_paths
+        and (plan.mapped_evdev_names or plan.mapped_bindings)
+        and state.grabbed_count == 0
     ):
-        if created_global_uinputs:
+        if state.created_global_uinputs:
             runtime_outputs.destroy_global_uinputs(manager, log=log)
         raise ValueError(
-            f"No interfaces for {hardware_id} matched mapped buttons "
-            f"(paths={len(requested_paths)}, mapped_names={len(mapped_evdev_names)}, "
-            f"mapped_bindings={len(mapped_bindings)})"
+            f"No interfaces for {request.hardware_id} matched mapped buttons "
+            f"(paths={len(plan.requested_paths)}, mapped_names={len(plan.mapped_evdev_names)}, "
+            f"mapped_bindings={len(plan.mapped_bindings)})"
         )
 
-    if devices:
-        manager.grabbed_devices[hardware_id] = devices
+    if state.devices:
+        manager.grabbed_devices[request.hardware_id] = state.devices
     else:
-        manager.grabbed_devices.pop(hardware_id, None)
+        manager.grabbed_devices.pop(request.hardware_id, None)
 
     log.info(
         "Configured device %s: total_interfaces=%d newly_grabbed=%d skipped=%d",
-        hardware_id,
-        len(devices),
-        grabbed_count,
-        skipped_count,
+        request.hardware_id,
+        len(state.devices),
+        state.grabbed_count,
+        state.skipped_count,
     )
-    if update_desired:
-        if requests_gamepad_source_hiding and waiting_for_device:
-            await _enable_hardware_hotplug_hiding_best_effort(manager, hardware_id)
+    if request.update_desired:
+        if plan.requests_gamepad_source_hiding and waiting_for_device:
+            await _enable_hardware_hotplug_hiding_best_effort(manager, request.hardware_id)
         else:
             await _disable_hardware_hotplug_hiding_if_unused_best_effort(
                 manager,
-                hardware_id,
+                request.hardware_id,
             )
 
     return {
         "grabbed": True,
-        "hardware_id": hardware_id,
-        "grabbed_count": len(devices),
-        "skipped_count": skipped_count,
+        "hardware_id": request.hardware_id,
+        "grabbed_count": len(state.devices),
+        "skipped_count": state.skipped_count,
         "waiting_for_device": waiting_for_device,
     }
 

--- a/tests/keymasqd/test_device_manager_core.py
+++ b/tests/keymasqd/test_device_manager_core.py
@@ -627,6 +627,42 @@ class TestDeviceManager:
         enable_hotplug_hiding.assert_not_awaited()
 
     @pytest.mark.asyncio
+    async def test_grab_device_waits_when_raw_interfaces_do_not_resolve(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        manager = DeviceManager()
+        path = "/dev/input/event404"
+        disable_hotplug_hiding = AsyncMock()
+        monkeypatch.setattr(
+            ldm.device_path_resolver,
+            "resolve_evdev_interfaces",
+            lambda *_args, **_kwargs: [],
+        )
+        monkeypatch.setattr(
+            ldm.source_hiding,
+            "disable_hardware_hotplug_hiding",
+            disable_hotplug_hiding,
+        )
+
+        result = await manager.grab_device(
+            hardware_id="1234:5678",
+            evdev_paths=[],
+            evdev_interfaces=[{"id": "kbd", "path": path, "type": "keyboard"}],
+            button_map={"a": "key_a"},
+        )
+
+        assert result == {
+            "grabbed": True,
+            "hardware_id": "1234:5678",
+            "grabbed_count": 0,
+            "skipped_count": 0,
+            "waiting_for_device": True,
+        }
+        assert manager.grab_state.desired_paths["1234:5678"] == {path}
+        disable_hotplug_hiding.assert_awaited_once_with("1234:5678")
+
+    @pytest.mark.asyncio
     async def test_release_device_disables_waiting_gamepad_hotplug_hiding(
         self,
         monkeypatch: pytest.MonkeyPatch,
@@ -1159,6 +1195,75 @@ class TestDeviceManager:
         assert observed_paths == [[path]]
 
     @pytest.mark.asyncio
+    async def test_grab_device_creates_global_uinputs_once_for_multiple_interfaces(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        manager = DeviceManager()
+        paths = ["/dev/input/event2", "/dev/input/event3"]
+        create_global_uinputs = Mock()
+
+        class _InputDevice:
+            name = "Pad"
+            phys = "usb-pad/input0"
+            info = SimpleNamespace(vendor=0x2DC8, product=0x3106)
+
+            def capabilities(self) -> dict[int, list[int]]:
+                return {evdev.ecodes.EV_KEY: [evdev.ecodes.BTN_SOUTH]}
+
+            def input_props(self) -> list[int]:
+                return []
+
+            def close(self) -> None:
+                return
+
+        class _GrabbedDevice:
+            def __init__(self, **kwargs) -> None:
+                self.path = kwargs["path"]
+                self.hardware_id = kwargs["hardware_id"]
+                self.stable_path = self.path
+                self.resolved_event_path = self.path
+                self.interface_id = kwargs.get("interface_id", "")
+
+            async def grab(self) -> None:
+                return
+
+            async def release(self) -> None:
+                return
+
+            def update_button_map(self, *args, **kwargs) -> None:
+                return
+
+            def update_analog_inputs(self, _inputs) -> None:
+                return
+
+        monkeypatch.setattr(dm, "resolve_stable_path", lambda value: value)
+        monkeypatch.setattr(dm, "GrabbedDevice", _GrabbedDevice)
+        monkeypatch.setattr(ldm.runtime_outputs, "create_global_uinputs", create_global_uinputs)
+        monkeypatch.setattr(
+            ldm.source_hiding,
+            "disable_hardware_hotplug_hiding",
+            AsyncMock(),
+        )
+        manager._device_input = lambda _path: _InputDevice()  # type: ignore[method-assign]
+        manager._detect_device_types = lambda _device: ["gamepad"]  # type: ignore[method-assign]
+
+        result = await manager.grab_device(
+            hardware_id="2dc8:3106",
+            evdev_paths=paths,
+            evdev_interfaces=[
+                {"id": "gamepad", "path": paths[0], "type": "gamepad"},
+                {"id": "gamepad", "path": paths[1], "type": "gamepad"},
+            ],
+            button_map={"btn_south": "btn_south"},
+            button_codes={"btn_south": evdev.ecodes.BTN_SOUTH},
+        )
+
+        assert result["grabbed_count"] == 2
+        assert [device.path for device in manager.grabbed_devices["2dc8:3106"]] == paths
+        create_global_uinputs.assert_called_once()
+
+    @pytest.mark.asyncio
     async def test_grab_device_reuses_combo_runtime_deps_for_callbacks(
         self,
         monkeypatch: pytest.MonkeyPatch,
@@ -1261,30 +1366,34 @@ class TestDeviceManager:
 
         await ldm.grab_device_unlocked(
             manager,
-            "2dc8:3106",
-            [path],
-            {"btn_south": "btn_south"},
-            {"btn_south": evdev.ecodes.BTN_SOUTH},
-            None,
-            None,
-            False,
-            evdev_interfaces=[{"id": "gamepad", "path": path, "type": "gamepad"}],
-            update_desired=False,
-            desired_grab_config_cls=lambda **kwargs: kwargs,
-            clear_device_path_cache_fn=lambda: None,
-            resolve_stable_path_fn=lambda value: value,
-            device_path_resolver_deps=ldm.device_path_resolver.DevicePathResolverDeps(
-                device_paths_fn=lambda: [],
-                device_input_fn=lambda _path: _InputDevice(),
-                detect_input_classes_fn=lambda _device: [],
-                primary_input_class_fn=lambda _types: DeviceType.GAMEPAD,
+            ldm.GrabRequest(
+                hardware_id="2dc8:3106",
+                evdev_paths=[path],
+                button_map={"btn_south": "btn_south"},
+                button_codes={"btn_south": evdev.ecodes.BTN_SOUTH},
+                button_values=None,
+                analog_inputs=None,
+                force_grab_unmapped=False,
+                evdev_interfaces=[{"id": "gamepad", "path": path, "type": "gamepad"}],
+                update_desired=False,
             ),
-            grabbed_device_cls=_GrabbedDevice,
-            get_interface_id_fn=lambda _path: "gamepad",
-            str_value_fn=str,
-            int_value_fn=int,
-            fire_and_observe_fn=lambda coro, _label: asyncio.ensure_future(coro),
-            errno_mod=errno,
+            ldm.GrabDeviceDeps(
+                desired_grab_config_cls=lambda **kwargs: kwargs,
+                clear_device_path_cache_fn=lambda: None,
+                resolve_stable_path_fn=lambda value: value,
+                device_path_resolver_deps=ldm.device_path_resolver.DevicePathResolverDeps(
+                    device_paths_fn=lambda: [],
+                    device_input_fn=lambda _path: _InputDevice(),
+                    detect_input_classes_fn=lambda _device: [],
+                    primary_input_class_fn=lambda _types: DeviceType.GAMEPAD,
+                ),
+                grabbed_device_cls=_GrabbedDevice,
+                get_interface_id_fn=lambda _path: "gamepad",
+                str_value_fn=str,
+                int_value_fn=int,
+                fire_and_observe_fn=lambda coro, _label: asyncio.ensure_future(coro),
+                errno_mod=errno,
+            ),
         )
 
         device = manager.grabbed_devices["2dc8:3106"][0]
@@ -1753,6 +1862,70 @@ class TestDeviceManager:
                 evdev_paths=["/dev/input/event10"],
                 button_map={"btn_side": "btn_side"},
             )
+
+    @pytest.mark.asyncio
+    async def test_grab_device_force_grab_unmapped_grabs_without_matching_capabilities(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        manager = DeviceManager()
+        path = "/dev/input/event10"
+
+        class _InputDevice:
+            name = "Keyboard"
+            phys = "usb-keyboard/input0"
+            info = SimpleNamespace(vendor=0x1234, product=0x5678)
+
+            def capabilities(self) -> dict[int, list[int]]:
+                return {evdev.ecodes.EV_KEY: [evdev.ecodes.KEY_A]}
+
+            def input_props(self) -> list[int]:
+                return []
+
+            def close(self) -> None:
+                return
+
+        class _GrabbedDevice:
+            def __init__(self, **kwargs) -> None:
+                self.path = kwargs["path"]
+                self.hardware_id = kwargs["hardware_id"]
+                self.stable_path = self.path
+                self.resolved_event_path = self.path
+                self.interface_id = kwargs.get("interface_id", "")
+
+            async def grab(self) -> None:
+                return
+
+            async def release(self) -> None:
+                return
+
+            def update_button_map(self, *args, **kwargs) -> None:
+                return
+
+            def update_analog_inputs(self, _inputs) -> None:
+                return
+
+        monkeypatch.setattr(dm, "resolve_stable_path", lambda value: value)
+        monkeypatch.setattr(dm, "GrabbedDevice", _GrabbedDevice)
+        monkeypatch.setattr(ldm.runtime_outputs, "create_global_uinputs", Mock())
+        monkeypatch.setattr(
+            ldm.source_hiding,
+            "disable_hardware_hotplug_hiding",
+            AsyncMock(),
+        )
+        manager._device_input = lambda _path: _InputDevice()  # type: ignore[method-assign]
+        manager._detect_device_types = lambda _device: ["keyboard"]  # type: ignore[method-assign]
+
+        result = await manager.grab_device(
+            hardware_id="1234:5678",
+            evdev_paths=[path],
+            button_map={"btn_side": "btn_side"},
+            force_grab_unmapped=True,
+        )
+
+        assert result["grabbed_count"] == 1
+        assert result["skipped_count"] == 0
+        assert manager.grabbed_devices["1234:5678"][0].path == path
 
     @pytest.mark.asyncio
     @requires_uinput

--- a/tests/keymasqd/test_grab_lifecycle_planning.py
+++ b/tests/keymasqd/test_grab_lifecycle_planning.py
@@ -80,9 +80,11 @@ def _plan(
     *,
     hardware_id: str = "2dc8:3106",
     raw_interfaces: list[ldm.JsonObject] | None = None,
+    evdev_interfaces_provided: bool = False,
     requested_paths: set[str] | None = None,
     mapped_evdev_names: set[str] | None = None,
     mapped_bindings: set[tuple[int, int]] | None = None,
+    analog_inputs: dict[str, object] | None = None,
     existing_devices: list[object] | None = None,
     previous_desired_paths: set[str] | None = None,
     previous_desired_config: object | None = None,
@@ -91,6 +93,7 @@ def _plan(
     return ldm.GrabPlan(
         hardware_id=hardware_id,
         raw_interfaces=raw_interfaces or [],
+        evdev_interfaces_provided=evdev_interfaces_provided,
         resolved_interfaces=[],
         requested_paths=requested_paths or set(),
         requested_claim_paths=set(),
@@ -101,6 +104,7 @@ def _plan(
         resolved_button_values={},
         button_mapped_bindings=set(),
         mapped_bindings=mapped_bindings or set(),
+        analog_inputs=analog_inputs or {},
         existing_devices=existing_devices or [],
         existing_by_claim_path={},
         previous_desired_paths=previous_desired_paths,
@@ -384,6 +388,12 @@ class _ExistingDevice(_ReleasedDevice):
         raise AssertionError("existing devices must not be released during rollback")
 
 
+class _FailingReleaseDevice(_ReleasedDevice):
+    async def release(self) -> None:
+        self.release_count += 1
+        raise RuntimeError("release failed")
+
+
 @pytest.mark.asyncio
 async def test_rollback_failed_grab_restores_existing_devices_and_desired_state(
     monkeypatch: pytest.MonkeyPatch,
@@ -437,4 +447,49 @@ async def test_rollback_failed_grab_restores_existing_devices_and_desired_state(
     )
     assert task.cancelled is True
     assert other_task.cancelled is False
+    destroy_global_uinputs.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_rollback_failed_grab_restores_state_when_new_device_release_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    existing = _ExistingDevice("/dev/input/event1")
+    failing_new = _FailingReleaseDevice("/dev/input/event2")
+    old_config = object()
+    task = _FakeTask()
+    manager = _manager(
+        grabbed_devices={"2dc8:3106": [existing, failing_new]},
+        desired_paths={"2dc8:3106": {"new-path"}},
+        desired_grabs={"2dc8:3106": object()},
+    )
+    manager.grab_state.pending_interface_release[("2dc8:3106", "/dev/input/event1")] = task
+    destroy_global_uinputs = Mock()
+    monkeypatch.setattr(ldm.runtime_outputs, "destroy_global_uinputs", destroy_global_uinputs)
+    exc = RuntimeError("grab failed")
+
+    reported = await ldm._rollback_failed_grab(
+        manager,
+        _request(update_desired=True),
+        _plan(
+            existing_devices=[existing],
+            previous_desired_paths={"old-path"},
+            previous_desired_config=old_config,
+        ),
+        _deps(),
+        ldm._GrabLoopState(
+            devices=[existing, failing_new],
+            created_global_uinputs=True,
+        ),
+        "/dev/input/event3",
+        exc,
+    )
+
+    assert reported is exc
+    assert failing_new.release_count == 1
+    assert manager.grabbed_devices["2dc8:3106"] == [existing]
+    assert manager.grab_state.desired_paths["2dc8:3106"] == {"old-path"}
+    assert manager.grab_state.desired_grabs["2dc8:3106"] is old_config
+    assert ("2dc8:3106", "/dev/input/event1") not in manager.grab_state.pending_interface_release
+    assert task.cancelled is True
     destroy_global_uinputs.assert_called_once()

--- a/tests/keymasqd/test_grab_lifecycle_planning.py
+++ b/tests/keymasqd/test_grab_lifecycle_planning.py
@@ -1,0 +1,440 @@
+import asyncio
+import errno
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import evdev
+import pytest
+
+from keymasq.common.models import DeviceType
+from keymasq.keymasqd.runtime import grab_lifecycle as ldm
+
+
+def _manager(
+    *,
+    grabbed_devices: dict[str, list[object]] | None = None,
+    desired_paths: dict[str, set[str]] | None = None,
+    desired_grabs: dict[str, object] | None = None,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        grabbed_devices=grabbed_devices or {},
+        grab_state=SimpleNamespace(
+            desired_paths=desired_paths or {},
+            desired_grabs=desired_grabs or {},
+            pending_interface_release={},
+            pending_hardware_release={},
+            release_grace_s=0.01,
+        ),
+    )
+
+
+def _deps(
+    *,
+    resolve_stable_path_fn=lambda path: path,
+) -> ldm.GrabDeviceDeps:
+    return ldm.GrabDeviceDeps(
+        desired_grab_config_cls=lambda **kwargs: SimpleNamespace(**kwargs),
+        clear_device_path_cache_fn=lambda: None,
+        resolve_stable_path_fn=resolve_stable_path_fn,
+        device_path_resolver_deps=ldm.device_path_resolver.DevicePathResolverDeps(
+            device_paths_fn=lambda: [],
+            device_input_fn=lambda _path: SimpleNamespace(),
+            detect_input_classes_fn=lambda _device: [],
+            primary_input_class_fn=lambda _types: DeviceType.KEYBOARD,
+        ),
+        grabbed_device_cls=lambda **kwargs: SimpleNamespace(**kwargs),
+        get_interface_id_fn=lambda _path: "",
+        str_value_fn=str,
+        int_value_fn=int,
+        fire_and_observe_fn=lambda coro, _label: asyncio.ensure_future(coro),
+        errno_mod=errno,
+    )
+
+
+def _request(
+    *,
+    hardware_id: str = "2dc8:3106",
+    evdev_paths: list[str] | None = None,
+    button_map: dict[str, str] | None = None,
+    button_codes: dict[str, int] | None = None,
+    button_values: dict[str, int] | None = None,
+    analog_inputs: dict[str, object] | None = None,
+    force_grab_unmapped: bool = False,
+    evdev_interfaces: list[ldm.JsonObject] | None = None,
+    update_desired: bool = False,
+) -> ldm.GrabRequest:
+    return ldm.GrabRequest(
+        hardware_id=hardware_id,
+        evdev_paths=evdev_paths or [],
+        button_map=button_map or {},
+        button_codes=button_codes,
+        button_values=button_values,
+        analog_inputs=analog_inputs,
+        force_grab_unmapped=force_grab_unmapped,
+        evdev_interfaces=evdev_interfaces,
+        update_desired=update_desired,
+    )
+
+
+def _plan(
+    *,
+    hardware_id: str = "2dc8:3106",
+    raw_interfaces: list[ldm.JsonObject] | None = None,
+    requested_paths: set[str] | None = None,
+    mapped_evdev_names: set[str] | None = None,
+    mapped_bindings: set[tuple[int, int]] | None = None,
+    existing_devices: list[object] | None = None,
+    previous_desired_paths: set[str] | None = None,
+    previous_desired_config: object | None = None,
+    requests_gamepad_source_hiding: bool = False,
+) -> ldm.GrabPlan:
+    return ldm.GrabPlan(
+        hardware_id=hardware_id,
+        raw_interfaces=raw_interfaces or [],
+        resolved_interfaces=[],
+        requested_paths=requested_paths or set(),
+        requested_claim_paths=set(),
+        resolved_by_claim_path={},
+        desired_paths=set(),
+        mapped_evdev_names=mapped_evdev_names or set(),
+        resolved_button_codes={},
+        resolved_button_values={},
+        button_mapped_bindings=set(),
+        mapped_bindings=mapped_bindings or set(),
+        existing_devices=existing_devices or [],
+        existing_by_claim_path={},
+        previous_desired_paths=previous_desired_paths,
+        previous_desired_config=previous_desired_config,
+        requests_gamepad_source_hiding=requests_gamepad_source_hiding,
+    )
+
+
+def test_build_grab_plan_computes_paths_bindings_aliases_and_snapshots(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    old_config = object()
+    first_existing = SimpleNamespace(
+        path="/dev/input/event4",
+        stable_path="",
+        resolved_event_path="",
+    )
+    second_existing = SimpleNamespace(
+        path="/dev/input/event5",
+        stable_path="",
+        resolved_event_path="",
+    )
+    manager = _manager(
+        grabbed_devices={
+            "2dc8:3106": [first_existing, second_existing],
+            "ffff:ffff": [SimpleNamespace(path="/dev/input/event9")],
+        },
+        desired_paths={"2dc8:3106": {"old-path"}},
+        desired_grabs={"2dc8:3106": old_config},
+    )
+    stable_paths = {
+        "/dev/input/event2": "/dev/input/by-id/kbd",
+        "/dev/input/event3": "/dev/input/by-id/stick",
+        "/dev/input/event4": "/dev/input/by-id/shared",
+        "/dev/input/event5": "/dev/input/by-id/shared",
+        "/dev/input/event9": "/dev/input/by-id/other",
+    }
+
+    def resolve_stable_path(path: str) -> str:
+        return stable_paths.get(path, path)
+
+    resolved = [
+        ldm.device_path_resolver.ResolvedInterface(
+            path="/dev/input/event2",
+            configured_path="/dev/input/event2",
+            interface_id="kbd",
+            device_type=DeviceType.KEYBOARD,
+            capabilities=["key_a"],
+        ),
+        ldm.device_path_resolver.ResolvedInterface(
+            path="/dev/input/event3",
+            configured_path="/dev/input/event3",
+            interface_id="stick",
+            device_type=DeviceType.GAMEPAD,
+            capabilities=["abs_x"],
+        ),
+    ]
+
+    def resolve_evdev_interfaces(_interfaces, **kwargs):
+        assert "/dev/input/by-id/other" in kwargs["excluded_paths"]
+        assert "/dev/input/by-id/shared" in kwargs["preferred_paths"]
+        return resolved
+
+    monkeypatch.setattr(
+        ldm.device_path_resolver,
+        "resolve_evdev_interfaces",
+        resolve_evdev_interfaces,
+    )
+    raw_interfaces = [
+        {"id": "gamepad", "path": "keymasq:2dc8:3106", "type": "gamepad"},
+        {"id": "kbd", "path": "/dev/input/event2", "type": "keyboard"},
+    ]
+    analog_inputs = {
+        "stick": {
+            "source": "stick",
+            "type": "stick",
+            "axes": [{"role": "x", "evdev_code": evdev.ecodes.ABS_X}],
+        }
+    }
+
+    plan = ldm._build_grab_plan(
+        manager,
+        _request(
+            evdev_interfaces=raw_interfaces,
+            button_map={
+                "fire": "key_a",
+                "missing": "not_an_evdev_name",
+                "south": "btn_south",
+            },
+            button_codes={
+                "fire": evdev.ecodes.KEY_A,
+                "missing": 99,
+                "south": evdev.ecodes.BTN_SOUTH,
+            },
+            button_values={"south": 1},
+            analog_inputs=analog_inputs,
+        ),
+        _deps(resolve_stable_path_fn=resolve_stable_path),
+    )
+
+    assert plan.desired_paths == {
+        "keymasq:2dc8:3106",
+        "/dev/input/event2",
+        "/dev/input/by-id/kbd",
+        "/dev/input/by-id/stick",
+    }
+    assert plan.requested_paths == {
+        "/dev/input/by-id/kbd",
+        "/dev/input/by-id/stick",
+    }
+    assert plan.requested_claim_paths >= {
+        "/dev/input/event2",
+        "/dev/input/by-id/kbd",
+    }
+    assert plan.resolved_by_claim_path["/dev/input/by-id/kbd"] is resolved[0]
+    assert plan.existing_by_claim_path["/dev/input/by-id/shared"] is first_existing
+    assert plan.previous_desired_paths == {"old-path"}
+    manager.grab_state.desired_paths["2dc8:3106"].add("changed")
+    assert plan.previous_desired_paths == {"old-path"}
+    assert plan.previous_desired_config is old_config
+    assert plan.button_mapped_bindings == {
+        (evdev.ecodes.EV_KEY, evdev.ecodes.KEY_A),
+        (evdev.ecodes.EV_KEY, evdev.ecodes.BTN_SOUTH),
+    }
+    assert plan.mapped_bindings == plan.button_mapped_bindings | {
+        (evdev.ecodes.EV_ABS, evdev.ecodes.ABS_X)
+    }
+    assert plan.requests_gamepad_source_hiding is True
+
+
+@pytest.mark.parametrize(
+    ("interfaces", "expected"),
+    [
+        ([{"path": "keymasq:2dc8:3106", "type": "gamepad"}], True),
+        ([{"path": "/dev/input/event2", "type": "gamepad"}], False),
+        ([{"path": "keymasq:2dc8:3106", "type": "keyboard"}], False),
+        ([], False),
+    ],
+)
+def test_build_grab_plan_source_hiding_requires_keymasq_gamepad(
+    monkeypatch: pytest.MonkeyPatch,
+    interfaces: list[ldm.JsonObject],
+    expected: bool,
+) -> None:
+    monkeypatch.setattr(
+        ldm.device_path_resolver,
+        "resolve_evdev_interfaces",
+        lambda *_args, **_kwargs: [],
+    )
+
+    plan = ldm._build_grab_plan(
+        _manager(),
+        _request(evdev_interfaces=interfaces),
+        _deps(),
+    )
+
+    assert plan.requests_gamepad_source_hiding is expected
+
+
+@pytest.mark.parametrize(
+    ("caps", "mapped_names", "mapped_bindings", "expected"),
+    [
+        ({evdev.ecodes.EV_KEY: [evdev.ecodes.KEY_A]}, set(), {(evdev.ecodes.EV_KEY, 30)}, True),
+        (
+            {evdev.ecodes.EV_ABS: [(evdev.ecodes.ABS_X, object())]},
+            set(),
+            {(evdev.ecodes.EV_ABS, evdev.ecodes.ABS_X)},
+            True,
+        ),
+        (
+            {evdev.ecodes.EV_KEY: ["KEY_A"]},
+            {"key_a"},
+            {(evdev.ecodes.EV_KEY, evdev.ecodes.KEY_A)},
+            False,
+        ),
+        (
+            {evdev.ecodes.EV_SYN: [evdev.ecodes.KEY_A]},
+            {"key_a"},
+            {(evdev.ecodes.EV_SYN, evdev.ecodes.KEY_A)},
+            False,
+        ),
+        ({evdev.ecodes.EV_REL: [7]}, set(), {(evdev.ecodes.EV_KEY, 7)}, False),
+        ({evdev.ecodes.EV_KEY: [evdev.ecodes.KEY_A]}, {"key_a"}, set(), True),
+        (
+            {evdev.ecodes.EV_KEY: [evdev.ecodes.KEY_B]},
+            set(),
+            {(evdev.ecodes.EV_KEY, evdev.ecodes.KEY_B)},
+            True,
+        ),
+    ],
+)
+def test_device_has_mapped_buttons_matrix(
+    caps: dict[int, list[object]],
+    mapped_names: set[str],
+    mapped_bindings: set[tuple[int, int]],
+    expected: bool,
+) -> None:
+    assert (
+        ldm.device_has_mapped_buttons(
+            caps,
+            mapped_names,
+            mapped_bindings,
+            evdev_mod=evdev,
+        )
+        is expected
+    )
+
+
+@pytest.mark.asyncio
+async def test_finalize_grab_waits_when_interfaces_requested_but_none_available() -> None:
+    manager = _manager()
+    result = await ldm._finalize_grab(
+        manager,
+        _request(update_desired=False),
+        _plan(raw_interfaces=[{"path": "keymasq:2dc8:3106"}]),
+        _deps(),
+        ldm._GrabLoopState(devices=[]),
+    )
+
+    assert result["waiting_for_device"] is True
+    assert result["grabbed_count"] == 0
+    assert manager.grabbed_devices == {}
+
+
+@pytest.mark.asyncio
+async def test_finalize_grab_raises_no_match_and_destroys_created_uinputs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    destroy_global_uinputs = Mock()
+    monkeypatch.setattr(ldm.runtime_outputs, "destroy_global_uinputs", destroy_global_uinputs)
+    state = ldm._GrabLoopState(
+        devices=[],
+        available_count=1,
+        created_global_uinputs=True,
+    )
+
+    with pytest.raises(ValueError) as excinfo:
+        await ldm._finalize_grab(
+            _manager(),
+            _request(update_desired=False),
+            _plan(
+                requested_paths={"/dev/input/event2"},
+                mapped_evdev_names={"key_a"},
+                mapped_bindings={(evdev.ecodes.EV_KEY, evdev.ecodes.KEY_A)},
+            ),
+            _deps(),
+            state,
+        )
+
+    assert "No interfaces for 2dc8:3106 matched mapped buttons" in str(excinfo.value)
+    assert "paths=1" in str(excinfo.value)
+    assert "mapped_names=1" in str(excinfo.value)
+    assert "mapped_bindings=1" in str(excinfo.value)
+    destroy_global_uinputs.assert_called_once()
+
+
+class _FakeTask:
+    def __init__(self) -> None:
+        self.cancelled = False
+
+    def done(self) -> bool:
+        return False
+
+    def cancel(self) -> None:
+        self.cancelled = True
+
+
+class _ReleasedDevice:
+    def __init__(self, path: str) -> None:
+        self.path = path
+        self.stable_path = path
+        self.resolved_event_path = path
+        self.release_count = 0
+
+    async def release(self) -> None:
+        self.release_count += 1
+
+
+class _ExistingDevice(_ReleasedDevice):
+    async def release(self) -> None:
+        raise AssertionError("existing devices must not be released during rollback")
+
+
+@pytest.mark.asyncio
+async def test_rollback_failed_grab_restores_existing_devices_and_desired_state(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    existing = _ExistingDevice("/dev/input/event1")
+    first_new = _ReleasedDevice("/dev/input/event2")
+    old_config = object()
+    new_config = object()
+    task = _FakeTask()
+    other_task = _FakeTask()
+    manager = _manager(
+        grabbed_devices={"2dc8:3106": [existing, first_new]},
+        desired_paths={"2dc8:3106": {"new-path"}},
+        desired_grabs={"2dc8:3106": new_config},
+    )
+    manager.grab_state.pending_interface_release[("2dc8:3106", "/dev/input/event1")] = task
+    manager.grab_state.pending_interface_release[("ffff:ffff", "/dev/input/event9")] = (
+        other_task
+    )
+    destroy_global_uinputs = Mock()
+    monkeypatch.setattr(ldm.runtime_outputs, "destroy_global_uinputs", destroy_global_uinputs)
+    exc = RuntimeError("grab failed")
+
+    reported = await ldm._rollback_failed_grab(
+        manager,
+        _request(update_desired=True),
+        _plan(
+            existing_devices=[existing],
+            previous_desired_paths={"old-path"},
+            previous_desired_config=old_config,
+        ),
+        _deps(),
+        ldm._GrabLoopState(
+            devices=[existing, first_new],
+            grabbed_count=1,
+            created_global_uinputs=True,
+        ),
+        "/dev/input/event3",
+        exc,
+    )
+
+    assert reported is exc
+    assert first_new.release_count == 1
+    assert manager.grabbed_devices["2dc8:3106"] == [existing]
+    assert manager.grab_state.desired_paths["2dc8:3106"] == {"old-path"}
+    assert manager.grab_state.desired_grabs["2dc8:3106"] is old_config
+    assert ("2dc8:3106", "/dev/input/event1") not in manager.grab_state.pending_interface_release
+    assert (
+        manager.grab_state.pending_interface_release[("ffff:ffff", "/dev/input/event9")]
+        is other_task
+    )
+    assert task.cancelled is True
+    assert other_task.cancelled is False
+    destroy_global_uinputs.assert_called_once()


### PR DESCRIPTION
## Summary

- Extract grab planning into `_build_grab_plan` pure function operating on `GrabRequest` + `GrabPlan` dataclasses
- Pull out `_persist_desired_grab`, `_log_grab_request`, `_update_existing_devices`, `_reconcile_existing_interface_releases` as separate phases
- Factor the per-interface grab loop into `_grab_one_interface` with error handling delegated to `_rollback_failed_grab`
- Introduce `_finalize_grab` for post-loop state cleanup and return value construction
- Wrap cross-cutting callbacks into `_RuntimeCallbacks` dataclass; bundle test seam dependencies into `GrabDeviceDeps`
- Add targeted unit tests: unresolved-interface wait path, single-pass global uinput creation, and a full `test_grab_lifecycle_planning.py` suite for the planning phase

## Testing

- `./scripts/check.sh` passes (ruff, basedpyright, pytest)
- Existing `test_device_manager_core.py` tests continue to pass
- New tests cover the planning phase isolately (`test_grab_lifecycle_planning.py`)
- New test `test_grab_device_waits_when_raw_interfaces_do_not_resolve` exercises the waiting path
- New test `test_grab_device_creates_global_uinputs_once_for_multiple_interfaces` verifies single-pass uinput creation