### PR TITLE
Persist GUI selected profile across restarts

### DIFF
--- a/docs/PROFILES.md
+++ b/docs/PROFILES.md
@@ -297,6 +297,8 @@ In the GUI:
   interface count, connected count, grabbed count, and selected-profile mapping count
 - `Passthrough` removes the mapping from the selected profile so lower profiles can still apply one
 - the app remembers the last selected device or combo tab and restores it on launch
+- selecting a profile in a device or combo tab remembers it and restores it
+  the next time the GUI opens
 - hardware settings are covered in [Hardware Configuration](HARDWARE.md)
 - deleting a hardware control can clear saved mappings for that control across profiles
 

--- a/keymasq/gui/preferences.py
+++ b/keymasq/gui/preferences.py
@@ -97,6 +97,24 @@ def save_selected_tab(selected_tab: str) -> None:
     _save_settings(data)
 
 
+def load_selected_profile() -> str:
+    data = _load_settings()
+    selected_profile = data.get("selected_profile")
+    if isinstance(selected_profile, str):
+        return selected_profile.strip()
+    return ""
+
+
+def save_selected_profile(selected_profile: str | None) -> None:
+    data = _load_settings()
+    cleaned = selected_profile.strip() if selected_profile is not None else ""
+    if cleaned:
+        data["selected_profile"] = cleaned
+    else:
+        data.pop("selected_profile", None)
+    _save_settings(data)
+
+
 def save_tab_layout(tab_order: list[str], hidden_tabs: set[str]) -> None:
     data = _load_settings()
     cleaned_order = _clean_string_list(tab_order)

--- a/keymasq/gui/window/core.py
+++ b/keymasq/gui/window/core.py
@@ -5,6 +5,7 @@ from collections.abc import Callable
 from keymasq.common.model.hardware import HardwareConfig
 from keymasq.gui.preferences import (
     load_hidden_tabs,
+    load_selected_profile,
     load_selected_tab,
     load_tab_order,
 )
@@ -78,7 +79,7 @@ class MainWindow(_runtime.Adw.ApplicationWindow):
         self._appearance_buttons: dict[str, _runtime.Gtk.ToggleButton] = {}
         self._syncing_appearance = False
         self._unlock_status_label: _runtime.Gtk.Label | None = None
-        self._selected_profile_name: str | None = None
+        self._selected_profile_name: str | None = load_selected_profile() or None
         self._syncing_profile_selection = False
         self._startup_probe_done = False
         self._lease_claim_inflight = False

--- a/keymasq/gui/window/profiles.py
+++ b/keymasq/gui/window/profiles.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from keymasq.gui.preferences import save_selected_profile
 from keymasq.gui.widgets.device_tab.tab import DeviceTab
 from keymasq.gui.widgets.profile_managed_tab import ProfileManagedTab
 from keymasq.session.profile.manager import ProfileManager
