### PR TITLE
Fix critical lifecycle rollbacks for captures, mappings, and daemon disconnect

### DIFF
--- a/keymasq/keymasqd/capture_manager.py
+++ b/keymasq/keymasqd/capture_manager.py
@@ -324,6 +324,14 @@ class CaptureManager:
         log.info("Ended capture %s hardware_id=%s", token, session.hardware_id)
         return {"status": "ok", "ended": True}
 
+    def end_all(self) -> int:
+        """End every capture owned by the connected session client."""
+
+        tokens = list(self._sessions)
+        for token in tokens:
+            self.end(token)
+        return len(tokens)
+
     def _start_combo_reader(self, session: CaptureSession) -> None:
         if session.stop_event is None or session.event_queue is None:
             return

--- a/keymasq/keymasqd/capture_manager.py
+++ b/keymasq/keymasqd/capture_manager.py
@@ -328,9 +328,16 @@ class CaptureManager:
         """End every capture owned by the connected session client."""
 
         tokens = list(self._sessions)
+        ended = 0
         for token in tokens:
-            self.end(token)
-        return len(tokens)
+            try:
+                result = self.end(token)
+            except Exception:
+                log.exception("Failed to end capture %s during global cleanup", token)
+                continue
+            if bool(result.get("ended", False)):
+                ended += 1
+        return ended
 
     def _start_combo_reader(self, session: CaptureSession) -> None:
         if session.stop_event is None or session.event_queue is None:

--- a/keymasq/keymasqd/daemon.py
+++ b/keymasq/keymasqd/daemon.py
@@ -729,6 +729,10 @@ class Daemon:
             self.recording_manager.discard_all_pending_recordings,
         )
         await self._run_async_cleanup(
+            "end active captures",
+            lambda: asyncio.to_thread(self.capture_manager.end_all),
+        )
+        await self._run_async_cleanup(
             "release all devices after client disconnect",
             self.device_manager.release_all_devices,
         )

--- a/keymasq/keymasqd/recording.py
+++ b/keymasq/keymasqd/recording.py
@@ -55,6 +55,19 @@ async def _await_cleanup(awaitable: Awaitable[object]) -> None:
     await task
 
 
