### PR TITLE
Harden daemon lifecycle, macro integrity, and GUI IPC cleanup

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -225,6 +225,7 @@ settings below:
 
               recording_guard = {
                 unlock_required = true;
+                macro_recording_time_limit = 10;
                 macro_edit_requires_unlock = false;
               };
             };
@@ -318,6 +319,7 @@ disable the capture unlock requirement in `/etc/keymasq/security.toml`:
 ```toml
 [recording_guard]
 unlock_required = false
+macro_recording_time_limit = 10
 ```
 
 This does not enable macro recording; macro recording still requires the

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -225,6 +225,7 @@ settings below:
 
               recording_guard = {
                 unlock_required = true;
+                # Stop recordings after this many minutes; set 0 to disable.
                 macro_recording_time_limit = 10;
                 macro_edit_requires_unlock = false;
               };
@@ -319,6 +320,7 @@ disable the capture unlock requirement in `/etc/keymasq/security.toml`:
 ```toml
 [recording_guard]
 unlock_required = false
+# Stop recordings after this many minutes; set 0 to disable.
 macro_recording_time_limit = 10
 ```
 

--- a/docs/MACROS.md
+++ b/docs/MACROS.md
@@ -104,6 +104,14 @@ different slot requires a binding that explicitly names that different slot.
 Keymasq never round-robins or infers a recording slot for mapped recording
 triggers.
 
+Recordings stop after 10 minutes by default. You can change the limit in
+`/etc/keymasq/security.toml`, or set it to `0` to disable automatic stopping:
+
+```toml
+[recording_guard]
+macro_recording_time_limit = 10
+```
+
 Starting and stopping from a hotkey keeps the recording clean. If you click
 buttons in the GUI to start or stop, those clicks and any mouse movement to
 reach them will be captured too, which is rarely what you want.
@@ -515,6 +523,14 @@ do not need to change these — they are intended for system administrators:
   ```toml
   [recording_guard]
   unlock_required = false
+  ```
+
+- **Change the maximum recording duration.** The default is 10 minutes; `0`
+  disables automatic stopping:
+
+  ```toml
+  [recording_guard]
+  macro_recording_time_limit = 10
   ```
 
 - **Require unlock for editing too** (stricter):

--- a/docs/MACROS.md
+++ b/docs/MACROS.md
@@ -94,9 +94,8 @@ dialog keeps the slot for Macro Manager; deleting a slot from Macro Manager
 removes it.
 If slot metadata is temporarily unreadable during daemon startup, Keymasq
 preserves every possibly related event file and retries on a later restart.
-Malformed metadata and uncertain event files are moved to
-`/var/lib/keymasq/recording-spool/quarantine/` instead of being deleted, so an
-administrator can inspect or recover them.
+Malformed temporary-slot metadata is discarded, and its unreferenced event
+data is removed during orphan cleanup.
 The slot that is currently recording cannot be played until recording stops;
 pressing its **Play Slot** action is ignored and Keymasq sends a desktop
 notification. Completed recordings in other slots remain playable.

--- a/docs/MACROS.md
+++ b/docs/MACROS.md
@@ -92,6 +92,11 @@ Macro Manager after the session reconnects. Saving a slot duplicates it into a
 regular macro and keeps the slot available for playback. Closing the save
 dialog keeps the slot for Macro Manager; deleting a slot from Macro Manager
 removes it.
+If slot metadata is temporarily unreadable during daemon startup, Keymasq
+preserves every possibly related event file and retries on a later restart.
+Malformed metadata and uncertain event files are moved to
+`/var/lib/keymasq/recording-spool/quarantine/` instead of being deleted, so an
+administrator can inspect or recover them.
 The slot that is currently recording cannot be played until recording stops;
 pressing its **Play Slot** action is ignored and Keymasq sends a desktop
 notification. Completed recordings in other slots remain playable.

--- a/docs/MACROS.md
+++ b/docs/MACROS.md
@@ -112,6 +112,12 @@ Recordings stop after 10 minutes by default. You can change the limit in
 macro_recording_time_limit = 10
 ```
 
+Restart the daemon after changing this setting:
+
+```sh
+sudo systemctl restart keymasqd
+```
+
 Starting and stopping from a hotkey keeps the recording clean. If you click
 buttons in the GUI to start or stop, those clicks and any mouse movement to
 reach them will be captured too, which is rarely what you want.
@@ -322,6 +328,10 @@ Macro duration is the minimum timeline length of one pass. If the pass reaches
 the end of its events before `duration_us`, playback waits until that duration
 has elapsed before looping or finishing. This trailing duration is scaled by
 macro speed; explicit wait controls keep their own wall-clock duration.
+
+Editing, renaming, or deleting a macro stops any looped playback of that macro
+before its next repetition. A repetition already in progress finishes using
+the version with which it started.
 
 ![Loop mode dropdown — None, Count, Hold, or Toggle](assets/screenshots/keymasq_macro_edit_loop_modes.png)
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -351,12 +351,19 @@ Relevant controls:
   - `emergency_cancel_combo_enabled`
 - `[recording_guard]`
   - `unlock_required`
+  - `macro_recording_time_limit`: maximum macro recording duration in whole minutes;
+    defaults to `10`, and `0` disables the time limit
   - `macro_edit_requires_unlock`
 
 Empty UID allowlists mean no UID restriction. This is the default and is appropriate for single-user desktops. On multi-user systems, populate `daemon_allowed_uids` and `session_allowed_uids` to restrict access to specific users.
 
 `[recording_guard].unlock_required` controls whether sensitive original-input
 observation flows require an explicit unlock before they are allowed.
+
+`[recording_guard].macro_recording_time_limit` limits how long one macro recording
+may remain active. Reaching the limit stops the recording normally, keeps the
+temporary slot available for saving or playback, and notifies the desktop.
+Set it to `0` only when recordings should have no time limit.
 
 When `unlock_required = true`:
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -119,8 +119,10 @@ restart of `keymasq-session` — `keymasqd` runs disconnect cleanup before the
 next client can claim ownership:
 
 1. The runtime capture unlock held by that owner is cleared.
-2. All pending (unsaved) recordings are discarded.
-3. All grabbed input devices are released, so hardware returns to passthrough.
+2. Any active recording is aborted without producing or persisting a recording.
+3. All live capture sessions are closed and unused capture authorizations are revoked.
+4. All non-slot pending (unsaved) recordings are discarded.
+5. All grabbed input devices are released, so hardware returns to passthrough.
 
 Ownership release is then logged and the owner slot becomes free. The
 per-user `keymasq-session` broker reconnects automatically with exponential
@@ -240,7 +242,9 @@ Saving a temporary slot into the macro library requires the capture unlock
 flow when `unlock_required = true`. This is enforced in the GUI, the
 session broker, and the daemon command handler.
 
-If `macro_edit_requires_unlock = true`, macro inspection and edit operations are promoted into the same sensitive class.
+If `macro_edit_requires_unlock = true`, macro inspection and every persistent
+edit operation (create, update, rename, and delete) are promoted into the same
+sensitive class.
 
 ## Runtime Unlock Ownership Chain
 
@@ -283,7 +287,8 @@ Daemon-side sensitive commands currently include:
 - `CAPTURE_READ`
 - `CAPTURE_END`
 - `CAPTURE_COMBO`
-- optionally `MACRO_GET`, `MACRO_CREATE`, `MACRO_UPDATE` when macro editing is guarded
+- optionally `MACRO_GET`, `MACRO_CREATE`, `MACRO_UPDATE`, `MACRO_RENAME`, and
+  `MACRO_DELETE` when macro editing is guarded
 
 If an owner already exists for that UID, the same process and connection must continue issuing those commands. Otherwise the request is rejected with `sensitive_command_denied`.
 
@@ -373,8 +378,8 @@ installs and development setups that do not provide the packaged Polkit-based
 unlock path. Macro recording still requires its separate opt-in.
 
 `[recording_guard].macro_edit_requires_unlock` is separate. It controls whether
-macro create/update/get APIs also require an unlock, in addition to live
-recording and capture.
+macro get/create/update/rename/delete APIs also require an unlock, in addition
+to live recording and capture.
 
 The GUI warns before editing left and right click mappings, and before saving a
 single-button, single-step combo that uses left or right click as the trigger.

--- a/docs/STEAMOS.md
+++ b/docs/STEAMOS.md
@@ -85,6 +85,7 @@ SteamOS/AppImage installs disable the recording unlock requirement in
 ```toml
 [recording_guard]
 unlock_required = false
