### PR TITLE
feat: edge auto-scroll on macro timeline drag

### DIFF
--- a/keymasq/gui/widgets/macro_editor/timeline.py
+++ b/keymasq/gui/widgets/macro_editor/timeline.py
@@ -7,7 +7,7 @@ gi.require_version("Gtk", "4.0")
 from typing import Any
 
 import evdev
-from gi.repository import Gdk, Gtk  # pyright: ignore[reportAttributeAccessIssue]
+from gi.repository import Gdk, GLib, Gtk  # pyright: ignore[reportAttributeAccessIssue]
 
 from keymasq.gui.widgets.macro_editor import timeline_render
 from keymasq.gui.widgets.macro_editor.model import (
@@ -46,6 +46,8 @@ class TimelineWidget(Gtk.DrawingArea):
     TRACK_HEIGHT = 88  # minimum track height; expands when lanes > 2
     LANE_HEIGHT_MIN = 32  # minimum height per sub-lane
     MIN_EVENT_WIDTH = 4
+    EDGE_SCROLL_MARGIN = 36  # px zone at each viewport edge that triggers auto-scroll
+    EDGE_SCROLL_MAX_SPEED = 900.0  # px/s at the deepest point of the margin
 
     def __init__(self, editor: Any):
         super().__init__()
@@ -73,6 +75,16 @@ class TimelineWidget(Gtk.DrawingArea):
         self._drag_orig_press: int = 0
         self._drag_orig_release: int = 0
         self._in_drag: bool = False
+
+        # Edge auto-scroll while dragging an event past the visible slice.
+        # The drag delta is gesture-relative, so the scroll movement since
+        # drag-begin has to be folded into the applied time delta.
+        self._drag_start_x: float = 0.0
+        self._drag_scroll_origin: float = 0.0
+        self._drag_last_offset_x: float = 0.0
+        self._autoscroll_velocity: float = 0.0
+        self._autoscroll_tick_id: int = 0
+        self._autoscroll_last_time: int | None = None
 
         # Erase-mode drag state. Left-drag bands are clamped to the track the
         # drag started in; a right-drag ripple band uses the sentinel "all".
@@ -455,6 +467,10 @@ class TimelineWidget(Gtk.DrawingArea):
         # Always hit-test on press; actual movement only starts after threshold.
         hit = self._hit_test(start_x, start_y)
         self._drag_selected_obj = hit
+        self._drag_start_x = float(start_x)
+        self._drag_scroll_origin = self._scroll_offset
+        self._drag_last_offset_x = 0.0
+        self._stop_autoscroll()
         self._reset_erase_drag()
         if self._editor._erase_mode:
             # In erase mode a drag sweeps a delete band instead of moving events;
@@ -506,7 +522,16 @@ class TimelineWidget(Gtk.DrawingArea):
                 return
             self._in_drag = True
 
-        delta_us = int(offset_x / self._pps * 1e6)
+        self._drag_last_offset_x = float(offset_x)
+        self._apply_drag_position()
+        self._update_autoscroll(self._drag_start_x + float(offset_x))
+
+    def _apply_drag_position(self) -> None:
+        """Move the dragged item to match the pointer, folding in any scroll
+        movement since drag-begin (edge auto-scroll shifts time under the
+        stationary pointer)."""
+        scroll_delta_px = self._scroll_offset - self._drag_scroll_origin
+        delta_us = int((self._drag_last_offset_x + scroll_delta_px) / self._pps * 1e6)
         if self._drag_event is not None:
             new_press = self._drag_orig_press + delta_us
             duration = self._drag_orig_release - self._drag_orig_press
@@ -528,7 +553,60 @@ class TimelineWidget(Gtk.DrawingArea):
             self._editor._on_selection_changed(self._drag_control)
         self.queue_draw()
 
+    def _edge_autoscroll_velocity(self, pointer_x: float) -> float:
+        """Scroll velocity in px/s for a pointer position, ramping up as the
+        pointer nears (or passes) either edge of the visible slice."""
+        width = self.get_width()
+        margin = float(self.EDGE_SCROLL_MARGIN)
+        if width < self.LABEL_WIDTH + 3 * margin:
+            return 0.0
+        left_edge = self.LABEL_WIDTH + margin
+        right_edge = width - margin
+        if pointer_x < left_edge:
+            depth = min((left_edge - pointer_x) / margin, 1.0)
+            return -depth * self.EDGE_SCROLL_MAX_SPEED
+        if pointer_x > right_edge:
+            depth = min((pointer_x - right_edge) / margin, 1.0)
+            return depth * self.EDGE_SCROLL_MAX_SPEED
+        return 0.0
+
+    def _update_autoscroll(self, pointer_x: float) -> None:
+        self._autoscroll_velocity = self._edge_autoscroll_velocity(pointer_x)
+        if self._autoscroll_velocity == 0.0:
+            self._stop_autoscroll()
+        elif self._autoscroll_tick_id == 0:
+            self._autoscroll_last_time = None
+            self._autoscroll_tick_id = self.add_tick_callback(self._on_autoscroll_tick)
+
+    def _stop_autoscroll(self) -> None:
+        if self._autoscroll_tick_id != 0:
+            self.remove_tick_callback(self._autoscroll_tick_id)
+            self._autoscroll_tick_id = 0
+        self._autoscroll_velocity = 0.0
+        self._autoscroll_last_time = None
+
+    def _on_autoscroll_tick(self, widget, frame_clock) -> bool:
+        if not self._in_drag or self._autoscroll_velocity == 0.0:
+            self._autoscroll_tick_id = 0
+            return GLib.SOURCE_REMOVE
+        now = frame_clock.get_frame_time()
+        last = self._autoscroll_last_time
+        self._autoscroll_last_time = now
+        if last is None:
+            return GLib.SOURCE_CONTINUE
+        dt_s = max(0.0, (now - last) / 1e6)
+        before = self._scroll_offset
+        self._editor._scroll_timeline_by(self._autoscroll_velocity * dt_s)
+        if abs(self._scroll_offset - before) < 0.01:
+            # Clamped at a timeline boundary; a later drag-update re-arms us.
+            self._autoscroll_tick_id = 0
+            self._autoscroll_velocity = 0.0
+            return GLib.SOURCE_REMOVE
+        self._apply_drag_position()
+        return GLib.SOURCE_CONTINUE
+
     def _on_drag_end(self, gesture, offset_x, offset_y) -> None:
+        self._stop_autoscroll()
         if self._erase_track is not None and self._in_drag:
             pending = self._erase_pending
             self._reset_erase_drag()

--- a/keymasq/gui/widgets/macro_editor/timeline.py
+++ b/keymasq/gui/widgets/macro_editor/timeline.py
@@ -88,8 +88,10 @@ class TimelineWidget(Gtk.DrawingArea):
 
         # Erase-mode drag state. Left-drag bands are clamped to the track the
         # drag started in; a right-drag ripple band uses the sentinel "all".
+        # The anchor is kept in time-space so edge auto-scroll can shift the
+        # visible slice without the band's fixed end drifting with it.
         self._erase_track: str | None = None
-        self._erase_anchor_x: float = 0.0
+        self._erase_anchor_t_us: int = 0
         self._erase_x0: float | None = None
         self._erase_x1: float | None = None
         self._erase_pending: list[object] = []
@@ -476,7 +478,7 @@ class TimelineWidget(Gtk.DrawingArea):
             # In erase mode a drag sweeps a delete band instead of moving events;
             # clicks below the drag threshold still select as usual.
             self._erase_track = self._get_track_at_y(start_y)
-            self._erase_anchor_x = start_x
+            self._erase_anchor_t_us = self._x_to_time_us(start_x)
             self._drag_event = None
             self._drag_move = None
             self._drag_control = None
@@ -503,15 +505,9 @@ class TimelineWidget(Gtk.DrawingArea):
                 if abs(offset_x) < 4:
                     return
                 self._in_drag = True
-            x_end = self._erase_anchor_x + offset_x
-            self._erase_x0 = min(self._erase_anchor_x, x_end)
-            self._erase_x1 = max(self._erase_anchor_x, x_end)
-            self._erase_pending = self._collect_erase_hits(
-                self._erase_track,
-                self._erase_x0,
-                self._erase_x1,
-            )
-            self.queue_draw()
+            self._drag_last_offset_x = float(offset_x)
+            self._apply_erase_band()
+            self._update_autoscroll(self._drag_start_x + float(offset_x))
             return
         if (
             self._drag_event is None and self._drag_move is None and self._drag_control is None
@@ -551,6 +547,28 @@ class TimelineWidget(Gtk.DrawingArea):
             self._drag_control.t_us = new_t
             self._editor._control_events.sort(key=lambda c: c.t_us)
             self._editor._on_selection_changed(self._drag_control)
+        self.queue_draw()
+
+    def _apply_erase_band(self) -> None:
+        """Recompute the erase band between the time-space anchor and the
+        pointer, so the fixed end stays put while edge auto-scroll shifts
+        the visible slice."""
+        if self._erase_track is None:
+            return
+        anchor_x = self._time_to_x(self._erase_anchor_t_us)
+        pointer_x = self._drag_start_x + self._drag_last_offset_x
+        self._erase_x0 = min(anchor_x, pointer_x)
+        self._erase_x1 = max(anchor_x, pointer_x)
+        if self._erase_track == "all":
+            t0_us = max(0, self._x_to_time_us(self._erase_x0))
+            t1_us = max(t0_us, self._x_to_time_us(self._erase_x1))
+            self._erase_pending = self._collect_ripple_hits(t0_us, t1_us)
+        else:
+            self._erase_pending = self._collect_erase_hits(
+                self._erase_track,
+                self._erase_x0,
+                self._erase_x1,
+            )
         self.queue_draw()
 
     def _edge_autoscroll_velocity(self, pointer_x: float) -> float:
@@ -602,7 +620,10 @@ class TimelineWidget(Gtk.DrawingArea):
             self._autoscroll_tick_id = 0
             self._autoscroll_velocity = 0.0
             return GLib.SOURCE_REMOVE
-        self._apply_drag_position()
+        if self._erase_track is not None:
+            self._apply_erase_band()
+        else:
+            self._apply_drag_position()
         return GLib.SOURCE_CONTINUE
 
     def _on_drag_end(self, gesture, offset_x, offset_y) -> None:
@@ -644,8 +665,11 @@ class TimelineWidget(Gtk.DrawingArea):
         if not self._editor._erase_mode:
             return
         self._reset_erase_drag()
+        self._stop_autoscroll()
         self._erase_track = "all"
-        self._erase_anchor_x = start_x
+        self._erase_anchor_t_us = self._x_to_time_us(start_x)
+        self._drag_start_x = float(start_x)
+        self._drag_last_offset_x = 0.0
         self._right_press_x = start_x
         self._right_press_y = start_y
         self._in_drag = False
@@ -657,15 +681,12 @@ class TimelineWidget(Gtk.DrawingArea):
             if abs(offset_x) < 4:
                 return
             self._in_drag = True
-        x_end = self._erase_anchor_x + offset_x
-        self._erase_x0 = min(self._erase_anchor_x, x_end)
-        self._erase_x1 = max(self._erase_anchor_x, x_end)
-        t0_us = max(0, self._x_to_time_us(self._erase_x0))
-        t1_us = max(t0_us, self._x_to_time_us(self._erase_x1))
-        self._erase_pending = self._collect_ripple_hits(t0_us, t1_us)
-        self.queue_draw()
+        self._drag_last_offset_x = float(offset_x)
+        self._apply_erase_band()
+        self._update_autoscroll(self._drag_start_x + float(offset_x))
 
     def _on_right_drag_end(self, gesture, offset_x, offset_y) -> None:
+        self._stop_autoscroll()
         if not self._editor._erase_mode or self._erase_track != "all":
             return
         x0 = self._erase_x0

--- a/tests/gui/test_macro_editor_dialog_widget.py
+++ b/tests/gui/test_macro_editor_dialog_widget.py
@@ -2080,14 +2080,17 @@ def test_macro_editor_move_drag_folds_autoscroll_into_position(monkeypatch) -> N
 
     # Simulate edge auto-scroll advancing the visible slice under a stationary
     # pointer: reapplying the drag must fold the scroll delta into the time.
+    # Mirror the implementation's single combined-offset conversion rather
+    # than summing separately truncated deltas.
     timeline.set_scroll_offset(timeline._scroll_offset + 20.0)
     timeline._apply_drag_position()
-    scrolled_delta_us = int(20.0 / timeline._pps * 1e6)
-    assert keyboard.press_t_us == press_after_drag + scrolled_delta_us
+    combined_delta_us = int((10.0 + 20.0) / timeline._pps * 1e6)
+    expected_press = 50_000 + combined_delta_us
+    assert keyboard.press_t_us == expected_press
 
     timeline._on_drag_end(None, 10.0, 0.0)
     assert timeline._autoscroll_tick_id == 0
-    assert keyboard.press_t_us == press_after_drag + scrolled_delta_us
+    assert keyboard.press_t_us == expected_press
 
 
 def test_macro_editor_move_drag_arms_autoscroll_only_at_edges(monkeypatch) -> None:
@@ -2114,6 +2117,52 @@ def test_macro_editor_move_drag_arms_autoscroll_only_at_edges(monkeypatch) -> No
     assert timeline._autoscroll_tick_id == 0
 
     timeline._on_drag_end(None, 300.0 - x_press, 0.0)
+
+
+def test_macro_editor_erase_band_stays_time_anchored_under_autoscroll(monkeypatch) -> None:
+    dialog, keyboard, *_ = _build_erase_mode_dialog(monkeypatch)
+    timeline = dialog._timeline
+    timeline.get_width = lambda: 800
+
+    x_start = timeline._time_to_x(keyboard.press_t_us) - 4.0
+    timeline._on_drag_begin(None, x_start, timeline._kb_y + 12)
+    timeline._on_drag_update(None, 20.0, 0.0)
+    x0_before = timeline._erase_x0
+    x1_before = timeline._erase_x1
+    assert x0_before is not None and x1_before is not None
+
+    # Simulate edge auto-scroll shifting the slice: the anchored end follows
+    # its time (moves left on screen) while the pointer end stays put.
+    timeline.set_scroll_offset(timeline._scroll_offset + 30.0)
+    timeline._apply_erase_band()
+    assert timeline._erase_x0 == pytest.approx(x0_before - 30.0, abs=0.01)
+    assert timeline._erase_x1 == pytest.approx(x1_before, abs=0.01)
+
+    timeline._on_drag_end(None, 20.0, 0.0)
+    assert timeline._autoscroll_tick_id == 0
+
+
+def test_macro_editor_erase_drags_arm_autoscroll_at_edges(monkeypatch) -> None:
+    dialog, *_ = _build_erase_mode_dialog(monkeypatch)
+    timeline = dialog._timeline
+    timeline.get_width = lambda: 800
+
+    # Left-drag erase band parked at the right edge arms the auto-scroll tick.
+    timeline._on_drag_begin(None, 100.0, timeline._kb_y + 12)
+    timeline._on_drag_update(None, 699.0, 0.0)
+    assert timeline._autoscroll_tick_id != 0
+    assert timeline._autoscroll_velocity > 0.0
+    timeline._on_drag_end(None, 699.0, 0.0)
+    assert timeline._autoscroll_tick_id == 0
+
+    # Right-drag ripple band behaves the same.
+    timeline._on_right_drag_begin(None, 100.0, timeline._kb_y + 12)
+    timeline._on_right_drag_update(None, 699.0, 0.0)
+    assert timeline._erase_track == "all"
+    assert timeline._autoscroll_tick_id != 0
+    assert timeline._autoscroll_velocity > 0.0
+    timeline._on_right_drag_end(None, 699.0, 0.0)
+    assert timeline._autoscroll_tick_id == 0
 
 
 def test_macro_editor_erase_band_draws_with_pending_highlights(monkeypatch) -> None:

--- a/tests/gui/test_macro_editor_dialog_widget.py
+++ b/tests/gui/test_macro_editor_dialog_widget.py
@@ -2045,6 +2045,77 @@ def test_macro_editor_erase_mode_click_still_selects_and_never_moves(monkeypatch
     assert keyboard not in dialog._events
 
 
+def test_macro_editor_edge_autoscroll_velocity_ramps_at_edges(monkeypatch) -> None:
+    dialog, *_ = _build_erase_mode_dialog(monkeypatch)
+    timeline = dialog._timeline
+    timeline.get_width = lambda: 800  # pretend a realized 800px viewport
+
+    margin = timeline.EDGE_SCROLL_MARGIN
+    assert timeline._edge_autoscroll_velocity(400.0) == 0.0
+    assert timeline._edge_autoscroll_velocity(timeline.LABEL_WIDTH + margin + 1.0) == 0.0
+    assert timeline._edge_autoscroll_velocity(timeline.LABEL_WIDTH + 4.0) < 0.0
+    assert timeline._edge_autoscroll_velocity(800.0 - margin + 4.0) > 0.0
+    # Fully at (or past) the edge scrolls at the maximum speed.
+    assert timeline._edge_autoscroll_velocity(0.0) == -timeline.EDGE_SCROLL_MAX_SPEED
+    assert timeline._edge_autoscroll_velocity(820.0) == timeline.EDGE_SCROLL_MAX_SPEED
+
+    # An unrealized (zero-width) widget never auto-scrolls.
+    timeline.get_width = lambda: 0
+    assert timeline._edge_autoscroll_velocity(820.0) == 0.0
+
+
+def test_macro_editor_move_drag_folds_autoscroll_into_position(monkeypatch) -> None:
+    dialog, keyboard, *_ = _build_erase_mode_dialog(monkeypatch)
+    dialog._erase_btn.set_active(False)
+    dialog._drag_locked = False
+    timeline = dialog._timeline
+    timeline.get_width = lambda: 800
+
+    x_press = timeline._time_to_x(keyboard.press_t_us) + 2.0
+    timeline._on_drag_begin(None, x_press, timeline._kb_y + 12)
+    timeline._on_drag_update(None, 10.0, 0.0)
+    assert timeline._in_drag
+    press_after_drag = keyboard.press_t_us
+    assert press_after_drag > 50_000
+
+    # Simulate edge auto-scroll advancing the visible slice under a stationary
+    # pointer: reapplying the drag must fold the scroll delta into the time.
+    timeline.set_scroll_offset(timeline._scroll_offset + 20.0)
+    timeline._apply_drag_position()
+    scrolled_delta_us = int(20.0 / timeline._pps * 1e6)
+    assert keyboard.press_t_us == press_after_drag + scrolled_delta_us
+
+    timeline._on_drag_end(None, 10.0, 0.0)
+    assert timeline._autoscroll_tick_id == 0
+    assert keyboard.press_t_us == press_after_drag + scrolled_delta_us
+
+
+def test_macro_editor_move_drag_arms_autoscroll_only_at_edges(monkeypatch) -> None:
+    dialog, keyboard, *_ = _build_erase_mode_dialog(monkeypatch)
+    dialog._erase_btn.set_active(False)
+    dialog._drag_locked = False
+    timeline = dialog._timeline
+    timeline.get_width = lambda: 800
+
+    x_press = timeline._time_to_x(keyboard.press_t_us) + 2.0
+    timeline._on_drag_begin(None, x_press, timeline._kb_y + 12)
+
+    # Pointer in the middle of the slice: no auto-scroll.
+    timeline._on_drag_update(None, 300.0 - x_press, 0.0)
+    assert timeline._autoscroll_tick_id == 0
+
+    # Pointer parked at the right edge: the auto-scroll tick arms.
+    timeline._on_drag_update(None, 799.0 - x_press, 0.0)
+    assert timeline._autoscroll_tick_id != 0
+    assert timeline._autoscroll_velocity > 0.0
+
+    # Back inside the slice: the tick disarms.
+    timeline._on_drag_update(None, 300.0 - x_press, 0.0)
+    assert timeline._autoscroll_tick_id == 0
+
+    timeline._on_drag_end(None, 300.0 - x_press, 0.0)
+
+
 def test_macro_editor_erase_band_draws_with_pending_highlights(monkeypatch) -> None:
     import cairo
 


### PR DESCRIPTION
## Summary

- Adds edge auto-scroll to the macro editor timeline when dragging events near the viewport edges, ramping scroll speed based on pointer distance
- Folds scroll delta into the drag position so the dragged event tracks correctly beneath the pointer during auto-scroll
- Cleans up unused `_pending_new_control_after_warning` and `_pending_new_superkey_after_warning` dialog state

## Testing

- Unit tests cover edge-scroll velocity ramp, zero-width guard, drag-position folding over scroll delta, and tick arm/disarm at edges
- `test_macro_editor_edge_autoscroll_velocity_ramps_at_edges` — pass
- `test_macro_editor_move_drag_folds_autoscroll_into_position` — pass
- `test_macro_editor_move_drag_arms_autoscroll_only_at_edges` — pass
- `ruff`, `basedpyright`, and full test suite pass via `./scripts/check.sh`