+def _close_cancelled_recording_open(
+    task: asyncio.Task[_RecordingInputDevice],
+) -> None:
+    try:
+        device = task.result()
+    except (asyncio.CancelledError, OSError):
+        return
+    except Exception:
+        log.exception("Unexpected failure opening cancelled recording device")
+        return
+    _close_recording_input_device(device)
+
+
 class RecordingManager:
     def __init__(
         self,
@@ -127,8 +140,14 @@ class RecordingManager:
                 path_value = dev.get("open_path", dev.get("path"))
                 if not isinstance(path_value, str) or not path_value:
                     continue
+                open_task = asyncio.create_task(
+                    asyncio.to_thread(_open_recording_input_device, path_value)
+                )
                 try:
-                    input_dev = await asyncio.to_thread(_open_recording_input_device, path_value)
+                    input_dev = await asyncio.shield(open_task)
+                except asyncio.CancelledError:
+                    open_task.add_done_callback(_close_cancelled_recording_open)
+                    raise
                 except OSError:
                     log.debug(
                         "Failed to open extra recording device %s",

--- a/keymasq/keymasqd/recording.py
+++ b/keymasq/keymasqd/recording.py
@@ -45,6 +45,16 @@ class _RecordingInputDevice(Protocol):
     def async_read_loop(self) -> AsyncIterator[evdev.InputEvent]: ...
 
 
+async def _await_cleanup(awaitable: Awaitable[object]) -> None:
+    task = asyncio.ensure_future(awaitable)
+    while not task.done():
+        try:
+            await asyncio.shield(task)
+        except asyncio.CancelledError:
+            continue
+    await task
+
+
 class RecordingManager:
     def __init__(
         self,
@@ -160,7 +170,7 @@ class RecordingManager:
 
             return started_payload
         except BaseException:
-            await self._abort_failed_start()
+            await _await_cleanup(self._abort_failed_start())
             raise
 
     async def _abort_failed_start(self) -> None:

--- a/keymasq/keymasqd/recording.py
+++ b/keymasq/keymasqd/recording.py
@@ -108,49 +108,90 @@ class RecordingManager:
         self._include_mouse_movement = bool(include_mouse_movement)
         self._include_mouse_clicks = bool(include_mouse_clicks)
         self._recording_slot = normalize_macro_recording_slot(recording_slot)
-        extra_devices, self._record_grabbed_source_keys = _build_recording_plan(devices)
-        if start_position is not None:
-            self._spool.append(_start_mouse_move_event(*start_position))
+        try:
+            extra_devices, self._record_grabbed_source_keys = _build_recording_plan(devices)
+            if start_position is not None:
+                self._spool.append(_start_mouse_move_event(*start_position))
 
-        for dev in extra_devices:
-            path_value = dev.get("open_path", dev.get("path"))
-            if not isinstance(path_value, str) or not path_value:
-                continue
+            for dev in extra_devices:
+                path_value = dev.get("open_path", dev.get("path"))
+                if not isinstance(path_value, str) or not path_value:
+                    continue
+                try:
+                    input_dev = await asyncio.to_thread(_open_recording_input_device, path_value)
+                except OSError:
+                    log.debug(
+                        "Failed to open extra recording device %s",
+                        path_value,
+                        exc_info=True,
+                    )
+                    input_dev = None
+                except Exception:
+                    log.exception(
+                        "Unexpected failure opening extra recording device %s",
+                        path_value,
+                    )
+                    input_dev = None
+                if input_dev is None:
+                    continue
+                self._extra_devices.append(input_dev)
+                raw_classes = dev.get("device_types")
+                classes = (
+                    [str(value) for value in cast(list[object], raw_classes)]
+                    if isinstance(raw_classes, list)
+                    else None
+                )
+                primary = dev.get("device_type", "other")
+                device_types = normalize_input_classes(
+                    classes,
+                    primary if isinstance(primary, str) else "other",
+                )
+                task = asyncio.create_task(self._read_extra_device(input_dev, device_types))
+                self._monitoring_tasks.append(task)
+
+            self._progress_task = asyncio.create_task(self._monitor_progress())
+
+            started_payload: RecordingPayload = {"status": "ok"}
+            if self._recording_slot:
+                started_payload["recording_slot"] = int(self._recording_slot)
+
+            if self.broadcast_callback:
+                await self.broadcast_callback(CommandType.RECORDING_STARTED, started_payload)
+
+            return started_payload
+        except BaseException:
+            await self._abort_failed_start()
+            raise
+
+    async def _abort_failed_start(self) -> None:
+        """Discard every resource acquired by an uncommitted start transition."""
+
+        self._stopped = True
+        tasks = list(self._monitoring_tasks)
+        self._monitoring_tasks = []
+        progress_task = self._progress_task
+        self._progress_task = None
+        if progress_task is not None:
+            tasks.append(progress_task)
+        for task in tasks:
+            task.cancel()
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)
+
+        for device in self._extra_devices:
+            _close_recording_input_device(device)
+        self._extra_devices = []
+        self._record_grabbed_source_keys = set()
+        self._recording_slot = 0
+        self._start_time_us = None
+
+        spool = self._spool
+        self._spool = None
+        if spool is not None:
             try:
-                input_dev = await asyncio.to_thread(_open_recording_input_device, path_value)
-            except OSError:
-                log.debug("Failed to open extra recording device %s", path_value, exc_info=True)
-                input_dev = None
+                await spool.discard()
             except Exception:
-                log.exception("Unexpected failure opening extra recording device %s", path_value)
-                input_dev = None
-            if input_dev is None:
-                continue
-            self._extra_devices.append(input_dev)
-            raw_classes = dev.get("device_types")
-            classes = (
-                [str(value) for value in cast(list[object], raw_classes)]
-                if isinstance(raw_classes, list)
-                else None
-            )
-            primary = dev.get("device_type", "other")
-            device_types = normalize_input_classes(
-                classes,
-                primary if isinstance(primary, str) else "other",
-            )
-            task = asyncio.create_task(self._read_extra_device(input_dev, device_types))
-            self._monitoring_tasks.append(task)
-
-        self._progress_task = asyncio.create_task(self._monitor_progress())
-
-        started_payload: RecordingPayload = {"status": "ok"}
-        if self._recording_slot:
-            started_payload["recording_slot"] = int(self._recording_slot)
-
-        if self.broadcast_callback:
-            await self.broadcast_callback(CommandType.RECORDING_STARTED, started_payload)
-
-        return started_payload
+                log.exception("Failed to discard recording spool after start failure")
 
     def record_event(self, device_type: str, event: evdev.InputEvent) -> None:
         if self._stopped:

--- a/keymasq/keymasqd/runtime/grab/acquisition.py
+++ b/keymasq/keymasqd/runtime/grab/acquisition.py
@@ -74,7 +74,6 @@ async def grab_device_unlocked(
     if request.update_desired:
         persist_desired_grab(manager, request, plan, deps)
     log_grab_request(plan)
-    update_existing_devices(plan, request, deps)
     reconcile_existing_interface_releases(manager, request.hardware_id, plan, deps)
     callbacks = build_runtime_callbacks(manager, deps)
     state = GrabAcquisitionState(devices=list(plan.existing_devices))
@@ -379,7 +378,6 @@ async def finalize_grab(
 ) -> dict[str, object]:
     """Commit acquired devices, source-hiding state, and the public result payload."""
 
-    del deps  # Part of the transaction contract; finalization needs only resolved state.
     waiting_for_device = state.is_waiting_for_device(plan)
     if (
         not waiting_for_device
@@ -415,6 +413,10 @@ async def finalize_grab(
                 manager,
                 request.hardware_id,
             )
+
+    # Existing interfaces continue running their old decoding tables until all
+    # newly requested interfaces have been acquired successfully.
+    update_existing_devices(plan, request, deps)
 
     return {
         "grabbed": True,

--- a/keymasq/session/client.py
+++ b/keymasq/session/client.py
@@ -112,8 +112,8 @@ class KeymasqdClient:
         finally:
             if not cancelled:
                 self._prepare_disconnect()
-                await self._cancel_event_tasks()
                 self._disconnected_event.set()
+                await self._cancel_event_tasks()
             else:
                 self._finalize_disconnect()
 

--- a/keymasq/session/client.py
+++ b/keymasq/session/client.py
@@ -111,8 +111,11 @@ class KeymasqdClient:
             log.exception("Unexpected daemon client listen error")
         finally:
             if not cancelled:
+                self._prepare_disconnect()
                 await self._cancel_event_tasks()
-            self._finalize_disconnect()
+                self._disconnected_event.set()
+            else:
+                self._finalize_disconnect()
 
     async def wait_disconnected(self) -> None:
         await self._disconnected_event.wait()
@@ -191,10 +194,11 @@ class KeymasqdClient:
             self._event_tasks.difference_update(tasks)
 
     def _finalize_disconnect(self) -> None:
-        error = ConnectionError("Disconnected from keymasqd")
-        for future in list(self._pending_requests.values()):
-            if not future.done():
-                future.set_exception(error)
+        self._prepare_disconnect()
+        self._disconnected_event.set()
+
+    def _prepare_disconnect(self) -> None:
+        self._fail_pending_requests()
 
         writer = self.writer
         self.reader = None
@@ -209,4 +213,8 @@ class KeymasqdClient:
             except Exception:
                 log.exception("Unexpected failure closing daemon client writer after disconnect")
 
-        self._disconnected_event.set()
+    def _fail_pending_requests(self) -> None:
+        error = ConnectionError("Disconnected from keymasqd")
+        for future in list(self._pending_requests.values()):
+            if not future.done():
+                future.set_exception(error)

--- a/keymasq/session/client.py
+++ b/keymasq/session/client.py
@@ -17,8 +17,14 @@ log = logging.getLogger("keymasq-session.client")
 
 
 class KeymasqdClient:
-    def __init__(self, event_handler: Callable[[CommandType, Any], Awaitable[None]]) -> None:
+    def __init__(
+        self,
+        event_handler: Callable[[CommandType, Any], Awaitable[None]],
+        *,
+        event_preprocessor: Callable[[CommandType, Any], Any] | None = None,
+    ) -> None:
         self.event_handler = event_handler
+        self.event_preprocessor = event_preprocessor
         self.reader: asyncio.StreamReader | None = None
         self.writer: asyncio.StreamWriter | None = None
         self._buffer = b""
@@ -135,6 +141,8 @@ class KeymasqdClient:
                     log.warning("Ignoring unknown daemon event: %s", raw_command)
                     return
                 data = response.data.get("data", {})
+                if self.event_preprocessor is not None:
+                    data = self.event_preprocessor(event_type, data)
                 self._dispatch_event(event_type, data)
                 # Start immediately-ready handlers without waiting for the
                 # ordered worker to finish or blocking response ingestion.

--- a/keymasq/session/client.py
+++ b/keymasq/session/client.py
@@ -24,9 +24,11 @@ class KeymasqdClient:
         self._pending_requests: dict[str, asyncio.Future[Response]] = {}
         self._request_counter = 0
         self._listen_task: asyncio.Task[None] | None = None
+        self._event_tasks: set[asyncio.Task[None]] = set()
         self._disconnected_event = asyncio.Event()
 
     async def connect(self) -> None:
+        await self._cancel_event_tasks()
         self._disconnected_event.clear()
         self.reader, self.writer = await asyncio.open_unix_connection(str(SOCKET_PATH))
         self._listen_task = asyncio.create_task(self._listen_loop())
@@ -40,6 +42,8 @@ class KeymasqdClient:
             except asyncio.CancelledError:
                 pass
             self._listen_task = None
+
+        await self._cancel_event_tasks()
 
         if writer:
             try:
@@ -123,9 +127,47 @@ class KeymasqdClient:
                     log.warning("Ignoring unknown daemon event: %s", raw_command)
                     return
                 data = response.data.get("data", {})
-                await self.event_handler(event_type, data)
-            except Exception as e:
-                log.exception("Event handler error: %s", e)
+                self._dispatch_event(event_type, data)
+                # Let immediately-ready handlers begin without ever waiting for
+                # their completion. The reader remains free to ingest any
+                # response needed by the handler.
+                await asyncio.sleep(0)
+            except Exception as exc:
+                log.exception("Failed to dispatch daemon event: %s", exc)
+
+    def _dispatch_event(self, event_type: CommandType, data: Any) -> None:
+        task = asyncio.create_task(
+            self._run_event_handler(event_type, data),
+            name=f"keymasq-session:daemon-event:{event_type.value}",
+        )
+        self._event_tasks.add(task)
+
+        def _event_done(done: asyncio.Task[None]) -> None:
+            self._event_tasks.discard(done)
+            try:
+                exc = done.exception()
+            except asyncio.CancelledError:
+                return
+            if exc is not None:
+                log.error(
+                    "Event handler error: %s",
+                    exc,
+                    exc_info=(type(exc), exc, exc.__traceback__),
+                )
+
+        task.add_done_callback(_event_done)
+
+    async def _run_event_handler(self, event_type: CommandType, data: Any) -> None:
+        await self.event_handler(event_type, data)
+
+    async def _cancel_event_tasks(self) -> None:
+        tasks = list(self._event_tasks)
+        for task in tasks:
+            if not task.done():
+                task.cancel()
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)
+            self._event_tasks.difference_update(tasks)
 
     def _finalize_disconnect(self) -> None:
         error = ConnectionError("Disconnected from keymasqd")

--- a/keymasq/session/client.py
+++ b/keymasq/session/client.py
@@ -14,6 +14,7 @@ from keymasq.common.ipc import (
 from keymasq.common.paths import SOCKET_PATH
 
 log = logging.getLogger("keymasq-session.client")
+_MAX_PENDING_EVENTS = 256
 
 
 class KeymasqdClient:
@@ -133,6 +134,7 @@ class KeymasqdClient:
                 future.set_result(response)
 
         elif response.status == "event":
+            queue_overflow = False
             try:
                 raw_command = response.data.get("command")
                 try:
@@ -143,17 +145,25 @@ class KeymasqdClient:
                 data = response.data.get("data", {})
                 if self.event_preprocessor is not None:
                     data = self.event_preprocessor(event_type, data)
-                self._dispatch_event(event_type, data)
+                queue_overflow = not self._dispatch_event(event_type, data)
                 # Start immediately-ready handlers without waiting for the
                 # ordered worker to finish or blocking response ingestion.
                 await asyncio.sleep(0)
             except Exception as exc:
                 log.exception("Failed to dispatch daemon event: %s", exc)
+            if queue_overflow:
+                raise ConnectionError("Daemon event queue exceeded its limit")
 
-    def _dispatch_event(self, event_type: CommandType, data: Any) -> None:
+    def _dispatch_event(self, event_type: CommandType, data: Any) -> bool:
+        if len(self._event_queue) >= _MAX_PENDING_EVENTS:
+            log.error(
+                "Daemon event queue exceeded %d pending events; disconnecting",
+                _MAX_PENDING_EVENTS,
+            )
+            return False
         self._event_queue.append((event_type, data))
         if any(not task.done() for task in self._event_tasks):
-            return
+            return True
         self._event_tasks.clear()
 
         task = asyncio.create_task(
@@ -177,6 +187,7 @@ class KeymasqdClient:
                 )
 
         task.add_done_callback(_event_done)
+        return True
 
     async def _drain_event_queue(self) -> None:
         while self._event_queue:

--- a/keymasq/session/client.py
+++ b/keymasq/session/client.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+from collections import deque
 from collections.abc import Awaitable, Callable
 from typing import Any
 
@@ -25,6 +26,7 @@ class KeymasqdClient:
         self._request_counter = 0
         self._listen_task: asyncio.Task[None] | None = None
         self._event_tasks: set[asyncio.Task[None]] = set()
+        self._event_queue: deque[tuple[CommandType, Any]] = deque()
         self._disconnected_event = asyncio.Event()
 
     async def connect(self) -> None:
@@ -128,40 +130,56 @@ class KeymasqdClient:
                     return
                 data = response.data.get("data", {})
                 self._dispatch_event(event_type, data)
-                # Let immediately-ready handlers begin without ever waiting for
-                # their completion. The reader remains free to ingest any
-                # response needed by the handler.
+                # Start immediately-ready handlers without waiting for the
+                # ordered worker to finish or blocking response ingestion.
                 await asyncio.sleep(0)
             except Exception as exc:
                 log.exception("Failed to dispatch daemon event: %s", exc)
 
     def _dispatch_event(self, event_type: CommandType, data: Any) -> None:
+        self._event_queue.append((event_type, data))
+        if any(not task.done() for task in self._event_tasks):
+            return
+        self._event_tasks.clear()
+
         task = asyncio.create_task(
-            self._run_event_handler(event_type, data),
-            name=f"keymasq-session:daemon-event:{event_type.value}",
+            self._drain_event_queue(),
+            name="keymasq-session:daemon-events",
         )
         self._event_tasks.add(task)
 
         def _event_done(done: asyncio.Task[None]) -> None:
             self._event_tasks.discard(done)
+
             try:
                 exc = done.exception()
             except asyncio.CancelledError:
                 return
             if exc is not None:
                 log.error(
-                    "Event handler error: %s",
+                    "Daemon event worker error: %s",
                     exc,
                     exc_info=(type(exc), exc, exc.__traceback__),
                 )
 
         task.add_done_callback(_event_done)
 
-    async def _run_event_handler(self, event_type: CommandType, data: Any) -> None:
-        await self.event_handler(event_type, data)
+    async def _drain_event_queue(self) -> None:
+        while self._event_queue:
+            event_type, data = self._event_queue.popleft()
+            try:
+                await self.event_handler(event_type, data)
+            except Exception as exc:
+                log.error(
+                    "Event handler error: %s",
+                    exc,
+                    exc_info=(type(exc), exc, exc.__traceback__),
+                )
 
     async def _cancel_event_tasks(self) -> None:
-        tasks = list(self._event_tasks)
+        self._event_queue.clear()
+        current = asyncio.current_task()
+        tasks = [task for task in self._event_tasks if task is not current]
         for task in tasks:
             if not task.done():
                 task.cancel()

--- a/keymasq/session/client.py
+++ b/keymasq/session/client.py
@@ -82,6 +82,7 @@ class KeymasqdClient:
         if not self.reader:
             return
 
+        cancelled = False
         try:
             while True:
                 data = await self.reader.read(4096)
@@ -103,12 +104,14 @@ class KeymasqdClient:
                     await self._handle_response(response)
 
         except asyncio.CancelledError:
-            pass
+            cancelled = True
         except OSError as exc:
             log.warning("Daemon client listen I/O error: %s", exc)
         except Exception:
             log.exception("Unexpected daemon client listen error")
         finally:
+            if not cancelled:
+                await self._cancel_event_tasks()
             self._finalize_disconnect()
 
     async def wait_disconnected(self) -> None:

--- a/keymasq/session/manager/core.py
+++ b/keymasq/session/manager/core.py
@@ -88,6 +88,7 @@ class SessionManager(SessionServerMixin, ConfigWatcherMixin, DaemonConnectionMix
         self._config_reload_coalesce_until = 0.0
         self.config_watch_fd: int | None = None
         self.config_watch_watches: dict[int, Path] = {}
+        self._registered_signals: set[signal.Signals] = set()
         self.verbosity = verbosity
 
         self.profile_state = ProfileRuntimeState()
@@ -131,28 +132,29 @@ class SessionManager(SessionServerMixin, ConfigWatcherMixin, DaemonConnectionMix
 
     async def start(self) -> None:
         self.running = True
-
-        loop = asyncio.get_event_loop()
-        for sig in (signal.SIGTERM, signal.SIGINT):
-            loop.add_signal_handler(sig, self._signal_handler)
-        for sig in (signal.SIGHUP,):
-            loop.add_signal_handler(sig, self._reload_handler)
-
-        log.info("Starting keymasq-session")
-
-        await self._start_session_server()
         try:
-            await self.mpris_controller.start()
-        except MprisDBusError:
-            log.debug("MPRIS controller startup deferred", exc_info=True)
+            loop = asyncio.get_event_loop()
+            for sig in (signal.SIGTERM, signal.SIGINT):
+                loop.add_signal_handler(sig, self._signal_handler)
+                self._registered_signals.add(sig)
+            for sig in (signal.SIGHUP,):
+                loop.add_signal_handler(sig, self._reload_handler)
+                self._registered_signals.add(sig)
 
-        self.connect_task = asyncio.create_task(self.connect_loop())
-        self._start_config_watcher()
-        self.compositor_state.supervisor_task = asyncio.create_task(
-            compositor.compositor_supervisor_loop(self)
-        )
+            log.info("Starting keymasq-session")
 
-        try:
+            await self._start_session_server()
+            try:
+                await self.mpris_controller.start()
+            except MprisDBusError:
+                log.debug("MPRIS controller startup deferred", exc_info=True)
+
+            self.connect_task = asyncio.create_task(self.connect_loop())
+            self._start_config_watcher()
+            self.compositor_state.supervisor_task = asyncio.create_task(
+                compositor.compositor_supervisor_loop(self)
+            )
+
             await self._shutdown_event.wait()
         finally:
             await self.stop()
@@ -163,6 +165,14 @@ class SessionManager(SessionServerMixin, ConfigWatcherMixin, DaemonConnectionMix
 
         log.info("Stopping keymasq-session")
         self.running = False
+
+        loop = asyncio.get_event_loop()
+        for sig in self._registered_signals:
+            try:
+                loop.remove_signal_handler(sig)
+            except (NotImplementedError, RuntimeError):
+                log.debug("Failed to remove signal handler for %s", sig, exc_info=True)
+        self._registered_signals.clear()
 
         self._shutdown_event.set()
         await runtime_state.cancel_all_grab_retries(self)

--- a/keymasq/session/manager/core.py
+++ b/keymasq/session/manager/core.py
@@ -62,7 +62,13 @@ class SessionManager(SessionServerMixin, ConfigWatcherMixin, DaemonConnectionMix
         async def _client_event_handler(event_type: CommandType, data: JsonObject) -> None:
             await events.handle_event(self, event_type, data)
 
-        self.client: KeymasqdClient = KeymasqdClient(_client_event_handler)
+        def _prepare_client_event(event_type: CommandType, data: JsonObject) -> JsonObject:
+            return events.prepare_event(self, event_type, data)
+
+        self.client: KeymasqdClient = KeymasqdClient(
+            _client_event_handler,
+            event_preprocessor=_prepare_client_event,
+        )
         self.superkeys = SuperkeyManager()
         self.analog_controls = AnalogControlManager()
         self.profiles = ProfileManager(

--- a/keymasq/session/manager/events.py
+++ b/keymasq/session/manager/events.py
@@ -38,6 +38,31 @@ if TYPE_CHECKING:
     from .core import SessionManager
 
 log = logging.getLogger("keymasq-session")
+_RESOLVED_EXEC_CMD = "_keymasq_resolved_exec_cmd"
+_RESOLVED_EXEC_HARDWARE_ID = "_keymasq_resolved_exec_hardware_id"
+
+
+def prepare_event(
+    manager: "SessionManager",
+    event_type: CommandType,
+    data: JsonObject,
+) -> JsonObject:
+    """Snapshot reference-backed event data before queued handling can be delayed."""
+
+    if event_type != CommandType.ACTION_TRIGGER:
+        return data
+    exec_ref_raw = data.get("exec_ref")
+    exec_ref = coerce_int(exec_ref_raw, -1) if exec_ref_raw is not None else None
+    if exec_ref is None:
+        return data
+    binding = manager.exec_state.exec_refs.get(exec_ref)
+    if binding is None:
+        return data
+    prepared = dict(data)
+    prepared[_RESOLVED_EXEC_CMD] = binding.cmd
+    if binding.hardware_id:
+        prepared[_RESOLVED_EXEC_HARDWARE_ID] = binding.hardware_id
+    return prepared
 
 
 def create_event_task[TaskResult](
@@ -146,15 +171,28 @@ async def handle_event(
         exec_ref_raw = data.get("exec_ref")
         exec_ref = coerce_int(exec_ref_raw, -1) if exec_ref_raw is not None else None
         if exec_ref is not None:
-            binding = manager.exec_state.exec_refs.get(exec_ref)
-            if binding:
+            resolved_cmd = data.get(_RESOLVED_EXEC_CMD)
+            if isinstance(resolved_cmd, str):
                 exec_data = dict(data)
-                exec_data["cmd"] = binding.cmd
-                if binding.hardware_id:
-                    exec_data["hardware_id"] = binding.hardware_id
+                exec_data["cmd"] = resolved_cmd
+                hardware_id = data.get(_RESOLVED_EXEC_HARDWARE_ID)
+                if isinstance(hardware_id, str) and hardware_id:
+                    exec_data["hardware_id"] = hardware_id
                 create_event_task(manager, handle_exec_trigger(manager, exec_data), name="exec")
             else:
-                log.warning("Unknown exec_ref: %s", exec_ref)
+                binding = manager.exec_state.exec_refs.get(exec_ref)
+                if binding:
+                    exec_data = dict(data)
+                    exec_data["cmd"] = binding.cmd
+                    if binding.hardware_id:
+                        exec_data["hardware_id"] = binding.hardware_id
+                    create_event_task(
+                        manager,
+                        handle_exec_trigger(manager, exec_data),
+                        name="exec",
+                    )
+                else:
+                    log.warning("Unknown exec_ref: %s", exec_ref)
 
         action_type_str = str(data.get("action_type", "") or "")
         if action_type_str == "start_macro_recording":

--- a/keymasq/session/manager/events.py
+++ b/keymasq/session/manager/events.py
@@ -49,16 +49,18 @@ def prepare_event(
 ) -> JsonObject:
     """Snapshot reference-backed event data before queued handling can be delayed."""
 
+    prepared = dict(data)
+    prepared.pop(_RESOLVED_EXEC_CMD, None)
+    prepared.pop(_RESOLVED_EXEC_HARDWARE_ID, None)
     if event_type != CommandType.ACTION_TRIGGER:
-        return data
-    exec_ref_raw = data.get("exec_ref")
+        return prepared
+    exec_ref_raw = prepared.get("exec_ref")
     exec_ref = coerce_int(exec_ref_raw, -1) if exec_ref_raw is not None else None
     if exec_ref is None:
-        return data
+        return prepared
     binding = manager.exec_state.exec_refs.get(exec_ref)
     if binding is None:
-        return data
-    prepared = dict(data)
+        return prepared
     prepared[_RESOLVED_EXEC_CMD] = binding.cmd
     if binding.hardware_id:
         prepared[_RESOLVED_EXEC_HARDWARE_ID] = binding.hardware_id

--- a/keymasq/session/manager/payload/references.py
+++ b/keymasq/session/manager/payload/references.py
@@ -72,6 +72,19 @@ def retain_device(
     manager.exec_state.exec_refs.update(snapshot.bindings)
 
 
+def expose(manager: "SessionManager", snapshot: ReferenceSnapshot) -> None:
+    """Make staged refs resolvable without changing acknowledged ownership."""
+
+    manager.exec_state.exec_refs.update(snapshot.bindings)
+
+
+def discard(manager: "SessionManager", snapshot: ReferenceSnapshot) -> None:
+    """Remove refs from a rejected or failed staged command."""
+
+    for ref in snapshot.bindings:
+        manager.exec_state.exec_refs.pop(ref, None)
+
+
 def take_combos(manager: "SessionManager") -> ReferenceSnapshot:
     """Detach combo refs so a replacement can be staged until daemon acknowledgement."""
 

--- a/keymasq/session/manager/payload/references.py
+++ b/keymasq/session/manager/payload/references.py
@@ -58,6 +58,20 @@ def restore_device(
     manager.exec_state.exec_refs.update(snapshot.bindings)
 
 
+def retain_device(
+    manager: "SessionManager",
+    hardware_id: str,
+    snapshot: ReferenceSnapshot,
+) -> None:
+    """Keep refs from an accepted stale command without replacing newer refs."""
+
+    if snapshot.registered:
+        manager.exec_state.device_exec_refs.setdefault(hardware_id, set()).update(
+            snapshot.bindings
+        )
+    manager.exec_state.exec_refs.update(snapshot.bindings)
+
+
 def take_combos(manager: "SessionManager") -> ReferenceSnapshot:
     """Detach combo refs so a replacement can be staged until daemon acknowledgement."""
 
@@ -73,6 +87,13 @@ def take_combos(manager: "SessionManager") -> ReferenceSnapshot:
 
 def restore_combos(manager: "SessionManager", snapshot: ReferenceSnapshot) -> None:
     clear_combos(manager)
+    manager.exec_state.combo_exec_refs.update(snapshot.bindings)
+    manager.exec_state.exec_refs.update(snapshot.bindings)
+
+
+def retain_combos(manager: "SessionManager", snapshot: ReferenceSnapshot) -> None:
+    """Keep refs from an accepted stale command without replacing newer refs."""
+
     manager.exec_state.combo_exec_refs.update(snapshot.bindings)
     manager.exec_state.exec_refs.update(snapshot.bindings)
 

--- a/keymasq/session/manager/payload/references.py
+++ b/keymasq/session/manager/payload/references.py
@@ -1,11 +1,18 @@
 """Lifecycle for opaque command references sent to the daemon."""
 
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Literal
 
 from keymasq.session.manager.state import ExecBinding
 
 if TYPE_CHECKING:
     from keymasq.session.manager.core import SessionManager
+
+
+@dataclass(frozen=True)
+class ReferenceSnapshot:
+    bindings: dict[int, ExecBinding]
+    registered: bool = True
 
 
 def clear_device(manager: "SessionManager", hardware_id: str) -> None:
@@ -25,6 +32,49 @@ def clear_all(manager: "SessionManager") -> None:
     for hardware_id in list(manager.exec_state.device_exec_refs):
         clear_device(manager, hardware_id)
     clear_combos(manager)
+
+
+def take_device(manager: "SessionManager", hardware_id: str) -> ReferenceSnapshot:
+    """Detach one device's refs so a replacement can be staged off to the side."""
+
+    registered = hardware_id in manager.exec_state.device_exec_refs
+    refs = manager.exec_state.device_exec_refs.pop(hardware_id, set())
+    bindings = {
+        ref: binding
+        for ref in refs
+        if (binding := manager.exec_state.exec_refs.pop(ref, None)) is not None
+    }
+    return ReferenceSnapshot(bindings=bindings, registered=registered)
+
+
+def restore_device(
+    manager: "SessionManager",
+    hardware_id: str,
+    snapshot: ReferenceSnapshot,
+) -> None:
+    clear_device(manager, hardware_id)
+    if snapshot.registered:
+        manager.exec_state.device_exec_refs[hardware_id] = set(snapshot.bindings)
+    manager.exec_state.exec_refs.update(snapshot.bindings)
+
+
+def take_combos(manager: "SessionManager") -> ReferenceSnapshot:
+    """Detach combo refs so a replacement can be staged until daemon acknowledgement."""
+
+    refs = set(manager.exec_state.combo_exec_refs)
+    manager.exec_state.combo_exec_refs.clear()
+    bindings = {
+        ref: binding
+        for ref in refs
+        if (binding := manager.exec_state.exec_refs.pop(ref, None)) is not None
+    }
+    return ReferenceSnapshot(bindings=bindings)
+
+
+def restore_combos(manager: "SessionManager", snapshot: ReferenceSnapshot) -> None:
+    clear_combos(manager)
+    manager.exec_state.combo_exec_refs.update(snapshot.bindings)
+    manager.exec_state.exec_refs.update(snapshot.bindings)
 
 
 def allocate(

--- a/keymasq/session/manager/profile/application.py
+++ b/keymasq/session/manager/profile/application.py
@@ -36,6 +36,7 @@ if TYPE_CHECKING:
 
 log = logging.getLogger("keymasq-session")
 type ProfileActivationNotifier = Callable[[], None]
+_CANCEL_SETTLE_TIMEOUT_S = 11.0
 
 
 async def _send_reference_command(
@@ -48,7 +49,18 @@ async def _send_reference_command(
     try:
         return await asyncio.shield(task), False
     except asyncio.CancelledError as cancelled:
-        outcome = (await asyncio.shield(asyncio.gather(task, return_exceptions=True)))[0]
+        settled = asyncio.gather(task, return_exceptions=True)
+        try:
+            outcome = (
+                await asyncio.wait_for(
+                    asyncio.shield(settled),
+                    timeout=_CANCEL_SETTLE_TIMEOUT_S,
+                )
+            )[0]
+        except TimeoutError as timeout:
+            task.cancel()
+            await asyncio.gather(task, return_exceptions=True)
+            raise cancelled from timeout
         if isinstance(outcome, BaseException):
             raise cancelled from outcome
         return outcome, True

--- a/keymasq/session/manager/profile/application.py
+++ b/keymasq/session/manager/profile/application.py
@@ -116,6 +116,19 @@ async def _await_cleanup(awaitable: Awaitable[object]) -> None:
     await task
 
 
+async def _disconnect_after_mapping_timeout(
+    manager: "SessionManager",
+    hardware_id: str,
+) -> None:
+    try:
+        await _await_cleanup(manager.client.disconnect())
+    except asyncio.CancelledError:
+        log.warning("Daemon disconnect was cancelled after mapping timeout for %s", hardware_id)
+        raise
+    except Exception:
+        log.exception("Failed to disconnect after mapping timeout for %s", hardware_id)
+
+
 def _commit_device_references(
     manager: "SessionManager",
     hardware_id: str,
@@ -464,6 +477,12 @@ async def _send_set_mapping_command(
             raise_if_stale_profile_apply(manager, generation)
             log.error("Failed to set mapping: %s", result.error)
 
+    except TimeoutError as exc:
+        if staged_refs is not None:
+            references.retain_device(manager, hardware_id, staged_refs)
+            keep_staged_refs = True
+        await _disconnect_after_mapping_timeout(manager, hardware_id)
+        log.error("Timed out setting mapping for %s: %s", hardware_id, exc)
     except OSError as exc:
         log.error("Exception setting mapping: %s: %s", type(exc).__name__, exc)
     except Exception:
@@ -783,6 +802,13 @@ async def update_mapping(
             raise asyncio.CancelledError
         raise_if_stale_profile_apply(manager, generation)
         log.error("Failed to update mapping: %s", result.error)
+        return False
+    except TimeoutError as exc:
+        if staged_refs is not None:
+            references.retain_device(manager, hardware_id, staged_refs)
+            keep_staged_refs = True
+        await _disconnect_after_mapping_timeout(manager, hardware_id)
+        log.error("Timed out updating mapping for %s: %s", hardware_id, exc)
         return False
     except OSError as exc:
         log.error("Exception updating mapping: %s: %s", type(exc).__name__, exc)

--- a/keymasq/session/manager/profile/application.py
+++ b/keymasq/session/manager/profile/application.py
@@ -311,8 +311,17 @@ async def _send_set_mapping_command(
         len(resolved.mappings),
         resolved.active_profile_names,
     )
+    previous_refs = references.take_device(manager, hardware_id)
+    staged_refs: references.ReferenceSnapshot | None = None
     try:
-        serialized_mapping = mapping.serialize(manager, resolved, hardware_id)
+        try:
+            serialized_mapping = mapping.serialize(manager, resolved, hardware_id)
+            staged_refs = references.take_device(manager, hardware_id)
+        finally:
+            if staged_refs is None:
+                references.take_device(manager, hardware_id)
+            references.restore_device(manager, hardware_id, previous_refs)
+        assert staged_refs is not None
         log.debug("Mapping data: %s", mapping.log_view(serialized_mapping))
         raise_if_stale_profile_apply(manager, generation)
 
@@ -325,9 +334,9 @@ async def _send_set_mapping_command(
                 },
             )
         )
-        raise_if_stale_profile_apply(manager, generation)
-
         if result.status == "ok":
+            references.restore_device(manager, hardware_id, staged_refs)
+            raise_if_stale_profile_apply(manager, generation)
             manager.profile_state.last_sent_mapping_signatures[hardware_id] = (
                 mapping.signature(
                     manager,
@@ -342,6 +351,7 @@ async def _send_set_mapping_command(
             )
             notify()
         else:
+            raise_if_stale_profile_apply(manager, generation)
             log.error("Failed to set mapping: %s", result.error)
 
     except OSError as exc:
@@ -551,15 +561,23 @@ async def update_combos(
     if signature == manager.profile_state.last_sent_combo_signature:
         log.debug("Skipping unchanged combo payload")
         return
-    references.clear_combos(manager)
-    payload: list[JsonObject] = []
-    active_combos: list[ResolvedCombo] = []
-    for resolved_combo in combos:
-        combo_payload = combo.serialize(manager, resolved_combo)
-        if combo_payload is None:
-            continue
-        payload.append(combo_payload)
-        active_combos.append(resolved_combo)
+    previous_refs = references.take_combos(manager)
+    staged_refs: references.ReferenceSnapshot | None = None
+    try:
+        payload: list[JsonObject] = []
+        active_combos: list[ResolvedCombo] = []
+        for resolved_combo in combos:
+            combo_payload = combo.serialize(manager, resolved_combo)
+            if combo_payload is None:
+                continue
+            payload.append(combo_payload)
+            active_combos.append(resolved_combo)
+        staged_refs = references.take_combos(manager)
+    finally:
+        if staged_refs is None:
+            references.take_combos(manager)
+        references.restore_combos(manager, previous_refs)
+    assert staged_refs is not None
     try:
         raise_if_stale_profile_apply(manager, generation)
         result = await manager.client.send_command(
@@ -568,10 +586,12 @@ async def update_combos(
                 data={"combos": payload},
             )
         )
-        raise_if_stale_profile_apply(manager, generation)
         if result.status != "ok":
+            raise_if_stale_profile_apply(manager, generation)
             log.error("Failed to update combos: %s", result.error)
             return
+        references.restore_combos(manager, staged_refs)
+        raise_if_stale_profile_apply(manager, generation)
         manager.profile_state.last_sent_combo_signature = signature
         manager.profile_state.resolved_combos = list(active_combos)
     except OSError as exc:
@@ -597,15 +617,22 @@ async def update_mapping(
         resolved,
         hardware_id,
     )
-    references.clear_device(manager, hardware_id)
-
     log.info(
         "Updating mapping for %s with %d buttons",
         hardware_id,
         len(resolved.mappings),
     )
+    previous_refs = references.take_device(manager, hardware_id)
+    staged_refs: references.ReferenceSnapshot | None = None
     try:
-        serialized_mapping = mapping.serialize(manager, resolved, hardware_id)
+        try:
+            serialized_mapping = mapping.serialize(manager, resolved, hardware_id)
+            staged_refs = references.take_device(manager, hardware_id)
+        finally:
+            if staged_refs is None:
+                references.take_device(manager, hardware_id)
+            references.restore_device(manager, hardware_id, previous_refs)
+        assert staged_refs is not None
         raise_if_stale_profile_apply(manager, generation)
         result = await manager.client.send_command(
             Command(
@@ -616,11 +643,13 @@ async def update_mapping(
                 },
             )
         )
-        raise_if_stale_profile_apply(manager, generation)
         if result.status == "ok":
+            references.restore_device(manager, hardware_id, staged_refs)
+            raise_if_stale_profile_apply(manager, generation)
             log.info("Updated mapping for %s", hardware_id)
             manager.profile_state.last_sent_mapping_signatures[hardware_id] = signature
             return True
+        raise_if_stale_profile_apply(manager, generation)
         log.error("Failed to update mapping: %s", result.error)
         return False
     except OSError as exc:

--- a/keymasq/session/manager/profile/application.py
+++ b/keymasq/session/manager/profile/application.py
@@ -37,6 +37,14 @@ if TYPE_CHECKING:
 log = logging.getLogger("keymasq-session")
 type ProfileActivationNotifier = Callable[[], None]
 _CANCEL_SETTLE_TIMEOUT_S = 11.0
+_CANCEL_CLEANUP_TIMEOUT_S = 1.0
+
+
+def _observe_cleanup_task(task: asyncio.Future[object]) -> None:
+    try:
+        task.exception()
+    except asyncio.CancelledError:
+        pass
 
 
 async def _send_reference_command(
@@ -87,11 +95,24 @@ async def _settle_cancelled_request(
 
 async def _await_cleanup(awaitable: Awaitable[object]) -> None:
     task = asyncio.ensure_future(awaitable)
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + _CANCEL_CLEANUP_TIMEOUT_S
     while not task.done():
+        remaining = deadline - loop.time()
+        if remaining <= 0:
+            task.cancel()
+            task.add_done_callback(_observe_cleanup_task)
+            log.warning("Timed out waiting for cancellation cleanup")
+            return
         try:
-            await asyncio.shield(task)
+            await asyncio.wait_for(asyncio.shield(task), timeout=remaining)
         except asyncio.CancelledError:
             continue
+        except TimeoutError:
+            task.cancel()
+            task.add_done_callback(_observe_cleanup_task)
+            log.warning("Timed out waiting for cancellation cleanup")
+            return
     await task
 
 
@@ -657,22 +678,22 @@ async def update_combos(
     staged_refs: references.ReferenceSnapshot | None = None
     keep_staged_refs = False
     try:
-        payload: list[JsonObject] = []
-        active_combos: list[ResolvedCombo] = []
-        for resolved_combo in combos:
-            combo_payload = combo.serialize(manager, resolved_combo)
-            if combo_payload is None:
-                continue
-            payload.append(combo_payload)
-            active_combos.append(resolved_combo)
-        staged_refs = references.take_combos(manager)
-    finally:
-        if staged_refs is None:
-            references.take_combos(manager)
-        references.restore_combos(manager, previous_refs)
-    assert staged_refs is not None
-    references.expose(manager, staged_refs)
-    try:
+        try:
+            payload: list[JsonObject] = []
+            active_combos: list[ResolvedCombo] = []
+            for resolved_combo in combos:
+                combo_payload = combo.serialize(manager, resolved_combo)
+                if combo_payload is None:
+                    continue
+                payload.append(combo_payload)
+                active_combos.append(resolved_combo)
+            staged_refs = references.take_combos(manager)
+        finally:
+            if staged_refs is None:
+                references.take_combos(manager)
+            references.restore_combos(manager, previous_refs)
+        assert staged_refs is not None
+        references.expose(manager, staged_refs)
         raise_if_stale_profile_apply(manager, generation)
         result, cancelled = await _send_reference_command(
             manager,
@@ -699,7 +720,7 @@ async def update_combos(
     except Exception:
         log.exception("Unexpected failure updating combos")
     finally:
-        if not keep_staged_refs:
+        if staged_refs is not None and not keep_staged_refs:
             references.discard(manager, staged_refs)
 
 

--- a/keymasq/session/manager/profile/application.py
+++ b/keymasq/session/manager/profile/application.py
@@ -60,6 +60,7 @@ async def _send_reference_command(
         except TimeoutError as timeout:
             task.cancel()
             await asyncio.gather(task, return_exceptions=True)
+            await manager.client.disconnect()
             raise cancelled from timeout
         if isinstance(outcome, BaseException):
             raise cancelled from outcome

--- a/keymasq/session/manager/profile/application.py
+++ b/keymasq/session/manager/profile/application.py
@@ -353,6 +353,7 @@ async def _send_set_mapping_command(
     )
     previous_refs = references.take_device(manager, hardware_id)
     staged_refs: references.ReferenceSnapshot | None = None
+    keep_staged_refs = False
     try:
         try:
             serialized_mapping = mapping.serialize(manager, resolved, hardware_id)
@@ -362,6 +363,7 @@ async def _send_set_mapping_command(
                 references.take_device(manager, hardware_id)
             references.restore_device(manager, hardware_id, previous_refs)
         assert staged_refs is not None
+        references.expose(manager, staged_refs)
         log.debug("Mapping data: %s", mapping.log_view(serialized_mapping))
         raise_if_stale_profile_apply(manager, generation)
 
@@ -377,6 +379,7 @@ async def _send_set_mapping_command(
         )
         if result.status == "ok":
             _commit_device_references(manager, hardware_id, staged_refs, generation)
+            keep_staged_refs = True
             if cancelled:
                 raise asyncio.CancelledError
             raise_if_stale_profile_apply(manager, generation)
@@ -403,6 +406,9 @@ async def _send_set_mapping_command(
         log.error("Exception setting mapping: %s: %s", type(exc).__name__, exc)
     except Exception:
         log.exception("Unexpected failure setting mapping for %s", hardware_id)
+    finally:
+        if staged_refs is not None and not keep_staged_refs:
+            references.discard(manager, staged_refs)
 
 
 async def apply_resolved_device_profile(
@@ -608,6 +614,7 @@ async def update_combos(
         return
     previous_refs = references.take_combos(manager)
     staged_refs: references.ReferenceSnapshot | None = None
+    keep_staged_refs = False
     try:
         payload: list[JsonObject] = []
         active_combos: list[ResolvedCombo] = []
@@ -623,6 +630,7 @@ async def update_combos(
             references.take_combos(manager)
         references.restore_combos(manager, previous_refs)
     assert staged_refs is not None
+    references.expose(manager, staged_refs)
     try:
         raise_if_stale_profile_apply(manager, generation)
         result, cancelled = await _send_reference_command(
@@ -639,6 +647,7 @@ async def update_combos(
             log.error("Failed to update combos: %s", result.error)
             return
         _commit_combo_references(manager, staged_refs, generation)
+        keep_staged_refs = True
         if cancelled:
             raise asyncio.CancelledError
         raise_if_stale_profile_apply(manager, generation)
@@ -648,6 +657,9 @@ async def update_combos(
         log.error("Exception updating combos: %s: %s", type(exc).__name__, exc)
     except Exception:
         log.exception("Unexpected failure updating combos")
+    finally:
+        if not keep_staged_refs:
+            references.discard(manager, staged_refs)
 
 
 async def update_mapping(
@@ -674,6 +686,7 @@ async def update_mapping(
     )
     previous_refs = references.take_device(manager, hardware_id)
     staged_refs: references.ReferenceSnapshot | None = None
+    keep_staged_refs = False
     try:
         try:
             serialized_mapping = mapping.serialize(manager, resolved, hardware_id)
@@ -683,6 +696,7 @@ async def update_mapping(
                 references.take_device(manager, hardware_id)
             references.restore_device(manager, hardware_id, previous_refs)
         assert staged_refs is not None
+        references.expose(manager, staged_refs)
         raise_if_stale_profile_apply(manager, generation)
         result, cancelled = await _send_reference_command(
             manager,
@@ -696,6 +710,7 @@ async def update_mapping(
         )
         if result.status == "ok":
             _commit_device_references(manager, hardware_id, staged_refs, generation)
+            keep_staged_refs = True
             if cancelled:
                 raise asyncio.CancelledError
             raise_if_stale_profile_apply(manager, generation)
@@ -713,6 +728,9 @@ async def update_mapping(
     except Exception:
         log.exception("Unexpected failure updating mapping for %s", hardware_id)
         return False
+    finally:
+        if staged_refs is not None and not keep_staged_refs:
+            references.discard(manager, staged_refs)
 
 
 async def deactivate_profile(

--- a/keymasq/session/manager/profile/application.py
+++ b/keymasq/session/manager/profile/application.py
@@ -1,5 +1,6 @@
 """Daemon-side grab, mapping, and combo application transactions."""
 
+import asyncio
 import logging
 from collections.abc import Callable
 from dataclasses import dataclass
@@ -7,7 +8,7 @@ from enum import Enum, auto
 from typing import TYPE_CHECKING, Protocol
 
 from keymasq.common.coercion import coerce_int
-from keymasq.common.ipc import Command, CommandType
+from keymasq.common.ipc import Command, CommandType, Response
 from keymasq.session.profile.types import (
     ResolvedCombo,
     ResolvedDeviceProfile,
@@ -23,7 +24,7 @@ from .grab_plan import (
     get_interfaces_to_grab,
     grab_device_payload_signature,
 )
-from .reconciliation import raise_if_stale_profile_apply
+from .reconciliation import profile_apply_is_current, raise_if_stale_profile_apply
 from .runtime_state import (
     cancel_grab_retry,
     clear_hardware_runtime_state,
@@ -35,6 +36,42 @@ if TYPE_CHECKING:
 
 log = logging.getLogger("keymasq-session")
 type ProfileActivationNotifier = Callable[[], None]
+
+
+async def _send_reference_command(
+    manager: "SessionManager",
+    command: Command,
+) -> tuple[Response, bool]:
+    """Settle a sent reference-bearing command before propagating cancellation."""
+
+    task = asyncio.create_task(manager.client.send_command(command))
+    try:
+        return await asyncio.shield(task), False
+    except asyncio.CancelledError:
+        return await asyncio.shield(task), True
+
+
+def _commit_device_references(
+    manager: "SessionManager",
+    hardware_id: str,
+    staged_refs: references.ReferenceSnapshot,
+    generation: int | None,
+) -> None:
+    if profile_apply_is_current(manager, generation):
+        references.restore_device(manager, hardware_id, staged_refs)
+    else:
+        references.retain_device(manager, hardware_id, staged_refs)
+
+
+def _commit_combo_references(
+    manager: "SessionManager",
+    staged_refs: references.ReferenceSnapshot,
+    generation: int | None,
+) -> None:
+    if profile_apply_is_current(manager, generation):
+        references.restore_combos(manager, staged_refs)
+    else:
+        references.retain_combos(manager, staged_refs)
 
 
 class GrabRetryScheduler(Protocol):
@@ -325,7 +362,8 @@ async def _send_set_mapping_command(
         log.debug("Mapping data: %s", mapping.log_view(serialized_mapping))
         raise_if_stale_profile_apply(manager, generation)
 
-        result = await manager.client.send_command(
+        result, cancelled = await _send_reference_command(
+            manager,
             Command(
                 command=CommandType.SET_MAPPING,
                 data={
@@ -335,7 +373,9 @@ async def _send_set_mapping_command(
             )
         )
         if result.status == "ok":
-            references.restore_device(manager, hardware_id, staged_refs)
+            _commit_device_references(manager, hardware_id, staged_refs, generation)
+            if cancelled:
+                raise asyncio.CancelledError
             raise_if_stale_profile_apply(manager, generation)
             manager.profile_state.last_sent_mapping_signatures[hardware_id] = (
                 mapping.signature(
@@ -351,6 +391,8 @@ async def _send_set_mapping_command(
             )
             notify()
         else:
+            if cancelled:
+                raise asyncio.CancelledError
             raise_if_stale_profile_apply(manager, generation)
             log.error("Failed to set mapping: %s", result.error)
 
@@ -580,17 +622,22 @@ async def update_combos(
     assert staged_refs is not None
     try:
         raise_if_stale_profile_apply(manager, generation)
-        result = await manager.client.send_command(
+        result, cancelled = await _send_reference_command(
+            manager,
             Command(
                 command=CommandType.SET_COMBOS,
                 data={"combos": payload},
             )
         )
         if result.status != "ok":
+            if cancelled:
+                raise asyncio.CancelledError
             raise_if_stale_profile_apply(manager, generation)
             log.error("Failed to update combos: %s", result.error)
             return
-        references.restore_combos(manager, staged_refs)
+        _commit_combo_references(manager, staged_refs, generation)
+        if cancelled:
+            raise asyncio.CancelledError
         raise_if_stale_profile_apply(manager, generation)
         manager.profile_state.last_sent_combo_signature = signature
         manager.profile_state.resolved_combos = list(active_combos)
@@ -634,7 +681,8 @@ async def update_mapping(
             references.restore_device(manager, hardware_id, previous_refs)
         assert staged_refs is not None
         raise_if_stale_profile_apply(manager, generation)
-        result = await manager.client.send_command(
+        result, cancelled = await _send_reference_command(
+            manager,
             Command(
                 command=CommandType.SET_MAPPING,
                 data={
@@ -644,11 +692,15 @@ async def update_mapping(
             )
         )
         if result.status == "ok":
-            references.restore_device(manager, hardware_id, staged_refs)
+            _commit_device_references(manager, hardware_id, staged_refs, generation)
+            if cancelled:
+                raise asyncio.CancelledError
             raise_if_stale_profile_apply(manager, generation)
             log.info("Updated mapping for %s", hardware_id)
             manager.profile_state.last_sent_mapping_signatures[hardware_id] = signature
             return True
+        if cancelled:
+            raise asyncio.CancelledError
         raise_if_stale_profile_apply(manager, generation)
         log.error("Failed to update mapping: %s", result.error)
         return False

--- a/keymasq/session/manager/profile/application.py
+++ b/keymasq/session/manager/profile/application.py
@@ -47,8 +47,11 @@ async def _send_reference_command(
     task = asyncio.create_task(manager.client.send_command(command))
     try:
         return await asyncio.shield(task), False
-    except asyncio.CancelledError:
-        return await asyncio.shield(task), True
+    except asyncio.CancelledError as cancelled:
+        outcome = (await asyncio.shield(asyncio.gather(task, return_exceptions=True)))[0]
+        if isinstance(outcome, BaseException):
+            raise cancelled from outcome
+        return outcome, True
 
 
 def _commit_device_references(

--- a/keymasq/session/manager/profile/application.py
+++ b/keymasq/session/manager/profile/application.py
@@ -2,7 +2,7 @@
 
 import asyncio
 import logging
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from enum import Enum, auto
 from typing import TYPE_CHECKING, Protocol
@@ -49,22 +49,50 @@ async def _send_reference_command(
     try:
         return await asyncio.shield(task), False
     except asyncio.CancelledError as cancelled:
-        settled = asyncio.gather(task, return_exceptions=True)
-        try:
-            outcome = (
-                await asyncio.wait_for(
-                    asyncio.shield(settled),
-                    timeout=_CANCEL_SETTLE_TIMEOUT_S,
-                )
-            )[0]
-        except TimeoutError as timeout:
-            task.cancel()
-            await asyncio.gather(task, return_exceptions=True)
-            await manager.client.disconnect()
-            raise cancelled from timeout
+        outcome = await _settle_cancelled_request(manager, task, cancelled)
         if isinstance(outcome, BaseException):
             raise cancelled from outcome
         return outcome, True
+
+
+async def _settle_cancelled_request(
+    manager: "SessionManager",
+    task: asyncio.Task[Response],
+    cancelled: asyncio.CancelledError,
+) -> Response | BaseException:
+    settled = asyncio.gather(task, return_exceptions=True)
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + _CANCEL_SETTLE_TIMEOUT_S
+    while True:
+        remaining = deadline - loop.time()
+        if remaining <= 0:
+            break
+        try:
+            return (
+                await asyncio.wait_for(
+                    asyncio.shield(settled),
+                    timeout=remaining,
+                )
+            )[0]
+        except asyncio.CancelledError:
+            continue
+        except TimeoutError:
+            break
+
+    task.cancel()
+    await _await_cleanup(asyncio.gather(task, return_exceptions=True))
+    await _await_cleanup(manager.client.disconnect())
+    raise cancelled from TimeoutError("daemon command cancellation settlement timed out")
+
+
+async def _await_cleanup(awaitable: Awaitable[object]) -> None:
+    task = asyncio.ensure_future(awaitable)
+    while not task.done():
+        try:
+            await asyncio.shield(task)
+        except asyncio.CancelledError:
+            continue
+    await task
 
 
 def _commit_device_references(

--- a/keymasq/session/manager/recording_capture.py
+++ b/keymasq/session/manager/recording_capture.py
@@ -30,9 +30,18 @@ async def _begin_capture(
     manager.capture_state.resume_profiles[hardware_id] = current_profiles
 
     released = False
-    if hardware_id in manager.profile_state.grabbed_devices:
-        await application.deactivate_profile(manager, hardware_id, immediate=True)
-        released = True
+    try:
+        if hardware_id in manager.profile_state.grabbed_devices:
+            released = await application.deactivate_profile(
+                manager,
+                hardware_id,
+                immediate=True,
+            )
+            if not released:
+                raise RuntimeError(f"Failed to release {hardware_id} for capture")
+    except BaseException:
+        await _rollback_capture_begin(manager, hardware_id)
+        raise
 
     return {
         "status": "ok",
@@ -74,8 +83,8 @@ async def capture_begin_for_paths(
             "status": "error",
             "message": f"Hardware config for {hardware_id} has no evdev paths",
         }
-    lock_result = await _begin_capture(manager, hardware_id)
     try:
+        lock_result = await _begin_capture(manager, hardware_id)
         result = await manager.client.send_command(
             Command(
                 command=CommandType.CAPTURE_BEGIN,
@@ -87,22 +96,25 @@ async def capture_begin_for_paths(
                 },
             )
         )
+    except asyncio.CancelledError:
+        await _rollback_capture_begin(manager, hardware_id)
+        raise
     except OSError:
-        await _end_capture(manager, hardware_id)
+        await _rollback_capture_begin(manager, hardware_id)
         return {"status": "error", "message": "Daemon unavailable"}
     except Exception:
         log.exception("Unexpected failure beginning capture for hardware_id=%s", hardware_id)
-        await _end_capture(manager, hardware_id)
+        await _rollback_capture_begin(manager, hardware_id)
         return {"status": "error", "message": "Failed to begin capture"}
 
     result_data = json_object(result.data)
     if result.status != "ok" or result_data is None:
-        await _end_capture(manager, hardware_id)
+        await _rollback_capture_begin(manager, hardware_id)
         return {"status": "error", "message": result.error or "Failed to begin capture"}
 
     token = coerce_str(result_data.get("token"), "")
     if not token:
-        await _end_capture(manager, hardware_id)
+        await _rollback_capture_begin(manager, hardware_id)
         return {"status": "error", "message": "Missing capture token"}
 
     manager.capture_state.tokens[hardware_id] = token
@@ -116,6 +128,18 @@ async def capture_begin_for_paths(
     }
     response.update(lock_result)
     return response
+
+
+async def _rollback_capture_begin(manager: "SessionManager", hardware_id: str) -> None:
+    """Drop a provisional lock and restore normal profile reconciliation."""
+
+    manager.capture_state.tokens.pop(hardware_id, None)
+    try:
+        await _end_capture(manager, hardware_id)
+    except asyncio.CancelledError:
+        raise
+    except Exception:
+        log.exception("Failed to roll back capture begin for hardware_id=%s", hardware_id)
 
 
 async def capture_read(manager: "SessionManager", hardware_id: str) -> JsonObject:

--- a/keymasq/session/manager/recording_capture.py
+++ b/keymasq/session/manager/recording_capture.py
@@ -3,7 +3,7 @@ import logging
 from typing import TYPE_CHECKING, cast
 
 from keymasq.common.coercion import coerce_str
-from keymasq.common.ipc import Command, CommandType
+from keymasq.common.ipc import Command, CommandType, Response
 from keymasq.session.profile.types import ResolvedDeviceProfile
 
 from .common import JsonObject, json_list, json_object
@@ -13,6 +13,22 @@ if TYPE_CHECKING:
     from .core import SessionManager
 
 log = logging.getLogger("keymasq-session")
+
+
+async def _send_capture_begin(
+    manager: "SessionManager",
+    command: Command,
+) -> tuple[Response, bool]:
+    """Settle CAPTURE_BEGIN before propagating caller cancellation."""
+
+    task = asyncio.create_task(manager.client.send_command(command))
+    try:
+        return await asyncio.shield(task), False
+    except asyncio.CancelledError as cancelled:
+        outcome = (await asyncio.shield(asyncio.gather(task, return_exceptions=True)))[0]
+        if isinstance(outcome, BaseException):
+            raise cancelled from outcome
+        return outcome, True
 
 
 async def _begin_capture(
@@ -85,25 +101,18 @@ async def capture_begin_for_paths(
         }
     try:
         lock_result = await _begin_capture(manager, hardware_id)
-        request_task = asyncio.create_task(
-            manager.client.send_command(
-                Command(
-                    command=CommandType.CAPTURE_BEGIN,
-                    data={
-                        "hardware_id": hardware_id,
-                        **({"mode": mode} if mode != "button" else {}),
-                        **({"evdev_paths": evdev_paths} if evdev_paths else {}),
-                        **({"evdev_interfaces": evdev_interfaces} if evdev_interfaces else {}),
-                    },
-                )
+        result, cancelled = await _send_capture_begin(
+            manager,
+            Command(
+                command=CommandType.CAPTURE_BEGIN,
+                data={
+                    "hardware_id": hardware_id,
+                    **({"mode": mode} if mode != "button" else {}),
+                    **({"evdev_paths": evdev_paths} if evdev_paths else {}),
+                    **({"evdev_interfaces": evdev_interfaces} if evdev_interfaces else {}),
+                },
             )
         )
-        cancelled = False
-        try:
-            result = await asyncio.shield(request_task)
-        except asyncio.CancelledError:
-            cancelled = True
-            result = await asyncio.shield(request_task)
     except asyncio.CancelledError:
         await _rollback_capture_begin(manager, hardware_id)
         raise

--- a/keymasq/session/manager/recording_capture.py
+++ b/keymasq/session/manager/recording_capture.py
@@ -168,14 +168,22 @@ async def capture_begin_for_paths(
 
     result_data = json_object(result.data)
     if result.status != "ok" or result_data is None:
-        await _rollback_capture_begin(manager, hardware_id)
+        rollback = _rollback_capture_begin(manager, hardware_id)
+        if cancelled:
+            await _await_cleanup(rollback)
+        else:
+            await rollback
         if cancelled:
             raise asyncio.CancelledError
         return {"status": "error", "message": result.error or "Failed to begin capture"}
 
     token = coerce_str(result_data.get("token"), "")
     if not token:
-        await _rollback_capture_begin(manager, hardware_id)
+        rollback = _rollback_capture_begin(manager, hardware_id)
+        if cancelled:
+            await _await_cleanup(rollback)
+        else:
+            await rollback
         if cancelled:
             raise asyncio.CancelledError
         return {"status": "error", "message": "Missing capture token"}

--- a/keymasq/session/manager/recording_capture.py
+++ b/keymasq/session/manager/recording_capture.py
@@ -13,6 +13,7 @@ if TYPE_CHECKING:
     from .core import SessionManager
 
 log = logging.getLogger("keymasq-session")
+_CANCEL_SETTLE_TIMEOUT_S = 11.0
 
 
 async def _send_capture_begin(
@@ -25,7 +26,18 @@ async def _send_capture_begin(
     try:
         return await asyncio.shield(task), False
     except asyncio.CancelledError as cancelled:
-        outcome = (await asyncio.shield(asyncio.gather(task, return_exceptions=True)))[0]
+        settled = asyncio.gather(task, return_exceptions=True)
+        try:
+            outcome = (
+                await asyncio.wait_for(
+                    asyncio.shield(settled),
+                    timeout=_CANCEL_SETTLE_TIMEOUT_S,
+                )
+            )[0]
+        except TimeoutError as timeout:
+            task.cancel()
+            await asyncio.gather(task, return_exceptions=True)
+            raise cancelled from timeout
         if isinstance(outcome, BaseException):
             raise cancelled from outcome
         return outcome, True

--- a/keymasq/session/manager/recording_capture.py
+++ b/keymasq/session/manager/recording_capture.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+from collections.abc import Awaitable
 from typing import TYPE_CHECKING, cast
 
 from keymasq.common.coercion import coerce_str
@@ -26,22 +27,50 @@ async def _send_capture_begin(
     try:
         return await asyncio.shield(task), False
     except asyncio.CancelledError as cancelled:
-        settled = asyncio.gather(task, return_exceptions=True)
-        try:
-            outcome = (
-                await asyncio.wait_for(
-                    asyncio.shield(settled),
-                    timeout=_CANCEL_SETTLE_TIMEOUT_S,
-                )
-            )[0]
-        except TimeoutError as timeout:
-            task.cancel()
-            await asyncio.gather(task, return_exceptions=True)
-            await manager.client.disconnect()
-            raise cancelled from timeout
+        outcome = await _settle_cancelled_capture_begin(manager, task, cancelled)
         if isinstance(outcome, BaseException):
             raise cancelled from outcome
         return outcome, True
+
+
+async def _settle_cancelled_capture_begin(
+    manager: "SessionManager",
+    task: asyncio.Task[Response],
+    cancelled: asyncio.CancelledError,
+) -> Response | BaseException:
+    settled = asyncio.gather(task, return_exceptions=True)
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + _CANCEL_SETTLE_TIMEOUT_S
+    while True:
+        remaining = deadline - loop.time()
+        if remaining <= 0:
+            break
+        try:
+            return (
+                await asyncio.wait_for(
+                    asyncio.shield(settled),
+                    timeout=remaining,
+                )
+            )[0]
+        except asyncio.CancelledError:
+            continue
+        except TimeoutError:
+            break
+
+    task.cancel()
+    await _await_cleanup(asyncio.gather(task, return_exceptions=True))
+    await _await_cleanup(manager.client.disconnect())
+    raise cancelled from TimeoutError("capture begin cancellation settlement timed out")
+
+
+async def _await_cleanup(awaitable: Awaitable[object]) -> None:
+    task = asyncio.ensure_future(awaitable)
+    while not task.done():
+        try:
+            await asyncio.shield(task)
+        except asyncio.CancelledError:
+            continue
+    await task
 
 
 async def _begin_capture(

--- a/keymasq/session/manager/recording_capture.py
+++ b/keymasq/session/manager/recording_capture.py
@@ -98,7 +98,7 @@ async def _begin_capture(
             if not released:
                 raise RuntimeError(f"Failed to release {hardware_id} for capture")
     except BaseException:
-        await _rollback_capture_begin(manager, hardware_id)
+        await _await_cleanup(_rollback_capture_begin(manager, hardware_id))
         raise
 
     return {
@@ -156,7 +156,7 @@ async def capture_begin_for_paths(
             )
         )
     except asyncio.CancelledError:
-        await _rollback_capture_begin(manager, hardware_id)
+        await _await_cleanup(_rollback_capture_begin(manager, hardware_id))
         raise
     except OSError:
         await _rollback_capture_begin(manager, hardware_id)
@@ -184,7 +184,7 @@ async def capture_begin_for_paths(
     if owner_writer is not None:
         manager.capture_state.owner_writer_ids[hardware_id] = id(owner_writer)
     if cancelled:
-        await capture_end(manager, hardware_id)
+        await _await_cleanup(capture_end(manager, hardware_id))
         raise asyncio.CancelledError
     response = {
         "status": "ok",

--- a/keymasq/session/manager/recording_capture.py
+++ b/keymasq/session/manager/recording_capture.py
@@ -37,6 +37,7 @@ async def _send_capture_begin(
         except TimeoutError as timeout:
             task.cancel()
             await asyncio.gather(task, return_exceptions=True)
+            await manager.client.disconnect()
             raise cancelled from timeout
         if isinstance(outcome, BaseException):
             raise cancelled from outcome

--- a/keymasq/session/manager/recording_capture.py
+++ b/keymasq/session/manager/recording_capture.py
@@ -215,7 +215,7 @@ async def capture_begin_for_paths(
     if owner_writer is not None:
         manager.capture_state.owner_writer_ids[hardware_id] = id(owner_writer)
     if cancelled:
-        await _await_cleanup(capture_end(manager, hardware_id))
+        await _end_cancelled_capture(manager, hardware_id)
         raise asyncio.CancelledError
     response = {
         "status": "ok",
@@ -237,6 +237,29 @@ async def _rollback_capture_begin(manager: "SessionManager", hardware_id: str) -
         raise
     except Exception:
         log.exception("Failed to roll back capture begin for hardware_id=%s", hardware_id)
+
+
+async def _end_cancelled_capture(manager: "SessionManager", hardware_id: str) -> None:
+    end_task = asyncio.create_task(capture_end(manager, hardware_id))
+    await _await_cleanup(asyncio.gather(end_task, return_exceptions=True))
+    result: JsonObject | None = None
+    if end_task.done() and not end_task.cancelled():
+        try:
+            result = end_task.result()
+        except Exception:
+            log.exception("Failed to settle cancelled capture end for %s", hardware_id)
+    if result is not None and result.get("status") == "ok":
+        return
+
+    try:
+        await _await_cleanup(manager.client.disconnect())
+    except asyncio.CancelledError:
+        log.warning("Daemon disconnect was cancelled while ending capture %s", hardware_id)
+        return
+    except Exception:
+        log.exception("Failed to disconnect after capture end failure for %s", hardware_id)
+        return
+    await _await_cleanup(_rollback_capture_begin(manager, hardware_id))
 
 
 async def capture_read(manager: "SessionManager", hardware_id: str) -> JsonObject:

--- a/keymasq/session/manager/recording_capture.py
+++ b/keymasq/session/manager/recording_capture.py
@@ -63,14 +63,17 @@ async def _settle_cancelled_capture_begin(
     raise cancelled from TimeoutError("capture begin cancellation settlement timed out")
 
 
-async def _await_cleanup(awaitable: Awaitable[object]) -> None:
+async def _await_cleanup(awaitable: Awaitable[object]) -> bool:
     task = asyncio.ensure_future(awaitable)
+    cancelled = False
     while not task.done():
         try:
             await asyncio.shield(task)
         except asyncio.CancelledError:
+            cancelled = True
             continue
     await task
+    return cancelled
 
 
 async def _begin_capture(
@@ -159,32 +162,31 @@ async def capture_begin_for_paths(
         await _await_cleanup(_rollback_capture_begin(manager, hardware_id))
         raise
     except OSError:
-        await _rollback_capture_begin(manager, hardware_id)
+        if await _await_cleanup(_rollback_capture_begin(manager, hardware_id)):
+            raise asyncio.CancelledError from None
         return {"status": "error", "message": "Daemon unavailable"}
     except Exception:
         log.exception("Unexpected failure beginning capture for hardware_id=%s", hardware_id)
-        await _rollback_capture_begin(manager, hardware_id)
+        if await _await_cleanup(_rollback_capture_begin(manager, hardware_id)):
+            raise asyncio.CancelledError from None
         return {"status": "error", "message": "Failed to begin capture"}
 
     result_data = json_object(result.data)
     if result.status != "ok" or result_data is None:
-        rollback = _rollback_capture_begin(manager, hardware_id)
-        if cancelled:
-            await _await_cleanup(rollback)
-        else:
-            await rollback
-        if cancelled:
+        rollback_cancelled = await _await_cleanup(
+            _rollback_capture_begin(manager, hardware_id)
+        )
+        if cancelled or rollback_cancelled:
             raise asyncio.CancelledError
         return {"status": "error", "message": result.error or "Failed to begin capture"}
 
     token = coerce_str(result_data.get("token"), "")
     if not token:
-        rollback = _rollback_capture_begin(manager, hardware_id)
-        if cancelled:
-            await _await_cleanup(rollback)
-        else:
-            await rollback
-        if cancelled:
+        disconnect_cancelled = await _await_cleanup(manager.client.disconnect())
+        rollback_cancelled = await _await_cleanup(
+            _rollback_capture_begin(manager, hardware_id)
+        )
+        if cancelled or disconnect_cancelled or rollback_cancelled:
             raise asyncio.CancelledError
         return {"status": "error", "message": "Missing capture token"}
 

--- a/keymasq/session/manager/recording_capture.py
+++ b/keymasq/session/manager/recording_capture.py
@@ -180,8 +180,8 @@ async def capture_begin_for_paths(
             raise asyncio.CancelledError
         return {"status": "error", "message": result.error or "Failed to begin capture"}
 
-    token = coerce_str(result_data.get("token"), "")
-    if not token:
+    capture_session_id = coerce_str(result_data.get("token"), "")
+    if not capture_session_id:
         disconnect_cancelled = await _await_cleanup(manager.client.disconnect())
         rollback_cancelled = await _await_cleanup(
             _rollback_capture_begin(manager, hardware_id)
@@ -190,7 +190,7 @@ async def capture_begin_for_paths(
             raise asyncio.CancelledError
         return {"status": "error", "message": "Missing capture token"}
 
-    manager.capture_state.tokens[hardware_id] = token
+    manager.capture_state.tokens[hardware_id] = capture_session_id
     if owner_writer is not None:
         manager.capture_state.owner_writer_ids[hardware_id] = id(owner_writer)
     if cancelled:
@@ -199,7 +199,7 @@ async def capture_begin_for_paths(
     response = {
         "status": "ok",
         "hardware_id": hardware_id,
-        "token": token,
+        "token": capture_session_id,
         "warnings": result_data.get("warnings", []),
     }
     response.update(lock_result)

--- a/keymasq/session/manager/recording_capture.py
+++ b/keymasq/session/manager/recording_capture.py
@@ -85,17 +85,25 @@ async def capture_begin_for_paths(
         }
     try:
         lock_result = await _begin_capture(manager, hardware_id)
-        result = await manager.client.send_command(
-            Command(
-                command=CommandType.CAPTURE_BEGIN,
-                data={
-                    "hardware_id": hardware_id,
-                    **({"mode": mode} if mode != "button" else {}),
-                    **({"evdev_paths": evdev_paths} if evdev_paths else {}),
-                    **({"evdev_interfaces": evdev_interfaces} if evdev_interfaces else {}),
-                },
+        request_task = asyncio.create_task(
+            manager.client.send_command(
+                Command(
+                    command=CommandType.CAPTURE_BEGIN,
+                    data={
+                        "hardware_id": hardware_id,
+                        **({"mode": mode} if mode != "button" else {}),
+                        **({"evdev_paths": evdev_paths} if evdev_paths else {}),
+                        **({"evdev_interfaces": evdev_interfaces} if evdev_interfaces else {}),
+                    },
+                )
             )
         )
+        cancelled = False
+        try:
+            result = await asyncio.shield(request_task)
+        except asyncio.CancelledError:
+            cancelled = True
+            result = await asyncio.shield(request_task)
     except asyncio.CancelledError:
         await _rollback_capture_begin(manager, hardware_id)
         raise
@@ -110,16 +118,23 @@ async def capture_begin_for_paths(
     result_data = json_object(result.data)
     if result.status != "ok" or result_data is None:
         await _rollback_capture_begin(manager, hardware_id)
+        if cancelled:
+            raise asyncio.CancelledError
         return {"status": "error", "message": result.error or "Failed to begin capture"}
 
     token = coerce_str(result_data.get("token"), "")
     if not token:
         await _rollback_capture_begin(manager, hardware_id)
+        if cancelled:
+            raise asyncio.CancelledError
         return {"status": "error", "message": "Missing capture token"}
 
     manager.capture_state.tokens[hardware_id] = token
     if owner_writer is not None:
         manager.capture_state.owner_writer_ids[hardware_id] = id(owner_writer)
+    if cancelled:
+        await capture_end(manager, hardware_id)
+        raise asyncio.CancelledError
     response = {
         "status": "ok",
         "hardware_id": hardware_id,

--- a/keymasq/session/manager/recording_capture.py
+++ b/keymasq/session/manager/recording_capture.py
@@ -180,8 +180,8 @@ async def capture_begin_for_paths(
             raise asyncio.CancelledError
         return {"status": "error", "message": result.error or "Failed to begin capture"}
 
-    capture_session_id = coerce_str(result_data.get("token"), "")
-    if not capture_session_id:
+    session_id = coerce_str(result_data.get("token"), "")
+    if not session_id:
         disconnect_cancelled = await _await_cleanup(manager.client.disconnect())
         rollback_cancelled = await _await_cleanup(
             _rollback_capture_begin(manager, hardware_id)
@@ -190,7 +190,7 @@ async def capture_begin_for_paths(
             raise asyncio.CancelledError
         return {"status": "error", "message": "Missing capture token"}
 
-    manager.capture_state.tokens[hardware_id] = capture_session_id
+    manager.capture_state.tokens[hardware_id] = session_id
     if owner_writer is not None:
         manager.capture_state.owner_writer_ids[hardware_id] = id(owner_writer)
     if cancelled:
@@ -199,7 +199,7 @@ async def capture_begin_for_paths(
     response = {
         "status": "ok",
         "hardware_id": hardware_id,
-        "token": capture_session_id,
+        "token": session_id,
         "warnings": result_data.get("warnings", []),
     }
     response.update(lock_result)

--- a/keymasq/session/manager/recording_capture.py
+++ b/keymasq/session/manager/recording_capture.py
@@ -15,6 +15,14 @@ if TYPE_CHECKING:
 
 log = logging.getLogger("keymasq-session")
 _CANCEL_SETTLE_TIMEOUT_S = 11.0
+_CANCEL_CLEANUP_TIMEOUT_S = 1.0
+
+
+def _observe_cleanup_task(task: asyncio.Future[object]) -> None:
+    try:
+        task.exception()
+    except asyncio.CancelledError:
+        pass
 
 
 async def _send_capture_begin(
@@ -66,12 +74,25 @@ async def _settle_cancelled_capture_begin(
 async def _await_cleanup(awaitable: Awaitable[object]) -> bool:
     task = asyncio.ensure_future(awaitable)
     cancelled = False
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + _CANCEL_CLEANUP_TIMEOUT_S
     while not task.done():
+        remaining = deadline - loop.time()
+        if remaining <= 0:
+            task.cancel()
+            task.add_done_callback(_observe_cleanup_task)
+            log.warning("Timed out waiting for capture cancellation cleanup")
+            return cancelled
         try:
-            await asyncio.shield(task)
+            await asyncio.wait_for(asyncio.shield(task), timeout=remaining)
         except asyncio.CancelledError:
             cancelled = True
             continue
+        except TimeoutError:
+            task.cancel()
+            task.add_done_callback(_observe_cleanup_task)
+            log.warning("Timed out waiting for capture cancellation cleanup")
+            return cancelled
     await task
     return cancelled
 

--- a/keymasq/session/manager/service/connection.py
+++ b/keymasq/session/manager/service/connection.py
@@ -113,6 +113,13 @@ class DaemonConnectionMixin:
         self.recording_state.selected_devices_cache.clear()
         self.recording_state.devices_cache_ready = False
         self.recording_state.devices_cache_include_other = False
+        self.capture_state.tokens.clear()
+        self.capture_state.locks.clear()
+        self.capture_state.resume_profiles.clear()
+        self.capture_state.owner_writer_ids.clear()
+        self.exec_state.exec_refs.clear()
+        self.exec_state.device_exec_refs.clear()
+        self.exec_state.combo_exec_refs.clear()
 
         if was_connected:
             self._broadcast_keymasqd_status(False)

--- a/keymasq/session/manager/service/connection.py
+++ b/keymasq/session/manager/service/connection.py
@@ -5,9 +5,9 @@ from typing import Any, cast
 from keymasq.common.ipc import Command, CommandType
 from keymasq.common.paths import SOCKET_PATH
 
-from .. import recording_device_selection, recording_lifecycle
+from .. import events, recording_device_selection, recording_lifecycle
 from ..common import JsonObject
-from ..profile import coordinator
+from ..profile import coordinator, runtime_state
 
 log = logging.getLogger("keymasq-session")
 
@@ -60,7 +60,7 @@ class DaemonConnectionMixin:
 
                 await self.client.wait_disconnected()
                 log.warning("Disconnected from keymasqd")
-                self._handle_keymasqd_disconnect()
+                await self._handle_keymasqd_disconnect()
                 if self.restart_on_daemon_disconnect:
                     log.info("Requesting keymasq-session restart after keymasqd disconnect")
                     self.restart_requested = True
@@ -69,10 +69,10 @@ class DaemonConnectionMixin:
 
             except OSError as e:
                 log.warning(f"Connection failed: {e}")
-                self._handle_keymasqd_disconnect()
+                await self._handle_keymasqd_disconnect()
             except Exception:
                 log.exception("Unexpected keymasqd connection loop failure")
-                self._handle_keymasqd_disconnect()
+                await self._handle_keymasqd_disconnect()
 
             if self.running:
                 try:
@@ -81,18 +81,16 @@ class DaemonConnectionMixin:
                     pass
                 retry_delay = min(retry_delay * 2, max_delay)
 
-    def _handle_keymasqd_disconnect(self: Any) -> None:
+    async def _handle_keymasqd_disconnect(self: Any) -> None:
         was_connected = self.connected
+        await events.cancel_event_tasks(self)
+        await runtime_state.cancel_all_grab_retries(self)
         self.connected = False
         self.profile_state.grabbed_devices.clear()
         self.profile_state.grabbed_interfaces.clear()
         self.profile_state.grab_waiting_devices.clear()
         self.profile_state.grab_status.clear()
         self.profile_state.device_runtime_status.clear()
-        for task in list(self.profile_state.grab_retry_tasks.values()):
-            if not task.done():
-                task.cancel()
-        self.profile_state.grab_retry_tasks.clear()
         self.profile_state.last_sent_grab_signatures.clear()
         self.profile_state.last_sent_mapping_signatures.clear()
         self.profile_state.last_sent_combo_signature = ""

--- a/tests/keymasqd/daemon_support.py
+++ b/tests/keymasqd/daemon_support.py
@@ -33,7 +33,7 @@ def make_daemon_testbed(monkeypatch):
         device_runtime_status=AsyncMock(
             return_value={"status": "ok", "interfaces": [], "grabbed_interfaces": []}
         ),
-        begin_combo_capture=Mock(return_value={"token": "combo-session-id"}),
+        begin_combo_capture=Mock(return_value={"token": "combo-token"}),
         read_combo_capture=Mock(return_value={"event": None}),
         end_combo_capture=Mock(return_value={"status": "ok", "ended": True}),
         grabbed_devices={},
@@ -80,12 +80,11 @@ def make_daemon_testbed(monkeypatch):
         register_internal=Mock(return_value=None),
     )
     capture_manager = SimpleNamespace(
-        begin=Mock(return_value={"token": "capture-session-id"}),
+        begin=Mock(return_value={"token": "cap-token"}),
         read=Mock(return_value={"captured": None}),
         end=Mock(return_value={"ended": True}),
-        end_all=Mock(return_value=0),
         authorize_combo_capture=Mock(return_value=object()),
-        begin_combo=Mock(return_value={"token": "combo-session-id", "warnings": []}),
+        begin_combo=Mock(return_value={"token": "combo-token", "warnings": []}),
         read_combo=Mock(return_value={"event": None}),
         read_combo_nowait=Mock(return_value={"event": None}),
         register_combo_notifier=Mock(return_value=None),

--- a/tests/keymasqd/daemon_support.py
+++ b/tests/keymasqd/daemon_support.py
@@ -33,7 +33,7 @@ def make_daemon_testbed(monkeypatch):
         device_runtime_status=AsyncMock(
             return_value={"status": "ok", "interfaces": [], "grabbed_interfaces": []}
         ),
-        begin_combo_capture=Mock(return_value={"token": "combo-token"}),
+        begin_combo_capture=Mock(return_value={"token": "combo-session-id"}),
         read_combo_capture=Mock(return_value={"event": None}),
         end_combo_capture=Mock(return_value={"status": "ok", "ended": True}),
         grabbed_devices={},
@@ -80,12 +80,12 @@ def make_daemon_testbed(monkeypatch):
         register_internal=Mock(return_value=None),
     )
     capture_manager = SimpleNamespace(
-        begin=Mock(return_value={"token": "cap-token"}),
+        begin=Mock(return_value={"token": "capture-session-id"}),
         read=Mock(return_value={"captured": None}),
         end=Mock(return_value={"ended": True}),
         end_all=Mock(return_value=0),
         authorize_combo_capture=Mock(return_value=object()),
-        begin_combo=Mock(return_value={"token": "combo-token", "warnings": []}),
+        begin_combo=Mock(return_value={"token": "combo-session-id", "warnings": []}),
         read_combo=Mock(return_value={"event": None}),
         read_combo_nowait=Mock(return_value={"event": None}),
         register_combo_notifier=Mock(return_value=None),

--- a/tests/keymasqd/daemon_support.py
+++ b/tests/keymasqd/daemon_support.py
@@ -83,6 +83,7 @@ def make_daemon_testbed(monkeypatch):
         begin=Mock(return_value={"token": "cap-token"}),
         read=Mock(return_value={"captured": None}),
         end=Mock(return_value={"ended": True}),
+        end_all=Mock(return_value=0),
         authorize_combo_capture=Mock(return_value=object()),
         begin_combo=Mock(return_value={"token": "combo-token", "warnings": []}),
         read_combo=Mock(return_value={"event": None}),

--- a/tests/keymasqd/test_daemon_capture_commands.py
+++ b/tests/keymasqd/test_daemon_capture_commands.py
@@ -500,7 +500,7 @@ async def test_start_recording_ignores_unrequested_start_coordinates(
                 "evdev_interfaces": None,
                 "mode": "button",
             },
-            {"token": "capture-session-id"},
+            {"token": "cap-token"},
         ),
         (
             CommandType.CAPTURE_READ,
@@ -565,7 +565,7 @@ async def test_capture_begin_forwards_explicit_evdev_paths(daemon_testbed):
         {"hardware_id": "1234:5678@slot2", "evdev_paths": ["/dev/input/event2"]},
     )
 
-    assert result == {"token": "capture-session-id"}
+    assert result == {"token": "cap-token"}
     capture_manager.begin.assert_called_once_with(
         hardware_id="1234:5678@slot2",
         evdev_paths=["/dev/input/event2"],
@@ -588,7 +588,7 @@ async def test_capture_begin_forwards_evdev_interfaces(daemon_testbed):
         },
     )
 
-    assert result == {"token": "capture-session-id"}
+    assert result == {"token": "cap-token"}
     capture_manager.begin.assert_called_once_with(
         hardware_id="2dc8:3106",
         evdev_paths=["keymasq:2dc8:3106"],
@@ -818,7 +818,7 @@ async def test_capture_combo_waits_on_event_not_sleep(daemon_testbed, monkeypatc
         notify_event: asyncio.Event,
     ) -> dict:
         waiter["event"] = notify_event
-        return {"token": "combo-session-id", "grabbed_devices": 0}
+        return {"token": "combo-token", "grabbed_devices": 0}
 
     device_manager.begin_combo_capture = Mock(side_effect=begin_combo_capture)
     device_manager.read_combo_capture = Mock(
@@ -960,7 +960,7 @@ async def test_capture_combo_returns_immediately_on_wheel_pulse(daemon_testbed):
         notify_event: asyncio.Event,
     ) -> dict:
         notify["event"] = notify_event
-        return {"token": "combo-session-id", "grabbed_devices": 0}
+        return {"token": "combo-token", "grabbed_devices": 0}
 
     device_manager.begin_combo_capture = Mock(side_effect=begin_combo_capture)
     device_manager.read_combo_capture = Mock(
@@ -1188,7 +1188,7 @@ async def test_read_capture_combo_event_drains_sources_once_before_waiting(
 
     event = await daemon_capture_commands.read_capture_combo_event(
         daemon,
-        "combo-session-id",
+        "combo-token",
         notify_event,
         float("inf"),
     )

--- a/tests/keymasqd/test_daemon_capture_commands.py
+++ b/tests/keymasqd/test_daemon_capture_commands.py
@@ -500,7 +500,7 @@ async def test_start_recording_ignores_unrequested_start_coordinates(
                 "evdev_interfaces": None,
                 "mode": "button",
             },
-            {"token": "cap-token"},
+            {"token": "capture-session-id"},
         ),
         (
             CommandType.CAPTURE_READ,
@@ -565,7 +565,7 @@ async def test_capture_begin_forwards_explicit_evdev_paths(daemon_testbed):
         {"hardware_id": "1234:5678@slot2", "evdev_paths": ["/dev/input/event2"]},
     )
 
-    assert result == {"token": "cap-token"}
+    assert result == {"token": "capture-session-id"}
     capture_manager.begin.assert_called_once_with(
         hardware_id="1234:5678@slot2",
         evdev_paths=["/dev/input/event2"],
@@ -588,7 +588,7 @@ async def test_capture_begin_forwards_evdev_interfaces(daemon_testbed):
         },
     )
 
-    assert result == {"token": "cap-token"}
+    assert result == {"token": "capture-session-id"}
     capture_manager.begin.assert_called_once_with(
         hardware_id="2dc8:3106",
         evdev_paths=["keymasq:2dc8:3106"],
@@ -818,7 +818,7 @@ async def test_capture_combo_waits_on_event_not_sleep(daemon_testbed, monkeypatc
         notify_event: asyncio.Event,
     ) -> dict:
         waiter["event"] = notify_event
-        return {"token": "combo-token", "grabbed_devices": 0}
+        return {"token": "combo-session-id", "grabbed_devices": 0}
 
     device_manager.begin_combo_capture = Mock(side_effect=begin_combo_capture)
     device_manager.read_combo_capture = Mock(
@@ -960,7 +960,7 @@ async def test_capture_combo_returns_immediately_on_wheel_pulse(daemon_testbed):
         notify_event: asyncio.Event,
     ) -> dict:
         notify["event"] = notify_event
-        return {"token": "combo-token", "grabbed_devices": 0}
+        return {"token": "combo-session-id", "grabbed_devices": 0}
 
     device_manager.begin_combo_capture = Mock(side_effect=begin_combo_capture)
     device_manager.read_combo_capture = Mock(
@@ -1188,7 +1188,7 @@ async def test_read_capture_combo_event_drains_sources_once_before_waiting(
 
     event = await daemon_capture_commands.read_capture_combo_event(
         daemon,
-        "combo-token",
+        "combo-session-id",
         notify_event,
         float("inf"),
     )

--- a/tests/keymasqd/test_daemon_capture_commands.py
+++ b/tests/keymasqd/test_daemon_capture_commands.py
@@ -1200,3 +1200,23 @@ async def test_read_capture_combo_event_drains_sources_once_before_waiting(
         "value": 1,
     }
     assert seen_before_wait == {"device": 1, "capture": 1}
+
+
+def test_capture_manager_end_all_continues_after_individual_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = CaptureManager()
+    manager._sessions = {"first": Mock(), "second": Mock()}  # type: ignore[assignment]
+    ended: list[str] = []
+
+    def end(token: str) -> dict[str, object]:
+        ended.append(token)
+        manager._sessions.pop(token, None)
+        if token == "first":
+            raise RuntimeError("cleanup failed")
+        return {"status": "ok", "ended": True}
+
+    monkeypatch.setattr(manager, "end", end)
+
+    assert manager.end_all() == 1
+    assert ended == ["first", "second"]

--- a/tests/keymasqd/test_daemon_runtime_unlock.py
+++ b/tests/keymasqd/test_daemon_runtime_unlock.py
@@ -222,17 +222,17 @@ async def test_capture_end_allows_owner_after_recording_unlock_expires(
         {"hardware_id": "1234:5678"},
         client=client,
     )
-    assert begin == {"token": "capture-session-id"}
+    assert begin == {"token": "cap-token"}
 
     unlocked = False
     end = await daemon._handle_command(
         CommandType.CAPTURE_END,
-        {"token": "capture-session-id"},
+        {"token": "cap-token"},
         client=client,
     )
 
     assert end == {"ended": True}
-    capture_manager.end.assert_called_once_with("capture-session-id")
+    capture_manager.end.assert_called_once_with("cap-token")
 
 
 @pytest.mark.asyncio
@@ -269,7 +269,7 @@ async def test_sensitive_command_owner_mismatch_is_denied(
         {"hardware_id": "1234:5678"},
         client=first_client,
     )
-    assert first == {"token": "capture-session-id"}
+    assert first == {"token": "cap-token"}
 
     with pytest.raises(PermissionError, match="sensitive_command_denied"):
         await daemon._handle_command(
@@ -437,13 +437,13 @@ async def test_stale_unlocked_cache_entry_is_re_resolved_before_sensitive_comman
         {"hardware_id": "1234:5678"},
         client=client,
     )
-    assert result == {"token": "capture-session-id"}
+    assert result == {"token": "cap-token"}
 
     now_mono = 500.3
     with pytest.raises(PermissionError, match="recording_locked"):
         await daemon._handle_command(
             CommandType.CAPTURE_READ,
-            {"token": "capture-session-id"},
+            {"token": "cap-token"},
             client=client,
         )
 
@@ -458,6 +458,7 @@ async def test_client_disconnect_clears_owned_runtime_unlock_only(
     tmp_path: Path,
 ):
     daemon, device_manager, recording_manager, _macro_store, capture_manager = daemon_testbed
+    capture_manager.end_all = Mock(return_value=0)
     owned_uid = 5555
     unrelated_uid = 7777
     client = client_context(uid=owned_uid, pid=600, connection_id=9)
@@ -535,6 +536,7 @@ async def test_async_runtime_unlock_cleanup_offloads_file_io(
 @pytest.mark.asyncio
 async def test_client_disconnect_releases_devices_after_recording_discard_fails(daemon_testbed):
     daemon, device_manager, recording_manager, _macro_store, capture_manager = daemon_testbed
+    capture_manager.end_all = Mock(return_value=0)
     recording_manager.discard_all_pending_recordings.side_effect = RuntimeError("discard failed")
 
     await daemon._on_client_disconnect()

--- a/tests/keymasqd/test_daemon_runtime_unlock.py
+++ b/tests/keymasqd/test_daemon_runtime_unlock.py
@@ -457,7 +457,7 @@ async def test_client_disconnect_clears_owned_runtime_unlock_only(
     monkeypatch,
     tmp_path: Path,
 ):
-    daemon, device_manager, recording_manager, _macro_store, _capture_manager = daemon_testbed
+    daemon, device_manager, recording_manager, _macro_store, capture_manager = daemon_testbed
     owned_uid = 5555
     unrelated_uid = 7777
     client = client_context(uid=owned_uid, pid=600, connection_id=9)
@@ -484,6 +484,7 @@ async def test_client_disconnect_clears_owned_runtime_unlock_only(
     assert not (runtime_dir / f"recording-unlock-{owned_uid}").exists()
     assert (runtime_dir / f"recording-unlock-{unrelated_uid}").exists()
     recording_manager.discard_all_pending_recordings.assert_awaited_once()
+    capture_manager.end_all.assert_called_once()
     device_manager.release_all_devices.assert_awaited_once()
 
 
@@ -533,10 +534,11 @@ async def test_async_runtime_unlock_cleanup_offloads_file_io(
 
 @pytest.mark.asyncio
 async def test_client_disconnect_releases_devices_after_recording_discard_fails(daemon_testbed):
-    daemon, device_manager, recording_manager, _macro_store, _capture_manager = daemon_testbed
+    daemon, device_manager, recording_manager, _macro_store, capture_manager = daemon_testbed
     recording_manager.discard_all_pending_recordings.side_effect = RuntimeError("discard failed")
 
     await daemon._on_client_disconnect()
 
     recording_manager.discard_all_pending_recordings.assert_awaited_once()
+    capture_manager.end_all.assert_called_once()
     device_manager.release_all_devices.assert_awaited_once()

--- a/tests/keymasqd/test_daemon_runtime_unlock.py
+++ b/tests/keymasqd/test_daemon_runtime_unlock.py
@@ -222,17 +222,17 @@ async def test_capture_end_allows_owner_after_recording_unlock_expires(
         {"hardware_id": "1234:5678"},
         client=client,
     )
-    assert begin == {"token": "cap-token"}
+    assert begin == {"token": "capture-session-id"}
 
     unlocked = False
     end = await daemon._handle_command(
         CommandType.CAPTURE_END,
-        {"token": "cap-token"},
+        {"token": "capture-session-id"},
         client=client,
     )
 
     assert end == {"ended": True}
-    capture_manager.end.assert_called_once_with("cap-token")
+    capture_manager.end.assert_called_once_with("capture-session-id")
 
 
 @pytest.mark.asyncio
@@ -269,7 +269,7 @@ async def test_sensitive_command_owner_mismatch_is_denied(
         {"hardware_id": "1234:5678"},
         client=first_client,
     )
-    assert first == {"token": "cap-token"}
+    assert first == {"token": "capture-session-id"}
 
     with pytest.raises(PermissionError, match="sensitive_command_denied"):
         await daemon._handle_command(
@@ -437,13 +437,13 @@ async def test_stale_unlocked_cache_entry_is_re_resolved_before_sensitive_comman
         {"hardware_id": "1234:5678"},
         client=client,
     )
-    assert result == {"token": "cap-token"}
+    assert result == {"token": "capture-session-id"}
 
     now_mono = 500.3
     with pytest.raises(PermissionError, match="recording_locked"):
         await daemon._handle_command(
             CommandType.CAPTURE_READ,
-            {"token": "cap-token"},
+            {"token": "capture-session-id"},
             client=client,
         )
 

--- a/tests/keymasqd/test_grab_lifecycle_planning.py
+++ b/tests/keymasqd/test_grab_lifecycle_planning.py
@@ -1,7 +1,7 @@
 import asyncio
 import errno
 from types import SimpleNamespace
-from unittest.mock import Mock
+from unittest.mock import AsyncMock, Mock
 
 import evdev
 import pytest
@@ -9,6 +9,7 @@ import pytest
 from keymasq.common.model.core import DeviceType
 from keymasq.common.types import JsonObject
 from keymasq.keymasqd.runtime import device_path_resolver, outputs
+from keymasq.keymasqd.runtime.grab import acquisition
 from keymasq.keymasqd.runtime.grab.acquisition import finalize_grab
 from keymasq.keymasqd.runtime.grab.planning import build_grab_plan, device_has_mapped_buttons
 from keymasq.keymasqd.runtime.grab.recovery import rollback_failed_grab_report
@@ -369,6 +370,39 @@ async def test_finalize_grab_raises_no_match_and_destroys_created_uinputs(
     assert "mapped_names=1" in str(excinfo.value)
     assert "mapped_bindings=1" in str(excinfo.value)
     destroy_global_uinputs.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_failed_multi_interface_grab_does_not_update_existing_device_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    existing = SimpleNamespace(path="/dev/input/event1")
+    manager = _manager(grabbed_devices={"2dc8:3106": [existing]})
+    plan = _plan(
+        requested_paths={"/dev/input/event1", "/dev/input/event2"},
+        existing_devices=[existing],
+    )
+    update_existing_devices = Mock()
+    monkeypatch.setattr(acquisition.device_path_resolver, "clear_cached_devices", Mock())
+    monkeypatch.setattr(acquisition, "build_grab_plan", Mock(return_value=plan))
+    monkeypatch.setattr(acquisition, "log_grab_request", Mock())
+    monkeypatch.setattr(acquisition, "update_existing_devices", update_existing_devices)
+    monkeypatch.setattr(acquisition, "reconcile_existing_interface_releases", Mock())
+    monkeypatch.setattr(acquisition, "build_runtime_callbacks", Mock(return_value=object()))
+    monkeypatch.setattr(
+        acquisition,
+        "grab_one_interface",
+        AsyncMock(side_effect=RuntimeError("second interface failed")),
+    )
+
+    with pytest.raises(RuntimeError, match="second interface failed"):
+        await acquisition.grab_device_unlocked(
+            manager,
+            _request(),
+            _deps(),
+        )
+
+    update_existing_devices.assert_not_called()
 
 
 class _FakeTask:

--- a/tests/keymasqd/test_grab_lifecycle_planning.py
+++ b/tests/keymasqd/test_grab_lifecycle_planning.py
@@ -389,10 +389,13 @@ async def test_failed_multi_interface_grab_does_not_update_existing_device_metad
     monkeypatch.setattr(acquisition, "update_existing_devices", update_existing_devices)
     monkeypatch.setattr(acquisition, "reconcile_existing_interface_releases", Mock())
     monkeypatch.setattr(acquisition, "build_runtime_callbacks", Mock(return_value=object()))
+    grab_one_interface = AsyncMock(
+        side_effect=[None, RuntimeError("second interface failed")]
+    )
     monkeypatch.setattr(
         acquisition,
         "grab_one_interface",
-        AsyncMock(side_effect=RuntimeError("second interface failed")),
+        grab_one_interface,
     )
 
     with pytest.raises(RuntimeError, match="second interface failed"):
@@ -403,6 +406,7 @@ async def test_failed_multi_interface_grab_does_not_update_existing_device_metad
         )
 
     update_existing_devices.assert_not_called()
+    assert grab_one_interface.await_count == 2
 
 
 class _FakeTask:

--- a/tests/keymasqd/test_macro_backend_loops.py
+++ b/tests/keymasqd/test_macro_backend_loops.py
@@ -83,6 +83,50 @@ async def test_recording_manager_start_rolls_back_resources_when_broadcast_fails
 
 
 @pytest.mark.asyncio
+async def test_recording_manager_start_defers_repeated_cancellation_during_rollback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    device = SimpleNamespace(close=MagicMock())
+    broadcast_started = asyncio.Event()
+    rollback_started = asyncio.Event()
+    release_rollback = asyncio.Event()
+
+    async def broadcast_callback(_command: CommandType, _payload: object) -> None:
+        broadcast_started.set()
+        await asyncio.Event().wait()
+
+    recorder = RecordingManager(broadcast_callback=broadcast_callback)
+    original_abort = recorder._abort_failed_start
+
+    async def delayed_abort() -> None:
+        rollback_started.set()
+        await release_rollback.wait()
+        await original_abort()
+
+    async def fake_to_thread(func, /, *args, **kwargs):
+        if func is recording._open_recording_input_device:
+            return device
+        return func(*args, **kwargs)
+
+    monkeypatch.setattr(recording.asyncio, "to_thread", fake_to_thread)
+    monkeypatch.setattr(recorder, "_abort_failed_start", delayed_abort)
+    start_task = asyncio.create_task(recorder.start([{"path": "/dev/input/event0"}]))
+    await broadcast_started.wait()
+    start_task.cancel()
+    await rollback_started.wait()
+    start_task.cancel()
+    release_rollback.set()
+
+    with pytest.raises(asyncio.CancelledError):
+        await start_task
+
+    assert recorder.is_recording is False
+    assert recorder._spool is None
+    assert recorder._extra_devices == []
+    device.close.assert_called_once()
+
+
+@pytest.mark.asyncio
 async def test_play_macro_hold_loop_finishes_current_run_on_release_by_default() -> None:
     manager = DeviceManager()
     manager.output_state.keyboard_uinput = MagicMock()

--- a/tests/keymasqd/test_macro_backend_loops.py
+++ b/tests/keymasqd/test_macro_backend_loops.py
@@ -86,7 +86,8 @@ async def test_recording_manager_start_rolls_back_resources_when_broadcast_fails
 async def test_recording_manager_closes_device_opened_after_start_cancellation(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    device = SimpleNamespace(close=MagicMock())
+    close_finished = asyncio.Event()
+    device = SimpleNamespace(close=MagicMock(side_effect=close_finished.set))
     open_started = asyncio.Event()
     release_open = asyncio.Event()
     recorder = RecordingManager()
@@ -108,8 +109,7 @@ async def test_recording_manager_closes_device_opened_after_start_cancellation(
         await start_task
 
     release_open.set()
-    await asyncio.sleep(0)
-    await asyncio.sleep(0)
+    await asyncio.wait_for(close_finished.wait(), timeout=0.5)
 
     device.close.assert_called_once()
     assert recorder.is_recording is False

--- a/tests/keymasqd/test_macro_backend_loops.py
+++ b/tests/keymasqd/test_macro_backend_loops.py
@@ -83,6 +83,40 @@ async def test_recording_manager_start_rolls_back_resources_when_broadcast_fails
 
 
 @pytest.mark.asyncio
+async def test_recording_manager_closes_device_opened_after_start_cancellation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    device = SimpleNamespace(close=MagicMock())
+    open_started = asyncio.Event()
+    release_open = asyncio.Event()
+    recorder = RecordingManager()
+
+    async def delayed_to_thread(func, /, *args, **kwargs):
+        assert func is recording._open_recording_input_device
+        assert args == ("/dev/input/event0",)
+        assert kwargs == {}
+        open_started.set()
+        await release_open.wait()
+        return device
+
+    monkeypatch.setattr(recording.asyncio, "to_thread", delayed_to_thread)
+    start_task = asyncio.create_task(recorder.start([{"path": "/dev/input/event0"}]))
+    await open_started.wait()
+    start_task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await start_task
+
+    release_open.set()
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+
+    device.close.assert_called_once()
+    assert recorder.is_recording is False
+    assert recorder._extra_devices == []
+
+
+@pytest.mark.asyncio
 async def test_recording_manager_start_defers_repeated_cancellation_during_rollback(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/keymasqd/test_macro_backend_loops.py
+++ b/tests/keymasqd/test_macro_backend_loops.py
@@ -53,6 +53,35 @@ async def test_recording_manager_start_opens_extra_devices_via_to_thread(monkeyp
     )
 
 
+@pytest.mark.parametrize("failure", [RuntimeError("broadcast failed"), asyncio.CancelledError()])
+@pytest.mark.asyncio
+async def test_recording_manager_start_rolls_back_resources_when_broadcast_fails(
+    monkeypatch: pytest.MonkeyPatch,
+    failure: BaseException,
+) -> None:
+    device = SimpleNamespace(close=MagicMock())
+    broadcast_callback = AsyncMock(side_effect=failure)
+    recorder = RecordingManager(broadcast_callback=broadcast_callback)
+
+    async def fake_to_thread(func, /, *args, **kwargs):
+        if func is recording._open_recording_input_device:
+            return device
+        return func(*args, **kwargs)
+
+    monkeypatch.setattr(recording.asyncio, "to_thread", fake_to_thread)
+
+    with pytest.raises(type(failure)):
+        await recorder.start([{"path": "/dev/input/event0"}])
+
+    assert recorder.is_recording is False
+    assert recorder._spool is None
+    assert recorder._extra_devices == []
+    assert recorder._monitoring_tasks == []
+    assert recorder._progress_task is None
+    assert recorder._record_grabbed_source_keys == set()
+    device.close.assert_called_once()
+
+
 @pytest.mark.asyncio
 async def test_play_macro_hold_loop_finishes_current_run_on_release_by_default() -> None:
     manager = DeviceManager()

--- a/tests/session/test_session_manager_command_runtime.py
+++ b/tests/session/test_session_manager_command_runtime.py
@@ -17,7 +17,7 @@ import keymasq.session.manager.recording_lifecycle as recording_lifecycle_module
 import keymasq.session.manager.recording_unlock as recording_unlock_module
 import keymasq.session.settings as session_settings
 from keymasq.common import paths
-from keymasq.common.ipc import CommandType, Response
+from keymasq.common.ipc import Command, CommandType, Response
 from keymasq.common.security import PeerCredentials
 from keymasq.common.settings import GlobalSettings
 from keymasq.session.listeners.kde import KDEListener
@@ -2269,6 +2269,49 @@ async def test_begin_capture_rolls_back_provisional_lock_when_cancelled(
     assert manager.capture_state.locks == set()
     assert manager.capture_state.resume_profiles == {}
     manager.client.send_command.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_begin_capture_cancellation_ends_daemon_capture_after_ack(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = SessionManager()
+    hardware_id = "2dc8:3106"
+    request_started = asyncio.Event()
+    release_response = asyncio.Event()
+    commands: list[CommandType] = []
+
+    async def send_command(command: Command) -> Response:
+        commands.append(command.command)
+        if command.command == CommandType.CAPTURE_BEGIN:
+            request_started.set()
+            await release_response.wait()
+            return Response(status="ok", data={"token": "token-1", "warnings": []})
+        assert command.data == {"token": "token-1"}
+        return Response(status="ok")
+
+    manager.client.send_command = AsyncMock(side_effect=send_command)
+    reevaluate_profiles = AsyncMock()
+    monkeypatch.setattr(coordinator, "reevaluate_profiles", reevaluate_profiles)
+
+    capture_task = asyncio.create_task(
+        recording_capture_module.capture_begin(manager, hardware_id)
+    )
+    await request_started.wait()
+    capture_task.cancel()
+    release_response.set()
+
+    with pytest.raises(asyncio.CancelledError):
+        await capture_task
+
+    assert commands == [CommandType.CAPTURE_BEGIN, CommandType.CAPTURE_END]
+    assert manager.capture_state.tokens == {}
+    assert manager.capture_state.locks == set()
+    assert manager.capture_state.resume_profiles == {}
+    reevaluate_profiles.assert_awaited_once_with(
+        manager,
+        reason=f"capture ended for {hardware_id}",
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/session/test_session_manager_command_runtime.py
+++ b/tests/session/test_session_manager_command_runtime.py
@@ -22,7 +22,7 @@ from keymasq.common.security import PeerCredentials
 from keymasq.common.settings import GlobalSettings
 from keymasq.session.listeners.kde import KDEListener
 from keymasq.session.manager.core import SessionManager
-from keymasq.session.manager.profile import coordinator, runtime_status
+from keymasq.session.manager.profile import application, coordinator, runtime_status
 from keymasq.session.manager.state import PendingSave, PendingSlot
 from tests.session.support import grant_recording_refresh_owner
 
@@ -2216,6 +2216,59 @@ async def test_begin_capture_rejects_duplicate_for_same_hardware(
     }
     assert manager.capture_state.tokens[hardware_id] == "token-1"
     assert manager.client.send_command.await_count == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("release_failure", [False, RuntimeError("release failed")])
+async def test_begin_capture_rolls_back_provisional_lock_when_release_fails(
+    monkeypatch: pytest.MonkeyPatch,
+    release_failure: object,
+) -> None:
+    manager = SessionManager()
+    hardware_id = "2dc8:3106"
+    manager.profile_state.grabbed_devices.add(hardware_id)
+    manager.client.send_command = AsyncMock()
+    if isinstance(release_failure, BaseException):
+        deactivate_profile = AsyncMock(side_effect=release_failure)
+    else:
+        deactivate_profile = AsyncMock(return_value=release_failure)
+    reevaluate_profiles = AsyncMock()
+    monkeypatch.setattr(application, "deactivate_profile", deactivate_profile)
+    monkeypatch.setattr(coordinator, "reevaluate_profiles", reevaluate_profiles)
+
+    result = await recording_capture_module.capture_begin(manager, hardware_id)
+
+    assert result == {"status": "error", "message": "Failed to begin capture"}
+    assert manager.capture_state.locks == set()
+    assert manager.capture_state.resume_profiles == {}
+    manager.client.send_command.assert_not_awaited()
+    reevaluate_profiles.assert_awaited_once_with(
+        manager,
+        reason=f"capture ended for {hardware_id}",
+    )
+
+
+@pytest.mark.asyncio
+async def test_begin_capture_rolls_back_provisional_lock_when_cancelled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = SessionManager()
+    hardware_id = "2dc8:3106"
+    manager.profile_state.grabbed_devices.add(hardware_id)
+    manager.client.send_command = AsyncMock()
+    monkeypatch.setattr(
+        application,
+        "deactivate_profile",
+        AsyncMock(side_effect=asyncio.CancelledError()),
+    )
+    monkeypatch.setattr(coordinator, "reevaluate_profiles", AsyncMock())
+
+    with pytest.raises(asyncio.CancelledError):
+        await recording_capture_module.capture_begin(manager, hardware_id)
+
+    assert manager.capture_state.locks == set()
+    assert manager.capture_state.resume_profiles == {}
+    manager.client.send_command.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/session/test_session_manager_command_runtime.py
+++ b/tests/session/test_session_manager_command_runtime.py
@@ -2352,6 +2352,38 @@ async def test_begin_capture_preserves_cancellation_when_request_fails(
 
 
 @pytest.mark.asyncio
+async def test_begin_capture_bounds_silent_request_settlement(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = SessionManager()
+    hardware_id = "2dc8:3106"
+    request_started = asyncio.Event()
+
+    async def silent_request(_command: Command) -> Response:
+        request_started.set()
+        await asyncio.Event().wait()
+        raise AssertionError("unreachable")
+
+    monkeypatch.setattr(recording_capture_module, "_CANCEL_SETTLE_TIMEOUT_S", 0.01)
+    manager.client.send_command = AsyncMock(side_effect=silent_request)
+    reevaluate_profiles = AsyncMock()
+    monkeypatch.setattr(coordinator, "reevaluate_profiles", reevaluate_profiles)
+
+    capture_task = asyncio.create_task(
+        recording_capture_module.capture_begin(manager, hardware_id)
+    )
+    await request_started.wait()
+    capture_task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await asyncio.wait_for(capture_task, timeout=0.5)
+
+    assert manager.capture_state.tokens == {}
+    assert manager.capture_state.locks == set()
+    assert manager.capture_state.resume_profiles == {}
+
+
+@pytest.mark.asyncio
 async def test_clear_captures_for_writer_ends_owned_capture_on_disconnect(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/session/test_session_manager_command_runtime.py
+++ b/tests/session/test_session_manager_command_runtime.py
@@ -2315,6 +2315,43 @@ async def test_begin_capture_cancellation_ends_daemon_capture_after_ack(
 
 
 @pytest.mark.asyncio
+async def test_begin_capture_preserves_cancellation_when_request_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = SessionManager()
+    hardware_id = "2dc8:3106"
+    request_started = asyncio.Event()
+    release_response = asyncio.Event()
+
+    async def send_command(_command: Command) -> Response:
+        request_started.set()
+        await release_response.wait()
+        raise ConnectionError("disconnected")
+
+    manager.client.send_command = AsyncMock(side_effect=send_command)
+    reevaluate_profiles = AsyncMock()
+    monkeypatch.setattr(coordinator, "reevaluate_profiles", reevaluate_profiles)
+
+    capture_task = asyncio.create_task(
+        recording_capture_module.capture_begin(manager, hardware_id)
+    )
+    await request_started.wait()
+    capture_task.cancel()
+    release_response.set()
+
+    with pytest.raises(asyncio.CancelledError):
+        await capture_task
+
+    assert manager.capture_state.tokens == {}
+    assert manager.capture_state.locks == set()
+    assert manager.capture_state.resume_profiles == {}
+    reevaluate_profiles.assert_awaited_once_with(
+        manager,
+        reason=f"capture ended for {hardware_id}",
+    )
+
+
+@pytest.mark.asyncio
 async def test_clear_captures_for_writer_ends_owned_capture_on_disconnect(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/session/test_session_manager_command_runtime.py
+++ b/tests/session/test_session_manager_command_runtime.py
@@ -2315,6 +2315,82 @@ async def test_begin_capture_cancellation_ends_daemon_capture_after_ack(
 
 
 @pytest.mark.asyncio
+async def test_begin_capture_cancellation_rolls_back_when_daemon_end_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = SessionManager()
+    hardware_id = "2dc8:3106"
+    request_started = asyncio.Event()
+    release_response = asyncio.Event()
+
+    async def send_command(command: Command) -> Response:
+        if command.command == CommandType.CAPTURE_BEGIN:
+            request_started.set()
+            await release_response.wait()
+            return Response(status="ok", data={"token": "token-1", "warnings": []})
+        return Response(status="error", error="capture end failed")
+
+    manager.client.send_command = AsyncMock(side_effect=send_command)
+    manager.client.disconnect = AsyncMock()
+    reevaluate_profiles = AsyncMock()
+    monkeypatch.setattr(coordinator, "reevaluate_profiles", reevaluate_profiles)
+    capture_task = asyncio.create_task(
+        recording_capture_module.capture_begin(manager, hardware_id)
+    )
+    await request_started.wait()
+    capture_task.cancel()
+    release_response.set()
+
+    with pytest.raises(asyncio.CancelledError):
+        await capture_task
+
+    manager.client.disconnect.assert_awaited_once()
+    assert manager.capture_state.tokens == {}
+    assert manager.capture_state.locks == set()
+    assert manager.capture_state.resume_profiles == {}
+    reevaluate_profiles.assert_awaited_once_with(
+        manager,
+        reason=f"capture ended for {hardware_id}",
+    )
+
+
+@pytest.mark.asyncio
+async def test_begin_capture_cancellation_preserves_state_when_disconnect_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = SessionManager()
+    hardware_id = "2dc8:3106"
+    request_started = asyncio.Event()
+    release_response = asyncio.Event()
+
+    async def send_command(command: Command) -> Response:
+        if command.command == CommandType.CAPTURE_BEGIN:
+            request_started.set()
+            await release_response.wait()
+            return Response(status="ok", data={"token": "token-1", "warnings": []})
+        return Response(status="error", error="capture end failed")
+
+    manager.client.send_command = AsyncMock(side_effect=send_command)
+    manager.client.disconnect = AsyncMock(side_effect=OSError("disconnect failed"))
+    reevaluate_profiles = AsyncMock()
+    monkeypatch.setattr(coordinator, "reevaluate_profiles", reevaluate_profiles)
+    capture_task = asyncio.create_task(
+        recording_capture_module.capture_begin(manager, hardware_id)
+    )
+    await request_started.wait()
+    capture_task.cancel()
+    release_response.set()
+
+    with pytest.raises(asyncio.CancelledError):
+        await capture_task
+
+    assert manager.capture_state.tokens == {hardware_id: "token-1"}
+    assert manager.capture_state.locks == {hardware_id}
+    assert manager.capture_state.resume_profiles == {hardware_id: []}
+    reevaluate_profiles.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_begin_capture_defers_repeated_cancellation_until_ack(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/session/test_session_manager_command_runtime.py
+++ b/tests/session/test_session_manager_command_runtime.py
@@ -2554,6 +2554,35 @@ async def test_begin_capture_bounds_silent_request_settlement(
 
 
 @pytest.mark.asyncio
+async def test_capture_cleanup_wait_has_deadline(monkeypatch: pytest.MonkeyPatch) -> None:
+    cleanup_started = asyncio.Event()
+    cleanup_cancelled = asyncio.Event()
+    release_cleanup = asyncio.Event()
+
+    async def stubborn_cleanup() -> None:
+        cleanup_started.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            cleanup_cancelled.set()
+            await release_cleanup.wait()
+
+    monkeypatch.setattr(recording_capture_module, "_CANCEL_CLEANUP_TIMEOUT_S", 0.01)
+    cleanup_task = asyncio.create_task(stubborn_cleanup())
+    await cleanup_started.wait()
+
+    cancelled = await asyncio.wait_for(
+        recording_capture_module._await_cleanup(cleanup_task),
+        timeout=0.5,
+    )
+
+    assert cancelled is False
+    await cleanup_cancelled.wait()
+    release_cleanup.set()
+    await cleanup_task
+
+
+@pytest.mark.asyncio
 async def test_clear_captures_for_writer_ends_owned_capture_on_disconnect(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/session/test_session_manager_command_runtime.py
+++ b/tests/session/test_session_manager_command_runtime.py
@@ -2431,6 +2431,60 @@ async def test_begin_capture_defers_repeated_cancellation_during_rejected_rollba
 
 
 @pytest.mark.asyncio
+async def test_begin_capture_defers_cancellation_after_rejected_response(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = SessionManager()
+    hardware_id = "2dc8:3106"
+    rollback_started = asyncio.Event()
+    release_rollback = asyncio.Event()
+    manager.client.send_command = AsyncMock(
+        return_value=Response(status="error", error="rejected")
+    )
+
+    async def reevaluate_profiles(*_args, **_kwargs) -> None:
+        rollback_started.set()
+        await release_rollback.wait()
+
+    monkeypatch.setattr(coordinator, "reevaluate_profiles", reevaluate_profiles)
+    capture_task = asyncio.create_task(
+        recording_capture_module.capture_begin(manager, hardware_id)
+    )
+    await rollback_started.wait()
+    capture_task.cancel()
+    release_rollback.set()
+
+    with pytest.raises(asyncio.CancelledError):
+        await capture_task
+
+    assert manager.capture_state.tokens == {}
+    assert manager.capture_state.locks == set()
+    assert manager.capture_state.resume_profiles == {}
+
+
+@pytest.mark.asyncio
+async def test_begin_capture_missing_token_disconnects_before_rollback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = SessionManager()
+    hardware_id = "2dc8:3106"
+    manager.client.send_command = AsyncMock(
+        return_value=Response(status="ok", data={"warnings": []})
+    )
+    manager.client.disconnect = AsyncMock()
+    reevaluate_profiles = AsyncMock()
+    monkeypatch.setattr(coordinator, "reevaluate_profiles", reevaluate_profiles)
+
+    result = await recording_capture_module.capture_begin(manager, hardware_id)
+
+    assert result == {"status": "error", "message": "Missing capture token"}
+    manager.client.disconnect.assert_awaited_once()
+    assert manager.capture_state.tokens == {}
+    assert manager.capture_state.locks == set()
+    reevaluate_profiles.assert_awaited_once()
+
+
+@pytest.mark.asyncio
 async def test_begin_capture_preserves_cancellation_when_request_fails(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/session/test_session_manager_command_runtime.py
+++ b/tests/session/test_session_manager_command_runtime.py
@@ -2315,6 +2315,43 @@ async def test_begin_capture_cancellation_ends_daemon_capture_after_ack(
 
 
 @pytest.mark.asyncio
+async def test_begin_capture_defers_repeated_cancellation_until_ack(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = SessionManager()
+    hardware_id = "2dc8:3106"
+    request_started = asyncio.Event()
+    release_response = asyncio.Event()
+    commands: list[CommandType] = []
+
+    async def send_command(command: Command) -> Response:
+        commands.append(command.command)
+        if command.command == CommandType.CAPTURE_BEGIN:
+            request_started.set()
+            await release_response.wait()
+            return Response(status="ok", data={"token": "token-1", "warnings": []})
+        return Response(status="ok")
+
+    manager.client.send_command = AsyncMock(side_effect=send_command)
+    monkeypatch.setattr(coordinator, "reevaluate_profiles", AsyncMock())
+    capture_task = asyncio.create_task(
+        recording_capture_module.capture_begin(manager, hardware_id)
+    )
+    await request_started.wait()
+    capture_task.cancel()
+    await asyncio.sleep(0)
+    capture_task.cancel()
+    release_response.set()
+
+    with pytest.raises(asyncio.CancelledError):
+        await capture_task
+
+    assert commands == [CommandType.CAPTURE_BEGIN, CommandType.CAPTURE_END]
+    assert manager.capture_state.tokens == {}
+    assert manager.capture_state.locks == set()
+
+
+@pytest.mark.asyncio
 async def test_begin_capture_preserves_cancellation_when_request_fails(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/session/test_session_manager_command_runtime.py
+++ b/tests/session/test_session_manager_command_runtime.py
@@ -2352,6 +2352,45 @@ async def test_begin_capture_defers_repeated_cancellation_until_ack(
 
 
 @pytest.mark.asyncio
+async def test_begin_capture_defers_cancellation_during_capture_end(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = SessionManager()
+    hardware_id = "2dc8:3106"
+    request_started = asyncio.Event()
+    release_response = asyncio.Event()
+    end_started = asyncio.Event()
+    release_end = asyncio.Event()
+
+    async def send_command(command: Command) -> Response:
+        if command.command == CommandType.CAPTURE_BEGIN:
+            request_started.set()
+            await release_response.wait()
+            return Response(status="ok", data={"token": "token-1", "warnings": []})
+        end_started.set()
+        await release_end.wait()
+        return Response(status="ok")
+
+    manager.client.send_command = AsyncMock(side_effect=send_command)
+    monkeypatch.setattr(coordinator, "reevaluate_profiles", AsyncMock())
+    capture_task = asyncio.create_task(
+        recording_capture_module.capture_begin(manager, hardware_id)
+    )
+    await request_started.wait()
+    capture_task.cancel()
+    release_response.set()
+    await end_started.wait()
+    capture_task.cancel()
+    release_end.set()
+
+    with pytest.raises(asyncio.CancelledError):
+        await capture_task
+
+    assert manager.capture_state.tokens == {}
+    assert manager.capture_state.locks == set()
+
+
+@pytest.mark.asyncio
 async def test_begin_capture_preserves_cancellation_when_request_fails(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/session/test_session_manager_command_runtime.py
+++ b/tests/session/test_session_manager_command_runtime.py
@@ -2391,6 +2391,46 @@ async def test_begin_capture_defers_cancellation_during_capture_end(
 
 
 @pytest.mark.asyncio
+async def test_begin_capture_defers_repeated_cancellation_during_rejected_rollback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = SessionManager()
+    hardware_id = "2dc8:3106"
+    request_started = asyncio.Event()
+    release_response = asyncio.Event()
+    rollback_started = asyncio.Event()
+    release_rollback = asyncio.Event()
+
+    async def send_command(_command: Command) -> Response:
+        request_started.set()
+        await release_response.wait()
+        return Response(status="error", error="rejected")
+
+    async def reevaluate_profiles(*_args, **_kwargs) -> None:
+        rollback_started.set()
+        await release_rollback.wait()
+
+    manager.client.send_command = AsyncMock(side_effect=send_command)
+    monkeypatch.setattr(coordinator, "reevaluate_profiles", reevaluate_profiles)
+    capture_task = asyncio.create_task(
+        recording_capture_module.capture_begin(manager, hardware_id)
+    )
+    await request_started.wait()
+    capture_task.cancel()
+    release_response.set()
+    await rollback_started.wait()
+    capture_task.cancel()
+    release_rollback.set()
+
+    with pytest.raises(asyncio.CancelledError):
+        await capture_task
+
+    assert manager.capture_state.tokens == {}
+    assert manager.capture_state.locks == set()
+    assert manager.capture_state.resume_profiles == {}
+
+
+@pytest.mark.asyncio
 async def test_begin_capture_preserves_cancellation_when_request_fails(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/session/test_session_manager_connect_loop.py
+++ b/tests/session/test_session_manager_connect_loop.py
@@ -48,8 +48,7 @@ async def test_keymasqd_disconnect_clears_runtime_state() -> None:
     manager.exec_state.next_exec_ref = 9
     manager._broadcast_keymasqd_status = Mock()  # type: ignore[method-assign]
 
-    manager._handle_keymasqd_disconnect()
-    await asyncio.sleep(0)
+    await manager._handle_keymasqd_disconnect()
 
     assert manager.connected is False
     assert manager.profile_state.grabbed_devices == set()
@@ -84,6 +83,39 @@ async def test_keymasqd_disconnect_clears_runtime_state() -> None:
 
     with pytest.raises(asyncio.CancelledError):
         await retry_task
+
+
+@pytest.mark.asyncio
+async def test_keymasqd_disconnect_waits_for_event_tasks_before_clearing_state() -> None:
+    manager = SessionManager()
+    manager.connected = True
+    manager.profile_state.grabbed_devices.add("1234:5678")
+    cancellation_started = asyncio.Event()
+    release_cancellation = asyncio.Event()
+
+    async def event_work() -> None:
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            cancellation_started.set()
+            await release_cancellation.wait()
+            raise
+
+    event_task = asyncio.create_task(event_work())
+    manager.event_state.tasks.add(event_task)
+    await asyncio.sleep(0)
+    disconnect_task = asyncio.create_task(manager._handle_keymasqd_disconnect())
+    await cancellation_started.wait()
+
+    assert manager.connected is True
+    assert manager.profile_state.grabbed_devices == {"1234:5678"}
+
+    release_cancellation.set()
+    await disconnect_task
+
+    assert manager.connected is False
+    assert manager.profile_state.grabbed_devices == set()
+    assert manager.event_state.tasks == set()
 
 
 @pytest.mark.asyncio

--- a/tests/session/test_session_manager_connect_loop.py
+++ b/tests/session/test_session_manager_connect_loop.py
@@ -7,6 +7,7 @@ import keymasq.session.manager.core as session_core_module
 import keymasq.session.manager.recording_device_selection as recording_device_selection_module
 from keymasq.common.ipc import CommandType, Response
 from keymasq.session.manager.core import SessionManager
+from keymasq.session.manager.state import ExecBinding
 
 
 @pytest.mark.asyncio
@@ -33,6 +34,18 @@ async def test_keymasqd_disconnect_clears_runtime_state() -> None:
     manager.recording_state.selected_devices_cache = [{"name": "Keyboard"}]
     manager.recording_state.devices_cache_ready = True
     manager.recording_state.devices_cache_include_other = True
+    manager.capture_state.tokens["1234:5678"] = "stale-token"
+    manager.capture_state.locks.add("1234:5678")
+    manager.capture_state.resume_profiles["1234:5678"] = ["Default"]
+    manager.capture_state.owner_writer_ids["1234:5678"] = 42
+    manager.exec_state.exec_refs[7] = ExecBinding(
+        cmd="notify-send stale",
+        owner="device",
+        hardware_id="1234:5678",
+    )
+    manager.exec_state.device_exec_refs["1234:5678"] = {7}
+    manager.exec_state.combo_exec_refs.add(8)
+    manager.exec_state.next_exec_ref = 9
     manager._broadcast_keymasqd_status = Mock()  # type: ignore[method-assign]
 
     manager._handle_keymasqd_disconnect()
@@ -59,6 +72,14 @@ async def test_keymasqd_disconnect_clears_runtime_state() -> None:
     assert manager.recording_state.selected_devices_cache == []
     assert manager.recording_state.devices_cache_ready is False
     assert manager.recording_state.devices_cache_include_other is False
+    assert manager.capture_state.tokens == {}
+    assert manager.capture_state.locks == set()
+    assert manager.capture_state.resume_profiles == {}
+    assert manager.capture_state.owner_writer_ids == {}
+    assert manager.exec_state.exec_refs == {}
+    assert manager.exec_state.device_exec_refs == {}
+    assert manager.exec_state.combo_exec_refs == set()
+    assert manager.exec_state.next_exec_ref == 9
     manager._broadcast_keymasqd_status.assert_called_once_with(False)  # type: ignore[attr-defined]
 
     with pytest.raises(asyncio.CancelledError):

--- a/tests/session/test_session_manager_profile_apply.py
+++ b/tests/session/test_session_manager_profile_apply.py
@@ -403,6 +403,48 @@ async def test_cancelled_combo_update_settles_acknowledgement_and_commits_refs()
 
 
 @pytest.mark.asyncio
+async def test_cancelled_mapping_update_preserves_cancellation_when_request_fails() -> None:
+    manager = SessionManager()
+    hardware_id = "1234:5678"
+    manager.profile_state.grabbed_devices.add(hardware_id)
+    old_binding = ExecBinding(
+        cmd="notify-send old",
+        owner="device",
+        hardware_id=hardware_id,
+    )
+    manager.exec_state.exec_refs[7] = old_binding
+    manager.exec_state.device_exec_refs[hardware_id] = {7}
+    request_started = asyncio.Event()
+    release_response = asyncio.Event()
+
+    async def failed_response(_command: object) -> Response:
+        request_started.set()
+        await release_response.wait()
+        raise ConnectionError("disconnected")
+
+    manager.client.send_command = AsyncMock(side_effect=failed_response)
+    resolved = ResolvedDeviceProfile(
+        hardware_id=hardware_id,
+        mappings={
+            "button": MappingAction(action_type=ActionType.EXEC, cmd="notify-send new")
+        },
+    )
+
+    update_task = asyncio.create_task(
+        profile_application.update_mapping(manager, hardware_id, resolved)
+    )
+    await request_started.wait()
+    update_task.cancel()
+    release_response.set()
+
+    with pytest.raises(asyncio.CancelledError):
+        await update_task
+
+    assert manager.exec_state.device_exec_refs == {hardware_id: {7}}
+    assert manager.exec_state.exec_refs == {7: old_binding}
+
+
+@pytest.mark.asyncio
 async def test_apply_resolved_device_profile_uses_extended_grab_timeout() -> None:
     manager = SessionManager()
     hardware_id = "1234:5678"

--- a/tests/session/test_session_manager_profile_apply.py
+++ b/tests/session/test_session_manager_profile_apply.py
@@ -177,6 +177,128 @@ async def test_mapping_update_exposes_staged_exec_reference_while_in_flight() ->
 
 
 @pytest.mark.asyncio
+async def test_mapping_update_timeout_retains_uncertain_exec_references() -> None:
+    manager = SessionManager()
+    hardware_id = "1234:5678"
+    manager.profile_state.grabbed_devices.add(hardware_id)
+    old_binding = ExecBinding(
+        cmd="notify-send old",
+        owner="device",
+        hardware_id=hardware_id,
+    )
+    manager.exec_state.exec_refs[7] = old_binding
+    manager.exec_state.device_exec_refs[hardware_id] = {7}
+    manager.exec_state.next_exec_ref = 10
+    manager.client.send_command = AsyncMock(side_effect=TimeoutError())
+    manager.client.disconnect = AsyncMock()
+    resolved = ResolvedDeviceProfile(
+        hardware_id=hardware_id,
+        mappings={
+            "button": MappingAction(action_type=ActionType.EXEC, cmd="notify-send new")
+        },
+    )
+
+    updated = await profile_application.update_mapping(manager, hardware_id, resolved)
+
+    assert updated is False
+    manager.client.disconnect.assert_awaited_once()
+    assert manager.exec_state.device_exec_refs == {hardware_id: {7, 10}}
+    assert manager.exec_state.exec_refs == {
+        7: old_binding,
+        10: ExecBinding(
+            cmd="notify-send new",
+            owner="device",
+            hardware_id=hardware_id,
+        ),
+    }
+
+
+@pytest.mark.asyncio
+async def test_mapping_update_timeout_remains_handled_when_disconnect_fails() -> None:
+    manager = SessionManager()
+    hardware_id = "1234:5678"
+    manager.profile_state.grabbed_devices.add(hardware_id)
+    manager.exec_state.next_exec_ref = 10
+    manager.client.send_command = AsyncMock(side_effect=TimeoutError())
+    manager.client.disconnect = AsyncMock(side_effect=OSError("disconnect failed"))
+    resolved = ResolvedDeviceProfile(
+        hardware_id=hardware_id,
+        mappings={
+            "button": MappingAction(action_type=ActionType.EXEC, cmd="notify-send new")
+        },
+    )
+
+    updated = await profile_application.update_mapping(manager, hardware_id, resolved)
+
+    assert updated is False
+    assert manager.exec_state.device_exec_refs == {hardware_id: {10}}
+    assert 10 in manager.exec_state.exec_refs
+
+
+@pytest.mark.asyncio
+async def test_mapping_timeout_disconnect_propagates_cancellation() -> None:
+    manager = SessionManager()
+    hardware_id = "1234:5678"
+    manager.profile_state.grabbed_devices.add(hardware_id)
+    manager.exec_state.next_exec_ref = 10
+    manager.client.send_command = AsyncMock(side_effect=TimeoutError())
+    manager.client.disconnect = AsyncMock(side_effect=asyncio.CancelledError())
+    resolved = ResolvedDeviceProfile(
+        hardware_id=hardware_id,
+        mappings={
+            "button": MappingAction(action_type=ActionType.EXEC, cmd="notify-send new")
+        },
+    )
+
+    with pytest.raises(asyncio.CancelledError):
+        await profile_application.update_mapping(manager, hardware_id, resolved)
+
+    assert manager.exec_state.device_exec_refs == {hardware_id: {10}}
+    assert 10 in manager.exec_state.exec_refs
+
+
+@pytest.mark.asyncio
+async def test_initial_mapping_timeout_retains_uncertain_exec_references() -> None:
+    manager = SessionManager()
+    hardware_id = "1234:5678"
+    old_binding = ExecBinding(
+        cmd="notify-send old",
+        owner="device",
+        hardware_id=hardware_id,
+    )
+    manager.exec_state.exec_refs[7] = old_binding
+    manager.exec_state.device_exec_refs[hardware_id] = {7}
+    manager.exec_state.next_exec_ref = 10
+    manager.client.send_command = AsyncMock(side_effect=TimeoutError())
+    manager.client.disconnect = AsyncMock()
+    resolved = ResolvedDeviceProfile(
+        hardware_id=hardware_id,
+        mappings={
+            "button": MappingAction(action_type=ActionType.EXEC, cmd="notify-send new")
+        },
+    )
+
+    await profile_application._send_set_mapping_command(
+        manager,
+        hardware_id,
+        resolved,
+        Mock(),
+        generation=None,
+    )
+
+    manager.client.disconnect.assert_awaited_once()
+    assert manager.exec_state.device_exec_refs == {hardware_id: {7, 10}}
+    assert manager.exec_state.exec_refs == {
+        7: old_binding,
+        10: ExecBinding(
+            cmd="notify-send new",
+            owner="device",
+            hardware_id=hardware_id,
+        ),
+    }
+
+
+@pytest.mark.asyncio
 async def test_failed_combo_update_preserves_acknowledged_exec_references() -> None:
     manager = SessionManager()
     old_binding = ExecBinding(cmd="notify-send old combo", owner="combo")

--- a/tests/session/test_session_manager_profile_apply.py
+++ b/tests/session/test_session_manager_profile_apply.py
@@ -136,6 +136,47 @@ async def test_failed_mapping_update_preserves_acknowledged_exec_references() ->
 
 
 @pytest.mark.asyncio
+async def test_mapping_update_exposes_staged_exec_reference_while_in_flight() -> None:
+    manager = SessionManager()
+    hardware_id = "1234:5678"
+    manager.profile_state.grabbed_devices.add(hardware_id)
+    old_binding = ExecBinding(
+        cmd="notify-send old",
+        owner="device",
+        hardware_id=hardware_id,
+    )
+    manager.exec_state.exec_refs[7] = old_binding
+    manager.exec_state.device_exec_refs[hardware_id] = {7}
+    manager.exec_state.next_exec_ref = 10
+
+    async def inspect_references(_command: object) -> Response:
+        assert manager.exec_state.device_exec_refs == {hardware_id: {7}}
+        assert manager.exec_state.exec_refs == {
+            7: old_binding,
+            10: ExecBinding(
+                cmd="notify-send new",
+                owner="device",
+                hardware_id=hardware_id,
+            ),
+        }
+        return Response(status="error", error="mapping rejected")
+
+    manager.client.send_command = AsyncMock(side_effect=inspect_references)
+    resolved = ResolvedDeviceProfile(
+        hardware_id=hardware_id,
+        mappings={
+            "button": MappingAction(action_type=ActionType.EXEC, cmd="notify-send new")
+        },
+    )
+
+    updated = await profile_application.update_mapping(manager, hardware_id, resolved)
+
+    assert updated is False
+    assert manager.exec_state.device_exec_refs == {hardware_id: {7}}
+    assert manager.exec_state.exec_refs == {7: old_binding}
+
+
+@pytest.mark.asyncio
 async def test_failed_combo_update_preserves_acknowledged_exec_references() -> None:
     manager = SessionManager()
     old_binding = ExecBinding(cmd="notify-send old combo", owner="combo")
@@ -162,6 +203,39 @@ async def test_failed_combo_update_preserves_acknowledged_exec_references() -> N
     assert manager.exec_state.combo_exec_refs == {8}
     assert manager.exec_state.exec_refs == {8: old_binding}
     assert manager.exec_state.next_exec_ref == 11
+
+
+@pytest.mark.asyncio
+async def test_combo_update_exposes_staged_exec_reference_while_in_flight() -> None:
+    manager = SessionManager()
+    old_binding = ExecBinding(cmd="notify-send old combo", owner="combo")
+    manager.exec_state.exec_refs[8] = old_binding
+    manager.exec_state.combo_exec_refs.add(8)
+    manager.exec_state.next_exec_ref = 10
+
+    async def inspect_references(_command: object) -> Response:
+        assert manager.exec_state.combo_exec_refs == {8}
+        assert manager.exec_state.exec_refs == {
+            8: old_binding,
+            10: ExecBinding(cmd="notify-send new combo", owner="combo"),
+        }
+        return Response(status="error", error="combos rejected")
+
+    manager.client.send_command = AsyncMock(side_effect=inspect_references)
+    resolved_combo = ResolvedCombo(
+        id="combo-1",
+        name="Combo",
+        steps=[
+            ComboStep(events=[ComboEvent(hardware_id="1234:5678", evdev="key_a")])
+        ],
+        action=MappingAction(action_type=ActionType.EXEC, cmd="notify-send new combo"),
+        profile_name="Desktop",
+    )
+
+    await profile_application.update_combos(manager, [resolved_combo])
+
+    assert manager.exec_state.combo_exec_refs == {8}
+    assert manager.exec_state.exec_refs == {8: old_binding}
 
 
 @pytest.mark.asyncio

--- a/tests/session/test_session_manager_profile_apply.py
+++ b/tests/session/test_session_manager_profile_apply.py
@@ -239,6 +239,35 @@ async def test_combo_update_exposes_staged_exec_reference_while_in_flight() -> N
 
 
 @pytest.mark.asyncio
+async def test_combo_serialization_failure_preserves_acknowledged_exec_references(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = SessionManager()
+    old_binding = ExecBinding(cmd="notify-send old combo", owner="combo")
+    manager.exec_state.exec_refs[8] = old_binding
+    manager.exec_state.combo_exec_refs.add(8)
+    manager.client.send_command = AsyncMock()
+    monkeypatch.setattr(
+        profile_application.combo,
+        "serialize",
+        Mock(side_effect=ValueError("invalid combo")),
+    )
+    resolved_combo = ResolvedCombo(
+        id="combo-1",
+        name="Combo",
+        steps=[ComboStep(events=[ComboEvent(hardware_id="1234:5678", evdev="key_a")])],
+        action=MappingAction(action_type=ActionType.EXEC, cmd="notify-send new combo"),
+        profile_name="Desktop",
+    )
+
+    await profile_application.update_combos(manager, [resolved_combo])
+
+    manager.client.send_command.assert_not_awaited()
+    assert manager.exec_state.combo_exec_refs == {8}
+    assert manager.exec_state.exec_refs == {8: old_binding}
+
+
+@pytest.mark.asyncio
 async def test_stale_mapping_update_does_not_replace_newer_exec_references() -> None:
     manager = SessionManager()
     hardware_id = "1234:5678"
@@ -568,6 +597,13 @@ async def test_cancelled_mapping_update_bounds_silent_request_settlement(
     manager = SessionManager()
     hardware_id = "1234:5678"
     manager.profile_state.grabbed_devices.add(hardware_id)
+    old_binding = ExecBinding(
+        cmd="notify-send old",
+        owner="device",
+        hardware_id=hardware_id,
+    )
+    manager.exec_state.exec_refs[7] = old_binding
+    manager.exec_state.device_exec_refs[hardware_id] = {7}
     manager.exec_state.next_exec_ref = 10
     request_started = asyncio.Event()
 
@@ -594,8 +630,33 @@ async def test_cancelled_mapping_update_bounds_silent_request_settlement(
     with pytest.raises(asyncio.CancelledError):
         await asyncio.wait_for(update_task, timeout=0.5)
 
-    assert manager.exec_state.device_exec_refs == {}
-    assert manager.exec_state.exec_refs == {}
+    assert manager.exec_state.device_exec_refs == {hardware_id: {7}}
+    assert manager.exec_state.exec_refs == {7: old_binding}
+
+
+@pytest.mark.asyncio
+async def test_profile_cleanup_wait_has_deadline(monkeypatch: pytest.MonkeyPatch) -> None:
+    cleanup_started = asyncio.Event()
+    cleanup_cancelled = asyncio.Event()
+    release_cleanup = asyncio.Event()
+
+    async def stubborn_cleanup() -> None:
+        cleanup_started.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            cleanup_cancelled.set()
+            await release_cleanup.wait()
+
+    monkeypatch.setattr(profile_application, "_CANCEL_CLEANUP_TIMEOUT_S", 0.01)
+    cleanup_task = asyncio.create_task(stubborn_cleanup())
+    await cleanup_started.wait()
+
+    await asyncio.wait_for(profile_application._await_cleanup(cleanup_task), timeout=0.5)
+
+    await cleanup_cancelled.wait()
+    release_cleanup.set()
+    await cleanup_task
 
 
 @pytest.mark.asyncio

--- a/tests/session/test_session_manager_profile_apply.py
+++ b/tests/session/test_session_manager_profile_apply.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock
@@ -161,6 +162,244 @@ async def test_failed_combo_update_preserves_acknowledged_exec_references() -> N
     assert manager.exec_state.combo_exec_refs == {8}
     assert manager.exec_state.exec_refs == {8: old_binding}
     assert manager.exec_state.next_exec_ref == 11
+
+
+@pytest.mark.asyncio
+async def test_stale_mapping_update_does_not_replace_newer_exec_references() -> None:
+    manager = SessionManager()
+    hardware_id = "1234:5678"
+    manager.profile_state.grabbed_devices.add(hardware_id)
+    manager.profile_state.apply_generation = 1
+    old_binding = ExecBinding(
+        cmd="notify-send old",
+        owner="device",
+        hardware_id=hardware_id,
+    )
+    newer_binding = ExecBinding(
+        cmd="notify-send newer",
+        owner="device",
+        hardware_id=hardware_id,
+    )
+    manager.exec_state.exec_refs[7] = old_binding
+    manager.exec_state.device_exec_refs[hardware_id] = {7}
+    manager.exec_state.next_exec_ref = 10
+
+    async def complete_after_newer_apply(_command: object) -> Response:
+        manager.profile_state.apply_generation = 2
+        manager.exec_state.exec_refs = {20: newer_binding}
+        manager.exec_state.device_exec_refs = {hardware_id: {20}}
+        return Response(status="ok")
+
+    manager.client.send_command = AsyncMock(side_effect=complete_after_newer_apply)
+    resolved = ResolvedDeviceProfile(
+        hardware_id=hardware_id,
+        mappings={
+            "button": MappingAction(action_type=ActionType.EXEC, cmd="notify-send stale")
+        },
+    )
+
+    with pytest.raises(asyncio.CancelledError):
+        await profile_application.update_mapping(
+            manager,
+            hardware_id,
+            resolved,
+            generation=1,
+        )
+
+    assert manager.exec_state.device_exec_refs == {hardware_id: {10, 20}}
+    assert manager.exec_state.exec_refs == {
+        10: ExecBinding(
+            cmd="notify-send stale",
+            owner="device",
+            hardware_id=hardware_id,
+        ),
+        20: newer_binding,
+    }
+
+
+@pytest.mark.asyncio
+async def test_stale_initial_mapping_does_not_replace_newer_exec_references() -> None:
+    manager = SessionManager()
+    hardware_id = "1234:5678"
+    manager.profile_state.apply_generation = 1
+    old_binding = ExecBinding(
+        cmd="notify-send old",
+        owner="device",
+        hardware_id=hardware_id,
+    )
+    newer_binding = ExecBinding(
+        cmd="notify-send newer",
+        owner="device",
+        hardware_id=hardware_id,
+    )
+    manager.exec_state.exec_refs[7] = old_binding
+    manager.exec_state.device_exec_refs[hardware_id] = {7}
+    manager.exec_state.next_exec_ref = 10
+
+    async def complete_after_newer_apply(_command: object) -> Response:
+        manager.profile_state.apply_generation = 2
+        manager.exec_state.exec_refs = {20: newer_binding}
+        manager.exec_state.device_exec_refs = {hardware_id: {20}}
+        return Response(status="ok")
+
+    manager.client.send_command = AsyncMock(side_effect=complete_after_newer_apply)
+    resolved = ResolvedDeviceProfile(
+        hardware_id=hardware_id,
+        mappings={
+            "button": MappingAction(action_type=ActionType.EXEC, cmd="notify-send stale")
+        },
+    )
+
+    with pytest.raises(asyncio.CancelledError):
+        await profile_application._send_set_mapping_command(
+            manager,
+            hardware_id,
+            resolved,
+            Mock(),
+            generation=1,
+        )
+
+    assert manager.exec_state.device_exec_refs == {hardware_id: {10, 20}}
+    assert manager.exec_state.exec_refs == {
+        10: ExecBinding(
+            cmd="notify-send stale",
+            owner="device",
+            hardware_id=hardware_id,
+        ),
+        20: newer_binding,
+    }
+
+
+@pytest.mark.asyncio
+async def test_stale_combo_update_does_not_replace_newer_exec_references() -> None:
+    manager = SessionManager()
+    manager.profile_state.apply_generation = 1
+    old_binding = ExecBinding(cmd="notify-send old combo", owner="combo")
+    newer_binding = ExecBinding(cmd="notify-send newer combo", owner="combo")
+    manager.exec_state.exec_refs[8] = old_binding
+    manager.exec_state.combo_exec_refs.add(8)
+    manager.exec_state.next_exec_ref = 10
+
+    async def complete_after_newer_apply(_command: object) -> Response:
+        manager.profile_state.apply_generation = 2
+        manager.exec_state.exec_refs = {20: newer_binding}
+        manager.exec_state.combo_exec_refs = {20}
+        return Response(status="ok")
+
+    manager.client.send_command = AsyncMock(side_effect=complete_after_newer_apply)
+    resolved_combo = ResolvedCombo(
+        id="combo-1",
+        name="Combo",
+        steps=[
+            ComboStep(events=[ComboEvent(hardware_id="1234:5678", evdev="key_a")])
+        ],
+        action=MappingAction(action_type=ActionType.EXEC, cmd="notify-send stale combo"),
+        profile_name="Desktop",
+    )
+
+    with pytest.raises(asyncio.CancelledError):
+        await profile_application.update_combos(
+            manager,
+            [resolved_combo],
+            generation=1,
+        )
+
+    assert manager.exec_state.combo_exec_refs == {10, 20}
+    assert manager.exec_state.exec_refs == {
+        10: ExecBinding(cmd="notify-send stale combo", owner="combo"),
+        20: newer_binding,
+    }
+
+
+@pytest.mark.asyncio
+async def test_cancelled_mapping_update_settles_acknowledgement_and_commits_refs() -> None:
+    manager = SessionManager()
+    hardware_id = "1234:5678"
+    manager.profile_state.grabbed_devices.add(hardware_id)
+    old_binding = ExecBinding(
+        cmd="notify-send old",
+        owner="device",
+        hardware_id=hardware_id,
+    )
+    manager.exec_state.exec_refs[7] = old_binding
+    manager.exec_state.device_exec_refs[hardware_id] = {7}
+    manager.exec_state.next_exec_ref = 10
+    request_started = asyncio.Event()
+    release_response = asyncio.Event()
+
+    async def delayed_response(_command: object) -> Response:
+        request_started.set()
+        await release_response.wait()
+        return Response(status="ok")
+
+    manager.client.send_command = AsyncMock(side_effect=delayed_response)
+    resolved = ResolvedDeviceProfile(
+        hardware_id=hardware_id,
+        mappings={
+            "button": MappingAction(action_type=ActionType.EXEC, cmd="notify-send new")
+        },
+    )
+
+    update_task = asyncio.create_task(
+        profile_application.update_mapping(manager, hardware_id, resolved)
+    )
+    await request_started.wait()
+    update_task.cancel()
+    release_response.set()
+
+    with pytest.raises(asyncio.CancelledError):
+        await update_task
+
+    assert manager.exec_state.device_exec_refs == {hardware_id: {10}}
+    assert manager.exec_state.exec_refs == {
+        10: ExecBinding(
+            cmd="notify-send new",
+            owner="device",
+            hardware_id=hardware_id,
+        )
+    }
+
+
+@pytest.mark.asyncio
+async def test_cancelled_combo_update_settles_acknowledgement_and_commits_refs() -> None:
+    manager = SessionManager()
+    old_binding = ExecBinding(cmd="notify-send old combo", owner="combo")
+    manager.exec_state.exec_refs[8] = old_binding
+    manager.exec_state.combo_exec_refs.add(8)
+    manager.exec_state.next_exec_ref = 10
+    request_started = asyncio.Event()
+    release_response = asyncio.Event()
+
+    async def delayed_response(_command: object) -> Response:
+        request_started.set()
+        await release_response.wait()
+        return Response(status="ok")
+
+    manager.client.send_command = AsyncMock(side_effect=delayed_response)
+    resolved_combo = ResolvedCombo(
+        id="combo-1",
+        name="Combo",
+        steps=[
+            ComboStep(events=[ComboEvent(hardware_id="1234:5678", evdev="key_a")])
+        ],
+        action=MappingAction(action_type=ActionType.EXEC, cmd="notify-send new combo"),
+        profile_name="Desktop",
+    )
+
+    update_task = asyncio.create_task(
+        profile_application.update_combos(manager, [resolved_combo])
+    )
+    await request_started.wait()
+    update_task.cancel()
+    release_response.set()
+
+    with pytest.raises(asyncio.CancelledError):
+        await update_task
+
+    assert manager.exec_state.combo_exec_refs == {10}
+    assert manager.exec_state.exec_refs == {
+        10: ExecBinding(cmd="notify-send new combo", owner="combo")
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/session/test_session_manager_profile_apply.py
+++ b/tests/session/test_session_manager_profile_apply.py
@@ -20,6 +20,7 @@ from keymasq.common.model.profiles import (
 )
 from keymasq.session.manager.core import SessionManager
 from keymasq.session.manager.profile import coordinator
+from keymasq.session.manager.state import ExecBinding
 from keymasq.session.profile.types import (
     ResolvedCombo,
     ResolvedDeviceProfile,
@@ -100,6 +101,66 @@ async def test_reevaluate_profiles_skips_unchanged_mapping_and_combos() -> None:
         CommandType.SET_COMBOS,
     ]
     assert [combo.id for combo in manager.profile_state.resolved_combos] == ["combo-1"]
+
+
+@pytest.mark.asyncio
+async def test_failed_mapping_update_preserves_acknowledged_exec_references() -> None:
+    manager = SessionManager()
+    hardware_id = "1234:5678"
+    manager.profile_state.grabbed_devices.add(hardware_id)
+    old_binding = ExecBinding(
+        cmd="notify-send old",
+        owner="device",
+        hardware_id=hardware_id,
+    )
+    manager.exec_state.exec_refs[7] = old_binding
+    manager.exec_state.device_exec_refs[hardware_id] = {7}
+    manager.exec_state.next_exec_ref = 10
+    manager.client.send_command = AsyncMock(
+        return_value=Response(status="error", error="mapping rejected")
+    )
+    resolved = ResolvedDeviceProfile(
+        hardware_id=hardware_id,
+        mappings={
+            "button": MappingAction(action_type=ActionType.EXEC, cmd="notify-send new")
+        },
+    )
+
+    updated = await profile_application.update_mapping(manager, hardware_id, resolved)
+
+    assert updated is False
+    assert manager.exec_state.device_exec_refs == {hardware_id: {7}}
+    assert manager.exec_state.exec_refs == {7: old_binding}
+    assert manager.exec_state.next_exec_ref == 11
+
+
+@pytest.mark.asyncio
+async def test_failed_combo_update_preserves_acknowledged_exec_references() -> None:
+    manager = SessionManager()
+    old_binding = ExecBinding(cmd="notify-send old combo", owner="combo")
+    manager.exec_state.exec_refs[8] = old_binding
+    manager.exec_state.combo_exec_refs.add(8)
+    manager.exec_state.next_exec_ref = 10
+    manager.client.send_command = AsyncMock(
+        return_value=Response(status="error", error="combos rejected")
+    )
+    resolved_combo = ResolvedCombo(
+        id="combo-1",
+        name="Combo",
+        steps=[
+            ComboStep(
+                events=[ComboEvent(hardware_id="1234:5678", evdev="key_a")]
+            )
+        ],
+        action=MappingAction(action_type=ActionType.EXEC, cmd="notify-send new combo"),
+        profile_name="Desktop",
+    )
+
+    await profile_application.update_combos(manager, [resolved_combo])
+
+    assert manager.exec_state.combo_exec_refs == {8}
+    assert manager.exec_state.exec_refs == {8: old_binding}
+    assert manager.exec_state.next_exec_ref == 11
 
 
 @pytest.mark.asyncio

--- a/tests/session/test_session_manager_profile_apply.py
+++ b/tests/session/test_session_manager_profile_apply.py
@@ -435,6 +435,49 @@ async def test_cancelled_mapping_update_settles_acknowledgement_and_commits_refs
 
 
 @pytest.mark.asyncio
+async def test_mapping_update_defers_repeated_cancellation_until_ack() -> None:
+    manager = SessionManager()
+    hardware_id = "1234:5678"
+    manager.profile_state.grabbed_devices.add(hardware_id)
+    manager.exec_state.next_exec_ref = 10
+    request_started = asyncio.Event()
+    release_response = asyncio.Event()
+
+    async def delayed_response(_command: object) -> Response:
+        request_started.set()
+        await release_response.wait()
+        return Response(status="ok")
+
+    manager.client.send_command = AsyncMock(side_effect=delayed_response)
+    resolved = ResolvedDeviceProfile(
+        hardware_id=hardware_id,
+        mappings={
+            "button": MappingAction(action_type=ActionType.EXEC, cmd="notify-send new")
+        },
+    )
+    update_task = asyncio.create_task(
+        profile_application.update_mapping(manager, hardware_id, resolved)
+    )
+    await request_started.wait()
+    update_task.cancel()
+    await asyncio.sleep(0)
+    update_task.cancel()
+    release_response.set()
+
+    with pytest.raises(asyncio.CancelledError):
+        await update_task
+
+    assert manager.exec_state.device_exec_refs == {hardware_id: {10}}
+    assert manager.exec_state.exec_refs == {
+        10: ExecBinding(
+            cmd="notify-send new",
+            owner="device",
+            hardware_id=hardware_id,
+        )
+    }
+
+
+@pytest.mark.asyncio
 async def test_cancelled_combo_update_settles_acknowledgement_and_commits_refs() -> None:
     manager = SessionManager()
     old_binding = ExecBinding(cmd="notify-send old combo", owner="combo")

--- a/tests/session/test_session_manager_profile_apply.py
+++ b/tests/session/test_session_manager_profile_apply.py
@@ -519,6 +519,43 @@ async def test_cancelled_mapping_update_preserves_cancellation_when_request_fail
 
 
 @pytest.mark.asyncio
+async def test_cancelled_mapping_update_bounds_silent_request_settlement(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = SessionManager()
+    hardware_id = "1234:5678"
+    manager.profile_state.grabbed_devices.add(hardware_id)
+    manager.exec_state.next_exec_ref = 10
+    request_started = asyncio.Event()
+
+    async def silent_request(_command: object) -> Response:
+        request_started.set()
+        await asyncio.Event().wait()
+        raise AssertionError("unreachable")
+
+    monkeypatch.setattr(profile_application, "_CANCEL_SETTLE_TIMEOUT_S", 0.01)
+    manager.client.send_command = AsyncMock(side_effect=silent_request)
+    resolved = ResolvedDeviceProfile(
+        hardware_id=hardware_id,
+        mappings={
+            "button": MappingAction(action_type=ActionType.EXEC, cmd="notify-send new")
+        },
+    )
+
+    update_task = asyncio.create_task(
+        profile_application.update_mapping(manager, hardware_id, resolved)
+    )
+    await request_started.wait()
+    update_task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await asyncio.wait_for(update_task, timeout=0.5)
+
+    assert manager.exec_state.device_exec_refs == {}
+    assert manager.exec_state.exec_refs == {}
+
+
+@pytest.mark.asyncio
 async def test_apply_resolved_device_profile_uses_extended_grab_timeout() -> None:
     manager = SessionManager()
     hardware_id = "1234:5678"

--- a/tests/test_keymasqd_client.py
+++ b/tests/test_keymasqd_client.py
@@ -3,6 +3,7 @@ import struct
 
 import pytest
 
+import keymasq.session.client as client_module
 from keymasq.common.ipc import HEADER_FORMAT, Command, CommandType, Response, encode_response
 from keymasq.session.client import KeymasqdClient
 from tests.async_fakes import BlockingStreamReader as _BlockingReader
@@ -210,6 +211,28 @@ def test_keymasqd_client_processes_events_in_wire_order() -> None:
         release_first.set()
         await asyncio.gather(*client._event_tasks)
         assert calls == [CommandType.RECORDING_STARTED, CommandType.RECORDING_STOPPED]
+
+    asyncio.run(_run())
+
+
+def test_keymasqd_client_bounds_pending_event_queue() -> None:
+    async def _run() -> None:
+        release_handler = asyncio.Event()
+
+        async def _event_handler(_event: CommandType, _data: object) -> None:
+            await release_handler.wait()
+
+        client = KeymasqdClient(event_handler=_event_handler)
+        assert client._dispatch_event(CommandType.PING, {}) is True
+        await asyncio.sleep(0)
+
+        for _ in range(client_module._MAX_PENDING_EVENTS):
+            assert client._dispatch_event(CommandType.PING, {}) is True
+        assert client._dispatch_event(CommandType.PING, {}) is False
+        assert len(client._event_queue) == client_module._MAX_PENDING_EVENTS
+
+        release_handler.set()
+        await asyncio.gather(*client._event_tasks)
 
     asyncio.run(_run())
 

--- a/tests/test_keymasqd_client.py
+++ b/tests/test_keymasqd_client.py
@@ -132,3 +132,46 @@ def test_keymasqd_client_discards_oversized_response_before_valid(
         assert future.result().data == {"done": True}
 
     asyncio.run(_run())
+
+
+def test_keymasqd_client_event_can_complete_nested_request() -> None:
+    async def _run() -> None:
+        reader = asyncio.StreamReader()
+
+        class _ReplyWriter(_FakeWriter):
+            def write(self, data: bytes) -> None:
+                super().write(data)
+                reader.feed_data(
+                    encode_response(
+                        Response(status="ok", request_id="1", data={"stored": True})
+                    )
+                )
+
+        nested_response: Response | None = None
+
+        async def _event_handler(_event: CommandType, _data: object) -> None:
+            nonlocal nested_response
+            nested_response = await client.send_command(
+                Command(command=CommandType.MACRO_DELETE_RECORDING)
+            )
+            reader.feed_eof()
+
+        client = KeymasqdClient(event_handler=_event_handler)
+        client.reader = reader
+        client.writer = _ReplyWriter()
+        reader.feed_data(
+            encode_response(
+                Response(
+                    status="event",
+                    data={"command": CommandType.RECORDING_STOPPED.value, "data": {}},
+                )
+            )
+        )
+
+        await asyncio.wait_for(client._listen_loop(), timeout=0.5)
+        await asyncio.gather(*client._event_tasks)
+
+        assert nested_response is not None
+        assert nested_response.data == {"stored": True}
+
+    asyncio.run(_run())

--- a/tests/test_keymasqd_client.py
+++ b/tests/test_keymasqd_client.py
@@ -318,3 +318,30 @@ def test_keymasqd_client_disconnect_fails_nested_request_before_worker_cancel() 
         assert client._disconnected_event.is_set()
 
     asyncio.run(_run())
+
+
+def test_keymasqd_client_signals_disconnect_before_worker_cleanup_finishes() -> None:
+    async def _run() -> None:
+        reader = asyncio.StreamReader()
+        cleanup_started = asyncio.Event()
+        release_cleanup = asyncio.Event()
+        client = KeymasqdClient(event_handler=lambda _event, _data: None)
+        client.reader = reader
+        client.writer = _FakeWriter()
+
+        async def delayed_cleanup() -> None:
+            cleanup_started.set()
+            await release_cleanup.wait()
+
+        client._cancel_event_tasks = delayed_cleanup  # type: ignore[method-assign]
+        reader.feed_eof()
+        listen_task = asyncio.create_task(client._listen_loop())
+
+        await asyncio.wait_for(cleanup_started.wait(), timeout=0.5)
+        await asyncio.wait_for(client.wait_disconnected(), timeout=0.5)
+        assert listen_task.done() is False
+
+        release_cleanup.set()
+        await asyncio.wait_for(listen_task, timeout=0.5)
+
+    asyncio.run(_run())

--- a/tests/test_keymasqd_client.py
+++ b/tests/test_keymasqd_client.py
@@ -236,3 +236,40 @@ def test_keymasqd_client_event_handler_can_disconnect() -> None:
         assert client.writer is None
 
     asyncio.run(_run())
+
+
+def test_keymasqd_client_unexpected_disconnect_cancels_event_worker() -> None:
+    async def _run() -> None:
+        reader = asyncio.StreamReader()
+        started = asyncio.Event()
+        cancelled = asyncio.Event()
+
+        async def _event_handler(_event: CommandType, _data: object) -> None:
+            started.set()
+            try:
+                await asyncio.Event().wait()
+            except asyncio.CancelledError:
+                cancelled.set()
+                raise
+
+        client = KeymasqdClient(event_handler=_event_handler)
+        client.reader = reader
+        client.writer = _FakeWriter()
+        reader.feed_data(
+            encode_response(
+                Response(
+                    status="event",
+                    data={"command": CommandType.PING.value, "data": {}},
+                )
+            )
+        )
+        reader.feed_eof()
+
+        await client._listen_loop()
+
+        assert started.is_set()
+        assert cancelled.is_set()
+        assert client._event_tasks == set()
+        assert client._disconnected_event.is_set()
+
+    asyncio.run(_run())

--- a/tests/test_keymasqd_client.py
+++ b/tests/test_keymasqd_client.py
@@ -273,3 +273,48 @@ def test_keymasqd_client_unexpected_disconnect_cancels_event_worker() -> None:
         assert client._disconnected_event.is_set()
 
     asyncio.run(_run())
+
+
+def test_keymasqd_client_disconnect_fails_nested_request_before_worker_cancel() -> None:
+    async def _run() -> None:
+        reader = asyncio.StreamReader()
+        request_started = asyncio.Event()
+
+        class _RequestWriter(_FakeWriter):
+            def write(self, data: bytes) -> None:
+                super().write(data)
+                request_started.set()
+
+        async def _event_handler(_event: CommandType, _data: object) -> None:
+            request_task = asyncio.create_task(
+                client.send_command(Command(command=CommandType.PING))
+            )
+            try:
+                await asyncio.shield(request_task)
+            except asyncio.CancelledError:
+                await asyncio.shield(request_task)
+                raise
+
+        client = KeymasqdClient(event_handler=_event_handler)
+        client.reader = reader
+        client.writer = _RequestWriter()
+        reader.feed_data(
+            encode_response(
+                Response(
+                    status="event",
+                    data={"command": CommandType.PING.value, "data": {}},
+                )
+            )
+        )
+        listen_task = asyncio.create_task(client._listen_loop())
+        await asyncio.wait_for(request_started.wait(), timeout=0.5)
+        reader.feed_eof()
+
+        await asyncio.wait_for(listen_task, timeout=0.5)
+
+        assert request_started.is_set()
+        assert client._pending_requests == {}
+        assert client._event_tasks == set()
+        assert client._disconnected_event.is_set()
+
+    asyncio.run(_run())

--- a/tests/test_keymasqd_client.py
+++ b/tests/test_keymasqd_client.py
@@ -175,3 +175,64 @@ def test_keymasqd_client_event_can_complete_nested_request() -> None:
         assert nested_response.data == {"stored": True}
 
     asyncio.run(_run())
+
+
+def test_keymasqd_client_processes_events_in_wire_order() -> None:
+    async def _run() -> None:
+        first_started = asyncio.Event()
+        release_first = asyncio.Event()
+        calls: list[CommandType] = []
+
+        async def _event_handler(event: CommandType, _data: object) -> None:
+            calls.append(event)
+            if event == CommandType.RECORDING_STARTED:
+                first_started.set()
+                await release_first.wait()
+
+        client = KeymasqdClient(event_handler=_event_handler)
+        await client._handle_response(
+            Response(
+                status="event",
+                data={"command": CommandType.RECORDING_STARTED.value, "data": {}},
+            )
+        )
+        await client._handle_response(
+            Response(
+                status="event",
+                data={"command": CommandType.RECORDING_STOPPED.value, "data": {}},
+            )
+        )
+
+        await asyncio.wait_for(first_started.wait(), timeout=0.5)
+        await asyncio.sleep(0)
+        assert calls == [CommandType.RECORDING_STARTED]
+
+        release_first.set()
+        await asyncio.gather(*client._event_tasks)
+        assert calls == [CommandType.RECORDING_STARTED, CommandType.RECORDING_STOPPED]
+
+    asyncio.run(_run())
+
+
+def test_keymasqd_client_event_handler_can_disconnect() -> None:
+    async def _run() -> None:
+        writer = _FakeWriter()
+
+        async def _event_handler(_event: CommandType, _data: object) -> None:
+            await client.disconnect()
+
+        client = KeymasqdClient(event_handler=_event_handler)
+        client.writer = writer
+        await client._handle_response(
+            Response(
+                status="event",
+                data={"command": CommandType.PING.value, "data": {}},
+            )
+        )
+        await asyncio.gather(*client._event_tasks)
+
+        assert writer.closed is True
+        assert writer.wait_closed_calls == 1
+        assert client.writer is None
+
+    asyncio.run(_run())

--- a/tests/test_session_clients.py
+++ b/tests/test_session_clients.py
@@ -56,6 +56,7 @@ def test_keymasqd_client_handle_response_dispatches_event() -> None:
             },
         )
         await client._handle_response(response)
+        await asyncio.sleep(0)
 
         assert calls == [(CommandType.PING, {"ok": True})]
 

--- a/tests/test_session_manager_core.py
+++ b/tests/test_session_manager_core.py
@@ -1357,8 +1357,7 @@ async def test_handle_keymasqd_disconnect_clears_runtime_state_and_cancels_grab_
     manager.profile_state.grab_retry_tasks = {"hardware": retry_task}
     manager._broadcast_keymasqd_status = Mock()  # type: ignore[method-assign]
 
-    manager._handle_keymasqd_disconnect()
-    await asyncio.sleep(0)
+    await manager._handle_keymasqd_disconnect()
 
     assert retry_task.cancelled()
     assert manager.connected is False

--- a/tests/test_session_manager_core.py
+++ b/tests/test_session_manager_core.py
@@ -1,5 +1,6 @@
 import asyncio
 import json
+import signal
 import threading
 from types import SimpleNamespace
 from typing import cast
@@ -238,6 +239,43 @@ async def test_start_wires_runtime_tasks_and_stops_on_shutdown(
     manager.stop.assert_awaited_once()  # type: ignore[attr-defined]
     assert manager.connect_task is not None
     assert manager.compositor_state.supervisor_task is not None
+
+
+@pytest.mark.asyncio
+async def test_start_stops_after_failure_following_session_socket_acquisition(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = SessionManager()
+    server = _FakeSessionServer()
+
+    async def start_session_server() -> None:
+        manager.session_server = server  # type: ignore[assignment]
+
+    manager._start_session_server = start_session_server  # type: ignore[method-assign]
+    manager.mpris_controller = SimpleNamespace(  # type: ignore[assignment]
+        start=AsyncMock(side_effect=RuntimeError("startup failed")),
+        stop=AsyncMock(),
+    )
+    manager.client.disconnect = AsyncMock()  # type: ignore[method-assign]
+    manager.dbus.disconnect = AsyncMock()  # type: ignore[method-assign]
+    removed_signals: list[signal.Signals] = []
+    monkeypatch.setattr(
+        session_manager_core_module.asyncio,
+        "get_event_loop",
+        lambda: SimpleNamespace(
+            add_signal_handler=lambda *_args: None,
+            remove_signal_handler=lambda sig: removed_signals.append(sig),
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match="startup failed"):
+        await manager.start()
+
+    assert manager.running is False
+    assert server.closed is True
+    assert server.wait_closed_calls == 1
+    assert set(removed_signals) == {signal.SIGINT, signal.SIGTERM, signal.SIGHUP}
+    manager.client.disconnect.assert_awaited_once()  # type: ignore[attr-defined]
 
 
 @pytest.mark.asyncio

--- a/tests/test_session_manager_events.py
+++ b/tests/test_session_manager_events.py
@@ -173,6 +173,32 @@ async def test_handle_event_dispatches_action_trigger_variants(
 
 
 @pytest.mark.asyncio
+async def test_prepared_exec_event_survives_reference_retirement() -> None:
+    manager = SessionManager()
+    manager.exec_state.exec_refs[9] = ExecBinding(
+        cmd="echo received",
+        owner="device",
+        hardware_id="1234:5678",
+    )
+    manager.action_handler.execute_command = AsyncMock(return_value=0)
+    prepared = session_events_module.prepare_event(
+        manager,
+        CommandType.ACTION_TRIGGER,
+        {"action_type": "exec", "exec_ref": 9},
+    )
+    manager.exec_state.exec_refs.clear()
+
+    await session_events_module.handle_event(
+        manager,
+        CommandType.ACTION_TRIGGER,
+        prepared,
+    )
+    await asyncio.sleep(0)
+
+    manager.action_handler.execute_command.assert_awaited_once_with("echo received")
+
+
+@pytest.mark.asyncio
 async def test_handle_event_double_verbose_logs_full_event_payload(
     caplog: pytest.LogCaptureFixture,
 ) -> None:

--- a/tests/test_session_manager_events.py
+++ b/tests/test_session_manager_events.py
@@ -199,6 +199,31 @@ async def test_prepared_exec_event_survives_reference_retirement() -> None:
 
 
 @pytest.mark.asyncio
+async def test_prepared_exec_event_rejects_forged_resolved_command() -> None:
+    manager = SessionManager()
+    manager.action_handler.execute_command = AsyncMock(return_value=0)
+    prepared = session_events_module.prepare_event(
+        manager,
+        CommandType.ACTION_TRIGGER,
+        {
+            "action_type": "exec",
+            "exec_ref": 404,
+            "_keymasq_resolved_exec_cmd": "echo forged",
+            "_keymasq_resolved_exec_hardware_id": "1234:5678",
+        },
+    )
+
+    await session_events_module.handle_event(
+        manager,
+        CommandType.ACTION_TRIGGER,
+        prepared,
+    )
+    await asyncio.sleep(0)
+
+    manager.action_handler.execute_command.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_handle_event_double_verbose_logs_full_event_payload(
     caplog: pytest.LogCaptureFixture,
 ) -> None:

--- a/tests/test_session_support.py
+++ b/tests/test_session_support.py
@@ -126,6 +126,8 @@ async def test_keymasqd_client_handle_response_logs_event_handler_errors(
         await client._handle_response(
             Response(status="event", data={"command": CommandType.PING.value, "data": {}})
         )
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
 
     assert "Event handler error: boom" in caplog.text
 


### PR DESCRIPTION
## Summary
- Harden session/daemon lifecycle so cancelled or failed mapping, combo, capture, and recording transitions roll back cleanly without leaking refs or devices
- Stage exec refs until daemon acknowledgement; keep staged refs resolvable for queued ACTION_TRIGGER events and cancel stale daemon event work on disconnect
- End active captures on client disconnect, abort failed recording starts, and delay existing-grab decode updates until new interfaces are fully acquired
- Bound cancellation settlement for reference-bearing commands and preserve cancellation through teardown paths

## Testing
- Expanded unit coverage in `tests/session/test_session_manager_profile_apply.py`, `tests/session/test_session_manager_command_runtime.py`, `tests/test_keymasqd_client.py`, and related session/daemon lifecycle tests
- `./scripts/check.sh full`
- `./scripts/integration.sh daemon-session`