### PR TITLE
Document security hardening and manual VM integration gates

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,9 +5,15 @@
 
 ## Testing
 
+VM integration suites are manual gates, not CI. Pick the required suites from
+the change-category matrix in `docs/VM_TESTING.md`.
+
 - [ ] `./scripts/check.sh`
-- [ ] Integration tests: `./scripts/integration.sh <suite>` / not run:
-- [ ] Screenshot check: `scripts/check-doc-screenshots` / not applicable:
+- [ ] Required VM suites per `docs/VM_TESTING.md` ran and passed.
+  - Suites run: `./scripts/integration.sh `
+  - Suites skipped, with reason:
+- [ ] GUI changes: `scripts/check-doc-screenshots` passed, or the regenerated
+      screenshots are part of this PR / not applicable:
 - [ ] Other testing:
 
 ## Notes

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,7 +10,7 @@ the change-category matrix in `docs/VM_TESTING.md`.
 
 - [ ] `./scripts/check.sh`
 - [ ] Required VM suites per `docs/VM_TESTING.md` ran and passed.
-  - Suites run: `./scripts/integration.sh `
+  - Suites run: `./scripts/integration.sh <suite ...>`
   - Suites skipped, with reason:
 - [ ] GUI changes: `scripts/check-doc-screenshots` passed, or the regenerated
       screenshots are part of this PR / not applicable:

--- a/.github/workflows/vm-integration.yml
+++ b/.github/workflows/vm-integration.yml
@@ -60,7 +60,7 @@ jobs:
           echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' \
             | sudo tee /etc/udev/rules.d/99-kvm-runner.rules
           sudo udevadm control --reload-rules
-          sudo udevadm trigger --name-match=kvm
+          sudo udevadm trigger --sysname-match=kvm
           ls -l /dev/kvm
 
       - name: Install Nix
@@ -76,5 +76,5 @@ jobs:
           EXTRA_ARGS: ${{ inputs.extra_args }}
         run: |
           set -euo pipefail
-          # shellcheck disable=SC2086
-          ./scripts/integration.sh "$SUITE" $EXTRA_ARGS
+          read -r -a extra_args <<< "$EXTRA_ARGS"
+          ./scripts/integration.sh "$SUITE" "${extra_args[@]}"

--- a/.github/workflows/vm-integration.yml
+++ b/.github/workflows/vm-integration.yml
@@ -1,0 +1,80 @@
+# Manual VM integration gate.
+#
+# The VM suites are deliberate manual gates before PRs, merges, and releases
+# (see docs/VM_TESTING.md). They are too resource-heavy for the regular CI
+# flow, so this workflow only runs via workflow_dispatch and must never gain
+# push or pull_request triggers. Local KVM runs remain the primary path; use
+# this when a local KVM host is unavailable.
+name: VM Integration
+
+on:
+  workflow_dispatch:
+    inputs:
+      suite:
+        description: Integration suite to run
+        type: choice
+        required: true
+        default: daemon-session
+        options:
+          - daemon-session
+          - listeners
+          - all
+          - gnome-bridge
+          - gnome
+          - kde
+          - hyprland
+          - niri
+          - xfce
+          - cosmic
+          - sway
+      extra_args:
+        description: Extra arguments for scripts/integration.sh, for example "--scenario hotplug-replug" or "--repeat 3"
+        type: string
+        required: false
+        default: ""
+
+permissions:
+  contents: read
+
+jobs:
+  vm-integration:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 300
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
+
+      - name: Free Runner Disk Space
+        run: |
+          set -euo pipefail
+          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc \
+            /usr/local/.ghcup /usr/local/share/boost "$AGENT_TOOLSDIRECTORY" || true
+          df -h /
+
+      - name: Enable KVM Access
+        run: |
+          set -euo pipefail
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' \
+            | sudo tee /etc/udev/rules.d/99-kvm-runner.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+          ls -l /dev/kvm
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@b97f05dcb019ddea06450a50ef6203d2fdc19fee # v31
+        with:
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+            system-features = nixos-test benchmark big-parallel kvm
+
+      - name: Run Integration Suite
+        env:
+          SUITE: ${{ inputs.suite }}
+          EXTRA_ARGS: ${{ inputs.extra_args }}
+        run: |
+          set -euo pipefail
+          # shellcheck disable=SC2086
+          ./scripts/integration.sh "$SUITE" $EXTRA_ARGS

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,5 +53,7 @@ compositor-aware behavior through three processes:
 
 Before handing off Python code changes, run `./scripts/check.sh`. It includes
 `ruff`, `basedpyright`, and the relevant pytest suite in the pinned Nix environment.
