### PR TITLE
Improve Macro Manager row actions and search

### DIFF
--- a/docs/MACROS.md
+++ b/docs/MACROS.md
@@ -356,9 +356,15 @@ responsible for the result.
 
 ## Editing Macros
 
-Open a saved macro in the editor from Macro Manager (or from a profile's macro
-action context). The editor shows your macro as a visual timeline of keyboard,
-mouse, and movement events.
+Open a saved macro in the editor from Macro Manager — click anywhere on its
+row, or use the pencil button (or open it from a profile's macro action
+context). Clicking a temporary recording slot row opens the save dialog
+instead. Right-clicking a saved macro's row opens a context menu with **Copy
+Name** (copies the exact macro name for use in profiles, superkeys, combos, or
+the CLI), **Play**, **Edit**, **Duplicate**, and **Delete**. In Macro Manager
+you can also just start typing (or press Ctrl+F) to filter the list by name,
+device type, or event count. The editor shows your macro as a visual timeline
+of keyboard, mouse, and movement events.
 
 You can:
 

--- a/keymasq/gui/widgets/macro_manager/actions.py
+++ b/keymasq/gui/widgets/macro_manager/actions.py
@@ -2,12 +2,20 @@
 
 # pyright: reportAttributeAccessIssue=false, reportUnknownMemberType=false
 
+from collections.abc import Callable
+
 import gi
 
 gi.require_version("Gtk", "4.0")
 gi.require_version("Adw", "1")
 
