### PR TITLE
Speed up repeated short macro playback with a bounded cache

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -243,9 +243,10 @@ journalctl -u keymasqd -f
 | Option | Description |
 |---|---|
 | `--interval SECONDS` | Logging interval in seconds |
-| `--include CATEGORY` | Add a diagnostics category: `mainline`, `combo`, `internal`, or `all` |
-| `--exclude CATEGORY` | Hide a diagnostics category after includes are applied: `mainline`, `combo`, or `internal` |
+| `--include CATEGORY` | Add a diagnostics category: `mainline`, `combo`, `macro`, `internal`, or `all` |
+| `--exclude CATEGORY` | Hide a diagnostics category after includes are applied: `mainline`, `combo`, `macro`, or `internal` |
 
 The default category is `mainline`, which shows the normal passthrough and
 remap-action paths. Use `--include combo` for combo-specific timing and
+`--include macro` for stored-macro loading and playback timing, or
 `--include internal` for low-level daemon details.

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -42,6 +42,12 @@ Benchmark results show:
 With `uvloop` installed (recommended), jitter improves further, especially for
 high-frequency mouse macros and keyboard bursts.
 
+Stored macros stream their first playback directly from the compressed file.
+When a complete iteration takes less than two seconds, including explicit
+waits and synchronous commands, Keymasq keeps its parsed events in a daemon-wide
+10 MiB LRU cache. Longer macros continue streaming, and changing the macro file
+invalidates its cached revision before reuse.
+
 ## Live Diagnostics
 
 You can measure latency on your own system with the built-in diagnostics mode:
@@ -58,6 +64,7 @@ behavior or daemon internals:
 
 ```bash
 keymasq diagnostics on --include combo
+keymasq diagnostics on --include macro
 keymasq diagnostics on --include internal
 keymasq diagnostics on --include all
 keymasq diagnostics on --include all --exclude internal
@@ -170,6 +177,35 @@ latency baseline.
 | `combo_passthrough` | A combo-relevant event was checked by the combo engine and then passed through normally. | Pressing the first key of a two-key combo where the key should still type if the combo is not completed. |
 | `combo_passthrough_held` | A later event for a combo key that was already allowed through. | Releasing that first combo key after it had been passed through. |
 | `combo_release_action_*` | A combo-related release event triggered an action. | Releasing a held combo chord that fires a remapped button. |
+
+### Macro Diagnostics
+
+Enable with:
+
+```bash
+keymasq diagnostics on --include macro
+```
+
+These labels measure stored-macro loading separately from the complete runtime
+of one playback iteration. This makes the effect of the short-macro replay
+cache visible without mixing in the macro's own timing.
+
+| Label | What it means |
+|---|---|
+| `macro_load` | Time spent resolving the stored revision and obtaining its events. Streamed iterations include worker batches that decompress and parse the file; cache hits include only revision validation and cache retrieval. Timeline sleeps, wait controls, and command execution are excluded. |
+| `macro_iteration` | Wall-clock runtime of one normally completed iteration, including event timing, explicit and random waits, synchronous commands, and trailing macro duration. Inter-iteration scheduling yields are excluded. |
+
+For a repeatable benchmark, save the test macro with `loop_mode` set to `count`
+and a fixed `loop_count`, enable macro diagnostics, and trigger it once:
+
+```bash
+keymasq diagnostics on --include macro --interval 5
+keymasq macros play benchmark-macro
+journalctl -u keymasqd -f
+```
+
+Only stored macros are sampled. Cancelled, interrupted, or failed iterations
+do not produce a complete iteration sample.
 
 ### Internal Diagnostics
 

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -42,12 +42,6 @@ Benchmark results show:
 With `uvloop` installed (recommended), jitter improves further, especially for
 high-frequency mouse macros and keyboard bursts.
 
-Stored macros stream their first playback directly from the compressed file.
-When a complete iteration takes less than two seconds, including explicit
-waits and synchronous commands, Keymasq keeps its parsed events in a daemon-wide
-10 MiB LRU cache. Longer macros continue streaming, and changing the macro file
-invalidates its cached revision before reuse.
-
 ## Live Diagnostics
 
 You can measure latency on your own system with the built-in diagnostics mode:

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -180,23 +180,13 @@ Enable with:
 keymasq diagnostics on --include macro
 ```
 
-These labels measure stored-macro loading separately from the complete runtime
-of one playback iteration. This makes the effect of the short-macro replay
-cache visible without mixing in the macro's own timing.
+These labels separate stored-macro loading from the complete runtime of one
+playback iteration.
 
 | Label | What it means |
 |---|---|
 | `macro_load` | Time spent resolving the stored revision and obtaining its events. Streamed iterations include worker batches that decompress and parse the file; cache hits include only revision validation and cache retrieval. Timeline sleeps, wait controls, and command execution are excluded. |
 | `macro_iteration` | Wall-clock runtime of one normally completed iteration, including event timing, explicit and random waits, synchronous commands, and trailing macro duration. Inter-iteration scheduling yields are excluded. |
-
-For a repeatable benchmark, save the test macro with `loop_mode` set to `count`
-and a fixed `loop_count`, enable macro diagnostics, and trigger it once:
-
-```bash
-keymasq diagnostics on --include macro --interval 5
-keymasq macros play benchmark-macro
-journalctl -u keymasqd -f
-```
 
 Only stored macros are sampled. Cancelled, interrupted, or failed iterations
 do not produce a complete iteration sample.

--- a/keymasq/cli/__main__.py
+++ b/keymasq/cli/__main__.py
@@ -113,7 +113,7 @@ def main() -> None:
             "Compact tokens: key_a, key_a:1, key_a:0, btn_left,\n"
             "move_abs:X:Y, move_rel:DX:DY, move:X:Y[:SPEED],\n"
             "wait:MS, wait:MIN:MAX\n"
-            'Example: keymasq play key_leftctrl:1 wait:20 key_c wait:20 key_leftctrl:0\n'
+            "Example: keymasq play key_leftctrl:1 wait:20 key_c wait:20 key_leftctrl:0\n"
             f"Full reference: {_docs_url()}"
         ),
     )
@@ -207,14 +207,14 @@ def main() -> None:
     diagnostics_parser.add_argument(
         "--include",
         action="append",
-        choices=("mainline", "combo", "internal", "all"),
+        choices=("mainline", "combo", "macro", "internal", "all"),
         default=[],
         help="Diagnostics category to log; repeat to add categories",
     )
     diagnostics_parser.add_argument(
         "--exclude",
         action="append",
-        choices=("mainline", "combo", "internal"),
+        choices=("mainline", "combo", "macro", "internal"),
         default=[],
         help="Diagnostics category to hide after includes are applied",
     )

--- a/keymasq/cli/commands.py
+++ b/keymasq/cli/commands.py
@@ -12,7 +12,7 @@ from keymasq.common.paths import SESSION_SOCKET_PATH
 from keymasq.common.types import JsonObject
 
 IntLike = int | float | str | bytes
-DIAGNOSTICS_CATEGORIES = ("mainline", "combo", "internal")
+DIAGNOSTICS_CATEGORIES = ("mainline", "combo", "macro", "internal")
 
 
 def _session_unavailable() -> JsonObject:
@@ -298,9 +298,7 @@ def status_cli(*, json_output: bool = False) -> None:
     if _handled_json_or_error(result, json_output):
         return
 
-    keymasqd_state = _bool_status(
-        result.get("keymasqd_connected"), "connected", "disconnected"
-    )
+    keymasqd_state = _bool_status(result.get("keymasqd_connected"), "connected", "disconnected")
     print(f"keymasqd: {keymasqd_state}")
 
     compositor_name = str(result.get("compositor_name") or result.get("compositor_id") or "unknown")