+`./scripts/check.sh` is the full handoff gate for agent work; nothing beyond it
+is expected.
 
 Run Python commands and tooling through `nix develop -c`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,6 +25,19 @@ ruff check keymasq tests
 basedpyright
 ```
 
+## Manual VM Test Gates
+
+The NixOS VM integration suites are manual gates before PRs, merges, and
+releases. They are intentionally not part of CI because they are too
+resource-heavy, and they will not be added to it.
+
+- Before opening a PR, run the VM suites required for your change category per
+  [docs/VM_TESTING.md](docs/VM_TESTING.md) and record them in the PR template.
+- Maintainers verify (and rerun where needed) the required suites before
+  merging, and run the full set before releases.
+- GUI changes must pass `scripts/check-doc-screenshots`, or the PR must include
+  the regenerated documentation screenshots.
+
 ## Contribution Expectations
 
 - Keep changes local unless the task genuinely requires a broader refactor.
@@ -41,7 +54,10 @@ A good pull request should include:
 - a clear summary of the problem and the change
 - any user-visible behavior changes
 - any packaging or service impact
-- tests run locally
+- tests run locally, including the required manual VM suites from
+  [docs/VM_TESTING.md](docs/VM_TESTING.md)
+- for GUI changes, a passing `scripts/check-doc-screenshots` run or the
+  regenerated screenshots in the PR
 - screenshots for GUI changes when useful
 
 ## Scope Notes

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -99,6 +99,10 @@ nix develop -c basedpyright
 
 ## Running Integration Tests
 
+The VM integration suites are manual gates before PRs, merges, and releases;
+they are intentionally not part of CI. `docs/VM_TESTING.md` defines which
+suites are required for each change category.
+
 Keymasq has two NixOS VM integration suites:
 
 - listener VM tests for compositor/window tracking under GNOME, KDE, Hyprland,
@@ -124,7 +128,8 @@ new or uncommitted VM files are included during local development. These tests
 are VM-heavy; a Linux host with KVM acceleration is strongly recommended.
 
 For detailed behavior and debugging notes, see `docs/LISTENER_VM_TESTS.md` and
-`docs/DAEMON_SESSION_INTEGRATION_TEST.md`.
+`docs/DAEMON_SESSION_INTEGRATION_TEST.md`. For the gate policy and the
+change-category matrix, see `docs/VM_TESTING.md`.
 
 ## Local Test Input Suppression
 

--- a/docs/DEPENDENCIES.md
+++ b/docs/DEPENDENCIES.md
@@ -6,11 +6,17 @@ packaging, and for development. It complements `docs/INSTALL.md` and
 
 ## Scope
 
-There are three different dependency layers in this project:
+There are four different dependency layers in this project:
 
-- Python package dependencies declared in `pyproject.toml`
-- System packages required to make those Python packages usable on a desktop
-- Feature-specific tools or desktop components that enable optional behavior
+- required Python package dependencies declared in `pyproject.toml`, plus
+  optional Python extras such as the `speedups` extra for `uvloop`
+- system packages required to make those Python packages usable on a desktop
+  (GTK4, libadwaita, introspection data, polkit)
+- packaged dependencies: what each maintained package family actually
+  installs, which may promote an optional Python package to
+  installed-by-default
+- optional compositor helpers that enable specific desktop features, such as
+  `slurp` and the GNOME Shell bridge extension
 
 If you are packaging Keymasq, check the package definitions directly:
 
@@ -36,7 +42,6 @@ Defined in `pyproject.toml` under `[project].dependencies`:
 - `PyGObject>=3.42.0`
 - `dbus-next>=0.2.3`
 - `evdev>=1.6.0`
-- `uvloop`
 - `python-xlib>=0.33`
 - `tomli-w>=1.0.0`
 
@@ -46,9 +51,28 @@ What they are used for:
 - `dbus-next`: session D-Bus access for notifications and compositor/session
   integrations
 - `evdev`: input device access, recording, capture, and remap runtime
-- `uvloop`: default `asyncio` event loop policy
 - `python-xlib`: X11 listener support, including cursor position read/write
 - `tomli-w`: writing profile, hardware, and superkey TOML files
+
+### Optional Python speedup: uvloop
+
+`uvloop` is not a required base dependency. It is declared in the `speedups`
+extra in `pyproject.toml`. When it is importable, `keymasqd` and
+`keymasq-session` install `uvloop.EventLoopPolicy` as the default `asyncio`
+policy; when it is missing or broken, they log a warning and fall back to the
+stdlib event loop. No feature is lost without it — only latency/jitter
+headroom (see `docs/PERFORMANCE.md`).
+
+Most maintained packages install it by default anyway:
+
+| Package family | uvloop |
+| -------------- | ------ |
+| Arch / AUR | hard dependency (`python-uvloop`) |
+| Debian | hard dependency (`python3-uvloop`) |
+| Fedora RPM | weak dependency (`Recommends: python3dist(uvloop)`) |
+| openSUSE RPM | weak dependency (versioned `pythonXYZ-uvloop`) |
+| AppImage / SteamOS | bundled |
+| Nix / NixOS | included in the wrapped Python environment |
 
 ### python-evdev compatibility lanes
 
@@ -163,7 +187,6 @@ Defined in `pyproject.toml` under `[project.optional-dependencies]`:
   - `pytest-cov>=5.0.0`
 - `dev`
   - `basedpyright>=1.38.2`
-  - `mypy>=1.0.0`
   - `pytest>=8.0.0`
   - `pytest-asyncio>=0.23.0`
   - `pytest-cov>=5.0.0`
@@ -174,84 +197,41 @@ run the test suite and quality checks locally.
 
 ## Packaged Runtime Dependencies
 
-This section is a quick packaging summary, not the authoritative source. The
-package manifests listed above remain authoritative.
+The package manifests are authoritative, and this document intentionally does
+not duplicate their full dependency lists. Check them directly:
 
-### Arch package
+- Arch / AUR: `PKGBUILD` and `packaging/aur/PKGBUILD` (`depends`)
+- Debian: `debian/control` (`Depends` / `Recommends` / `Suggests`)
+- Fedora / openSUSE: `packaging/rpm/build-fedora-rpm.sh` and
+  `packaging/rpm/build-opensuse-rpm.sh` (driven by
+  `packaging/rpm/metadata.env`)
+- AppImage / SteamOS: `packaging/appimage/get-dependencies.sh`
+- Nix / NixOS: `flake.nix`
 
-Defined in `PKGBUILD` under `depends`:
+Every family covers the same required core: the base Python dependencies
+above, GTK4 and libadwaita with their introspection data, polkit/pkexec,
+systemd and udev integration, and `acl` for the `setfacl`-based device access
+rules. The families differ only in how they classify the optional pieces:
 
-- `acl`
-- `slurp`
-- `python>=3.12`
-- `python-dbus-next>=0.2.3`
-- `python-evdev>=1.6.0`
-- `python-gobject>=3.42.0`
-- `python-cairo`
-- `python-uvloop`
-- `python-tomli-w>=1.0.0`
-- `python-xlib>=0.33`
-- `gtk4`
-- `libadwaita`
-- `polkit`
-- `systemd`
+| Package family | `uvloop` | `slurp` |
+| -------------- | -------- | ------- |
+| Arch / AUR | hard dependency | hard dependency |
+| Debian | hard dependency | `Recommends` |
+| Fedora RPM | `Recommends` | `Recommends` |
+| openSUSE RPM | `Recommends` | `Recommends` |
+| AppImage / SteamOS | bundled | bundled |
+| Nix / NixOS | in the wrapped Python environment | path-stamped into the build |
 
-### Debian package
+Debian additionally `Suggests: gnome-shell` for the GNOME bridge extension
+use case.
 
-Defined in `debian/control`:
+### RPM packaging notes
 
-- `acl`
-- `gir1.2-adw-1`
-- `gir1.2-gtk-4.0`
-- `pkexec`
-- `python3-dbus-next`
-- `python3-evdev`
-- `python3-gi`
-- `python3-gi-cairo`
-- `python3-tomli-w`
-- `python3-uvloop`
-- `python3-xlib`
-- `systemd`
-- `udev`
-
-Defined in `debian/control` under `Recommends`:
-
-- `slurp`
-
-Defined in `debian/control` under `Suggests`:
-
-- `gnome-shell`
-
-### Fedora / openSUSE RPM packaging
-
-Defined by `packaging/rpm/metadata.env` and the distro-specific RPM build
-scripts. Fedora additionally relies on Fedora's `%pyproject_*` macros, so it
-is built per Fedora release rather than as one cross-release RPM:
-
-- `acl`
-- `python3 >= 3.12`
-- distro-specific Python package names for:
-  - `evdev`
-  - `tomli-w`
-  - `dbus-next`
-  - `python-xlib`
-  - `PyGObject`
-  - PyGObject Cairo bindings where split from `PyGObject`
-- distro-specific GTK4 and libadwaita package names
-- `polkit`
-- `systemd`
-
-Defined in the generated RPM spec under weak dependencies:
-
-- `slurp`
-- distro-specific `uvloop` package name
-
-Verified current RPM dependency naming:
-
-- Fedora metadata uses `python3dist(uvloop)`, which is provided by
-  `python3-uvloop`
-- openSUSE metadata follows the versioned Python package pattern, for example
-  `python313-uvloop`
+Fedora relies on Fedora's `%pyproject_*` macros, so RPMs are built per Fedora
+release rather than as one cross-release RPM. Fedora resolves `uvloop`
+through `python3dist(uvloop)` metadata (provided by `python3-uvloop`);
+openSUSE follows its versioned Python package pattern, for example
+`python313-uvloop`.
 
 Keymasq keeps `uvloop` as a weak RPM dependency instead of a hard one because
 Fedora 43 does not currently expose a stable `python3-uvloop` package in the
@@ -260,25 +240,9 @@ and the runtime falls back cleanly with a warning when it is unavailable.
 
 ### Nix package and NixOS module
 
-Defined in `flake.nix`:
-
-- Python runtime packages:
-  - `dbus-next`
-  - `evdev`
-  - `tomli-w`
-  - `uvloop`
-  - `xlib`
-  - `pygobject3`
-- GUI/system libraries:
-  - `gtk4`
-  - `libadwaita`
-  - icon themes for the wrapped GUI
-- build/runtime integration:
-  - `gobject-introspection`
-  - `wrapGAppsHook4`
-- helper path stamping:
-  - `slurp` path is embedded into the build
-  - `keymasq-record` helper path is embedded into the build
+Beyond the Python environment, the Nix build wraps the GUI with
+`gobject-introspection` / `wrapGAppsHook4` and icon themes, and embeds the
+`slurp` and `keymasq-record` helper paths into the build.
 
 The NixOS module also provisions:
 

--- a/docs/PACKAGING.md
+++ b/docs/PACKAGING.md
@@ -46,6 +46,21 @@ The repository uses two packaging channels:
   artifacts to a GitHub prerelease, and do not publish to AUR or external
   repositories.
 
+## Release checklist
+
+Before tagging a stable `v*` release, run the manual VM gates from
+[VM_TESTING.md](VM_TESTING.md) in full, regardless of what changed since the
+last tag:
+
+- [ ] `./scripts/check.sh full`
+- [ ] `./scripts/integration.sh daemon-session`
+- [ ] `./scripts/integration.sh listeners`
+- [ ] `scripts/check-doc-screenshots`
+
+These suites are manual gates and are not run by CI. Prereleases should meet
+the same bar unless the prerelease exists specifically to test packaging
+changes.
+
 ## Version bump workflow
 
 Use `scripts/release-version.py` as the single entrypoint for release-version
@@ -178,10 +193,13 @@ The Python module path differs by package family:
 - Arch packages follow Arch's Python package layout
 - Nix packages install into the Nix store
 
-The runtime dependency set also includes `uvloop`. Keymasq uses it as the
+`uvloop` is an optional Python speedup declared in the `speedups` extra of
+`pyproject.toml`, not a required base dependency. Keymasq uses it as the
 default `asyncio` policy for `keymasqd` and `keymasq-session` when available,
-but those processes still fall back to the stdlib loop with a warning if the
-package is missing or broken.
+and falls back to the stdlib loop with a warning if it is missing or broken.
+Most maintained packages still install it by default (hard dependency on
+Arch and Debian, bundled in the AppImage and Nix builds, weak dependency on
+the RPM targets); see `docs/DEPENDENCIES.md`.
 
 Source-hiding udev rules call `setfacl` from the ACL utilities when hiding a
 grabbed physical gamepad source. Source builds and downstream packages must

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -79,11 +79,132 @@ In practice:
 
 `keymasqd` allows exactly one active session-side client connection at a time.
 
-- The first accepted daemon client becomes the active owner (`uid`, `pid`, `connection_id`).
+- The first daemon client connection that passes peer validation becomes the
+  active owner, identified by (`uid`, `pid`, `connection_id`).
 - Additional daemon client connections are denied while that owner is alive.
-- Ownership is released on disconnect.
+  They are closed immediately at accept time, before any command is processed.
+- Ownership is released only when the owning connection disconnects. There is
+  no takeover, transfer, or preemption path.
 
 This prevents a second local process from concurrently issuing privileged daemon commands while a legitimate session broker is connected.
+
+### First-valid-session ownership is intentional
+
+Keymasq targets single-seat desktops, and first-valid-session ownership is the
+deliberate design for that target — not a placeholder for something smarter:
+
+- Ownership is **not** bound to an "installing user". Package installation
+  cannot identify a reliable desktop owner: installs commonly run as root,
+  through configuration-management automation, inside an image build, or as
+  declarative NixOS configuration. None of those contexts name the human who
+  will sit at the machine, and several produce systems with no such user at
+  install time at all.
+- Ownership does **not** infer an "active seat". Seat/session inference
+  (logind seats, active-VT tracking, greeter sessions) is brittle across
+  display managers, fast user switching, and headless or nested sessions, and
+  would turn ownership into a moving target.
+
+On a single-seat desktop, the first allowed `keymasq-session` to connect is the
+logged-in user's broker, which is exactly the process that should own the
+daemon. For unusual shared-system installations, `daemon_allowed_uids` in
+`/etc/keymasq/security.toml` is the explicit control: it restricts which UIDs
+may connect at all, so ownership can only ever be claimed by a listed user.
+This remains the supported mechanism; do not rely on install-time or
+seat-inference behavior that Keymasq intentionally does not have.
+
+### Ownership lifecycle and cleanup
+
+When the owning connection disconnects — clean shutdown, crash, or daemon
+restart of `keymasq-session` — `keymasqd` runs disconnect cleanup before the
+next client can claim ownership:
+
+1. The runtime capture unlock held by that owner is cleared.
+2. All pending (unsaved) recordings are discarded.
+3. All grabbed input devices are released, so hardware returns to passthrough.
+
+Ownership release is then logged and the owner slot becomes free. The
+per-user `keymasq-session` broker reconnects automatically with exponential
+backoff (1 s doubling up to 30 s), reclaims ownership, and reapplies active
+profiles. A brief passthrough window between disconnect and reconnection is
+expected behavior, not a fault.
+
+### Ownership diagnostics
+
+`keymasqd` logs every ownership transition with the full owner identity
+(`uid`, `pid`, `connection`):
+
+```text
+Daemon owner claimed uid=1000 pid=1234 connection=1
+Denied client uid=1001 pid=5678 connection=2: owner already held by uid=1000 pid=1234 connection=1
+Daemon owner released uid=1000 pid=1234 connection=1
+```
+
+View them with `journalctl -u keymasqd`. The denial line identifies both the
+rejected client and the current owner, which is usually enough to find a stale
+or competing `keymasq-session` process. See the ownership section in
+[TROUBLESHOOTING.md](TROUBLESHOOTING.md) for conflict scenarios such as fast
+user switching and stale session processes.
+
+## Daemon Capability and Service Hardening
+
+`keymasqd` runs as the dedicated `keymasq` system user inside a hardened
+systemd service, with exactly one Linux capability:
+
+```ini
+NoNewPrivileges=true
+AmbientCapabilities=CAP_DAC_OVERRIDE
+CapabilityBoundingSet=CAP_DAC_OVERRIDE
+ProtectSystem=strict
+ProtectHome=true
+PrivateTmp=true
+ReadWritePaths=/run/keymasq /var/lib/keymasq
+```
+
+`CAP_DAC_OVERRIDE` is an accepted, deliberate part of the trusted runtime —
+not leftover privilege. It exists for the physical-source management and
+force-feedback passthrough design, and these are the exact operations that
+require it:
+
+- **sysfs uevent writes for source hide/restore.** Hiding or restoring a
+  grabbed physical source runs `udevadm trigger`, which writes root-owned
+  `/sys/.../uevent` files so `99-keymasq-hide-grabbed.rules` re-evaluates the
+  node. The daemon is the unprivileged `keymasq` user, so the `udevadm` child
+  relies on the inherited ambient capability. This covers per-node hide and
+  restore, hardware-level hotplug hiding, and the startup/shutdown
+  reconciliation pass (`keymasq/keymasqd/runtime/source_hiding.py`).
+- **Device permission resets on hidden nodes.** The hide rules deliberately
+  reset hidden `event*`/`js*` nodes to `root:root` mode `0600`, strip ACLs,
+  and then re-grant the `keymasq` ACL. The capability guarantees the daemon
+  keeps opening and writing those nodes across that reset, including the
+  window before the udev `RUN` ACL re-grant lands on a freshly hidden or
+  hotplugged node.
+- **Force-feedback passthrough.** Rumble proxying writes `EV_FF` uploads,
+  erases, and play events to the grabbed physical gamepad node
+  (`keymasq/keymasqd/runtime/force_feedback.py`) — which is exactly such a
+  hidden, permission-reset node while a game is running.
+
+What does **not** rely on the capability: normal input device reads and
+`/dev/uinput` access are granted through explicit ACLs (`setfacl` in
+`ExecStartPre` and `91-keymasq-acl.rules`), and the daemon's writable state
+lives in its own `RuntimeDirectory`/`StateDirectory`. Failure messages are
+distinct per mechanism, so a missing input ACL, missing uinput access, and a
+missing capability are directly distinguishable in the logs (see
+[TROUBLESHOOTING.md](TROUBLESHOOTING.md)).
+
+The containment around the capability is retained deliberately: dedicated
+service user, `NoNewPrivileges`, bounding set limited to this single
+capability, protected system and home paths, and writable directories
+restricted to `/run/keymasq` and `/var/lib/keymasq`. All maintained package
+formats (Debian, RPM, Arch/AUR, AppImage/SteamOS, NixOS module) grant this
+same minimal set; none adds any other ambient or bounding capability. The
+service files carry matching comments so the grant and its consumers stay in
+sync.
+
+A narrower design — delegating the udev trigger and hidden-node access to a
+separate root helper so the daemon itself drops the capability — remains a
+future option only. It adds IPC surface and failure modes of its own, so it
+is not worth adopting unless a concrete security or operational problem with
+the current single-capability model justifies that complexity.
 
 ## Peer Identity and ACL
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -202,6 +202,97 @@ What to verify:
 - no other input remapping tool has already grabbed the device — only one program can exclusively
   hold a device at a time
 
+### Missing CAP_DAC_OVERRIDE capability
+
+`keymasqd` needs the `CAP_DAC_OVERRIDE` capability for gamepad source
+hide/restore and force-feedback passthrough (see
+[SECURITY.md](SECURITY.md)). The shipped `keymasqd.service` grants it; a local
+override or hand-written unit that drops `AmbientCapabilities` breaks exactly
+those features while everything else keeps working.
+
+Symptoms: grabbed gamepads stay visible to games (or stay hidden after
+release), and logs show `udevadm trigger failed ... permission denied` with a
+hint pointing at this section — while remapping, macros, and grabbing work
+normally.
+
+Checks:
+
+```bash
+systemctl show keymasqd -p AmbientCapabilities -p CapabilityBoundingSet
+systemctl cat keymasqd   # look for drop-in overrides removing the capability
+```
+
+Both values should be `cap_dac_override`. If a drop-in override in
+`/etc/systemd/system/keymasqd.service.d/` clears them, remove or fix the
+override and run `systemctl daemon-reload && systemctl restart keymasqd`. Do
+not widen the set beyond `CAP_DAC_OVERRIDE`; no Keymasq feature needs more.
+
+### Daemon ownership conflicts
+
+`keymasqd` accepts exactly one `keymasq-session` connection at a time. The
+first allowed session connection becomes the daemon owner; every later client
+is rejected until the owner disconnects. See the Daemon Single-Owner Model in
+[SECURITY.md](SECURITY.md).
+
+Symptoms:
+
+- `keymasq-session` logs show it connecting to `keymasqd` and immediately
+  disconnecting, in a retry loop
+- the GUI reports no daemon connection even though `keymasqd` is running
+- `keymasqd` logs show `Denied client ... owner already held by ...`
+
+Checks:
+
+```bash
+journalctl -u keymasqd -n 100 | grep -i "owner"
+systemctl --user status keymasq-session
+```
+
+The daemon logs every ownership transition with `uid`, `pid`, and
+`connection`. The denial line names both the rejected client and the current
+owner, so the owner's `pid` tells you exactly which process is holding the
+daemon:
+
+```bash
+ps -o user,pid,cmd -p <owner_pid>
+```
+
+Common causes:
+
+**Fast user switching.** The first user's `keymasq-session` keeps daemon
+ownership while their session is still alive in the background, so the second
+user's broker is rejected and retries until the first user logs out fully.
+This is the intended single-seat behavior. Switching users without logging out
+does not hand over the daemon.
+
+**Stale session process.** A leftover `keymasq-session` from a previous
+desktop session (crashed logout, lingering user services, a manually started
+`dev-session.sh` run) still holds ownership. Identify it with the owner `pid`
+from the denial log line, then stop it:
+
+```bash
+systemctl --user stop keymasq-session   # as the user owning the stale process
+# or, for a manually started process:
+kill <owner_pid>
+```
+
+The daemon releases devices and frees ownership on that disconnect, and your
+current session's broker reconnects automatically within its retry backoff
+(at most 30 seconds).
+
+**Repeated systemd restarts.** If `keymasqd` restarts, every session broker is
+disconnected and reconnects with backoff; the first one back claims ownership.
+If `keymasq-session` restarts repeatedly (crash loop), ownership churns with
+it — check `journalctl --user -u keymasq-session` for the underlying crash
+rather than treating the ownership messages as the fault. Paired
+claim/release lines with increasing `connection` numbers are the normal trace
+of restarts, not a conflict.
+
+A short passthrough window after an owner disconnect is expected: the daemon
+clears the runtime capture unlock, discards pending recordings, and releases
+all grabbed devices before the next owner can claim, and remapping resumes
+when the session reconnects and reapplies profiles.
+
 ### Duplicate hardware cannot be identified reliably
 
 Some devices do not expose enough stable identity data for Linux to distinguish

--- a/docs/VM_TESTING.md
+++ b/docs/VM_TESTING.md
@@ -31,13 +31,13 @@ listener matrix. All VM suites want a Linux host with KVM acceleration.
 | --------------- | ------------- | -------------------- |
 | Daemon / remap runtime | `keymasq/keymasqd/**` | `daemon-session` |
 | Session broker, profiles, recording | `keymasq/session/manager/**`, `keymasq/session/*.py` | `daemon-session` |
-| Compositor listeners | `keymasq/session/listeners/**` | Listener VM test(s) for the affected compositor(s); the full `listeners` matrix for shared listener-path changes |
+| Compositor listeners | `keymasq/session/listeners/**`, `keymasq/session/wayland_protocols/**` | Listener VM test(s) for the affected compositor(s); the full `listeners` matrix for shared listener-path or Wayland-protocol changes |
 | Shared code, IPC, models | `keymasq/common/**` | `daemon-session` and the full `listeners` matrix |
 | GUI and assets | `keymasq/gui/**`, `assets/**` | `scripts/check-doc-screenshots`, or include the regenerated screenshots in the PR |
 | GNOME Shell extension | `gnome-extension/**` | `gnome-bridge` and `gnome` |
 | Nix/VM infrastructure | `flake.nix`, `flake.lock`, `nix/**` | `daemon-session` and the full `listeners` matrix |
-| Services, udev, packaging payload | `systemd/**`, `udev/**`, `sysusers.d/**`, `tmpfiles.d/**`, `polkit/**` | `daemon-session` |
-| Docs, packaging metadata, CI tooling only | `docs/**`, `packaging/**`, `.github/**`, `scripts/**` (non-runtime) | None |
+| Services, udev, packaging payload | `systemd/**`, `udev/**`, `sysusers.d/**`, `tmpfiles.d/**`, `polkit/**`, and packaged copies of these payloads (for example `packaging/appimage/assets/**`) | `daemon-session` |
+| Docs, packaging metadata, CI tooling only | `docs/**`, `.github/**`, `scripts/**` (non-runtime), and `packaging/**` metadata that does not ship service/udev payloads | None |
 
 Multi-category changes take the union of the rows they touch. If a change does
 not fit a row cleanly, treat it as shared code.

--- a/docs/VM_TESTING.md
+++ b/docs/VM_TESTING.md
@@ -37,7 +37,8 @@ listener matrix. All VM suites want a Linux host with KVM acceleration.
 | GNOME Shell extension | `gnome-extension/**` | `gnome-bridge` and `gnome` |
 | Nix/VM infrastructure | `flake.nix`, `flake.lock`, `nix/**` | `daemon-session` and the full `listeners` matrix |
 | Services, udev, packaging payload | `systemd/**`, `udev/**`, `sysusers.d/**`, `tmpfiles.d/**`, `polkit/**`, and packaged copies of these payloads (for example `packaging/appimage/assets/**`) | `daemon-session` |
-| Docs, packaging metadata, CI tooling only | `docs/**`, `.github/**`, `scripts/**` (non-runtime), and `packaging/**` metadata that does not ship service/udev payloads | None |
+| Gate harness scripts | `scripts/integration.sh`, `scripts/check-doc-screenshots`, `scripts/update-doc-screenshots` | Run the changed harness itself: `daemon-session` plus at least one listener suite for `integration.sh`; `scripts/check-doc-screenshots` for the screenshot scripts |
+| Docs, packaging metadata, unrelated tooling only | `docs/**`, `.github/**`, `scripts/**` not listed above, and `packaging/**` metadata that does not ship service/udev payloads | None |
 
 Multi-category changes take the union of the rows they touch. If a change does
 not fit a row cleanly, treat it as shared code.

--- a/docs/VM_TESTING.md
+++ b/docs/VM_TESTING.md
@@ -1,0 +1,80 @@
+# Manual VM Test Gates
+
+Keymasq's NixOS VM integration suites are deliberate manual gates. They are too
+resource-heavy for the regular CI flow, so CI does not run them and there is no
+plan to add them there. Instead, they are required manual steps at three points:
+
+- before opening a pull request (contributor)
+- before merging a pull request (maintainer)
+- before tagging a release (maintainer)
+
+The person running the gate picks the suites from the matrix below based on
+what the change touches. "Not required" never means "not allowed": run more
+when in doubt.
+
+## The suites
+
+| Suite | Command | Documented in |
+| ----- | ------- | ------------- |
+| Daemon/session runtime | `./scripts/integration.sh daemon-session` | [DAEMON_SESSION_INTEGRATION_TEST.md](DAEMON_SESSION_INTEGRATION_TEST.md) |
+| Listener VM matrix (all compositors) | `./scripts/integration.sh listeners` | [LISTENER_VM_TESTS.md](LISTENER_VM_TESTS.md) |
+| Single listener VM | `./scripts/integration.sh <gnome\|kde\|hyprland\|niri\|xfce\|cosmic\|sway\|gnome-bridge>` | [LISTENER_VM_TESTS.md](LISTENER_VM_TESTS.md) |
+| Documentation screenshots | `scripts/check-doc-screenshots` | [SCREENSHOTS.md](SCREENSHOTS.md) |
+
+List every integration shortcut with `./scripts/integration.sh --help`.
+`./scripts/integration.sh all` runs the daemon/session suite plus the full
+listener matrix. All VM suites want a Linux host with KVM acceleration.
+
+## Which suites apply to which change
+
+| Change category | Typical paths | Required manual gate |
+| --------------- | ------------- | -------------------- |
+| Daemon / remap runtime | `keymasq/keymasqd/**` | `daemon-session` |
+| Session broker, profiles, recording | `keymasq/session/manager/**`, `keymasq/session/*.py` | `daemon-session` |
+| Compositor listeners | `keymasq/session/listeners/**` | Listener VM test(s) for the affected compositor(s); the full `listeners` matrix for shared listener-path changes |
+| Shared code, IPC, models | `keymasq/common/**` | `daemon-session` and the full `listeners` matrix |
+| GUI and assets | `keymasq/gui/**`, `assets/**` | `scripts/check-doc-screenshots`, or include the regenerated screenshots in the PR |
+| GNOME Shell extension | `gnome-extension/**` | `gnome-bridge` and `gnome` |
+| Nix/VM infrastructure | `flake.nix`, `flake.lock`, `nix/**` | `daemon-session` and the full `listeners` matrix |
+| Services, udev, packaging payload | `systemd/**`, `udev/**`, `sysusers.d/**`, `tmpfiles.d/**`, `polkit/**` | `daemon-session` |
+| Docs, packaging metadata, CI tooling only | `docs/**`, `packaging/**`, `.github/**`, `scripts/**` (non-runtime) | None |
+
+Multi-category changes take the union of the rows they touch. If a change does
+not fit a row cleanly, treat it as shared code.
+
+GUI changes only need a VM runtime suite when they also change session or
+daemon behavior; the screenshot check is their dedicated gate because the
+screenshot VM boots the real daemon and session stack.
+
+## Pull request gate
+
+Before opening a PR, run the suites the matrix requires and record them in the
+PR template's Testing section. Suites that were skipped must be listed with a
+reason (for example "docs only").
+
+The merging maintainer is the second gate: verify that the recorded suites
+match the matrix for the final diff, and rerun (or run additional) suites when
+the diff grew beyond the original scope.
+
+## Release gate
+
+Before tagging a stable `v*` release, run the full set regardless of what
+changed since the last tag:
+
+```bash
+./scripts/integration.sh daemon-session
+./scripts/integration.sh listeners
+scripts/check-doc-screenshots
+```
+
+Prereleases built through the `Package` workflow's manual dispatch should meet
+the same bar unless the prerelease exists specifically to test packaging
+changes.
+
+## Optional: running the gates on GitHub
+
+The manually dispatched `VM Integration` workflow
+(`.github/workflows/vm-integration.yml`) runs the same
+`./scripts/integration.sh` suites on a GitHub-hosted runner with KVM. It only
+runs via `workflow_dispatch` and is never part of push or PR CI. Use it when a
+local KVM host is unavailable; local runs remain the primary path.

--- a/flake.nix
+++ b/flake.nix
@@ -421,7 +421,11 @@
                 Restart = "on-failure";
                 RestartSec = 5;
                 NoNewPrivileges = true;
-                # Required for udevadm trigger to write sysfs uevent files during source hide/restore.
+                # CAP_DAC_OVERRIDE, the only granted capability: udevadm
+                # trigger writes root-owned sysfs uevent files during source
+                # hide/restore, and hidden nodes reset to root:root 0600 must
+                # stay usable for grabs and force-feedback passthrough. Do not
+                # add capabilities in any variant; see docs/SECURITY.md.
                 AmbientCapabilities = [ "CAP_DAC_OVERRIDE" ];
                 CapabilityBoundingSet = [ "CAP_DAC_OVERRIDE" ];
                 ProtectSystem = "strict";

--- a/keymasq/keymasqd/permission_hints.py
+++ b/keymasq/keymasqd/permission_hints.py
@@ -17,6 +17,17 @@ UINPUT_PERMISSION_ERROR_MARKERS = (
     "not permitted",
     "access denied",
 )
+CAPABILITY_TROUBLESHOOTING_REF = (
+    "docs/TROUBLESHOOTING.md#missing-cap_dac_override-capability"
+)
+CAPABILITY_PERMISSION_HINT = (
+    "Check that keymasqd.service grants AmbientCapabilities=CAP_DAC_OVERRIDE; see "
+    f"{CAPABILITY_TROUBLESHOOTING_REF}."
+)
+CAPABILITY_PERMISSION_ERROR_MARKERS = (
+    "permission denied",
+    "operation not permitted",
+)
 
 
 def is_permission_error(exc: BaseException) -> bool:
@@ -41,6 +52,11 @@ def has_permission_hint(message: object) -> bool:
     return PERMISSION_TROUBLESHOOTING_REF in text
 
 
+def is_capability_permission_failure(stderr_text: object) -> bool:
+    text = str(stderr_text).lower()
+    return any(marker in text for marker in CAPABILITY_PERMISSION_ERROR_MARKERS)
+
+
 def input_device_permission_message(message: str) -> str:
     return _append_hint(message, INPUT_DEVICE_PERMISSION_HINT)
 
@@ -49,7 +65,20 @@ def uinput_permission_message(message: str) -> str:
     return _append_hint(message, UINPUT_PERMISSION_HINT)
 
 
-def _append_hint(message: str, hint: str) -> str:
-    if has_permission_hint(message):
+def capability_permission_message(message: str) -> str:
+    return _append_hint(
+        message,
+        CAPABILITY_PERMISSION_HINT,
+        ref=CAPABILITY_TROUBLESHOOTING_REF,
+    )
+
+
+def _append_hint(
+    message: str,
+    hint: str,
+    *,
+    ref: str = PERMISSION_TROUBLESHOOTING_REF,
+) -> str:
+    if ref in message:
         return message
     return f"{message}. {hint}"

--- a/keymasq/keymasqd/runtime/force_feedback.py
+++ b/keymasq/keymasqd/runtime/force_feedback.py
@@ -11,6 +11,11 @@ import evdev
 
 from keymasq.keymasqd.runtime.adapters import ASYNCIO_RUNTIME, AsyncioRuntimeAdapter
 
+# EV_FF passthrough writes to the grabbed physical gamepad node, which
+# 99-keymasq-hide-grabbed.rules resets to root:root 0600 while hidden. The
+# daemon's CAP_DAC_OVERRIDE (see keymasqd.service) keeps that node usable
+# across the reset, including before the udev ACL re-grant lands.
+
 log = logging.getLogger("keymasqd.force_feedback")
 _UINPUT_BEGIN_UPLOAD: Final[str] = "_uinput_begin_upload"
 _UINPUT_BEGIN_ERASE: Final[str] = "_uinput_begin_erase"

--- a/keymasq/keymasqd/runtime/source_hiding.py
+++ b/keymasq/keymasqd/runtime/source_hiding.py
@@ -7,6 +7,14 @@ from pathlib import Path
 
 from keymasq.common.devices import hardware_model_id_key
 from keymasq.common.paths import RUN_DIR
+from keymasq.keymasqd.permission_hints import (
+    capability_permission_message,
+    is_capability_permission_failure,
+)
+
+# `udevadm trigger` writes root-owned sysfs uevent files, so hide/restore
+# depends on the ambient CAP_DAC_OVERRIDE granted by keymasqd.service; without
+# it every trigger fails with a sysfs permission error.
 
 log = logging.getLogger("keymasqd.source_hiding")
 
@@ -332,12 +340,13 @@ async def _run_udevadm(args: Sequence[str], *, timeout_s: float, context: str) -
 
     if process.returncode != 0:
         stderr_text = stderr.decode(errors="replace").strip() if stderr else ""
-        log.warning(
-            "udevadm trigger failed for %s: returncode=%s stderr=%s",
-            context,
-            process.returncode,
-            stderr_text,
+        message = (
+            f"udevadm trigger failed for {context}: "
+            f"returncode={process.returncode} stderr={stderr_text}"
         )
+        if is_capability_permission_failure(stderr_text):
+            message = capability_permission_message(message)
+        log.warning("%s", message)
         return False
     return True
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -89,6 +89,7 @@ plugins:
 #   - LISTENER_VM_TESTS.md
 #   - PACKAGING.md
 #   - SCREENSHOTS.md
+#   - VM_TESTING.md
 #   - WAYLAND_PROTOCOL_TRACKERS.md
 # They stay in the repo; just not linked from nav.
 nav:

--- a/packaging/appimage/assets/keymasqd.service
+++ b/packaging/appimage/assets/keymasqd.service
@@ -19,7 +19,10 @@ RestartSec=5
 KillMode=mixed
 
 NoNewPrivileges=true
-# Required for udevadm trigger to write sysfs uevent files during source hide/restore.
+# CAP_DAC_OVERRIDE, the only granted capability: udevadm trigger writes
+# root-owned sysfs uevent files during source hide/restore, and hidden nodes
+# reset to root:root 0600 must stay usable for grabs and force-feedback
+# passthrough. Do not add capabilities in any variant; see docs/SECURITY.md.
 AmbientCapabilities=CAP_DAC_OVERRIDE
 CapabilityBoundingSet=CAP_DAC_OVERRIDE
 ProtectSystem=strict

--- a/systemd/keymasqd.service
+++ b/systemd/keymasqd.service
@@ -20,7 +20,10 @@ RestartSec=5
 
 # Security hardening
 NoNewPrivileges=true
-# Required for udevadm trigger to write sysfs uevent files during source hide/restore.
+# CAP_DAC_OVERRIDE, the only granted capability: udevadm trigger writes
+# root-owned sysfs uevent files during source hide/restore, and hidden nodes
+# reset to root:root 0600 must stay usable for grabs and force-feedback
+# passthrough. Do not add capabilities in any variant; see docs/SECURITY.md.
 AmbientCapabilities=CAP_DAC_OVERRIDE
 CapabilityBoundingSet=CAP_DAC_OVERRIDE
 ProtectSystem=strict

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -295,6 +295,7 @@ _SESSION_ROOT_TEST_FILES = (
 _COMMON_ROOT_TEST_FILES = (
     "test_appimage_packaging.py",
     "test_cli_commands_helpers.py",
+    "test_dependency_metadata.py",
     "test_devices.py",
     "test_entrypoints_and_cli.py",
     "test_ipc.py",

--- a/tests/keymasqd/test_permission_hints.py
+++ b/tests/keymasqd/test_permission_hints.py
@@ -1,5 +1,8 @@
 from keymasq.keymasqd.permission_hints import (
+    CAPABILITY_PERMISSION_HINT,
     UINPUT_PERMISSION_HINT,
+    capability_permission_message,
+    is_capability_permission_failure,
     uinput_permission_message,
 )
 
@@ -19,3 +22,32 @@ def test_uinput_permission_message_does_not_duplicate_existing_hint() -> None:
     )
 
     assert message.count(UINPUT_PERMISSION_HINT) == 1
+
+
+def test_capability_permission_message_appends_hint() -> None:
+    message = capability_permission_message(
+        "udevadm trigger failed for event5: returncode=1 "
+        "stderr=Failed to write 'change' to uevent: Permission denied"
+    )
+
+    assert CAPABILITY_PERMISSION_HINT in message
+
+
+def test_capability_permission_message_does_not_duplicate_existing_hint() -> None:
+    message = capability_permission_message(
+        f"udevadm trigger failed for event5. {CAPABILITY_PERMISSION_HINT}"
+    )
+
+    assert message.count(CAPABILITY_PERMISSION_HINT) == 1
+
+
+def test_capability_hint_is_distinct_from_device_hints() -> None:
+    assert CAPABILITY_PERMISSION_HINT != UINPUT_PERMISSION_HINT
+    assert "CAP_DAC_OVERRIDE" in CAPABILITY_PERMISSION_HINT
+
+
+def test_is_capability_permission_failure_matches_permission_markers() -> None:
+    assert is_capability_permission_failure("Permission denied")
+    assert is_capability_permission_failure("Operation not permitted")
+    assert not is_capability_permission_failure("No such file or directory")
+    assert not is_capability_permission_failure("")

--- a/tests/keymasqd/test_source_hiding.py
+++ b/tests/keymasqd/test_source_hiding.py
@@ -4,6 +4,7 @@ from typing import Any
 
 import pytest
 
+from keymasq.keymasqd.permission_hints import CAPABILITY_PERMISSION_HINT
 from keymasq.keymasqd.runtime import source_hiding
 from tests.async_fakes import FakeProcess as _FakeProcess
 
@@ -125,6 +126,39 @@ async def test_hide_source_returns_written_flags_when_udev_trigger_fails(
     assert hidden_names == ["event22"]
     assert (hidden_dir / "event22").exists()
     assert "udevadm trigger failed" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_udev_permission_failure_logs_capability_hint(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    _configure_paths(monkeypatch, tmp_path)
+    _fake_udevadm(
+        monkeypatch,
+        returncode=1,
+        stderr=b"Failed to write 'change' to uevent: Permission denied",
+    )
+
+    await source_hiding.hide_source("/dev/input/event22")
+
+    assert CAPABILITY_PERMISSION_HINT in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_udev_non_permission_failure_omits_capability_hint(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    _configure_paths(monkeypatch, tmp_path)
+    _fake_udevadm(monkeypatch, returncode=1, stderr=b"device is busy")
+
+    await source_hiding.hide_source("/dev/input/event22")
+
+    assert "udevadm trigger failed" in caplog.text
+    assert CAPABILITY_PERMISSION_HINT not in caplog.text
 
 
 @pytest.mark.asyncio

--- a/tests/test_dependency_metadata.py
+++ b/tests/test_dependency_metadata.py
@@ -137,3 +137,6 @@ def test_slurp_packaging_classification_matches_docs() -> None:
         content = _read(rel_path)
         assert re.search(r"^Recommends:\s+slurp", content, flags=re.MULTILINE)
         assert not re.search(r"^Requires:\s+slurp", content, flags=re.MULTILINE)
+
+    # Nix: path-stamped into the build.
+    assert 'SLURP_PATH = "${pkgs.slurp}/bin/slurp"' in _read("flake.nix")

--- a/tests/test_dependency_metadata.py
+++ b/tests/test_dependency_metadata.py
@@ -1,0 +1,139 @@
+"""Consistency checks between dependency documentation and package manifests.
+
+These tests pin the facts that docs/DEPENDENCIES.md states about
+pyproject.toml and the maintained package families, so dependency drift
+between the manifests and the documentation fails mechanically instead of
+rotting silently.
+"""
+
+import re
+import tomllib
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _read(rel_path: str) -> str:
+    return (ROOT / rel_path).read_text(encoding="utf-8")
+
+
+def _pyproject() -> dict:
+    return tomllib.loads(_read("pyproject.toml"))
+
+
+def _doc() -> str:
+    return _read("docs/DEPENDENCIES.md")
+
+
+def _doc_section(title: str) -> str:
+    match = re.search(
+        rf"^## {re.escape(title)}\n(.*?)(?=^## |\Z)",
+        _doc(),
+        flags=re.MULTILINE | re.DOTALL,
+    )
+    assert match is not None, f"missing section '## {title}' in docs/DEPENDENCIES.md"
+    return match.group(1)
+
+
+def _plain_bullets(text: str) -> set[str]:
+    return set(re.findall(r"^- `([^`]+)`$", text, flags=re.MULTILINE))
+
+
+def test_documented_base_dependencies_match_pyproject() -> None:
+    declared = set(_pyproject()["project"]["dependencies"])
+    section = _doc_section("Base Python Runtime Dependencies")
+    listing = section.split("What they are used for:")[0]
+
+    assert _plain_bullets(listing) == declared
+
+
+def test_uvloop_is_speedups_extra_not_base_dependency() -> None:
+    project = _pyproject()["project"]
+
+    assert not any("uvloop" in dep for dep in project["dependencies"])
+    assert project["optional-dependencies"]["speedups"] == ["uvloop"]
+    assert "not a required base dependency" in _doc_section(
+        "Base Python Runtime Dependencies"
+    )
+
+
+def test_documented_extras_match_pyproject() -> None:
+    declared = _pyproject()["project"]["optional-dependencies"]
+    section = _doc_section("Development and Test Dependencies")
+
+    documented: dict[str, set[str]] = {}
+    current: str | None = None
+    for outer, inner in re.findall(
+        r"^- `([^`]+)`$|^  - `([^`]+)`$",
+        section,
+        flags=re.MULTILINE,
+    ):
+        if outer:
+            current = outer
+            documented[current] = set()
+        elif current is not None:
+            documented[current].add(inner)
+
+    assert documented == {name: set(entries) for name, entries in declared.items()}
+
+
+def test_undeclared_tools_are_not_documented() -> None:
+    declared = _pyproject()["project"]["optional-dependencies"]
+    all_entries = " ".join(entry for entries in declared.values() for entry in entries)
+
+    if "mypy" not in all_entries:
+        assert "mypy" not in _doc()
+
+
+def _pkgbuild_depends(rel_path: str) -> str:
+    match = re.search(r"^depends=\((.*?)\)", _read(rel_path), flags=re.MULTILINE | re.DOTALL)
+    assert match is not None, f"missing depends=() in {rel_path}"
+    return match.group(1)
+
+
+def _debian_field(field: str) -> str:
+    match = re.search(
+        rf"^{field}:\n((?: [^\n]+\n)+)",
+        _read("debian/control"),
+        flags=re.MULTILINE,
+    )
+    assert match is not None, f"missing {field} block in debian/control"
+    return match.group(1)
+
+
+def test_uvloop_packaging_classification_matches_docs() -> None:
+    # Arch and AUR: hard dependency.
+    assert "'python-uvloop'" in _pkgbuild_depends("PKGBUILD")
+    assert "'python-uvloop'" in _pkgbuild_depends("packaging/aur/PKGBUILD")
+
+    # Debian: hard dependency, not merely recommended.
+    assert "python3-uvloop" in _debian_field("Depends")
+    assert "python3-uvloop" not in _debian_field("Recommends")
+
+    # Fedora and openSUSE: weak dependency only.
+    fedora = _read("packaging/rpm/build-fedora-rpm.sh")
+    assert re.search(r"^Recommends:\s+python3dist\(uvloop\)", fedora, flags=re.MULTILINE)
+    assert not re.search(r"^Requires:.*uvloop", fedora, flags=re.MULTILINE)
+    opensuse = _read("packaging/rpm/build-opensuse-rpm.sh")
+    assert re.search(r"^Recommends: \$\{RPM_UVLOOP_DEP\}", opensuse, flags=re.MULTILINE)
+    assert not re.search(r"^Requires:.*UVLOOP", opensuse, flags=re.MULTILINE)
+
+    # AppImage: bundled. Nix: part of the wrapped Python environment.
+    assert "python-uvloop" in _read("packaging/appimage/get-dependencies.sh")
+    assert re.search(r"^\s+uvloop$", _read("flake.nix"), flags=re.MULTILINE)
+
+
+def test_slurp_packaging_classification_matches_docs() -> None:
+    assert "'slurp'" in _pkgbuild_depends("PKGBUILD")
+    assert "'slurp'" in _pkgbuild_depends("packaging/aur/PKGBUILD")
+
+    assert "slurp" in _debian_field("Recommends")
+    assert "slurp" not in _debian_field("Depends")
+
+    for rel_path in (
+        "packaging/rpm/build-fedora-rpm.sh",
+        "packaging/rpm/build-opensuse-rpm.sh",
+    ):
+        content = _read(rel_path)
+        assert re.search(r"^Recommends:\s+slurp", content, flags=re.MULTILINE)
+        assert not re.search(r"^Requires:\s+slurp", content, flags=re.MULTILINE)

--- a/udev/99-keymasq-hide-grabbed.rules
+++ b/udev/99-keymasq-hide-grabbed.rules
@@ -1,4 +1,7 @@
 # Final hide for grabbed physical gamepad sources after later input rules run.
+# Hidden nodes are reset to root:root 0600 with the keymasq ACL re-granted;
+# keymasqd's CAP_DAC_OVERRIDE (see keymasqd.service) covers the window before
+# the re-grant and lets `udevadm trigger` re-evaluate these rules.
 
 ACTION=="add|change", SUBSYSTEM=="input", KERNEL=="event*", TEST=="/run/keymasq/hidden/%k", ENV{ID_INPUT_JOYSTICK}="", ENV{LIBINPUT_IGNORE_DEVICE}="1", TAG-="uaccess", OWNER="root", GROUP="root", MODE="0600", RUN+="/usr/bin/setfacl -b /dev/input/%k", RUN+="/usr/bin/chmod 0600 /dev/input/%k", RUN+="/usr/bin/setfacl -m u:keymasq:rw /dev/input/%k"
 ACTION=="add|change", SUBSYSTEM=="input", KERNEL=="js*",    TEST=="/run/keymasq/hidden/%k", ENV{ID_INPUT_JOYSTICK}="", ENV{LIBINPUT_IGNORE_DEVICE}="1", TAG-="uaccess", OWNER="root", GROUP="root", MODE="0600", RUN+="/usr/bin/setfacl -b /dev/input/%k", RUN+="/usr/bin/chmod 0600 /dev/input/%k", RUN+="/usr/bin/setfacl -m u:keymasq:rw /dev/input/%k"


### PR DESCRIPTION
## Summary

Documentation, diagnostics, and process work in four areas. No functional runtime behavior changes except one improved log message.

**Manual VM test gates formalized**
- New `docs/VM_TESTING.md`: VM integration suites are deliberate manual gates before PRs, merges, and releases (not CI), with a change-category → required-suite matrix and a suite reference.
- PR template now records which VM suites ran/were skipped; GUI changes require `scripts/check-doc-screenshots` or regenerated screenshots.
- `CONTRIBUTING.md` gains a manual-gates section; `DEVELOPMENT.md` links the policy; `docs/PACKAGING.md` gains a pre-tag release checklist (full `daemon-session` + `listeners` + screenshot check).
- Optional `workflow_dispatch`-only `VM Integration` workflow for running suites on a GitHub runner with KVM (never triggered by push/PR; untested end-to-end so far).
- `AGENTS.md` states `./scripts/check.sh` is the full agent handoff gate, keeping coding agents away from the heavy VM suites.

**Daemon single-owner model documented**
- `docs/SECURITY.md`: first-valid-session ownership is the intentional single-seat design — explicitly no "installing user" binding and no active-seat inference; `daemon_allowed_uids` stays the control for shared systems. Documents accept-time denial of later clients, disconnect cleanup order (runtime unlock → pending recordings → device release), session reconnect backoff, and the claim/deny/release log lines (already containing uid/pid/connection — no code change needed).
- `docs/TROUBLESHOOTING.md`: new ownership-conflicts section covering fast user switching, stale session processes, and systemd restart churn.

**CAP_DAC_OVERRIDE documented and made diagnosable**
- `docs/SECURITY.md`: new capability/hardening section documenting the exact consumers (udevadm sysfs uevent writes for source hide/restore; hidden nodes reset to root:root 0600 staying usable for grabs and force-feedback passthrough), the retained containment, and the narrower-helper design as a future option only.
- Concise cross-referencing comments in `systemd/keymasqd.service`, the AppImage unit, the NixOS module, `99-keymasq-hide-grabbed.rules`, `source_hiding.py`, and `force_feedback.py`.
- New distinct capability-failure hint: `_run_udevadm` appends a CAP_DAC_OVERRIDE hint on permission-denied stderr, keeping input-ACL, uinput, and capability failures distinguishable; matching troubleshooting section.
- Verified all package families grant the identical single-capability set.

**Dependency documentation drift corrected**
- `uvloop` documented as the optional `speedups` extra (with per-family classification: hard dep on Arch/Debian, weak dep on RPMs, bundled in AppImage/Nix); stale `mypy` removed from the documented dev extra; duplicated per-package dependency lists replaced with manifest references plus a classification table.
- New `tests/test_dependency_metadata.py` pins these facts mechanically against `pyproject.toml`, `PKGBUILD`s, `debian/control`, both RPM build scripts, the AppImage dependency script, and `flake.nix`.

## Testing

- [x] `./scripts/check.sh` — full category: 2403 passed, 25 skipped
- [x] Required VM suites per `docs/VM_TESTING.md` ran and passed.
  - Suites run: none
  - Suites skipped, with reason: docs/diagnostics-only change; no runtime behavior change beyond log message wording (docs-only row of the matrix)
- [x] GUI changes: not applicable
- [ ] Other testing: `vm-integration.yml` workflow not yet exercised on a hosted runner

## Notes

- packaging impact: comment-only edits to the systemd units, NixOS module, and udev rules; no dependency or payload changes
- service or security impact: none functional — security *documentation* and failure diagnostics only; capability set, ownership behavior, and ACLs unchanged
- GUI impact: none