-from gi.repository import Adw, Gtk  # pyright: ignore[reportAttributeAccessIssue]
+from gi.repository import (  # pyright: ignore[reportAttributeAccessIssue]
+    Adw,  # pyright: ignore[reportAttributeAccessIssue]
+    Gdk,  # pyright: ignore[reportAttributeAccessIssue]
+    Gio,  # pyright: ignore[reportAttributeAccessIssue]
+    GLib,  # pyright: ignore[reportAttributeAccessIssue]
+    Gtk,  # pyright: ignore[reportAttributeAccessIssue]
+)
 
 from keymasq.gui.session_client import GuiTaskResult, JsonDict
 from keymasq.gui.widgets.macro_manager.state import (
@@ -22,20 +30,123 @@ class MacroActionsMixin:
     def _on_edit_clicked(self, _btn: Gtk.Button, name: str) -> None:
         self._open_macro_editor(name)
 
+    def _on_row_right_pressed(
+        self,
+        gesture: Gtk.GestureClick,
+        _n_press: int,
+        x: float,
+        y: float,
+        row: Gtk.ListBoxRow,
+        name: str,
+    ) -> None:
+        gesture.set_state(Gtk.EventSequenceState.CLAIMED)
+        self._listbox.select_row(row)
+        self._show_macro_context_menu(row, name, x, y)
+
+    def _show_macro_context_menu(
+        self,
+        row: Gtk.ListBoxRow,
+        name: str,
+        x: float,
+        y: float,
+    ) -> None:
+        def make_action(action_name: str, handler: Callable[[], None]) -> Gio.SimpleAction:
+            def on_activate(_action: Gio.SimpleAction, _param: object) -> None:
+                handler()
+
+            action = Gio.SimpleAction.new(action_name, None)
+            action.connect("activate", on_activate)
+            return action
+
+        def copy_name() -> None:
+            self._copy_macro_name(name)
+
+        def play() -> None:
+            self._play_macro(name)
+
+        def edit() -> None:
+            self._open_macro_editor(name)
+
+        def duplicate() -> None:
+            self._duplicate_macro(name)
+
+        def delete() -> None:
+            self._on_delete_clicked(None, name)
+
+        actions = Gio.SimpleActionGroup()
+        menu = Gio.Menu()
+        for action_name, label, handler in (
+            ("copy-name", "Copy Name", copy_name),
+            ("play", "Play", play),
+            ("edit", "Edit", edit),
+            ("duplicate", "Duplicate", duplicate),
+        ):
+            actions.add_action(make_action(action_name, handler))
+            menu.append(label, f"macro-row.{action_name}")
+
+        actions.add_action(make_action("delete", delete))
+        delete_section = Gio.Menu()
+        delete_section.append("Delete", "macro-row.delete")
+        menu.append_section(None, delete_section)
+
+        row.insert_action_group("macro-row", actions)
+        popover = Gtk.PopoverMenu.new_from_model(menu)
+        popover.set_parent(row)
+        popover.set_has_arrow(False)
+        popover.set_halign(Gtk.Align.START)
+        pointing_rect = Gdk.Rectangle()
+        pointing_rect.x = int(x)
+        pointing_rect.y = int(y)
+        pointing_rect.width = 1
+        pointing_rect.height = 1
+        popover.set_pointing_to(pointing_rect)
+        popover.connect("closed", self._on_context_menu_closed, row)
+        popover.popup()
+
+    def _on_context_menu_closed(self, popover: Gtk.PopoverMenu, row: Gtk.ListBoxRow) -> None:
+        # Unparenting while the menu-item activation is still being dispatched
+        # would cancel it, so defer teardown to idle.
+        def teardown() -> bool:
+            popover.unparent()
+            row.insert_action_group("macro-row", None)
+            return False
+
+        GLib.idle_add(teardown)
+
+    def _copy_macro_name(self, name: str) -> None:
+        display = Gdk.Display.get_default()
+        if display is not None:
+            display.get_clipboard().set(name)
+
+    def _on_row_activated(self, _listbox: Gtk.ListBox, row: Gtk.ListBoxRow) -> None:
+        macro = getattr(row, "_macro", None)
+        state = getattr(row, "_row_state", None)
+        if not isinstance(macro, dict) or state is None:
+            return
+        if state.is_temporary_slot:
+            self._on_save_slot_clicked(None, macro)
+        elif state.name:
+            self._open_macro_editor(state.name)
+
     def _on_duplicate_clicked(
         self,
         _btn: Gtk.Button,
         name: str,
         duplicate_btn: Gtk.Button,
     ) -> None:
+        self._duplicate_macro(name, duplicate_btn)
+
+    def _duplicate_macro(self, name: str, duplicate_btn: Gtk.Button | None = None) -> None:
         def request_duplicate() -> JsonDict | None:
             return self._duplicate_macro_request(name)
 
         def on_duplicate_start() -> None:
-            duplicate_btn.set_sensitive(False)
+            if duplicate_btn is not None:
+                duplicate_btn.set_sensitive(False)
 
         def on_duplicate_done() -> None:
-            duplicate_btn.set_sensitive(True)
+            if duplicate_btn is not None:
+                duplicate_btn.set_sensitive(True)
 
         self._run_gui_task(
             request_duplicate,
@@ -72,7 +183,7 @@ class MacroActionsMixin:
         dialog.present(self._parent)
         return False
 
-    def _on_save_slot_clicked(self, _btn: Gtk.Button, macro: JsonDict) -> None:
+    def _on_save_slot_clicked(self, _btn: Gtk.Button | None, macro: JsonDict) -> None:
         from keymasq.gui.widgets.save_macro_dialog import SaveMacroDialog
 
         dialog = SaveMacroDialog(self._parent, dict(macro))
@@ -133,7 +244,11 @@ class MacroActionsMixin:
         self._load_macros()
 
     def _on_play_clicked(self, play_btn: Gtk.Button, name: str) -> None:
-        play_btn.set_sensitive(False)
+        self._play_macro(name, play_btn)
+
+    def _play_macro(self, name: str, play_btn: Gtk.Button | None = None) -> None:
+        if play_btn is not None:
+            play_btn.set_sensitive(False)
 
         def on_play_requested(result: JsonDict | None) -> bool:
             return self._on_play_requested(result, play_btn)
@@ -146,12 +261,13 @@ class MacroActionsMixin:
     def _on_play_requested(
         self,
         _result: JsonDict | None,
-        play_btn: Gtk.Button,
+        play_btn: Gtk.Button | None,
     ) -> bool:
-        play_btn.set_sensitive(True)
+        if play_btn is not None:
+            play_btn.set_sensitive(True)
         return False
 
-    def _on_delete_clicked(self, _btn: Gtk.Button, name: str) -> None:
+    def _on_delete_clicked(self, _btn: Gtk.Button | None, name: str) -> None:
         dialog = Adw.AlertDialog()
         dialog.set_heading("Delete Macro")
         dialog.set_body(f"Delete '{name}'? This cannot be undone.")

--- a/keymasq/gui/widgets/macro_manager/catalog.py
+++ b/keymasq/gui/widgets/macro_manager/catalog.py
@@ -72,20 +72,33 @@ class CatalogControllerMixin:
         while self._listbox.get_first_child():
             self._listbox.remove(self._listbox.get_first_child())
 
-        if not self._catalog.macros:
-            self._empty_label.set_visible(True)
-            return
-
-        self._empty_label.set_visible(False)
         for macro in self._catalog.macros:
             self._listbox.append(self._build_macro_row(macro))
         self._listbox.invalidate_filter()
+        self._update_empty_state()
+
+    def _update_empty_state(self) -> None:
+        if not self._catalog.macros:
+            self._empty_label.set_label("No macros recorded yet")
+            self._empty_label.set_visible(True)
+            return
+        if self._catalog.query and not self._catalog.filtered_macros():
+            self._empty_label.set_label("No macros match your search")
+            self._empty_label.set_visible(True)
+            return
+        self._empty_label.set_visible(False)
 
     def _build_macro_row(self, macro: JsonDict) -> Gtk.ListBoxRow:
         state = MacroRowState.from_macro(macro)
         row = Gtk.ListBoxRow()
-        row.set_selectable(False)
         row._search_text = state.search_text
+        row._macro = macro
+        row._row_state = state
+        if not state.is_temporary_slot and state.name:
+            right_click = Gtk.GestureClick()
+            right_click.set_button(3)
+            right_click.connect("pressed", self._on_row_right_pressed, row, state.name)
+            row.add_controller(right_click)
 
         row_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=8)
         row_box.set_margin_top(6)

--- a/keymasq/gui/widgets/macro_manager/view.py
+++ b/keymasq/gui/widgets/macro_manager/view.py
@@ -106,8 +106,9 @@ class ManagerViewMixin:
         scrolled.set_vexpand(True)
 
         self._listbox = Gtk.ListBox()
-        self._listbox.set_selection_mode(Gtk.SelectionMode.NONE)
+        self._listbox.set_selection_mode(Gtk.SelectionMode.SINGLE)
         self._listbox.add_css_class("boxed-list")
+        self._listbox.connect("row-activated", self._on_row_activated)
         install_listbox_fuzzy_filter(self._listbox, self._search_entry)
         scrolled.set_child(self._listbox)
         content.append(scrolled)
@@ -156,7 +157,35 @@ class ManagerViewMixin:
         if keyval in (Gdk.KEY_f, Gdk.KEY_F) and state & Gdk.ModifierType.CONTROL_MASK:
             self._show_search()
             return True
-        return False
+        if keyval == Gdk.KEY_Escape and self._search_entry.get_visible():
+            self._hide_search()
+            return True
+        if state & (
+            Gdk.ModifierType.CONTROL_MASK
+            | Gdk.ModifierType.ALT_MASK
+            | Gdk.ModifierType.SUPER_MASK
+            | Gdk.ModifierType.META_MASK
+        ):
+            return False
+        if self._search_focused():
+            return False
+        unicode_value = Gdk.keyval_to_unicode(keyval)
+        if not unicode_value:
+            return False
+        char = chr(unicode_value)
+        if not char.isprintable() or char.isspace():
+            return False
+        self._show_search()
+        self._search_entry.set_text(char)
+        self._search_entry.set_position(-1)
+        return True
+
+    def _search_focused(self) -> bool:
+        root = self.get_root()
+        focus = root.get_focus() if root is not None else None
+        return focus is not None and (
+            focus is self._search_entry or focus.is_ancestor(self._search_entry)
+        )
 
     def _show_search(self) -> None:
         self._catalog.show_search()
@@ -168,9 +197,11 @@ class ManagerViewMixin:
         self._catalog.hide_search()
         self._search_entry.set_text("")
         self._search_entry.set_visible(False)
+        self._update_empty_state()
 
     def _on_search_changed(self, entry: Gtk.SearchEntry) -> None:
         self._catalog.set_query(entry.get_text())
+        self._update_empty_state()
 
     def _on_search_clicked(self, _button: Gtk.Button) -> None:
         self._show_search()

--- a/tests/gui/test_gui_demo_and_dialogs.py
+++ b/tests/gui/test_gui_demo_and_dialogs.py
@@ -2231,6 +2231,181 @@ class TestDialogConstruction:
         assert captured["callback"] == dialog._on_editor_closed
         assert captured["present_parent"] is parent
 
+    def test_macro_manager_row_activation_opens_editor_or_slot_save(self, monkeypatch):
+        gi.require_version("Gtk", "4.0")
+        from gi.repository import GLib, Gtk
+
+        from keymasq.gui.widgets.macro_manager_dialog import MacroManagerDialog
+
+        monkeypatch.setattr(GLib, "idle_add", lambda callback, *args: 0)
+        dialog = MacroManagerDialog(Gtk.Window())
+        dialog._on_macros_loaded(
+            {
+                "macros": [
+                    {
+                        "name": "stored",
+                        "duration_us": 250_000,
+                        "device_types": ["keyboard"],
+                        "event_count": 2,
+                    },
+                    {
+                        "name": "slot_1",
+                        "kind": "recording_slot",
+                        "recording_slot": 1,
+                        "duration_us": 100_000,
+                        "event_count": 1,
+                    },
+                ]
+            }
+        )
+
+        opened: list[str] = []
+        saved: list[dict] = []
+        monkeypatch.setattr(dialog, "_open_macro_editor", opened.append)
+        monkeypatch.setattr(
+            dialog,
+            "_on_save_slot_clicked",
+            lambda _btn, macro: saved.append(macro),
+        )
+
+        dialog._on_row_activated(dialog._listbox, dialog._listbox.get_row_at_index(0))
+        assert opened == ["stored"]
+        assert saved == []
+
+        dialog._on_row_activated(dialog._listbox, dialog._listbox.get_row_at_index(1))
+        assert opened == ["stored"]
+        assert saved and saved[0]["name"] == "slot_1"
+
+    def test_macro_manager_row_context_menu_lists_actions(self, monkeypatch):
+        gi.require_version("Gtk", "4.0")
+        from gi.repository import GLib, Gtk
+
+        from keymasq.gui.widgets.macro_manager_dialog import MacroManagerDialog
+
+        monkeypatch.setattr(GLib, "idle_add", lambda callback, *args: 0)
+        dialog = MacroManagerDialog(Gtk.Window())
+        dialog._on_macros_loaded(
+            {
+                "macros": [
+                    {
+                        "name": "stored",
+                        "duration_us": 250_000,
+                        "device_types": ["keyboard"],
+                        "event_count": 2,
+                    },
+                    {
+                        "name": "slot_1",
+                        "kind": "recording_slot",
+                        "recording_slot": 1,
+                        "duration_us": 100_000,
+                        "event_count": 1,
+                    },
+                ]
+            }
+        )
+
+        popovers: list[Gtk.PopoverMenu] = []
+        monkeypatch.setattr(Gtk.PopoverMenu, "popup", lambda popover: popovers.append(popover))
+
+        row = dialog._listbox.get_row_at_index(0)
+
+        class FakeGesture:
+            def set_state(self, _state) -> bool:
+                return True
+
+        dialog._on_row_right_pressed(FakeGesture(), 1, 10.0, 10.0, row, "stored")
+
+        assert dialog._listbox.get_selected_row() is row
+        assert len(popovers) == 1
+        model = popovers[0].get_menu_model()
+        labels: list[str] = []
+        for index in range(model.get_n_items()):
+            label = model.get_item_attribute_value(index, "label", None)
+            if label is not None:
+                labels.append(label.get_string())
+                continue
+            section = model.get_item_link(index, "section")
+            assert section is not None
+            for section_index in range(section.get_n_items()):
+                section_label = section.get_item_attribute_value(section_index, "label", None)
+                assert section_label is not None
+                labels.append(section_label.get_string())
+        assert labels == ["Copy Name", "Play", "Edit", "Duplicate", "Delete"]
+
+        called: list[str] = []
+        monkeypatch.setattr(dialog, "_open_macro_editor", called.append)
+        assert row.activate_action("macro-row.edit") is True
+        assert called == ["stored"]
+
+        copied: list[str] = []
+        monkeypatch.setattr(dialog, "_copy_macro_name", copied.append)
+        assert row.activate_action("macro-row.copy-name") is True
+        assert copied == ["stored"]
+
+        slot_row = dialog._listbox.get_row_at_index(1)
+        assert slot_row.observe_controllers().get_n_items() == 0
+
+    def test_macro_manager_typing_starts_search(self, monkeypatch):
+        gi.require_version("Gtk", "4.0")
+        from gi.repository import Gdk, GLib, Gtk
+
+        from keymasq.gui.widgets.macro_manager_dialog import MacroManagerDialog
+
+        monkeypatch.setattr(GLib, "idle_add", lambda callback, *args: 0)
+        dialog = MacroManagerDialog(Gtk.Window())
+
+        assert dialog._search_entry.get_visible() is False
+        assert dialog._on_key_pressed(None, Gdk.KEY_d, 0, Gdk.ModifierType(0)) is True
+        assert dialog._search_entry.get_visible() is True
+        assert dialog._search_entry.get_text() == "d"
+
+        assert dialog._on_key_pressed(None, Gdk.KEY_Escape, 0, Gdk.ModifierType(0)) is True
+        assert dialog._search_entry.get_visible() is False
+        assert dialog._search_entry.get_text() == ""
+
+        modified = dialog._on_key_pressed(
+            None,
+            Gdk.KEY_d,
+            0,
+            Gdk.ModifierType.CONTROL_MASK,
+        )
+        assert modified is False
+        assert dialog._search_entry.get_visible() is False
+
+    def test_macro_manager_search_without_matches_shows_empty_state(self, monkeypatch):
+        gi.require_version("Gtk", "4.0")
+        from gi.repository import GLib, Gtk
+
+        from keymasq.gui.widgets.macro_manager_dialog import MacroManagerDialog
+
+        monkeypatch.setattr(GLib, "idle_add", lambda callback, *args: 0)
+        dialog = MacroManagerDialog(Gtk.Window())
+        dialog._on_macros_loaded(
+            {
+                "macros": [
+                    {
+                        "name": "stored",
+                        "duration_us": 250_000,
+                        "device_types": ["keyboard"],
+                        "event_count": 2,
+                    }
+                ]
+            }
+        )
+        assert dialog._empty_label.get_visible() is False
+
+        dialog._show_search()
+        dialog._search_entry.set_text("zzzz")
+        assert dialog._empty_label.get_visible() is True
+        assert dialog._empty_label.get_label() == "No macros match your search"
+
+        dialog._search_entry.set_text("stored")
+        assert dialog._empty_label.get_visible() is False
+
+        dialog._search_entry.set_text("zzzz")
+        dialog._hide_search()
+        assert dialog._empty_label.get_visible() is False
+
     def test_macro_manager_initial_state_populates_macro_rows(self, monkeypatch):
         gi.require_version("Gtk", "4.0")
         from gi.repository import GLib, Gtk


### PR DESCRIPTION
## Summary
- Click a saved macro row to open the editor; temporary recording slots open the save dialog instead
- Right-click saved macros for a context menu: Copy Name, Play, Edit, Duplicate, Delete
- Type-to-search (or Ctrl+F) filters the list; Escape hides search; empty states distinguish no macros vs no matches
- Document the new Macro Manager UX in `docs/MACROS.md`

## Testing
- Added GUI tests for row activation, context menu actions, type-to-search/Escape, and no-match empty state (`tests/gui/test_gui_demo_and_dialogs.py`)
- Ran: full `./scripts/check.sh`