### PR TITLE
Remove session and daemon command ACL system

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -227,9 +227,6 @@ settings below:
                 unlock_required = true;
                 macro_edit_requires_unlock = false;
               };
-
-              session_command_acl.client = [];
-              daemon_command_acl.session = [];
             };
           };
         }

--- a/docs/MACROS.md
+++ b/docs/MACROS.md
@@ -527,18 +527,6 @@ do not need to change these — they are intended for system administrators:
   emergency_cancel_combo_enabled = false
   ```
 
-- **Block recording entirely** for GUI/CLI users:
-
-  ```toml
-  [session_command_acl]
-  client = [
-    "deny:start_recording",
-    "deny:stop_recording",
-    "deny:save_recording",
-    "deny:delete_recording_slot",
-  ]
-  ```
-
 ## Best Practices
 
 - **Name macros clearly.** Use descriptive, stable names like

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -35,7 +35,7 @@ GUI and CLI do not access kernel input devices directly.
 
 ## Target Environment
 
-Keymasq is designed for single-user Linux desktops. The default security policy reflects this: open access with optional hardening via ACL and UID allowlists for multi-user systems.
+Keymasq is designed for single-user Linux desktops. The default security policy reflects this: open access with optional UID allowlists for multi-user systems.
 
 ## Connection Chain
 
@@ -85,17 +85,11 @@ In practice:
 
 This prevents a second local process from concurrently issuing privileged daemon commands while a legitimate session broker is connected.
 
-## Peer Identity and ACL
+## Peer Identity and Admission
 
 On each accepted Unix socket connection, Keymasq reads `SO_PEERCRED` (`pid`, `uid`, `gid`).
 
-Authorization is then layered as:
-
-- optional UID allowlists
-- session command ACL
-- daemon command ACL
-
-This prevents bypass when a local process attempts to talk directly to the daemon socket.
+Optional UID allowlists can restrict which local users may connect to the session and daemon sockets.
 
 ## Recording Guard
 
@@ -152,7 +146,7 @@ The runtime TTL remains a bounded fallback, but normal and abnormal disconnect p
 
 ## Sensitive Command Binding
 
-Sensitive commands are bound to the active recording owner, not just to UID/ACL permission.
+Sensitive commands are bound to the active recording owner, not just to UID admission.
 
 Session-side sensitive commands currently include:
 
@@ -193,7 +187,6 @@ This is important because combo capture is effectively a short-lived privileged 
 In practice, this means:
 
 - an unlocked lease alone is not enough if another process owns the sensitive-command chain
-- ACL permission alone is not enough if capture is locked
 - GUI capture of combos is intentionally tied to the capture unlock owner chain
 
 ## Compositor Dispatch
@@ -222,8 +215,6 @@ Security policy path:
 
 Relevant controls:
 
-- `session_command_acl`
-- `daemon_command_acl`
 - `session_allowed_uids`
 - `daemon_allowed_uids`
 - `[macro]`
@@ -237,10 +228,6 @@ Relevant controls:
   - `macro_edit_requires_unlock`
 
 Empty UID allowlists mean no UID restriction. This is the default and is appropriate for single-user desktops. On multi-user systems, populate `daemon_allowed_uids` and `session_allowed_uids` to restrict access to specific users.
-
-`session_command_acl` applies to the single session-side client class: `client`. The session socket is a same-user endpoint, so Keymasq does not model GUI and CLI as separate enforceable trust classes there.
-
-Command ACLs are denylists, not allowlists. Supported deny forms are `!command`, `-command`, or `deny:command`. Commands not explicitly denied for the caller's client class are allowed. Positive entries (entries without a deny prefix) are ignored and should not be used to express allow-only policy. Unconfigured or unknown client classes default to allow unless separately blocked by UID policy, unlock state, or owner binding.
 
 `[recording_guard].unlock_required` controls whether sensitive original-input
 observation flows require an explicit unlock before they are allowed.
@@ -299,7 +286,7 @@ The daemon socket is world-accessible because `keymasqd` starts as a system serv
 
 The session socket is restricted to the owning user via `XDG_RUNTIME_DIR` permissions and explicit `0o700` on the socket directory.
 
-Socket permissions only gate connection attempts. Actual command authority still depends on peer identity, ACL, unlock state, and owner binding.
+Socket permissions only gate connection attempts. Sensitive command authority still depends on peer identity, unlock state, and owner binding.
 
 ## Security Goal
 
@@ -308,7 +295,7 @@ Default operation should avoid repeated auth prompts while still protecting priv
 The effective security model is:
 
 - peer credential checks on every socket connection
-- layered ACL enforcement at session and daemon boundaries
+- optional UID admission controls at session and daemon boundaries
 - owner-bound runtime unlock refresh
 - owner-bound sensitive command execution
 - recording guard for original-input observation features

--- a/examples/security.toml
+++ b/examples/security.toml
@@ -13,14 +13,3 @@ emergency_cancel_combo_enabled = true
 unlock_required = true
 # Tier 2 (optional): require unlock for macro get/create/update APIs.
 macro_edit_requires_unlock = false
-
-[session_command_acl]
-# ACL entries are deny rules only.
-# Supported forms: "!command", "-command", or "deny:command".
-# Empty list means allow all commands for that client class.
-gui = []
-cli = []
-
-[daemon_command_acl]
-# Same deny-rule semantics as [session_command_acl].
-session = []

--- a/flake.nix
+++ b/flake.nix
@@ -372,9 +372,6 @@
                   unlock_required = true;
                   macro_edit_requires_unlock = false;
                 };
-                session_command_acl.gui = [ ];
-                session_command_acl.cli = [ ];
-                daemon_command_acl.session = [ ];
               };
               description = "Security policy configuration (rendered to /etc/keymasq/security.toml)";
             };

--- a/keymasq.install
+++ b/keymasq.install
@@ -26,14 +26,6 @@ exec_timeout_max_ms = 30000
 unlock_required = true
 # Tier 2 (optional): require unlock for macro inspection/edit commands.
 macro_edit_requires_unlock = false
-
-[session_command_acl]
-# Denylist syntax (optional): "!command", "-command", or "deny:command"
-gui = []
-cli = []
-
-[daemon_command_acl]
-session = []
 EOF
     chown root:root /etc/keymasq/security.toml 2>/dev/null || true
 }
@@ -58,7 +50,7 @@ post_install() {
     echo ""
     echo "A system user 'keymasq' has been created for the daemon."
     echo ""
-    echo "Security defaults use socket UID checks and command ACL policy."
+    echo "Security defaults use socket UID checks and recording guards."
     echo "Policy file: /etc/keymasq/security.toml"
     echo ""
     echo "To use Keymasq:"
@@ -96,7 +88,7 @@ post_upgrade() {
     echo ""
     echo "Keymasq has been upgraded!"
     echo ""
-    echo "Security policy uses UID/ACL controls; verify /etc/keymasq/security.toml"
+    echo "Security policy uses UID and recording guard controls; verify /etc/keymasq/security.toml"
     echo "If session cannot connect to daemon, verify runtime socket policy in /etc/keymasq/security.toml"
     echo "The package tried to restart keymasqd if it was already running."
     echo "If needed, restart services manually:"

--- a/keymasq/common/security.py
+++ b/keymasq/common/security.py
@@ -18,8 +18,6 @@ class PeerCredentials:
 
 @dataclass
 class SecurityPolicy:
-    session_command_acl: dict[str, list[str]] = field(default_factory=dict)
-    daemon_command_acl: dict[str, list[str]] = field(default_factory=dict)
     daemon_allowed_uids: list[int] = field(default_factory=list)
     session_allowed_uids: list[int] = field(default_factory=list)
     macro_exec_timeout_max_ms: int = 30000
@@ -30,29 +28,6 @@ class SecurityPolicy:
 
 class SecurityPolicyError(RuntimeError):
     """Raised when the security policy file exists but cannot be loaded."""
-
-
-def _to_str_list(value: Any) -> list[str]:
-    if not isinstance(value, list):
-        return []
-    items = cast(list[object], value)
-    out: list[str] = []
-    for item in items:
-        if isinstance(item, str) and item.strip():
-            out.append(item.strip())
-    return out
-
-
-def _to_acl_map(value: Any) -> dict[str, list[str]]:
-    if not isinstance(value, dict):
-        return {}
-    raw_acl = cast(dict[object, object], value)
-    out: dict[str, list[str]] = {}
-    for client_class, commands in raw_acl.items():
-        if not isinstance(client_class, str):
-            continue
-        out[client_class] = _to_str_list(commands)
-    return out
 
 
 def _to_int_list(value: Any) -> list[int]:
@@ -71,10 +46,7 @@ def _to_int_list(value: Any) -> list[int]:
 
 
 def load_security_policy(config_path: Path) -> SecurityPolicy:
-    policy = SecurityPolicy(
-        session_command_acl={"client": []},
-        daemon_command_acl={"session": []},
-    )
+    policy = SecurityPolicy()
 
     try:
         config_text = config_path.read_text()
@@ -87,14 +59,6 @@ def load_security_policy(config_path: Path) -> SecurityPolicy:
         raw: dict[str, Any] = tomllib.loads(config_text)
     except tomllib.TOMLDecodeError as exc:
         raise SecurityPolicyError(f"Invalid security policy TOML at {config_path}: {exc}") from exc
-
-    session_acl = _to_acl_map(raw.get("session_command_acl"))
-    if session_acl:
-        policy.session_command_acl = session_acl
-
-    daemon_acl = _to_acl_map(raw.get("daemon_command_acl"))
-    if daemon_acl:
-        policy.daemon_command_acl = daemon_acl
 
     policy.daemon_allowed_uids = _to_int_list(raw.get("daemon_allowed_uids"))
     policy.session_allowed_uids = _to_int_list(raw.get("session_allowed_uids"))
@@ -151,26 +115,6 @@ def get_peer_credentials(transport_socket: Any) -> PeerCredentials | None:
         return None
 
     return PeerCredentials(pid=pid, uid=uid, gid=gid)
-
-
-def command_allowed(command: str, acl: dict[str, list[str]], client_class: str) -> bool:
-    entries = acl.get(client_class, [])
-
-    for raw in entries:
-        token = raw.strip()
-        if token.startswith("!"):
-            denied = token[1:].strip()
-        elif token.startswith("-"):
-            denied = token[1:].strip()
-        elif token.lower().startswith("deny:"):
-            denied = token[5:].strip()
-        else:
-            continue
-
-        if denied in {"*", command}:
-            return False
-
-    return True
 
 
 def uid_allowed(uid: int, allowed_uids: list[int]) -> bool:

--- a/keymasq/common/security.py
+++ b/keymasq/common/security.py
@@ -30,18 +30,21 @@ class SecurityPolicyError(RuntimeError):
     """Raised when the security policy file exists but cannot be loaded."""
 
 
-def _to_int_list(value: Any) -> list[int]:
-    if not isinstance(value, list):
+def _to_int_list(value: Any, setting_name: str) -> list[int]:
+    if value is None:
         return []
+    if not isinstance(value, list):
+        raise SecurityPolicyError(f"{setting_name} must be a list of integer UIDs")
+
     items = cast(list[object], value)
     out: list[int] = []
     for item in items:
-        if not isinstance(item, int | str):
-            continue
+        if isinstance(item, bool) or not isinstance(item, int | str):
+            raise SecurityPolicyError(f"{setting_name} contains invalid UID {item!r}")
         try:
             out.append(int(item))
-        except (TypeError, ValueError):
-            continue
+        except ValueError as exc:
+            raise SecurityPolicyError(f"{setting_name} contains invalid UID {item!r}") from exc
     return out
 
 
@@ -60,8 +63,14 @@ def load_security_policy(config_path: Path) -> SecurityPolicy:
     except tomllib.TOMLDecodeError as exc:
         raise SecurityPolicyError(f"Invalid security policy TOML at {config_path}: {exc}") from exc
 
-    policy.daemon_allowed_uids = _to_int_list(raw.get("daemon_allowed_uids"))
-    policy.session_allowed_uids = _to_int_list(raw.get("session_allowed_uids"))
+    policy.daemon_allowed_uids = _to_int_list(
+        raw.get("daemon_allowed_uids"),
+        "daemon_allowed_uids",
+    )
+    policy.session_allowed_uids = _to_int_list(
+        raw.get("session_allowed_uids"),
+        "session_allowed_uids",
+    )
 
     macro_cfg = raw.get("macro")
     if isinstance(macro_cfg, dict):
@@ -118,6 +127,6 @@ def get_peer_credentials(transport_socket: Any) -> PeerCredentials | None:
 
 
 def uid_allowed(uid: int, allowed_uids: list[int]) -> bool:
-    if not allowed_uids:
+    if allowed_uids == []:
         return True
     return uid in set(allowed_uids)

--- a/keymasq/keymasqd/daemon.py
+++ b/keymasq/keymasqd/daemon.py
@@ -227,7 +227,7 @@ class Daemon:
         client: ClientContext | None = None,
     ) -> JsonObject:
         if client and self.security_policy:
-            self._ensure_sensitive_command_allowed(command_type, client)
+            await self._ensure_sensitive_command_allowed(command_type, client)
 
         if self.verbosity >= 1:
             log.debug(f"Command: {command_type.value} -> {self._log_view(data)}")
@@ -285,19 +285,16 @@ class Daemon:
 
         raise ValueError(f"Unknown command: {command_type}")
 
-    def _ensure_sensitive_command_allowed(
+    async def _ensure_sensitive_command_allowed(
         self,
         command_type: CommandType,
         client: ClientContext,
     ) -> None:
         if command_type == CommandType.START_RECORDING:
-            self._ensure_macro_recording_enabled(client.uid)
+            await asyncio.to_thread(self._ensure_macro_recording_enabled, client.uid)
             return
 
         policy = self.security_policy
-        if policy is None or not policy.recording_unlock_required:
-            return
-
         tier1_commands = {
             CommandType.CAPTURE_BEGIN,
             CommandType.CAPTURE_READ,
@@ -314,23 +311,34 @@ class Daemon:
             CommandType.MACRO_UPDATE,
         }
 
-        requires_unlock = command_type in tier1_commands
+        is_tier1_command = command_type in tier1_commands
+        if is_tier1_command:
+            self._ensure_sensitive_owner(
+                command_type,
+                client,
+                claim_if_missing=command_type != CommandType.CAPTURE_END,
+            )
+
+        if policy is None or not policy.recording_unlock_required:
+            return
+
+        requires_unlock = is_tier1_command
         if not requires_unlock and policy.macro_edit_requires_unlock:
             requires_unlock = command_type in tier2_commands
 
         if not requires_unlock:
             return
 
-        self._ensure_sensitive_owner(
-            command_type,
-            client,
-            claim_if_missing=command_type != CommandType.CAPTURE_END,
-        )
+        if not is_tier1_command:
+            self._ensure_sensitive_owner(command_type, client)
 
         if command_type == CommandType.CAPTURE_END:
             return
 
-        unlocked, expires_at, source = self._recording_unlocked_for_uid(client.uid)
+        unlocked, expires_at, source = await asyncio.to_thread(
+            self._recording_unlocked_for_uid,
+            client.uid,
+        )
         if unlocked:
             return
 

--- a/keymasq/keymasqd/daemon.py
+++ b/keymasq/keymasqd/daemon.py
@@ -31,7 +31,6 @@ from keymasq.common.security import (
     PeerCredentials,
     SecurityPolicy,
     SecurityPolicyError,
-    command_allowed,
     load_security_policy,
     uid_allowed,
 )
@@ -228,15 +227,6 @@ class Daemon:
         client: ClientContext | None = None,
     ) -> JsonObject:
         if client and self.security_policy:
-            if not command_allowed(
-                command_type.value,
-                self.security_policy.daemon_command_acl,
-                client.client_class,
-            ):
-                raise PermissionError(
-                    f"{client.client_class} is not allowed to call {command_type.value}"
-                )
-
             self._ensure_sensitive_command_allowed(command_type, client)
 
         if self.verbosity >= 1:
@@ -355,9 +345,7 @@ class Daemon:
         if enabled:
             return
         if source == "none":
-            raise PermissionError(
-                "macro_recording_disabled: macro recording opt-in required"
-            )
+            raise PermissionError("macro_recording_disabled: macro recording opt-in required")
         raise PermissionError(f"macro_recording_disabled: opt-in expired at {expires_at}")
 
     def _macro_recording_enabled_for_uid(self, uid: int) -> tuple[bool, int, str]:
@@ -755,14 +743,14 @@ class Daemon:
         except OSError as exc:
             raise RuntimeError(f"Failed to remove daemon socket path {SOCKET_PATH}: {exc}") from exc
 
-    def _validate_peer(self, peer: PeerCredentials) -> tuple[bool, str, str]:
+    def _validate_peer(self, peer: PeerCredentials) -> tuple[bool, str]:
         if self.security_policy is None:
-            return False, "unknown", "security policy not loaded"
+            return False, "security policy not loaded"
 
         if not uid_allowed(peer.uid, self.security_policy.daemon_allowed_uids):
-            return False, "unknown", f"uid {peer.uid} is not allowed by daemon policy"
+            return False, f"uid {peer.uid} is not allowed by daemon policy"
 
-        return True, "session", "peer uid allowed"
+        return True, "peer uid allowed"
 
 
 def main() -> None:

--- a/keymasq/keymasqd/socket_server.py
+++ b/keymasq/keymasqd/socket_server.py
@@ -23,7 +23,6 @@ class ClientContext:
     pid: int
     uid: int
     gid: int
-    client_class: str
 
 
 class CommandHandler(Protocol):
@@ -40,7 +39,7 @@ class DisconnectHandler(Protocol):
 
 
 class PeerValidator(Protocol):
-    def __call__(self, peer: PeerCredentials) -> tuple[bool, str, str]: ...
+    def __call__(self, peer: PeerCredentials) -> tuple[bool, str]: ...
 
 
 class SocketServer:
@@ -138,10 +137,7 @@ class SocketServer:
             log.warning(f"Failed to inspect {description}: {exc}")
             return
 
-        if (
-            current_stat.st_dev != socket_stat.st_dev
-            or current_stat.st_ino != socket_stat.st_ino
-        ):
+        if current_stat.st_dev != socket_stat.st_dev or current_stat.st_ino != socket_stat.st_ino:
             return
 
         try:
@@ -193,11 +189,10 @@ class SocketServer:
             return
 
         allowed = True
-        client_class = "session"
         deny_reason = ""
         if self.peer_validator:
             try:
-                allowed, client_class, deny_reason = self.peer_validator(peer)
+                allowed, deny_reason = self.peer_validator(peer)
             except Exception as exc:
                 log.exception("Peer validator failed")
                 allowed = False
@@ -219,7 +214,6 @@ class SocketServer:
             pid=peer.pid,
             uid=peer.uid,
             gid=peer.gid,
-            client_class=client_class,
         )
         self._next_connection_id += 1
 
@@ -250,13 +244,7 @@ class SocketServer:
                 await writer.wait_closed()
                 return
 
-        log.info(
-            "Client connected pid=%s uid=%s class=%s addr=%s",
-            context.pid,
-            context.uid,
-            context.client_class,
-            addr,
-        )
+        log.info("Client connected pid=%s uid=%s addr=%s", context.pid, context.uid, addr)
 
         self.clients.add(writer)
         self._buffer[writer] = b""
@@ -419,10 +407,9 @@ class SocketServer:
                 log.warning("Timed out waiting for client socket to close")
             else:
                 log.warning(
-                    "Timed out waiting for client socket to close pid=%s uid=%s class=%s",
+                    "Timed out waiting for client socket to close pid=%s uid=%s",
                     peer.pid,
                     peer.uid,
-                    peer.client_class,
                 )
             transport = getattr(writer, "transport", None)
             if transport is not None:

--- a/keymasq/session/manager/commands.py
+++ b/keymasq/session/manager/commands.py
@@ -14,7 +14,7 @@ from keymasq.common.models import (
     normalize_macro_recording_slot,
     parse_mpris_command,
 )
-from keymasq.common.security import PeerCredentials, SecurityPolicy, command_allowed
+from keymasq.common.security import PeerCredentials
 from keymasq.common.settings import GlobalSettings
 from keymasq.common.virtual_devices import (
     MAX_VIRTUAL_GAMEPADS,
@@ -76,18 +76,11 @@ async def _send_daemon_request(
 async def handle_session_request(
     manager: "SessionManager",
     request: JsonObject,
-    client_class: str,
     peer: PeerCredentials,
     writer: asyncio.StreamWriter,
 ) -> JsonObject:
     command = coerce_str(request.get("command"), "")
     policy = manager.security_policy
-
-    if not command_allowed(command, policy.session_command_acl, client_class):
-        return {
-            "status": "error",
-            "message": f"{client_class} is not allowed to call '{command}'",
-        }
 
     if runtime_recording.is_sensitive_session_command(
         manager, command, policy
@@ -103,7 +96,7 @@ async def handle_session_request(
             "message": "Sensitive command denied: caller is not active GUI owner",
         }
 
-    result = await _handle_profile_commands(manager, command, request, client_class, policy)
+    result = await _handle_profile_commands(manager, command, request)
     if result is not None:
         return result
 
@@ -111,7 +104,6 @@ async def handle_session_request(
         manager,
         command,
         request,
-        client_class,
         peer,
         writer,
     )
@@ -152,26 +144,12 @@ async def _handle_profile_commands(
     manager: "SessionManager",
     command: str,
     request: JsonObject,
-    client_class: str,
-    policy: SecurityPolicy,
 ) -> JsonObject | None:
     if command == "get_active_profiles":
         await runtime_profiles.refresh_device_runtime_status(manager)
         return runtime_profiles.build_active_profiles_payload(manager)
 
     if command == "get_combo_inspector_snapshot":
-        if not command_allowed(
-            "get_active_profiles",
-            policy.session_command_acl,
-            client_class,
-        ):
-            return {
-                "status": "error",
-                "message": (
-                    f"{client_class} is not allowed to call "
-                    "'get_combo_inspector_snapshot' while 'get_active_profiles' is denied"
-                ),
-            }
         return runtime_combo_inspector.build_combo_inspector_snapshot(manager)
 
     if command == "list_profiles":
@@ -405,11 +383,9 @@ async def _handle_compositor_commands(
     manager: "SessionManager",
     command: str,
     request: JsonObject,
-    client_class: str,
     peer: PeerCredentials,
     writer: asyncio.StreamWriter,
 ) -> JsonObject | None:
-    _ = peer, writer
     if command == "get_compositor":
         return await runtime_compositor.build_compositor_payload(manager)
 
@@ -483,8 +459,7 @@ async def _handle_compositor_commands(
         compositor_status = await runtime_compositor.build_compositor_payload(manager)
         compositor_details = cast(dict[str, object], compositor_status["details"])
         policy = manager.security_policy
-        if command_allowed("get_active_profiles", policy.session_command_acl, client_class):
-            await runtime_profiles.refresh_device_runtime_status(manager)
+        await runtime_profiles.refresh_device_runtime_status(manager)
         profile_payload = runtime_profiles.build_active_profiles_payload(manager)
         status_payload: JsonObject = {
             "status": "ok",
@@ -512,14 +487,11 @@ async def _handle_compositor_commands(
                 ),
             ),
             **runtime_recording.serialize_macro_recording_state(macro_recording_status),
+            "mpris": manager.mpris_controller.status_snapshot(),
+            "active_profiles": profile_payload["active_profiles"],
+            "devices": profile_payload["devices"],
+            "window": manager.compositor_state.current_window,
         }
-        if command_allowed("mpris", policy.session_command_acl, client_class):
-            status_payload["mpris"] = manager.mpris_controller.status_snapshot()
-        if command_allowed("get_active_profiles", policy.session_command_acl, client_class):
-            status_payload["active_profiles"] = profile_payload["active_profiles"]
-            status_payload["devices"] = profile_payload["devices"]
-        if command_allowed("get_active_window", policy.session_command_acl, client_class):
-            status_payload["window"] = manager.compositor_state.current_window
         return status_payload
 
     return None

--- a/keymasq/session/manager/core.py
+++ b/keymasq/session/manager/core.py
@@ -360,13 +360,10 @@ class SessionManager:
             await self._close_session_writer(writer, peer)
             return
 
-        client_class = "client"
-
         log.debug(
-            "Session client connected pid=%s uid=%s class=%s",
+            "Session client connected pid=%s uid=%s",
             peer.pid,
             peer.uid,
-            client_class,
         )
         self.session_clients.add(writer)
         self.session_client_peers[writer] = peer
@@ -401,7 +398,6 @@ class SessionManager:
                         try:
                             response = await self._handle_session_request(
                                 request,
-                                client_class,
                                 peer,
                                 writer,
                             )
@@ -443,14 +439,12 @@ class SessionManager:
     async def _handle_session_request(
         self,
         request: JsonObject,
-        client_class: str,
         peer: PeerCredentials,
         writer: asyncio.StreamWriter,
     ) -> JsonObject:
         return await session_commands.handle_session_request(
             self,
             request,
-            client_class,
             peer,
             writer,
         )
@@ -588,9 +582,7 @@ class SessionManager:
         try:
             await asyncio.to_thread(self.reload_config_from_disk)
         except Exception as exc:
-            log.exception(
-                "Failed to reload user config from disk; keeping previous active config"
-            )
+            log.exception("Failed to reload user config from disk; keeping previous active config")
             self.send_notification(
                 "Keymasq Config Error",
                 "Failed to reload config; keeping the previous active config. See logs.",

--- a/packaging/appimage/assets/security-steamos.toml
+++ b/packaging/appimage/assets/security-steamos.toml
@@ -12,9 +12,3 @@ emergency_cancel_combo_enabled = true
 # unlock is disabled because the package already installs a system daemon.
 unlock_required = false
 macro_edit_requires_unlock = false
-
-[session_command_acl]
-client = []
-
-[daemon_command_acl]
-session = []

--- a/packaging/aur/keymasq.install
+++ b/packaging/aur/keymasq.install
@@ -26,14 +26,6 @@ exec_timeout_max_ms = 30000
 unlock_required = true
 # Tier 2 (optional): require unlock for macro inspection/edit commands.
 macro_edit_requires_unlock = false
-
-[session_command_acl]
-# Denylist syntax (optional): "!command", "-command", or "deny:command"
-gui = []
-cli = []
-
-[daemon_command_acl]
-session = []
 EOF
     chown root:root /etc/keymasq/security.toml 2>/dev/null || true
 }
@@ -58,7 +50,7 @@ post_install() {
     echo ""
     echo "A system user 'keymasq' has been created for the daemon."
     echo ""
-    echo "Security defaults use socket UID checks and command ACL policy."
+    echo "Security defaults use socket UID checks and recording guards."
     echo "Policy file: /etc/keymasq/security.toml"
     echo ""
     echo "To use Keymasq:"
@@ -96,7 +88,7 @@ post_upgrade() {
     echo ""
     echo "Keymasq has been upgraded!"
     echo ""
-    echo "Security policy uses UID/ACL controls; verify /etc/keymasq/security.toml"
+    echo "Security policy uses UID and recording guard controls; verify /etc/keymasq/security.toml"
     echo "If session cannot connect to daemon, verify runtime socket policy in /etc/keymasq/security.toml"
     echo "The package tried to restart keymasqd if it was already running."
     echo "If needed, restart services manually:"

--- a/packaging/pacman/templates/keymasq.install.in
+++ b/packaging/pacman/templates/keymasq.install.in
@@ -25,14 +25,6 @@ exec_timeout_max_ms = 30000
 unlock_required = true
 # Tier 2 (optional): require unlock for macro inspection/edit commands.
 macro_edit_requires_unlock = false
-
-[session_command_acl]
-# Denylist syntax (optional): "!command", "-command", or "deny:command"
-gui = []
-cli = []
-
-[daemon_command_acl]
-session = []
 EOF
     chown root:root /etc/keymasq/security.toml 2>/dev/null || true
 }
@@ -57,7 +49,7 @@ post_install() {
     echo ""
     echo "A system user 'keymasq' has been created for the daemon."
     echo ""
-    echo "Security defaults use socket UID checks and command ACL policy."
+    echo "Security defaults use socket UID checks and recording guards."
     echo "Policy file: /etc/keymasq/security.toml"
     echo ""
     echo "To use Keymasq:"
@@ -95,7 +87,7 @@ post_upgrade() {
     echo ""
     echo "Keymasq has been upgraded!"
     echo ""
-    echo "Security policy uses UID/ACL controls; verify /etc/keymasq/security.toml"
+    echo "Security policy uses UID and recording guard controls; verify /etc/keymasq/security.toml"
     echo "If session cannot connect to daemon, verify runtime socket policy in /etc/keymasq/security.toml"
     echo "The package tried to restart keymasqd if it was already running."
     echo "If needed, restart services manually:"

--- a/tests/keymasqd/daemon_support.py
+++ b/tests/keymasqd/daemon_support.py
@@ -110,5 +110,4 @@ def client_context(
         pid=pid,
         uid=uid,
         gid=uid,
-        client_class="session",
     )

--- a/tests/keymasqd/test_daemon_macro_resolution.py
+++ b/tests/keymasqd/test_daemon_macro_resolution.py
@@ -1,3 +1,4 @@
+import threading
 from typing import cast
 
 import pytest
@@ -415,11 +416,17 @@ async def test_handle_command_start_recording_requires_macro_recording_opt_in(
 ):
     daemon, _device_manager, _recording_manager, _macro_store, _capture_manager = daemon_testbed
     daemon.security_policy = SecurityPolicy(recording_unlock_required=True)
+    event_loop_thread = threading.get_ident()
+    resolver_threads: list[int] = []
+
+    def resolve_status(_uid: int) -> dict[str, object]:
+        resolver_threads.append(threading.get_ident())
+        return {"unlocked": False, "source": "none", "expires_at": 0}
 
     monkeypatch.setattr(
         daemon_module,
         "resolve_macro_recording_status",
-        lambda _uid: {"unlocked": False, "source": "none", "expires_at": 0},
+        resolve_status,
     )
 
     with pytest.raises(PermissionError, match="macro_recording_disabled"):
@@ -428,6 +435,9 @@ async def test_handle_command_start_recording_requires_macro_recording_opt_in(
             {},
             client=client_context(uid=1000, pid=111, connection_id=7),
         )
+
+    assert len(resolver_threads) == 1
+    assert resolver_threads[0] != event_loop_thread
 
 
 def test_macro_recording_enabled_cache_rechecks_persistent_opt_in(

--- a/tests/keymasqd/test_daemon_runtime_unlock.py
+++ b/tests/keymasqd/test_daemon_runtime_unlock.py
@@ -1,4 +1,5 @@
 import os
+import threading
 from pathlib import Path
 from unittest.mock import Mock
 
@@ -132,7 +133,14 @@ async def test_device_inspector_commands_forward_to_device_manager(daemon_testbe
 async def test_device_inspector_start_requires_recording_unlock(daemon_testbed, monkeypatch):
     daemon, _device_manager, _recording_manager, _macro_store, _capture_manager = daemon_testbed
     daemon.security_policy = SecurityPolicy(recording_unlock_required=True)
-    monkeypatch.setattr(daemon, "_recording_unlocked_for_uid", lambda _uid: (False, 0, "none"))
+    event_loop_thread = threading.get_ident()
+    resolver_threads: list[int] = []
+
+    def recording_unlocked_for_uid(_uid: int) -> tuple[bool, int, str]:
+        resolver_threads.append(threading.get_ident())
+        return False, 0, "none"
+
+    monkeypatch.setattr(daemon, "_recording_unlocked_for_uid", recording_unlocked_for_uid)
 
     with pytest.raises(PermissionError, match="recording_locked"):
         await daemon._handle_command(
@@ -140,6 +148,9 @@ async def test_device_inspector_start_requires_recording_unlock(daemon_testbed, 
             {"hardware_id": "1234:5678"},
             client=client_context(),
         )
+
+    assert len(resolver_threads) == 1
+    assert resolver_threads[0] != event_loop_thread
 
 
 @pytest.mark.asyncio
@@ -237,10 +248,17 @@ async def test_macro_exec_complete_forwards_wait_id_and_returncode(daemon_testbe
     device_manager.complete_macro_exec_wait.assert_called_once_with("99", 7)
 
 
+@pytest.mark.parametrize("recording_unlock_required", [True, False])
 @pytest.mark.asyncio
-async def test_sensitive_command_owner_mismatch_is_denied(daemon_testbed, monkeypatch):
+async def test_sensitive_command_owner_mismatch_is_denied(
+    daemon_testbed,
+    monkeypatch,
+    recording_unlock_required: bool,
+):
     daemon, _device_manager, _recording_manager, _macro_store, capture_manager = daemon_testbed
-    daemon.security_policy = SecurityPolicy(recording_unlock_required=True)
+    daemon.security_policy = SecurityPolicy(
+        recording_unlock_required=recording_unlock_required,
+    )
     monkeypatch.setattr(daemon, "_recording_unlocked_for_uid", lambda _uid: (True, 0, "runtime"))
 
     first_client = client_context(uid=2000, pid=111, connection_id=10)

--- a/tests/keymasqd/test_daemon_security.py
+++ b/tests/keymasqd/test_daemon_security.py
@@ -58,15 +58,13 @@ def test_validate_peer_behavior(daemon_testbed, expected_allowed: bool):
     )
 
     peer = SimpleNamespace(uid=1111 if expected_allowed else 2222, pid=1, gid=1)
-    allowed, peer_class, reason = daemon._validate_peer(peer)
+    allowed, reason = daemon._validate_peer(peer)
 
     if expected_allowed:
         assert allowed is True
-        assert peer_class == "session"
         assert reason == "peer uid allowed"
     else:
         assert allowed is False
-        assert peer_class == "unknown"
         assert "not allowed" in reason
 
 

--- a/tests/session/test_mpris_events.py
+++ b/tests/session/test_mpris_events.py
@@ -37,14 +37,13 @@ async def test_handle_mpris_trigger_uses_session_controller() -> None:
 async def test_session_mpris_command_uses_session_controller() -> None:
     controller = _FakeMprisController()
     manager = SimpleNamespace(
-        security_policy=SecurityPolicy(session_command_acl={"client": []}),
+        security_policy=SecurityPolicy(),
         mpris_controller=controller,
     )
 
     result = await session_commands.handle_session_request(
         manager,  # type: ignore[arg-type]
         {"command": "mpris", "mpris_command": "play-pause"},
-        "client",
         PeerCredentials(pid=1, uid=1000, gid=1000),
         None,  # type: ignore[arg-type]
     )
@@ -59,18 +58,15 @@ async def test_session_mpris_command_uses_session_controller() -> None:
 
 @pytest.mark.asyncio
 async def test_session_mpris_command_reports_controller_failure() -> None:
-    controller = _FakeMprisController(
-        MprisDBusError("", "session D-Bus transport failed: no bus")
-    )
+    controller = _FakeMprisController(MprisDBusError("", "session D-Bus transport failed: no bus"))
     manager = SimpleNamespace(
-        security_policy=SecurityPolicy(session_command_acl={"client": []}),
+        security_policy=SecurityPolicy(),
         mpris_controller=controller,
     )
 
     result = await session_commands.handle_session_request(
         manager,  # type: ignore[arg-type]
         {"command": "mpris", "mpris_command": "play"},
-        "client",
         PeerCredentials(pid=1, uid=1000, gid=1000),
         None,  # type: ignore[arg-type]
     )
@@ -85,17 +81,16 @@ async def test_session_mpris_command_reports_controller_failure() -> None:
 
 
 @pytest.mark.asyncio
-async def test_session_mpris_status_uses_mpris_acl_path() -> None:
+async def test_session_mpris_status_uses_session_controller() -> None:
     controller = _FakeMprisController()
     manager = SimpleNamespace(
-        security_policy=SecurityPolicy(session_command_acl={"client": []}),
+        security_policy=SecurityPolicy(),
         mpris_controller=controller,
     )
 
     result = await session_commands.handle_session_request(
         manager,  # type: ignore[arg-type]
         {"command": "mpris", "mpris_command": "status"},
-        "client",
         PeerCredentials(pid=1, uid=1000, gid=1000),
         None,  # type: ignore[arg-type]
     )
@@ -112,14 +107,13 @@ async def test_session_mpris_status_uses_mpris_acl_path() -> None:
 async def test_session_mpris_command_rejects_unknown_command() -> None:
     controller = _FakeMprisController()
     manager = SimpleNamespace(
-        security_policy=SecurityPolicy(session_command_acl={"client": []}),
+        security_policy=SecurityPolicy(),
         mpris_controller=controller,
     )
 
     result = await session_commands.handle_session_request(
         manager,  # type: ignore[arg-type]
         {"command": "mpris", "mpris_command": "shuffle"},
-        "client",
         PeerCredentials(pid=1, uid=1000, gid=1000),
         None,  # type: ignore[arg-type]
     )

--- a/tests/session/test_session_manager_command_authorization.py
+++ b/tests/session/test_session_manager_command_authorization.py
@@ -1,4 +1,3 @@
-from types import SimpleNamespace
 from typing import cast
 from unittest.mock import AsyncMock
 
@@ -7,7 +6,7 @@ import pytest
 import keymasq.session.manager.compositor as session_compositor_module
 import keymasq.session.manager.recording as session_recording_module
 import keymasq.session.manager.recording_unlock as recording_unlock_module
-from keymasq.common.security import PeerCredentials, SecurityPolicy
+from keymasq.common.security import PeerCredentials
 from keymasq.session.listeners.hyprland import HyprlandListener
 from keymasq.session.manager import SessionManager
 from tests.session.support import grant_recording_refresh_owner
@@ -34,7 +33,6 @@ async def test_sensitive_command_requires_active_recording_owner(
 
     denied = await manager._handle_session_request(
         {"command": "lock_recording_unlock"},
-        "client",
         peer,
         other_writer,  # type: ignore[arg-type]
     )
@@ -43,7 +41,6 @@ async def test_sensitive_command_requires_active_recording_owner(
 
     allowed = await manager._handle_session_request(
         {"command": "lock_recording_unlock", "lease_id": "lease-1"},
-        "client",
         peer,
         owner_writer,  # type: ignore[arg-type]
     )
@@ -77,7 +74,6 @@ async def test_sensitive_command_rejects_refresh_owner_when_unlock_expired(
 
     result = await manager._handle_session_request(
         {"command": "get_macro", "name": "Secret"},
-        "client",
         peer,
         writer,  # type: ignore[arg-type]
     )
@@ -90,57 +86,12 @@ async def test_sensitive_command_rejects_refresh_owner_when_unlock_expired(
 
 
 @pytest.mark.asyncio
-async def test_session_request_uses_single_policy_snapshot_for_acl_and_sensitivity(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    manager = SessionManager()
-    peer = PeerCredentials(pid=111, uid=1000, gid=1000)
-    writer = object()
-    capture_begin_for_paths = AsyncMock(return_value={"status": "ok"})
-    manager.security_policy = SecurityPolicy(
-        session_command_acl={"client": []},
-        daemon_command_acl={"session": []},
-        recording_unlock_required=True,
-    )
-
-    def fake_command_allowed(command: str, acl: dict[str, list[str]], client_class: str) -> bool:
-        assert command == "begin_capture"
-        assert acl is manager.security_policy.session_command_acl
-        assert client_class == "client"
-        manager.security_policy = SecurityPolicy(
-            session_command_acl={"client": []},
-            daemon_command_acl={"session": []},
-            recording_unlock_required=False,
-        )
-        return True
-
-    monkeypatch.setattr("keymasq.session.manager.commands.command_allowed", fake_command_allowed)
-    monkeypatch.setattr(
-        session_recording_module,
-        "capture_begin_for_paths",
-        capture_begin_for_paths,
-    )
-
-    result = await manager._handle_session_request(
-        {"command": "begin_capture", "hardware_id": "1234:5678"},
-        "client",
-        peer,
-        writer,  # type: ignore[arg-type]
-    )
-
-    assert result["status"] == "error"
-    assert result["error_code"] == "sensitive_command_denied"
-    capture_begin_for_paths.assert_not_awaited()
-
-
-@pytest.mark.asyncio
 async def test_handle_session_request_returns_unknown_command_error() -> None:
     manager = SessionManager()
     peer = PeerCredentials(pid=1, uid=1000, gid=1000)
 
     result = await manager._handle_session_request(
         {"command": "does_not_exist"},
-        "client",
         peer,
         object(),
     )
@@ -163,7 +114,6 @@ async def test_handle_session_request_get_active_window_uses_listener() -> None:
 
     result = await manager._handle_session_request(
         {"command": "get_active_window"},
-        "client",
         peer,
         object(),
     )
@@ -193,7 +143,6 @@ async def test_handle_session_request_get_active_window_falls_back_to_cached_win
 
     result = await manager._handle_session_request(
         {"command": "get_active_window"},
-        "client",
         peer,
         object(),
     )
@@ -207,88 +156,9 @@ async def test_handle_session_request_get_active_window_falls_back_to_cached_win
 
 
 @pytest.mark.asyncio
-async def test_get_status_omits_acl_gated_profile_window_and_mpris_sections() -> None:
-    manager = SessionManager()
-    manager.security_policy = SecurityPolicy(
-        session_command_acl={"client": ["!get_active_profiles", "!get_active_window", "!mpris"]},
-        daemon_command_acl={"session": []},
-    )
-    manager.profile_state.active_profile_names = ["Gaming"]
-    manager.profile_state.resolved_devices = {
-        "1234:5678": SimpleNamespace(
-            active_profile_names=["Gaming"],
-            mapping_count=3,
-            always_grab_all=False,
-        )
-    }
-    manager.compositor_state.current_window = {
-        "class": "steam",
-        "title": "Counter-Strike 2",
-        "tags": ["game"],
-    }
-    peer = PeerCredentials(pid=1, uid=1000, gid=1000)
-
-    result = await manager._handle_session_request(
-        {"command": "get_status"},
-        "client",
-        peer,
-        object(),
-    )
-
-    assert result["status"] == "ok"
-    assert "active_profiles" not in result
-    assert "devices" not in result
-    assert "window" not in result
-    assert "mpris" not in result
-
-
-@pytest.mark.asyncio
-async def test_combo_inspector_snapshot_requires_active_profile_permission() -> None:
-    from keymasq.common.models import ActionType, ComboEvent, ComboStep, MappingAction
-    from keymasq.session.profiles import ResolvedCombo
-
-    manager = SessionManager()
-    manager.security_policy = SecurityPolicy(
-        session_command_acl={"client": ["!get_active_profiles"]},
-        daemon_command_acl={"session": []},
-    )
-    manager.profile_state.active_profile_names = ["Base", "Overlay"]
-    manager.profile_state.resolved_combos = [
-        ResolvedCombo(
-            id="combo-1",
-            name="Quick Save",
-            profile_name="Overlay",
-            steps=[
-                ComboStep(
-                    events=[
-                        ComboEvent(
-                            evdev="key_s",
-                            hardware_id="1234:5678",
-                            source="kbd",
-                        )
-                    ],
-                )
-            ],
-            action=MappingAction(action_type=ActionType.KEYBOARD, target="key_f5"),
-        )
-    ]
-    peer = PeerCredentials(pid=1, uid=1000, gid=1000)
-
-    result = await manager._handle_session_request(
-        {"command": "get_combo_inspector_snapshot"},
-        "client",
-        peer,
-        object(),
-    )
-
-    assert result["status"] == "error"
-    assert "get_active_profiles" in str(result["message"])
-    assert "combos" not in result
-
-
-@pytest.mark.asyncio
-async def test_handle_session_request_get_compositor_reports_compositor_dispatch_availability(
-) -> None:
+async def test_handle_session_request_get_compositor_reports_compositor_dispatch_availability() -> (
+    None
+):
     manager = SessionManager()
     peer = PeerCredentials(pid=1, uid=1000, gid=1000)
 
@@ -299,7 +169,6 @@ async def test_handle_session_request_get_compositor_reports_compositor_dispatch
 
     result = await manager._handle_session_request(
         {"command": "get_compositor"},
-        "client",
         peer,
         object(),
     )
@@ -327,7 +196,6 @@ async def test_handle_session_request_dispatch_compositor_uses_runtime_dispatch(
             "dispatcher": "toggle-window-floating",
             "args": "",
         },
-        "client",
         peer,
         object(),
     )
@@ -370,7 +238,6 @@ async def test_handle_session_request_get_compositor_merges_listener_runtime_war
 
     result = await manager._handle_session_request(
         {"command": "get_compositor"},
-        "client",
         peer,
         object(),
     )

--- a/tests/session/test_session_manager_command_runtime.py
+++ b/tests/session/test_session_manager_command_runtime.py
@@ -72,7 +72,6 @@ async def test_handle_session_request_get_compositor_reports_kde_dispatch_availa
 
     result = await manager._handle_session_request(
         {"command": "get_compositor"},
-        "client",
         peer,
         object(),
     )
@@ -100,7 +99,6 @@ async def test_handle_session_request_set_settings_does_not_broadcast_on_daemon_
 
     result = await manager._handle_session_request(
         {"command": "set_settings", "virtual_gamepad_count": 2},
-        "client",
         peer,
         object(),
     )
@@ -130,7 +128,6 @@ async def test_handle_session_request_set_virtual_gamepads_keeps_state_on_daemon
 
     result = await manager._handle_session_request(
         {"command": "set_virtual_gamepads", "count": 2},
-        "client",
         peer,
         object(),
     )
@@ -149,9 +146,7 @@ async def test_release_device_command_forwards_to_daemon_and_clears_runtime_stat
     manager = SessionManager()
     hardware_id = "045e:02a1"
     manager.profile_state.grabbed_devices.add(hardware_id)
-    manager.profile_state.grabbed_interfaces[hardware_id] = {
-        "gamepad": "/dev/input/event20"
-    }
+    manager.profile_state.grabbed_interfaces[hardware_id] = {"gamepad": "/dev/input/event20"}
     manager.profile_state.grab_waiting_devices.add(hardware_id)
     manager.profile_state.last_sent_grab_signatures[hardware_id] = "grab"
     manager.profile_state.last_sent_mapping_signatures[hardware_id] = "mapping"
@@ -162,7 +157,6 @@ async def test_release_device_command_forwards_to_daemon_and_clears_runtime_stat
 
     result = await manager._handle_session_request(
         {"command": "release_device", "hardware_id": hardware_id},
-        "client",
         peer,
         object(),
     )
@@ -189,7 +183,6 @@ async def test_handle_session_request_refresh_compositor_forces_binding_retry(
 
     result = await manager._handle_session_request(
         {"command": "refresh_compositor"},
-        "client",
         peer,
         object(),
     )
@@ -218,7 +211,6 @@ async def test_handle_session_request_run_compositor_setup_action(
             "compositor": "gnome",
             "action": "enable_bridge",
         },
-        "client",
         peer,
         object(),
     )
@@ -263,7 +255,6 @@ async def test_get_status_uses_async_unlock_helper(monkeypatch: pytest.MonkeyPat
 
     result = await manager._handle_session_request(
         {"command": "get_status"},
-        "client",
         peer,
         writer,  # type: ignore[arg-type]
     )
@@ -456,7 +447,6 @@ async def test_get_active_profiles_does_not_include_window_state() -> None:
 
     result = await manager._handle_session_request(
         {"command": "get_active_profiles"},
-        "client",
         peer,
         object(),
     )
@@ -604,7 +594,7 @@ async def test_get_combo_inspector_snapshot_returns_resolved_active_combos() -> 
                         )
                     ],
                     timeout_ms=500,
-                )
+                ),
             ],
             action=MappingAction(action_type=ActionType.KEYBOARD, target="key_f5"),
             recall_trigger_keys=True,
@@ -619,7 +609,6 @@ async def test_get_combo_inspector_snapshot_returns_resolved_active_combos() -> 
 
     result = await manager._handle_session_request(
         {"command": "get_combo_inspector_snapshot"},
-        "client",
         peer,
         object(),
     )
@@ -668,7 +657,6 @@ async def test_get_combo_inspector_snapshot_preserves_profile_deactivation() -> 
 
     result = await manager._handle_session_request(
         {"command": "get_combo_inspector_snapshot"},
-        "client",
         peer,
         object(),
     )
@@ -713,7 +701,6 @@ async def test_get_recording_settings_uses_unlock_and_owner_state_only(
 
     result = await manager._handle_session_request(
         {"command": "get_recording_settings"},
-        "client",
         peer,
         writer,  # type: ignore[arg-type]
     )
@@ -754,7 +741,6 @@ async def test_play_macro_payload_forwards_sanitized_events() -> None:
             ],
             "speed": 1.5,
         },
-        "client",
         peer,
         object(),
     )
@@ -793,7 +779,6 @@ async def test_type_text_compiles_in_thread_and_forwards_events(
             "pause_ms": 0,
             "speed": 1.25,
         },
-        "client",
         peer,
         object(),
     )
@@ -833,7 +818,6 @@ async def test_play_compact_macro_compiles_in_thread_and_forwards_events(
             "tokens": ["key_a", "wait:10:20", "btn_left"],
             "speed": 0.5,
         },
-        "client",
         peer,
         object(),
     )
@@ -859,7 +843,6 @@ async def test_play_macro_payload_requires_events() -> None:
 
     result = await manager._handle_session_request(
         {"command": "play_macro_payload", "macro_events": []},
-        "client",
         peer,
         object(),
     )
@@ -880,7 +863,6 @@ async def test_sensitive_recording_commands_do_not_require_owner_when_unlock_not
 
     result = await manager._handle_session_request(
         {"command": "start_recording", "recording_slot": 1},
-        "client",
         peer,
         writer,  # type: ignore[arg-type]
     )
@@ -908,7 +890,6 @@ async def test_start_recording_command_requires_explicit_slot(
 
     result = await manager._handle_session_request(
         {"command": "start_recording"},
-        "client",
         peer,
         writer,  # type: ignore[arg-type]
     )
@@ -1226,9 +1207,7 @@ async def test_play_macro_slot_trigger_refreshes_empty_cache_before_playback() -
     )
 
     assert result == {"status": "ok", "played": True}
-    sent_commands = [
-        call.args[0].command for call in manager.client.send_command.await_args_list
-    ]
+    sent_commands = [call.args[0].command for call in manager.client.send_command.await_args_list]
     assert sent_commands == [
         CommandType.MACRO_LIST_RECORDINGS,
         CommandType.MACRO_PLAY_RECORDING,
@@ -1264,14 +1243,11 @@ async def test_list_macros_include_slots_syncs_slots_from_daemon() -> None:
 
     result = await manager._handle_session_request(
         {"command": "list_macros", "include_slots": True},
-        "client",
         peer,
         object(),
     )
 
-    sent_commands = [
-        call.args[0].command for call in manager.client.send_command.await_args_list
-    ]
+    sent_commands = [call.args[0].command for call in manager.client.send_command.await_args_list]
     macros = cast(list[dict[str, object]], result["macros"])
     assert sent_commands == [CommandType.MACRO_LIST_META, CommandType.MACRO_LIST_RECORDINGS]
     assert manager.recording_state.pending_slots[3].data["pending_recording_id"] == "recording-3"
@@ -1407,7 +1383,6 @@ async def test_reevaluate_profiles_command_invalidates_runtime_payload_signature
 
     result = await manager._handle_session_request(
         {"command": "reevaluate_profiles"},
-        "client",
         peer,
         object(),
     )
@@ -1440,7 +1415,6 @@ async def test_reevaluate_profiles_command_runs_fresh_reload_after_running_confi
 
     result = await manager._handle_session_request(
         {"command": "reevaluate_profiles"},
-        "client",
         peer,
         object(),
     )
@@ -1471,7 +1445,6 @@ async def test_reevaluate_profiles_command_runs_fresh_reload_after_failed_runnin
 
     result = await manager._handle_session_request(
         {"command": "reevaluate_profiles"},
-        "client",
         peer,
         object(),
     )
@@ -1525,7 +1498,6 @@ async def test_device_inspector_disable_session_command_forwards_reason() -> Non
             "hardware_id": "1234:5678",
             "reason": "key_esc",
         },
-        "client",
         peer,
         object(),  # type: ignore[arg-type]
     )
@@ -1731,9 +1703,7 @@ async def test_clear_device_inspectors_for_writer_continues_after_stop_failure(
 
     assert stopped == ["bad", "good"]
     assert manager.device_inspector_state.owners_by_hardware_id["bad"] == set()
-    assert (
-        "Failed to stop device inspector for disconnected owner hardware_id=bad" in caplog.text
-    )
+    assert "Failed to stop device inspector for disconnected owner hardware_id=bad" in caplog.text
     assert "stop failed" in caplog.text
 
 
@@ -1819,9 +1789,7 @@ async def test_start_device_inspector_returns_snapshot_and_forces_profile_reeval
     manager.profile_state.resolved_devices[hardware_id] = ResolvedDeviceProfile(
         hardware_id=hardware_id,
         active_profile_names=["Desktop"],
-        mappings={
-            "btn_south": MappingAction(action_type=ActionType.KEYBOARD, target="key_space")
-        },
+        mappings={"btn_south": MappingAction(action_type=ActionType.KEYBOARD, target="key_space")},
         mapping_profile_names={"btn_south": "Desktop"},
     )
     manager.client.send_command = AsyncMock(
@@ -1835,7 +1803,6 @@ async def test_start_device_inspector_returns_snapshot_and_forces_profile_reeval
 
     result = await manager._handle_session_request(
         {"command": "start_device_inspector", "hardware_id": hardware_id},
-        "client",
         PeerCredentials(pid=1, uid=1000, gid=1000),
         object(),  # type: ignore[arg-type]
     )
@@ -1887,7 +1854,6 @@ async def test_enable_device_inspector_suppression_requires_successful_grab(
 
     result = await manager._handle_session_request(
         {"command": "enable_device_inspector_suppression", "hardware_id": hardware_id},
-        "client",
         PeerCredentials(pid=1, uid=1000, gid=1000),
         writer,  # type: ignore[arg-type]
     )
@@ -1934,7 +1900,6 @@ async def test_enable_device_inspector_suppression_rolls_back_on_daemon_error(
 
     result = await manager._handle_session_request(
         {"command": "enable_device_inspector_suppression", "hardware_id": hardware_id},
-        "client",
         PeerCredentials(pid=1, uid=1000, gid=1000),
         writer,  # type: ignore[arg-type]
     )
@@ -1985,7 +1950,6 @@ async def test_enable_device_inspector_suppression_preserves_existing_inspector_
 
     result = await manager._handle_session_request(
         {"command": "enable_device_inspector_suppression", "hardware_id": hardware_id},
-        "client",
         PeerCredentials(pid=1, uid=1000, gid=1000),
         writer,  # type: ignore[arg-type]
     )
@@ -2038,7 +2002,6 @@ async def test_get_status_reports_effective_unlock_when_unlock_not_required(
 
     result = await manager._handle_session_request(
         {"command": "get_status"},
-        "client",
         peer,
         writer,  # type: ignore[arg-type]
     )
@@ -2062,7 +2025,6 @@ async def test_capture_commands_with_owner_return_error_on_missing_hardware_id(
 
     result = await manager._handle_session_request(
         {"command": command},
-        "client",
         peer,
         writer,
     )
@@ -2100,7 +2062,6 @@ async def test_end_capture_allows_owner_after_unlock_expiry(
 
     result = await manager._handle_session_request(
         {"command": "end_capture", "hardware_id": "1234:5678"},
-        "client",
         peer,
         writer,
     )
@@ -2130,13 +2091,11 @@ async def test_begin_capture_rejects_duplicate_for_same_hardware(
 
     first = await manager._handle_session_request(
         {"command": "begin_capture", "hardware_id": hardware_id},
-        "client",
         peer,
         writer,
     )
     second = await manager._handle_session_request(
         {"command": "begin_capture", "hardware_id": hardware_id},
-        "client",
         peer,
         writer,
     )
@@ -2176,7 +2135,6 @@ async def test_clear_captures_for_writer_ends_owned_capture_on_disconnect(
             "hardware_id": hardware_id,
             "end_on_disconnect": True,
         },
-        "client",
         peer,
         writer,
     )
@@ -2222,7 +2180,6 @@ async def test_begin_capture_for_numbered_hardware_uses_configured_paths(
 
     result = await manager._handle_session_request(
         {"command": "begin_capture", "hardware_id": hardware_id},
-        "client",
         peer,
         writer,
     )
@@ -2253,7 +2210,6 @@ async def test_begin_capture_default_lifetime_survives_request_writer_disconnect
 
     result = await manager._handle_session_request(
         {"command": "begin_capture", "hardware_id": hardware_id},
-        "client",
         peer,
         writer,
     )
@@ -2370,7 +2326,6 @@ async def test_begin_capture_with_paths_uses_configured_interfaces_when_omitted(
             "evdev_paths": ["keymasq:2dc8:3106"],
             "mode": "analog",
         },
-        "client",
         peer,
         writer,
     )
@@ -2424,7 +2379,6 @@ async def test_begin_capture_with_explicit_path_does_not_use_saved_interface(
             "hardware_id": hardware_id,
             "evdev_paths": ["/dev/input/event17"],
         },
-        "client",
         peer,
         writer,
     )
@@ -2475,7 +2429,6 @@ async def test_begin_capture_with_duplicate_logical_paths_preserves_interfaces(
             "hardware_id": hardware_id,
             "evdev_paths": ["keymasq:2dc8:3106", "keymasq:2dc8:3106"],
         },
-        "client",
         peer,
         writer,
     )
@@ -2519,7 +2472,6 @@ async def test_begin_capture_for_numbered_hardware_requires_configured_paths(
 
     result = await manager._handle_session_request(
         {"command": "begin_capture", "hardware_id": hardware_id},
-        "client",
         peer,
         writer,
     )
@@ -2551,7 +2503,6 @@ async def test_handle_session_request_create_macro_broadcasts_saved_event(
     peer = PeerCredentials(pid=1, uid=1000, gid=1000)
     result = await manager._handle_session_request(
         {"command": "create_macro", "macro": {"name": "Speedrun"}},
-        "client",
         peer,
         object(),
     )
@@ -2571,7 +2522,6 @@ async def test_handle_session_request_list_macros_reports_daemon_connection_erro
 
     result = await manager._handle_session_request(
         {"command": "list_macros"},
-        "client",
         peer,
         object(),
     )
@@ -2588,7 +2538,6 @@ async def test_handle_session_request_list_macros_does_not_mask_runtime_errors()
     with pytest.raises(RuntimeError, match="request bug"):
         await manager._handle_session_request(
             {"command": "list_macros"},
-            "client",
             peer,
             object(),
         )
@@ -2633,7 +2582,6 @@ async def test_save_recording_keeps_pending_macro_save_slot(
             "start_y": 200,
             "block_mouse_movement": True,
         },
-        "client",
         peer,
         writer,  # type: ignore[arg-type]
     )
@@ -2684,7 +2632,6 @@ async def test_save_recording_rejects_empty_sanitized_macro_name(
             "name": "!!!",
             "pending_save_token": "pending-1",
         },
-        "client",
         peer,
         writer,  # type: ignore[arg-type]
     )
@@ -2719,7 +2666,6 @@ async def test_save_recording_requires_active_unlock_owner() -> None:
             "name": "Saved",
             "pending_save_token": "pending-1",
         },
-        "client",
         peer,
         object(),
     )
@@ -2741,7 +2687,6 @@ async def test_delete_recording_slot_rejects_stale_pending_macro_save_token() ->
 
     result = await manager._handle_session_request(
         {"command": "delete_recording_slot", "pending_save_token": "stale"},
-        "client",
         peer,
         object(),
     )
@@ -2820,7 +2765,6 @@ async def test_replaced_pending_slot_rejects_previous_pending_save_token(
     ):
         result = await manager._handle_session_request(
             request,
-            "client",
             peer,
             object(),
         )
@@ -2864,7 +2808,6 @@ async def test_delete_recording_slot_keeps_state_when_daemon_delete_fails() -> N
 
     result = await manager._handle_session_request(
         {"command": "delete_recording_slot", "pending_save_token": "pending-1"},
-        "client",
         peer,
         object(),
     )
@@ -2887,7 +2830,6 @@ async def test_delete_recording_slot_clears_pending_macro_save_state() -> None:
 
     result = await manager._handle_session_request(
         {"command": "delete_recording_slot", "pending_save_token": "pending-1"},
-        "client",
         peer,
         object(),
     )
@@ -2916,7 +2858,6 @@ async def test_handle_session_request_update_macro_refreshes_runtime_bindings(
     peer = PeerCredentials(pid=1, uid=1000, gid=1000)
     result = await manager._handle_session_request(
         {"command": "update_macro", "name": "Speedrun", "macro": {"name": "Speedrun"}},
-        "client",
         peer,
         object(),
     )
@@ -2945,7 +2886,6 @@ async def test_handle_session_request_delete_macro_broadcasts_deleted_event(
     peer = PeerCredentials(pid=1, uid=1000, gid=1000)
     result = await manager._handle_session_request(
         {"command": "delete_macro", "name": "Speedrun"},
-        "client",
         peer,
         object(),
     )
@@ -2977,31 +2917,26 @@ async def test_profile_commands_cover_simple_and_error_branches(
 
     listed = await manager._handle_session_request(
         {"command": "list_profiles"},
-        "client",
         peer,
         object(),
     )
     missing = await manager._handle_session_request(
         {"command": "enable_profile"},
-        "client",
         peer,
         object(),
     )
     enabled = await manager._handle_session_request(
         {"command": "enable_profile", "profile_name": "Base"},
-        "client",
         peer,
         object(),
     )
     toggled = await manager._handle_session_request(
         {"command": "toggle_profile", "profile_name": "Base"},
-        "client",
         peer,
         object(),
     )
     ping = await manager._handle_session_request(
         {"command": "ping"},
-        "client",
         peer,
         object(),
     )
@@ -3025,13 +2960,11 @@ async def test_profile_commands_report_reload_and_release_failures() -> None:
 
     reload_result = await manager._handle_session_request(
         {"command": "reload"},
-        "client",
         peer,
         object(),
     )
     missing_release = await manager._handle_session_request(
         {"command": "release_device"},
-        "client",
         peer,
         object(),
     )
@@ -3039,7 +2972,6 @@ async def test_profile_commands_report_reload_and_release_failures() -> None:
     manager.client.send_command = AsyncMock(side_effect=OSError("daemon down"))
     unavailable_release = await manager._handle_session_request(
         {"command": "release_device", "hardware_id": "1234:5678"},
-        "client",
         peer,
         object(),
     )
@@ -3049,7 +2981,6 @@ async def test_profile_commands_report_reload_and_release_failures() -> None:
     )
     rejected_release = await manager._handle_session_request(
         {"command": "release_device", "hardware_id": "1234:5678", "immediate": False},
-        "client",
         peer,
         object(),
     )
@@ -3058,7 +2989,6 @@ async def test_profile_commands_report_reload_and_release_failures() -> None:
     manager.send_notification = Mock()  # type: ignore[method-assign]
     reevaluate = await manager._handle_session_request(
         {"command": "reevaluate_profiles"},
-        "client",
         peer,
         object(),
     )
@@ -3088,13 +3018,11 @@ async def test_settings_and_virtual_gamepad_commands_cover_success_and_unavailab
 
     virtuals = await manager._handle_session_request(
         {"command": "get_virtual_gamepads"},
-        "client",
         peer,
         object(),
     )
     settings = await manager._handle_session_request(
         {"command": "get_settings"},
-        "client",
         peer,
         object(),
     )
@@ -3103,23 +3031,18 @@ async def test_settings_and_virtual_gamepad_commands_cover_success_and_unavailab
     manager.client.send_command = AsyncMock(side_effect=OSError("daemon down"))
     virtual_unavailable = await manager._handle_session_request(
         {"command": "set_virtual_gamepads", "count": 3},
-        "client",
         peer,
         object(),
     )
     settings_unavailable = await manager._handle_session_request(
         {"command": "set_settings", "virtual_gamepad_count": 3},
-        "client",
         peer,
         object(),
     )
 
-    manager.client.send_command = AsyncMock(
-        return_value=Response(status="ok", data={"count": 4})
-    )
+    manager.client.send_command = AsyncMock(return_value=Response(status="ok", data={"count": 4}))
     settings_saved = await manager._handle_session_request(
         {"command": "set_settings", "virtual_gamepad_count": 3},
-        "client",
         peer,
         object(),
     )
@@ -3192,8 +3115,7 @@ async def test_macro_commands_cover_remaining_daemon_variants(
         {"command": "cancel_macro_playback"},
     ]
     results = [
-        await manager._handle_session_request(request, "client", peer, object())
-        for request in requests
+        await manager._handle_session_request(request, peer, object()) for request in requests
     ]
 
     assert results == [
@@ -3244,31 +3166,26 @@ async def test_macro_commands_validate_payloads_and_compile_errors(
 
     create_missing = await manager._handle_session_request(
         {"command": "create_macro"},
-        "client",
         peer,
         object(),
     )
     update_missing = await manager._handle_session_request(
         {"command": "update_macro", "name": "Demo"},
-        "client",
         peer,
         object(),
     )
     type_text_error = await manager._handle_session_request(
         {"command": "type_text", "text": "Hi"},
-        "client",
         peer,
         object(),
     )
     compact_empty = await manager._handle_session_request(
         {"command": "play_compact_macro", "tokens": []},
-        "client",
         peer,
         object(),
     )
     compact_error = await manager._handle_session_request(
         {"command": "play_compact_macro", "tokens": ["key_a"]},
-        "client",
         peer,
         object(),
     )
@@ -3290,12 +3207,12 @@ async def test_adhoc_macro_payload_reports_daemon_failures() -> None:
     }
 
     manager.client.send_command = AsyncMock(side_effect=OSError("daemon down"))
-    unavailable = await manager._handle_session_request(payload, "client", peer, object())
+    unavailable = await manager._handle_session_request(payload, peer, object())
 
     manager.client.send_command = AsyncMock(
         return_value=Response(status="error", error="play failed")
     )
-    failed = await manager._handle_session_request(payload, "client", peer, object())
+    failed = await manager._handle_session_request(payload, peer, object())
 
     assert unavailable == {"status": "error", "message": "Daemon unavailable"}
     assert failed == {"status": "error", "message": "play failed"}
@@ -3331,7 +3248,6 @@ async def test_list_devices_for_recording_coerces_include_other(
 
     result = await manager._handle_session_request(
         {"command": "list_devices_for_recording", "include_other": value},
-        "client",
         peer,
         object(),
     )
@@ -3367,19 +3283,16 @@ async def test_capture_and_diagnostics_commands_cover_remaining_branches(
 
     devices = await manager._handle_session_request(
         {"command": "list_devices_for_recording", "include_other": True},
-        "client",
         peer,
         writer,
     )
     read = await manager._handle_session_request(
         {"command": "capture_read", "hardware_id": "1234:5678"},
-        "client",
         peer,
         writer,
     )
     combo_missing = await manager._handle_session_request(
         {"command": "capture_combo"},
-        "client",
         peer,
         writer,
     )
@@ -3387,7 +3300,6 @@ async def test_capture_and_diagnostics_commands_cover_remaining_branches(
     manager.client.send_command = AsyncMock(side_effect=OSError("daemon down"))
     diagnostics_unavailable = await manager._handle_session_request(
         {"command": "set_diagnostics", "enabled": True},
-        "client",
         peer,
         writer,
     )
@@ -3402,7 +3314,6 @@ async def test_capture_and_diagnostics_commands_cover_remaining_branches(
             "interval": 2,
             "categories": ["runtime", "", "devices"],
         },
-        "client",
         peer,
         writer,
     )
@@ -3420,7 +3331,6 @@ async def test_capture_and_diagnostics_commands_cover_remaining_branches(
     )
     diagnostics_error = await manager._handle_session_request(
         {"command": "set_diagnostics"},
-        "client",
         peer,
         writer,
     )
@@ -3484,7 +3394,6 @@ async def test_capture_combo_session_command_round_trip(
 
     capture = await manager._handle_session_request(
         {"command": "capture_combo", "profile_name": "Desktop"},
-        "client",
         peer,
         writer,
     )

--- a/tests/test_appimage_packaging.py
+++ b/tests/test_appimage_packaging.py
@@ -406,10 +406,6 @@ def test_appimage_installer_writes_steamos_integration(tmp_path: Path) -> None:
     assert "unlock_required = false" in (
         fake_root / "etc/keymasq/security.toml"
     ).read_text(encoding="utf-8")
-    security_toml = (fake_root / "etc/keymasq/security.toml").read_text(encoding="utf-8")
-    assert "client = []" in security_toml
-    assert "gui = []" not in security_toml
-    assert "cli = []" not in security_toml
     record_rule = (fake_root / "etc/polkit-1/rules.d/50-keymasq-record.rules").read_text(
         encoding="utf-8"
     )

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -7,7 +7,6 @@ import pytest
 
 from keymasq.common.security import (
     SecurityPolicyError,
-    command_allowed,
     get_peer_credentials,
     load_security_policy,
     uid_allowed,
@@ -17,9 +16,6 @@ from keymasq.common.security import (
 def test_load_security_policy_defaults_when_missing(tmp_path: Path) -> None:
     policy = load_security_policy(tmp_path / "missing-security.toml")
 
-    assert command_allowed("play_macro", policy.session_command_acl, "client")
-    assert command_allowed("delete_macro", policy.session_command_acl, "client")
-    assert command_allowed("unknown_command", policy.daemon_command_acl, "session")
     assert policy.recording_unlock_required is True
     assert policy.macro_edit_requires_unlock is False
     assert policy.emergency_cancel_combo_enabled is True
@@ -58,23 +54,6 @@ def test_get_peer_credentials_logs_unexpected_socket_error(caplog) -> None:
 
     assert get_peer_credentials(_Socket()) is None
     assert "Unexpected failure reading peer credentials" in caplog.text
-
-
-def test_load_security_policy_overrides_acl(tmp_path: Path) -> None:
-    policy_path = tmp_path / "security.toml"
-    policy_path.write_text(
-        "\n".join(
-            [
-                "[session_command_acl]",
-                'client = ["!list_macros"]',
-            ]
-        )
-    )
-
-    policy = load_security_policy(policy_path)
-
-    assert not command_allowed("list_macros", policy.session_command_acl, "client")
-    assert command_allowed("play_macro", policy.session_command_acl, "client")
 
 
 def test_load_security_policy_macro_section(tmp_path: Path) -> None:
@@ -125,85 +104,6 @@ def test_load_security_policy_gui_section(tmp_path: Path) -> None:
     policy = load_security_policy(policy_path)
 
     assert policy.emergency_cancel_combo_enabled is False
-
-
-def test_allowlist_entries_are_non_blocking(tmp_path: Path) -> None:
-    policy_path = tmp_path / "security.toml"
-    policy_path.write_text(
-        "\n".join(
-            [
-                "[session_command_acl]",
-                'client = ["get_status", "play_macro"]',
-            ]
-        )
-    )
-
-    policy = load_security_policy(policy_path)
-
-    assert command_allowed("play_macro", policy.session_command_acl, "client")
-    assert command_allowed("get_status", policy.session_command_acl, "client")
-    assert command_allowed("list_profiles", policy.session_command_acl, "client")
-
-
-def test_acl_deny_prefixes_are_supported(tmp_path: Path) -> None:
-    policy_path = tmp_path / "security.toml"
-    policy_path.write_text(
-        "\n".join(
-            [
-                "[session_command_acl]",
-                'client = ["!reload", "-delete_macro", "deny:play_macro"]',
-            ]
-        )
-    )
-
-    policy = load_security_policy(policy_path)
-
-    assert not command_allowed("reload", policy.session_command_acl, "client")
-    assert not command_allowed("delete_macro", policy.session_command_acl, "client")
-    assert not command_allowed("play_macro", policy.session_command_acl, "client")
-    assert command_allowed("get_status", policy.session_command_acl, "client")
-
-
-def test_acl_unknown_client_class_does_not_inherit_other_denies() -> None:
-    acl = {"session": ["!emergency_reset"]}
-
-    assert not command_allowed("emergency_reset", acl, "session")
-    assert command_allowed("emergency_reset", acl, "unknown")
-
-
-def test_acl_explicit_wildcard_deny_blocks_all_commands(tmp_path: Path) -> None:
-    policy_path = tmp_path / "security.toml"
-    policy_path.write_text(
-        "\n".join(
-            [
-                "[session_command_acl]",
-                'client = ["!*"]',
-            ]
-        )
-    )
-
-    policy = load_security_policy(policy_path)
-
-    assert not command_allowed("play_macro", policy.session_command_acl, "client")
-    assert not command_allowed("get_active_profiles", policy.session_command_acl, "client")
-
-
-def test_default_client_acl_allows_all_commands(tmp_path: Path) -> None:
-    policy = load_security_policy(tmp_path / "missing-security.toml")
-
-    assert command_allowed("list_macros", policy.session_command_acl, "client")
-    assert command_allowed("play_macro", policy.session_command_acl, "client")
-    assert command_allowed("cancel_macro_playback", policy.session_command_acl, "client")
-    assert command_allowed("list_profiles", policy.session_command_acl, "client")
-    assert command_allowed("enable_profile", policy.session_command_acl, "client")
-    assert command_allowed("disable_profile", policy.session_command_acl, "client")
-    assert command_allowed("toggle_profile", policy.session_command_acl, "client")
-    assert command_allowed("get_macro", policy.session_command_acl, "client")
-    assert command_allowed("create_macro", policy.session_command_acl, "client")
-    assert command_allowed("update_macro", policy.session_command_acl, "client")
-    assert command_allowed("rename_macro", policy.session_command_acl, "client")
-    assert command_allowed("delete_macro", policy.session_command_acl, "client")
-    assert command_allowed("unknown_command", policy.daemon_command_acl, "session")
 
 
 def test_uid_allowlist_optional_and_enforced(tmp_path: Path) -> None:

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -116,7 +116,7 @@ def test_uid_allowlist_optional_and_enforced(tmp_path: Path) -> None:
     policy_path.write_text(
         "\n".join(
             [
-                "daemon_allowed_uids = [1000, 1001]",
+                'daemon_allowed_uids = [1000, "1001"]',
                 "session_allowed_uids = [1000]",
             ]
         )
@@ -127,3 +127,23 @@ def test_uid_allowlist_optional_and_enforced(tmp_path: Path) -> None:
     assert policy.session_allowed_uids == [1000]
     assert uid_allowed(1000, policy.daemon_allowed_uids)
     assert not uid_allowed(2000, policy.daemon_allowed_uids)
+
+
+@pytest.mark.parametrize(
+    ("setting_name", "setting_value"),
+    [
+        ("daemon_allowed_uids", '[1000, "invalid"]'),
+        ("session_allowed_uids", "[true]"),
+        ("daemon_allowed_uids", '"1000"'),
+    ],
+)
+def test_load_security_policy_rejects_malformed_uid_allowlists(
+    tmp_path: Path,
+    setting_name: str,
+    setting_value: str,
+) -> None:
+    policy_path = tmp_path / "security.toml"
+    policy_path.write_text(f"{setting_name} = {setting_value}\n")
+
+    with pytest.raises(SecurityPolicyError, match=setting_name):
+        load_security_policy(policy_path)

--- a/tests/test_socket_server.py
+++ b/tests/test_socket_server.py
@@ -348,6 +348,9 @@ class TestSocketServer:
         assert response.status == "ok"
         assert len(contexts) == 1
         assert contexts[0].connection_id == 1
+        assert contexts[0].pid == os.getpid()
+        assert contexts[0].uid == os.geteuid()
+        assert contexts[0].gid == os.getegid()
 
         writer.close()
         await writer.wait_closed()

--- a/tests/test_socket_server.py
+++ b/tests/test_socket_server.py
@@ -135,7 +135,7 @@ class TestSocketServer:
         server = SocketServer(
             str(paths.SOCKET_PATH),
             cmd_handler.handle,
-            peer_validator=lambda _peer: (False, "unknown", "denied for test"),
+            peer_validator=lambda _peer: (False, "denied for test"),
         )
         await server.start()
 
@@ -348,7 +348,6 @@ class TestSocketServer:
         assert response.status == "ok"
         assert len(contexts) == 1
         assert contexts[0].connection_id == 1
-        assert contexts[0].client_class == "session"
 
         writer.close()
         await writer.wait_closed()
@@ -495,7 +494,6 @@ class TestSocketServer:
             pid=100,
             uid=1000,
             gid=1000,
-            client_class="session",
         )
         server.clients.add(owner_writer)
         server._buffer[owner_writer] = b""


### PR DESCRIPTION
## Summary

- Remove the configurable `session_command_acl` and `daemon_command_acl` command denylists from the security policy, including their parser and enforcement paths.
- Remove the synthetic `client`/`session` client-class plumbing from session requests, daemon peer validation, client contexts, and logs.
- Make session API responses consistent now that commands cannot be selectively hidden: status always includes profile, device, window, and MPRIS state, and combo inspector snapshots no longer depend on a separate command permission.
- Remove command ACL settings and guidance from the example policy, NixOS defaults, distro/AppImage packaging, install messages, and security/install/macro documentation.
- Remove ACL-specific tests and rename the remaining session command test module around the sensitive-command authorization behavior it still covers.

Existing `session_command_acl` and `daemon_command_acl` sections are no longer read. They are accepted as unknown TOML settings and have no effect.

This does not change socket modes, peer credential checks, optional UID allowlists, daemon single-owner behavior, recording opt-in/unlock requirements, or sensitive-command owner binding.

## Testing

- `./scripts/check.sh`
  - Ruff: passed
  - Basedpyright: passed
  - Stylelint: passed
  - Pytest: 2,382 passed, 25 skipped