+macro_recording_time_limit = 10
 ```
 
 Recording works out of the box, without a per-session unlock.

--- a/examples/security.toml
+++ b/examples/security.toml
@@ -11,5 +11,7 @@ emergency_cancel_combo_enabled = true
 [recording_guard]
 # Tier 1 (recommended): require explicit unlock for live capture/recording APIs.
 unlock_required = true
+# Stop a recording normally after this many minutes. Set to 0 for no time limit.
+macro_recording_time_limit = 10
 # Tier 2 (optional): require unlock for macro get/create/update APIs.
 macro_edit_requires_unlock = false

--- a/keymasq/common/security.py
+++ b/keymasq/common/security.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import Any, cast
 
 log = logging.getLogger(__name__)
+DEFAULT_MACRO_RECORDING_TIME_LIMIT = 10
 
 
 @dataclass
@@ -22,6 +23,7 @@ class SecurityPolicy:
     session_allowed_uids: list[int] = field(default_factory=list)
     macro_exec_timeout_max_ms: int = 30000
     recording_unlock_required: bool = True
+    macro_recording_time_limit: int = DEFAULT_MACRO_RECORDING_TIME_LIMIT
     macro_edit_requires_unlock: bool = False
     emergency_cancel_combo_enabled: bool = True
 
@@ -90,6 +92,19 @@ def load_security_policy(config_path: Path) -> SecurityPolicy:
         policy.macro_edit_requires_unlock = bool(
             recording_guard.get("macro_edit_requires_unlock", policy.macro_edit_requires_unlock)
         )
+        time_limit = recording_guard.get(
+            "macro_recording_time_limit",
+            policy.macro_recording_time_limit,
+        )
+        if isinstance(time_limit, bool) or not isinstance(time_limit, int):
+            raise SecurityPolicyError(
+                "recording_guard.macro_recording_time_limit must be a non-negative integer"
+            )
+        if time_limit < 0:
+            raise SecurityPolicyError(
+                "recording_guard.macro_recording_time_limit must be a non-negative integer"
+            )
+        policy.macro_recording_time_limit = time_limit
 
     gui_cfg = raw.get("gui")
     if isinstance(gui_cfg, dict):

--- a/keymasq/gui/application.py
+++ b/keymasq/gui/application.py
@@ -123,6 +123,12 @@ class Application(Adw.Application):
 
         self.window.present()
 
+    def do_shutdown(self) -> None:
+        from keymasq.gui.session_client import shutdown_gui_runtime
+
+        shutdown_gui_runtime()
+        Adw.Application.do_shutdown(self)
+
     def _on_superkeys(self, action, param) -> None:
         self._open_superkey_dialog()
 

--- a/keymasq/gui/session_client.py
+++ b/keymasq/gui/session_client.py
@@ -377,6 +377,10 @@ class _PersistentSessionConnection:
             self._buffer = b""
         if sock is not None:
             try:
+                sock.shutdown(socket.SHUT_RDWR)
+            except (AttributeError, OSError):
+                pass
+            try:
                 sock.close()
             except OSError:
                 pass
@@ -408,6 +412,10 @@ class _PersistentSessionConnection:
             else:
                 current = False
 
+        try:
+            sock.shutdown(socket.SHUT_RDWR)
+        except (AttributeError, OSError):
+            pass
         try:
             sock.close()
         except OSError:

--- a/keymasq/gui/session_client.py
+++ b/keymasq/gui/session_client.py
@@ -361,7 +361,7 @@ class _PersistentSessionConnection:
         message: JsonDict,
     ) -> bool:
         with self._state_lock:
-            if self._closed or generation != self._generation or self._sock is None:
+            if self._closed or generation != self._generation:
                 return False
         try:
             callback(message)

--- a/keymasq/gui/session_client.py
+++ b/keymasq/gui/session_client.py
@@ -138,12 +138,12 @@ class _PersistentSessionConnection:
                     response = response_queue.get(timeout=timeout)
                 except queue.Empty:
                     log.debug("persistent request timed out")
-                    self._close_connection()
+                    self._close_connection_if_current(sock, generation)
                     return None
                 return response
             except Exception:
                 log.exception("persistent request failed")
-                self._close_connection()
+                self._close_connection_if_current(sock, generation)
                 return None
             finally:
                 with self._state_lock:
@@ -575,6 +575,8 @@ def run_gui_task[T](
                 return False
             try:
                 callback(result)
+            except Exception:
+                log.exception("GUI task callback failed")
             finally:
                 if on_done is not None:
                     on_done()
@@ -607,6 +609,7 @@ def shutdown_gui_runtime(timeout: float = 1.0) -> None:
         _gui_shutdown = True
         _gui_runtime_generation += 1
         pool = _gui_pool
-    _PERSISTENT_SESSION.shutdown(timeout=timeout)
+    deadline = time.monotonic() + max(0.0, float(timeout))
+    _PERSISTENT_SESSION.shutdown(timeout=max(0.0, deadline - time.monotonic()))
     if pool is not None:
-        pool.shutdown(timeout=timeout)
+        pool.shutdown(timeout=max(0.0, deadline - time.monotonic()))

--- a/keymasq/gui/session_client.py
+++ b/keymasq/gui/session_client.py
@@ -1,8 +1,10 @@
 import json
 import logging
 import queue
+import select
 import socket
 import threading
+import time
 from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any
@@ -24,6 +26,68 @@ class GuiTaskResult[T]:
         return self.error is None
 
 
+class _BoundedWorkerPool:
+    def __init__(self, *, workers: int = 4, capacity: int = 64) -> None:
+        self._queue: queue.Queue[Callable[[], None] | None] = queue.Queue(
+            maxsize=max(workers, capacity)
+        )
+        self._closed = False
+        self._lock = threading.Lock()
+        self._threads = [
+            threading.Thread(
+                target=self._worker_loop,
+                daemon=True,
+                name=f"keymasq-gui-worker-{index + 1}",
+            )
+            for index in range(max(1, workers))
+        ]
+        for thread in self._threads:
+            thread.start()
+
+    def submit(self, work: Callable[[], None]) -> bool:
+        with self._lock:
+            if self._closed:
+                return False
+            try:
+                self._queue.put_nowait(work)
+            except queue.Full:
+                return False
+            return True
+
+    def shutdown(self, timeout: float = 1.0) -> None:
+        with self._lock:
+            if self._closed:
+                return
+            self._closed = True
+            while True:
+                try:
+                    pending = self._queue.get_nowait()
+                except queue.Empty:
+                    break
+                else:
+                    self._queue.task_done()
+                    del pending
+            for _thread in self._threads:
+                self._queue.put_nowait(None)
+
+        deadline = time.monotonic() + max(0.0, float(timeout))
+        for thread in self._threads:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                break
+            thread.join(remaining)
+
+    def _worker_loop(self) -> None:
+        while True:
+            work = self._queue.get()
+            try:
+                if work is None:
+                    return
+                work()
+            finally:
+                self._queue.task_done()
+
+
 def _gui_task_error_payload(error: Exception) -> JsonDict:
     message = str(error).strip() or error.__class__.__name__
     return {
@@ -37,11 +101,16 @@ class _PersistentSessionConnection:
     def __init__(self) -> None:
         self._sock: socket.socket | None = None
         self._reader_thread: threading.Thread | None = None
+        self._reader_threads: dict[int, threading.Thread] = {}
+        self._reader_sockets: dict[int, socket.socket] = {}
+        self._generation = 0
+        self._closed = False
         self._buffer = b""
         self._state_lock = threading.Lock()
         self._connect_lock = threading.Lock()
         self._request_lock = threading.Lock()
         self._response_queue: queue.Queue[JsonDict | None] | None = None
+        self._response_generation: int | None = None
         self._callbacks: dict[str, list[Callable[[JsonDict], bool | None]]] = {}
 
     def request(self, payload: JsonDict, timeout: float = 5.0) -> JsonDict | None:
@@ -54,14 +123,16 @@ class _PersistentSessionConnection:
 
             response_queue: queue.Queue[JsonDict | None] = queue.Queue(maxsize=1)
             with self._state_lock:
+                sock = self._sock
+                generation = self._generation
+                if sock is None or self._closed:
+                    return None
                 self._response_queue = response_queue
+                self._response_generation = generation
 
             try:
                 encoded_payload = (json.dumps(payload) + "\n").encode()
-                with self._state_lock:
-                    if self._sock is None:
-                        return None
-                    self._sock.sendall(encoded_payload)
+                self._send_with_deadline(sock, encoded_payload, timeout)
 
                 try:
                     response = response_queue.get(timeout=timeout)
@@ -76,8 +147,12 @@ class _PersistentSessionConnection:
                 return None
             finally:
                 with self._state_lock:
-                    if self._response_queue is response_queue:
+                    if (
+                        self._response_queue is response_queue
+                        and self._response_generation == generation
+                    ):
                         self._response_queue = None
+                        self._response_generation = None
 
     def register_callback(self, event: str, callback: Callable[[JsonDict], bool | None]) -> None:
         with self._state_lock:
@@ -94,6 +169,8 @@ class _PersistentSessionConnection:
 
     def _ensure_connected(self, timeout: float) -> bool:
         with self._state_lock:
+            if self._closed:
+                return False
             if self._sock is not None:
                 return True
 
@@ -102,6 +179,8 @@ class _PersistentSessionConnection:
 
         with self._connect_lock:
             with self._state_lock:
+                if self._closed:
+                    return False
                 if self._sock is not None:
                     return True
 
@@ -121,69 +200,122 @@ class _PersistentSessionConnection:
                 return False
 
             with self._state_lock:
+                if self._closed:
+                    sock.close()
+                    return False
+                self._generation += 1
+                generation = self._generation
                 self._sock = sock
                 self._buffer = b""
-                if self._reader_thread is None or not self._reader_thread.is_alive():
-                    self._reader_thread = threading.Thread(target=self._reader_loop, daemon=True)
-                    self._reader_thread.start()
+                reader = threading.Thread(
+                    target=self._reader_loop,
+                    args=(generation, sock),
+                    daemon=True,
+                    name=f"keymasq-session-reader-{generation}",
+                )
+                self._reader_thread = reader
+                self._reader_threads[generation] = reader
+                self._reader_sockets[generation] = sock
+                reader.start()
         return True
 
-    def _reader_loop(self) -> None:
-        while True:
-            sock: socket.socket | None = None
-            try:
-                with self._state_lock:
-                    sock = self._sock
-                if sock is None:
-                    return
-
-                data = sock.recv(4096)
-                if not data:
-                    if self._close_connection_if_current(sock):
+    def _reader_loop(
+        self,
+        generation: int | None = None,
+        sock: socket.socket | None = None,
+    ) -> None:
+        with self._state_lock:
+            generation = self._generation if generation is None else generation
+            sock = self._sock if sock is None else sock
+        if sock is None:
+            return
+        local_buffer = b""
+        try:
+            while True:
+                try:
+                    data = sock.recv(4096)
+                    if not data:
+                        self._close_connection_if_current(sock, generation)
                         return
-                    continue
 
-                with self._state_lock:
-                    if sock is not self._sock:
-                        continue
-                    self._buffer += data
+                    local_buffer += data
                     lines: list[bytes] = []
-                    while b"\n" in self._buffer:
-                        line, self._buffer = self._buffer.split(b"\n", 1)
+                    while b"\n" in local_buffer:
+                        line, local_buffer = local_buffer.split(b"\n", 1)
                         lines.append(line)
 
-                for line in lines:
-                    if not line.strip():
-                        continue
-
-                    try:
-                        message = json.loads(line.decode())
-                    except json.JSONDecodeError:
-                        continue
-
-                    if "event" in message:
-                        self._dispatch_event(message)
-                        continue
-
                     with self._state_lock:
-                        response_queue = self._response_queue
-                    if response_queue is not None:
-                        try:
-                            response_queue.put_nowait(message)
-                        except queue.Full:
-                            pass
-            except Exception:
-                log.exception("persistent reader error")
-                if sock is not None and self._close_connection_if_current(sock):
-                    return
-                continue
+                        if generation != self._generation or sock is not self._sock:
+                            continue
+                        self._buffer = local_buffer
 
-    def _dispatch_event(self, message: JsonDict) -> None:
+                    for line in lines:
+                        if not line.strip():
+                            continue
+
+                        try:
+                            message = json.loads(line.decode())
+                        except (json.JSONDecodeError, UnicodeDecodeError):
+                            continue
+                        if not isinstance(message, dict):
+                            continue
+
+                        if "event" in message:
+                            self._dispatch_event(message, generation)
+                            continue
+
+                        with self._state_lock:
+                            response_queue = (
+                                self._response_queue
+                                if generation == self._generation
+                                and self._response_generation in (None, generation)
+                                else None
+                            )
+                        if response_queue is not None:
+                            try:
+                                response_queue.put_nowait(message)
+                            except queue.Full:
+                                pass
+                except Exception:
+                    log.exception("persistent reader error")
+                    self._close_connection_if_current(sock, generation)
+                    return
+        finally:
+            with self._state_lock:
+                self._reader_threads.pop(generation, None)
+                self._reader_sockets.pop(generation, None)
+
+    def _send_with_deadline(self, sock: socket.socket, payload: bytes, timeout: float) -> None:
+        deadline = time.monotonic() + max(0.01, float(timeout))
+        view = memoryview(payload)
+        try:
+            fileno = sock.fileno()
+        except (AttributeError, OSError):
+            sock.sendall(payload)
+            return
+
+        while view:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise TimeoutError("session request write timed out")
+            _readable, writable, _exceptional = select.select([], [fileno], [], remaining)
+            if not writable:
+                raise TimeoutError("session request write timed out")
+            try:
+                sent = sock.send(view, getattr(socket, "MSG_DONTWAIT", 0))
+            except BlockingIOError:
+                continue
+            if sent <= 0:
+                raise ConnectionError("session socket closed during write")
+            view = view[sent:]
+
+    def _dispatch_event(self, message: JsonDict, generation: int | None = None) -> None:
         event = message.get("event")
         if not isinstance(event, str):
             return
 
         with self._state_lock:
+            generation = self._generation if generation is None else generation
             callbacks = list(self._callbacks.get(event, [])) + list(self._callbacks.get("*", []))
 
         if not callbacks:
@@ -212,7 +344,7 @@ class _PersistentSessionConnection:
                 continue
 
             try:
-                idle_add(self._dispatch_event_callback_once, callback, message)
+                idle_add(self._dispatch_event_callback_once, generation, callback, message)
             except (RuntimeError, TypeError) as exc:
                 log.warning(
                     "Failed to schedule session event callback with GLib: %s; dropping event %s",
@@ -222,11 +354,15 @@ class _PersistentSessionConnection:
             except Exception:
                 log.exception("Unexpected failure scheduling session event callback")
 
-    @staticmethod
     def _dispatch_event_callback_once(
+        self,
+        generation: int,
         callback: Callable[[JsonDict], bool | None],
         message: JsonDict,
     ) -> bool:
+        with self._state_lock:
+            if self._closed or generation != self._generation or self._sock is None:
+                return False
         try:
             callback(message)
         except Exception:
@@ -236,6 +372,7 @@ class _PersistentSessionConnection:
     def _close_connection(self) -> None:
         with self._state_lock:
             sock = self._sock
+            generation = self._generation
             self._sock = None
             self._buffer = b""
         if sock is not None:
@@ -245,17 +382,25 @@ class _PersistentSessionConnection:
                 pass
 
         with self._state_lock:
-            response_queue = self._response_queue
+            response_queue = (
+                self._response_queue
+                if self._response_generation in (None, generation)
+                else None
+            )
         if response_queue is not None:
             try:
                 response_queue.put_nowait(None)
             except queue.Full:
                 pass
 
-    def _close_connection_if_current(self, sock: socket.socket) -> bool:
+    def _close_connection_if_current(
+        self,
+        sock: socket.socket,
+        generation: int | None = None,
+    ) -> bool:
         response_queue: queue.Queue[JsonDict | None] | None = None
         with self._state_lock:
-            if sock is self._sock:
+            if sock is self._sock and generation in (None, self._generation):
                 self._sock = None
                 self._buffer = b""
                 response_queue = self._response_queue
@@ -275,8 +420,72 @@ class _PersistentSessionConnection:
                 pass
         return current
 
+    def shutdown(self, timeout: float = 1.0) -> None:
+        """Prevent future callbacks and close every connection generation."""
+
+        with self._state_lock:
+            if self._closed:
+                return
+            self._closed = True
+            self._generation += 1
+            sockets = set(self._reader_sockets.values())
+            if self._sock is not None:
+                sockets.add(self._sock)
+            self._sock = None
+            self._buffer = b""
+            response_queue = self._response_queue
+            self._response_queue = None
+            self._response_generation = None
+            readers = list(self._reader_threads.values())
+
+        for current_sock in sockets:
+            try:
+                current_sock.shutdown(socket.SHUT_RDWR)
+            except OSError:
+                pass
+            try:
+                current_sock.close()
+            except OSError:
+                pass
+        if response_queue is not None:
+            try:
+                response_queue.put_nowait(None)
+            except queue.Full:
+                pass
+
+        deadline = time.monotonic() + max(0.0, float(timeout))
+        for reader in readers:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                break
+            reader.join(remaining)
+
 
 _PERSISTENT_SESSION = _PersistentSessionConnection()
+_gui_state_lock = threading.Lock()
+_gui_runtime_generation = 0
+_gui_shutdown = False
+_gui_pool: _BoundedWorkerPool | None = None
+
+
+def _gui_generation() -> int | None:
+    with _gui_state_lock:
+        return None if _gui_shutdown else _gui_runtime_generation
+
+
+def _gui_generation_is_current(generation: int) -> bool:
+    with _gui_state_lock:
+        return not _gui_shutdown and generation == _gui_runtime_generation
+
+
+def _gui_worker_pool() -> _BoundedWorkerPool | None:
+    global _gui_pool
+    with _gui_state_lock:
+        if _gui_shutdown:
+            return None
+        if _gui_pool is None:
+            _gui_pool = _BoundedWorkerPool()
+        return _gui_pool
 
 
 def session_request(payload: JsonDict, timeout: float = 5.0) -> JsonDict | None:
@@ -321,6 +530,10 @@ def run_gui_task[T](
 ) -> None:
     from gi.repository import GLib  # pyright: ignore[reportAttributeAccessIssue]
 
+    generation = _gui_generation()
+    if generation is None:
+        return
+
     if on_start is not None:
         on_start()
 
@@ -332,6 +545,8 @@ def run_gui_task[T](
             result = GuiTaskResult(error=exc)
 
         def _dispatch() -> bool:
+            if not _gui_generation_is_current(generation):
+                return False
             try:
                 callback(result)
             except Exception:
@@ -343,7 +558,21 @@ def run_gui_task[T](
 
         GLib.idle_add(_dispatch)
 
-    threading.Thread(target=_worker, daemon=True).start()
+    pool = _gui_worker_pool()
+    if pool is None or not pool.submit(_worker):
+        result = GuiTaskResult[T](error=RuntimeError("GUI worker queue is unavailable"))
+
+        def _dispatch_rejected() -> bool:
+            if not _gui_generation_is_current(generation):
+                return False
+            try:
+                callback(result)
+            finally:
+                if on_done is not None:
+                    on_done()
+            return False
+
+        GLib.idle_add(_dispatch_rejected)
 
 
 def register_session_event_callback(
@@ -358,3 +587,18 @@ def unregister_session_event_callback(
     callback: Callable[[JsonDict], bool | None],
 ) -> None:
     _PERSISTENT_SESSION.unregister_callback(event, callback)
+
+
+def shutdown_gui_runtime(timeout: float = 1.0) -> None:
+    """Invalidate GTK callbacks and drain GUI IPC/background ownership."""
+
+    global _gui_runtime_generation, _gui_shutdown
+    with _gui_state_lock:
+        if _gui_shutdown:
+            return
+        _gui_shutdown = True
+        _gui_runtime_generation += 1
+        pool = _gui_pool
+    _PERSISTENT_SESSION.shutdown(timeout=timeout)
+    if pool is not None:
+        pool.shutdown(timeout=timeout)

--- a/keymasq/keymasqd/capture_manager.py
+++ b/keymasq/keymasqd/capture_manager.py
@@ -339,6 +339,14 @@ class CaptureManager:
                 ended += 1
         return ended
 
+    def close_all(self) -> int:
+        """Close all sessions and revoke every unused capture authorization."""
+
+        try:
+            return self.end_all()
+        finally:
+            self._combo_capture_authorizations.clear()
+
     def _start_combo_reader(self, session: CaptureSession) -> None:
         if session.stop_event is None or session.event_queue is None:
             return

--- a/keymasq/keymasqd/daemon.py
+++ b/keymasq/keymasqd/daemon.py
@@ -330,12 +330,12 @@ class Daemon:
                 claim_if_missing=command_type != CommandType.CAPTURE_END,
             )
 
-        if policy is None or not policy.recording_unlock_required:
+        if policy is None:
             return
 
-        requires_unlock = is_tier1_command
-        if not requires_unlock and policy.macro_edit_requires_unlock:
-            requires_unlock = command_type in tier2_commands
+        requires_unlock = is_tier1_command and policy.recording_unlock_required
+        if command_type in tier2_commands and policy.macro_edit_requires_unlock:
+            requires_unlock = True
 
         if not requires_unlock:
             return

--- a/keymasq/keymasqd/daemon.py
+++ b/keymasq/keymasqd/daemon.py
@@ -154,6 +154,15 @@ class Daemon:
             self._cleanup_socket_path()
 
         await self._run_async_cleanup(
+            "abort active recording",
+            self.recording_manager.abort,
+        )
+        await self._run_async_cleanup(
+            "close active captures",
+            lambda: asyncio.to_thread(self.capture_manager.close_all),
+        )
+
+        await self._run_async_cleanup(
             "stop topology watcher",
             self.device_manager.stop_topology_watcher,
         )
@@ -309,6 +318,8 @@ class Daemon:
             CommandType.MACRO_GET,
             CommandType.MACRO_CREATE,
             CommandType.MACRO_UPDATE,
+            CommandType.MACRO_RENAME,
+            CommandType.MACRO_DELETE,
         }
 
         is_tier1_command = command_type in tier1_commands
@@ -725,12 +736,16 @@ class Daemon:
                 ),
             )
         await self._run_async_cleanup(
+            "abort active recording",
+            self.recording_manager.abort,
+        )
+        await self._run_async_cleanup(
             "discard pending recordings",
             self.recording_manager.discard_all_pending_recordings,
         )
         await self._run_async_cleanup(
             "end active captures",
-            lambda: asyncio.to_thread(self.capture_manager.end_all),
+            lambda: asyncio.to_thread(self.capture_manager.close_all),
         )
         await self._run_async_cleanup(
             "release all devices after client disconnect",

--- a/keymasq/keymasqd/daemon.py
+++ b/keymasq/keymasqd/daemon.py
@@ -99,6 +99,9 @@ class Daemon:
         self.device_manager.emergency_cancel_combo_enabled = bool(
             self.security_policy.emergency_cancel_combo_enabled
         )
+        self.recording_manager.macro_recording_time_limit = int(
+            self.security_policy.macro_recording_time_limit
+        )
         await asyncio.to_thread(self._prepare_macro_store)
         await self.recording_manager.load_persisted_slot_recordings()
         log.info(

--- a/keymasq/keymasqd/macro_file.py
+++ b/keymasq/keymasqd/macro_file.py
@@ -21,22 +21,28 @@ MACRO_FILE_VERSION = 1
 type MacroEvent = dict[str, object]
 
 
+class MacroFileChangedError(RuntimeError):
+    """The macro file no longer matches the revision opened for playback."""
+
+
 class MacroFileSnapshot:
-    """Immutable compressed bytes for one repeatable macro-file revision."""
+    """Metadata and identity for one repeatable macro-file revision."""
 
     def __init__(self, path: Path) -> None:
-        self._compressed = path.read_bytes()
-        with self._open_text() as handle:
-            self.meta = _macro_meta_from_line(handle.readline())
-
-    def _open_text(self) -> io.TextIOWrapper:
-        compressed = lzma.LZMAFile(io.BytesIO(self._compressed), "rb")
-        return io.TextIOWrapper(compressed, encoding="utf-8", newline="\n")
+        self._path = path
+        with _open_text(path, "rb") as handle:
+            self._meta_line = handle.readline()
+        self.meta = _macro_meta_from_line(self._meta_line)
 
     def iter_events(self) -> Iterator[MacroEvent]:
         def generate() -> Iterator[MacroEvent]:
-            with self._open_text() as handle:
-                _macro_meta_from_line(handle.readline())
+            try:
+                handle = _open_text(self._path, "rb")
+            except FileNotFoundError as exc:
+                raise MacroFileChangedError(str(self._path)) from exc
+            with handle:
+                if handle.readline() != self._meta_line:
+                    raise MacroFileChangedError(str(self._path))
                 yield from _iter_macro_event_lines(handle)
 
         return generate()

--- a/keymasq/keymasqd/macro_file.py
+++ b/keymasq/keymasqd/macro_file.py
@@ -9,7 +9,7 @@ from collections.abc import Iterable, Iterator
 from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
-from typing import BinaryIO, cast
+from typing import Any, BinaryIO, cast
 
 from keymasq.common.coercion import require_json_object
 from keymasq.common.config_files import write_config_atomically
@@ -21,6 +21,18 @@ MACRO_FILE_FORMAT = "keymasq-macro"
 MACRO_FILE_VERSION = 1
 
 type MacroEvent = dict[str, object]
+
+
+class _OwnedMacroText(io.TextIOWrapper):
+    def __init__(self, buffer: Any, owner: BinaryIO) -> None:
+        self._owner = owner
+        super().__init__(buffer, encoding="utf-8", newline="\n")
+
+    def close(self) -> None:
+        try:
+            super().close()
+        finally:
+            self._owner.close()
 
 
 class MacroFileSnapshot:
@@ -51,8 +63,16 @@ class MacroFileSnapshot:
         except BaseException:
             os.close(duplicated_fd)
             raise
-        compressed = lzma.LZMAFile(duplicated, "rb")
-        return io.TextIOWrapper(compressed, encoding="utf-8", newline="\n")
+        try:
+            compressed = lzma.LZMAFile(duplicated, "rb")
+            try:
+                return _OwnedMacroText(compressed, duplicated)
+            except BaseException:
+                compressed.close()
+                raise
+        except BaseException:
+            duplicated.close()
+            raise
 
     def _read_meta(self) -> MacroFileMeta:
         with self._open_text() as handle:

--- a/keymasq/keymasqd/macro_file.py
+++ b/keymasq/keymasqd/macro_file.py
@@ -1,6 +1,10 @@
+from __future__ import annotations
+
 import io
 import json
 import lzma
+import os
+import threading
 from collections.abc import Iterable, Iterator
 from dataclasses import dataclass, field
 from datetime import datetime
@@ -17,6 +21,68 @@ MACRO_FILE_FORMAT = "keymasq-macro"
 MACRO_FILE_VERSION = 1
 
 type MacroEvent = dict[str, object]
+
+
+class MacroFileSnapshot:
+    """An open, immutable macro-file revision with repeatable event streams."""
+
+    def __init__(self, path: Path) -> None:
+        self._raw = path.open("rb")
+        self._lock = threading.Lock()
+        self._closed = False
+        try:
+            self.meta = self._read_meta()
+        except BaseException:
+            self._raw.close()
+            self._closed = True
+            raise
+
+    def _open_text(self) -> io.TextIOWrapper:
+        with self._lock:
+            if self._closed:
+                raise ValueError("Macro snapshot is closed")
+            source_fd = self._raw.fileno()
+            duplicated_fd = os.open(
+                f"/proc/self/fd/{source_fd}",
+                os.O_RDONLY | os.O_CLOEXEC,
+            )
+        try:
+            duplicated = os.fdopen(duplicated_fd, "rb")
+        except BaseException:
+            os.close(duplicated_fd)
+            raise
+        compressed = lzma.LZMAFile(duplicated, "rb")
+        return io.TextIOWrapper(compressed, encoding="utf-8", newline="\n")
+
+    def _read_meta(self) -> MacroFileMeta:
+        with self._open_text() as handle:
+            first_line = handle.readline()
+        return _macro_meta_from_line(first_line)
+
+    def iter_events(self) -> Iterator[MacroEvent]:
+        def generate() -> Iterator[MacroEvent]:
+            with self._open_text() as handle:
+                first_line = handle.readline()
+                _macro_meta_from_line(first_line)
+                for line in handle:
+                    stripped = line.strip()
+                    if stripped:
+                        yield require_json_object(json.loads(stripped))
+
+        return generate()
+
+    def close(self) -> None:
+        with self._lock:
+            if self._closed:
+                return
+            self._closed = True
+            self._raw.close()
+
+    def __enter__(self) -> MacroFileSnapshot:
+        return self
+
+    def __exit__(self, *_exc: object) -> None:
+        self.close()
 
 
 @dataclass(frozen=True)
@@ -42,7 +108,7 @@ class MacroFileMeta:
     type_use_unicode_input: bool = False
 
     @classmethod
-    def from_payload(cls, payload: JsonObject, *, name: str | None = None) -> "MacroFileMeta":
+    def from_payload(cls, payload: JsonObject, *, name: str | None = None) -> MacroFileMeta:
         return cls(
             name=name or macro_payload_str(payload, "name"),
             duration_us=macro_payload_int(payload, "duration_us", 0),
@@ -107,11 +173,7 @@ class MacroFileMeta:
 def read_macro_meta(path: Path) -> MacroFileMeta:
     with _open_text(path, "rb") as f:
         first_line = f.readline()
-    if not first_line:
-        raise ValueError("Empty macro file")
-    record = require_json_object(json.loads(first_line))
-    _validate_meta_record(record)
-    return MacroFileMeta.from_payload(record)
+    return _macro_meta_from_line(first_line)
 
 
 def iter_macro_events(path: Path) -> Iterator[MacroEvent]:
@@ -129,10 +191,10 @@ def iter_macro_events(path: Path) -> Iterator[MacroEvent]:
 
 
 def load_macro(path: Path) -> JsonObject:
-    meta = read_macro_meta(path)
-    payload = meta.to_payload(include_type_text=True)
-    payload["events"] = list(iter_macro_events(path))
-    return payload
+    with MacroFileSnapshot(path) as snapshot:
+        payload = snapshot.meta.to_payload(include_type_text=True)
+        payload["events"] = list(snapshot.iter_events())
+        return payload
 
 
 def write_macro(
@@ -191,6 +253,14 @@ def _validate_meta_record(record: JsonObject) -> None:
         raise ValueError("Unsupported macro file format")
     if record.get("version") != MACRO_FILE_VERSION:
         raise ValueError("Unsupported macro file version")
+
+
+def _macro_meta_from_line(first_line: str) -> MacroFileMeta:
+    if not first_line:
+        raise ValueError("Empty macro file")
+    record = require_json_object(json.loads(first_line))
+    _validate_meta_record(record)
+    return MacroFileMeta.from_payload(record)
 
 
 def macro_payload_str(payload: JsonObject, key: str, default: str = "") -> str:

--- a/keymasq/keymasqd/macro_file.py
+++ b/keymasq/keymasqd/macro_file.py
@@ -3,13 +3,11 @@ from __future__ import annotations
 import io
 import json
 import lzma
-import os
-import threading
 from collections.abc import Iterable, Iterator
 from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
-from typing import Any, BinaryIO, cast
+from typing import BinaryIO, cast
 
 from keymasq.common.coercion import require_json_object
 from keymasq.common.config_files import write_config_atomically
@@ -23,86 +21,25 @@ MACRO_FILE_VERSION = 1
 type MacroEvent = dict[str, object]
 
 
-class _OwnedMacroText(io.TextIOWrapper):
-    def __init__(self, buffer: Any, owner: BinaryIO) -> None:
-        self._owner = owner
-        super().__init__(buffer, encoding="utf-8", newline="\n")
-
-    def close(self) -> None:
-        try:
-            super().close()
-        finally:
-            self._owner.close()
-
-
 class MacroFileSnapshot:
-    """An open, immutable macro-file revision with repeatable event streams."""
+    """Immutable compressed bytes for one repeatable macro-file revision."""
 
     def __init__(self, path: Path) -> None:
-        self._raw = path.open("rb")
-        self._lock = threading.Lock()
-        self._closed = False
-        try:
-            self.meta = self._read_meta()
-        except BaseException:
-            self._raw.close()
-            self._closed = True
-            raise
+        self._compressed = path.read_bytes()
+        with self._open_text() as handle:
+            self.meta = _macro_meta_from_line(handle.readline())
 
     def _open_text(self) -> io.TextIOWrapper:
-        with self._lock:
-            if self._closed:
-                raise ValueError("Macro snapshot is closed")
-            source_fd = self._raw.fileno()
-            duplicated_fd = os.open(
-                f"/proc/self/fd/{source_fd}",
-                os.O_RDONLY | os.O_CLOEXEC,
-            )
-        try:
-            duplicated = os.fdopen(duplicated_fd, "rb")
-        except BaseException:
-            os.close(duplicated_fd)
-            raise
-        try:
-            compressed = lzma.LZMAFile(duplicated, "rb")
-            try:
-                return _OwnedMacroText(compressed, duplicated)
-            except BaseException:
-                compressed.close()
-                raise
-        except BaseException:
-            duplicated.close()
-            raise
-
-    def _read_meta(self) -> MacroFileMeta:
-        with self._open_text() as handle:
-            first_line = handle.readline()
-        return _macro_meta_from_line(first_line)
+        compressed = lzma.LZMAFile(io.BytesIO(self._compressed), "rb")
+        return io.TextIOWrapper(compressed, encoding="utf-8", newline="\n")
 
     def iter_events(self) -> Iterator[MacroEvent]:
         def generate() -> Iterator[MacroEvent]:
             with self._open_text() as handle:
-                first_line = handle.readline()
-                _macro_meta_from_line(first_line)
-                for line in handle:
-                    stripped = line.strip()
-                    if stripped:
-                        yield require_json_object(json.loads(stripped))
+                _macro_meta_from_line(handle.readline())
+                yield from _iter_macro_event_lines(handle)
 
         return generate()
-
-    def close(self) -> None:
-        with self._lock:
-            if self._closed:
-                return
-            self._closed = True
-            self._raw.close()
-
-    def __enter__(self) -> MacroFileSnapshot:
-        return self
-
-    def __exit__(self, *_exc: object) -> None:
-        self.close()
 
 
 @dataclass(frozen=True)
@@ -198,22 +135,15 @@ def read_macro_meta(path: Path) -> MacroFileMeta:
 
 def iter_macro_events(path: Path) -> Iterator[MacroEvent]:
     with _open_text(path, "rb") as f:
-        first_line = f.readline()
-        if not first_line:
-            raise ValueError("Empty macro file")
-        _validate_meta_record(require_json_object(json.loads(first_line)))
-        for line in f:
-            stripped = line.strip()
-            if not stripped:
-                continue
-            event = require_json_object(json.loads(stripped))
-            yield event
+        _macro_meta_from_line(f.readline())
+        yield from _iter_macro_event_lines(f)
 
 
 def load_macro(path: Path) -> JsonObject:
-    with MacroFileSnapshot(path) as snapshot:
-        payload = snapshot.meta.to_payload(include_type_text=True)
-        payload["events"] = list(snapshot.iter_events())
+    with _open_text(path, "rb") as handle:
+        meta = _macro_meta_from_line(handle.readline())
+        payload = meta.to_payload(include_type_text=True)
+        payload["events"] = list(_iter_macro_event_lines(handle))
         return payload
 
 
@@ -281,6 +211,13 @@ def _macro_meta_from_line(first_line: str) -> MacroFileMeta:
     record = require_json_object(json.loads(first_line))
     _validate_meta_record(record)
     return MacroFileMeta.from_payload(record)
+
+
+def _iter_macro_event_lines(handle: Iterable[str]) -> Iterator[MacroEvent]:
+    for line in handle:
+        stripped = line.strip()
+        if stripped:
+            yield require_json_object(json.loads(stripped))
 
 
 def macro_payload_str(payload: JsonObject, key: str, default: str = "") -> str:

--- a/keymasq/keymasqd/macro_store.py
+++ b/keymasq/keymasqd/macro_store.py
@@ -139,7 +139,7 @@ class MacroStore:
         return iter_macro_events(path)
 
     def open_snapshot(self, name: str) -> MacroStoreSnapshot:
-        """Pin metadata and repeatable event reads to one stored revision."""
+        """Open repeatable event reads that stop if the stored revision changes."""
 
         if name in self._internal_macros:
             payload = copy.deepcopy(self._internal_macros[name])

--- a/keymasq/keymasqd/macro_store.py
+++ b/keymasq/keymasqd/macro_store.py
@@ -6,7 +6,7 @@ import lzma
 import os
 import re
 import threading
-from collections.abc import Generator, Iterable, Iterator
+from collections.abc import Callable, Generator, Iterable, Iterator
 from contextlib import contextmanager
 from datetime import datetime
 from pathlib import Path
@@ -15,6 +15,7 @@ from typing import cast
 from keymasq.keymasqd.macro_file import (
     MACRO_FILE_SUFFIX,
     MacroFileMeta,
+    MacroFileSnapshot,
     iter_macro_events,
     load_macro,
     macro_payload_from_events,
@@ -30,6 +31,18 @@ _PROCESS_MUTATION_LOCK = threading.Lock()
 log = logging.getLogger("keymasqd.macros")
 type MacroEvent = dict[str, object]
 type MacroPayload = dict[str, object]
+
+
+class MacroStoreSnapshot:
+    def __init__(
+        self,
+        meta: MacroPayload,
+        iter_events: Callable[[], Iterator[MacroEvent]],
+        close: Callable[[], None],
+    ) -> None:
+        self.meta = meta
+        self.iter_events = iter_events
+        self.close = close
 
 
 def _payload_list(payload: MacroPayload, key: str) -> list[object]:
@@ -129,6 +142,25 @@ class MacroStore:
         if not path.exists():
             raise FileNotFoundError(f"Macro '{name}' not found")
         return iter_macro_events(path)
+
+    def open_snapshot(self, name: str) -> MacroStoreSnapshot:
+        """Pin metadata and repeatable event reads to one stored revision."""
+
+        if name in self._internal_macros:
+            payload = copy.deepcopy(self._internal_macros[name])
+            events = _payload_events(payload)
+            meta = MacroFileMeta.from_payload(payload, name=name).to_payload()
+            return MacroStoreSnapshot(meta, lambda: iter(copy.deepcopy(events)), lambda: None)
+
+        path = self._macro_path(name)
+        if not path.exists():
+            raise FileNotFoundError(f"Macro '{name}' not found")
+        snapshot = MacroFileSnapshot(path)
+        return MacroStoreSnapshot(
+            snapshot.meta.to_payload(),
+            snapshot.iter_events,
+            snapshot.close,
+        )
 
     def create(self, payload: MacroPayload) -> MacroPayload:
         events = _payload_events(payload)

--- a/keymasq/keymasqd/macro_store.py
+++ b/keymasq/keymasqd/macro_store.py
@@ -8,6 +8,7 @@ import re
 import threading
 from collections.abc import Callable, Generator, Iterable, Iterator
 from contextlib import contextmanager
+from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
 from typing import cast
@@ -33,16 +34,10 @@ type MacroEvent = dict[str, object]
 type MacroPayload = dict[str, object]
 
 
+@dataclass(frozen=True)
 class MacroStoreSnapshot:
-    def __init__(
-        self,
-        meta: MacroPayload,
-        iter_events: Callable[[], Iterator[MacroEvent]],
-        close: Callable[[], None],
-    ) -> None:
-        self.meta = meta
-        self.iter_events = iter_events
-        self.close = close
+    meta: MacroPayload
+    iter_events: Callable[[], Iterator[MacroEvent]]
 
 
 def _payload_list(payload: MacroPayload, key: str) -> list[object]:
@@ -150,7 +145,7 @@ class MacroStore:
             payload = copy.deepcopy(self._internal_macros[name])
             events = _payload_events(payload)
             meta = MacroFileMeta.from_payload(payload, name=name).to_payload()
-            return MacroStoreSnapshot(meta, lambda: iter(copy.deepcopy(events)), lambda: None)
+            return MacroStoreSnapshot(meta, lambda: iter(copy.deepcopy(events)))
 
         path = self._macro_path(name)
         if not path.exists():
@@ -159,7 +154,6 @@ class MacroStore:
         return MacroStoreSnapshot(
             snapshot.meta.to_payload(),
             snapshot.iter_events,
-            snapshot.close,
         )
 
     def create(self, payload: MacroPayload) -> MacroPayload:

--- a/keymasq/keymasqd/recording.py
+++ b/keymasq/keymasqd/recording.py
@@ -470,8 +470,7 @@ class RecordingManager:
             return
 
         scan_complete = True
-        quarantine_uncertain_events = False
-        preserve_uncertain_events = False
+        invalid_meta_stems: set[str] = set()
         for meta_path in meta_paths:
             try:
                 decoded = json.loads(meta_path.read_text(encoding="utf-8"))
@@ -512,7 +511,6 @@ class RecordingManager:
                 loaded_event_paths.add(event_path)
             except FileNotFoundError as exc:
                 scan_complete = False
-                preserve_uncertain_events = True
                 log.debug(
                     "Recording slot metadata disappeared while loading %s: %s",
                     meta_path,
@@ -520,7 +518,6 @@ class RecordingManager:
                 )
             except PermissionError as exc:
                 scan_complete = False
-                preserve_uncertain_events = True
                 log.warning(
                     "Ignoring unreadable recording slot metadata %s: %s. Check recording "
                     "spool ownership and permissions for the keymasqd user.",
@@ -529,11 +526,10 @@ class RecordingManager:
                 )
             except OSError as exc:
                 scan_complete = False
-                preserve_uncertain_events = True
                 log.warning("Ignoring unreadable recording slot metadata %s: %s", meta_path, exc)
             except json.JSONDecodeError as exc:
                 scan_complete = False
-                quarantine_uncertain_events = True
+                invalid_meta_stems.add(meta_path.stem)
                 log.warning(
                     "Ignoring invalid recording slot metadata %s: invalid JSON: %s",
                     meta_path,
@@ -542,7 +538,7 @@ class RecordingManager:
                 _quarantine_invalid_slot_metadata(meta_path)
             except UnicodeDecodeError as exc:
                 scan_complete = False
-                quarantine_uncertain_events = True
+                invalid_meta_stems.add(meta_path.stem)
                 log.warning(
                     "Ignoring invalid recording slot metadata %s: invalid UTF-8: %s",
                     meta_path,
@@ -551,12 +547,11 @@ class RecordingManager:
                 _quarantine_invalid_slot_metadata(meta_path)
             except ValueError as exc:
                 scan_complete = False
-                quarantine_uncertain_events = True
+                invalid_meta_stems.add(meta_path.stem)
                 log.warning("Ignoring invalid recording slot metadata %s: %s", meta_path, exc)
                 _quarantine_invalid_slot_metadata(meta_path)
             except Exception:
                 scan_complete = False
-                preserve_uncertain_events = True
                 log.exception("Unexpected failure loading recording slot metadata %s", meta_path)
 
         if not scan_complete:
@@ -565,12 +560,12 @@ class RecordingManager:
                 "event files in %s",
                 self._spool_dir,
             )
-            if quarantine_uncertain_events and not preserve_uncertain_events:
+            for meta_stem in invalid_meta_stems:
                 try:
-                    uncertain_paths = list(self._spool_dir.glob("slot-*-*.jsonl"))
+                    invalid_slot_paths = list(self._spool_dir.glob(f"{meta_stem}-*.jsonl"))
                 except OSError:
-                    uncertain_paths = []
-                for path in uncertain_paths:
+                    continue
+                for path in invalid_slot_paths:
                     try:
                         is_loaded = path.resolve() in loaded_event_paths
                     except OSError:

--- a/keymasq/keymasqd/recording.py
+++ b/keymasq/keymasqd/recording.py
@@ -222,6 +222,15 @@ class RecordingManager:
             except Exception:
                 log.exception("Failed to discard recording spool after start failure")
 
+    async def abort(self) -> None:
+        """Stop observing input and discard an unfinished recording.
+
+        Unlike :meth:`stop`, abort never publishes or persists a recording. It is
+        idempotent so owner-disconnect and shutdown cleanup may safely overlap.
+        """
+
+        await self._abort_failed_start()
+
     def record_event(self, device_type: str, event: evdev.InputEvent) -> None:
         if self._stopped:
             return
@@ -460,6 +469,8 @@ class RecordingManager:
             )
             return
 
+        scan_complete = True
+        quarantine_uncertain_events = False
         for meta_path in meta_paths:
             try:
                 decoded = json.loads(meta_path.read_text(encoding="utf-8"))
@@ -499,12 +510,14 @@ class RecordingManager:
                 self._pending_recording_created_at[recording_id] = time.monotonic()
                 loaded_event_paths.add(event_path)
             except FileNotFoundError as exc:
+                scan_complete = False
                 log.debug(
                     "Recording slot metadata disappeared while loading %s: %s",
                     meta_path,
                     exc,
                 )
             except PermissionError as exc:
+                scan_complete = False
                 log.warning(
                     "Ignoring unreadable recording slot metadata %s: %s. Check recording "
                     "spool ownership and permissions for the keymasqd user.",
@@ -512,26 +525,54 @@ class RecordingManager:
                     exc,
                 )
             except OSError as exc:
+                scan_complete = False
                 log.warning("Ignoring unreadable recording slot metadata %s: %s", meta_path, exc)
             except json.JSONDecodeError as exc:
+                scan_complete = False
+                quarantine_uncertain_events = True
                 log.warning(
                     "Ignoring invalid recording slot metadata %s: invalid JSON: %s",
                     meta_path,
                     exc,
                 )
-                _remove_invalid_slot_metadata(meta_path)
+                _quarantine_invalid_slot_metadata(meta_path)
             except UnicodeDecodeError as exc:
+                scan_complete = False
+                quarantine_uncertain_events = True
                 log.warning(
                     "Ignoring invalid recording slot metadata %s: invalid UTF-8: %s",
                     meta_path,
                     exc,
                 )
-                _remove_invalid_slot_metadata(meta_path)
+                _quarantine_invalid_slot_metadata(meta_path)
             except ValueError as exc:
+                scan_complete = False
+                quarantine_uncertain_events = True
                 log.warning("Ignoring invalid recording slot metadata %s: %s", meta_path, exc)
-                _remove_invalid_slot_metadata(meta_path)
+                _quarantine_invalid_slot_metadata(meta_path)
             except Exception:
+                scan_complete = False
                 log.exception("Unexpected failure loading recording slot metadata %s", meta_path)
+
+        if not scan_complete:
+            log.warning(
+                "Recording slot metadata scan was incomplete; preserving all unreferenced "
+                "event files in %s",
+                self._spool_dir,
+            )
+            if quarantine_uncertain_events:
+                try:
+                    uncertain_paths = list(self._spool_dir.glob("slot-*-*.jsonl"))
+                except OSError:
+                    uncertain_paths = []
+                for path in uncertain_paths:
+                    try:
+                        is_loaded = path.resolve() in loaded_event_paths
+                    except OSError:
+                        is_loaded = False
+                    if not is_loaded:
+                        _quarantine_slot_artifact(path, reason="uncertain")
+            return
 
         try:
             event_paths = list(self._spool_dir.glob("slot-*-*.jsonl"))
@@ -774,13 +815,24 @@ def _close_recording_input_device(device: _RecordingInputDevice) -> None:
         log.exception("Unexpected failure closing extra recording device")
 
 
-def _remove_invalid_slot_metadata(meta_path: Path) -> None:
+def _quarantine_invalid_slot_metadata(meta_path: Path) -> None:
+    _quarantine_slot_artifact(meta_path, reason="invalid")
+
+
+def _quarantine_slot_artifact(path: Path, *, reason: str) -> None:
     try:
-        meta_path.unlink(missing_ok=True)
+        quarantine_dir = path.parent / "quarantine"
+        quarantine_dir.mkdir(mode=0o700, exist_ok=True)
+        os.chmod(quarantine_dir, 0o700)
+        target = quarantine_dir / f"{path.name}.{reason}-{time.time_ns()}"
+        os.replace(path, target)
+        target.chmod(0o600)
+    except FileNotFoundError:
+        return
     except OSError as exc:
-        log.debug("Failed to remove invalid recording slot metadata %s: %s", meta_path, exc)
+        log.warning("Failed to quarantine recording slot artifact %s: %s", path, exc)
     except Exception:
-        log.exception("Unexpected failure removing invalid recording slot metadata %s", meta_path)
+        log.exception("Unexpected failure quarantining recording slot artifact %s", path)
 
 
 def _start_mouse_move_event(x: int, y: int) -> RecordingEvent:

--- a/keymasq/keymasqd/recording.py
+++ b/keymasq/keymasqd/recording.py
@@ -470,7 +470,6 @@ class RecordingManager:
             return
 
         scan_complete = True
-        invalid_meta_stems: set[str] = set()
         for meta_path in meta_paths:
             try:
                 decoded = json.loads(meta_path.read_text(encoding="utf-8"))
@@ -528,28 +527,22 @@ class RecordingManager:
                 scan_complete = False
                 log.warning("Ignoring unreadable recording slot metadata %s: %s", meta_path, exc)
             except json.JSONDecodeError as exc:
-                scan_complete = False
-                invalid_meta_stems.add(meta_path.stem)
                 log.warning(
                     "Ignoring invalid recording slot metadata %s: invalid JSON: %s",
                     meta_path,
                     exc,
                 )
-                _quarantine_invalid_slot_metadata(meta_path)
+                _remove_invalid_slot_metadata(meta_path)
             except UnicodeDecodeError as exc:
-                scan_complete = False
-                invalid_meta_stems.add(meta_path.stem)
                 log.warning(
                     "Ignoring invalid recording slot metadata %s: invalid UTF-8: %s",
                     meta_path,
                     exc,
                 )
-                _quarantine_invalid_slot_metadata(meta_path)
+                _remove_invalid_slot_metadata(meta_path)
             except ValueError as exc:
-                scan_complete = False
-                invalid_meta_stems.add(meta_path.stem)
                 log.warning("Ignoring invalid recording slot metadata %s: %s", meta_path, exc)
-                _quarantine_invalid_slot_metadata(meta_path)
+                _remove_invalid_slot_metadata(meta_path)
             except Exception:
                 scan_complete = False
                 log.exception("Unexpected failure loading recording slot metadata %s", meta_path)
@@ -560,18 +553,6 @@ class RecordingManager:
                 "event files in %s",
                 self._spool_dir,
             )
-            for meta_stem in invalid_meta_stems:
-                try:
-                    invalid_slot_paths = list(self._spool_dir.glob(f"{meta_stem}-*.jsonl"))
-                except OSError:
-                    continue
-                for path in invalid_slot_paths:
-                    try:
-                        is_loaded = path.resolve() in loaded_event_paths
-                    except OSError:
-                        is_loaded = False
-                    if not is_loaded:
-                        _quarantine_slot_artifact(path, reason="uncertain")
             return
 
         try:
@@ -815,24 +796,13 @@ def _close_recording_input_device(device: _RecordingInputDevice) -> None:
         log.exception("Unexpected failure closing extra recording device")
 
 
-def _quarantine_invalid_slot_metadata(meta_path: Path) -> None:
-    _quarantine_slot_artifact(meta_path, reason="invalid")
-
-
-def _quarantine_slot_artifact(path: Path, *, reason: str) -> None:
+def _remove_invalid_slot_metadata(meta_path: Path) -> None:
     try:
-        quarantine_dir = path.parent / "quarantine"
-        quarantine_dir.mkdir(mode=0o700, exist_ok=True)
-        os.chmod(quarantine_dir, 0o700)
-        target = quarantine_dir / f"{path.name}.{reason}-{time.time_ns()}"
-        os.replace(path, target)
-        target.chmod(0o600)
-    except FileNotFoundError:
-        return
+        meta_path.unlink(missing_ok=True)
     except OSError as exc:
-        log.warning("Failed to quarantine recording slot artifact %s: %s", path, exc)
+        log.debug("Failed to remove invalid recording slot metadata %s: %s", meta_path, exc)
     except Exception:
-        log.exception("Unexpected failure quarantining recording slot artifact %s", path)
+        log.exception("Unexpected failure removing invalid recording slot metadata %s", meta_path)
 
 
 def _start_mouse_move_event(x: int, y: int) -> RecordingEvent:

--- a/keymasq/keymasqd/recording.py
+++ b/keymasq/keymasqd/recording.py
@@ -88,6 +88,7 @@ class RecordingManager:
         self._claimed_recording_created_at: dict[str, float] = {}
         self._claimed_recording_discard_requested: set[str] = set()
         self._pending_recording_lock = asyncio.Lock()
+        self._stop_lock = asyncio.Lock()
         self._start_time_us: int | None = None
         self._extra_devices: list[_RecordingInputDevice] = []
         self._monitoring_tasks: list[asyncio.Task[None]] = []
@@ -285,6 +286,10 @@ class RecordingManager:
             log.exception("Extra recording device reader stopped after unexpected error")
 
     async def stop(self, *, stop_reason: str | None = None) -> RecordingPayload:
+        async with self._stop_lock:
+            return await self._stop_locked(stop_reason=stop_reason)
+
+    async def _stop_locked(self, *, stop_reason: str | None = None) -> RecordingPayload:
         was_recording = not self._stopped
         self._stopped = True
         self._recording_started_at = None

--- a/keymasq/keymasqd/recording.py
+++ b/keymasq/keymasqd/recording.py
@@ -471,6 +471,7 @@ class RecordingManager:
 
         scan_complete = True
         quarantine_uncertain_events = False
+        preserve_uncertain_events = False
         for meta_path in meta_paths:
             try:
                 decoded = json.loads(meta_path.read_text(encoding="utf-8"))
@@ -511,6 +512,7 @@ class RecordingManager:
                 loaded_event_paths.add(event_path)
             except FileNotFoundError as exc:
                 scan_complete = False
+                preserve_uncertain_events = True
                 log.debug(
                     "Recording slot metadata disappeared while loading %s: %s",
                     meta_path,
@@ -518,6 +520,7 @@ class RecordingManager:
                 )
             except PermissionError as exc:
                 scan_complete = False
+                preserve_uncertain_events = True
                 log.warning(
                     "Ignoring unreadable recording slot metadata %s: %s. Check recording "
                     "spool ownership and permissions for the keymasqd user.",
@@ -526,6 +529,7 @@ class RecordingManager:
                 )
             except OSError as exc:
                 scan_complete = False
+                preserve_uncertain_events = True
                 log.warning("Ignoring unreadable recording slot metadata %s: %s", meta_path, exc)
             except json.JSONDecodeError as exc:
                 scan_complete = False
@@ -552,6 +556,7 @@ class RecordingManager:
                 _quarantine_invalid_slot_metadata(meta_path)
             except Exception:
                 scan_complete = False
+                preserve_uncertain_events = True
                 log.exception("Unexpected failure loading recording slot metadata %s", meta_path)
 
         if not scan_complete:
@@ -560,7 +565,7 @@ class RecordingManager:
                 "event files in %s",
                 self._spool_dir,
             )
-            if quarantine_uncertain_events:
+            if quarantine_uncertain_events and not preserve_uncertain_events:
                 try:
                     uncertain_paths = list(self._spool_dir.glob("slot-*-*.jsonl"))
                 except OSError:

--- a/keymasq/keymasqd/recording.py
+++ b/keymasq/keymasqd/recording.py
@@ -26,6 +26,7 @@ from keymasq.common.model.actions import (
     normalize_macro_recording_slot,
 )
 from keymasq.common.paths import STATE_DIR
+from keymasq.common.security import DEFAULT_MACRO_RECORDING_TIME_LIMIT
 from keymasq.keymasqd.evdev_clock import set_evdev_clock_monotonic
 from keymasq.keymasqd.recording_spool import RecordingSnapshot, RecordingSpool
 
@@ -76,6 +77,7 @@ class RecordingManager:
         ) = None,
         *,
         spool_dir: Path | None = None,
+        macro_recording_time_limit: int = DEFAULT_MACRO_RECORDING_TIME_LIMIT,
     ) -> None:
         self.broadcast_callback = broadcast_callback
         self._spool_dir = spool_dir or STATE_DIR / "recording-spool"
@@ -95,6 +97,8 @@ class RecordingManager:
         self._include_mouse_clicks = False
         self._record_grabbed_source_keys: set[str] = set()
         self._recording_slot = 0
+        self.macro_recording_time_limit = max(0, int(macro_recording_time_limit))
+        self._recording_started_at: float | None = None
 
     @property
     def is_recording(self) -> bool:
@@ -128,6 +132,7 @@ class RecordingManager:
         self._extra_devices = []
         self._monitoring_tasks = []
         self._stopped = False
+        self._recording_started_at = asyncio.get_running_loop().time()
         self._include_mouse_movement = bool(include_mouse_movement)
         self._include_mouse_clicks = bool(include_mouse_clicks)
         self._recording_slot = normalize_macro_recording_slot(recording_slot)
@@ -213,6 +218,7 @@ class RecordingManager:
         self._record_grabbed_source_keys = set()
         self._recording_slot = 0
         self._start_time_us = None
+        self._recording_started_at = None
 
         spool = self._spool
         self._spool = None
@@ -278,17 +284,19 @@ class RecordingManager:
         except Exception:
             log.exception("Extra recording device reader stopped after unexpected error")
 
-    async def stop(self) -> RecordingPayload:
+    async def stop(self, *, stop_reason: str | None = None) -> RecordingPayload:
         was_recording = not self._stopped
         self._stopped = True
+        self._recording_started_at = None
 
         for task in self._monitoring_tasks:
             task.cancel()
         self._monitoring_tasks = []
 
-        if self._progress_task:
-            self._progress_task.cancel()
-            self._progress_task = None
+        progress_task = self._progress_task
+        self._progress_task = None
+        if progress_task is not None and progress_task is not asyncio.current_task():
+            progress_task.cancel()
 
         for device in self._extra_devices:
             _close_recording_input_device(device)
@@ -340,6 +348,10 @@ class RecordingManager:
         }
         if recording_slot:
             payload["recording_slot"] = recording_slot
+        if stop_reason:
+            payload["stop_reason"] = stop_reason
+            if stop_reason == "duration_limit":
+                payload["macro_recording_time_limit"] = int(self.macro_recording_time_limit)
 
         if was_recording and self.broadcast_callback:
             await self.broadcast_callback(CommandType.RECORDING_STOPPED, payload)
@@ -766,7 +778,25 @@ class RecordingManager:
     async def _monitor_progress(self) -> None:
         while not self._stopped:
             await asyncio.sleep(0.5)
-            if self._stopped or not self.broadcast_callback:
+            if self._stopped:
+                continue
+
+            started_at = self._recording_started_at
+            time_limit = int(self.macro_recording_time_limit)
+            if (
+                time_limit > 0
+                and started_at is not None
+                and asyncio.get_running_loop().time() - started_at
+                >= time_limit * 60
+            ):
+                log.info(
+                    "Stopping macro recording after configured %d minute limit",
+                    time_limit,
+                )
+                await self.stop(stop_reason="duration_limit")
+                return
+
+            if not self.broadcast_callback:
                 continue
 
             spool = self._spool

--- a/keymasq/keymasqd/runtime/macro/playback.py
+++ b/keymasq/keymasqd/runtime/macro/playback.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from dataclasses import replace
 from typing import Any
 
 from keymasq.common.model.actions import normalize_macro_loop_stop_behavior
@@ -79,6 +80,23 @@ async def play_macro(
     if event_source.event_count <= 0:
         _close_event_source(event_source)
         return {"status": "ok"}
+
+    source_closed = False
+    original_close = event_source.close
+
+    def close_event_source_once() -> None:
+        nonlocal source_closed
+        if source_closed:
+            return
+        source_closed = True
+        if original_close is None:
+            return
+        try:
+            original_close()
+        except Exception:
+            deps.log.exception("Failed to close macro playback snapshot")
+
+    event_source = replace(event_source, close=close_event_source_once)
 
     instance_id = manager.macro_state.allocate_instance(
         loop_mode=normalized_loop,

--- a/keymasq/keymasqd/runtime/macro/playback.py
+++ b/keymasq/keymasqd/runtime/macro/playback.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from dataclasses import replace
 from typing import Any
 
 from keymasq.common.model.actions import normalize_macro_loop_stop_behavior
@@ -27,7 +26,6 @@ async def play_macro(
         or manager.output_state.gamepad_uinput
         or manager.output_state.virtual_gamepad_uinputs
     ):
-        _close_event_source(macro_event_source, deps=deps)
         return {"status": "error", "message": "No output uinput devices available"}
 
     normalized_loop = loops.normalize_loop_mode(playback_options.loop_mode)
@@ -45,13 +43,10 @@ async def play_macro(
         )
         if hold_instances:
             cancelled = await _stop_loop_instances(manager, hold_instances, deps=deps)
-            _close_event_source(macro_event_source, deps=deps)
             return {"status": "ok", "cancelled": cancelled > 0}
-        _close_event_source(macro_event_source, deps=deps)
         return {"status": "ok", "cancelled": False}
 
     if int(playback_options.trigger_value) != 1:
-        _close_event_source(macro_event_source, deps=deps)
         return {"status": "ok"}
 
     if normalized_loop == "toggle":
@@ -62,7 +57,6 @@ async def play_macro(
         )
         if toggle_instances:
             cancelled = await _stop_loop_instances(manager, toggle_instances, deps=deps)
-            _close_event_source(macro_event_source, deps=deps)
             return {"status": "ok", "cancelled": cancelled > 0}
 
     if normalized_loop == "hold" and loops.find_matching_macro_instances(
@@ -70,7 +64,6 @@ async def play_macro(
         loop_mode="hold",
         source_key=source_key,
     ):
-        _close_event_source(macro_event_source, deps=deps)
         return {"status": "ok", "already_running": True}
 
     event_source = macro_event_source or list_macro_event_source(
@@ -78,25 +71,7 @@ async def play_macro(
         int_value_fn=deps.int_value_fn,
     )
     if event_source.event_count <= 0:
-        _close_event_source(event_source, deps=deps)
         return {"status": "ok"}
-
-    source_closed = False
-    original_close = event_source.close
-
-    def close_event_source_once() -> None:
-        nonlocal source_closed
-        if source_closed:
-            return
-        source_closed = True
-        if original_close is None:
-            return
-        try:
-            original_close()
-        except Exception:
-            deps.log.exception("Failed to close macro playback snapshot")
-
-    event_source = replace(event_source, close=close_event_source_once)
 
     instance_id = manager.macro_state.allocate_instance(
         loop_mode=normalized_loop,
@@ -125,23 +100,7 @@ async def play_macro(
     )
     manager.macro_state.tasks[instance_id] = task
 
-    def close_event_source(_task: object) -> None:
-        _close_event_source(event_source, deps=deps)
-
-    task.add_done_callback(close_event_source)
     return {"status": "ok"}
-
-
-def _close_event_source(
-    source: MacroEventSource | None,
-    *,
-    deps: MacroRuntimeDeps,
-) -> None:
-    if source is not None and source.close is not None:
-        try:
-            source.close()
-        except Exception:
-            deps.log.exception("Failed to close macro playback snapshot")
 
 
 async def _stop_loop_instances(

--- a/keymasq/keymasqd/runtime/macro/playback.py
+++ b/keymasq/keymasqd/runtime/macro/playback.py
@@ -27,7 +27,7 @@ async def play_macro(
         or manager.output_state.gamepad_uinput
         or manager.output_state.virtual_gamepad_uinputs
     ):
-        _close_event_source(macro_event_source)
+        _close_event_source(macro_event_source, deps=deps)
         return {"status": "error", "message": "No output uinput devices available"}
 
     normalized_loop = loops.normalize_loop_mode(playback_options.loop_mode)
@@ -45,13 +45,13 @@ async def play_macro(
         )
         if hold_instances:
             cancelled = await _stop_loop_instances(manager, hold_instances, deps=deps)
-            _close_event_source(macro_event_source)
+            _close_event_source(macro_event_source, deps=deps)
             return {"status": "ok", "cancelled": cancelled > 0}
-        _close_event_source(macro_event_source)
+        _close_event_source(macro_event_source, deps=deps)
         return {"status": "ok", "cancelled": False}
 
     if int(playback_options.trigger_value) != 1:
-        _close_event_source(macro_event_source)
+        _close_event_source(macro_event_source, deps=deps)
         return {"status": "ok"}
 
     if normalized_loop == "toggle":
@@ -62,7 +62,7 @@ async def play_macro(
         )
         if toggle_instances:
             cancelled = await _stop_loop_instances(manager, toggle_instances, deps=deps)
-            _close_event_source(macro_event_source)
+            _close_event_source(macro_event_source, deps=deps)
             return {"status": "ok", "cancelled": cancelled > 0}
 
     if normalized_loop == "hold" and loops.find_matching_macro_instances(
@@ -70,7 +70,7 @@ async def play_macro(
         loop_mode="hold",
         source_key=source_key,
     ):
-        _close_event_source(macro_event_source)
+        _close_event_source(macro_event_source, deps=deps)
         return {"status": "ok", "already_running": True}
 
     event_source = macro_event_source or list_macro_event_source(
@@ -78,7 +78,7 @@ async def play_macro(
         int_value_fn=deps.int_value_fn,
     )
     if event_source.event_count <= 0:
-        _close_event_source(event_source)
+        _close_event_source(event_source, deps=deps)
         return {"status": "ok"}
 
     source_closed = False
@@ -126,15 +126,22 @@ async def play_macro(
     manager.macro_state.tasks[instance_id] = task
 
     def close_event_source(_task: object) -> None:
-        _close_event_source(event_source)
+        _close_event_source(event_source, deps=deps)
 
     task.add_done_callback(close_event_source)
     return {"status": "ok"}
 
 
-def _close_event_source(source: MacroEventSource | None) -> None:
+def _close_event_source(
+    source: MacroEventSource | None,
+    *,
+    deps: MacroRuntimeDeps,
+) -> None:
     if source is not None and source.close is not None:
-        source.close()
+        try:
+            source.close()
+        except Exception:
+            deps.log.exception("Failed to close macro playback snapshot")
 
 
 async def _stop_loop_instances(

--- a/keymasq/keymasqd/runtime/macro/playback.py
+++ b/keymasq/keymasqd/runtime/macro/playback.py
@@ -26,6 +26,7 @@ async def play_macro(
         or manager.output_state.gamepad_uinput
         or manager.output_state.virtual_gamepad_uinputs
     ):
+        _close_event_source(macro_event_source)
         return {"status": "error", "message": "No output uinput devices available"}
 
     normalized_loop = loops.normalize_loop_mode(playback_options.loop_mode)
@@ -43,10 +44,13 @@ async def play_macro(
         )
         if hold_instances:
             cancelled = await _stop_loop_instances(manager, hold_instances, deps=deps)
+            _close_event_source(macro_event_source)
             return {"status": "ok", "cancelled": cancelled > 0}
+        _close_event_source(macro_event_source)
         return {"status": "ok", "cancelled": False}
 
     if int(playback_options.trigger_value) != 1:
+        _close_event_source(macro_event_source)
         return {"status": "ok"}
 
     if normalized_loop == "toggle":
@@ -57,6 +61,7 @@ async def play_macro(
         )
         if toggle_instances:
             cancelled = await _stop_loop_instances(manager, toggle_instances, deps=deps)
+            _close_event_source(macro_event_source)
             return {"status": "ok", "cancelled": cancelled > 0}
 
     if normalized_loop == "hold" and loops.find_matching_macro_instances(
@@ -64,6 +69,7 @@ async def play_macro(
         loop_mode="hold",
         source_key=source_key,
     ):
+        _close_event_source(macro_event_source)
         return {"status": "ok", "already_running": True}
 
     event_source = macro_event_source or list_macro_event_source(
@@ -71,6 +77,7 @@ async def play_macro(
         int_value_fn=deps.int_value_fn,
     )
     if event_source.event_count <= 0:
+        _close_event_source(event_source)
         return {"status": "ok"}
 
     instance_id = manager.macro_state.allocate_instance(
@@ -99,7 +106,17 @@ async def play_macro(
         )
     )
     manager.macro_state.tasks[instance_id] = task
+
+    def close_event_source(_task: object) -> None:
+        _close_event_source(event_source)
+
+    task.add_done_callback(close_event_source)
     return {"status": "ok"}
+
+
+def _close_event_source(source: MacroEventSource | None) -> None:
+    if source is not None and source.close is not None:
+        source.close()
 
 
 async def _stop_loop_instances(

--- a/keymasq/keymasqd/runtime/macro/scheduler.py
+++ b/keymasq/keymasqd/runtime/macro/scheduler.py
@@ -144,6 +144,8 @@ async def play_macro_task(
     except Exception:
         deps.log.exception("Macro playback aborted")
     finally:
+        if macro_event_source.close is not None:
+            macro_event_source.close()
         manager.macro_state.cancel_instance_ids.discard(instance_id)
         release_held(manager, instance_id, deps=deps)
         manager.macro_state.forget_instance(instance_id)

--- a/keymasq/keymasqd/runtime/macro/scheduler.py
+++ b/keymasq/keymasqd/runtime/macro/scheduler.py
@@ -145,7 +145,10 @@ async def play_macro_task(
         deps.log.exception("Macro playback aborted")
     finally:
         if macro_event_source.close is not None:
-            macro_event_source.close()
+            try:
+                macro_event_source.close()
+            except Exception:
+                deps.log.exception("Failed to close macro playback snapshot")
         manager.macro_state.cancel_instance_ids.discard(instance_id)
         release_held(manager, instance_id, deps=deps)
         manager.macro_state.forget_instance(instance_id)

--- a/keymasq/keymasqd/runtime/macro/scheduler.py
+++ b/keymasq/keymasqd/runtime/macro/scheduler.py
@@ -8,6 +8,7 @@ from keymasq.common.model.actions import (
     DEFAULT_NATURAL_MOUSE_MOVE_CURVE,
     DEFAULT_NATURAL_MOUSE_MOVE_SPEED,
 )
+from keymasq.keymasqd.macro_file import MacroFileChangedError
 from keymasq.keymasqd.runtime.macro import controls, events, mouse, outputs
 from keymasq.keymasqd.runtime.macro.loops import (
     MacroLoopStateMachine,
@@ -141,6 +142,11 @@ async def play_macro_task(
                 break
     except asyncio_mod.CancelledError:
         pass
+    except MacroFileChangedError:
+        deps.log.debug(
+            "Macro playback ended because %s was modified or removed",
+            macro_name or "<unnamed>",
+        )
     except Exception:
         deps.log.exception("Macro playback aborted")
     finally:

--- a/keymasq/keymasqd/runtime/macro/scheduler.py
+++ b/keymasq/keymasqd/runtime/macro/scheduler.py
@@ -144,11 +144,6 @@ async def play_macro_task(
     except Exception:
         deps.log.exception("Macro playback aborted")
     finally:
-        if macro_event_source.close is not None:
-            try:
-                macro_event_source.close()
-            except Exception:
-                deps.log.exception("Failed to close macro playback snapshot")
         manager.macro_state.cancel_instance_ids.discard(instance_id)
         release_held(manager, instance_id, deps=deps)
         manager.macro_state.forget_instance(instance_id)

--- a/keymasq/keymasqd/runtime/macro/state.py
+++ b/keymasq/keymasqd/runtime/macro/state.py
@@ -13,6 +13,7 @@ type NaturalMacroMover = Callable[
     Awaitable[dict[str, object]],
 ]
 type MacroEventIteratorFactory = Callable[[], Iterator[dict[str, object]]]
+type MacroEventSourceCloser = Callable[[], None]
 
 
 @dataclass(frozen=True)
@@ -84,3 +85,4 @@ class MacroEventSource:
     event_count: int
     duration_us: int
     iter_events: MacroEventIteratorFactory
+    close: MacroEventSourceCloser | None = None

--- a/keymasq/keymasqd/runtime/macro/state.py
+++ b/keymasq/keymasqd/runtime/macro/state.py
@@ -13,7 +13,6 @@ type NaturalMacroMover = Callable[
     Awaitable[dict[str, object]],
 ]
 type MacroEventIteratorFactory = Callable[[], Iterator[dict[str, object]]]
-type MacroEventSourceCloser = Callable[[], None]
 
 
 @dataclass(frozen=True)
@@ -85,4 +84,3 @@ class MacroEventSource:
     event_count: int
     duration_us: int
     iter_events: MacroEventIteratorFactory
-    close: MacroEventSourceCloser | None = None

--- a/keymasq/keymasqd/runtime/manager_macros.py
+++ b/keymasq/keymasqd/runtime/manager_macros.py
@@ -68,6 +68,27 @@ class MacroManagerMixin:
         store = self.macro_store
         if store is None:
             return None
+        open_snapshot = getattr(store, "open_snapshot", None)
+        if callable(open_snapshot):
+            snapshot = await asyncio.to_thread(open_snapshot, macro_name)
+            meta_raw = getattr(snapshot, "meta", None)
+            iter_snapshot_events = getattr(snapshot, "iter_events", None)
+            close_snapshot = getattr(snapshot, "close", None)
+            if not isinstance(meta_raw, dict) or not callable(iter_snapshot_events):
+                if callable(close_snapshot):
+                    close_snapshot()
+                return None
+            meta = cast(JsonObject, meta_raw)
+            close_callback = (
+                cast(Callable[[], None], close_snapshot) if callable(close_snapshot) else None
+            )
+            return MacroEventSource(
+                event_count=coerce_int(meta.get("event_count"), 0),
+                duration_us=coerce_int(meta.get("duration_us"), 0),
+                iter_events=lambda: cast(Iterator[JsonObject], iter_snapshot_events()),
+                close=close_callback,
+            )
+
         get_meta = getattr(store, "get_meta", None)
         iter_events = getattr(store, "iter_events", None)
         if not callable(get_meta) or not callable(iter_events):

--- a/keymasq/keymasqd/runtime/manager_macros.py
+++ b/keymasq/keymasqd/runtime/manager_macros.py
@@ -68,44 +68,13 @@ class MacroManagerMixin:
         store = self.macro_store
         if store is None:
             return None
-        open_snapshot = getattr(store, "open_snapshot", None)
-        if callable(open_snapshot):
-            snapshot = await asyncio.to_thread(open_snapshot, macro_name)
-            meta_raw = getattr(snapshot, "meta", None)
-            iter_snapshot_events = getattr(snapshot, "iter_events", None)
-            close_snapshot = getattr(snapshot, "close", None)
-            if not isinstance(meta_raw, dict) or not callable(iter_snapshot_events):
-                if callable(close_snapshot):
-                    close_snapshot()
-                return None
-            meta = cast(JsonObject, meta_raw)
-            close_callback = (
-                cast(Callable[[], None], close_snapshot) if callable(close_snapshot) else None
-            )
-            return MacroEventSource(
-                event_count=coerce_int(meta.get("event_count"), 0),
-                duration_us=coerce_int(meta.get("duration_us"), 0),
-                iter_events=lambda: cast(Iterator[JsonObject], iter_snapshot_events()),
-                close=close_callback,
-            )
-
-        get_meta = getattr(store, "get_meta", None)
-        iter_events = getattr(store, "iter_events", None)
-        if not callable(get_meta) or not callable(iter_events):
-            return None
-
-        meta_raw = await asyncio.to_thread(get_meta, macro_name)
-        if not isinstance(meta_raw, dict):
-            return None
-        meta = cast(JsonObject, meta_raw)
-
-        def iter_stored_events() -> Iterator[JsonObject]:
-            return cast(Iterator[JsonObject], iter_events(macro_name))
+        snapshot = await asyncio.to_thread(store.open_snapshot, macro_name)
+        meta = cast(JsonObject, snapshot.meta)
 
         return MacroEventSource(
             event_count=coerce_int(meta.get("event_count"), 0),
             duration_us=coerce_int(meta.get("duration_us"), 0),
-            iter_events=iter_stored_events,
+            iter_events=lambda: cast(Iterator[JsonObject], snapshot.iter_events()),
         )
 
     async def cancel_macro_playback(self) -> JsonObject:

--- a/keymasq/keymasqd/socket_server.py
+++ b/keymasq/keymasqd/socket_server.py
@@ -53,6 +53,7 @@ class SocketServer:
         single_owner: bool = False,
         broadcast_drain_timeout_s: float = 0.25,
         close_timeout_s: float = 0.25,
+        handler_drain_timeout_s: float = 2.0,
     ) -> None:
         self.socket_path = socket_path
         self.command_handler = command_handler
@@ -62,6 +63,7 @@ class SocketServer:
         self.single_owner = single_owner
         self.broadcast_drain_timeout_s = max(0.01, float(broadcast_drain_timeout_s))
         self.close_timeout_s = max(0.01, float(close_timeout_s))
+        self.handler_drain_timeout_s = max(0.01, float(handler_drain_timeout_s))
         self.server: asyncio.Server | None = None
         self.clients: set[asyncio.StreamWriter] = set()
         self._buffer: dict[asyncio.StreamWriter, bytes] = {}
@@ -69,14 +71,17 @@ class SocketServer:
         self._next_connection_id = 1
         self._owner_context: ClientContext | None = None
         self._socket_stat: os.stat_result | None = None
+        self._handler_tasks: set[asyncio.Task[None]] = set()
+        self._quiescing = False
 
     @property
     def owner_context(self) -> ClientContext | None:
         return self._owner_context
 
     async def start(self) -> None:
+        self._quiescing = False
         server = await asyncio.start_unix_server(
-            self._handle_client,
+            self._accept_client,
             path=self.socket_path,
         )
         self.server = server
@@ -148,6 +153,7 @@ class SocketServer:
             log.warning(f"Failed to remove {description}: {exc}")
 
     async def stop(self) -> None:
+        self._quiescing = True
         server = self.server
         socket_stat = self._socket_stat
         if server:
@@ -157,6 +163,7 @@ class SocketServer:
         for writer in writers:
             self._request_writer_close(writer)
 
+        await self._drain_handler_tasks()
         await asyncio.gather(
             *(self._wait_writer_closed(writer) for writer in writers),
             return_exceptions=True,
@@ -167,6 +174,10 @@ class SocketServer:
             if self.server is server:
                 self.server = None
 
+        # A transport accepted just before server.close() may register its
+        # synchronously-owned handler while the first drain is in progress.
+        await self._drain_handler_tasks()
+
         self._unlink_socket_path(socket_stat, "daemon socket")
 
         self.clients.clear()
@@ -175,12 +186,60 @@ class SocketServer:
         self._owner_context = None
         self._socket_stat = None
 
-    async def _handle_client(
+    async def _drain_handler_tasks(self) -> None:
+        current = asyncio.current_task()
+        tasks = {task for task in self._handler_tasks if task is not current and not task.done()}
+        if not tasks:
+            return
+
+        _done, pending = await asyncio.wait(
+            tasks,
+            timeout=self.handler_drain_timeout_s,
+        )
+        if not pending:
+            return
+
+        log.warning("Cancelling %d daemon client handler(s) after shutdown deadline", len(pending))
+        for task in pending:
+            task.cancel()
+        await asyncio.gather(*pending, return_exceptions=True)
+
+    def _accept_client(
+        self,
+        reader: asyncio.StreamReader,
+        writer: asyncio.StreamWriter,
+    ) -> None:
+        task = asyncio.create_task(
+            self._serve_client(reader, writer),
+            name="keymasqd:client-handler",
+        )
+        self._handler_tasks.add(task)
+
+        def _handler_done(done: asyncio.Task[None]) -> None:
+            self._handler_tasks.discard(task)
+            try:
+                error = done.exception()
+            except asyncio.CancelledError:
+                return
+            if error is not None:
+                log.error(
+                    "Unhandled daemon client handler error: %s",
+                    error,
+                    exc_info=(type(error), error, error.__traceback__),
+                )
+
+        task.add_done_callback(_handler_done)
+
+    async def _serve_client(
         self,
         reader: asyncio.StreamReader,
         writer: asyncio.StreamWriter,
     ) -> None:
         addr = writer.get_extra_info("peername") or "unknown"
+        if self._quiescing:
+            self._request_writer_close(writer)
+            await self._wait_writer_closed(writer)
+            return
         peer = self._extract_peer(writer)
         if peer is None:
             log.warning("Rejecting client without peer credentials")
@@ -282,6 +341,12 @@ class SocketServer:
             await self._drop_client(writer)
 
     async def _process_command(self, cmd: Command, context: ClientContext) -> Response:
+        if self._quiescing:
+            return Response(
+                status="error",
+                error="Daemon is shutting down",
+                request_id=cmd.request_id,
+            )
         try:
             result = await self.command_handler(cmd.command, cmd.data, context)
             return Response(

--- a/keymasq/keymasqd/socket_server.py
+++ b/keymasq/keymasqd/socket_server.py
@@ -202,15 +202,7 @@ class SocketServer:
         log.warning("Cancelling %d daemon client handler(s) after shutdown deadline", len(pending))
         for task in pending:
             task.cancel()
-        _done, still_pending = await asyncio.wait(
-            pending,
-            timeout=self.handler_drain_timeout_s,
-        )
-        if still_pending:
-            log.error(
-                "%d daemon client handler(s) did not stop after cancellation",
-                len(still_pending),
-            )
+        await asyncio.gather(*pending, return_exceptions=True)
 
     def _accept_client(
         self,

--- a/keymasq/keymasqd/socket_server.py
+++ b/keymasq/keymasqd/socket_server.py
@@ -202,7 +202,15 @@ class SocketServer:
         log.warning("Cancelling %d daemon client handler(s) after shutdown deadline", len(pending))
         for task in pending:
             task.cancel()
-        await asyncio.gather(*pending, return_exceptions=True)
+        _done, still_pending = await asyncio.wait(
+            pending,
+            timeout=self.handler_drain_timeout_s,
+        )
+        if still_pending:
+            log.error(
+                "%d daemon client handler(s) did not stop after cancellation",
+                len(still_pending),
+            )
 
     def _accept_client(
         self,

--- a/keymasq/keymasqd/socket_server.py
+++ b/keymasq/keymasqd/socket_server.py
@@ -179,6 +179,10 @@ class SocketServer:
             if self.server is server:
                 self.server = None
 
+        # Let accept callbacks already queued by the event loop register their
+        # handler tasks while the server is still quiescing.
+        await asyncio.sleep(0)
+
         # A transport accepted just before server.close() may register its
         # synchronously-owned handler while the first drain is in progress.
         await self._drain_handler_tasks()

--- a/keymasq/keymasqd/socket_server.py
+++ b/keymasq/keymasqd/socket_server.py
@@ -79,6 +79,11 @@ class SocketServer:
         return self._owner_context
 
     async def start(self) -> None:
+        active_handlers = {task for task in self._handler_tasks if not task.done()}
+        if active_handlers:
+            raise RuntimeError(
+                f"Cannot start daemon socket with {len(active_handlers)} prior handler(s) active"
+            )
         self._quiescing = False
         server = await asyncio.start_unix_server(
             self._accept_client,
@@ -202,7 +207,16 @@ class SocketServer:
         log.warning("Cancelling %d daemon client handler(s) after shutdown deadline", len(pending))
         for task in pending:
             task.cancel()
-        await asyncio.gather(*pending, return_exceptions=True)
+        _done, still_pending = await asyncio.wait(
+            pending,
+            timeout=self.handler_drain_timeout_s,
+        )
+        if still_pending:
+            log.error(
+                "%d daemon client handler(s) remain active after cancellation; "
+                "socket restart is disabled until they exit",
+                len(still_pending),
+            )
 
     def _accept_client(
         self,

--- a/keymasq/keymasqd/socket_server.py
+++ b/keymasq/keymasqd/socket_server.py
@@ -76,12 +76,17 @@ class SocketServer:
         self._active_command_tasks: set[asyncio.Task[None]] = set()
         self._server_generation = 0
         self._quiescing = False
+        self._lifecycle_lock = asyncio.Lock()
 
     @property
     def owner_context(self) -> ClientContext | None:
         return self._owner_context
 
     async def start(self) -> None:
+        async with self._lifecycle_lock:
+            await self._start_locked()
+
+    async def _start_locked(self) -> None:
         active_handlers = {task for task in self._handler_tasks if not task.done()}
         if active_handlers:
             raise RuntimeError(
@@ -167,6 +172,10 @@ class SocketServer:
             log.warning(f"Failed to remove {description}: {exc}")
 
     async def stop(self) -> None:
+        async with self._lifecycle_lock:
+            await self._stop_locked()
+
+    async def _stop_locked(self) -> None:
         self._quiescing = True
         server = self.server
         socket_stat = self._socket_stat

--- a/keymasq/keymasqd/socket_server.py
+++ b/keymasq/keymasqd/socket_server.py
@@ -72,6 +72,8 @@ class SocketServer:
         self._owner_context: ClientContext | None = None
         self._socket_stat: os.stat_result | None = None
         self._handler_tasks: set[asyncio.Task[None]] = set()
+        self._handler_writers: dict[asyncio.Task[None], asyncio.StreamWriter] = {}
+        self._active_command_tasks: set[asyncio.Task[None]] = set()
         self._quiescing = False
 
     @property
@@ -164,28 +166,32 @@ class SocketServer:
         if server:
             server.close()
 
-        writers = set(self.clients) | set(self._buffer) | set(self._client_context)
+        # Let accept callbacks already queued by the event loop register their
+        # handler tasks while the server is still quiescing.
+        await asyncio.sleep(0)
+
+        # Keep response streams open during the graceful drain so commands that
+        # finish before the deadline can acknowledge their result to clients.
+        await self._drain_active_commands()
+
+        writers = (
+            set(self.clients)
+            | set(self._buffer)
+            | set(self._client_context)
+            | set(self._handler_writers.values())
+        )
         for writer in writers:
             self._request_writer_close(writer)
-
-        await self._drain_handler_tasks()
         await asyncio.gather(
             *(self._wait_writer_closed(writer) for writer in writers),
             return_exceptions=True,
         )
+        await self._drain_handler_tasks(graceful=False)
 
         if server:
             await server.wait_closed()
             if self.server is server:
                 self.server = None
-
-        # Let accept callbacks already queued by the event loop register their
-        # handler tasks while the server is still quiescing.
-        await asyncio.sleep(0)
-
-        # A transport accepted just before server.close() may register its
-        # synchronously-owned handler while the first drain is in progress.
-        await self._drain_handler_tasks()
 
         self._unlink_socket_path(socket_stat, "daemon socket")
 
@@ -195,20 +201,36 @@ class SocketServer:
         self._owner_context = None
         self._socket_stat = None
 
-    async def _drain_handler_tasks(self) -> None:
+    async def _drain_active_commands(self) -> None:
+        tasks = {task for task in self._active_command_tasks if not task.done()}
+        if not tasks:
+            return
+        await self._drain_tasks(tasks, description="active daemon command", graceful=True)
+
+    async def _drain_handler_tasks(self, *, graceful: bool = True) -> None:
         current = asyncio.current_task()
         tasks = {task for task in self._handler_tasks if task is not current and not task.done()}
         if not tasks:
             return
+        await self._drain_tasks(tasks, description="daemon client handler", graceful=graceful)
 
-        _done, pending = await asyncio.wait(
-            tasks,
-            timeout=self.handler_drain_timeout_s,
-        )
-        if not pending:
-            return
+    async def _drain_tasks(
+        self,
+        tasks: set[asyncio.Task[None]],
+        *,
+        description: str,
+        graceful: bool,
+    ) -> None:
+        pending = tasks
+        if graceful:
+            _done, pending = await asyncio.wait(
+                tasks,
+                timeout=self.handler_drain_timeout_s,
+            )
+            if not pending:
+                return
 
-        log.warning("Cancelling %d daemon client handler(s) after shutdown deadline", len(pending))
+        log.warning("Cancelling %d %s(s) after shutdown deadline", len(pending), description)
         for task in pending:
             task.cancel()
         _done, still_pending = await asyncio.wait(
@@ -217,9 +239,10 @@ class SocketServer:
         )
         if still_pending:
             log.error(
-                "%d daemon client handler(s) remain active after cancellation; "
+                "%d %s(s) remain active after cancellation; "
                 "socket restart is disabled until they exit",
                 len(still_pending),
+                description,
             )
 
     def _accept_client(
@@ -232,9 +255,12 @@ class SocketServer:
             name="keymasqd:client-handler",
         )
         self._handler_tasks.add(task)
+        self._handler_writers[task] = writer
 
         def _handler_done(done: asyncio.Task[None]) -> None:
             self._handler_tasks.discard(task)
+            self._handler_writers.pop(task, None)
+            self._active_command_tasks.discard(task)
             try:
                 error = done.exception()
             except asyncio.CancelledError:
@@ -346,9 +372,15 @@ class SocketServer:
                         break
 
                     self._buffer[writer] = remaining
-                    response = await self._process_command(cmd, context)
-                    writer.write(encode_response(response))
-                    await writer.drain()
+                    command_task = asyncio.create_task(
+                        self._process_and_send_command(cmd, context, writer),
+                        name="keymasqd:command",
+                    )
+                    self._active_command_tasks.add(command_task)
+                    try:
+                        await command_task
+                    finally:
+                        self._active_command_tasks.discard(command_task)
 
         except asyncio.CancelledError:
             pass
@@ -357,6 +389,16 @@ class SocketServer:
         finally:
             log.info(f"Client disconnected: {addr}")
             await self._drop_client(writer)
+
+    async def _process_and_send_command(
+        self,
+        cmd: Command,
+        context: ClientContext,
+        writer: asyncio.StreamWriter,
+    ) -> None:
+        response = await self._process_command(cmd, context)
+        writer.write(encode_response(response))
+        await writer.drain()
 
     async def _process_command(self, cmd: Command, context: ClientContext) -> Response:
         if self._quiescing:

--- a/keymasq/keymasqd/socket_server.py
+++ b/keymasq/keymasqd/socket_server.py
@@ -74,6 +74,7 @@ class SocketServer:
         self._handler_tasks: set[asyncio.Task[None]] = set()
         self._handler_writers: dict[asyncio.Task[None], asyncio.StreamWriter] = {}
         self._active_command_tasks: set[asyncio.Task[None]] = set()
+        self._server_generation = 0
         self._quiescing = False
 
     @property
@@ -86,9 +87,15 @@ class SocketServer:
             raise RuntimeError(
                 f"Cannot start daemon socket with {len(active_handlers)} prior handler(s) active"
             )
+        self._server_generation += 1
+        generation = self._server_generation
         self._quiescing = False
+
+        def accept_client(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+            self._accept_client(reader, writer, generation)
+
         server = await asyncio.start_unix_server(
-            self._accept_client,
+            accept_client,
             path=self.socket_path,
         )
         self.server = server
@@ -165,10 +172,6 @@ class SocketServer:
         socket_stat = self._socket_stat
         if server:
             server.close()
-
-        # Let accept callbacks already queued by the event loop register their
-        # handler tasks while the server is still quiescing.
-        await asyncio.sleep(0)
 
         # Keep response streams open during the graceful drain so commands that
         # finish before the deadline can acknowledge their result to clients.
@@ -249,7 +252,12 @@ class SocketServer:
         self,
         reader: asyncio.StreamReader,
         writer: asyncio.StreamWriter,
+        generation: int | None = None,
     ) -> None:
+        generation = self._server_generation if generation is None else generation
+        if self._quiescing or generation != self._server_generation:
+            self._request_writer_close(writer)
+            return
         task = asyncio.create_task(
             self._serve_client(reader, writer),
             name="keymasqd:client-handler",

--- a/keymasq/keymasqd/socket_server.py
+++ b/keymasq/keymasqd/socket_server.py
@@ -189,7 +189,7 @@ class SocketServer:
             *(self._wait_writer_closed(writer) for writer in writers),
             return_exceptions=True,
         )
-        await self._drain_handler_tasks(graceful=False)
+        await self._drain_handler_tasks(graceful=True)
 
         if server:
             await server.wait_closed()

--- a/keymasq/session/manager/events.py
+++ b/keymasq/session/manager/events.py
@@ -346,6 +346,12 @@ async def handle_event(
         }
         if coerce_bool(recording_data.get("start_position_recorded"), False):
             stopped_payload["start_position_recorded"] = True
+        if recording_data.get("stop_reason") == "duration_limit":
+            stopped_payload["stop_reason"] = "duration_limit"
+            stopped_payload["macro_recording_time_limit"] = coerce_int(
+                recording_data.get("macro_recording_time_limit"),
+                0,
+            )
         manager.broadcast_to_session_clients(stopped_payload)
         return
 
@@ -376,6 +382,14 @@ def _notify_recording_stopped(
         duration_text = f"{duration_ms}ms"
     event_word = "event" if event_count == 1 else "events"
     prefix = f"Slot {slot}" if slot else "Macro recording"
+    if recording_data.get("stop_reason") == "duration_limit":
+        time_limit = coerce_int(recording_data.get("macro_recording_time_limit"), 0)
+        manager.send_notification(
+            "Keymasq: Macro Recording Limit Reached",
+            f"{prefix} stopped after the configured {time_limit} minute limit "
+            f"with {event_count} {event_word} captured.",
+        )
+        return
     manager.send_notification(
         "Keymasq: Macro Recording Stopped",
         f"{prefix} captured {event_count} {event_word} over {duration_text}.",

--- a/keymasq/session/manager/recording_unlock.py
+++ b/keymasq/session/manager/recording_unlock.py
@@ -43,6 +43,8 @@ def is_sensitive_session_command(
         "get_macro",
         "create_macro",
         "update_macro",
+        "rename_macro",
+        "delete_macro",
     }:
         return True
 

--- a/packaging/appimage/assets/security-steamos.toml
+++ b/packaging/appimage/assets/security-steamos.toml
@@ -11,4 +11,5 @@ emergency_cancel_combo_enabled = true
 # SteamOS/AppImage installs default to the easier flow: privileged capture
 # unlock is disabled because the package already installs a system daemon.
 unlock_required = false
+macro_recording_time_limit = 10
 macro_edit_requires_unlock = false

--- a/packaging/aur/keymasq.install
+++ b/packaging/aur/keymasq.install
@@ -24,6 +24,8 @@ exec_timeout_max_ms = 30000
 [recording_guard]
 # Tier 1 (recommended): require unlock for capture and recording commands.
 unlock_required = true
+# Stop a recording normally after this many minutes. Set to 0 for no time limit.
+macro_recording_time_limit = 10
 # Tier 2 (optional): require unlock for macro inspection/edit commands.
 macro_edit_requires_unlock = false
 EOF

--- a/packaging/pacman/templates/keymasq.install.in
+++ b/packaging/pacman/templates/keymasq.install.in
@@ -23,6 +23,8 @@ exec_timeout_max_ms = 30000
 [recording_guard]
 # Tier 1 (recommended): require unlock for capture and recording commands.
 unlock_required = true
+# Stop a recording normally after this many minutes. Set to 0 for no time limit.
+macro_recording_time_limit = 10
 # Tier 2 (optional): require unlock for macro inspection/edit commands.
 macro_edit_requires_unlock = false
 EOF

--- a/tests/gui/test_session_client.py
+++ b/tests/gui/test_session_client.py
@@ -11,6 +11,7 @@ class _FakeSocket:
     def __init__(self, chunks: list[bytes]) -> None:
         self._chunks = list(chunks)
         self.closed = False
+        self.shutdown_calls: list[int] = []
 
     def recv(self, _size: int) -> bytes:
         if self._chunks:
@@ -19,6 +20,9 @@ class _FakeSocket:
 
     def close(self) -> None:
         self.closed = True
+
+    def shutdown(self, how: int) -> None:
+        self.shutdown_calls.append(how)
 
 
 class _NeverWritableSocket:
@@ -57,6 +61,17 @@ def test_stale_event_callback_is_suppressed_after_generation_change() -> None:
 
     assert connection._dispatch_event_callback_once(3, calls.append, {"event": "new"}) is False
     assert calls == [{"event": "new"}]
+
+
+def test_close_connection_shuts_down_active_reader_socket() -> None:
+    connection = _PersistentSessionConnection()
+    sock = _FakeSocket([])
+    connection._sock = sock  # type: ignore[assignment]
+
+    connection._close_connection()
+
+    assert sock.shutdown_calls == [session_client_module.socket.SHUT_RDWR]
+    assert sock.closed is True
 
 
 def test_reconnect_starts_new_reader_while_old_generation_is_still_blocked(

--- a/tests/gui/test_session_client.py
+++ b/tests/gui/test_session_client.py
@@ -1,0 +1,146 @@
+import queue
+import threading
+
+import pytest
+
+import keymasq.gui.session_client as session_client_module
+from keymasq.gui.session_client import _BoundedWorkerPool, _PersistentSessionConnection
+
+
+class _FakeSocket:
+    def __init__(self, chunks: list[bytes]) -> None:
+        self._chunks = list(chunks)
+        self.closed = False
+
+    def recv(self, _size: int) -> bytes:
+        if self._chunks:
+            return self._chunks.pop(0)
+        return b""
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class _NeverWritableSocket:
+    def fileno(self) -> int:
+        return 123
+
+    def send(self, _payload: memoryview, _flags: int) -> int:
+        raise AssertionError("send must not run without writable readiness")
+
+
+def test_old_reader_generation_cannot_deliver_response_to_replacement() -> None:
+    connection = _PersistentSessionConnection()
+    old_socket = _FakeSocket([b'{"status":"ok","generation":1}\n'])
+    new_socket = _FakeSocket([b'{"status":"ok","generation":2}\n'])
+    response_queue: queue.Queue[dict | None] = queue.Queue(maxsize=1)
+    connection._generation = 2
+    connection._sock = new_socket  # type: ignore[assignment]
+    connection._response_queue = response_queue
+    connection._response_generation = 2
+
+    connection._reader_loop(1, old_socket)  # type: ignore[arg-type]
+    assert response_queue.empty()
+
+    connection._reader_loop(2, new_socket)  # type: ignore[arg-type]
+    assert response_queue.get_nowait() == {"status": "ok", "generation": 2}
+
+
+def test_stale_event_callback_is_suppressed_after_generation_change() -> None:
+    connection = _PersistentSessionConnection()
+    connection._generation = 3
+    connection._sock = _FakeSocket([])  # type: ignore[assignment]
+    calls: list[dict] = []
+
+    assert connection._dispatch_event_callback_once(2, calls.append, {"event": "old"}) is False
+    assert calls == []
+
+    assert connection._dispatch_event_callback_once(3, calls.append, {"event": "new"}) is False
+    assert calls == [{"event": "new"}]
+
+
+def test_reconnect_starts_new_reader_while_old_generation_is_still_blocked(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _SocketPath:
+        def exists(self) -> bool:
+            return True
+
+        def __str__(self) -> str:
+            return "/fake/session.sock"
+
+    class _BlockingSocket:
+        def __init__(self) -> None:
+            self.read_started = threading.Event()
+            self.release = threading.Event()
+
+        def settimeout(self, _timeout: float | None) -> None:
+            return
+
+        def connect(self, _path: str) -> None:
+            return
+
+        def recv(self, _size: int) -> bytes:
+            self.read_started.set()
+            self.release.wait(1.0)
+            return b""
+
+        def close(self) -> None:
+            return
+
+        def shutdown(self, _how: int) -> None:
+            self.release.set()
+
+    sockets = [_BlockingSocket(), _BlockingSocket()]
+    monkeypatch.setattr(session_client_module, "SESSION_SOCKET_PATH", _SocketPath())
+    monkeypatch.setattr(session_client_module.socket, "socket", lambda *_args: sockets.pop(0))
+    connection = _PersistentSessionConnection()
+
+    assert connection._ensure_connected(timeout=0.1) is True
+    first_socket = connection._sock
+    assert isinstance(first_socket, _BlockingSocket)
+    assert first_socket.read_started.wait(1.0) is True
+    with connection._state_lock:
+        connection._sock = None
+        connection._buffer = b""
+
+    assert connection._ensure_connected(timeout=0.1) is True
+    second_socket = connection._sock
+    assert isinstance(second_socket, _BlockingSocket)
+    assert second_socket.read_started.wait(1.0) is True
+    assert set(connection._reader_threads) == {1, 2}
+
+    connection.shutdown(timeout=1.0)
+    first_socket.release.set()
+
+
+def test_gui_worker_pool_has_bounded_admission() -> None:
+    pool = _BoundedWorkerPool(workers=1, capacity=1)
+    started = threading.Event()
+    release = threading.Event()
+
+    def blocking_work() -> None:
+        started.set()
+        release.wait(1.0)
+
+    assert pool.submit(blocking_work) is True
+    assert started.wait(1.0) is True
+    assert pool.submit(lambda: None) is True
+    assert pool.submit(lambda: None) is False
+
+    release.set()
+    pool.shutdown(timeout=1.0)
+
+
+def test_persistent_session_write_has_a_deadline(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    connection = _PersistentSessionConnection()
+    monkeypatch.setattr(
+        session_client_module.select,
+        "select",
+        lambda *_args: ([], [], []),
+    )
+
+    with pytest.raises(TimeoutError, match="write timed out"):
+        connection._send_with_deadline(_NeverWritableSocket(), b"request", 0.01)  # type: ignore[arg-type]

--- a/tests/gui/test_session_client.py
+++ b/tests/gui/test_session_client.py
@@ -1,5 +1,6 @@
 import queue
 import threading
+from types import SimpleNamespace
 
 import pytest
 
@@ -168,3 +169,66 @@ def test_persistent_session_write_has_a_deadline(
 
     with pytest.raises(TimeoutError, match="write timed out"):
         connection._send_with_deadline(_NeverWritableSocket(), b"request", 0.01)  # type: ignore[arg-type]
+
+
+def test_rejected_gui_task_contains_callback_failure_and_runs_done(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    callbacks: list[object] = []
+    done: list[bool] = []
+    fake_glib = SimpleNamespace(idle_add=lambda callback: callbacks.append(callback))
+    fake_gi = SimpleNamespace(repository=SimpleNamespace(GLib=fake_glib))
+    monkeypatch.setitem(__import__("sys").modules, "gi", fake_gi)
+    monkeypatch.setitem(
+        __import__("sys").modules,
+        "gi.repository",
+        SimpleNamespace(GLib=fake_glib),
+    )
+    monkeypatch.setattr(session_client_module, "_gui_pool", None)
+    monkeypatch.setattr(session_client_module, "_gui_shutdown", False)
+    monkeypatch.setattr(
+        session_client_module,
+        "_gui_worker_pool",
+        lambda: None,
+    )
+
+    def fail_callback(_result: object) -> None:
+        raise RuntimeError("callback failed")
+
+    session_client_module.run_gui_task(
+        lambda: None,
+        fail_callback,
+        on_done=lambda: done.append(True),
+    )
+
+    with caplog.at_level("ERROR", logger="keymasq.gui.session_client"):
+        assert len(callbacks) == 1
+        assert callbacks[0]() is False  # type: ignore[operator]
+    assert done == [True]
+    assert "GUI task callback failed" in caplog.text
+
+
+def test_shutdown_gui_runtime_shares_one_timeout_budget(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    time_values = iter([10.0, 10.1, 10.7])
+    session_timeouts: list[float] = []
+    pool_timeouts: list[float] = []
+    monkeypatch.setattr(session_client_module.time, "monotonic", lambda: next(time_values))
+    monkeypatch.setattr(session_client_module, "_gui_shutdown", False)
+    monkeypatch.setattr(
+        session_client_module._PERSISTENT_SESSION,
+        "shutdown",
+        lambda timeout: session_timeouts.append(timeout),
+    )
+    monkeypatch.setattr(
+        session_client_module,
+        "_gui_pool",
+        SimpleNamespace(shutdown=lambda timeout: pool_timeouts.append(timeout)),
+    )
+
+    session_client_module.shutdown_gui_runtime(timeout=1.0)
+
+    assert session_timeouts == [pytest.approx(0.9)]
+    assert pool_timeouts == [pytest.approx(0.3)]

--- a/tests/gui/test_session_client.py
+++ b/tests/gui/test_session_client.py
@@ -63,6 +63,15 @@ def test_stale_event_callback_is_suppressed_after_generation_change() -> None:
     assert calls == [{"event": "new"}]
 
 
+def test_current_event_callback_survives_same_generation_disconnect() -> None:
+    connection = _PersistentSessionConnection()
+    connection._generation = 3
+    calls: list[dict] = []
+
+    assert connection._dispatch_event_callback_once(3, calls.append, {"event": "final"}) is False
+    assert calls == [{"event": "final"}]
+
+
 def test_close_connection_shuts_down_active_reader_socket() -> None:
     connection = _PersistentSessionConnection()
     sock = _FakeSocket([])

--- a/tests/keymasqd/daemon_support.py
+++ b/tests/keymasqd/daemon_support.py
@@ -71,6 +71,12 @@ def make_daemon_testbed(monkeypatch):
     macro_store = SimpleNamespace(
         get=Mock(return_value={"events": []}),
         get_meta=Mock(return_value={"events": []}),
+        open_snapshot=Mock(
+            return_value=SimpleNamespace(
+                meta={"event_count": 0, "duration_us": 0},
+                iter_events=lambda: iter(()),
+            )
+        ),
         list_meta=Mock(return_value=[]),
         create=Mock(return_value={"name": "new"}),
         create_from_events=Mock(return_value={"name": "new"}),

--- a/tests/keymasqd/daemon_support.py
+++ b/tests/keymasqd/daemon_support.py
@@ -57,6 +57,7 @@ def make_daemon_testbed(monkeypatch):
         release_all_devices=AsyncMock(return_value=None),
     )
     recording_manager = SimpleNamespace(
+        abort=AsyncMock(return_value=None),
         start=AsyncMock(return_value={"recording": "started"}),
         stop=AsyncMock(return_value={"recording": "stopped"}),
         list_pending_recordings=AsyncMock(return_value=[]),
@@ -88,6 +89,7 @@ def make_daemon_testbed(monkeypatch):
         read_combo=Mock(return_value={"event": None}),
         read_combo_nowait=Mock(return_value={"event": None}),
         register_combo_notifier=Mock(return_value=None),
+        close_all=Mock(return_value=0),
     )
 
     monkeypatch.setattr(daemon, "DeviceManager", lambda verbosity=0: device_manager)

--- a/tests/keymasqd/test_daemon_capture_commands.py
+++ b/tests/keymasqd/test_daemon_capture_commands.py
@@ -1016,7 +1016,7 @@ async def test_start_offloads_macro_store_prep_to_thread(
 
     def fake_load_security_policy(_path: Path) -> SecurityPolicy:
         startup_order.append("policy")
-        return SecurityPolicy()
+        return SecurityPolicy(macro_recording_time_limit=23)
 
     monkeypatch.setattr(daemon_module.asyncio, "to_thread", fake_to_thread)
     monkeypatch.setattr(daemon_module, "SocketServer", lambda *args, **kwargs: fake_socket_server)
@@ -1042,6 +1042,7 @@ async def test_start_offloads_macro_store_prep_to_thread(
     device_manager.stop_topology_watcher.assert_awaited_once()
     assert device_manager.broadcast_callback == fake_socket_server.broadcast_event
     assert recording_manager.broadcast_callback == fake_socket_server.broadcast_event
+    assert recording_manager.macro_recording_time_limit == 23
 
 
 @pytest.mark.asyncio

--- a/tests/keymasqd/test_daemon_capture_commands.py
+++ b/tests/keymasqd/test_daemon_capture_commands.py
@@ -1083,7 +1083,7 @@ async def test_stop_lets_socket_server_own_socket_path_cleanup(
     daemon_testbed,
     monkeypatch,
 ):
-    daemon, device_manager, _recording_manager, _macro_store, _capture_manager = daemon_testbed
+    daemon, device_manager, recording_manager, _macro_store, capture_manager = daemon_testbed
     socket_server = SimpleNamespace(stop=AsyncMock())
     cleanup_socket_path = Mock()
     daemon.running = True
@@ -1094,6 +1094,8 @@ async def test_stop_lets_socket_server_own_socket_path_cleanup(
 
     socket_server.stop.assert_awaited_once()
     cleanup_socket_path.assert_not_called()
+    recording_manager.abort.assert_awaited_once()
+    capture_manager.close_all.assert_called_once()
     device_manager.shutdown_output_devices.assert_called_once()
 
 

--- a/tests/keymasqd/test_daemon_runtime_unlock.py
+++ b/tests/keymasqd/test_daemon_runtime_unlock.py
@@ -367,6 +367,37 @@ async def test_macro_rename_and_delete_require_configured_edit_unlock(
     ],
 )
 @pytest.mark.asyncio
+async def test_macro_edits_require_unlock_independently_of_recording_policy(
+    daemon_testbed,
+    monkeypatch,
+    command_type: CommandType,
+    data: dict[str, object],
+) -> None:
+    daemon, _device_manager, _recording_manager, macro_store, _capture_manager = daemon_testbed
+    daemon.security_policy = SecurityPolicy(
+        recording_unlock_required=False,
+        macro_edit_requires_unlock=True,
+    )
+    monkeypatch.setattr(daemon, "_recording_unlocked_for_uid", lambda _uid: (False, 0, "none"))
+
+    with pytest.raises(PermissionError, match="recording_locked"):
+        await daemon._handle_command(command_type, data, client=client_context())
+
+    macro_store.rename.assert_not_called()
+    macro_store.delete.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("command_type", "data"),
+    [
+        (
+            CommandType.MACRO_RENAME,
+            {"old_name": "recorded", "new_name": "renamed"},
+        ),
+        (CommandType.MACRO_DELETE, {"name": "recorded"}),
+    ],
+)
+@pytest.mark.asyncio
 async def test_macro_rename_and_delete_allow_policy_disabled(
     daemon_testbed,
     monkeypatch,

--- a/tests/keymasqd/test_daemon_runtime_unlock.py
+++ b/tests/keymasqd/test_daemon_runtime_unlock.py
@@ -295,6 +295,11 @@ async def test_sensitive_command_owner_mismatch_is_denied(
             CommandType.MACRO_UPDATE,
             {"name": "recorded", "macro": {"name": "recorded"}},
         ),
+        (
+            CommandType.MACRO_RENAME,
+            {"old_name": "recorded", "new_name": "renamed"},
+        ),
+        (CommandType.MACRO_DELETE, {"name": "recorded"}),
     ],
 )
 @pytest.mark.asyncio
@@ -318,6 +323,69 @@ async def test_macro_edit_unlock_commands_enforce_active_owner(
 
     with pytest.raises(PermissionError, match="sensitive_command_denied"):
         await daemon._handle_command(command_type, data, client=second_client)
+
+
+@pytest.mark.parametrize(
+    ("command_type", "data"),
+    [
+        (
+            CommandType.MACRO_RENAME,
+            {"old_name": "recorded", "new_name": "renamed"},
+        ),
+        (CommandType.MACRO_DELETE, {"name": "recorded"}),
+    ],
+)
+@pytest.mark.asyncio
+async def test_macro_rename_and_delete_require_configured_edit_unlock(
+    daemon_testbed,
+    monkeypatch,
+    command_type: CommandType,
+    data: dict[str, object],
+) -> None:
+    daemon, _device_manager, _recording_manager, macro_store, _capture_manager = daemon_testbed
+    daemon.security_policy = SecurityPolicy(
+        recording_unlock_required=True,
+        macro_edit_requires_unlock=True,
+    )
+    monkeypatch.setattr(daemon, "_recording_unlocked_for_uid", lambda _uid: (False, 0, "none"))
+
+    with pytest.raises(PermissionError, match="recording_locked"):
+        await daemon._handle_command(command_type, data, client=client_context())
+
+    macro_store.rename.assert_not_called()
+    macro_store.delete.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("command_type", "data"),
+    [
+        (
+            CommandType.MACRO_RENAME,
+            {"old_name": "recorded", "new_name": "renamed"},
+        ),
+        (CommandType.MACRO_DELETE, {"name": "recorded"}),
+    ],
+)
+@pytest.mark.asyncio
+async def test_macro_rename_and_delete_allow_policy_disabled(
+    daemon_testbed,
+    monkeypatch,
+    command_type: CommandType,
+    data: dict[str, object],
+) -> None:
+    daemon, _device_manager, _recording_manager, macro_store, _capture_manager = daemon_testbed
+    daemon.security_policy = SecurityPolicy(
+        recording_unlock_required=True,
+        macro_edit_requires_unlock=False,
+    )
+    monkeypatch.setattr(daemon, "_recording_unlocked_for_uid", lambda _uid: (False, 0, "none"))
+
+    await daemon._handle_command(command_type, data, client=client_context())
+
+    if command_type == CommandType.MACRO_RENAME:
+        macro_store.rename.assert_called_once()
+    else:
+        macro_store.delete.assert_called_once()
 
 
 @pytest.mark.asyncio
@@ -458,7 +526,7 @@ async def test_client_disconnect_clears_owned_runtime_unlock_only(
     tmp_path: Path,
 ):
     daemon, device_manager, recording_manager, _macro_store, capture_manager = daemon_testbed
-    capture_manager.end_all = Mock(return_value=0)
+    capture_manager.close_all = Mock(return_value=0)
     owned_uid = 5555
     unrelated_uid = 7777
     client = client_context(uid=owned_uid, pid=600, connection_id=9)
@@ -484,8 +552,9 @@ async def test_client_disconnect_clears_owned_runtime_unlock_only(
     assert unrelated_uid not in daemon._unlock_cache
     assert not (runtime_dir / f"recording-unlock-{owned_uid}").exists()
     assert (runtime_dir / f"recording-unlock-{unrelated_uid}").exists()
+    recording_manager.abort.assert_awaited_once()
     recording_manager.discard_all_pending_recordings.assert_awaited_once()
-    capture_manager.end_all.assert_called_once()
+    capture_manager.close_all.assert_called_once()
     device_manager.release_all_devices.assert_awaited_once()
 
 
@@ -536,11 +605,12 @@ async def test_async_runtime_unlock_cleanup_offloads_file_io(
 @pytest.mark.asyncio
 async def test_client_disconnect_releases_devices_after_recording_discard_fails(daemon_testbed):
     daemon, device_manager, recording_manager, _macro_store, capture_manager = daemon_testbed
-    capture_manager.end_all = Mock(return_value=0)
+    capture_manager.close_all = Mock(return_value=0)
     recording_manager.discard_all_pending_recordings.side_effect = RuntimeError("discard failed")
 
     await daemon._on_client_disconnect()
 
+    recording_manager.abort.assert_awaited_once()
     recording_manager.discard_all_pending_recordings.assert_awaited_once()
-    capture_manager.end_all.assert_called_once()
+    capture_manager.close_all.assert_called_once()
     device_manager.release_all_devices.assert_awaited_once()

--- a/tests/keymasqd/test_macro_backend_recording.py
+++ b/tests/keymasqd/test_macro_backend_recording.py
@@ -1099,6 +1099,26 @@ async def test_play_macro_releases_runtime_state_when_snapshot_close_fails() -> 
 
 
 @pytest.mark.asyncio
+async def test_play_macro_early_return_suppresses_snapshot_close_failure() -> None:
+    manager = DeviceManager()
+
+    def fail_close() -> None:
+        raise OSError("close failed")
+
+    result = await manager.play_macro(
+        macro_name="unavailable",
+        macro_event_source=MacroEventSource(
+            event_count=1,
+            duration_us=0,
+            iter_events=lambda: iter(()),
+            close=fail_close,
+        ),
+    )
+
+    assert result == {"status": "error", "message": "No output uinput devices available"}
+
+
+@pytest.mark.asyncio
 async def test_play_macro_does_not_double_sleep_when_wait_exceeds_duration(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/keymasqd/test_macro_backend_recording.py
+++ b/tests/keymasqd/test_macro_backend_recording.py
@@ -754,16 +754,14 @@ async def test_play_macro_allows_concurrent_playback(
 
 
 @pytest.mark.asyncio
-async def test_stored_macro_playback_uses_and_releases_revision_snapshot(
+async def test_stored_macro_playback_uses_revision_snapshot(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     manager = DeviceManager()
     manager.output_state.keyboard_uinput = MagicMock()
-    closed = MagicMock()
     snapshot = SimpleNamespace(
         meta={"event_count": 1, "duration_us": 0, "revision": 1},
         iter_events=lambda: iter([{"t_us": 0, "type": 1, "code": 30, "value": 1}]),
-        close=closed,
     )
     manager.macro_store = SimpleNamespace(open_snapshot=MagicMock(return_value=snapshot))
 
@@ -778,7 +776,6 @@ async def test_stored_macro_playback_uses_and_releases_revision_snapshot(
 
     assert result == {"status": "ok"}
     manager.macro_store.open_snapshot.assert_called_once_with("stored")
-    closed.assert_called_once()
 
 
 @pytest.mark.asyncio
@@ -820,8 +817,8 @@ async def test_play_macro_uses_daemon_lifetime_outputs_without_active_grab(
 async def test_play_macro_can_skip_stored_lookup_for_empty_explicit_events() -> None:
     manager = DeviceManager()
     manager.output_state.keyboard_uinput = MagicMock()
-    get_meta = MagicMock(side_effect=AssertionError("stored macro lookup should be skipped"))
-    manager.macro_store = SimpleNamespace(get_meta=get_meta, iter_events=MagicMock())
+    open_snapshot = MagicMock(side_effect=AssertionError("stored macro lookup should be skipped"))
+    manager.macro_store = SimpleNamespace(open_snapshot=open_snapshot)
 
     result = await manager.play_macro(
         macro_events=[],
@@ -830,7 +827,7 @@ async def test_play_macro_can_skip_stored_lookup_for_empty_explicit_events() -> 
     )
 
     assert result == {"status": "ok"}
-    get_meta.assert_not_called()
+    open_snapshot.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -1042,72 +1039,6 @@ async def test_play_macro_honors_empty_macro_duration_as_scaled_minimum(
     )
 
     assert sleep_calls == [pytest.approx(5.0), 0]
-
-
-@pytest.mark.asyncio
-async def test_play_macro_releases_runtime_state_when_snapshot_close_fails() -> None:
-    manager = DeviceManager()
-    manager.macro_state.allocate_instance(
-        loop_mode="none",
-        source_key=("keyboard", "key_a"),
-        macro_name="close_failure",
-        loop_stop_behavior="finish_run",
-    )
-    release_held = MagicMock()
-
-    def fail_close() -> None:
-        raise OSError("close failed")
-
-    await scheduler.play_macro_task(
-        manager,
-        instance_id=1,
-        macro_events=[],
-        macro_event_source=MacroEventSource(
-            event_count=0,
-            duration_us=0,
-            iter_events=lambda: iter(()),
-            close=fail_close,
-        ),
-        macro_name="close_failure",
-        replay_mouse_movement=True,
-        replay_mouse_clicks=True,
-        speed=1.0,
-        loop_mode="none",
-        loop_count=1,
-        move_to_start=False,
-        start_x=0,
-        start_y=0,
-        block_mouse_movement=False,
-        deps=device_manager._macro_runtime_deps(),
-        release_held_fn=release_held,
-    )
-
-    release_held.assert_called_once_with(
-        manager,
-        1,
-        deps=device_manager._macro_runtime_deps(),
-    )
-    assert 1 not in manager.macro_state.instance_meta
-
-
-@pytest.mark.asyncio
-async def test_play_macro_early_return_suppresses_snapshot_close_failure() -> None:
-    manager = DeviceManager()
-
-    def fail_close() -> None:
-        raise OSError("close failed")
-
-    result = await manager.play_macro(
-        macro_name="unavailable",
-        macro_event_source=MacroEventSource(
-            event_count=1,
-            duration_us=0,
-            iter_events=lambda: iter(()),
-            close=fail_close,
-        ),
-    )
-
-    assert result == {"status": "error", "message": "No output uinput devices available"}
 
 
 @pytest.mark.asyncio

--- a/tests/keymasqd/test_macro_backend_recording.py
+++ b/tests/keymasqd/test_macro_backend_recording.py
@@ -350,6 +350,37 @@ async def test_transient_unreadable_slot_metadata_preserves_event_file(
 
 
 @pytest.mark.asyncio
+async def test_transient_metadata_failure_preserves_events_from_mixed_scan(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    invalid_event_path = tmp_path / "slot-2-invalid.jsonl"
+    invalid_event_path.write_text('{"t_us":0}\n', encoding="utf-8")
+    invalid_meta_path = tmp_path / "slot-2.json"
+    invalid_meta_path.write_text("not-json\n", encoding="utf-8")
+    unreadable_event_path = tmp_path / "slot-3-recording.jsonl"
+    unreadable_event_path.write_text('{"t_us":0}\n', encoding="utf-8")
+    unreadable_meta_path = tmp_path / "slot-3.json"
+    unreadable_meta_path.write_text('{"recording_slot":3}\n', encoding="utf-8")
+    original_read_text = Path.read_text
+
+    def read_text(path: Path, *args: object, **kwargs: object) -> str:
+        if path == unreadable_meta_path:
+            raise PermissionError("temporarily unreadable")
+        return original_read_text(path, *args, **kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(Path, "read_text", read_text)
+
+    recorder = RecordingManager(spool_dir=tmp_path)
+    await recorder.load_persisted_slot_recordings()
+
+    assert not invalid_meta_path.exists()
+    assert invalid_event_path.exists()
+    assert unreadable_meta_path.exists()
+    assert unreadable_event_path.exists()
+
+
+@pytest.mark.asyncio
 async def test_recording_manager_drops_msc_and_syn_events() -> None:
     recorder = RecordingManager(broadcast_callback=AsyncMock())
     await recorder.start([])

--- a/tests/keymasqd/test_macro_backend_recording.py
+++ b/tests/keymasqd/test_macro_backend_recording.py
@@ -303,7 +303,7 @@ async def test_invalid_recording_slot_is_treated_as_unslotted(tmp_path: Path) ->
 
 
 @pytest.mark.asyncio
-async def test_incomplete_slot_metadata_scan_preserves_uncertain_event_files(
+async def test_invalid_slot_metadata_and_orphaned_event_file_are_removed(
     tmp_path: Path,
 ) -> None:
     event_path = tmp_path / "slot-2-recording.jsonl"
@@ -316,12 +316,7 @@ async def test_incomplete_slot_metadata_scan_preserves_uncertain_event_files(
 
     assert not event_path.exists()
     assert not invalid_meta.exists()
-    quarantined = list((tmp_path / "quarantine").glob("slot-2.json.invalid-*"))
-    assert len(quarantined) == 1
-    quarantined_events = list(
-        (tmp_path / "quarantine").glob("slot-2-recording.jsonl.uncertain-*")
-    )
-    assert len(quarantined_events) == 1
+    assert not (tmp_path / "quarantine").exists()
 
 
 @pytest.mark.asyncio
@@ -350,7 +345,7 @@ async def test_transient_unreadable_slot_metadata_preserves_event_file(
 
 
 @pytest.mark.asyncio
-async def test_transient_metadata_failure_preserves_events_from_mixed_scan(
+async def test_transient_metadata_failure_defers_all_orphan_cleanup(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -375,13 +370,10 @@ async def test_transient_metadata_failure_preserves_events_from_mixed_scan(
     await recorder.load_persisted_slot_recordings()
 
     assert not invalid_meta_path.exists()
-    assert not invalid_event_path.exists()
+    assert invalid_event_path.exists()
     assert unreadable_meta_path.exists()
     assert unreadable_event_path.exists()
-    quarantined_events = list(
-        (tmp_path / "quarantine").glob("slot-2-invalid.jsonl.uncertain-*")
-    )
-    assert len(quarantined_events) == 1
+    assert not (tmp_path / "quarantine").exists()
 
 
 @pytest.mark.asyncio

--- a/tests/keymasqd/test_macro_backend_recording.py
+++ b/tests/keymasqd/test_macro_backend_recording.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+from collections.abc import Iterator
 from pathlib import Path
 from types import SimpleNamespace
 from typing import cast
@@ -15,6 +16,7 @@ from keymasq.common.model.actions import (
 from keymasq.common.model.core import ActionType, DeviceType
 from keymasq.keymasqd import device_manager, recording
 from keymasq.keymasqd.device_manager import DeviceManager
+from keymasq.keymasqd.macro_file import MacroFileChangedError
 from keymasq.keymasqd.recording import RecordingManager
 from keymasq.keymasqd.runtime import outputs as global_outputs
 from keymasq.keymasqd.runtime.grabbed_device import device as grabbed_device
@@ -1083,6 +1085,48 @@ async def test_play_macro_does_not_double_sleep_when_wait_exceeds_duration(
     )
 
     assert sleep_calls == [pytest.approx(0.2), 0]
+
+
+@pytest.mark.asyncio
+async def test_looped_macro_ends_cleanly_when_stored_revision_changes(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    manager = DeviceManager()
+    iteration_count = 0
+
+    def iter_events() -> Iterator[dict[str, object]]:
+        nonlocal iteration_count
+        iteration_count += 1
+        if iteration_count > 1:
+            raise MacroFileChangedError("changed.kmacro.xz")
+        yield {"t_us": 0, "macro_action": "wait", "duration_us": 0}
+
+    with caplog.at_level(logging.DEBUG, logger="keymasqd.devices"):
+        await scheduler.play_macro_task(
+            manager,
+            instance_id=1,
+            macro_events=[],
+            macro_event_source=MacroEventSource(
+                event_count=1,
+                duration_us=0,
+                iter_events=iter_events,
+            ),
+            macro_name="changed",
+            replay_mouse_movement=True,
+            replay_mouse_clicks=True,
+            speed=1.0,
+            loop_mode="count",
+            loop_count=3,
+            move_to_start=False,
+            start_x=0,
+            start_y=0,
+            block_mouse_movement=False,
+            deps=device_manager._macro_runtime_deps(),
+        )
+
+    assert iteration_count == 2
+    assert "Macro playback ended because changed was modified or removed" in caplog.text
+    assert "Macro playback aborted" not in caplog.text
 
 
 @pytest.mark.asyncio

--- a/tests/keymasqd/test_macro_backend_recording.py
+++ b/tests/keymasqd/test_macro_backend_recording.py
@@ -375,9 +375,13 @@ async def test_transient_metadata_failure_preserves_events_from_mixed_scan(
     await recorder.load_persisted_slot_recordings()
 
     assert not invalid_meta_path.exists()
-    assert invalid_event_path.exists()
+    assert not invalid_event_path.exists()
     assert unreadable_meta_path.exists()
     assert unreadable_event_path.exists()
+    quarantined_events = list(
+        (tmp_path / "quarantine").glob("slot-2-invalid.jsonl.uncertain-*")
+    )
+    assert len(quarantined_events) == 1
 
 
 @pytest.mark.asyncio
@@ -1046,6 +1050,52 @@ async def test_play_macro_honors_empty_macro_duration_as_scaled_minimum(
     )
 
     assert sleep_calls == [pytest.approx(5.0), 0]
+
+
+@pytest.mark.asyncio
+async def test_play_macro_releases_runtime_state_when_snapshot_close_fails() -> None:
+    manager = DeviceManager()
+    manager.macro_state.allocate_instance(
+        loop_mode="none",
+        source_key=("keyboard", "key_a"),
+        macro_name="close_failure",
+        loop_stop_behavior="finish_run",
+    )
+    release_held = MagicMock()
+
+    def fail_close() -> None:
+        raise OSError("close failed")
+
+    await scheduler.play_macro_task(
+        manager,
+        instance_id=1,
+        macro_events=[],
+        macro_event_source=MacroEventSource(
+            event_count=0,
+            duration_us=0,
+            iter_events=lambda: iter(()),
+            close=fail_close,
+        ),
+        macro_name="close_failure",
+        replay_mouse_movement=True,
+        replay_mouse_clicks=True,
+        speed=1.0,
+        loop_mode="none",
+        loop_count=1,
+        move_to_start=False,
+        start_x=0,
+        start_y=0,
+        block_mouse_movement=False,
+        deps=device_manager._macro_runtime_deps(),
+        release_held_fn=release_held,
+    )
+
+    release_held.assert_called_once_with(
+        manager,
+        1,
+        deps=device_manager._macro_runtime_deps(),
+    )
+    assert 1 not in manager.macro_state.instance_meta
 
 
 @pytest.mark.asyncio

--- a/tests/keymasqd/test_macro_backend_recording.py
+++ b/tests/keymasqd/test_macro_backend_recording.py
@@ -89,6 +89,28 @@ async def test_recording_manager_records_start_position_as_initial_natural_move(
 
 
 @pytest.mark.asyncio
+async def test_recording_abort_discards_active_spool_without_stop_event(tmp_path: Path) -> None:
+    broadcast = AsyncMock()
+    recorder = RecordingManager(broadcast_callback=broadcast, spool_dir=tmp_path)
+    await recorder.start([])
+    broadcast.reset_mock()
+    recorder.record_event(
+        "keyboard",
+        evdev.InputEvent(10, 100, evdev.ecodes.EV_KEY, evdev.ecodes.KEY_A, 1),
+    )
+
+    await recorder.abort()
+    await recorder.abort()
+
+    assert recorder.is_recording is False
+    assert recorder._spool is None
+    assert recorder._progress_task is None
+    assert recorder._monitoring_tasks == []
+    assert list(tmp_path.glob("recording-*.jsonl")) == []
+    broadcast.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_recording_slot_survives_recording_manager_restart(tmp_path: Path) -> None:
     recorder = RecordingManager(spool_dir=tmp_path)
     await recorder.start([], recording_slot=2)
@@ -278,6 +300,53 @@ async def test_invalid_recording_slot_is_treated_as_unslotted(tmp_path: Path) ->
 
     snapshot = await recorder.pending_recording(str(result["pending_recording_id"]))
     assert snapshot.recording_slot == 0
+
+
+@pytest.mark.asyncio
+async def test_incomplete_slot_metadata_scan_preserves_uncertain_event_files(
+    tmp_path: Path,
+) -> None:
+    event_path = tmp_path / "slot-2-recording.jsonl"
+    event_path.write_text('{"t_us":0}\n', encoding="utf-8")
+    invalid_meta = tmp_path / "slot-2.json"
+    invalid_meta.write_text("not-json\n", encoding="utf-8")
+
+    recorder = RecordingManager(spool_dir=tmp_path)
+    await recorder.load_persisted_slot_recordings()
+
+    assert not event_path.exists()
+    assert not invalid_meta.exists()
+    quarantined = list((tmp_path / "quarantine").glob("slot-2.json.invalid-*"))
+    assert len(quarantined) == 1
+    quarantined_events = list(
+        (tmp_path / "quarantine").glob("slot-2-recording.jsonl.uncertain-*")
+    )
+    assert len(quarantined_events) == 1
+
+
+@pytest.mark.asyncio
+async def test_transient_unreadable_slot_metadata_preserves_event_file(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    event_path = tmp_path / "slot-2-recording.jsonl"
+    event_path.write_text('{"t_us":0}\n', encoding="utf-8")
+    meta_path = tmp_path / "slot-2.json"
+    meta_path.write_text('{"recording_slot":2}\n', encoding="utf-8")
+    original_read_text = Path.read_text
+
+    def read_text(path: Path, *args: object, **kwargs: object) -> str:
+        if path == meta_path:
+            raise PermissionError("temporarily unreadable")
+        return original_read_text(path, *args, **kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(Path, "read_text", read_text)
+
+    recorder = RecordingManager(spool_dir=tmp_path)
+    await recorder.load_persisted_slot_recordings()
+
+    assert meta_path.exists()
+    assert event_path.exists()
 
 
 @pytest.mark.asyncio
@@ -655,6 +724,34 @@ async def test_play_macro_allows_concurrent_playback(
     assert "second" in started
     assert "first" in finished
     assert "second" in finished
+
+
+@pytest.mark.asyncio
+async def test_stored_macro_playback_uses_and_releases_revision_snapshot(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = DeviceManager()
+    manager.output_state.keyboard_uinput = MagicMock()
+    closed = MagicMock()
+    snapshot = SimpleNamespace(
+        meta={"event_count": 1, "duration_us": 0, "revision": 1},
+        iter_events=lambda: iter([{"t_us": 0, "type": 1, "code": 30, "value": 1}]),
+        close=closed,
+    )
+    manager.macro_store = SimpleNamespace(open_snapshot=MagicMock(return_value=snapshot))
+
+    async def fake_play_macro_task(_manager: DeviceManager, **_kwargs: object) -> None:
+        return None
+
+    monkeypatch.setattr(scheduler, "play_macro_task", fake_play_macro_task)
+
+    result = await manager.play_macro(macro_name="stored")
+    await asyncio.gather(*manager.macro_state.tasks.values())
+    await asyncio.sleep(0)
+
+    assert result == {"status": "ok"}
+    manager.macro_store.open_snapshot.assert_called_once_with("stored")
+    closed.assert_called()
 
 
 @pytest.mark.asyncio

--- a/tests/keymasqd/test_macro_backend_recording.py
+++ b/tests/keymasqd/test_macro_backend_recording.py
@@ -786,7 +786,7 @@ async def test_stored_macro_playback_uses_and_releases_revision_snapshot(
 
     assert result == {"status": "ok"}
     manager.macro_store.open_snapshot.assert_called_once_with("stored")
-    closed.assert_called()
+    closed.assert_called_once()
 
 
 @pytest.mark.asyncio

--- a/tests/session/test_session_manager_command_authorization.py
+++ b/tests/session/test_session_manager_command_authorization.py
@@ -84,6 +84,44 @@ async def test_sensitive_command_rejects_refresh_owner_when_unlock_expired(
     resolve_unlock_status_async.assert_awaited_once_with(manager, peer.uid)
 
 
+@pytest.mark.parametrize(
+    ("command", "payload"),
+    [
+        ("rename_macro", {"old": "Secret", "new": "Public"}),
+        ("delete_macro", {"name": "Secret"}),
+    ],
+)
+@pytest.mark.asyncio
+async def test_macro_rename_and_delete_require_edit_unlock(
+    monkeypatch: pytest.MonkeyPatch,
+    command: str,
+    payload: dict[str, str],
+) -> None:
+    manager = SessionManager()
+    manager.security_policy.macro_edit_requires_unlock = True
+    manager.client.send_command = AsyncMock()
+    peer = PeerCredentials(pid=111, uid=1000, gid=1000)
+    writer = object()
+    resolve_unlock_status_async = AsyncMock(
+        return_value={"unlocked": False, "source": "none", "expires_at": 0}
+    )
+    monkeypatch.setattr(
+        recording_unlock_module,
+        "resolve_unlock_status_async",
+        resolve_unlock_status_async,
+    )
+
+    result = await manager._handle_session_request(
+        {"command": command, **payload},
+        peer,
+        writer,  # type: ignore[arg-type]
+    )
+
+    assert result["status"] == "error"
+    assert result["error_code"] == "sensitive_command_denied"
+    manager.client.send_command.assert_not_awaited()
+
+
 @pytest.mark.asyncio
 async def test_handle_session_request_returns_unknown_command_error() -> None:
     manager = SessionManager()

--- a/tests/session/test_session_manager_command_runtime.py
+++ b/tests/session/test_session_manager_command_runtime.py
@@ -1199,6 +1199,38 @@ async def test_recording_stopped_event_notifies_user_with_slot_summary() -> None
 
 
 @pytest.mark.asyncio
+async def test_recording_duration_limit_event_explains_automatic_stop() -> None:
+    manager = SessionManager()
+    manager.send_notification = Mock()  # type: ignore[method-assign]
+    manager.broadcast_to_session_clients = Mock()  # type: ignore[method-assign]
+
+    await session_events_module.handle_event(
+        manager,
+        CommandType.RECORDING_STOPPED,
+        {
+            "pending_recording_id": "recording-limited",
+            "recording_slot": 1,
+            "duration_ms": 600_000,
+            "event_count": 20,
+            "device_types": ["keyboard"],
+            "stop_reason": "duration_limit",
+            "macro_recording_time_limit": 10,
+        },
+    )
+
+    manager.send_notification.assert_called_once_with(  # type: ignore[attr-defined]
+        "Keymasq: Macro Recording Limit Reached",
+        "Slot 1 stopped after the configured 10 minute limit with 20 events captured.",
+    )
+    broadcast = manager.broadcast_to_session_clients.call_args.args[0]  # type: ignore[attr-defined]
+    assert broadcast["stop_reason"] == "duration_limit"
+    assert broadcast["macro_recording_time_limit"] == 10
+    assert manager.recording_state.pending_slots[1].data["pending_recording_id"] == (
+        "recording-limited"
+    )
+
+
+@pytest.mark.asyncio
 async def test_action_trigger_play_macro_slot_dispatches_slot_playback(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_capture_manager.py
+++ b/tests/test_capture_manager.py
@@ -681,3 +681,12 @@ def test_capture_manager_parse_hardware_id_strips_duplicate_suffix() -> None:
     manager = CaptureManager()
 
     assert manager._parse_hardware_id("045E:02A1@2") == ("045e", "02a1")
+
+
+def test_close_all_revokes_unused_combo_capture_authorizations() -> None:
+    manager = CaptureManager()
+    manager.authorize_combo_capture()
+
+    assert manager._combo_capture_authorizations
+    assert manager.close_all() == 0
+    assert manager._combo_capture_authorizations == set()

--- a/tests/test_macro_file.py
+++ b/tests/test_macro_file.py
@@ -68,6 +68,22 @@ def test_macro_snapshot_close_does_not_block_suspended_stream(tmp_path: Path) ->
     assert list(iterator) == events[1:]
 
 
+def test_macro_snapshot_repeated_streams_close_duplicated_descriptors(tmp_path: Path) -> None:
+    path = tmp_path / "macro.kmacro.xz"
+    events = [{"type": 1, "code": 30, "value": 1, "t_us": 0}]
+    write_macro(path, MacroFileMeta(name="macro", event_count=1), events)
+    baseline = _open_fd_count()
+
+    snapshot = MacroFileSnapshot(path)
+    assert _open_fd_count() == baseline + 1
+    for _ in range(10):
+        assert list(snapshot.iter_events()) == events
+        assert _open_fd_count() == baseline + 1
+
+    snapshot.close()
+    assert _open_fd_count() == baseline
+
+
 def test_write_macro_without_overwrite_preserves_existing_destination(tmp_path: Path) -> None:
     path = tmp_path / "macro.kmacro.xz"
     original_event = {"type": 1, "code": 30, "value": 1, "t_us": 0}

--- a/tests/test_macro_file.py
+++ b/tests/test_macro_file.py
@@ -7,6 +7,7 @@ import pytest
 
 from keymasq.keymasqd.macro_file import (
     MacroFileMeta,
+    MacroFileSnapshot,
     load_macro,
     macro_payload_from_events,
     write_macro,
@@ -52,6 +53,19 @@ def test_write_macro_closes_temp_file_descriptor(tmp_path: Path) -> None:
             [{"type": 1, "code": 30, "value": 1, "t_us": index}],
         )
         assert _open_fd_count() == baseline
+
+
+def test_macro_snapshot_close_does_not_block_suspended_stream(tmp_path: Path) -> None:
+    path = tmp_path / "macro.kmacro.xz"
+    events = [{"type": 1, "code": index, "value": 1, "t_us": index} for index in range(200)]
+    write_macro(path, MacroFileMeta(name="macro", event_count=len(events)), events)
+    snapshot = MacroFileSnapshot(path)
+    iterator = snapshot.iter_events()
+
+    assert next(iterator) == events[0]
+    snapshot.close()
+
+    assert list(iterator) == events[1:]
 
 
 def test_write_macro_without_overwrite_preserves_existing_destination(tmp_path: Path) -> None:

--- a/tests/test_macro_file.py
+++ b/tests/test_macro_file.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import pytest
 
 from keymasq.keymasqd.macro_file import (
+    MacroFileChangedError,
     MacroFileMeta,
     MacroFileSnapshot,
     load_macro,
@@ -70,7 +71,19 @@ def test_macro_snapshot_stream_survives_source_replacement(tmp_path: Path) -> No
     )
 
     assert list(iterator) == events[1:]
-    assert list(snapshot.iter_events()) == events
+    with pytest.raises(MacroFileChangedError):
+        list(snapshot.iter_events())
+
+
+def test_macro_snapshot_detects_removed_source(tmp_path: Path) -> None:
+    path = tmp_path / "macro.kmacro.xz"
+    write_macro(path, MacroFileMeta(name="macro", event_count=0), [])
+    snapshot = MacroFileSnapshot(path)
+
+    path.unlink()
+
+    with pytest.raises(MacroFileChangedError):
+        list(snapshot.iter_events())
 
 
 def test_macro_snapshot_repeated_streams_do_not_hold_descriptors(tmp_path: Path) -> None:

--- a/tests/test_macro_file.py
+++ b/tests/test_macro_file.py
@@ -55,7 +55,7 @@ def test_write_macro_closes_temp_file_descriptor(tmp_path: Path) -> None:
         assert _open_fd_count() == baseline
 
 
-def test_macro_snapshot_close_does_not_block_suspended_stream(tmp_path: Path) -> None:
+def test_macro_snapshot_stream_survives_source_replacement(tmp_path: Path) -> None:
     path = tmp_path / "macro.kmacro.xz"
     events = [{"type": 1, "code": index, "value": 1, "t_us": index} for index in range(200)]
     write_macro(path, MacroFileMeta(name="macro", event_count=len(events)), events)
@@ -63,25 +63,27 @@ def test_macro_snapshot_close_does_not_block_suspended_stream(tmp_path: Path) ->
     iterator = snapshot.iter_events()
 
     assert next(iterator) == events[0]
-    snapshot.close()
+    write_macro(
+        path,
+        MacroFileMeta(name="macro", event_count=1, revision=2),
+        [{"type": 1, "code": 999, "value": 1, "t_us": 0}],
+    )
 
     assert list(iterator) == events[1:]
+    assert list(snapshot.iter_events()) == events
 
 
-def test_macro_snapshot_repeated_streams_close_duplicated_descriptors(tmp_path: Path) -> None:
+def test_macro_snapshot_repeated_streams_do_not_hold_descriptors(tmp_path: Path) -> None:
     path = tmp_path / "macro.kmacro.xz"
     events = [{"type": 1, "code": 30, "value": 1, "t_us": 0}]
     write_macro(path, MacroFileMeta(name="macro", event_count=1), events)
     baseline = _open_fd_count()
 
     snapshot = MacroFileSnapshot(path)
-    assert _open_fd_count() == baseline + 1
+    assert _open_fd_count() == baseline
     for _ in range(10):
         assert list(snapshot.iter_events()) == events
-        assert _open_fd_count() == baseline + 1
-
-    snapshot.close()
-    assert _open_fd_count() == baseline
+        assert _open_fd_count() == baseline
 
 
 def test_write_macro_without_overwrite_preserves_existing_destination(tmp_path: Path) -> None:

--- a/tests/test_macro_store.py
+++ b/tests/test_macro_store.py
@@ -71,6 +71,27 @@ def test_macro_store_revision_conflict(tmp_path: Path) -> None:
         store.update("macro_a", {"duration_us": 10_000}, expected_revision=7)
 
 
+def test_macro_store_snapshot_pins_metadata_and_repeated_events_to_one_revision(
+    tmp_path: Path,
+) -> None:
+    store = MacroStore(tmp_path / "macros")
+    old_event = {"type": 1, "code": 30, "value": 1, "t_us": 0}
+    new_event = {"type": 1, "code": 31, "value": 1, "t_us": 100}
+    store.create({"name": "macro", "events": [old_event]})
+
+    snapshot = store.open_snapshot("macro")
+    store.update("macro", {"events": [new_event]}, expected_revision=1)
+    try:
+        assert snapshot.meta["revision"] == 1
+        assert list(snapshot.iter_events()) == [old_event]
+        assert list(snapshot.iter_events()) == [old_event]
+    finally:
+        snapshot.close()
+
+    assert store.get("macro")["revision"] == 2
+    assert list(store.iter_events("macro")) == [new_event]
+
+
 def test_macro_store_update_rechecks_revision_under_mutation_lock(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_macro_store.py
+++ b/tests/test_macro_store.py
@@ -81,12 +81,9 @@ def test_macro_store_snapshot_pins_metadata_and_repeated_events_to_one_revision(
 
     snapshot = store.open_snapshot("macro")
     store.update("macro", {"events": [new_event]}, expected_revision=1)
-    try:
-        assert snapshot.meta["revision"] == 1
-        assert list(snapshot.iter_events()) == [old_event]
-        assert list(snapshot.iter_events()) == [old_event]
-    finally:
-        snapshot.close()
+    assert snapshot.meta["revision"] == 1
+    assert list(snapshot.iter_events()) == [old_event]
+    assert list(snapshot.iter_events()) == [old_event]
 
     assert store.get("macro")["revision"] == 2
     assert list(store.iter_events("macro")) == [new_event]

--- a/tests/test_macro_store.py
+++ b/tests/test_macro_store.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import pytest
 
 from keymasq.keymasqd import macro_store as macro_store_module
-from keymasq.keymasqd.macro_file import MacroFileMeta
+from keymasq.keymasqd.macro_file import MacroFileChangedError, MacroFileMeta
 from keymasq.keymasqd.macro_store import MacroStore
 
 
@@ -71,7 +71,7 @@ def test_macro_store_revision_conflict(tmp_path: Path) -> None:
         store.update("macro_a", {"duration_us": 10_000}, expected_revision=7)
 
 
-def test_macro_store_snapshot_pins_metadata_and_repeated_events_to_one_revision(
+def test_macro_store_snapshot_ends_repeated_reads_after_revision_change(
     tmp_path: Path,
 ) -> None:
     store = MacroStore(tmp_path / "macros")
@@ -80,10 +80,12 @@ def test_macro_store_snapshot_pins_metadata_and_repeated_events_to_one_revision(
     store.create({"name": "macro", "events": [old_event]})
 
     snapshot = store.open_snapshot("macro")
-    store.update("macro", {"events": [new_event]}, expected_revision=1)
     assert snapshot.meta["revision"] == 1
     assert list(snapshot.iter_events()) == [old_event]
-    assert list(snapshot.iter_events()) == [old_event]
+
+    store.update("macro", {"events": [new_event]}, expected_revision=1)
+    with pytest.raises(MacroFileChangedError):
+        list(snapshot.iter_events())
 
     assert store.get("macro")["revision"] == 2
     assert list(store.iter_events("macro")) == [new_event]

--- a/tests/test_recording_extended.py
+++ b/tests/test_recording_extended.py
@@ -196,6 +196,47 @@ async def test_recording_stop_skips_callback_when_not_recording():
 
 
 @pytest.mark.asyncio
+async def test_concurrent_recording_stops_finalize_the_spool_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    callback = AsyncMock()
+    recorder = RecordingManager(broadcast_callback=callback)
+    await recorder.start([])
+    spool = recorder._spool
+    assert spool is not None
+    original_finish = spool.finish
+    finish_started = asyncio.Event()
+    release_finish = asyncio.Event()
+    finish_calls = 0
+
+    async def finish() -> RecordingSnapshot:
+        nonlocal finish_calls
+        finish_calls += 1
+        finish_started.set()
+        await release_finish.wait()
+        return await original_finish()
+
+    monkeypatch.setattr(spool, "finish", finish)
+    callback.reset_mock()
+
+    automatic_stop = asyncio.create_task(recorder.stop(stop_reason="duration_limit"))
+    await asyncio.wait_for(finish_started.wait(), timeout=0.5)
+    manual_stop = asyncio.create_task(recorder.stop())
+    await asyncio.sleep(0)
+
+    assert manual_stop.done() is False
+    release_finish.set()
+    automatic_result, manual_result = await asyncio.gather(automatic_stop, manual_stop)
+
+    assert finish_calls == 1
+    assert automatic_result["stop_reason"] == "duration_limit"
+    assert manual_result == {"status": "ok"}
+    recording_id = str(automatic_result["pending_recording_id"])
+    assert (await recorder.pending_recording(recording_id)).recording_id == recording_id
+    callback.assert_awaited_once()
+
+
+@pytest.mark.asyncio
 async def test_recording_event_filters_sync_and_msc_events() -> None:
     recorder = RecordingManager()
 

--- a/tests/test_recording_extended.py
+++ b/tests/test_recording_extended.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock
 import evdev
 import pytest
 
+from keymasq.common.ipc import CommandType
 from keymasq.keymasqd.recording import RecordingManager
 from keymasq.keymasqd.recording_spool import RecordingSnapshot, RecordingSpool
 
@@ -233,6 +234,58 @@ async def test_recording_progress_reports_latest_event() -> None:
     callback.assert_awaited_once()
     assert callback.await_args.args[0].value == "recording_progress"
     assert callback.await_args.args[1] == {"event_count": 2, "duration_ms": 2}
+
+
+@pytest.mark.asyncio
+async def test_recording_duration_limit_stops_normally_from_progress_task(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    callback = AsyncMock()
+    recorder = RecordingManager(broadcast_callback=callback, macro_recording_time_limit=1)
+    await recorder.start([])
+    original_progress_task = recorder._progress_task
+    assert original_progress_task is not None
+    original_progress_task.cancel()
+    await asyncio.gather(original_progress_task, return_exceptions=True)
+    recorder._recording_started_at = asyncio.get_running_loop().time() - 60
+    callback.reset_mock()
+    monkeypatch.setattr("keymasq.keymasqd.recording.asyncio.sleep", AsyncMock())
+
+    progress_task = asyncio.create_task(recorder._monitor_progress())
+    recorder._progress_task = progress_task
+    await progress_task
+
+    assert recorder.is_recording is False
+    callback.assert_awaited_once()
+    event_type, payload = callback.await_args.args
+    assert event_type is CommandType.RECORDING_STOPPED
+    assert payload["stop_reason"] == "duration_limit"
+    assert payload["macro_recording_time_limit"] == 1
+    assert isinstance(payload["pending_recording_id"], str)
+
+
+@pytest.mark.asyncio
+async def test_zero_recording_duration_limit_does_not_auto_stop(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    callback = AsyncMock()
+    recorder = RecordingManager(broadcast_callback=callback, macro_recording_time_limit=0)
+    await recorder.start([])
+    original_progress_task = recorder._progress_task
+    assert original_progress_task is not None
+    original_progress_task.cancel()
+    await asyncio.gather(original_progress_task, return_exceptions=True)
+    recorder._progress_task = None
+    recorder._recording_started_at = asyncio.get_running_loop().time() - 24 * 60 * 60
+    callback.reset_mock()
+    callback.side_effect = lambda *_args: setattr(recorder, "_stopped", True)
+    monkeypatch.setattr("keymasq.keymasqd.recording.asyncio.sleep", AsyncMock())
+
+    await recorder._monitor_progress()
+
+    callback.assert_awaited_once()
+    assert callback.await_args.args[0] is CommandType.RECORDING_PROGRESS
+    await recorder.abort()
 
 
 @pytest.mark.asyncio

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -17,6 +17,7 @@ def test_load_security_policy_defaults_when_missing(tmp_path: Path) -> None:
     policy = load_security_policy(tmp_path / "missing-security.toml")
 
     assert policy.recording_unlock_required is True
+    assert policy.macro_recording_time_limit == 10
     assert policy.macro_edit_requires_unlock is False
     assert policy.emergency_cancel_combo_enabled is True
 
@@ -79,6 +80,7 @@ def test_load_security_policy_recording_guard_section(tmp_path: Path) -> None:
             [
                 "[recording_guard]",
                 "unlock_required = false",
+                "macro_recording_time_limit = 0",
                 "macro_edit_requires_unlock = true",
             ]
         )
@@ -87,7 +89,27 @@ def test_load_security_policy_recording_guard_section(tmp_path: Path) -> None:
     policy = load_security_policy(policy_path)
 
     assert policy.recording_unlock_required is False
+    assert policy.macro_recording_time_limit == 0
     assert policy.macro_edit_requires_unlock is True
+
+
+@pytest.mark.parametrize("value", ["-1", "true", '"10"'])
+def test_load_security_policy_rejects_invalid_recording_duration(
+    tmp_path: Path,
+    value: str,
+) -> None:
+    policy_path = tmp_path / "security.toml"
+    policy_path.write_text(
+        "\n".join(
+            [
+                "[recording_guard]",
+                f"macro_recording_time_limit = {value}",
+            ]
+        )
+    )
+
+    with pytest.raises(SecurityPolicyError, match="macro_recording_time_limit"):
+        load_security_policy(policy_path)
 
 
 def test_load_security_policy_gui_section(tmp_path: Path) -> None:

--- a/tests/test_session_clients.py
+++ b/tests/test_session_clients.py
@@ -509,21 +509,32 @@ def test_persistent_session_reader_thread_survives_socket_swap(
     new_sock = _FakeSocket([b'{"status":"new"}\n', b""])
 
     connection._response_queue = response_queue
+    connection._response_generation = 2
+    connection._generation = 1
     connection._sock = old_sock
-    thread = threading.Thread(target=connection._reader_loop, daemon=True)
+    thread = threading.Thread(target=connection._reader_loop, args=(1, old_sock), daemon=True)
     connection._reader_thread = thread
     thread.start()
 
     assert ready.wait(1.0) is True
     with connection._state_lock:
+        connection._generation = 2
         connection._sock = new_sock
         connection._buffer = b""
+    new_thread = threading.Thread(
+        target=connection._reader_loop,
+        args=(2, new_sock),
+        daemon=True,
+    )
+    new_thread.start()
     release.set()
 
     queued = response_queue.get(timeout=1.0)
     assert queued == {"status": "new"}
     thread.join(1.0)
+    new_thread.join(1.0)
     assert thread.is_alive() is False
+    assert new_thread.is_alive() is False
 
 
 def test_persistent_session_reader_ignores_stale_eof_after_socket_swap(
@@ -538,22 +549,33 @@ def test_persistent_session_reader_ignores_stale_eof_after_socket_swap(
     new_sock = _FakeSocket([b'{"status":"new"}\n', b""])
 
     connection._response_queue = response_queue
+    connection._response_generation = 2
+    connection._generation = 1
     connection._sock = old_sock
-    thread = threading.Thread(target=connection._reader_loop, daemon=True)
+    thread = threading.Thread(target=connection._reader_loop, args=(1, old_sock), daemon=True)
     connection._reader_thread = thread
     thread.start()
 
     assert ready.wait(1.0) is True
     with connection._state_lock:
+        connection._generation = 2
         connection._sock = new_sock
         connection._buffer = b""
+    new_thread = threading.Thread(
+        target=connection._reader_loop,
+        args=(2, new_sock),
+        daemon=True,
+    )
+    new_thread.start()
     release.set()
 
     queued = response_queue.get(timeout=1.0)
     assert queued == {"status": "new"}
     assert new_sock.closed is True
     thread.join(1.0)
+    new_thread.join(1.0)
     assert thread.is_alive() is False
+    assert new_thread.is_alive() is False
 
 
 def test_persistent_session_reader_ignores_stale_error_after_socket_swap(
@@ -568,35 +590,48 @@ def test_persistent_session_reader_ignores_stale_error_after_socket_swap(
     new_sock = _FakeSocket([b'{"status":"new"}\n', b""])
 
     connection._response_queue = response_queue
+    connection._response_generation = 2
+    connection._generation = 1
     connection._sock = old_sock
-    thread = threading.Thread(target=connection._reader_loop, daemon=True)
+    thread = threading.Thread(target=connection._reader_loop, args=(1, old_sock), daemon=True)
     connection._reader_thread = thread
     thread.start()
 
     assert ready.wait(1.0) is True
     with connection._state_lock:
+        connection._generation = 2
         connection._sock = new_sock
         connection._buffer = b""
+    new_thread = threading.Thread(
+        target=connection._reader_loop,
+        args=(2, new_sock),
+        daemon=True,
+    )
+    new_thread.start()
     release.set()
 
     queued = response_queue.get(timeout=1.0)
     assert queued == {"status": "new"}
     assert new_sock.closed is True
     thread.join(1.0)
+    new_thread.join(1.0)
     assert thread.is_alive() is False
+    assert new_thread.is_alive() is False
 
 
 def test_run_gui_task_invokes_hooks_and_callback(monkeypatch: pytest.MonkeyPatch) -> None:
     _install_fake_glib(monkeypatch)
     events: list[tuple[str, Any]] = []
+    done = threading.Event()
 
     gui_session_client.run_gui_task(
         lambda: {"status": "ok"},
         lambda result: events.append(("callback", result)),
         on_start=lambda: events.append(("start", None)),
-        on_done=lambda: events.append(("done", None)),
+        on_done=lambda: events.append(("done", None)) or done.set(),
     )
 
+    assert done.wait(1.0) is True
     assert events == [
         ("start", None),
         ("callback", gui_session_client.GuiTaskResult(value={"status": "ok"})),
@@ -609,6 +644,7 @@ def test_session_request_async_uses_session_request_and_hooks(
 ) -> None:
     _install_fake_glib(monkeypatch)
     calls: list[tuple[str, Any]] = []
+    done = threading.Event()
 
     monkeypatch.setattr(
         gui_session_client,
@@ -621,9 +657,10 @@ def test_session_request_async_uses_session_request_and_hooks(
         lambda result: calls.append(("callback", result)),
         timeout=2.0,
         on_start=lambda: calls.append(("start", None)),
-        on_done=lambda: calls.append(("done", None)),
+        on_done=lambda: calls.append(("done", None)) or done.set(),
     )
 
+    assert done.wait(1.0) is True
     assert calls == [
         ("start", None),
         (

--- a/tests/test_session_clients.py
+++ b/tests/test_session_clients.py
@@ -428,6 +428,34 @@ def test_persistent_session_request_timeout_closes_connection() -> None:
     assert connection._sock is None  # pyright: ignore[reportPrivateUsage]
 
 
+def test_stale_request_timeout_does_not_close_replacement_connection() -> None:
+    connection = gui_session_client._PersistentSessionConnection()
+    old_sock = _RequestOnlySocket()
+    new_sock = _RequestOnlySocket()
+    connection._sock = old_sock  # pyright: ignore[reportPrivateUsage]
+
+    def replace_during_wait(*, timeout: float) -> None:
+        _ = timeout
+        with connection._state_lock:
+            connection._generation += 1
+            connection._sock = new_sock
+        raise queue.Empty
+
+    response_queue: queue.Queue[dict[str, Any] | None] = queue.Queue(maxsize=1)
+    response_queue.get = replace_during_wait  # type: ignore[method-assign]
+    original_queue = gui_session_client.queue.Queue
+    gui_session_client.queue.Queue = lambda maxsize=0: response_queue  # type: ignore[assignment]
+    try:
+        response = connection.request({"command": "get_status"}, timeout=0.01)
+    finally:
+        gui_session_client.queue.Queue = original_queue
+
+    assert response is None
+    assert old_sock.closed is True
+    assert new_sock.closed is False
+    assert connection._sock is new_sock  # pyright: ignore[reportPrivateUsage]
+
+
 def test_persistent_session_failed_connect_closes_socket(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_socket_server.py
+++ b/tests/test_socket_server.py
@@ -697,6 +697,38 @@ class TestSocketServer:
         assert cancelled.is_set()
         assert server._handler_tasks == set()
 
+    async def test_handler_drain_remains_bounded_when_task_suppresses_cancellation(
+        self,
+        temp_socket_dir,
+    ):
+        cancel_seen = asyncio.Event()
+        release = asyncio.Event()
+
+        async def stubborn_handler() -> None:
+            try:
+                await asyncio.Event().wait()
+            except asyncio.CancelledError:
+                cancel_seen.set()
+                await release.wait()
+
+        server = SocketServer(
+            str(paths.SOCKET_PATH),
+            _ok_handler,
+            handler_drain_timeout_s=0.01,
+        )
+        task = asyncio.create_task(stubborn_handler())
+        server._handler_tasks.add(task)
+        await asyncio.sleep(0)
+
+        try:
+            await asyncio.wait_for(server._drain_handler_tasks(), timeout=0.2)
+            assert cancel_seen.is_set()
+            assert not task.done()
+        finally:
+            release.set()
+            await task
+            server._handler_tasks.discard(task)
+
     async def test_quiescing_server_rejects_newly_processed_command(self, temp_socket_dir):
         handler_calls: list[bool] = []
 

--- a/tests/test_socket_server.py
+++ b/tests/test_socket_server.py
@@ -680,18 +680,39 @@ class TestSocketServer:
     ):
         server = SocketServer(str(paths.SOCKET_PATH), _ok_handler)
         await server.start()
+        old_generation = server._server_generation
         reader = asyncio.StreamReader()
         writer = _BroadcastWriter()
         asyncio.get_running_loop().call_soon(
             server._accept_client,
             reader,
             writer,
+            old_generation,
         )
 
         await server.stop()
+        await asyncio.sleep(0)
 
         assert writer.closed is True
         assert server._handler_tasks == set()
+
+    async def test_restarted_server_rejects_accept_from_prior_generation(
+        self,
+        temp_socket_dir,
+    ):
+        server = SocketServer(str(paths.SOCKET_PATH), _ok_handler)
+        await server.start()
+        old_generation = server._server_generation
+        await server.stop()
+        await server.start()
+        reader = asyncio.StreamReader()
+        writer = _BroadcastWriter()
+
+        server._accept_client(reader, writer, old_generation)  # type: ignore[arg-type]
+
+        assert writer.closed is True
+        assert server._handler_tasks == set()
+        await server.stop()
 
     async def test_server_stop_cancels_stuck_command_after_deadline(self, temp_socket_dir):
         started = asyncio.Event()

--- a/tests/test_socket_server.py
+++ b/tests/test_socket_server.py
@@ -646,7 +646,7 @@ class TestSocketServer:
             handler_drain_timeout_s=0.5,
         )
         await server.start()
-        _reader, writer = await asyncio.open_unix_connection(str(paths.SOCKET_PATH))
+        reader, writer = await asyncio.open_unix_connection(str(paths.SOCKET_PATH))
         writer.write(encode_command(Command(command=CommandType.PING, data={})))
         await writer.drain()
         await started.wait()
@@ -654,8 +654,12 @@ class TestSocketServer:
         stop_task = asyncio.create_task(server.stop())
         await asyncio.sleep(0)
         release.set()
-        await stop_task
+        await asyncio.wait_for(stop_task, timeout=1.0)
 
+        response_data = await asyncio.wait_for(reader.read(1024), timeout=1.0)
+        response, _ = decode_response(response_data)
+        assert response is not None
+        assert response.status == "ok"
         assert completed.is_set()
         assert server._handler_tasks == set()
 
@@ -739,7 +743,7 @@ class TestSocketServer:
         server._handler_tasks.add(task)
         await asyncio.sleep(0)
 
-        await asyncio.wait_for(server._drain_handler_tasks(), timeout=0.2)
+        await asyncio.wait_for(server._drain_handler_tasks(graceful=True), timeout=0.2)
         assert cancel_seen.is_set()
         assert not task.done()
         with pytest.raises(RuntimeError, match="prior handler"):

--- a/tests/test_socket_server.py
+++ b/tests/test_socket_server.py
@@ -741,6 +741,40 @@ class TestSocketServer:
         assert cancelled.is_set()
         assert server._handler_tasks == set()
 
+    async def test_server_stop_allows_disconnect_cleanup_before_handler_cancellation(
+        self,
+        temp_socket_dir,
+    ):
+        cleanup_started = asyncio.Event()
+        release_cleanup = asyncio.Event()
+        cleanup_completed = asyncio.Event()
+
+        async def handle_disconnect() -> None:
+            cleanup_started.set()
+            await release_cleanup.wait()
+            cleanup_completed.set()
+
+        server = SocketServer(
+            str(paths.SOCKET_PATH),
+            _ok_handler,
+            disconnect_handler=handle_disconnect,
+            handler_drain_timeout_s=0.5,
+        )
+        await server.start()
+        reader, writer = await asyncio.open_unix_connection(str(paths.SOCKET_PATH))
+        writer.write(encode_command(Command(command=CommandType.PING, data={})))
+        await writer.drain()
+        await asyncio.wait_for(reader.read(1024), timeout=1.0)
+
+        stop_task = asyncio.create_task(server.stop())
+        await asyncio.wait_for(cleanup_started.wait(), timeout=1.0)
+        assert not stop_task.done()
+        release_cleanup.set()
+        await asyncio.wait_for(stop_task, timeout=1.0)
+
+        assert cleanup_completed.is_set()
+        assert server._handler_tasks == set()
+
     async def test_handler_drain_bounds_cancellation_cleanup_and_blocks_restart(
         self,
         temp_socket_dir,

--- a/tests/test_socket_server.py
+++ b/tests/test_socket_server.py
@@ -697,7 +697,7 @@ class TestSocketServer:
         assert cancelled.is_set()
         assert server._handler_tasks == set()
 
-    async def test_handler_drain_waits_for_cancellation_cleanup(
+    async def test_handler_drain_bounds_cancellation_cleanup_and_blocks_restart(
         self,
         temp_socket_dir,
     ):
@@ -720,13 +720,14 @@ class TestSocketServer:
         server._handler_tasks.add(task)
         await asyncio.sleep(0)
 
-        drain_task = asyncio.create_task(server._drain_handler_tasks())
-        await asyncio.wait_for(cancel_seen.wait(), timeout=0.2)
-        assert not drain_task.done()
+        await asyncio.wait_for(server._drain_handler_tasks(), timeout=0.2)
+        assert cancel_seen.is_set()
+        assert not task.done()
+        with pytest.raises(RuntimeError, match="prior handler"):
+            await server.start()
 
         release.set()
-        await asyncio.wait_for(drain_task, timeout=0.2)
-        assert task.done()
+        await asyncio.wait_for(task, timeout=0.2)
         server._handler_tasks.discard(task)
 
     async def test_quiescing_server_rejects_newly_processed_command(self, temp_socket_dir):

--- a/tests/test_socket_server.py
+++ b/tests/test_socket_server.py
@@ -130,6 +130,35 @@ class TestSocketServer:
         await server.start()
         await server.stop()
 
+    async def test_stop_waits_for_start_listener_creation(
+        self,
+        monkeypatch,
+        temp_socket_dir,
+    ):
+        real_start_unix_server = asyncio.start_unix_server
+        start_entered = asyncio.Event()
+        release_start = asyncio.Event()
+
+        async def blocked_start_unix_server(*args, **kwargs):
+            start_entered.set()
+            await release_start.wait()
+            return await real_start_unix_server(*args, **kwargs)
+
+        monkeypatch.setattr(asyncio, "start_unix_server", blocked_start_unix_server)
+        server = SocketServer(str(paths.SOCKET_PATH), _ok_handler)
+        start_task = asyncio.create_task(server.start())
+        await start_entered.wait()
+
+        stop_task = asyncio.create_task(server.stop())
+        await asyncio.sleep(0)
+        assert not stop_task.done()
+
+        release_start.set()
+        await start_task
+        await stop_task
+        assert server.server is None
+        assert not paths.SOCKET_PATH.exists()
+
     async def test_denied_peer_is_disconnected(self, temp_socket_dir):
         cmd_handler = MockCommandHandler()
         server = SocketServer(
@@ -625,9 +654,11 @@ class TestSocketServer:
         )
         await server.start()
 
-        _reader, _writer = await asyncio.open_unix_connection(str(paths.SOCKET_PATH))
+        _reader, writer = await asyncio.open_unix_connection(str(paths.SOCKET_PATH))
 
         await asyncio.wait_for(server.stop(), timeout=1.0)
+        writer.close()
+        await writer.wait_closed()
 
     async def test_server_stop_drains_active_command_before_deadline(self, temp_socket_dir):
         started = asyncio.Event()
@@ -662,6 +693,8 @@ class TestSocketServer:
         assert response.status == "ok"
         assert completed.is_set()
         assert server._handler_tasks == set()
+        writer.close()
+        await writer.wait_closed()
 
     async def test_accept_registers_handler_before_coroutine_runs(self, temp_socket_dir):
         server = SocketServer(str(paths.SOCKET_PATH), _ok_handler)
@@ -740,6 +773,8 @@ class TestSocketServer:
 
         assert cancelled.is_set()
         assert server._handler_tasks == set()
+        writer.close()
+        await writer.wait_closed()
 
     async def test_server_stop_allows_disconnect_cleanup_before_handler_cancellation(
         self,
@@ -774,6 +809,8 @@ class TestSocketServer:
 
         assert cleanup_completed.is_set()
         assert server._handler_tasks == set()
+        writer.close()
+        await writer.wait_closed()
 
     async def test_handler_drain_bounds_cancellation_cleanup_and_blocks_restart(
         self,

--- a/tests/test_socket_server.py
+++ b/tests/test_socket_server.py
@@ -697,7 +697,7 @@ class TestSocketServer:
         assert cancelled.is_set()
         assert server._handler_tasks == set()
 
-    async def test_handler_drain_remains_bounded_when_task_suppresses_cancellation(
+    async def test_handler_drain_waits_for_cancellation_cleanup(
         self,
         temp_socket_dir,
     ):
@@ -720,14 +720,14 @@ class TestSocketServer:
         server._handler_tasks.add(task)
         await asyncio.sleep(0)
 
-        try:
-            await asyncio.wait_for(server._drain_handler_tasks(), timeout=0.2)
-            assert cancel_seen.is_set()
-            assert not task.done()
-        finally:
-            release.set()
-            await task
-            server._handler_tasks.discard(task)
+        drain_task = asyncio.create_task(server._drain_handler_tasks())
+        await asyncio.wait_for(cancel_seen.wait(), timeout=0.2)
+        assert not drain_task.done()
+
+        release.set()
+        await asyncio.wait_for(drain_task, timeout=0.2)
+        assert task.done()
+        server._handler_tasks.discard(task)
 
     async def test_quiescing_server_rejects_newly_processed_command(self, temp_socket_dir):
         handler_calls: list[bool] = []

--- a/tests/test_socket_server.py
+++ b/tests/test_socket_server.py
@@ -629,6 +629,92 @@ class TestSocketServer:
 
         await asyncio.wait_for(server.stop(), timeout=1.0)
 
+    async def test_server_stop_drains_active_command_before_deadline(self, temp_socket_dir):
+        started = asyncio.Event()
+        release = asyncio.Event()
+        completed = asyncio.Event()
+
+        async def handler(_command, _data, _client):
+            started.set()
+            await release.wait()
+            completed.set()
+            return {"ok": True}
+
+        server = SocketServer(
+            str(paths.SOCKET_PATH),
+            handler,
+            handler_drain_timeout_s=0.5,
+        )
+        await server.start()
+        _reader, writer = await asyncio.open_unix_connection(str(paths.SOCKET_PATH))
+        writer.write(encode_command(Command(command=CommandType.PING, data={})))
+        await writer.drain()
+        await started.wait()
+
+        stop_task = asyncio.create_task(server.stop())
+        await asyncio.sleep(0)
+        release.set()
+        await stop_task
+
+        assert completed.is_set()
+        assert server._handler_tasks == set()
+
+    async def test_accept_registers_handler_before_coroutine_runs(self, temp_socket_dir):
+        server = SocketServer(str(paths.SOCKET_PATH), _ok_handler)
+        reader = asyncio.StreamReader()
+        writer = _BroadcastWriter()
+
+        server._accept_client(reader, writer)  # type: ignore[arg-type]
+
+        assert len(server._handler_tasks) == 1
+        await server.stop()
+        assert server._handler_tasks == set()
+
+    async def test_server_stop_cancels_stuck_command_after_deadline(self, temp_socket_dir):
+        started = asyncio.Event()
+        cancelled = asyncio.Event()
+
+        async def handler(_command, _data, _client):
+            started.set()
+            try:
+                await asyncio.Event().wait()
+            finally:
+                cancelled.set()
+
+        server = SocketServer(
+            str(paths.SOCKET_PATH),
+            handler,
+            handler_drain_timeout_s=0.01,
+        )
+        await server.start()
+        _reader, writer = await asyncio.open_unix_connection(str(paths.SOCKET_PATH))
+        writer.write(encode_command(Command(command=CommandType.PING, data={})))
+        await writer.drain()
+        await started.wait()
+
+        await asyncio.wait_for(server.stop(), timeout=1.0)
+
+        assert cancelled.is_set()
+        assert server._handler_tasks == set()
+
+    async def test_quiescing_server_rejects_newly_processed_command(self, temp_socket_dir):
+        handler_calls: list[bool] = []
+
+        async def handler(_command, _data, _client):
+            handler_calls.append(True)
+            return {"ok": True}
+
+        server = SocketServer(str(paths.SOCKET_PATH), handler)
+        server._quiescing = True
+        response = await server._process_command(
+            Command(command=CommandType.PING, data={}, request_id="late"),
+            ClientContext(connection_id=1, pid=2, uid=3, gid=4),
+        )
+
+        assert response.status == "error"
+        assert response.request_id == "late"
+        assert handler_calls == []
+
     async def test_server_stop_clears_single_owner_state_for_restart(self, temp_socket_dir):
         server = SocketServer(
             str(paths.SOCKET_PATH),

--- a/tests/test_socket_server.py
+++ b/tests/test_socket_server.py
@@ -670,6 +670,25 @@ class TestSocketServer:
         await server.stop()
         assert server._handler_tasks == set()
 
+    async def test_server_stop_drains_accept_callback_already_queued(
+        self,
+        temp_socket_dir,
+    ):
+        server = SocketServer(str(paths.SOCKET_PATH), _ok_handler)
+        await server.start()
+        reader = asyncio.StreamReader()
+        writer = _BroadcastWriter()
+        asyncio.get_running_loop().call_soon(
+            server._accept_client,
+            reader,
+            writer,
+        )
+
+        await server.stop()
+
+        assert writer.closed is True
+        assert server._handler_tasks == set()
+
     async def test_server_stop_cancels_stuck_command_after_deadline(self, temp_socket_dir):
         started = asyncio.Event()
         cancelled = asyncio.Event()


### PR DESCRIPTION
## Summary
- Close socket accept/shutdown races: drain active commands, reject stale accept callbacks, fence cancellation-resistant handlers, and allow disconnect cleanup during shutdown.
- Deliver final session events after disconnect; abort recordings, close captures (including unused authorizations), and discard non-slot pending recordings on owner disconnect/shutdown.
- Harden macro spool recovery (quarantine invalid/uncertain artifacts), pin macro file snapshots so event streams close cleanly, and treat rename/delete as unlock-guarded when macro edit requires unlock.
- Stabilize GUI session IPC with generation-aware readers, bounded worker pool, timed writes, and full runtime shutdown on app exit.

## Testing
- `tests/test_socket_server.py` — accept/shutdown, command drain, disconnect cleanup
- `tests/gui/test_session_client.py` and `tests/test_session_clients.py` — generation fencing, shutdown, IPC races
- `tests/keymasqd/test_macro_backend_recording.py`, `tests/test_macro_file.py`, `tests/test_macro_store.py` — spool quarantine, snapshot close, store integrity
- `tests/keymasqd/test_daemon_runtime_unlock.py`, capture/authorization tests — disconnect abort and unlock chain
- Full `./scripts/check.sh` 