@@ -791,9 +789,7 @@ def list_profiles_cli(*, json_output: bool = False) -> None:
             print(f"    mappings: {mapping_count}")
 
 
-def set_profile_state_cli(
-    command: str, profile_name: str, *, json_output: bool = False
-) -> None:
+def set_profile_state_cli(command: str, profile_name: str, *, json_output: bool = False) -> None:
     result = _request_or_error(
         {
             "command": command,

--- a/keymasq/gui/widgets/diagnostics_dialog.py
+++ b/keymasq/gui/widgets/diagnostics_dialog.py
@@ -18,7 +18,7 @@ from keymasq.gui.session_client import (
 )
 from keymasq.gui.widgets.docs_links import docs_page_url
 
-DIAGNOSTICS_CATEGORIES = ("mainline", "combo", "internal")
+DIAGNOSTICS_CATEGORIES = ("mainline", "combo", "macro", "internal")
 DIAGNOSTICS_LABELS = {
     "passthrough_fast": "Unmapped passthrough",
     "passthrough_mapped": "Passthrough with mappings",
@@ -30,6 +30,8 @@ DIAGNOSTICS_LABELS = {
     "wheel_high_res_suppressed": "High-res wheel suppressed",
     "combo_recalled_repeat_suppressed": "Combo recall repeat suppressed",
     "combo_recalled_release_suppressed": "Combo recall release suppressed",
+    "macro_load": "Macro loading",
+    "macro_iteration": "Macro iteration",
 }
 PEAK_TOOLTIP = (
     "One unusually slow event. If p95 and p99 are low, this usually reflects "
@@ -172,6 +174,7 @@ class DiagnosticsDialog(Adw.Dialog):
         for category, label_text in (
             ("mainline", "Mainline"),
             ("combo", "Combo"),
+            ("macro", "Macro"),
             ("internal", "Internal"),
         ):
             btn = Gtk.ToggleButton(label=label_text)

--- a/keymasq/keymasqd/device_manager.py
+++ b/keymasq/keymasqd/device_manager.py
@@ -59,7 +59,11 @@ from keymasq.keymasqd.runtime.grab.state import (
     GrabRuntimeState,
 )
 from keymasq.keymasqd.runtime.grabbed_device.device import GrabbedDevice
-from keymasq.keymasqd.runtime.macro.state import MacroRuntimeDeps, MacroRuntimeState
+from keymasq.keymasqd.runtime.macro.state import (
+    DiagnosticRecorder,
+    MacroRuntimeDeps,
+    MacroRuntimeState,
+)
 from keymasq.keymasqd.runtime.manager_combos import ComboManagerMixin
 from keymasq.keymasqd.runtime.manager_cursor import CursorManagerMixin
 from keymasq.keymasqd.runtime.manager_macros import MacroManagerMixin
@@ -129,7 +133,9 @@ def _device_path_resolver_deps() -> device_path_resolver.DevicePathResolverDeps:
     return device_path_resolver.evdev_device_path_resolver_deps(_device_input)
 
 
-def _macro_runtime_deps() -> MacroRuntimeDeps:
+def _macro_runtime_deps(
+    diagnostics_recorder: DiagnosticRecorder | None = None,
+) -> MacroRuntimeDeps:
     return MacroRuntimeDeps(
         asyncio_mod=adapters.ASYNCIO_RUNTIME,
         evdev_mod=evdev,
@@ -137,6 +143,7 @@ def _macro_runtime_deps() -> MacroRuntimeDeps:
         log=log,
         int_value_fn=coerce_int,
         str_value_fn=coerce_str,
+        diagnostics_recorder=diagnostics_recorder,
     )
 
 
@@ -159,7 +166,7 @@ class DeviceManager(CursorManagerMixin, MacroManagerMixin, ComboManagerMixin):
         self._gamepad_output_router = virtual_gamepads.GamepadOutputRouter(log)
         self.recording_manager: RecordingManager | None = None
         self.macro_store: Any | None = None
-        self._initialize_macro_runtime(_macro_runtime_deps)
+        self._initialize_macro_runtime(self._macro_runtime_deps_with_diagnostics)
         self.macro_exec_timeout_max_ms = 30000
         self.macro_state = MacroRuntimeState()
         self._op_lock = asyncio.Lock()
@@ -503,6 +510,15 @@ class DeviceManager(CursorManagerMixin, MacroManagerMixin, ComboManagerMixin):
 
     def _record_diagnostic(self, label: str, duration_us: float) -> None:
         self._diagnostics.record(label, duration_us)
+
+    def _macro_runtime_deps_with_diagnostics(self) -> MacroRuntimeDeps:
+        recorder = (
+            self._record_diagnostic
+            if self.diagnostics_state.enabled
+            and diagnostics.label_enabled("macro_load", self.diagnostics_state.categories)
+            else None
+        )
+        return _macro_runtime_deps(recorder)
 
     async def _diagnostics_loop(self) -> None:
         await self._diagnostics.run(

--- a/keymasq/keymasqd/macro_file.py
+++ b/keymasq/keymasqd/macro_file.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 import io
 import json
 import lzma
-from collections.abc import Iterable, Iterator
+import os
+from collections.abc import Generator, Iterable, Iterator
+from contextlib import contextmanager
 from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
@@ -21,6 +23,41 @@ MACRO_FILE_VERSION = 1
 type MacroEvent = dict[str, object]
 
 
+@dataclass(frozen=True)
+class MacroFileIdentity:
+    device: int
+    inode: int
+    size: int
+    modified_ns: int
+
+    @classmethod
+    def from_stat(cls, result: os.stat_result) -> MacroFileIdentity:
+        return cls(
+            device=int(result.st_dev),
+            inode=int(result.st_ino),
+            size=int(result.st_size),
+            modified_ns=int(result.st_mtime_ns),
+        )
+
+
+@dataclass(frozen=True)
+class MacroFileRevision:
+    path: Path
+    identity: MacroFileIdentity
+
+    @classmethod
+    def from_path(cls, path: Path) -> MacroFileRevision:
+        return cls(path=path, identity=MacroFileIdentity.from_stat(path.stat()))
+
+    def verify_unchanged(self) -> None:
+        try:
+            current = MacroFileIdentity.from_stat(self.path.stat())
+        except FileNotFoundError as exc:
+            raise MacroFileChangedError(str(self.path)) from exc
+        if current != self.identity:
+            raise MacroFileChangedError(str(self.path))
+
+
 class MacroFileChangedError(RuntimeError):
     """The macro file no longer matches the revision opened for playback."""
 
@@ -30,20 +67,22 @@ class MacroFileSnapshot:
 
     def __init__(self, path: Path) -> None:
         self._path = path
-        with _open_text(path, "rb") as handle:
+        with _open_text_revision(path) as (handle, identity):
             self._meta_line = handle.readline()
         self.meta = _macro_meta_from_line(self._meta_line)
+        self.revision = MacroFileRevision(path=path, identity=identity)
 
     def iter_events(self) -> Iterator[MacroEvent]:
         def generate() -> Iterator[MacroEvent]:
             try:
-                handle = _open_text(self._path, "rb")
+                with _open_text_revision(self._path) as (handle, identity):
+                    if identity != self.revision.identity:
+                        raise MacroFileChangedError(str(self._path))
+                    if handle.readline() != self._meta_line:
+                        raise MacroFileChangedError(str(self._path))
+                    yield from _iter_macro_event_lines(handle)
             except FileNotFoundError as exc:
                 raise MacroFileChangedError(str(self._path)) from exc
-            with handle:
-                if handle.readline() != self._meta_line:
-                    raise MacroFileChangedError(str(self._path))
-                yield from _iter_macro_event_lines(handle)
 
         return generate()
 
@@ -198,6 +237,17 @@ def macro_payload_from_events(
 def _open_text(path: Path, mode: str) -> io.TextIOWrapper:
     raw = lzma.LZMAFile(path, mode)
     return io.TextIOWrapper(raw, encoding="utf-8", newline="\n")
+
+
+@contextmanager
+def _open_text_revision(
+    path: Path,
+) -> Generator[tuple[io.TextIOWrapper, MacroFileIdentity]]:
+    with path.open("rb") as fileobj:
+        identity = MacroFileIdentity.from_stat(os.fstat(fileobj.fileno()))
+        with lzma.LZMAFile(fileobj, "rb") as compressed:
+            with io.TextIOWrapper(compressed, encoding="utf-8", newline="\n") as text:
+                yield text, identity
 
 
 def _json_line(value: JsonObject) -> str:

--- a/keymasq/keymasqd/macro_store.py
+++ b/keymasq/keymasqd/macro_store.py
@@ -16,6 +16,7 @@ from typing import cast
 from keymasq.keymasqd.macro_file import (
     MACRO_FILE_SUFFIX,
     MacroFileMeta,
+    MacroFileRevision,
     MacroFileSnapshot,
     iter_macro_events,
     load_macro,
@@ -38,6 +39,7 @@ type MacroPayload = dict[str, object]
 class MacroStoreSnapshot:
     meta: MacroPayload
     iter_events: Callable[[], Iterator[MacroEvent]]
+    revision: MacroFileRevision | None = None
 
 
 def _payload_list(payload: MacroPayload, key: str) -> list[object]:
@@ -154,7 +156,19 @@ class MacroStore:
         return MacroStoreSnapshot(
             snapshot.meta.to_payload(),
             snapshot.iter_events,
+            snapshot.revision,
         )
+
+    def probe_revision(self, name: str) -> MacroFileRevision | None:
+        """Return a cheap stored-file identity for playback-cache lookup."""
+
+        if name in self._internal_macros:
+            return None
+        path = self._macro_path(name)
+        try:
+            return MacroFileRevision.from_path(path)
+        except FileNotFoundError as exc:
+            raise FileNotFoundError(f"Macro '{name}' not found") from exc
 
     def create(self, payload: MacroPayload) -> MacroPayload:
         events = _payload_events(payload)

--- a/keymasq/keymasqd/runtime/diagnostics.py
+++ b/keymasq/keymasqd/runtime/diagnostics.py
@@ -9,7 +9,7 @@ from typing import Any
 
 from keymasq.common.types import JsonObject
 
-DIAGNOSTICS_CATEGORIES = frozenset({"mainline", "combo", "internal"})
+DIAGNOSTICS_CATEGORIES = frozenset({"mainline", "combo", "macro", "internal"})
 DEFAULT_DIAGNOSTICS_CATEGORIES = frozenset({"mainline"})
 
 type DiagnosticsSummary = dict[str, JsonObject]
@@ -46,6 +46,8 @@ def normalize_categories(categories: Sequence[object] | None) -> set[str]:
 
 def label_enabled(label: str, categories: set[str]) -> bool:
     normalized = str(label or "").lower()
+    if "macro" in categories and normalized.startswith("macro_"):
+        return True
     if "internal" in categories and _label_is_internal(normalized):
         return True
     if "combo" in categories and _label_is_combo(normalized):

--- a/keymasq/keymasqd/runtime/macro/cache.py
+++ b/keymasq/keymasqd/runtime/macro/cache.py
@@ -1,0 +1,201 @@
+from __future__ import annotations
+
+import sys
+from collections import OrderedDict
+from dataclasses import dataclass
+from typing import cast
+
+from keymasq.keymasqd.macro_file import MacroFileRevision
+
+DEFAULT_MACRO_CACHE_BYTES = 10 * 1024 * 1024
+MAX_CACHEABLE_MACRO_RUNTIME_US = 2_000_000.0
+MAX_INELIGIBLE_REVISIONS = 256
+_EVENT_SLOT_BYTES = sys.getsizeof((None,)) - sys.getsizeof(())
+
+type MacroEvent = dict[str, object]
+
+
+@dataclass(frozen=True)
+class MacroCacheEntry:
+    revision: MacroFileRevision
+    event_count: int
+    duration_us: int
+    events: tuple[MacroEvent, ...]
+    weight: int
+
+
+class MacroCacheCandidate:
+    """One streamed iteration being considered for cache admission."""
+
+    def __init__(
+        self,
+        cache: MacroReplayCache,
+        revision: MacroFileRevision,
+        *,
+        event_count: int,
+        duration_us: int,
+    ) -> None:
+        self._cache = cache
+        self.revision = revision
+        self.event_count = max(0, int(event_count))
+        self.duration_us = max(0, int(duration_us))
+        self._events: list[MacroEvent] = []
+        self._weight = 0
+        self._active = True
+
+    @property
+    def active(self) -> bool:
+        return self._active
+
+    def observe(self, event: MacroEvent) -> None:
+        if not self._active:
+            return
+        weight = _estimate_event_heap_bytes(event)
+        if not self._cache.reserve_candidate_bytes(weight):
+            self._finish(ineligible=True)
+            return
+        self._events.append(event)
+        self._weight += weight
+
+    def commit(self) -> MacroCacheEntry | None:
+        if not self._active:
+            return None
+        if len(self._events) != self.event_count:
+            self._finish(ineligible=True)
+            return None
+
+        events = tuple(self._events)
+        entry = MacroCacheEntry(
+            revision=self.revision,
+            event_count=self.event_count,
+            duration_us=self.duration_us,
+            events=events,
+            weight=self._weight,
+        )
+        self._cache.commit_candidate(entry, candidate_bytes=self._weight)
+        self._events.clear()
+        self._weight = 0
+        self._active = False
+        return entry
+
+    def reject(self) -> None:
+        self._finish(ineligible=True)
+
+    def discard(self) -> None:
+        self._finish(ineligible=False)
+
+    def _finish(self, *, ineligible: bool) -> None:
+        if not self._active:
+            return
+        self._cache.release_candidate(
+            self.revision,
+            self._weight,
+            ineligible=ineligible,
+        )
+        self._events.clear()
+        self._weight = 0
+        self._active = False
+
+
+class MacroReplayCache:
+    """Daemon-wide LRU of parsed stored-macro revisions."""
+
+    def __init__(self, max_bytes: int = DEFAULT_MACRO_CACHE_BYTES) -> None:
+        self.max_bytes = max(0, int(max_bytes))
+        self._entries: OrderedDict[MacroFileRevision, MacroCacheEntry] = OrderedDict()
+        self._ineligible: OrderedDict[MacroFileRevision, None] = OrderedDict()
+        self._resident_bytes = 0
+        self._candidate_bytes = 0
+
+    @property
+    def total_bytes(self) -> int:
+        return self._resident_bytes + self._candidate_bytes
+
+    def get(self, revision: MacroFileRevision) -> MacroCacheEntry | None:
+        self._discard_other_revisions(revision)
+        entry = self._entries.pop(revision, None)
+        if entry is None:
+            return None
+        self._entries[revision] = entry
+        return entry
+
+    def begin_candidate(
+        self,
+        revision: MacroFileRevision,
+        *,
+        event_count: int,
+        duration_us: int,
+    ) -> MacroCacheCandidate | None:
+        self._discard_other_revisions(revision)
+        if (
+            self.max_bytes <= 0
+            or int(event_count) <= 0
+            or revision in self._entries
+            or revision in self._ineligible
+        ):
+            return None
+        return MacroCacheCandidate(
+            self,
+            revision,
+            event_count=event_count,
+            duration_us=duration_us,
+        )
+
+    def reserve_candidate_bytes(self, weight: int) -> bool:
+        required = max(0, int(weight))
+        while self.total_bytes + required > self.max_bytes and self._entries:
+            _, evicted = self._entries.popitem(last=False)
+            self._resident_bytes -= evicted.weight
+        if self.total_bytes + required > self.max_bytes:
+            return False
+        self._candidate_bytes += required
+        return True
+
+    def commit_candidate(self, entry: MacroCacheEntry, *, candidate_bytes: int) -> None:
+        self._candidate_bytes = max(0, self._candidate_bytes - max(0, candidate_bytes))
+        previous = self._entries.pop(entry.revision, None)
+        if previous is not None:
+            self._resident_bytes -= previous.weight
+        self._entries[entry.revision] = entry
+        self._resident_bytes += entry.weight
+        self._ineligible.pop(entry.revision, None)
+
+    def release_candidate(
+        self,
+        revision: MacroFileRevision,
+        weight: int,
+        *,
+        ineligible: bool,
+    ) -> None:
+        self._candidate_bytes = max(0, self._candidate_bytes - max(0, int(weight)))
+        if not ineligible:
+            return
+        self._ineligible.pop(revision, None)
+        self._ineligible[revision] = None
+        while len(self._ineligible) > MAX_INELIGIBLE_REVISIONS:
+            self._ineligible.popitem(last=False)
+
+    def _discard_other_revisions(self, current: MacroFileRevision) -> None:
+        for revision in tuple(self._entries):
+            if revision.path == current.path and revision != current:
+                entry = self._entries.pop(revision)
+                self._resident_bytes -= entry.weight
+        for revision in tuple(self._ineligible):
+            if revision.path == current.path and revision != current:
+                self._ineligible.pop(revision, None)
+
+
+def _estimate_event_heap_bytes(event: MacroEvent) -> int:
+    """Conservatively account for one independently parsed JSON event."""
+
+    def estimate(value: object) -> int:
+        size = sys.getsizeof(value)
+        if isinstance(value, dict):
+            mapping = cast(dict[object, object], value)
+            size += sum(estimate(key) + estimate(item) for key, item in mapping.items())
+        elif isinstance(value, (list, tuple)):
+            sequence = cast(list[object] | tuple[object, ...], value)
+            size += sum(estimate(item) for item in sequence)
+        return size
+
+    return _EVENT_SLOT_BYTES + estimate(event)

--- a/keymasq/keymasqd/runtime/macro/cache.py
+++ b/keymasq/keymasqd/runtime/macro/cache.py
@@ -52,7 +52,7 @@ class MacroCacheCandidate:
             return
         weight = _estimate_event_heap_bytes(event)
         if not self._cache.reserve_candidate_bytes(weight):
-            self._finish(ineligible=True)
+            self._finish(ineligible=self._weight + weight > self._cache.max_bytes)
             return
         self._events.append(event)
         self._weight += weight

--- a/keymasq/keymasqd/runtime/macro/events.py
+++ b/keymasq/keymasqd/runtime/macro/events.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import time
 from collections.abc import AsyncIterator
 from typing import Any
 
@@ -43,11 +44,35 @@ async def iter_macro_source_events(
     source: MacroEventSource,
     *,
     deps: MacroRuntimeDeps,
+    diagnostic_initial_load_us: float | None = None,
+    cached_events: tuple[dict[str, object], ...] | None = None,
+    verify_cached_revision: bool = False,
 ) -> AsyncIterator[dict[str, object]]:
+    recorder = deps.diagnostics_recorder
+    measure_load = recorder is not None and diagnostic_initial_load_us is not None
+    load_us = float(diagnostic_initial_load_us or 0.0)
+
+    if cached_events is not None:
+        if verify_cached_revision and source.verify_revision is not None:
+            started_ns = time.perf_counter_ns() if measure_load else None
+            await deps.asyncio_mod.to_thread(source.verify_revision)
+            if started_ns is not None:
+                load_us += (time.perf_counter_ns() - started_ns) / 1000.0
+        if measure_load and recorder is not None:
+            recorder("macro_load", load_us)
+        for event in cached_events:
+            yield event
+        return
+
     reader = MacroBatchReader(source)
     while True:
+        started_ns = time.perf_counter_ns() if measure_load else None
         batch = await deps.asyncio_mod.to_thread(reader.next_batch)
+        if started_ns is not None:
+            load_us += (time.perf_counter_ns() - started_ns) / 1000.0
         if not batch:
+            if measure_load and recorder is not None:
+                recorder("macro_load", load_us)
             break
         for event in batch:
             yield event

--- a/keymasq/keymasqd/runtime/macro/scheduler.py
+++ b/keymasq/keymasqd/runtime/macro/scheduler.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import time
 from collections.abc import Awaitable, Callable
 from typing import Any, cast
 
@@ -10,6 +11,10 @@ from keymasq.common.model.actions import (
 )
 from keymasq.keymasqd.macro_file import MacroFileChangedError
 from keymasq.keymasqd.runtime.macro import controls, events, mouse, outputs
+from keymasq.keymasqd.runtime.macro.cache import (
+    MAX_CACHEABLE_MACRO_RUNTIME_US,
+    MacroCacheCandidate,
+)
 from keymasq.keymasqd.runtime.macro.loops import (
     MacroLoopStateMachine,
     is_loop_instance_active,
@@ -79,6 +84,14 @@ async def play_macro_task(
     )
     event_loop = asyncio_mod.get_running_loop()
     loop_state = MacroLoopStateMachine(loop_mode, loop_count)
+    diagnostic_initial_load_us = macro_event_source.diagnostic_initial_load_us
+    cached_events = macro_event_source.cached_events
+    verify_cached_revision = cached_events is not None
+    cache_candidate = (
+        macro_event_source.begin_cache_candidate()
+        if cached_events is None and macro_event_source.begin_cache_candidate is not None
+        else None
+    )
     try:
         if block_mouse_movement:
             acquire_mouse_inhibit(
@@ -90,6 +103,14 @@ async def play_macro_task(
         while True:
             if instance_id in manager.macro_state.cancel_instance_ids:
                 break
+            iteration_started_ns = (
+                time.perf_counter_ns()
+                if cache_candidate is not None
+                or (
+                    diagnostic_initial_load_us is not None and deps.diagnostics_recorder is not None
+                )
+                else None
+            )
             if block_mouse_movement:
                 begin_mouse_suppression(
                     manager,
@@ -114,7 +135,15 @@ async def play_macro_task(
                 deps=deps,
                 control_action_fn=control_action,
                 renew_mouse_suppression_fn=renew_mouse_suppression,
+                diagnostic_initial_load_us=diagnostic_initial_load_us,
+                cached_events=cached_events,
+                verify_cached_revision=verify_cached_revision,
+                cache_candidate=cache_candidate,
             )
+            if diagnostic_initial_load_us is not None:
+                diagnostic_initial_load_us = 0.0
+            if cached_events is not None:
+                verify_cached_revision = True
             if stop_current_run:
                 break
 
@@ -131,6 +160,28 @@ async def play_macro_task(
                             deps=deps,
                         )
                     await asyncio_mod.sleep(remaining)
+
+            iteration_elapsed_us = (
+                max(0, time.perf_counter_ns() - iteration_started_ns) / 1000.0
+                if iteration_started_ns is not None
+                else None
+            )
+            if instance_id not in manager.macro_state.cancel_instance_ids:
+                if iteration_elapsed_us is not None and deps.diagnostics_recorder is not None:
+                    deps.diagnostics_recorder("macro_iteration", iteration_elapsed_us)
+                if cache_candidate is not None:
+                    entry = (
+                        cache_candidate.commit()
+                        if iteration_elapsed_us is not None
+                        and iteration_elapsed_us < MAX_CACHEABLE_MACRO_RUNTIME_US
+                        else None
+                    )
+                    if entry is None and cache_candidate.active:
+                        cache_candidate.reject()
+                    cache_candidate = None
+                    if entry is not None:
+                        cached_events = entry.events
+                        verify_cached_revision = True
 
             if macro_event_source.event_count <= 0 and loop_state.mode in {"hold", "toggle"}:
                 await asyncio_mod.sleep(0.01)
@@ -150,6 +201,8 @@ async def play_macro_task(
     except Exception:
         deps.log.exception("Macro playback aborted")
     finally:
+        if cache_candidate is not None:
+            cache_candidate.discard()
         manager.macro_state.cancel_instance_ids.discard(instance_id)
         release_held(manager, instance_id, deps=deps)
         manager.macro_state.forget_instance(instance_id)
@@ -173,14 +226,26 @@ async def _play_iteration(
     deps: MacroRuntimeDeps,
     control_action_fn: ControlActionRunner,
     renew_mouse_suppression_fn: RuntimeAction,
+    diagnostic_initial_load_us: float | None,
+    cached_events: tuple[dict[str, object], ...] | None,
+    verify_cached_revision: bool,
+    cache_candidate: MacroCacheCandidate | None,
 ) -> bool:
     """Replay one source iteration; return true when a semantic move aborts it."""
 
     asyncio_mod = deps.asyncio_mod
     index = 0
-    async for event in events.iter_macro_source_events(macro_event_source, deps=deps):
+    async for event in events.iter_macro_source_events(
+        macro_event_source,
+        deps=deps,
+        diagnostic_initial_load_us=diagnostic_initial_load_us,
+        cached_events=cached_events,
+        verify_cached_revision=verify_cached_revision,
+    ):
         if instance_id in manager.macro_state.cancel_instance_ids:
             break
+        if cache_candidate is not None:
+            cache_candidate.observe(event)
         if (index & 127) == 127:
             await asyncio_mod.sleep(0)
         index += 1

--- a/keymasq/keymasqd/runtime/macro/state.py
+++ b/keymasq/keymasqd/runtime/macro/state.py
@@ -6,13 +6,18 @@ from collections.abc import Awaitable, Callable, Iterator
 from dataclasses import dataclass, field
 from typing import Any
 
+from keymasq.keymasqd.runtime.macro.cache import MacroCacheCandidate, MacroReplayCache
+
 type IntValueFn = Callable[[object, int], int]
 type StrValueFn = Callable[[object, str], str]
+type DiagnosticRecorder = Callable[[str, float], None]
 type NaturalMacroMover = Callable[
     [int, int, float, float, str, int, int],
     Awaitable[dict[str, object]],
 ]
 type MacroEventIteratorFactory = Callable[[], Iterator[dict[str, object]]]
+type MacroCacheCandidateFactory = Callable[[], MacroCacheCandidate | None]
+type MacroRevisionVerifier = Callable[[], None]
 
 
 @dataclass(frozen=True)
@@ -25,6 +30,7 @@ class MacroRuntimeDeps:
     log: logging.Logger
     int_value_fn: IntValueFn
     str_value_fn: StrValueFn
+    diagnostics_recorder: DiagnosticRecorder | None = None
 
 
 @dataclass
@@ -43,6 +49,7 @@ class MacroRuntimeState:
     exec_waiters: dict[str, asyncio.Future[int]] = field(default_factory=dict)
     mouse_rel_suppressed: bool = False
     mouse_rel_suppression_watchdog_task: asyncio.Task[None] | None = None
+    replay_cache: MacroReplayCache = field(default_factory=MacroReplayCache)
 
     def allocate_instance(
         self,
@@ -84,3 +91,7 @@ class MacroEventSource:
     event_count: int
     duration_us: int
     iter_events: MacroEventIteratorFactory
+    diagnostic_initial_load_us: float | None = None
+    cached_events: tuple[dict[str, object], ...] | None = None
+    verify_revision: MacroRevisionVerifier | None = None
+    begin_cache_candidate: MacroCacheCandidateFactory | None = None

--- a/keymasq/keymasqd/runtime/manager_macros.py
+++ b/keymasq/keymasqd/runtime/manager_macros.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import asyncio
+import time
 from collections.abc import Callable, Iterator
+from functools import partial
 from typing import Any, cast
 
 from keymasq.common.coercion import coerce_int
@@ -12,7 +14,11 @@ from keymasq.keymasqd.runtime.macro.options import (
     MacroPlaybackOptions,
     macro_playback_options_from_mapping,
 )
-from keymasq.keymasqd.runtime.macro.state import MacroEventSource, MacroRuntimeDeps
+from keymasq.keymasqd.runtime.macro.state import (
+    MacroEventSource,
+    MacroRuntimeDeps,
+    MacroRuntimeState,
+)
 
 type MacroRuntimeDepsFactory = Callable[[], MacroRuntimeDeps]
 
@@ -21,6 +27,7 @@ class MacroManagerMixin:
     """Macro playback, storage lookup, and cancellation for ``DeviceManager``."""
 
     macro_store: Any | None
+    macro_state: MacroRuntimeState
 
     def _initialize_macro_runtime(self, deps_factory: MacroRuntimeDepsFactory) -> None:
         self._macro_runtime_deps_factory = deps_factory
@@ -47,34 +54,78 @@ class MacroManagerMixin:
         elif playback_kwargs:
             raise TypeError("playback kwargs cannot be combined with playback_options")
 
+        deps = self._macro_runtime_deps_factory()
         if (
             playback_options.load_stored_macro
             and macro_event_source is None
             and playback_options.macro_name
             and not playback_options.macro_events
         ):
-            macro_event_source = await self._stored_macro_event_source(playback_options.macro_name)
+            macro_event_source = await self._stored_macro_event_source(
+                playback_options.macro_name,
+                deps=deps,
+            )
         return await playback.play_macro(
             self,
             playback_options,
-            deps=self._macro_runtime_deps_factory(),
+            deps=deps,
             macro_event_source=macro_event_source,
         )
 
     async def _stored_macro_event_source(
         self,
         macro_name: str,
+        *,
+        deps: MacroRuntimeDeps,
     ) -> MacroEventSource | None:
         store = self.macro_store
         if store is None:
             return None
+        started_ns = time.perf_counter_ns() if deps.diagnostics_recorder is not None else None
+        revision = await asyncio.to_thread(store.probe_revision, macro_name)
+        if revision is not None:
+            cached = self.macro_state.replay_cache.get(revision)
+            if cached is not None:
+                initial_load_us = (
+                    (time.perf_counter_ns() - started_ns) / 1000.0
+                    if started_ns is not None
+                    else None
+                )
+                return MacroEventSource(
+                    event_count=cached.event_count,
+                    duration_us=cached.duration_us,
+                    iter_events=lambda: iter(cached.events),
+                    diagnostic_initial_load_us=initial_load_us,
+                    cached_events=cached.events,
+                    verify_revision=revision.verify_unchanged,
+                )
+
         snapshot = await asyncio.to_thread(store.open_snapshot, macro_name)
+        initial_load_us = (
+            (time.perf_counter_ns() - started_ns) / 1000.0 if started_ns is not None else None
+        )
         meta = cast(JsonObject, snapshot.meta)
+        event_count = coerce_int(meta.get("event_count"), 0)
+        duration_us = coerce_int(meta.get("duration_us"), 0)
+        snapshot_revision = snapshot.revision
+        begin_cache_candidate = None
+        if snapshot_revision is not None:
+            begin_cache_candidate = partial(
+                self.macro_state.replay_cache.begin_candidate,
+                snapshot_revision,
+                event_count=event_count,
+                duration_us=duration_us,
+            )
 
         return MacroEventSource(
-            event_count=coerce_int(meta.get("event_count"), 0),
-            duration_us=coerce_int(meta.get("duration_us"), 0),
+            event_count=event_count,
+            duration_us=duration_us,
             iter_events=lambda: cast(Iterator[JsonObject], snapshot.iter_events()),
+            diagnostic_initial_load_us=initial_load_us,
+            verify_revision=(
+                snapshot_revision.verify_unchanged if snapshot_revision is not None else None
+            ),
+            begin_cache_candidate=begin_cache_candidate,
         )
 
     async def cancel_macro_playback(self) -> JsonObject:

--- a/tests/gui/test_diagnostics_dialog.py
+++ b/tests/gui/test_diagnostics_dialog.py
@@ -32,6 +32,8 @@ def test_diagnostics_format_helpers() -> None:
     assert _format_latency(1500.0) == "1.50 ms"
     assert _label_title("action_key") == "Action: key"
     assert _label_title("combo_passthrough") == "Combo candidate passthrough"
+    assert _label_title("macro_load") == "Macro loading"
+    assert _label_title("macro_iteration") == "Macro iteration"
     assert _diagnostics_docs_url().endswith("/PERFORMANCE/#diagnostics-labels")
 
 

--- a/tests/keymasqd/daemon_support.py
+++ b/tests/keymasqd/daemon_support.py
@@ -71,10 +71,12 @@ def make_daemon_testbed(monkeypatch):
     macro_store = SimpleNamespace(
         get=Mock(return_value={"events": []}),
         get_meta=Mock(return_value={"events": []}),
+        probe_revision=Mock(return_value=None),
         open_snapshot=Mock(
             return_value=SimpleNamespace(
                 meta={"event_count": 0, "duration_us": 0},
                 iter_events=lambda: iter(()),
+                revision=None,
             )
         ),
         list_meta=Mock(return_value=[]),

--- a/tests/keymasqd/test_device_manager_core.py
+++ b/tests/keymasqd/test_device_manager_core.py
@@ -2427,6 +2427,8 @@ class TestListDevices:
         manager._record_diagnostic("action_key", 20.0)
         manager._record_diagnostic("combo_passthrough", 30.0)
         manager._record_diagnostic("syn", 40.0)
+        manager._record_diagnostic("macro_load", 50.0)
+        manager._record_diagnostic("macro_iteration", 60.0)
 
         assert set(manager.diagnostics_state.samples) == {
             "passthrough_mapped",

--- a/tests/keymasqd/test_device_manager_core.py
+++ b/tests/keymasqd/test_device_manager_core.py
@@ -2435,22 +2435,26 @@ class TestListDevices:
         }
 
     @pytest.mark.asyncio
-    async def test_diagnostics_can_include_combo_and_internal_categories(self) -> None:
+    async def test_diagnostics_can_include_non_default_categories(self) -> None:
         manager = DeviceManager()
         manager.diagnostics_state.enabled = True
-        manager.diagnostics_state.categories = {"combo", "internal"}
+        manager.diagnostics_state.categories = {"combo", "macro", "internal"}
 
         manager._record_diagnostic("passthrough_mapped", 10.0)
         manager._record_diagnostic("combo_passthrough", 20.0)
         manager._record_diagnostic("combo_passthrough_held", 30.0)
         manager._record_diagnostic("syn", 40.0)
         manager._record_diagnostic("combo_recalled_release_suppressed", 50.0)
+        manager._record_diagnostic("macro_load", 60.0)
+        manager._record_diagnostic("macro_iteration", 70.0)
 
         assert set(manager.diagnostics_state.samples) == {
             "combo_passthrough",
             "combo_passthrough_held",
             "syn",
             "combo_recalled_release_suppressed",
+            "macro_load",
+            "macro_iteration",
         }
 
     @pytest.mark.asyncio

--- a/tests/keymasqd/test_macro_backend_recording.py
+++ b/tests/keymasqd/test_macro_backend_recording.py
@@ -17,6 +17,7 @@ from keymasq.common.model.core import ActionType, DeviceType
 from keymasq.keymasqd import device_manager, recording
 from keymasq.keymasqd.device_manager import DeviceManager
 from keymasq.keymasqd.macro_file import MacroFileChangedError
+from keymasq.keymasqd.macro_store import MacroStore
 from keymasq.keymasqd.recording import RecordingManager
 from keymasq.keymasqd.runtime import outputs as global_outputs
 from keymasq.keymasqd.runtime.grabbed_device import device as grabbed_device
@@ -764,8 +765,12 @@ async def test_stored_macro_playback_uses_revision_snapshot(
     snapshot = SimpleNamespace(
         meta={"event_count": 1, "duration_us": 0, "revision": 1},
         iter_events=lambda: iter([{"t_us": 0, "type": 1, "code": 30, "value": 1}]),
+        revision=None,
     )
-    manager.macro_store = SimpleNamespace(open_snapshot=MagicMock(return_value=snapshot))
+    manager.macro_store = SimpleNamespace(
+        probe_revision=MagicMock(return_value=None),
+        open_snapshot=MagicMock(return_value=snapshot),
+    )
 
     async def fake_play_macro_task(_manager: DeviceManager, **_kwargs: object) -> None:
         return None
@@ -778,6 +783,172 @@ async def test_stored_macro_playback_uses_revision_snapshot(
 
     assert result == {"status": "ok"}
     manager.macro_store.open_snapshot.assert_called_once_with("stored")
+
+
+@pytest.mark.asyncio
+async def test_short_stored_macro_streams_once_then_reuses_cached_events(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = DeviceManager()
+    manager.output_state.keyboard_uinput = MagicMock()
+    store = MacroStore(tmp_path / "macros")
+    store.create(
+        {
+            "name": "short",
+            "events": [{"t_us": 0, "macro_action": "wait", "duration_us": 0}],
+        }
+    )
+    snapshot = store.open_snapshot("short")
+    iter_events = MagicMock(wraps=snapshot.iter_events)
+    open_snapshot = MagicMock(
+        return_value=SimpleNamespace(
+            meta=snapshot.meta,
+            iter_events=iter_events,
+            revision=snapshot.revision,
+        )
+    )
+    monkeypatch.setattr(store, "open_snapshot", open_snapshot)
+    manager.macro_store = store
+
+    result = await manager.play_macro(
+        macro_name="short",
+        loop_mode="count",
+        loop_count=3,
+    )
+    await asyncio.gather(*manager.macro_state.tasks.values())
+
+    assert result == {"status": "ok"}
+    assert open_snapshot.call_count == 1
+    assert iter_events.call_count == 1
+    revision = store.probe_revision("short")
+    assert revision is not None
+    entry = manager.macro_state.replay_cache.get(revision)
+    assert entry is not None
+    assert entry.events == ({"t_us": 0, "macro_action": "wait", "duration_us": 0},)
+
+    result = await manager.play_macro(macro_name="short")
+    await asyncio.gather(*manager.macro_state.tasks.values())
+
+    assert result == {"status": "ok"}
+    assert open_snapshot.call_count == 1
+    assert iter_events.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_cached_stored_macro_is_revalidated_when_playback_task_starts(
+    tmp_path: Path,
+) -> None:
+    manager = DeviceManager()
+    manager.output_state.keyboard_uinput = MagicMock()
+    store = MacroStore(tmp_path / "macros")
+    store.create(
+        {
+            "name": "edited",
+            "events": [
+                {
+                    "t_us": 0,
+                    "device_type": "keyboard",
+                    "type": evdev.ecodes.EV_KEY,
+                    "code": evdev.ecodes.KEY_A,
+                    "value": 1,
+                }
+            ],
+        }
+    )
+    manager.macro_store = store
+
+    await manager.play_macro(macro_name="edited")
+    await asyncio.gather(*manager.macro_state.tasks.values())
+    manager.output_state.keyboard_uinput.reset_mock()
+
+    result = await manager.play_macro(macro_name="edited")
+    store.update(
+        "edited",
+        {
+            "events": [
+                {
+                    "t_us": 0,
+                    "device_type": "keyboard",
+                    "type": evdev.ecodes.EV_KEY,
+                    "code": evdev.ecodes.KEY_B,
+                    "value": 1,
+                }
+            ]
+        },
+        expected_revision=1,
+    )
+    await asyncio.gather(*manager.macro_state.tasks.values())
+
+    assert result == {"status": "ok"}
+    manager.output_state.keyboard_uinput.write.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_stored_macro_over_runtime_threshold_is_not_cached(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = DeviceManager()
+    manager.output_state.keyboard_uinput = MagicMock()
+    store = MacroStore(tmp_path / "macros")
+    store.create(
+        {
+            "name": "slow",
+            "events": [{"t_us": 0, "macro_action": "wait", "duration_us": 20_000}],
+        }
+    )
+    open_snapshot = MagicMock(wraps=store.open_snapshot)
+    monkeypatch.setattr(store, "open_snapshot", open_snapshot)
+    monkeypatch.setattr(scheduler, "MAX_CACHEABLE_MACRO_RUNTIME_US", 5_000.0)
+    manager.macro_store = store
+
+    result = await manager.play_macro(macro_name="slow")
+    await asyncio.gather(*manager.macro_state.tasks.values())
+
+    assert result == {"status": "ok"}
+    revision = store.probe_revision("slow")
+    assert revision is not None
+    assert manager.macro_state.replay_cache.get(revision) is None
+
+    result = await manager.play_macro(macro_name="slow")
+    await asyncio.gather(*manager.macro_state.tasks.values())
+
+    assert result == {"status": "ok"}
+    assert open_snapshot.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_stored_macro_diagnostics_measure_load_and_actual_iteration_runtime() -> None:
+    manager = DeviceManager()
+    manager.output_state.keyboard_uinput = MagicMock()
+    manager.diagnostics_state.enabled = True
+    manager.diagnostics_state.categories = {"macro"}
+    snapshot = SimpleNamespace(
+        meta={"event_count": 1, "duration_us": 3, "revision": 1},
+        iter_events=lambda: iter([{"t_us": 0, "macro_action": "wait", "duration_us": 20_000}]),
+        revision=None,
+    )
+    manager.macro_store = SimpleNamespace(
+        probe_revision=MagicMock(return_value=None),
+        open_snapshot=MagicMock(return_value=snapshot),
+    )
+
+    result = await manager.play_macro(
+        macro_name="measured",
+        loop_mode="count",
+        loop_count=2,
+    )
+    await asyncio.gather(*manager.macro_state.tasks.values())
+
+    assert result == {"status": "ok"}
+    manager.macro_store.open_snapshot.assert_called_once_with("measured")
+    load_samples = list(manager.diagnostics_state.samples["macro_load"])
+    iteration_samples = list(manager.diagnostics_state.samples["macro_iteration"])
+    assert len(load_samples) == 2
+    assert all(sample > 0 for sample in load_samples)
+    assert len(iteration_samples) == 2
+    assert all(sample >= 20_000 for sample in iteration_samples)
 
 
 @pytest.mark.asyncio

--- a/tests/keymasqd/test_macro_cache.py
+++ b/tests/keymasqd/test_macro_cache.py
@@ -62,6 +62,32 @@ def test_macro_cache_rejects_revision_that_exceeds_budget(tmp_path: Path) -> Non
     assert cache.begin_candidate(revision, event_count=1, duration_us=0) is None
 
 
+def test_macro_cache_retries_after_transient_candidate_contention(tmp_path: Path) -> None:
+    event = {"t_us": 0}
+    probe_cache = MacroReplayCache()
+    probe_entry = _admit(probe_cache, _revision(tmp_path / "probe", 1), event)
+    cache = MacroReplayCache(max_bytes=probe_entry.weight)
+    first = cache.begin_candidate(
+        _revision(tmp_path / "first", 1),
+        event_count=1,
+        duration_us=0,
+    )
+    second_revision = _revision(tmp_path / "second", 2)
+    second = cache.begin_candidate(second_revision, event_count=1, duration_us=0)
+    assert first is not None
+    assert second is not None
+    first.observe(event)
+
+    second.observe(event)
+
+    assert not second.active
+    first.discard()
+    retry = cache.begin_candidate(second_revision, event_count=1, duration_us=0)
+    assert retry is not None
+    retry.observe(event)
+    assert retry.commit() is not None
+
+
 def test_macro_cache_discard_releases_budget_and_allows_retry(tmp_path: Path) -> None:
     cache = MacroReplayCache()
     revision = _revision(tmp_path / "cancelled", 1)

--- a/tests/keymasqd/test_macro_cache.py
+++ b/tests/keymasqd/test_macro_cache.py
@@ -1,0 +1,101 @@
+from pathlib import Path
+
+from keymasq.keymasqd.macro_file import MacroFileIdentity, MacroFileRevision
+from keymasq.keymasqd.runtime.macro.cache import MacroCacheEntry, MacroReplayCache
+
+
+def _revision(path: Path, serial: int) -> MacroFileRevision:
+    return MacroFileRevision(
+        path=path,
+        identity=MacroFileIdentity(
+            device=1,
+            inode=serial,
+            size=serial,
+            modified_ns=serial,
+        ),
+    )
+
+
+def _admit(
+    cache: MacroReplayCache,
+    revision: MacroFileRevision,
+    event: dict[str, object] | None = None,
+) -> MacroCacheEntry:
+    candidate = cache.begin_candidate(revision, event_count=1, duration_us=0)
+    assert candidate is not None
+    candidate.observe(event or {"t_us": 0, "macro_action": "wait", "duration_us": 0})
+    entry = candidate.commit()
+    assert entry is not None
+    return entry
+
+
+def test_macro_cache_evicts_least_recently_used_entry(tmp_path: Path) -> None:
+    probe_cache = MacroReplayCache()
+    probe_entry = _admit(probe_cache, _revision(tmp_path / "probe", 1))
+    cache = MacroReplayCache(max_bytes=probe_entry.weight * 2)
+    first = _revision(tmp_path / "first", 1)
+    second = _revision(tmp_path / "second", 2)
+    third = _revision(tmp_path / "third", 3)
+
+    _admit(cache, first)
+    _admit(cache, second)
+    assert cache.get(first) is not None
+
+    _admit(cache, third)
+
+    assert cache.get(second) is None
+    assert cache.get(first) is not None
+    assert cache.get(third) is not None
+    assert cache.total_bytes <= cache.max_bytes
+
+
+def test_macro_cache_rejects_revision_that_exceeds_budget(tmp_path: Path) -> None:
+    cache = MacroReplayCache(max_bytes=1)
+    revision = _revision(tmp_path / "large", 1)
+    candidate = cache.begin_candidate(revision, event_count=1, duration_us=0)
+    assert candidate is not None
+
+    candidate.observe({"t_us": 0, "payload": "too large"})
+
+    assert not candidate.active
+    assert cache.total_bytes == 0
+    assert cache.begin_candidate(revision, event_count=1, duration_us=0) is None
+
+
+def test_macro_cache_discard_releases_budget_and_allows_retry(tmp_path: Path) -> None:
+    cache = MacroReplayCache()
+    revision = _revision(tmp_path / "cancelled", 1)
+    candidate = cache.begin_candidate(revision, event_count=1, duration_us=0)
+    assert candidate is not None
+    candidate.observe({"t_us": 0})
+    assert cache.total_bytes > 0
+
+    candidate.discard()
+
+    assert cache.total_bytes == 0
+    assert cache.begin_candidate(revision, event_count=1, duration_us=0) is not None
+
+
+def test_macro_cache_rejects_incomplete_event_stream(tmp_path: Path) -> None:
+    cache = MacroReplayCache()
+    revision = _revision(tmp_path / "truncated", 1)
+    candidate = cache.begin_candidate(revision, event_count=2, duration_us=0)
+    assert candidate is not None
+    candidate.observe({"t_us": 0})
+
+    assert candidate.commit() is None
+    assert cache.total_bytes == 0
+    assert cache.begin_candidate(revision, event_count=2, duration_us=0) is None
+
+
+def test_macro_cache_discards_an_old_revision_for_the_same_path(tmp_path: Path) -> None:
+    cache = MacroReplayCache()
+    path = tmp_path / "edited.kmacro.xz"
+    old_revision = _revision(path, 1)
+    new_revision = _revision(path, 2)
+    _admit(cache, old_revision)
+
+    assert cache.get(new_revision) is None
+
+    assert cache.total_bytes == 0
+    assert cache.get(old_revision) is None

--- a/tests/test_cli_commands_helpers.py
+++ b/tests/test_cli_commands_helpers.py
@@ -190,7 +190,7 @@ def test_mpris_status_cli_prints_controller_state(
                             "artists": ["Artist Name"],
                             "album": "Album Name",
                         },
-                    }
+                    },
                 ],
                 "player_order": [":1.20", ":1.10"],
                 "started_order": [":1.20", ":1.10"],
@@ -483,19 +483,23 @@ def test_set_diagnostics_cli_sends_categories(
         sent.append(payload)
         return {
             "status": "ok",
-            "data": {"enabled": True, "interval": 3.0, "categories": ["mainline", "combo"]},
+            "data": {
+                "enabled": True,
+                "interval": 3.0,
+                "categories": ["mainline", "combo", "macro"],
+            },
         }
 
     monkeypatch.setattr(commands, "_session_request", _session_request)
 
-    commands.set_diagnostics_cli(True, interval=3.0, include=["combo"])
+    commands.set_diagnostics_cli(True, interval=3.0, include=["combo", "macro"])
 
     assert sent == [
         {
             "command": "set_diagnostics",
             "enabled": True,
             "interval": 3.0,
-            "categories": ["mainline", "combo"],
+            "categories": ["mainline", "combo", "macro"],
         }
     ]
     assert "categories=mainline, combo" in capsys.readouterr().out

--- a/tests/test_cli_commands_helpers.py
+++ b/tests/test_cli_commands_helpers.py
@@ -502,7 +502,9 @@ def test_set_diagnostics_cli_sends_categories(
             "categories": ["mainline", "combo", "macro"],
         }
     ]
-    assert "categories=mainline, combo" in capsys.readouterr().out
+    assert capsys.readouterr().out == (
+        "Diagnostics enabled (interval=3.00s, categories=mainline, combo, macro)\n"
+    )
 
 
 def test_type_cli_compiles_and_sends_payload(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_macro_file.py
+++ b/tests/test_macro_file.py
@@ -86,6 +86,20 @@ def test_macro_snapshot_detects_removed_source(tmp_path: Path) -> None:
         list(snapshot.iter_events())
 
 
+def test_macro_snapshot_detects_replacement_with_unchanged_metadata(tmp_path: Path) -> None:
+    path = tmp_path / "macro.kmacro.xz"
+    meta = MacroFileMeta(name="macro", event_count=1)
+    write_macro(path, meta, [{"type": 1, "code": 30, "value": 1, "t_us": 0}])
+    snapshot = MacroFileSnapshot(path)
+
+    write_macro(path, meta, [{"type": 1, "code": 31, "value": 1, "t_us": 0}])
+
+    with pytest.raises(MacroFileChangedError):
+        list(snapshot.iter_events())
+    with pytest.raises(MacroFileChangedError):
+        snapshot.revision.verify_unchanged()
+
+
 def test_macro_snapshot_repeated_streams_do_not_hold_descriptors(tmp_path: Path) -> None:
     path = tmp_path / "macro.kmacro.xz"
     events = [{"type": 1, "code": 30, "value": 1, "t_us": 0}]


### PR DESCRIPTION
## Summary

- Add a daemon-wide, revision-keyed LRU cache for parsed stored-macro events, bounded to 10 MiB of estimated heap use
- Stream the first complete iteration from the compressed macro file and admit it only when its actual wall-clock runtime is under two seconds, including timeline delays, explicit waits, synchronous commands, and trailing duration
- Keep long, oversized, cancelled, failed, and incomplete iterations on the streaming path; internal macros continue using their existing in-memory representation
- Validate the macro file identity before cache reuse and between loop repetitions so edits, renames, or deletion stop reuse of stale events
- Add the `macro` diagnostics category with separate `macro_load` and `macro_iteration` measurements in the CLI, GUI, tests, and documentation

## Benchmark

These are controlled **in-process microbenchmarks**, not live-daemon measurements. The harness used the real `DeviceManager`, `MacroStore`, compressed `.kmacro.xz` files, scheduler, revision validation, and cache. Uinput was mocked and filesystem pages were warm for both paths. The numbers exclude daemon/session IPC, systemd scheduling, and real uinput writes.

For separately triggered macros, the baseline used the same playback path with the replay cache disabled:

| Events | Runs | Streamed trigger p50 | Cached trigger p50 | Reduction |
|---:|---:|---:|---:|---:|
| 1 | 1,000 | 784.28 µs | 241.98 µs | 69.1% |
| 8 | 750 | 833.30 µs | 259.35 µs | 68.9% |
| 32 | 500 | 953.66 µs | 347.54 µs | 63.6% |
| 128 | 250 | 1,489.81 µs | 586.55 µs | 60.6% |

A one-event macro repeated 2,000 times from a single count-mode trigger improved from **528.92 ms to 222.82 ms** overall. Median per-iteration load work fell from **221.92 µs to 81.82 µs**.

## Testing

- `./scripts/check.sh`
- Ruff: passed
- basedpyright: passed
- stylelint: passed
- pytest: **2,624 passed, 25 skipped**
- Focused coverage includes cache admission, LRU eviction, heap-budget rejection, cancellation cleanup, incomplete streams, revision replacement, loop reuse, later-trigger reuse, and wall-clock runtime rejection
