### PR TITLE
Warn before discarding unsaved changes when creating new superkey or analog control

### DIFF
--- a/keymasq/gui/widgets/analog_control/dialog.py
+++ b/keymasq/gui/widgets/analog_control/dialog.py
@@ -105,6 +105,7 @@ class AnalogControlDialog(Adw.Dialog):
         self._selection_warning_dialog: Adw.AlertDialog | None = None
         self._active_selection_key: tuple[str, str | None] | None = None
         self._pending_selection_key: tuple[str, str | None] | None = None
+        self._pending_new_control_after_warning = False
         self._suppress_selection_guard = False
         self._editing_new_control = False
         self._syncing_mouse_speed = False
@@ -1123,6 +1124,7 @@ class AnalogControlDialog(Adw.Dialog):
             and selection_key != self._active_selection_key
         ):
             self._pending_selection_key = selection_key
+            self._pending_new_control_after_warning = selection_key == ("new", None)
             self._restore_active_selection()
             self._show_unsaved_selection_warning()
             return
@@ -1324,6 +1326,15 @@ class AnalogControlDialog(Adw.Dialog):
         self.name_entry.grab_focus()
 
     def _on_add_clicked(self, _button=None) -> None:
+        self._request_new_control()
+
+    def _request_new_control(self) -> None:
+        if self._new_control_reset_needs_warning():
+            self._queue_new_control_warning()
+            return
+        self._select_or_begin_new_control()
+
+    def _select_or_begin_new_control(self) -> None:
         if (
             self.new_control_row is not None
             and self.list_box.get_selected_row() is not self.new_control_row
@@ -1331,6 +1342,60 @@ class AnalogControlDialog(Adw.Dialog):
             self.list_box.select_row(self.new_control_row)
         else:
             self._begin_new_control()
+
+    def _new_control_reset_needs_warning(self) -> bool:
+        if not self._modified:
+            return False
+        if self._active_selection_key != ("new", None):
+            return True
+        return not self._is_pristine_new_control_draft()
+
+    def _is_pristine_new_control_draft(self) -> bool:
+        default = AnalogControlConfig(
+            name="New Analog Control",
+            gamepad_output=AnalogGamepadOutputConfig(output_id=SAME_DEVICE_OUTPUT_ID),
+        )
+        mouse = default.mouse_motion
+        gamepad = default.gamepad_output
+        return (
+            self._editing_new_control
+            and self.name_entry.get_text() == default.name
+            and self.description_entry.get_text() == ""
+            and self._current_input_type() == default.input_type
+            and self._current_mode() == self._mode_value(default)
+            and not self._thresholds
+            and self.speed_row.get_value() == mouse.speed
+            and self.speed_x_row.get_value() == mouse.speed_x
+            and self.speed_y_row.get_value() == mouse.speed_y
+            and self.area_radius_x_row.get_value() == mouse.area_radius_x
+            and self.area_radius_y_row.get_value() == mouse.area_radius_y
+            and self.area_start_enabled_row.get_active() == mouse.area_start_enabled
+            and self._entry_int_value(self.area_start_x_entry) == mouse.area_start_x
+            and self._entry_int_value(self.area_start_y_entry) == mouse.area_start_y
+            and self.deadzone_row.get_value() == mouse.deadzone
+            and self.mouse_sensitivity_row.get_value() == mouse.sensitivity
+            and self.mouse_response_curve_row.get_value() == mouse.response_curve
+            and self._current_mouse_direction() == mouse.direction
+            and self.invert_x_btn.get_active() == mouse.invert_x
+            and self.invert_y_btn.get_active() == mouse.invert_y
+            and self._selected_gamepad_output_id == gamepad.output_id
+            and self.gamepad_output_deadzone_row.get_value() == gamepad.deadzone * 100.0
+            and self._current_gamepad_output_target() == gamepad.target
+            and self._current_gamepad_output_target_analog_id() == gamepad.target_analog_id
+            and int(self.gamepad_output_rest_row.get_value()) == (gamepad.output_rest or 0)
+            and self._current_gamepad_output_direction() == gamepad.output_direction
+            and self.gamepad_output_invert_x_btn.get_active() == gamepad.output_invert_x
+            and self.gamepad_output_invert_y_btn.get_active() == gamepad.output_invert_y
+            and self.gamepad_output_sensitivity_row.get_value() == gamepad.sensitivity
+            and self.gamepad_output_response_curve_row.get_value() == gamepad.response_curve
+        )
+
+    def _queue_new_control_warning(self) -> None:
+        if self._selection_warning_dialog is not None:
+            return
+        self._pending_selection_key = ("new", None)
+        self._pending_new_control_after_warning = True
+        self._show_unsaved_selection_warning()
 
     def _open_threshold_actions_dialog(self, index: int) -> None:
         if not 0 <= index < len(self._thresholds):
@@ -1467,7 +1532,11 @@ class AnalogControlDialog(Adw.Dialog):
 
         dialog = Adw.AlertDialog()
         dialog.set_heading("Unsaved Analog Control Changes")
-        dialog.set_body("Save your changes before switching, or discard them?")
+        dialog.set_body(
+            "Save your changes before starting a new Analog Control, or discard them?"
+            if self._pending_new_control_after_warning
+            else "Save your changes before switching, or discard them?"
+        )
         dialog.add_response("cancel", "Cancel")
         dialog.add_response("discard", "Discard")
         dialog.add_response("save", "Save")
@@ -1481,15 +1550,23 @@ class AnalogControlDialog(Adw.Dialog):
 
     def _on_unsaved_selection_response(self, _dialog: Adw.AlertDialog, response: str) -> None:
         pending_key = self._pending_selection_key
+        pending_new_control = self._pending_new_control_after_warning
         self._selection_warning_dialog = None
         self._pending_selection_key = None
+        self._pending_new_control_after_warning = False
         if response == "discard":
             self._modified = False
             self._update_buttons()
-            self._select_selection_key(pending_key)
+            if pending_new_control:
+                self._select_or_begin_new_control()
+            else:
+                self._select_selection_key(pending_key)
             return
         if response == "save" and self._save_current_control():
-            self._select_selection_key(pending_key)
+            if pending_new_control:
+                self._select_or_begin_new_control()
+            else:
+                self._select_selection_key(pending_key)
 
     def _on_analog_controls_docs_clicked(self, _button: Gtk.Button) -> None:
         url = _analog_controls_docs_url()

--- a/keymasq/gui/widgets/superkey_dialog.py
+++ b/keymasq/gui/widgets/superkey_dialog.py
@@ -462,6 +462,7 @@ class SuperkeyDialog(Adw.Dialog):
         self._selection_warning_dialog: Adw.AlertDialog | None = None
         self._active_selection_key: tuple[str, str | None] | None = None
         self._pending_selection_key: tuple[str, str | None] | None = None
+        self._pending_new_superkey_after_warning = False
         self._suppress_selection_guard = False
         self._mode_items = [SuperkeyMode.PATTERN, SuperkeyMode.OVERLOAD]
         self.new_superkey_row: Gtk.ListBoxRow | None = None
@@ -883,11 +884,15 @@ class SuperkeyDialog(Adw.Dialog):
             and selection_key != self._active_selection_key
         ):
             self._pending_selection_key = selection_key