@@ -28,6 +29,7 @@ def _sync_selected_profile_name(
         return
 
     window._selected_profile_name = profile_name
+    save_selected_profile(profile_name)
     window._syncing_profile_selection = True
     try:
         for child in tab_layout._iter_profile_tabs(window):

--- a/tests/gui/test_application_and_reload.py
+++ b/tests/gui/test_application_and_reload.py
@@ -151,20 +151,24 @@ def test_gui_preferences_warns_for_invalid_settings_toml(temp_config_dir, caplog
 
 def test_gui_tab_layout_preference_round_trips_with_appearance(temp_config_dir) -> None:
     from keymasq.gui.preferences import (
-        load_hidden_tabs,
         load_appearance_mode,
+        load_hidden_tabs,
+        load_selected_profile,
         load_selected_tab,
         load_tab_order,
         save_appearance_mode,
+        save_selected_profile,
         save_selected_tab,
         save_tab_layout,
     )
 
     assert load_tab_order() == []
     assert load_hidden_tabs() == set()
+    assert load_selected_profile() == ""
     assert load_selected_tab() == ""
 
     save_appearance_mode("dark")
+    save_selected_profile(" Gaming ")
     save_selected_tab(" 1234:5678 ")
     save_tab_layout(
         [" device:2222:0002 ", "combos", "device:1111:0001", "combos", ""],
@@ -172,6 +176,7 @@ def test_gui_tab_layout_preference_round_trips_with_appearance(temp_config_dir) 
     )
 
     assert load_appearance_mode() == "dark"
+    assert load_selected_profile() == "Gaming"
     assert load_selected_tab() == "1234:5678"
     assert load_tab_order() == ["device:2222:0002", "combos", "device:1111:0001"]
     assert load_hidden_tabs() == {"combos"}

--- a/tests/gui/test_combo_tab_widget.py
+++ b/tests/gui/test_combo_tab_widget.py
@@ -63,6 +63,7 @@ class TestComboTabWidget:
     def test_combo_tab_profile_selection_syncs_back_to_device_tabs(self, temp_config_dir):
         from keymasq.common.model.hardware import ButtonDefinition, HardwareConfig
         from keymasq.common.model.profiles import DeviceProfileLayer, ProfileConfig
+        from keymasq.gui.preferences import load_selected_profile
         from keymasq.gui.window.core import MainWindow
 
         window = MainWindow(demo_mode=True)
@@ -100,6 +101,7 @@ class TestComboTabWidget:
         )
 
         assert window._selected_profile_name == "Gaming"
+        assert load_selected_profile() == "Gaming"
         assert tab._selected_profile is not None
         assert tab._selected_profile.config.name == "Gaming"
 

--- a/tests/gui/test_main_window.py
+++ b/tests/gui/test_main_window.py
@@ -18,6 +18,62 @@ from keymasq.gui.window import (
 
 
 class TestMainWindow:
+    def test_main_window_restores_selected_profile(self, temp_config_dir):
+        from keymasq.common.model.hardware import ButtonDefinition, HardwareConfig
+        from keymasq.common.model.profiles import ProfileConfig
+        from keymasq.gui.preferences import save_selected_profile
+        from keymasq.gui.window.core import MainWindow
+        from keymasq.session.profile.manager import ProfileManager
+
+        profile_manager = ProfileManager()
+        profile_manager.save_profile(
+            ProfileConfig(name="Alpha", enabled=True, is_permanent=True)
+        )
+        profile_manager.save_profile(
+            ProfileConfig(name="Gaming", enabled=True, is_permanent=True)
+        )
+        save_selected_profile("Gaming")
+
+        window = MainWindow(demo_mode=True)
+        device = HardwareConfig(
+            vendor_id="1234",
+            product_id="5678",
+            name="Mouse One",
+            evdev_devices=[],
+            buttons=[ButtonDefinition(id="btn_back", label="Back", evdev="btn_side")],
+        )
+        device_tabs._add_device_tab(window, device)
+        device_tab = tab_layout._child_for_hardware_id(window, device.hardware_id)
+
+        assert window._selected_profile_name == "Gaming"
+        assert window.combo_tab is not None
+        assert window.combo_tab.selected_profile_name() == "Gaming"
+        assert device_tab.selected_profile_name() == "Gaming"
+
+    def test_main_window_missing_selected_profile_falls_back_to_first(
+        self, temp_config_dir
+    ):
+        from keymasq.common.model.profiles import ProfileConfig
+        from keymasq.gui.preferences import load_selected_profile, save_selected_profile
+        from keymasq.gui.window.core import MainWindow
+        from keymasq.session.profile.manager import ProfileManager
+
+        profile_manager = ProfileManager()
+        profile_manager.save_profile(
+            ProfileConfig(name="Zulu", enabled=True, is_permanent=True)
+        )
+        profile_manager.save_profile(
+            ProfileConfig(name="Alpha", enabled=True, is_permanent=True)
+        )
+        save_selected_profile("Missing")
+
+        window = MainWindow(demo_mode=True)
+
+        assert window._selected_profile_name == "Alpha"
+        assert window.combo_tab is not None
+        assert window.combo_tab.selected_profile_name() == "Alpha"
+        assert load_selected_profile() == "Alpha"
+
     def test_main_window_does_not_seed_default_profile_for_first_device(self, temp_config_dir):
         from keymasq.common.model.hardware import ButtonDefinition, HardwareConfig
         from keymasq.gui.window.core import MainWindow
@@ -373,6 +429,7 @@ class TestMainWindow:
     def test_main_window_syncs_manual_profile_selection_across_tabs(self, temp_config_dir):
         from keymasq.common.model.hardware import ButtonDefinition, HardwareConfig
         from keymasq.common.model.profiles import DeviceProfileLayer, ProfileConfig
+        from keymasq.gui.preferences import load_selected_profile
         from keymasq.gui.window.core import MainWindow
 
         window = MainWindow(demo_mode=True)
@@ -423,6 +480,7 @@ class TestMainWindow:
         tab1.profile_dropdown.set_selected(tab1._profile_names.index("Desktop"))
 
         assert window._selected_profile_name == "Desktop"
+        assert load_selected_profile() == "Desktop"
         assert tab1._selected_profile is not None
         assert tab1._selected_profile.config.name == "Desktop"
         assert tab2._selected_profile is not None


### PR DESCRIPTION
## Summary
- Save the last selected profile name in GUI preferences when the user changes it
- Restore that profile on MainWindow startup for device and combo tabs
- Fall back to the first available profile (and update prefs) if the saved name is missing
- Document the behavior in `docs/PROFILES.md`

## Testing
- `tests/gui/test_main_window.py`: restore selected profile; missing profile falls back to first
- `tests/gui/test_application_and_reload.py`: preference load/save round-trip for `selected_profile`
- `tests/gui/test_combo_tab_widget.py` / main window sync tests: selection writes preferences