### PR TITLE
Select placeholder tab when device list is empty

### DIFF
--- a/keymasq/gui/window/device_tabs.py
+++ b/keymasq/gui/window/device_tabs.py
@@ -290,3 +290,4 @@ def _check_empty_state(window) -> None:
     if not window._device_pages:
         _ensure_placeholder_page(window)
         _set_empty_placeholder_state(window)
+        tab_layout._select_empty_placeholder_tab(window)

--- a/keymasq/gui/window/tab_layout.py
+++ b/keymasq/gui/window/tab_layout.py
@@ -223,6 +223,9 @@ def _page_for_selected_tab(window, selected_tab: str) -> _runtime.Adw.TabPage | 
 
 
 def _default_selected_tab_page(window) -> _runtime.Adw.TabPage | None:
+    if not window._device_pages and window._placeholder_page is not None:
+        return window._placeholder_page
+
     for tab_id in _desired_visible_tab_order(window):
         page = _page_for_tab_id(window, tab_id)
         if page is not None:
@@ -234,7 +237,18 @@ def _default_selected_tab_page(window) -> _runtime.Adw.TabPage | None:
     return None
 
 
+def _select_empty_placeholder_tab(window) -> bool:
+    if window._device_pages or window._placeholder_page is None:
+        return False
+    window.tab_view.set_selected_page(window._placeholder_page)
+    window._initial_tab_selection_pending = False
+    return True
+
+
 def _select_saved_or_default_tab(window) -> None:
+    if _select_empty_placeholder_tab(window):
+        return
+
     page = _page_for_selected_tab(window, window._selected_tab)
     if page is None:
         page = _default_selected_tab_page(window)

--- a/tests/gui/test_main_window.py
+++ b/tests/gui/test_main_window.py
@@ -1693,8 +1693,10 @@ class TestMainWindow:
         self, temp_config_dir
     ):
         from keymasq.gui.icons import resolve_icon_name, device_icon_names
+        from keymasq.gui.preferences import save_selected_tab
         from keymasq.gui.window import MainWindow
 
+        save_selected_tab("combos")
         window = MainWindow(demo_mode=False)
 
         device_tabs._apply_loaded_devices(window, [])
@@ -1705,6 +1707,7 @@ class TestMainWindow:
         assert window._placeholder_subtitle.get_label() == "Click + to add a new device"
         placeholder_page = tab_layout._page_for_child(window, window.placeholder)
         assert placeholder_page is not None
+        assert window.tab_view.get_selected_page() is placeholder_page
         icon = placeholder_page.get_icon()
         assert icon is not None
         assert icon.to_string() == resolve_icon_name(*device_icon_names(False))
@@ -1719,6 +1722,10 @@ class TestMainWindow:
         device_tabs._check_empty_state(window)
 
         assert tab_layout._page_for_child(window, window.placeholder) is not None
+        assert (
+            window.tab_view.get_selected_page()
+            is tab_layout._page_for_child(window, window.placeholder)
+        )
         assert window._placeholder_title.get_label() == "No devices configured"
         assert window._placeholder_subtitle.get_label() == "Click + to add a new device"
 


### PR DESCRIPTION
## Summary
- Select the empty placeholder tab whenever no devices are configured.
- Make default tab selection fall back to the placeholder page before other visible tabs.
- Add GUI coverage for saved-tab state being ignored when the device list is empty.