+            self._pending_new_superkey_after_warning = selection_key == ("new", None)
             self._restore_active_selection()
             self._show_unsaved_selection_warning()
             return
 
         if getattr(row, "_is_new_superkey", False):
+            if self._new_superkey_reset_needs_warning():
+                self._queue_new_superkey_warning()
+                return
             self._begin_new_superkey()
             return
 
@@ -1059,6 +1064,15 @@ class SuperkeyDialog(Adw.Dialog):
         self.name_entry.grab_focus()
 
     def _on_new_clicked(self, _button) -> None:
+        self._request_new_superkey()
+
+    def _request_new_superkey(self) -> None:
+        if self._new_superkey_reset_needs_warning():
+            self._queue_new_superkey_warning()
+            return
+        self._select_or_begin_new_superkey()
+
+    def _select_or_begin_new_superkey(self) -> None:
         if (
             self.new_superkey_row is not None
             and self.list_box.get_selected_row() is not self.new_superkey_row
@@ -1066,6 +1080,41 @@ class SuperkeyDialog(Adw.Dialog):
             self.list_box.select_row(self.new_superkey_row)
         else:
             self._begin_new_superkey()
+
+    def _new_superkey_reset_needs_warning(self) -> bool:
+        if not self._modified:
+            return False
+        if self._active_selection_key != ("new", None):
+            return True
+        return not self._is_pristine_new_superkey_draft()
+
+    def _is_pristine_new_superkey_draft(self) -> bool:
+        default = SuperkeyConfig(name="New Super Key")
+        return (
+            self.name_entry.get_text() == default.name
+            and self.desc_entry.get_text() == ""
+            and self._current_mode() == default.mode
+            and not self.tap_row._action_items
+            and not self.double_tap_row._action_items
+            and not self.hold_row._action_items
+            and not self.tap_hold_row._action_items
+            and not self.overload_row._action_items
+            and not self.overload_down_row._action_items
+            and not self.overload_up_row._action_items
+            and self.tap_timeout_spin.get_value_as_int() == default.tap_timeout_ms
+            and (
+                self.double_tap_window_spin.get_value_as_int()
+                == default.double_tap_window_ms
+            )
+            and self.hold_threshold_spin.get_value_as_int() == default.hold_threshold_ms
+        )
+
+    def _queue_new_superkey_warning(self) -> None:
+        if self._selection_warning_dialog is not None:
+            return
+        self._pending_selection_key = ("new", None)
+        self._pending_new_superkey_after_warning = True
+        self._show_unsaved_selection_warning()
 
     def start_new_superkey(self) -> None:
         self._on_new_clicked(None)
@@ -1275,7 +1324,11 @@ class SuperkeyDialog(Adw.Dialog):
 
         dialog = Adw.AlertDialog()
         dialog.set_heading("Unsaved Super Key Changes")
-        dialog.set_body("Save your changes before switching, or discard them?")
+        dialog.set_body(
+            "Save your changes before starting a new Super Key, or discard them?"
+            if self._pending_new_superkey_after_warning
+            else "Save your changes before switching, or discard them?"
+        )
         dialog.add_response("cancel", "Cancel")
         dialog.add_response("discard", "Discard")
         dialog.add_response("save", "Save")
@@ -1289,15 +1342,23 @@ class SuperkeyDialog(Adw.Dialog):
 
     def _on_unsaved_selection_response(self, _dialog: Adw.AlertDialog, response: str) -> None:
         pending_key = self._pending_selection_key
+        pending_new_superkey = self._pending_new_superkey_after_warning
         self._selection_warning_dialog = None
         self._pending_selection_key = None
+        self._pending_new_superkey_after_warning = False
         if response == "discard":
             self._modified = False
             self._update_buttons()
-            self._select_selection_key(pending_key)
+            if pending_new_superkey:
+                self._select_or_begin_new_superkey()
+            else:
+                self._select_selection_key(pending_key)
             return
         if response == "save" and self._save_current_superkey():
-            self._select_selection_key(pending_key)
+            if pending_new_superkey:
+                self._select_or_begin_new_superkey()
+            else:
+                self._select_selection_key(pending_key)
 
     def _on_superkeys_docs_clicked(self, _button: Gtk.Button) -> None:
         url = _superkeys_docs_url()

--- a/tests/gui/test_analog_control_dialog.py
+++ b/tests/gui/test_analog_control_dialog.py
@@ -207,6 +207,44 @@ def test_analog_control_dialog_unsaved_selection_warns_and_can_discard(
     assert dialog._modified is False
 
 
+def test_analog_control_dialog_add_button_warns_before_resetting_dirty_new_draft(
+    temp_config_dir,
+    monkeypatch,
+) -> None:
+    gi.require_version("Gtk", "4.0")
+    from gi.repository import Gtk
+
+    import keymasq.gui.widgets.analog_control_dialog as analog_dialog
+
+    alerts: list[tuple[object, object]] = []
+    monkeypatch.setattr(
+        analog_dialog.Adw.AlertDialog,
+        "present",
+        lambda alert, parent: alerts.append((alert, parent)),
+    )
+
+    dialog = analog_dialog.AnalogControlDialog(Gtk.Window())
+    assert dialog.list_box.get_selected_row() is dialog.new_control_row
+
+    dialog.name_entry.set_text("Edited Draft")
+    dialog._on_add_clicked(Gtk.Button())
+
+    assert len(alerts) == 1
+    alert = alerts[0][0]
+    assert alerts[0][1] is dialog
+    assert alert.get_heading() == "Unsaved Analog Control Changes"
+    assert alert.get_body() == (
+        "Save your changes before starting a new Analog Control, or discard them?"
+    )
+    assert dialog.name_entry.get_text() == "Edited Draft"
+
+    dialog._on_unsaved_selection_response(alert, "discard")
+
+    assert dialog.list_box.get_selected_row() is dialog.new_control_row
+    assert dialog.name_entry.get_text() == "New Analog Control"
+    assert dialog._modified is True
+
+
 def test_analog_control_dialog_failed_delete_keeps_state(
     temp_config_dir,
 ) -> None:

--- a/tests/gui/test_gui_demo_and_dialogs.py
+++ b/tests/gui/test_gui_demo_and_dialogs.py
@@ -1463,6 +1463,77 @@ class TestDialogConstruction:
         assert dialog._current_config.name == "Beta"
         assert dialog._modified is False
 
+    def test_superkey_dialog_new_button_warns_before_resetting_dirty_new_draft(
+        self, temp_config_dir, monkeypatch
+    ):
+        gi.require_version("Gtk", "4.0")
+        from gi.repository import Gtk
+
+        import keymasq.gui.widgets.superkey_dialog as superkey_dialog_module
+        from keymasq.gui.widgets.superkey_dialog import SuperkeyDialog
+
+        alerts: list[tuple[object, object]] = []
+        monkeypatch.setattr(
+            superkey_dialog_module.Adw.AlertDialog,
+            "present",
+            lambda alert, parent: alerts.append((alert, parent)),
+        )
+
+        dialog = SuperkeyDialog(Gtk.Window())
+        assert dialog.list_box.get_selected_row() is dialog.new_superkey_row
+
+        dialog.name_entry.set_text("Edited Draft")
+        dialog._on_new_clicked(Gtk.Button())
+
+        assert len(alerts) == 1
+        alert = alerts[0][0]
+        assert alerts[0][1] is dialog
+        assert alert.get_heading() == "Unsaved Super Key Changes"
+        assert alert.get_body() == (
+            "Save your changes before starting a new Super Key, or discard them?"
+        )
+        assert dialog.name_entry.get_text() == "Edited Draft"
+
+        dialog._on_unsaved_selection_response(alert, "discard")
+
+        assert dialog.list_box.get_selected_row() is dialog.new_superkey_row
+        assert dialog.name_entry.get_text() == "New Super Key"
+        assert dialog._modified is True
+
+    def test_superkey_dialog_add_row_warns_before_resetting_dirty_new_draft(
+        self, temp_config_dir, monkeypatch
+    ):
+        gi.require_version("Gtk", "4.0")
+        from gi.repository import Gtk
+
+        import keymasq.gui.widgets.superkey_dialog as superkey_dialog_module
+        from keymasq.gui.widgets.superkey_dialog import SuperkeyDialog
+
+        alerts: list[tuple[object, object]] = []
+        monkeypatch.setattr(
+            superkey_dialog_module.Adw.AlertDialog,
+            "present",
+            lambda alert, parent: alerts.append((alert, parent)),
+        )
+
+        dialog = SuperkeyDialog(Gtk.Window())
+        new_row = dialog.new_superkey_row
+        assert new_row is not None
+        assert dialog.list_box.get_selected_row() is new_row
+
+        dialog.name_entry.set_text("Edited Draft")
+        dialog._on_superkey_selected(dialog.list_box, new_row)
+
+        assert len(alerts) == 1
+        assert alerts[0][1] is dialog
+        assert dialog.name_entry.get_text() == "Edited Draft"
+
+        dialog._on_unsaved_selection_response(alerts[0][0], "discard")
+
+        assert dialog.list_box.get_selected_row() is new_row
+        assert dialog.name_entry.get_text() == "New Super Key"
+        assert dialog._modified is True
+
     def test_superkey_dialog_select_superkey_by_name_selects_saved_superkey(
         self, temp_config_dir
     ):


### PR DESCRIPTION
## Summary

- Show a confirmation dialog when the user tries to create a new superkey or analog control while there are unsaved edits on the current draft or a previously saved item.
- Previously, unsaved changes were silently discarded; now the user is prompted to save, discard, or cancel.
- Applies to both the **+** button and clicking the **"New…"** row in the list for both dialog types.
- Analog control dialog: `_request_new_control`, `_queue_new_control_warning`, `_is_pristine_new_control_draft`.
- Superkey dialog: `_request_new_superkey`, `_queue_new_superkey_warning`, `_is_pristine_new_superkey_draft`.
- Both dialogs use a `_pending_new_control_after_warning` / `_pending_new_superkey_after_warning` flag so the warning body text mentions "starting a new …" instead of the generic "switching" message.

## Testing

- `test_analog_control_dialog_add_button_warns_before_resetting_dirty_new_draft` — verifies warning is shown when + is clicked with modified draft; discarding resets to pristine state.
- `test_superkey_dialog_new_button_warns_before_resetting_dirty_new_draft` — same scenario for the superkey + button.
- `test_superkey_dialog_add_row_warns_before_resetting_dirty_new_draft` — verifies warning is also shown when the "New…" list row is clicked while editing a dirty draft.
- Each test checks the alert heading, body text, and post-discard state (selected row, reset name, modified flag).
- Existing test suite continues to pass.