### PR TITLE
Harden state consistency across profiles, macros, and settings

### DIFF
--- a/docs/ACTIONS.md
+++ b/docs/ACTIONS.md
@@ -563,6 +563,11 @@ after_actions = 1
 timeout_ms = 1500
 ```
 
+Hand-edited `on_trigger_end` values are parsed with Keymasq's tolerant boolean
+coercion for compatibility: common strings such as `"false"` and `"true"`, and
+numeric `0` and `1`, keep their expected meaning. A later save writes the
+canonical TOML boolean form.
+
 ![Profile tab — Toggle/Enable/Disable dropdown and profile selector](assets/screenshots/key_selector_profile.png)
 
 ## Action Modifiers

--- a/docs/ACTIONS.md
+++ b/docs/ACTIONS.md
@@ -565,8 +565,9 @@ timeout_ms = 1500
 
 Hand-edited `on_trigger_end` values are parsed with Keymasq's tolerant boolean
 coercion for compatibility: common strings such as `"false"` and `"true"`, and
-numeric `0` and `1`, keep their expected meaning. A later save writes the
-canonical TOML boolean form.
+numeric `0` and `1`, keep their expected meaning. A later save emits
+`on_trigger_end = true` only when enabled; coerced false values are omitted
+rather than written as `false`.
 
 ![Profile tab — Toggle/Enable/Disable dropdown and profile selector](assets/screenshots/key_selector_profile.png)
 

--- a/docs/GAMEPAD.md
+++ b/docs/GAMEPAD.md
@@ -327,6 +327,10 @@ the GUI hamburger menu under **Settings**. The setting is stored in
 virtual_count = 1
 ```
 
+If the setting cannot be written to disk, the requested count remains active
+for the current session and Keymasq shows a warning that it may revert after a
+restart.
+
 Each virtual gamepad uses Xbox 360 hardware IDs:
 
 - **Name**: `keymasq-gamepad` (first), `keymasq-gamepad-2` through `-4`

--- a/docs/MACROS.md
+++ b/docs/MACROS.md
@@ -150,6 +150,8 @@ devices from direct physical input sources.
 Recording preferences are stored in
 `~/.config/keymasq/recording_settings.toml`. Device-specific overrides use
 stable recording IDs instead of volatile `/dev/input/eventN` paths.
+If the preferences cannot be written to disk, they remain active for the
+current session and Keymasq warns that they may revert after a restart.
 
 ![Recording settings — initial mouse position and source options](assets/screenshots/keymasq_macro_recording_settings.png)
 

--- a/docs/MACROS.md
+++ b/docs/MACROS.md
@@ -368,7 +368,9 @@ you can also just start typing (or press Ctrl+F) to filter the list by name,
 device type, or event count. The editor shows your macro as a visual timeline
 of keyboard, mouse, and movement events. While the saved macro is being loaded,
 the editor stays read-only behind a spinner, so edits can't be made and lost
-before the existing content arrives.
+before the existing content arrives. The same read-only state is shown while
+applying or saving changes, preventing newer edits from being mistaken for
+persisted ones.
 
 You can:
 

--- a/docs/MACROS.md
+++ b/docs/MACROS.md
@@ -366,7 +366,9 @@ Name** (copies the exact macro name for use in profiles, superkeys, combos, or
 the CLI), **Play**, **Edit**, **Duplicate**, and **Delete**. In Macro Manager
 you can also just start typing (or press Ctrl+F) to filter the list by name,
 device type, or event count. The editor shows your macro as a visual timeline
-of keyboard, mouse, and movement events.
+of keyboard, mouse, and movement events. While the saved macro is being loaded,
+the editor stays read-only behind a spinner, so edits can't be made and lost
+before the existing content arrives.
 
 You can:
 

--- a/docs/MACROS.md
+++ b/docs/MACROS.md
@@ -374,6 +374,10 @@ persisted ones. Save failures are shown immediately. If a renamed macro is saved
 successfully but its old file cannot be removed, the editor keeps the successful
 save and warns that both names remain.
 
+The editor only starts with an empty document when opened through **Create Empty
+Macro**. If an existing macro cannot be loaded, the editor closes and shows the
+daemon or filesystem error instead of treating the failed load as a new macro.
+
 You can:
 
 - Add or delete individual events.

--- a/docs/MACROS.md
+++ b/docs/MACROS.md
@@ -370,7 +370,9 @@ of keyboard, mouse, and movement events. While the saved macro is being loaded,
 the editor stays read-only behind a spinner, so edits can't be made and lost
 before the existing content arrives. The same read-only state is shown while
 applying or saving changes, preventing newer edits from being mistaken for
-persisted ones.
+persisted ones. Save failures are shown immediately. If a renamed macro is saved
+successfully but its old file cannot be removed, the editor keeps the successful
+save and warns that both names remain.
 
 You can:
 

--- a/docs/PROFILES.md
+++ b/docs/PROFILES.md
@@ -93,9 +93,11 @@ Profiles are stored in:
 
 The visible profile name can contain arbitrary characters. The on-disk filename is derived from that name by replacing unsafe filename characters so the file always stays inside `profiles/`.
 
-Keymasq keeps at least one editable profile. On first start, and whenever the
-session reloads an empty profiles directory, `keymasq-session` seeds a permanent
-profile named `Default` so new devices can be remapped immediately.
+Keymasq keeps at least one editable profile. On startup when no valid profile can
+be loaded, and whenever the session reloads an empty profiles directory,
+`keymasq-session` seeds a permanent profile named `Default` so new devices can
+be remapped immediately. Existing files are never overwritten; filename
+collisions use `Default_2.toml`, `Default_3.toml`, and so on.
 
 Hardware definitions are still separate:
 

--- a/docs/PROFILES.md
+++ b/docs/PROFILES.md
@@ -152,6 +152,11 @@ The last applied mapping wins. In practice:
 - if priorities are equal, newer `created_at` overrides older
 - if both are equal, name order is the tiebreaker
 
+`created_at` is internal ordering bookkeeping. Keymasq stores it as a quoted,
+timezone-naive ISO timestamp. Missing, malformed, timezone-aware, or native TOML
+datetime values are replaced with the current time and repaired to that
+canonical form when the profile loads.
+
 Conditional profiles always override permanent profiles, even if the permanent profile has a higher numeric priority.
 
 Runtime profile activations are temporary overlays. They do not write

--- a/docs/PROFILES.md
+++ b/docs/PROFILES.md
@@ -252,6 +252,11 @@ action = "mpris"
 command = "play_pause"
 ```
 
+Window-rule fields are `class`, `title`, and `tag`. The hand-edited alias
+`tags` is accepted and normalized to `tag` on the next save. Unknown fields and
+unexpected non-string class/title values safely fail to match instead of
+interrupting profile resolution.
+
 `activation_macro` and `deactivation_macro` are optional stored macro names.
 When set, `keymasq-session` asks `keymasqd` to play the macro after the global
 active profile set changes. They fire once when a profile enters or leaves the

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -355,6 +355,12 @@ Relevant controls:
     defaults to `10`, and `0` disables the time limit
   - `macro_edit_requires_unlock`
 
+Policy boolean values must use the TOML literals `true` or `false`. Strings,
+numbers, arrays, and other types are rejected rather than interpreted by
+truthiness. An invalid security policy prevents both `keymasqd` and
+`keymasq-session` from starting; their logs identify the invalid field so the
+administrator can correct `/etc/keymasq/security.toml` and restart the services.
+
 Empty UID allowlists mean no UID restriction. This is the default and is appropriate for single-user desktops. On multi-user systems, populate `daemon_allowed_uids` and `session_allowed_uids` to restrict access to specific users.
 
 `[recording_guard].unlock_required` controls whether sensitive original-input

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -367,6 +367,9 @@ without restarting services:
 systemctl --user kill --signal=HUP keymasq-session
 ```
 
+SIGHUP reloads use a 500 ms debounce. Additional SIGHUP requests received while
+the reload is pending or running are dropped rather than queued.
+
 ### `keymasq-session` user service does not start
 
 Symptoms:

--- a/keymasq/common/coercion.py
+++ b/keymasq/common/coercion.py
@@ -1,3 +1,4 @@
+import math
 from collections.abc import Callable
 from typing import cast, overload
 
@@ -108,7 +109,7 @@ def coerce_float(
     value: object,
     default: float | None = 0.0,
 ) -> float | None:
-    """Return float(value), or default when the value is missing or invalid."""
+    """Return a finite float(value), or default when missing or invalid."""
     return _coerce_number(value, default, _coerce_float)
 
 
@@ -154,7 +155,10 @@ def _coerce_int(value: object) -> int:
 
 
 def _coerce_float(value: object) -> float:
-    return float(cast(_NumberInput, value))
+    converted = float(cast(_NumberInput, value))
+    if not math.isfinite(converted):
+        raise ValueError("float must be finite")
+    return converted
 
 
 def _is_empty_number_text(value: object) -> bool:

--- a/keymasq/common/model/actions.py
+++ b/keymasq/common/model/actions.py
@@ -4,7 +4,7 @@ import logging
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Protocol, cast
 
-from keymasq.common.coercion import bool_value, coerce_int
+from keymasq.common.coercion import bool_value, coerce_bool, coerce_int
 from keymasq.common.gamepad_axes import clamp_gamepad_axis_value, normalize_gamepad_axis_target
 from keymasq.common.model.core import ActionType
 
@@ -299,7 +299,7 @@ def parse_profile_deactivation_policy(data: object) -> ProfileDeactivationPolicy
         return None
     payload = cast(dict[str, object], data)
     policy = ProfileDeactivationPolicy(
-        on_trigger_end=bool(payload.get("on_trigger_end", False)),
+        on_trigger_end=coerce_bool(payload.get("on_trigger_end"), False),
         after_actions=_positive_int_or_none(payload.get("after_actions")),
         timeout_ms=_positive_int_or_none(payload.get("timeout_ms")),
     )

--- a/keymasq/common/security.py
+++ b/keymasq/common/security.py
@@ -50,6 +50,14 @@ def _to_int_list(value: Any, setting_name: str) -> list[int]:
     return out
 
 
+def _to_bool(value: Any, setting_name: str, default: bool) -> bool:
+    if value is None:
+        return default
+    if not isinstance(value, bool):
+        raise SecurityPolicyError(f"{setting_name} must be a boolean")
+    return value
+
+
 def load_security_policy(config_path: Path) -> SecurityPolicy:
     policy = SecurityPolicy()
 
@@ -86,11 +94,15 @@ def load_security_policy(config_path: Path) -> SecurityPolicy:
     recording_guard_cfg = raw.get("recording_guard")
     if isinstance(recording_guard_cfg, dict):
         recording_guard = cast(dict[str, Any], recording_guard_cfg)
-        policy.recording_unlock_required = bool(
-            recording_guard.get("unlock_required", policy.recording_unlock_required)
+        policy.recording_unlock_required = _to_bool(
+            recording_guard.get("unlock_required"),
+            "recording_guard.unlock_required",
+            policy.recording_unlock_required,
         )
-        policy.macro_edit_requires_unlock = bool(
-            recording_guard.get("macro_edit_requires_unlock", policy.macro_edit_requires_unlock)
+        policy.macro_edit_requires_unlock = _to_bool(
+            recording_guard.get("macro_edit_requires_unlock"),
+            "recording_guard.macro_edit_requires_unlock",
+            policy.macro_edit_requires_unlock,
         )
         time_limit = recording_guard.get(
             "macro_recording_time_limit",
@@ -109,11 +121,10 @@ def load_security_policy(config_path: Path) -> SecurityPolicy:
     gui_cfg = raw.get("gui")
     if isinstance(gui_cfg, dict):
         gui_settings = cast(dict[str, Any], gui_cfg)
-        policy.emergency_cancel_combo_enabled = bool(
-            gui_settings.get(
-                "emergency_cancel_combo_enabled",
-                policy.emergency_cancel_combo_enabled,
-            )
+        policy.emergency_cancel_combo_enabled = _to_bool(
+            gui_settings.get("emergency_cancel_combo_enabled"),
+            "gui.emergency_cancel_combo_enabled",
+            policy.emergency_cancel_combo_enabled,
         )
 
     return policy

--- a/keymasq/gui/widgets/diagnostics_dialog.py
+++ b/keymasq/gui/widgets/diagnostics_dialog.py
@@ -328,6 +328,8 @@ class DiagnosticsDialog(Adw.Dialog):
             self._syncing_controls = False
 
     def _on_diagnostics_snapshot(self, event: JsonDict) -> bool:
+        if self._closing:
+            return False
         samples = event.get("samples")
         if not isinstance(samples, dict):
             return False

--- a/keymasq/gui/widgets/macro_editor/controller/lifecycle.py
+++ b/keymasq/gui/widgets/macro_editor/controller/lifecycle.py
@@ -57,6 +57,7 @@ class LifecycleControllerMixin:
         self._show_unsaved_close_warning()
 
     def _force_close_without_warning(self) -> None:
+        self._load_aborted = True
         self._cancel_capture_start_position("")
         self._cancel_capture_selected_move("")
         self.set_can_close(True)

--- a/keymasq/gui/widgets/macro_editor/controller/lifecycle.py
+++ b/keymasq/gui/widgets/macro_editor/controller/lifecycle.py
@@ -57,7 +57,7 @@ class LifecycleControllerMixin:
         self._show_unsaved_close_warning()
 
     def _force_close_without_warning(self) -> None:
-        self._load_aborted = True
+        self._dialog_closed = True
         self._cancel_capture_start_position("")
         self._cancel_capture_selected_move("")
         self.set_can_close(True)

--- a/keymasq/gui/widgets/macro_editor/controller/load.py
+++ b/keymasq/gui/widgets/macro_editor/controller/load.py
@@ -46,16 +46,9 @@ class LoadControllerMixin:
         )
 
     def _exit_loading_state(self) -> None:
-        if (
-            self._load_aborted
-            or self._loading_overlay is None
-            or self._editor_content is None
-        ):
+        if self._dialog_closed:
             return
-        self._loading_overlay.set_visible(False)
-        self._editor_content.set_sensitive(True)
-        if self._loading_spinner is not None:
-            self._loading_spinner.stop()
+        self._set_editor_busy(False)
 
     def _load_initial_state(self) -> dict[str, object]:
         timeout_max = 30000
@@ -85,7 +78,7 @@ class LoadControllerMixin:
         }
 
     def _on_initial_state_loaded(self, result: GuiTaskResult[dict[str, object]]) -> bool:
-        if self._load_aborted:
+        if self._dialog_closed:
             return False
         payload = result.value if result.ok and isinstance(result.value, dict) else {}
         timeout_max_raw = payload.get("timeout_max", 30000)

--- a/keymasq/gui/widgets/macro_editor/controller/load.py
+++ b/keymasq/gui/widgets/macro_editor/controller/load.py
@@ -4,6 +4,12 @@
 
 from typing import Any
 
+import gi
+
+gi.require_version("Adw", "1")
+
+from gi.repository import Adw  # pyright: ignore[reportAttributeAccessIssue]
+
 from keymasq.gui.session_client import GuiTaskResult
 from keymasq.gui.widgets.macro_editor.document import MacroDocument, selection_order
 
@@ -61,26 +67,48 @@ class LoadControllerMixin:
             timeout_max = 30000
 
         macro: dict[str, Any] | None = None
-        try:
-            response = (
-                self._session_request({"command": "get_macro", "name": self._macro_name}) or {}
-            )
-            loaded_macro = response.get("macro")
-            if response.get("status") == "ok" and isinstance(loaded_macro, dict):
-                macro = loaded_macro
-        except (OSError, RuntimeError, TypeError, ValueError):
-            macro = None
+        macro_load_error: str | None = None
+        if not self._create_new:
+            try:
+                response = (
+                    self._session_request({"command": "get_macro", "name": self._macro_name})
+                    or {}
+                )
+                loaded_macro = response.get("macro")
+                if response.get("status") == "ok" and isinstance(loaded_macro, dict):
+                    macro = loaded_macro
+                else:
+                    macro_load_error = str(
+                        response.get("message", "Failed to load macro")
+                        or "Failed to load macro"
+                    )
+            except (OSError, RuntimeError, TypeError, ValueError) as exc:
+                macro_load_error = str(exc).strip() or exc.__class__.__name__
 
         return {
             "timeout_max": max(1, timeout_max),
             "compositor_status": compositor_status,
             "macro": macro,
+            "macro_load_error": macro_load_error,
         }
 
     def _on_initial_state_loaded(self, result: GuiTaskResult[dict[str, object]]) -> bool:
         if self._dialog_closed:
             return False
         payload = result.value if result.ok and isinstance(result.value, dict) else {}
+        load_error = payload.get("macro_load_error")
+        if result.error is not None:
+            load_error = str(result.error).strip() or result.error.__class__.__name__
+        if (
+            not self._create_new
+            and not isinstance(payload.get("macro"), dict)
+            and not load_error
+        ):
+            load_error = "The macro response did not contain a valid macro"
+        if isinstance(load_error, str) and load_error:
+            self._show_macro_load_error(load_error)
+            return False
+
         timeout_max_raw = payload.get("timeout_max", 30000)
         timeout_max = timeout_max_raw if isinstance(timeout_max_raw, int) else 30000
         self._macro_exec_timeout_max_ms = max(1, timeout_max)
@@ -108,6 +136,16 @@ class LoadControllerMixin:
         self._initial_state_loaded = True
         self._sync_close_guard()
         return False
+
+    def _show_macro_load_error(self, message: str) -> None:
+        self._force_close_without_warning()
+        dialog = Adw.AlertDialog()
+        dialog.set_heading("Unable To Load Macro")
+        dialog.set_body(message)
+        dialog.add_response("ok", "OK")
+        dialog.set_default_response("ok")
+        dialog.set_close_response("ok")
+        dialog.present(self._parent)
 
     def _refresh_loaded_macro_state(self) -> None:
         self._update_stats()

--- a/keymasq/gui/widgets/macro_editor/controller/load.py
+++ b/keymasq/gui/widgets/macro_editor/controller/load.py
@@ -42,7 +42,20 @@ class LoadControllerMixin:
         self._run_gui_task(
             self._load_initial_state,
             self._on_initial_state_loaded,
+            on_done=self._exit_loading_state,
         )
+
+    def _exit_loading_state(self) -> None:
+        if (
+            self._load_aborted
+            or self._loading_overlay is None
+            or self._editor_content is None
+        ):
+            return
+        self._loading_overlay.set_visible(False)
+        self._editor_content.set_sensitive(True)
+        if self._loading_spinner is not None:
+            self._loading_spinner.stop()
 
     def _load_initial_state(self) -> dict[str, object]:
         timeout_max = 30000
@@ -72,6 +85,8 @@ class LoadControllerMixin:
         }
 
     def _on_initial_state_loaded(self, result: GuiTaskResult[dict[str, object]]) -> bool:
+        if self._load_aborted:
+            return False
         payload = result.value if result.ok and isinstance(result.value, dict) else {}
         timeout_max_raw = payload.get("timeout_max", 30000)
         timeout_max = timeout_max_raw if isinstance(timeout_max_raw, int) else 30000

--- a/keymasq/gui/widgets/macro_editor/controller/save.py
+++ b/keymasq/gui/widgets/macro_editor/controller/save.py
@@ -114,13 +114,22 @@ class SaveControllerMixin:
             )
             if create_result.get("status") != "ok":
                 return create_result
-            delete_result = self._session_request(
-                {
-                    "command": "delete_macro",
-                    "name": target.current_name,
-                    "expected_revision": target.revision,
-                }
-            ) or {}
+            try:
+                delete_result = self._session_request(
+                    {
+                        "command": "delete_macro",
+                        "name": target.current_name,
+                        "expected_revision": target.revision,
+                    }
+                ) or {}
+            except (OSError, RuntimeError) as exc:
+                detail = str(exc).strip() or exc.__class__.__name__
+                create_result["warning"] = (
+                    f"Macro saved as '{target.requested_name}', but removal of "
+                    f"'{target.current_name}' could not be confirmed: {detail}. "
+                    "Check whether both macros remain."
+                )
+                return create_result
             if delete_result.get("status") != "ok":
                 detail = str(
                     delete_result.get("message", "Failed to remove the old macro")

--- a/keymasq/gui/widgets/macro_editor/controller/save.py
+++ b/keymasq/gui/widgets/macro_editor/controller/save.py
@@ -114,13 +114,23 @@ class SaveControllerMixin:
             )
             if create_result.get("status") != "ok":
                 return create_result
-            self._session_request(
+            delete_result = self._session_request(
                 {
                     "command": "delete_macro",
                     "name": target.current_name,
                     "expected_revision": target.revision,
                 }
-            )
+            ) or {}
+            if delete_result.get("status") != "ok":
+                detail = str(
+                    delete_result.get("message", "Failed to remove the old macro")
+                    or "Failed to remove the old macro"
+                )
+                create_result["warning"] = (
+                    f"Macro saved as '{target.requested_name}', but "
+                    f"'{target.current_name}' could not be removed: {detail}. "
+                    "Both macros remain."
+                )
             return create_result
 
         return (
@@ -153,6 +163,9 @@ class SaveControllerMixin:
 
         self._apply_saved_macro_state(payload, requested_name, requested_payload)
         self._notify_session_reload()
+        warning = payload.get("warning")
+        if isinstance(warning, str) and warning.strip():
+            self._show_save_warning(warning)
         if close_after_save:
             self._force_close_without_warning()
         return False
@@ -305,6 +318,15 @@ class SaveControllerMixin:
     def _show_save_error(self, message: str) -> None:
         dialog = Adw.AlertDialog()
         dialog.set_heading("Unable To Save Macro")
+        dialog.set_body(message)
+        dialog.add_response("ok", "OK")
+        dialog.set_default_response("ok")
+        dialog.set_close_response("ok")
+        dialog.present(self._parent)
+
+    def _show_save_warning(self, message: str) -> None:
+        dialog = Adw.AlertDialog()
+        dialog.set_heading("Macro Saved With Warning")
         dialog.set_body(message)
         dialog.add_response("ok", "OK")
         dialog.set_default_response("ok")

--- a/keymasq/gui/widgets/macro_editor/controller/save.py
+++ b/keymasq/gui/widgets/macro_editor/controller/save.py
@@ -114,22 +114,13 @@ class SaveControllerMixin:
             )
             if create_result.get("status") != "ok":
                 return create_result
-            try:
-                delete_result = self._session_request(
-                    {
-                        "command": "delete_macro",
-                        "name": target.current_name,
-                        "expected_revision": target.revision,
-                    }
-                ) or {}
-            except (OSError, RuntimeError, TypeError, ValueError) as exc:
-                detail = str(exc).strip() or exc.__class__.__name__
-                create_result["warning"] = (
-                    f"Macro saved as '{target.requested_name}', but removal of "
-                    f"'{target.current_name}' could not be confirmed: {detail}. "
-                    "Check whether both macros remain."
-                )
-                return create_result
+            delete_result = self._session_request(
+                {
+                    "command": "delete_macro",
+                    "name": target.current_name,
+                    "expected_revision": target.revision,
+                }
+            ) or {}
             if delete_result.get("status") != "ok":
                 detail = str(
                     delete_result.get("message", "Failed to remove the old macro")

--- a/keymasq/gui/widgets/macro_editor/controller/save.py
+++ b/keymasq/gui/widgets/macro_editor/controller/save.py
@@ -122,7 +122,7 @@ class SaveControllerMixin:
                         "expected_revision": target.revision,
                     }
                 ) or {}
-            except (OSError, RuntimeError) as exc:
+            except (OSError, RuntimeError, TypeError, ValueError) as exc:
                 detail = str(exc).strip() or exc.__class__.__name__
                 create_result["warning"] = (
                     f"Macro saved as '{target.requested_name}', but removal of "

--- a/keymasq/gui/widgets/macro_editor/controller/save.py
+++ b/keymasq/gui/widgets/macro_editor/controller/save.py
@@ -58,6 +58,7 @@ class SaveControllerMixin:
 
         def on_save_start() -> None:
             self._set_save_controls_sensitive(False, extra_button=btn)
+            self._set_editor_busy(True, "Saving macro…")
 
         def on_save_done() -> None:
             self._finish_save_request(extra_button=btn)
@@ -86,6 +87,9 @@ class SaveControllerMixin:
 
     def _finish_save_request(self, *, extra_button: Gtk.Button | None = None) -> None:
         self._save_in_flight = False
+        if self._dialog_closed:
+            return
+        self._set_editor_busy(False)
         self._set_save_controls_sensitive(True, extra_button=extra_button)
         self._sync_close_guard()
 
@@ -188,7 +192,7 @@ class SaveControllerMixin:
         _set_entry_text_if_needed(self._name_entry, saved_name)
         self.set_title(f"Edit macro ({saved_name})")
         self._initial_state_loaded = True
-        self._initial_macro_data = self._current_macro_payload()
+        self._initial_macro_data = copy.deepcopy(saved_macro)
         self._sync_close_guard()
 
     def _on_save_as_copy(self, _btn) -> None:

--- a/keymasq/gui/widgets/macro_editor/dialog.py
+++ b/keymasq/gui/widgets/macro_editor/dialog.py
@@ -80,6 +80,7 @@ class MacroEditorDialog(
         macro_name: str,
         *,
         select_initial_event: bool = True,
+        create_new: bool = False,
     ):
         dialog_width, dialog_height = _compute_macro_editor_dialog_size(parent)
         super().__init__(
@@ -90,6 +91,7 @@ class MacroEditorDialog(
         self._parent = parent
         self._macro_name = macro_name
         self._select_initial_event = bool(select_initial_event)
+        self._create_new = bool(create_new)
         self._macro_data: dict = {}
         self._events: list[EditableEvent] = []
         self._rel_events: list[MacroEvent] = []

--- a/keymasq/gui/widgets/macro_editor/dialog.py
+++ b/keymasq/gui/widgets/macro_editor/dialog.py
@@ -144,6 +144,10 @@ class MacroEditorDialog(
         self._close_warning_dialog: Adw.AlertDialog | None = None
         self._save_in_flight = False
         self._footer_action_buttons: list[Gtk.Button] = []
+        self._editor_content: Gtk.Widget | None = None
+        self._loading_overlay: Gtk.Widget | None = None
+        self._loading_spinner: Gtk.Spinner | None = None
+        self._load_aborted: bool = False
         self._updating_props = False
         self._drag_locked: bool = True
         self._erase_mode: bool = False
@@ -160,6 +164,9 @@ class MacroEditorDialog(
             .macro-editor-outline {
                 border: 1px solid #000;
                 border-radius: 6px;
+            }
+            .macro-editor-loading-overlay {
+                background-color: alpha(@window_bg_color, 0.7);
             }
             """
         )

--- a/keymasq/gui/widgets/macro_editor/dialog.py
+++ b/keymasq/gui/widgets/macro_editor/dialog.py
@@ -145,9 +145,10 @@ class MacroEditorDialog(
         self._save_in_flight = False
         self._footer_action_buttons: list[Gtk.Button] = []
         self._editor_content: Gtk.Widget | None = None
-        self._loading_overlay: Gtk.Widget | None = None
-        self._loading_spinner: Gtk.Spinner | None = None
-        self._load_aborted: bool = False
+        self._editor_busy_overlay: Gtk.Widget | None = None
+        self._editor_busy_spinner: Gtk.Spinner | None = None
+        self._editor_busy_label: Gtk.Label | None = None
+        self._dialog_closed: bool = False
         self._updating_props = False
         self._drag_locked: bool = True
         self._erase_mode: bool = False
@@ -165,7 +166,7 @@ class MacroEditorDialog(
                 border: 1px solid #000;
                 border-radius: 6px;
             }
-            .macro-editor-loading-overlay {
+            .macro-editor-busy-overlay {
                 background-color: alpha(@window_bg_color, 0.7);
             }
             """

--- a/keymasq/gui/widgets/macro_editor/panel/chrome.py
+++ b/keymasq/gui/widgets/macro_editor/panel/chrome.py
@@ -35,7 +35,33 @@ class EditorChromeMixin:
         frame = Gtk.Frame()
         frame.add_css_class("macro-editor-outline")
         frame.set_child(root)
-        self.set_child(frame)
+
+        loading_content = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=8)
+        loading_content.set_halign(Gtk.Align.CENTER)
+        loading_content.set_valign(Gtk.Align.CENTER)
+        loading_spinner = Gtk.Spinner()
+        loading_spinner.set_size_request(32, 32)
+        loading_content.append(loading_spinner)
+        loading_label = Gtk.Label(label="Loading macro…")
+        loading_label.add_css_class("dim-label")
+        loading_content.append(loading_label)
+
+        loading_overlay = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
+        loading_overlay.add_css_class("macro-editor-loading-overlay")
+        loading_overlay.append(loading_content)
+
+        overlay = Gtk.Overlay()
+        overlay.set_child(frame)
+        overlay.add_overlay(loading_overlay)
+        self.set_child(overlay)
+
+        # The editor starts read-only until the initial macro load finishes;
+        # see LoadControllerMixin._exit_loading_state.
+        self._editor_content = frame
+        self._loading_overlay = loading_overlay
+        self._loading_spinner = loading_spinner
+        frame.set_sensitive(False)
+        loading_spinner.start()
         GLib.idle_add(self._update_canvas_width)
 
     def _build_toolbar(self) -> Gtk.Widget:

--- a/keymasq/gui/widgets/macro_editor/panel/chrome.py
+++ b/keymasq/gui/widgets/macro_editor/panel/chrome.py
@@ -36,33 +36,46 @@ class EditorChromeMixin:
         frame.add_css_class("macro-editor-outline")
         frame.set_child(root)
 
-        loading_content = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=8)
-        loading_content.set_halign(Gtk.Align.CENTER)
-        loading_content.set_valign(Gtk.Align.CENTER)
-        loading_spinner = Gtk.Spinner()
-        loading_spinner.set_size_request(32, 32)
-        loading_content.append(loading_spinner)
-        loading_label = Gtk.Label(label="Loading macro…")
-        loading_label.add_css_class("dim-label")
-        loading_content.append(loading_label)
+        busy_content = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=8)
+        busy_content.set_halign(Gtk.Align.CENTER)
+        busy_content.set_valign(Gtk.Align.CENTER)
+        busy_spinner = Gtk.Spinner()
+        busy_spinner.set_size_request(32, 32)
+        busy_content.append(busy_spinner)
+        busy_label = Gtk.Label(label="Loading macro…")
+        busy_label.add_css_class("dim-label")
+        busy_content.append(busy_label)
 
-        loading_overlay = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
-        loading_overlay.add_css_class("macro-editor-loading-overlay")
-        loading_overlay.append(loading_content)
+        busy_overlay = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
+        busy_overlay.add_css_class("macro-editor-busy-overlay")
+        busy_overlay.append(busy_content)
 
         overlay = Gtk.Overlay()
         overlay.set_child(frame)
-        overlay.add_overlay(loading_overlay)
+        overlay.add_overlay(busy_overlay)
         self.set_child(overlay)
 
-        # The editor starts read-only until the initial macro load finishes;
-        # see LoadControllerMixin._exit_loading_state.
         self._editor_content = frame
-        self._loading_overlay = loading_overlay
-        self._loading_spinner = loading_spinner
-        frame.set_sensitive(False)
-        loading_spinner.start()
+        self._editor_busy_overlay = busy_overlay
+        self._editor_busy_spinner = busy_spinner
+        self._editor_busy_label = busy_label
+        self._set_editor_busy(True, "Loading macro…")
         GLib.idle_add(self._update_canvas_width)
+
+    def _set_editor_busy(self, busy: bool, message: str = "") -> None:
+        if self._dialog_closed:
+            return
+        if self._editor_content is not None:
+            self._editor_content.set_sensitive(not busy)
+        if self._editor_busy_overlay is not None:
+            self._editor_busy_overlay.set_visible(busy)
+        if message and self._editor_busy_label is not None:
+            self._editor_busy_label.set_label(message)
+        if self._editor_busy_spinner is not None:
+            if busy:
+                self._editor_busy_spinner.start()
+            else:
+                self._editor_busy_spinner.stop()
 
     def _build_toolbar(self) -> Gtk.Widget:
         bar = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=6)

--- a/keymasq/gui/widgets/macro_manager/actions.py
+++ b/keymasq/gui/widgets/macro_manager/actions.py
@@ -231,12 +231,12 @@ class MacroActionsMixin:
         return False
 
     def _open_empty_macro_editor(self, name: str) -> None:
-        self._open_macro_editor(name)
+        self._open_macro_editor(name, create_new=True)
 
-    def _open_macro_editor(self, name: str) -> None:
+    def _open_macro_editor(self, name: str, *, create_new: bool = False) -> None:
         from keymasq.gui.widgets.macro_editor.dialog import MacroEditorDialog
 
-        dialog = MacroEditorDialog(self._parent, name)
+        dialog = MacroEditorDialog(self._parent, name, create_new=create_new)
         dialog.connect("closed", self._on_editor_closed)
         dialog.present(self._parent)
 

--- a/keymasq/gui/widgets/settings_dialog.py
+++ b/keymasq/gui/widgets/settings_dialog.py
@@ -171,6 +171,7 @@ class SettingsDialog(Adw.Dialog):
                 raw_saved = response.get("virtual_gamepad_count", count)
                 saved_count = _count_value(raw_saved, count)
                 applied_count = clamp_virtual_gamepad_count(saved_count)
+                warning = str(response.get("warning") or "")
                 if save_seq != self._save_seq:
                     if save_seq > self._applied_save_seq:
                         self._applied_gamepad_count = applied_count
@@ -187,6 +188,7 @@ class SettingsDialog(Adw.Dialog):
                 self._save_applied = True
                 self._gamepad_count = applied_count
                 self._sync_gamepad_count_controls()
+                self._status.set_text(warning)
                 return False
             if save_seq != self._save_seq:
                 return False

--- a/keymasq/session/manager/command/settings.py
+++ b/keymasq/session/manager/command/settings.py
@@ -1,3 +1,4 @@
+import logging
 from typing import TYPE_CHECKING, cast
 
 from keymasq.common.coercion import coerce_int
@@ -15,6 +16,18 @@ from .common import daemon_unavailable_response, send_daemon_request
 
 if TYPE_CHECKING:
     from ..core import SessionManager
+
+log = logging.getLogger("keymasq-session")
+_PERSISTENCE_WARNING = (
+    "Virtual gamepad count was applied for this session but could not be saved. "
+    "It may revert after Keymasq restarts."
+)
+
+
+def _warn_persistence_failed(manager: "SessionManager") -> str:
+    log.exception("Failed to persist virtual gamepad count; keeping the runtime value")
+    manager.send_notification("Keymasq Settings Warning", _PERSISTENCE_WARNING)
+    return _PERSISTENCE_WARNING
 
 
 async def handle_virtual_gamepad_commands(
@@ -46,17 +59,25 @@ async def handle_virtual_gamepad_commands(
         if isinstance(response.data, dict):
             data = cast(JsonObject, response.data)
             count = coerce_int(data.get("count"), count)
-    count = save_virtual_gamepad_count(count)
+    persistence_warning = ""
+    try:
+        count = save_virtual_gamepad_count(count)
+    except OSError:
+        persistence_warning = _warn_persistence_failed(manager)
     manager.virtual_gamepad_count = count
     manager.broadcast_to_session_clients(
         {"event": "virtual_gamepads_changed", "count": int(manager.virtual_gamepad_count)}
     )
-    return {
+    payload: JsonObject = {
         "status": "ok",
         "count": int(manager.virtual_gamepad_count),
         "min_count": MIN_VIRTUAL_GAMEPADS,
         "max_count": MAX_VIRTUAL_GAMEPADS,
     }
+    if persistence_warning:
+        payload["persisted"] = False
+        payload["warning"] = persistence_warning
+    return payload
 
 
 async def handle_settings_commands(
@@ -98,13 +119,21 @@ async def handle_settings_commands(
             data = cast(JsonObject, response.data)
             count = coerce_int(data.get("count"), count)
 
-    saved = save_global_settings(
-        GlobalSettings(
-            virtual_gamepad_count=count,
+    persistence_warning = ""
+    try:
+        saved = save_global_settings(
+            GlobalSettings(
+                virtual_gamepad_count=count,
+            )
         )
-    )
-    manager.virtual_gamepad_count = saved.virtual_gamepad_count
+        count = saved.virtual_gamepad_count
+    except OSError:
+        persistence_warning = _warn_persistence_failed(manager)
+    manager.virtual_gamepad_count = count
     payload = _settings_payload(manager)
+    if persistence_warning:
+        payload["persisted"] = False
+        payload["warning"] = persistence_warning
     manager.broadcast_to_session_clients(
         {
             "event": "settings_changed",

--- a/keymasq/session/manager/command/settings.py
+++ b/keymasq/session/manager/command/settings.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 from typing import TYPE_CHECKING, cast
 
@@ -61,7 +62,7 @@ async def handle_virtual_gamepad_commands(
             count = coerce_int(data.get("count"), count)
     persistence_warning = ""
     try:
-        count = save_virtual_gamepad_count(count)
+        count = await asyncio.to_thread(save_virtual_gamepad_count, count)
     except OSError:
         persistence_warning = _warn_persistence_failed(manager)
     manager.virtual_gamepad_count = count
@@ -121,10 +122,11 @@ async def handle_settings_commands(
 
     persistence_warning = ""
     try:
-        saved = save_global_settings(
+        saved = await asyncio.to_thread(
+            save_global_settings,
             GlobalSettings(
                 virtual_gamepad_count=count,
-            )
+            ),
         )
         count = saved.virtual_gamepad_count
     except OSError:

--- a/keymasq/session/manager/core.py
+++ b/keymasq/session/manager/core.py
@@ -57,6 +57,7 @@ class SessionManager(SessionServerMixin, ConfigWatcherMixin, DaemonConnectionMix
     RECORDING_SETTINGS_PATH = CONFIG_DIR / "recording_settings.toml"
     MAX_SESSION_CLIENT_BUFFER_BYTES = 16 * 1024 * 1024
     SESSION_CLIENT_CLOSE_TIMEOUT_S = 0.5
+    RELOAD_DEBOUNCE_S = 0.5
 
     def __init__(self, verbosity: int = 0) -> None:
         async def _client_event_handler(event_type: CommandType, data: JsonObject) -> None:
@@ -287,19 +288,19 @@ class SessionManager(SessionServerMixin, ConfigWatcherMixin, DaemonConnectionMix
             log.debug("Reload already pending, skipping")
             return
 
-        self.reload_pending = True
-
         if self.reload_task and not self.reload_task.done():
-            log.debug("Reload task still running, will retry after")
+            log.debug("Reload task still running, dropping reload request")
             return
 
+        self.reload_pending = True
         log.info("Received reload signal (SIGHUP)")
         self.reload_task = asyncio.create_task(self.reload_profiles())
 
     async def reload_profiles(self) -> bool:
-        await asyncio.sleep(0.05)
-
-        self.reload_pending = False
+        try:
+            await asyncio.sleep(self.RELOAD_DEBOUNCE_S)
+        finally:
+            self.reload_pending = False
 
         try:
             await asyncio.to_thread(self.reload_config_from_disk)

--- a/keymasq/session/manager/profile/application.py
+++ b/keymasq/session/manager/profile/application.py
@@ -632,37 +632,31 @@ async def apply_resolved_device_profile(
     prepared_mapping = _prepare_mapping(manager, hardware_id, resolved)
     if prepared_mapping is None:
         return
-    mapping_dispatched = False
-    try:
-        log.info(
-            "Grabbing device %s (interfaces: %s)",
-            hardware_id,
-            list(new_interfaces.keys()),
-        )
-        grab_outcome = await _send_grab_device_command(
-            manager,
-            hardware_id,
-            resolved,
-            grab_payload,
-            grab_signature,
-            new_interfaces,
-            operations,
-            generation=generation,
-        )
-        if grab_outcome is _GrabOutcome.STOP:
-            return
-        mapping_dispatched = True
-        await _send_set_mapping_command(
-            manager,
-            hardware_id,
-            resolved,
-            _notify,
-            generation=generation,
-            prepared=prepared_mapping,
-        )
-    finally:
-        if not mapping_dispatched:
-            references.discard(manager, prepared_mapping.refs)
+    log.info(
+        "Grabbing device %s (interfaces: %s)",
+        hardware_id,
+        list(new_interfaces.keys()),
+    )
+    grab_outcome = await _send_grab_device_command(
+        manager,
+        hardware_id,
+        resolved,
+        grab_payload,
+        grab_signature,
+        new_interfaces,
+        operations,
+        generation=generation,
+    )
+    if grab_outcome is _GrabOutcome.STOP:
+        return
+    await _send_set_mapping_command(
+        manager,
+        hardware_id,
+        resolved,
+        _notify,
+        generation=generation,
+        prepared=prepared_mapping,
+    )
 
 
 async def update_grab_device_payload(

--- a/keymasq/session/manager/profile/application.py
+++ b/keymasq/session/manager/profile/application.py
@@ -214,6 +214,36 @@ class _GrabOutcome(Enum):
     STOP = auto()
 
 
+@dataclass(frozen=True, slots=True)
+class _PreparedMapping:
+    payload: JsonObject
+    refs: references.ReferenceSnapshot
+
+
+def _prepare_mapping(
+    manager: "SessionManager",
+    hardware_id: str,
+    resolved: ResolvedDeviceProfile,
+) -> _PreparedMapping | None:
+    """Serialize a mapping without replacing the currently acknowledged refs."""
+
+    previous_refs = references.take_device(manager, hardware_id)
+    staged_refs: references.ReferenceSnapshot | None = None
+    try:
+        payload = mapping.serialize(manager, resolved, hardware_id)
+        staged_refs = references.take_device(manager, hardware_id)
+    except Exception:
+        log.exception("Failed to prepare mapping for %s before device grab", hardware_id)
+        return None
+    finally:
+        if staged_refs is None:
+            references.discard(manager, references.take_device(manager, hardware_id))
+        references.restore_device(manager, hardware_id, previous_refs)
+
+    assert staged_refs is not None
+    return _PreparedMapping(payload=payload, refs=staged_refs)
+
+
 async def _reconcile_existing_grab(
     manager: "SessionManager",
     hardware_id: str,
@@ -419,6 +449,7 @@ async def _send_set_mapping_command(
     notify: ProfileActivationNotifier,
     *,
     generation: int | None,
+    prepared: _PreparedMapping | None = None,
 ) -> None:
     log.info(
         "Setting mapping for %s with %d buttons from profiles=%s",
@@ -426,20 +457,15 @@ async def _send_set_mapping_command(
         len(resolved.mappings),
         resolved.active_profile_names,
     )
-    previous_refs = references.take_device(manager, hardware_id)
-    staged_refs: references.ReferenceSnapshot | None = None
+    prepared = prepared or _prepare_mapping(manager, hardware_id, resolved)
+    if prepared is None:
+        return
+
+    staged_refs = prepared.refs
     keep_staged_refs = False
     try:
-        try:
-            serialized_mapping = mapping.serialize(manager, resolved, hardware_id)
-            staged_refs = references.take_device(manager, hardware_id)
-        finally:
-            if staged_refs is None:
-                references.take_device(manager, hardware_id)
-            references.restore_device(manager, hardware_id, previous_refs)
-        assert staged_refs is not None
         references.expose(manager, staged_refs)
-        log.debug("Mapping data: %s", mapping.log_view(serialized_mapping))
+        log.debug("Mapping data: %s", mapping.log_view(prepared.payload))
         raise_if_stale_profile_apply(manager, generation)
 
         result, cancelled = await _send_reference_command(
@@ -448,7 +474,7 @@ async def _send_set_mapping_command(
                 command=CommandType.SET_MAPPING,
                 data={
                     "hardware_id": hardware_id,
-                    "mapping": serialized_mapping,
+                    "mapping": prepared.payload,
                 },
             )
         )
@@ -478,9 +504,8 @@ async def _send_set_mapping_command(
             log.error("Failed to set mapping: %s", result.error)
 
     except TimeoutError as exc:
-        if staged_refs is not None:
-            references.retain_device(manager, hardware_id, staged_refs)
-            keep_staged_refs = True
+        references.retain_device(manager, hardware_id, staged_refs)
+        keep_staged_refs = True
         await _disconnect_after_mapping_timeout(manager, hardware_id)
         log.error("Timed out setting mapping for %s: %s", hardware_id, exc)
     except OSError as exc:
@@ -488,7 +513,7 @@ async def _send_set_mapping_command(
     except Exception:
         log.exception("Unexpected failure setting mapping for %s", hardware_id)
     finally:
-        if staged_refs is not None and not keep_staged_refs:
+        if not keep_staged_refs:
             references.discard(manager, staged_refs)
 
 
@@ -604,6 +629,9 @@ async def apply_resolved_device_profile(
             list(new_interfaces.keys()),
         )
 
+    prepared_mapping = _prepare_mapping(manager, hardware_id, resolved)
+    if prepared_mapping is None:
+        return
     log.info(
         "Grabbing device %s (interfaces: %s)",
         hardware_id,
@@ -627,6 +655,7 @@ async def apply_resolved_device_profile(
         resolved,
         _notify,
         generation=generation,
+        prepared=prepared_mapping,
     )
 
 

--- a/keymasq/session/manager/profile/application.py
+++ b/keymasq/session/manager/profile/application.py
@@ -632,31 +632,37 @@ async def apply_resolved_device_profile(
     prepared_mapping = _prepare_mapping(manager, hardware_id, resolved)
     if prepared_mapping is None:
         return
-    log.info(
-        "Grabbing device %s (interfaces: %s)",
-        hardware_id,
-        list(new_interfaces.keys()),
-    )
-    grab_outcome = await _send_grab_device_command(
-        manager,
-        hardware_id,
-        resolved,
-        grab_payload,
-        grab_signature,
-        new_interfaces,
-        operations,
-        generation=generation,
-    )
-    if grab_outcome is _GrabOutcome.STOP:
-        return
-    await _send_set_mapping_command(
-        manager,
-        hardware_id,
-        resolved,
-        _notify,
-        generation=generation,
-        prepared=prepared_mapping,
-    )
+    mapping_dispatched = False
+    try:
+        log.info(
+            "Grabbing device %s (interfaces: %s)",
+            hardware_id,
+            list(new_interfaces.keys()),
+        )
+        grab_outcome = await _send_grab_device_command(
+            manager,
+            hardware_id,
+            resolved,
+            grab_payload,
+            grab_signature,
+            new_interfaces,
+            operations,
+            generation=generation,
+        )
+        if grab_outcome is _GrabOutcome.STOP:
+            return
+        mapping_dispatched = True
+        await _send_set_mapping_command(
+            manager,
+            hardware_id,
+            resolved,
+            _notify,
+            generation=generation,
+            prepared=prepared_mapping,
+        )
+    finally:
+        if not mapping_dispatched:
+            references.discard(manager, prepared_mapping.refs)
 
 
 async def update_grab_device_payload(

--- a/keymasq/session/manager/recording_device_selection.py
+++ b/keymasq/session/manager/recording_device_selection.py
@@ -16,6 +16,10 @@ if TYPE_CHECKING:
 log = logging.getLogger("keymasq-session")
 CORE_RECORDING_DEVICE_FILTER_TYPES: tuple[str, ...] = ("keyboard", "gamepad", "mouse")
 OTHER_RECORDING_DEVICE_FILTER_TYPES: tuple[str, ...] = ("touchpad", "pointstick", "other")
+_PERSISTENCE_WARNING = (
+    "Recording settings were applied for this session but could not be saved. "
+    "They may revert after Keymasq restarts."
+)
 
 
 def recording_device_filter_types(include_other: bool = False) -> list[str]:
@@ -67,13 +71,18 @@ def queue_recording_settings_save(
 
 
 async def flush_recording_settings_saves(manager: "SessionManager") -> None:
+    latest_save_succeeded = True
     try:
         while manager.recording_state.settings_pending_save is not None:
             pending = manager.recording_state.settings_pending_save
             manager.recording_state.settings_pending_save = None
-            await asyncio.to_thread(save_recording_settings_to_disk, manager, pending)
+            latest_save_succeeded = await asyncio.to_thread(
+                save_recording_settings_to_disk, manager, pending
+            )
     finally:
         manager.recording_state.settings_save_task = None
+        if not latest_save_succeeded and manager.running:
+            manager.send_notification("Keymasq Settings Warning", _PERSISTENCE_WARNING)
 
 
 def load_recording_settings_from_disk(manager: "SessionManager") -> None:
@@ -104,7 +113,7 @@ def load_recording_settings_from_disk(manager: "SessionManager") -> None:
 def save_recording_settings_to_disk(
     manager: "SessionManager",
     settings: JsonObject | None = None,
-) -> None:
+) -> bool:
     settings = settings or manager.recording_state.settings
     try:
         data: JsonObject = {
@@ -120,11 +129,13 @@ def save_recording_settings_to_disk(
         }
 
         write_toml_atomically(manager.RECORDING_SETTINGS_PATH, data)
+        return True
     except Exception:
         log.exception(
             "Failed to save recording settings to %s",
             manager.RECORDING_SETTINGS_PATH,
         )
+        return False
 
 
 def prune_stale_recording_device_overrides(

--- a/keymasq/session/profile/codec.py
+++ b/keymasq/session/profile/codec.py
@@ -82,11 +82,20 @@ class ProfileCodec:
         created_at_raw = profile.get("created_at")
         if isinstance(created_at_raw, str):
             try:
-                created_at = datetime.fromisoformat(created_at_raw)
+                parsed_created_at = datetime.fromisoformat(created_at_raw)
             except ValueError:
                 created_at_repair_reason = f"malformed created_at '{created_at_raw}'"
-        else:
+            else:
+                if parsed_created_at.utcoffset() is None:
+                    created_at = parsed_created_at
+                else:
+                    created_at_repair_reason = (
+                        f"timezone-aware created_at '{created_at_raw}'"
+                    )
+        elif created_at_raw is None:
             created_at_repair_reason = "missing created_at"
+        else:
+            created_at_repair_reason = "noncanonical created_at"
 
         device_layers: dict[str, DeviceProfileLayer] = {}
         devices_data = data.get("devices", {})

--- a/keymasq/session/profile/codec.py
+++ b/keymasq/session/profile/codec.py
@@ -24,6 +24,7 @@ from keymasq.session.action_toml import (
     mapping_action_type_from_toml,
 )
 
+from .rules import SUPPORTED_WINDOW_RULE_FIELDS, normalize_window_rule_field
 from .types import TomlDict
 
 log = logging.getLogger("keymasq-session.profiles")
@@ -68,14 +69,20 @@ class ProfileCodec:
         now: datetime | None = None,
     ) -> DecodedProfile:
         profile = as_toml_dict(data.get("profile")) or {}
-        window_rules = [
-            WindowRule(
-                field=str(rule_dict.get("field", "class")),
-                pattern=str(rule_dict.get("pattern", "")),
+        window_rules: list[WindowRule] = []
+        for rule_data in as_toml_list(profile.get("window_rules", [])):
+            rule_dict = as_toml_dict(rule_data)
+            if rule_dict is None:
+                continue
+            field = normalize_window_rule_field(rule_dict.get("field", "class"))
+            if field not in SUPPORTED_WINDOW_RULE_FIELDS:
+                log.warning("Unknown window rule field '%s'; rule will not match", field)
+            window_rules.append(
+                WindowRule(
+                    field=field,
+                    pattern=str(rule_dict.get("pattern", "")),
+                )
             )
-            for rule_data in as_toml_list(profile.get("window_rules", []))
-            if (rule_dict := as_toml_dict(rule_data)) is not None
-        ]
 
         created_at = now or datetime.now()
         created_at_repair_reason: str | None = None

--- a/keymasq/session/profile/manager.py
+++ b/keymasq/session/profile/manager.py
@@ -19,7 +19,7 @@ from keymasq.common.model.profiles import (
 from . import references
 from .codec import ProfileCodec
 from .repair import repair_created_at
-from .repository import ProfileRepository
+from .repository import MAX_PATH_ATTEMPTS, ProfileRepository
 from .resolution import ProfileResolver
 from .rules import has_unsupported_rules, matches_window_rules, validate_window_rules
 from .types import ProfileInfo, ResolvedProfiles, TomlDict
@@ -128,16 +128,22 @@ class ProfileManager:
             notify_on_activation=False,
             created_at=datetime.now(),
         )
-        path = self._repository.canonical_path(config.name)
-        try:
-            self._write_profile_file(
-                config,
-                path,
-                validate_window_rules=False,
-                exclusive=True,
+        for _attempt in range(MAX_PATH_ATTEMPTS):
+            path = self._profile_path_for_name(config.name)
+            try:
+                self._write_profile_file(
+                    config,
+                    path,
+                    validate_window_rules=False,
+                    exclusive=True,
+                )
+            except FileExistsError:
+                continue
+            break
+        else:
+            raise RuntimeError(
+                f"Unable to allocate default profile storage path for '{config.name}'"
             )
-        except FileExistsError:
-            return self._load_profiles(strict=strict)
 
         profiles[config.name] = ProfileInfo(path=path, config=config)
         log.info("Created default profile: %s", path)

--- a/keymasq/session/profile/manager.py
+++ b/keymasq/session/profile/manager.py
@@ -130,6 +130,11 @@ class ProfileManager:
         )
         for _attempt in range(MAX_PATH_ATTEMPTS):
             path = self._profile_path_for_name(config.name)
+            if path != self._repository.canonical_path(config.name):
+                concurrently_loaded = self._load_profiles(strict=strict)
+                if concurrently_loaded:
+                    return concurrently_loaded
+                path = self._profile_path_for_name(config.name)
             try:
                 self._write_profile_file(
                     config,
@@ -138,6 +143,9 @@ class ProfileManager:
                     exclusive=True,
                 )
             except FileExistsError:
+                concurrently_loaded = self._load_profiles(strict=strict)
+                if concurrently_loaded:
+                    return concurrently_loaded
                 continue
             break
         else:

--- a/keymasq/session/profile/repair.py
+++ b/keymasq/session/profile/repair.py
@@ -22,11 +22,12 @@ def repair_created_at(path: Path, created_at: datetime) -> None:
     current_created_at = profile.get("created_at")
     if isinstance(current_created_at, str):
         try:
-            datetime.fromisoformat(current_created_at)
+            parsed_created_at = datetime.fromisoformat(current_created_at)
         except ValueError:
             pass
         else:
-            return
+            if parsed_created_at.utcoffset() is None:
+                return
 
     profile["created_at"] = created_at.isoformat()
     write_toml_atomically(path, data)

--- a/keymasq/session/profile/rules.py
+++ b/keymasq/session/profile/rules.py
@@ -10,11 +10,17 @@ from keymasq.common.model.profiles import (
 from .types import TomlDict
 
 log = logging.getLogger("keymasq-session.profiles")
+SUPPORTED_WINDOW_RULE_FIELDS = frozenset({"class", "title", "tag"})
+
+
+def normalize_window_rule_field(value: object) -> str:
+    field = str(value).strip().lower()
+    return "tag" if field == "tags" else field
 
 
 def has_unsupported_rules(config: ProfileConfig, capabilities: list[str]) -> bool:
     return "window_tags" not in capabilities and any(
-        rule.field == "tag" for rule in config.window_rules
+        normalize_window_rule_field(rule.field) == "tag" for rule in config.window_rules
     )
 
 
@@ -34,17 +40,22 @@ def matches_window_rules(profile: ProfileConfig, window_info: TomlDict | None) -
 
     for rule in profile.window_rules:
         try:
-            if rule.field == "tag":
+            field = normalize_window_rule_field(rule.field)
+            if field == "tag":
                 window_tags = window_info.get("tags", [])
                 if not isinstance(window_tags, list):
                     window_tags = []
                 tags = cast(list[object], window_tags)
                 if not any(re.search(rule.pattern, str(tag)) for tag in tags):
                     return False
-            else:
-                field_value = window_info.get(rule.field, "")
-                if not field_value or not re.search(rule.pattern, cast(str, field_value)):
+            elif field in {"class", "title"}:
+                field_value = window_info.get(field, "")
+                if not isinstance(field_value, str):
                     return False
+                if not field_value or not re.search(rule.pattern, field_value):
+                    return False
+            else:
+                return False
         except re.error as exc:
             log.warning(
                 "Invalid window rule regex for profile '%s' field '%s': %s",

--- a/tests/common/test_coercion.py
+++ b/tests/common/test_coercion.py
@@ -28,6 +28,22 @@ def test_coerce_float_uses_default_for_missing_or_invalid_values() -> None:
     assert coerce_float("2.25", 1.5) == 2.25
 
 
+@pytest.mark.parametrize(
+    "value",
+    [
+        float("nan"),
+        float("inf"),
+        float("-inf"),
+        "nan",
+        "inf",
+        "-inf",
+    ],
+)
+def test_coerce_float_uses_default_for_non_finite_values(value: object) -> None:
+    assert coerce_float(value, 1.5) == 1.5
+    assert coerce_float(value, None) is None
+
+
 def test_coerce_bool_parses_common_boolean_values() -> None:
     assert coerce_bool(True) is True
     assert coerce_bool(False, True) is False

--- a/tests/common/test_profile_manager.py
+++ b/tests/common/test_profile_manager.py
@@ -69,6 +69,26 @@ class TestProfileManager:
         assert profiles[0].path == temp_config_dir / "profiles" / "Default.toml"
         assert profiles[0].path.exists()
 
+    def test_auto_create_default_profile_preserves_invalid_colliding_files(
+        self,
+        temp_config_dir,
+    ) -> None:
+        profiles_dir = temp_config_dir / "profiles"
+        invalid_default = profiles_dir / "Default.toml"
+        invalid_fallback = profiles_dir / "Default_2.toml"
+        invalid_default.write_text("not = [valid toml", encoding="utf-8")
+        invalid_fallback.write_text("also = [invalid toml", encoding="utf-8")
+
+        manager = ProfileManager(auto_create_default_if_empty=True)
+
+        profiles = manager.list_profiles()
+        assert len(profiles) == 1
+        assert profiles[0].config.name == "Default"
+        assert profiles[0].path == profiles_dir / "Default_3.toml"
+        assert profiles[0].path.exists()
+        assert invalid_default.read_text(encoding="utf-8") == "not = [valid toml"
+        assert invalid_fallback.read_text(encoding="utf-8") == "also = [invalid toml"
+
     def test_save_and_load_profile(self, temp_config_dir, sample_profile_config):
         manager = ProfileManager()
         manager.save_profile(sample_profile_config)

--- a/tests/common/test_profile_manager.py
+++ b/tests/common/test_profile_manager.py
@@ -935,6 +935,56 @@ created_at = "not-a-date"
         assert 'created_at = "' in content
         assert 'created_at = "not-a-date"' not in content
 
+    @pytest.mark.parametrize(
+        "created_at_line",
+        [
+            'created_at = "2026-03-09T12:34:56+02:00"',
+            "created_at = 2026-03-09T12:34:56Z",
+        ],
+    )
+    def test_noncanonical_created_at_is_repaired_before_resolution(
+        self,
+        temp_config_dir,
+        created_at_line: str,
+    ) -> None:
+        _write_profile_toml(
+            Path(temp_config_dir),
+            "canonical.toml",
+            name="Canonical",
+            priority=1,
+            created_at="2026-03-09T12:34:56",
+        )
+        profile_path = Path(temp_config_dir) / "profiles" / "noncanonical.toml"
+        profile_path.write_text(
+            "\n".join(
+                [
+                    "[profile]",
+                    'name = "Noncanonical"',
+                    "enabled = true",
+                    "is_permanent = true",
+                    "priority = 1",
+                    "notify_on_activation = true",
+                    created_at_line,
+                ]
+            ),
+            encoding="utf-8",
+        )
+
+        manager = ProfileManager()
+        loaded = manager.get_profile("Noncanonical")
+        resolved = manager.resolve_active_profiles()
+
+        assert loaded is not None
+        assert loaded.config.created_at is not None
+        assert loaded.config.created_at.utcoffset() is None
+        assert {profile.name for profile in resolved.active_profiles} == {
+            "Canonical",
+            "Noncanonical",
+        }
+        repaired_content = profile_path.read_text(encoding="utf-8")
+        assert 'created_at = "' in repaired_content
+        assert created_at_line not in repaired_content
+
     def test_created_at_repair_logs_unexpected_failure(
         self,
         temp_config_dir,

--- a/tests/common/test_profile_manager.py
+++ b/tests/common/test_profile_manager.py
@@ -89,6 +89,42 @@ class TestProfileManager:
         assert invalid_default.read_text(encoding="utf-8") == "not = [valid toml"
         assert invalid_fallback.read_text(encoding="utf-8") == "also = [invalid toml"
 
+    def test_auto_create_default_adopts_concurrently_created_profile(
+        self,
+        temp_config_dir,
+        monkeypatch,
+    ) -> None:
+        profiles_dir = temp_config_dir / "profiles"
+        original_allocate = ProfileManager._profile_path_for_name
+        created = False
+
+        def allocate_after_concurrent_create(manager, profile_name, *args, **kwargs):
+            nonlocal created
+            if not created:
+                created = True
+                _write_profile_toml(
+                    temp_config_dir,
+                    "Default.toml",
+                    name="Default",
+                    enabled=True,
+                    is_permanent=True,
+                )
+            return original_allocate(manager, profile_name, *args, **kwargs)
+
+        monkeypatch.setattr(
+            ProfileManager,
+            "_profile_path_for_name",
+            allocate_after_concurrent_create,
+        )
+
+        manager = ProfileManager(auto_create_default_if_empty=True)
+
+        profiles = manager.list_profiles()
+        assert len(profiles) == 1
+        assert profiles[0].config.name == "Default"
+        assert profiles[0].path == profiles_dir / "Default.toml"
+        assert not (profiles_dir / "Default_2.toml").exists()
+
     def test_save_and_load_profile(self, temp_config_dir, sample_profile_config):
         manager = ProfileManager()
         manager.save_profile(sample_profile_config)

--- a/tests/common/test_profile_manager.py
+++ b/tests/common/test_profile_manager.py
@@ -890,6 +890,83 @@ pattern = "("
 
         assert resolved.active_profiles == []
 
+    def test_plural_tags_window_rule_is_normalized_and_matches(self, temp_config_dir):
+        profile_path = Path(temp_config_dir) / "profiles" / "tagged.toml"
+        profile_path.write_text(
+            """
+[profile]
+name = "Tagged"
+enabled = true
+is_permanent = false
+priority = 1
+notify_on_activation = true
+created_at = "2026-03-09T12:34:56"
+
+[[profile.window_rules]]
+field = "tags"
+pattern = "game"
+""".strip(),
+            encoding="utf-8",
+        )
+
+        manager = ProfileManager()
+        loaded = manager.get_profile("Tagged")
+        resolved = manager.resolve_active_profiles(
+            window_info={"tags": ["game", "fullscreen"]},
+            capabilities=["window_tags"],
+        )
+
+        assert loaded is not None
+        assert loaded.config.window_rules == [WindowRule(field="tag", pattern="game")]
+        assert [profile.name for profile in resolved.active_profiles] == ["Tagged"]
+
+        manager.save_profile(loaded.config)
+
+        content = profile_path.read_text(encoding="utf-8")
+        assert 'field = "tag"' in content
+        assert 'field = "tags"' not in content
+
+    def test_unknown_or_nonscalar_window_rule_fields_do_not_crash_matching(
+        self,
+        temp_config_dir,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        profile_path = Path(temp_config_dir) / "profiles" / "unknown-rule.toml"
+        profile_path.write_text(
+            """
+[profile]
+name = "Unknown Rule"
+enabled = true
+is_permanent = false
+priority = 1
+notify_on_activation = true
+created_at = "2026-03-09T12:34:56"
+
+[[profile.window_rules]]
+field = "workspace"
+pattern = "one"
+""".strip(),
+            encoding="utf-8",
+        )
+
+        manager = ProfileManager()
+        unknown_resolved = manager.resolve_active_profiles(
+            window_info={"workspace": ["one"]},
+        )
+
+        assert unknown_resolved.active_profiles == []
+        assert "Unknown window rule field 'workspace'; rule will not match" in caplog.text
+
+        loaded = manager.get_profile("Unknown Rule")
+        assert loaded is not None
+        loaded.config.window_rules = [WindowRule(field="class", pattern="steam")]
+
+        nonscalar_resolved = manager.resolve_active_profiles(
+            window_info={"class": ["steam"]},
+        )
+
+        assert nonscalar_resolved.active_profiles == []
+
     def test_missing_created_at_is_repaired_on_load(self, temp_config_dir):
         profile_path = Path(temp_config_dir) / "profiles" / "missing-created-at.toml"
         profile_path.write_text(

--- a/tests/gui/macro_editor_dialog_support.py
+++ b/tests/gui/macro_editor_dialog_support.py
@@ -32,7 +32,12 @@ class _FakeSlurpCapture:
         self.capture_callback = callback
 
 
-def _build_macro_dialog(monkeypatch, *, slurp_available: bool = False) -> MacroEditorDialog:
+def _build_macro_dialog(
+    monkeypatch,
+    *,
+    slurp_available: bool = False,
+    create_new: bool = False,
+) -> MacroEditorDialog:
     fake_slurp = _FakeSlurpCapture(available=slurp_available)
     monkeypatch.setattr(macro_editor_dialog_module, "get_slurp_capture", lambda: fake_slurp)
     monkeypatch.setattr(macro_editor_dialog_module, "session_compositor_id", lambda: "hyprland")
@@ -42,6 +47,6 @@ def _build_macro_dialog(monkeypatch, *, slurp_available: bool = False) -> MacroE
         lambda parent: (800, 600),
     )
     monkeypatch.setattr(MacroEditorDialog, "_load_initial_state_async", lambda self: None)
-    dialog = MacroEditorDialog(Gtk.Window(), "demo_macro")
+    dialog = MacroEditorDialog(Gtk.Window(), "demo_macro", create_new=create_new)
     dialog._test_slurp = fake_slurp  # type: ignore[attr-defined]
     return dialog

--- a/tests/gui/test_diagnostics_dialog.py
+++ b/tests/gui/test_diagnostics_dialog.py
@@ -98,6 +98,36 @@ def test_diagnostics_dialog_sends_settings_and_renders_snapshot(monkeypatch) -> 
     ]
 
 
+def test_diagnostics_dialog_ignores_snapshot_queued_before_close(monkeypatch) -> None:
+    import keymasq.gui.widgets.diagnostics_dialog as dialog_module
+    from keymasq.gui.widgets.diagnostics_dialog import DiagnosticsDialog
+
+    SessionIpcHarness(request_handler=_diagnostics_request_handler).install(
+        monkeypatch, dialog_module
+    )
+    dialog = DiagnosticsDialog(Gtk.Window())
+    dialog._on_closed(dialog)
+
+    dialog._on_diagnostics_snapshot(
+        {
+            "event": "diagnostics_snapshot",
+            "enabled": True,
+            "samples": {
+                "passthrough_mapped": {
+                    "n": 1,
+                    "p50": 1,
+                    "p95": 1,
+                    "p99": 1,
+                    "max": 1,
+                }
+            },
+        }
+    )
+
+    assert dialog._enabled is False
+    assert dialog._rows == {}
+
+
 def test_diagnostics_sort_by_priority(monkeypatch) -> None:
     import keymasq.gui.widgets.diagnostics_dialog as dialog_module
     from keymasq.gui.widgets.diagnostics_dialog import DiagnosticsDialog, _label_sort_key

--- a/tests/gui/test_gui_demo_and_dialogs.py
+++ b/tests/gui/test_gui_demo_and_dialogs.py
@@ -2208,9 +2208,10 @@ class TestDialogConstruction:
         captured: dict[str, object] = {}
 
         class DummyEditorDialog:
-            def __init__(self, parent, name):
+            def __init__(self, parent, name, *, create_new=False):
                 captured["parent"] = parent
                 captured["name"] = name
+                captured["create_new"] = create_new
 
             def connect(self, signal_name, callback):
                 captured["signal_name"] = signal_name
@@ -2227,9 +2228,15 @@ class TestDialogConstruction:
 
         assert captured["parent"] is parent
         assert captured["name"] == "demo_macro"
+        assert captured["create_new"] is False
         assert captured["signal_name"] == "closed"
         assert captured["callback"] == dialog._on_editor_closed
         assert captured["present_parent"] is parent
+
+        dialog._open_empty_macro_editor("new_macro")
+
+        assert captured["name"] == "new_macro"
+        assert captured["create_new"] is True
 
     def test_macro_manager_row_activation_opens_editor_or_slot_save(self, monkeypatch):
         gi.require_version("Gtk", "4.0")

--- a/tests/gui/test_macro_editor_dialog_widget.py
+++ b/tests/gui/test_macro_editor_dialog_widget.py
@@ -1578,29 +1578,6 @@ def test_macro_editor_save_request_paths_and_undo(monkeypatch) -> None:
         "Read-only file system. Both macros remain."
     )
 
-    def fake_uncertain_rename_request(payload):
-        if payload["command"] == "create_macro":
-            return {"status": "ok", "macro": {"name": "renamed", "revision": 1}}
-        if payload["command"] == "delete_macro":
-            raise ValueError("invalid delete response")
-        return {}
-
-    monkeypatch.setattr(
-        macro_editor_dialog_module,
-        "session_request",
-        fake_uncertain_rename_request,
-    )
-
-    uncertain_result = dialog._save_macro_request("renamed", {"name": "renamed"}, 7)
-
-    assert isinstance(uncertain_result, dict)
-    assert uncertain_result["status"] == "ok"
-    assert uncertain_result["macro"]["name"] == "renamed"
-    assert uncertain_result["warning"] == (
-        "Macro saved as 'renamed', but removal of 'original' could not be confirmed: "
-        "invalid delete response. Check whether both macros remain."
-    )
-
     dialog._apply_macro_state(dialog._initial_macro_data)
     dialog._events[0].press_t_us = 9000
     _set_dropdown_selected_id(

--- a/tests/gui/test_macro_editor_dialog_widget.py
+++ b/tests/gui/test_macro_editor_dialog_widget.py
@@ -1582,7 +1582,7 @@ def test_macro_editor_save_request_paths_and_undo(monkeypatch) -> None:
         if payload["command"] == "create_macro":
             return {"status": "ok", "macro": {"name": "renamed", "revision": 1}}
         if payload["command"] == "delete_macro":
-            raise TimeoutError("session request timed out")
+            raise ValueError("invalid delete response")
         return {}
 
     monkeypatch.setattr(
@@ -1598,7 +1598,7 @@ def test_macro_editor_save_request_paths_and_undo(monkeypatch) -> None:
     assert uncertain_result["macro"]["name"] == "renamed"
     assert uncertain_result["warning"] == (
         "Macro saved as 'renamed', but removal of 'original' could not be confirmed: "
-        "session request timed out. Check whether both macros remain."
+        "invalid delete response. Check whether both macros remain."
     )
 
     dialog._apply_macro_state(dialog._initial_macro_data)

--- a/tests/gui/test_macro_editor_dialog_widget.py
+++ b/tests/gui/test_macro_editor_dialog_widget.py
@@ -1578,6 +1578,29 @@ def test_macro_editor_save_request_paths_and_undo(monkeypatch) -> None:
         "Read-only file system. Both macros remain."
     )
 
+    def fake_uncertain_rename_request(payload):
+        if payload["command"] == "create_macro":
+            return {"status": "ok", "macro": {"name": "renamed", "revision": 1}}
+        if payload["command"] == "delete_macro":
+            raise TimeoutError("session request timed out")
+        return {}
+
+    monkeypatch.setattr(
+        macro_editor_dialog_module,
+        "session_request",
+        fake_uncertain_rename_request,
+    )
+
+    uncertain_result = dialog._save_macro_request("renamed", {"name": "renamed"}, 7)
+
+    assert isinstance(uncertain_result, dict)
+    assert uncertain_result["status"] == "ok"
+    assert uncertain_result["macro"]["name"] == "renamed"
+    assert uncertain_result["warning"] == (
+        "Macro saved as 'renamed', but removal of 'original' could not be confirmed: "
+        "session request timed out. Check whether both macros remain."
+    )
+
     dialog._apply_macro_state(dialog._initial_macro_data)
     dialog._events[0].press_t_us = 9000
     _set_dropdown_selected_id(

--- a/tests/gui/test_macro_editor_dialog_widget.py
+++ b/tests/gui/test_macro_editor_dialog_widget.py
@@ -1026,31 +1026,56 @@ def test_macro_editor_clean_close_skips_unsaved_warning(monkeypatch) -> None:
     assert closed == [True]
 
 
-def test_macro_editor_failed_load_closes_without_unsaved_warning(monkeypatch) -> None:
+def test_macro_editor_failed_existing_load_shows_error_and_closes(monkeypatch) -> None:
     from keymasq.gui.session_client import GuiTaskResult
 
     dialog = _build_macro_dialog(monkeypatch)
     closed: list[bool] = []
-    alerts: list[tuple[object, object]] = []
+    alerts: list[tuple[str | None, str | None, object]] = []
     monkeypatch.setattr(dialog, "force_close", lambda: closed.append(True))
     monkeypatch.setattr(
         macro_editor_dialog_module.Adw.AlertDialog,
         "present",
-        lambda alert, parent: alerts.append((alert, parent)),
+        lambda alert, parent: alerts.append(
+            (alert.get_heading(), alert.get_body(), parent)
+        ),
     )
 
     result = {
         "timeout_max": 30000,
         "macro": None,
+        "macro_load_error": "Read-only file system",
     }
     assert dialog._on_initial_state_loaded(GuiTaskResult(value=result)) is False
-    assert dialog.get_can_close() is True
-    assert dialog._initial_macro_data == dialog._current_macro_payload()
-
-    dialog._request_close()
-
-    assert alerts == []
     assert closed == [True]
+    assert dialog._dialog_closed is True
+    assert dialog._initial_state_loaded is False
+    assert alerts == [
+        ("Unable To Load Macro", "Read-only file system", dialog._parent)
+    ]
+
+
+def test_macro_editor_create_new_skips_lookup_and_opens_empty(monkeypatch) -> None:
+    from keymasq.gui.session_client import GuiTaskResult
+
+    dialog = _build_macro_dialog(monkeypatch, create_new=True)
+    requests: list[dict] = []
+
+    def fake_session_request(payload):
+        requests.append(payload)
+        return {"status": "ok", "macro_exec_timeout_max_ms": 30000}
+
+    monkeypatch.setattr(macro_editor_dialog_module, "session_request", fake_session_request)
+
+    result = dialog._load_initial_state()
+
+    assert requests == [{"command": "get_status"}]
+    assert result["macro"] is None
+    assert result["macro_load_error"] is None
+    assert dialog._on_initial_state_loaded(GuiTaskResult(value=result)) is False
+    assert dialog._initial_state_loaded is True
+    assert dialog._macro_exists is False
+    assert dialog._initial_macro_data == dialog._current_macro_payload()
 
 
 def test_macro_editor_content_is_read_only_until_initial_load_finishes(monkeypatch) -> None:

--- a/tests/gui/test_macro_editor_dialog_widget.py
+++ b/tests/gui/test_macro_editor_dialog_widget.py
@@ -1057,19 +1057,20 @@ def test_macro_editor_content_is_read_only_until_initial_load_finishes(monkeypat
     dialog = _build_macro_dialog(monkeypatch)
 
     assert dialog._editor_content.get_sensitive() is False
-    assert dialog._loading_overlay.get_visible() is True
-    assert dialog._loading_spinner.get_property("spinning") is True
+    assert dialog._editor_busy_overlay.get_visible() is True
+    assert dialog._editor_busy_spinner.get_property("spinning") is True
+    assert dialog._editor_busy_label.get_label() == "Loading macro…"
 
     dialog._exit_loading_state()
 
     assert dialog._editor_content.get_sensitive() is True
-    assert dialog._loading_overlay.get_visible() is False
-    assert dialog._loading_spinner.get_property("spinning") is False
+    assert dialog._editor_busy_overlay.get_visible() is False
+    assert dialog._editor_busy_spinner.get_property("spinning") is False
 
     dialog._exit_loading_state()
 
     assert dialog._editor_content.get_sensitive() is True
-    assert dialog._loading_overlay.get_visible() is False
+    assert dialog._editor_busy_overlay.get_visible() is False
 
 
 def test_macro_editor_load_completion_unlocks_content(monkeypatch) -> None:
@@ -1133,7 +1134,7 @@ def test_macro_editor_load_completion_unlocks_content(monkeypatch) -> None:
         on_done()
 
     assert dialog._editor_content.get_sensitive() is True
-    assert dialog._loading_overlay.get_visible() is False
+    assert dialog._editor_busy_overlay.get_visible() is False
     assert len(dialog._events) == 1
     assert dialog._initial_state_loaded is True
 
@@ -1148,7 +1149,7 @@ def test_macro_editor_load_ignored_after_close_during_load(monkeypatch) -> None:
     dialog._force_close_without_warning()
 
     assert closed == [True]
-    assert dialog._load_aborted is True
+    assert dialog._dialog_closed is True
 
     result = {
         "macro": {
@@ -1172,7 +1173,7 @@ def test_macro_editor_load_ignored_after_close_during_load(monkeypatch) -> None:
     assert dialog._events == []
     assert dialog._initial_state_loaded is False
     assert dialog._editor_content.get_sensitive() is False
-    assert dialog._loading_overlay.get_visible() is True
+    assert dialog._editor_busy_overlay.get_visible() is True
 
 
 def test_macro_editor_unsaved_close_warns_and_can_discard(monkeypatch) -> None:
@@ -1276,10 +1277,11 @@ def test_macro_editor_save_failures_distinguish_conflict_from_generic_error(
     ]
 
 
-def test_macro_editor_save_in_flight_disables_footer_and_blocks_duplicate(
+def test_macro_editor_save_in_flight_blocks_editor_duplicates_and_tracks_snapshot(
     monkeypatch,
 ) -> None:
     dialog = _build_macro_dialog(monkeypatch)
+    dialog._exit_loading_state()
     dialog._macro_name = "demo_macro"
     dialog._macro_exists = True
     dialog._macro_data = {"name": "demo_macro", "revision": 2}
@@ -1312,6 +1314,10 @@ def test_macro_editor_save_in_flight_disables_footer_and_blocks_duplicate(
     dialog._on_apply(apply_btn)
 
     assert dialog._save_in_flight is True
+    assert dialog._editor_content.get_sensitive() is False
+    assert dialog._editor_busy_overlay.get_visible() is True
+    assert dialog._editor_busy_spinner.get_property("spinning") is True
+    assert dialog._editor_busy_label.get_label() == "Saving macro…"
     assert [button.get_sensitive() for button in dialog._footer_action_buttons] == [
         False,
         False,
@@ -1326,19 +1332,35 @@ def test_macro_editor_save_in_flight_disables_footer_and_blocks_duplicate(
     assert len(scheduled) == 1
     assert requests == []
 
+    dialog._events = [
+        EditableEvent(
+            device_type="keyboard",
+            ev_type=evdev.ecodes.EV_KEY,
+            code=evdev.ecodes.KEY_B,
+            press_t_us=1000,
+            release_t_us=2000,
+        )
+    ]
+
     worker, callback, on_done = scheduled[0]
     assert callback(macro_editor_dialog_module.GuiTaskResult(value=worker())) is False
     if on_done is not None:
         on_done()
 
     assert requests[0]["command"] == "update_macro"
+    assert requests[0]["macro"]["events"] == []
     assert dialog._save_in_flight is False
+    assert dialog._editor_content.get_sensitive() is True
+    assert dialog._editor_busy_overlay.get_visible() is False
+    assert dialog._editor_busy_spinner.get_property("spinning") is False
     assert [button.get_sensitive() for button in dialog._footer_action_buttons] == [
         True,
         True,
         True,
         True,
     ]
+    assert dialog._initial_macro_data["events"] == []
+    assert dialog._has_pending_changes() is True
 
 
 def test_macro_editor_unsaved_close_save_response_saves_and_closes(monkeypatch) -> None:

--- a/tests/gui/test_macro_editor_dialog_widget.py
+++ b/tests/gui/test_macro_editor_dialog_widget.py
@@ -855,7 +855,9 @@ def test_macro_editor_insert_delete_and_save_payload(monkeypatch) -> None:
 def test_macro_editor_footer_is_pinned_and_includes_apply(monkeypatch) -> None:
     dialog = _build_macro_dialog(monkeypatch)
 
-    frame = dialog.get_child()
+    overlay = dialog.get_child()
+    assert isinstance(overlay, Gtk.Overlay)
+    frame = overlay.get_child()
     assert isinstance(frame, Gtk.Frame)
     root = frame.get_child()
     children = list(iter_widget_children(root))
@@ -1049,6 +1051,128 @@ def test_macro_editor_failed_load_closes_without_unsaved_warning(monkeypatch) ->
 
     assert alerts == []
     assert closed == [True]
+
+
+def test_macro_editor_content_is_read_only_until_initial_load_finishes(monkeypatch) -> None:
+    dialog = _build_macro_dialog(monkeypatch)
+
+    assert dialog._editor_content.get_sensitive() is False
+    assert dialog._loading_overlay.get_visible() is True
+    assert dialog._loading_spinner.get_property("spinning") is True
+
+    dialog._exit_loading_state()
+
+    assert dialog._editor_content.get_sensitive() is True
+    assert dialog._loading_overlay.get_visible() is False
+    assert dialog._loading_spinner.get_property("spinning") is False
+
+    dialog._exit_loading_state()
+
+    assert dialog._editor_content.get_sensitive() is True
+    assert dialog._loading_overlay.get_visible() is False
+
+
+def test_macro_editor_load_completion_unlocks_content(monkeypatch) -> None:
+    from keymasq.gui.session_client import GuiTaskResult
+    from keymasq.gui.widgets.macro_editor.controller.load import LoadControllerMixin
+
+    dialog = _build_macro_dialog(monkeypatch)
+
+    scheduled: list[
+        tuple[
+            Callable[[], dict[str, object]],
+            Callable[[GuiTaskResult[dict[str, object]]], bool | None],
+            Callable[[], None] | None,
+        ]
+    ] = []
+
+    def fake_run_gui_task(worker, callback, *, on_start=None, on_done=None) -> None:
+        if on_start is not None:
+            on_start()
+        scheduled.append((worker, callback, on_done))
+
+    def fake_session_request(payload):
+        if payload["command"] == "get_macro":
+            return {
+                "status": "ok",
+                "macro": {
+                    "name": "demo_macro",
+                    "revision": 2,
+                    "events": [
+                        {
+                            "device_type": "keyboard",
+                            "type": evdev.ecodes.EV_KEY,
+                            "code": evdev.ecodes.KEY_A,
+                            "value": 1,
+                            "t_us": 1000,
+                        },
+                        {
+                            "device_type": "keyboard",
+                            "type": evdev.ecodes.EV_KEY,
+                            "code": evdev.ecodes.KEY_A,
+                            "value": 0,
+                            "t_us": 2000,
+                        },
+                    ],
+                    "duration_us": 2000,
+                },
+            }
+        return {"status": "ok", "macro_exec_timeout_max_ms": 30000}
+
+    monkeypatch.setattr(macro_editor_dialog_module, "run_gui_task", fake_run_gui_task)
+    monkeypatch.setattr(macro_editor_dialog_module, "session_request", fake_session_request)
+
+    LoadControllerMixin._load_initial_state_async(dialog)
+
+    assert dialog._editor_content.get_sensitive() is False
+    assert len(scheduled) == 1
+
+    worker, callback, on_done = scheduled[0]
+    assert callback(GuiTaskResult(value=worker())) is False
+    if on_done is not None:
+        on_done()
+
+    assert dialog._editor_content.get_sensitive() is True
+    assert dialog._loading_overlay.get_visible() is False
+    assert len(dialog._events) == 1
+    assert dialog._initial_state_loaded is True
+
+
+def test_macro_editor_load_ignored_after_close_during_load(monkeypatch) -> None:
+    from keymasq.gui.session_client import GuiTaskResult
+
+    dialog = _build_macro_dialog(monkeypatch)
+    closed: list[bool] = []
+    monkeypatch.setattr(dialog, "force_close", lambda: closed.append(True))
+
+    dialog._force_close_without_warning()
+
+    assert closed == [True]
+    assert dialog._load_aborted is True
+
+    result = {
+        "macro": {
+            "name": "demo_macro",
+            "revision": 2,
+            "events": [
+                {
+                    "device_type": "keyboard",
+                    "type": evdev.ecodes.EV_KEY,
+                    "code": evdev.ecodes.KEY_A,
+                    "value": 1,
+                    "t_us": 1000,
+                },
+            ],
+            "duration_us": 1000,
+        },
+    }
+    assert dialog._on_initial_state_loaded(GuiTaskResult(value=result)) is False
+    dialog._exit_loading_state()
+
+    assert dialog._events == []
+    assert dialog._initial_state_loaded is False
+    assert dialog._editor_content.get_sensitive() is False
+    assert dialog._loading_overlay.get_visible() is True
 
 
 def test_macro_editor_unsaved_close_warns_and_can_discard(monkeypatch) -> None:

--- a/tests/gui/test_macro_editor_dialog_widget.py
+++ b/tests/gui/test_macro_editor_dialog_widget.py
@@ -1244,7 +1244,7 @@ def test_macro_editor_save_failures_distinguish_conflict_from_generic_error(
         is False
     )
 
-    generic = GuiTaskResult(value={"status": "error", "message": "Revision conflict"})
+    generic = GuiTaskResult(value={"status": "error", "message": "Read-only file system"})
     assert (
         dialog._on_save_finished(
             generic,
@@ -1272,9 +1272,53 @@ def test_macro_editor_save_failures_distinguish_conflict_from_generic_error(
             "A macro named 'demo_macro' already exists. Choose a different name.",
             dialog._parent,
         ),
-        ("Unable To Save Macro", "Revision conflict", dialog._parent),
+        ("Unable To Save Macro", "Read-only file system", dialog._parent),
         ("Unable To Save Macro", "worker failed", dialog._parent),
     ]
+
+
+def test_macro_editor_partial_rename_warns_and_adopts_saved_macro(monkeypatch) -> None:
+    from keymasq.gui.session_client import GuiTaskResult
+
+    dialog = _build_macro_dialog(monkeypatch)
+    alerts: list[tuple[str | None, str | None, object]] = []
+    reloads: list[bool] = []
+    requested = dialog._current_macro_payload()
+    requested["name"] = "renamed"
+    saved = {**requested, "revision": 3}
+    warning = (
+        "Macro saved as 'renamed', but 'demo_macro' could not be removed: "
+        "Read-only file system. Both macros remain."
+    )
+
+    monkeypatch.setattr(
+        macro_editor_dialog_module.Adw.AlertDialog,
+        "present",
+        lambda alert, parent: alerts.append(
+            (alert.get_heading(), alert.get_body(), parent)
+        ),
+    )
+    monkeypatch.setattr(
+        macro_editor_dialog_module,
+        "notify_session_reload_async",
+        lambda: reloads.append(True),
+    )
+
+    result = GuiTaskResult(value={"status": "ok", "macro": saved, "warning": warning})
+    assert (
+        dialog._on_save_finished(
+            result,
+            "renamed",
+            requested,
+            close_after_save=False,
+        )
+        is False
+    )
+
+    assert dialog._macro_name == "renamed"
+    assert dialog._macro_data["revision"] == 3
+    assert reloads == [True]
+    assert alerts == [("Macro Saved With Warning", warning, dialog._parent)]
 
 
 def test_macro_editor_save_in_flight_blocks_editor_duplicates_and_tracks_snapshot(
@@ -1482,6 +1526,32 @@ def test_macro_editor_save_request_paths_and_undo(monkeypatch) -> None:
     assert requests[0]["command"] == "create_macro"
     assert requests[1]["command"] == "delete_macro"
     assert requests[1]["expected_revision"] == 7
+
+    requests.clear()
+
+    def fake_partial_rename_request(payload):
+        requests.append(payload)
+        if payload["command"] == "create_macro":
+            return {"status": "ok", "macro": {"name": "renamed", "revision": 1}}
+        if payload["command"] == "delete_macro":
+            return {"status": "error", "message": "Read-only file system"}
+        return {}
+
+    monkeypatch.setattr(
+        macro_editor_dialog_module,
+        "session_request",
+        fake_partial_rename_request,
+    )
+
+    partial_result = dialog._save_macro_request("renamed", {"name": "renamed"}, 7)
+
+    assert isinstance(partial_result, dict)
+    assert partial_result["status"] == "ok"
+    assert partial_result["macro"]["name"] == "renamed"
+    assert partial_result["warning"] == (
+        "Macro saved as 'renamed', but 'original' could not be removed: "
+        "Read-only file system. Both macros remain."
+    )
 
     dialog._apply_macro_state(dialog._initial_macro_data)
     dialog._events[0].press_t_us = 9000

--- a/tests/gui/test_settings_dialog.py
+++ b/tests/gui/test_settings_dialog.py
@@ -251,6 +251,38 @@ def test_settings_dialog_plus_minus_auto_applies(monkeypatch, temp_config_dir) -
     assert callbacks[-1][0]["virtual_gamepad_count"] == 1
 
 
+def test_settings_dialog_shows_persistence_warning_without_reverting(
+    monkeypatch,
+    temp_config_dir,
+) -> None:
+    from keymasq.gui.widgets import settings_dialog as dialog_module
+    from keymasq.gui.widgets.settings_dialog import SettingsDialog
+
+    callbacks = []
+
+    def fake_session_request_async(payload, callback, timeout=5.0):
+        callbacks.append((payload, callback))
+
+    monkeypatch.setattr(dialog_module, "session_request_async", fake_session_request_async)
+
+    dialog = SettingsDialog()
+    callbacks[0][1]({"status": "ok", "virtual_gamepad_count": 1})
+    dialog._on_increment_gamepads_clicked(dialog._plus_button)
+
+    callbacks[-1][1](
+        {
+            "status": "ok",
+            "virtual_gamepad_count": 2,
+            "persisted": False,
+            "warning": "Applied for this session but could not be saved.",
+        }
+    )
+
+    assert dialog._gamepad_count == 2
+    assert dialog._count_label.get_text() == "2"
+    assert dialog._status.get_text() == "Applied for this session but could not be saved."
+
+
 def test_settings_dialog_reverts_to_stale_success_when_newest_save_fails(
     monkeypatch,
     temp_config_dir,

--- a/tests/session/test_profile_domain.py
+++ b/tests/session/test_profile_domain.py
@@ -1,5 +1,7 @@
-from datetime import datetime
+from datetime import UTC, datetime
 from pathlib import Path
+
+import pytest
 
 from keymasq.common.model.actions import MappingAction
 from keymasq.common.model.core import ActionType
@@ -70,6 +72,32 @@ def test_codec_reports_timestamp_repair_without_filesystem_state() -> None:
     assert decoded.created_at_repair_reason == "missing created_at"
     assert decoded.config.created_at == datetime(2026, 7, 10, 12, 0)
     assert decoded.config.device_layers["mouse"].mappings["btn_side"].target == "key_f13"
+
+
+@pytest.mark.parametrize(
+    ("created_at", "reason"),
+    [
+        (
+            "2026-07-10T12:00:00+02:00",
+            "timezone-aware created_at '2026-07-10T12:00:00+02:00'",
+        ),
+        (datetime(2026, 7, 10, 12, 0, tzinfo=UTC), "noncanonical created_at"),
+    ],
+)
+def test_codec_replaces_noncanonical_timestamps_with_current_time(
+    created_at: object,
+    reason: str,
+) -> None:
+    now = datetime(2026, 7, 18, 9, 30)
+
+    decoded = ProfileCodec().decode(
+        {"profile": {"name": "Portable", "created_at": created_at}},
+        default_name="fallback",
+        now=now,
+    )
+
+    assert decoded.created_at_repair_reason == reason
+    assert decoded.config.created_at == now
 
 
 def test_codec_round_trip_preserves_combo_scope() -> None:

--- a/tests/session/test_session_manager_command_runtime.py
+++ b/tests/session/test_session_manager_command_runtime.py
@@ -179,11 +179,15 @@ async def test_virtual_gamepad_persistence_failure_keeps_applied_runtime_value(
     )
     manager.send_notification = Mock()  # type: ignore[method-assign]
     manager.broadcast_to_session_clients = Mock()  # type: ignore[method-assign]
-    monkeypatch.setattr(
-        settings_commands_module,
-        save_name,
-        Mock(side_effect=OSError("disk full")),
-    )
+    save = Mock(side_effect=OSError("disk full"))
+    monkeypatch.setattr(settings_commands_module, save_name, save)
+    thread_calls: list[object] = []
+
+    async def fake_to_thread(function, *args):
+        thread_calls.append(function)
+        return function(*args)
+
+    monkeypatch.setattr(settings_commands_module.asyncio, "to_thread", fake_to_thread)
     peer = PeerCredentials(pid=1, uid=1000, gid=1000)
 
     result = await manager._handle_session_request(
@@ -201,6 +205,7 @@ async def test_virtual_gamepad_persistence_failure_keeps_applied_runtime_value(
         "Keymasq Settings Warning",
         result["warning"],
     )
+    assert thread_calls == [save]
     manager.broadcast_to_session_clients.assert_called_once_with(event)  # type: ignore[attr-defined]
 
 

--- a/tests/session/test_session_manager_command_runtime.py
+++ b/tests/session/test_session_manager_command_runtime.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock, Mock, call
 import pytest
 
 import keymasq.session.manager.command.macro as macro_commands_module
+import keymasq.session.manager.command.settings as settings_commands_module
 import keymasq.session.manager.compositor as session_compositor_module
 import keymasq.session.manager.device_inspector as session_device_inspector_module
 import keymasq.session.manager.events as session_events_module
@@ -140,6 +141,67 @@ async def test_handle_session_request_set_virtual_gamepads_keeps_state_on_daemon
     assert manager.virtual_gamepad_count == 3
     assert session_settings.load_global_settings().virtual_gamepad_count == 3
     manager.broadcast_to_session_clients.assert_not_called()  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("command", "request_count_key", "save_name", "response_count_key", "event"),
+    [
+        (
+            "set_virtual_gamepads",
+            "count",
+            "save_virtual_gamepad_count",
+            "count",
+            {"event": "virtual_gamepads_changed", "count": 2},
+        ),
+        (
+            "set_settings",
+            "virtual_gamepad_count",
+            "save_global_settings",
+            "virtual_gamepad_count",
+            {"event": "settings_changed", "virtual_gamepad_count": 2},
+        ),
+    ],
+)
+async def test_virtual_gamepad_persistence_failure_keeps_applied_runtime_value(
+    monkeypatch: pytest.MonkeyPatch,
+    command: str,
+    request_count_key: str,
+    save_name: str,
+    response_count_key: str,
+    event: dict[str, object],
+) -> None:
+    manager = SessionManager()
+    manager.virtual_gamepad_count = 1
+    manager.connected = True
+    manager.client.send_command = AsyncMock(
+        return_value=Response(status="ok", data={"count": 2})
+    )
+    manager.send_notification = Mock()  # type: ignore[method-assign]
+    manager.broadcast_to_session_clients = Mock()  # type: ignore[method-assign]
+    monkeypatch.setattr(
+        settings_commands_module,
+        save_name,
+        Mock(side_effect=OSError("disk full")),
+    )
+    peer = PeerCredentials(pid=1, uid=1000, gid=1000)
+
+    result = await manager._handle_session_request(
+        {"command": command, request_count_key: 2},
+        peer,
+        object(),
+    )
+
+    assert result["status"] == "ok"
+    assert result[response_count_key] == 2
+    assert result["persisted"] is False
+    assert "may revert" in str(result["warning"])
+    assert manager.virtual_gamepad_count == 2
+    manager.send_notification.assert_called_once_with(  # type: ignore[attr-defined]
+        "Keymasq Settings Warning",
+        result["warning"],
+    )
+    manager.broadcast_to_session_clients.assert_called_once_with(event)  # type: ignore[attr-defined]
 
 
 @pytest.mark.asyncio

--- a/tests/session/test_session_manager_profile_apply.py
+++ b/tests/session/test_session_manager_profile_apply.py
@@ -863,46 +863,6 @@ async def test_initial_mapping_is_prepared_before_device_grab(caplog) -> None:
 
 
 @pytest.mark.asyncio
-async def test_prepared_mapping_refs_are_discarded_when_device_grab_stops() -> None:
-    manager = SessionManager()
-    hardware_id = "1234:5678"
-    old_binding = ExecBinding(
-        cmd="notify-send old",
-        owner="device",
-        hardware_id=hardware_id,
-    )
-    manager.exec_state.exec_refs[7] = old_binding
-    manager.exec_state.device_exec_refs[hardware_id] = {7}
-    manager.exec_state.next_exec_ref = 10
-    manager.hardware.get_hardware = lambda _hardware_id: SimpleNamespace(  # type: ignore[assignment]
-        hardware_id=hardware_id,
-        name="Test Mouse",
-        evdev_devices=[SimpleNamespace(id="mouse", path="/dev/input/event10")],
-        buttons=[SimpleNamespace(id="btn_side", evdev="btn_side", source="mouse")],
-    )
-    manager.client.send_command = AsyncMock(
-        return_value=Response(status="error", error="grab failed")
-    )
-    resolved = ResolvedDeviceProfile(
-        hardware_id=hardware_id,
-        active_profile_names=["Desktop"],
-        mappings={
-            "btn_side": MappingAction(
-                action_type=ActionType.EXEC,
-                cmd="notify-send new",
-            )
-        },
-    )
-
-    await coordinator.apply_resolved_device_profile(manager, hardware_id, resolved)
-
-    manager.client.send_command.assert_awaited_once()
-    assert manager.client.send_command.await_args.args[0].command == CommandType.GRAB_DEVICE
-    assert manager.exec_state.device_exec_refs == {hardware_id: {7}}
-    assert manager.exec_state.exec_refs == {7: old_binding}
-
-
-@pytest.mark.asyncio
 async def test_apply_resolved_device_profile_force_grabs_all_interfaces_for_inspector() -> None:
     from keymasq.common.model.core import DeviceType
     from keymasq.common.model.hardware import (

--- a/tests/session/test_session_manager_profile_apply.py
+++ b/tests/session/test_session_manager_profile_apply.py
@@ -811,6 +811,58 @@ async def test_apply_resolved_device_profile_uses_extended_grab_timeout() -> Non
 
 
 @pytest.mark.asyncio
+async def test_initial_mapping_is_prepared_before_device_grab(caplog) -> None:
+    from keymasq.common.model.core import SuperkeyMode
+    from keymasq.common.model.superkeys import SuperkeyConfig
+
+    manager = SessionManager()
+    hardware_id = "1234:5678"
+    old_binding = ExecBinding(
+        cmd="notify-send old",
+        owner="device",
+        hardware_id=hardware_id,
+    )
+    manager.exec_state.exec_refs[7] = old_binding
+    manager.exec_state.device_exec_refs[hardware_id] = {7}
+    manager.exec_state.next_exec_ref = 10
+    invalid_superkey = SuperkeyConfig(
+        name="Invalid Nested Analog",
+        mode=SuperkeyMode.OVERLOAD,
+        overload_actions=[
+            MappingAction(action_type=ActionType.EXEC, cmd="notify-send new"),
+            MappingAction(action_type=ActionType.ANALOG_CONTROL),
+        ],
+    )
+    manager.superkeys.get_superkey = lambda _name: invalid_superkey  # type: ignore[method-assign]
+    manager.hardware.get_hardware = lambda _hardware_id: SimpleNamespace(  # type: ignore[assignment]
+        hardware_id=hardware_id,
+        name="Test Mouse",
+        evdev_devices=[SimpleNamespace(id="mouse", path="/dev/input/event10")],
+        buttons=[SimpleNamespace(id="btn_side", evdev="btn_side", source="mouse")],
+    )
+    manager.client.send_command = AsyncMock()
+    resolved = ResolvedDeviceProfile(
+        hardware_id=hardware_id,
+        active_profile_names=["Desktop"],
+        mappings={
+            "btn_side": MappingAction(
+                action_type=ActionType.SUPERKEY,
+                superkey_name=invalid_superkey.name,
+            )
+        },
+    )
+
+    with caplog.at_level(logging.ERROR, logger="keymasq-session"):
+        await coordinator.apply_resolved_device_profile(manager, hardware_id, resolved)
+
+    manager.client.send_command.assert_not_awaited()
+    assert hardware_id not in manager.profile_state.grabbed_devices
+    assert manager.exec_state.device_exec_refs == {hardware_id: {7}}
+    assert manager.exec_state.exec_refs == {7: old_binding}
+    assert f"Failed to prepare mapping for {hardware_id} before device grab" in caplog.text
+
+
+@pytest.mark.asyncio
 async def test_apply_resolved_device_profile_force_grabs_all_interfaces_for_inspector() -> None:
     from keymasq.common.model.core import DeviceType
     from keymasq.common.model.hardware import (

--- a/tests/session/test_session_manager_profile_apply.py
+++ b/tests/session/test_session_manager_profile_apply.py
@@ -863,6 +863,46 @@ async def test_initial_mapping_is_prepared_before_device_grab(caplog) -> None:
 
 
 @pytest.mark.asyncio
+async def test_prepared_mapping_refs_are_discarded_when_device_grab_stops() -> None:
+    manager = SessionManager()
+    hardware_id = "1234:5678"
+    old_binding = ExecBinding(
+        cmd="notify-send old",
+        owner="device",
+        hardware_id=hardware_id,
+    )
+    manager.exec_state.exec_refs[7] = old_binding
+    manager.exec_state.device_exec_refs[hardware_id] = {7}
+    manager.exec_state.next_exec_ref = 10
+    manager.hardware.get_hardware = lambda _hardware_id: SimpleNamespace(  # type: ignore[assignment]
+        hardware_id=hardware_id,
+        name="Test Mouse",
+        evdev_devices=[SimpleNamespace(id="mouse", path="/dev/input/event10")],
+        buttons=[SimpleNamespace(id="btn_side", evdev="btn_side", source="mouse")],
+    )
+    manager.client.send_command = AsyncMock(
+        return_value=Response(status="error", error="grab failed")
+    )
+    resolved = ResolvedDeviceProfile(
+        hardware_id=hardware_id,
+        active_profile_names=["Desktop"],
+        mappings={
+            "btn_side": MappingAction(
+                action_type=ActionType.EXEC,
+                cmd="notify-send new",
+            )
+        },
+    )
+
+    await coordinator.apply_resolved_device_profile(manager, hardware_id, resolved)
+
+    manager.client.send_command.assert_awaited_once()
+    assert manager.client.send_command.await_args.args[0].command == CommandType.GRAB_DEVICE
+    assert manager.exec_state.device_exec_refs == {hardware_id: {7}}
+    assert manager.exec_state.exec_refs == {7: old_binding}
+
+
+@pytest.mark.asyncio
 async def test_apply_resolved_device_profile_force_grabs_all_interfaces_for_inspector() -> None:
     from keymasq.common.model.core import DeviceType
     from keymasq.common.model.hardware import (

--- a/tests/session/test_session_manager_recording_settings.py
+++ b/tests/session/test_session_manager_recording_settings.py
@@ -4,7 +4,7 @@ import threading
 import tomllib
 from types import SimpleNamespace
 from typing import cast
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, Mock
 
 import pytest
 
@@ -39,12 +39,12 @@ async def test_recording_settings_persistence_applies_latest_snapshot_last(
     latest_finished = threading.Event()
     release_stale = threading.Event()
 
-    def fake_save(_manager, settings: dict | None = None) -> None:
+    def fake_save(_manager, settings: dict | None = None) -> bool:
         state = dict(settings or {})
         if state.get("include_mouse_movement", False):
             stale_started.set()
             if not release_stale.wait(timeout=1.0):
-                return
+                return False
         with writes_lock:
             persisted.clear()
             persisted.update(state)
@@ -53,6 +53,7 @@ async def test_recording_settings_persistence_applies_latest_snapshot_last(
             stale_finished.set()
         else:
             latest_finished.set()
+        return True
 
     async def wait_for_event(event: threading.Event, message: str) -> None:
         if not await asyncio.to_thread(event.wait, 1.0):
@@ -189,9 +190,45 @@ def test_recording_settings_save_logs_errors(tmp_path, caplog, monkeypatch) -> N
     monkeypatch.setattr(config_files_module.tomli_w, "dump", raise_dump_error)
     caplog.set_level(logging.ERROR, logger="keymasq-session")
 
-    recording_device_selection_module.save_recording_settings_to_disk(manager)
+    saved = recording_device_selection_module.save_recording_settings_to_disk(manager)
 
+    assert saved is False
     assert f"Failed to save recording settings to {manager.RECORDING_SETTINGS_PATH}" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_recording_settings_persistence_failure_warns_without_reverting(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = SessionManager()
+    manager.running = True
+    manager.recording_state.settings = {
+        "include_mouse_movement": False,
+        "include_mouse_clicks": False,
+        "record_start_position": False,
+        "device_overrides": {},
+    }
+    manager.send_notification = Mock()  # type: ignore[method-assign]
+    monkeypatch.setattr(
+        recording_device_selection_module,
+        "save_recording_settings_to_disk",
+        Mock(return_value=False),
+    )
+
+    recording_device_selection_module.update_recording_settings(
+        manager,
+        {"include_mouse_movement": True},
+    )
+    save_task = manager.recording_state.settings_save_task
+    assert save_task is not None
+    await save_task
+
+    assert manager.recording_state.settings["include_mouse_movement"] is True
+    manager.send_notification.assert_called_once()  # type: ignore[attr-defined]
+    title, warning = manager.send_notification.call_args.args  # type: ignore[attr-defined]
+    assert title == "Keymasq Settings Warning"
+    assert "applied for this session" in warning
+    assert "may revert" in warning
 
 
 @pytest.mark.asyncio

--- a/tests/test_analog_controls.py
+++ b/tests/test_analog_controls.py
@@ -30,6 +30,33 @@ def test_gamepad_output_deadzone_defaults_to_zero() -> None:
     assert AnalogGamepadOutputConfig().deadzone == 0.0
 
 
+def test_analog_control_non_finite_mouse_values_use_defaults(temp_config_dir) -> None:
+    config_path = temp_config_dir / "analog_controls" / "non_finite.toml"
+    config_path.write_text(
+        """\
+name = "Non-finite Mouse"
+
+[mouse_motion]
+enabled = true
+speed = inf
+speed_x = nan
+speed_y = -inf
+area_radius_x = inf
+area_radius_y = nan
+""",
+        encoding="utf-8",
+    )
+
+    loaded = AnalogControlManager().get_analog_control("Non-finite Mouse")
+
+    assert loaded is not None
+    assert loaded.mouse_motion.speed == 900.0
+    assert loaded.mouse_motion.speed_x == 900.0
+    assert loaded.mouse_motion.speed_y == 900.0
+    assert loaded.mouse_motion.area_radius_x == 400.0
+    assert loaded.mouse_motion.area_radius_y == 400.0
+
+
 def test_analog_control_manager_round_trip_rename_delete(temp_config_dir) -> None:
     manager = AnalogControlManager()
     config = AnalogControlConfig(

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -128,6 +128,28 @@ def test_load_security_policy_gui_section(tmp_path: Path) -> None:
     assert policy.emergency_cancel_combo_enabled is False
 
 
+@pytest.mark.parametrize(
+    ("section", "setting"),
+    [
+        ("recording_guard", "unlock_required"),
+        ("recording_guard", "macro_edit_requires_unlock"),
+        ("gui", "emergency_cancel_combo_enabled"),
+    ],
+)
+@pytest.mark.parametrize("value", ['"false"', "[]", "0"])
+def test_load_security_policy_rejects_non_boolean_policy_values(
+    tmp_path: Path,
+    section: str,
+    setting: str,
+    value: str,
+) -> None:
+    policy_path = tmp_path / "security.toml"
+    policy_path.write_text(f"[{section}]\n{setting} = {value}\n")
+
+    with pytest.raises(SecurityPolicyError, match=rf"{section}\.{setting} must be a boolean"):
+        load_security_policy(policy_path)
+
+
 def test_uid_allowlist_optional_and_enforced(tmp_path: Path) -> None:
     default_policy = load_security_policy(tmp_path / "missing-security.toml")
     assert default_policy.daemon_allowed_uids == []

--- a/tests/test_session_manager_core.py
+++ b/tests/test_session_manager_core.py
@@ -462,6 +462,7 @@ async def test_reload_profiles_failure_keeps_previous_config_and_notifies(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     manager = SessionManager()
+    manager.reload_pending = True
     manager.send_notification = Mock()  # type: ignore[method-assign]
     manager.broadcast_to_session_clients = Mock()  # type: ignore[method-assign]
     reevaluate_profiles = AsyncMock()
@@ -481,6 +482,7 @@ async def test_reload_profiles_failure_keeps_previous_config_and_notifies(
     )
     manager.broadcast_to_session_clients.assert_called_once()  # type: ignore[attr-defined]
     reevaluate_profiles.assert_not_awaited()
+    assert manager.reload_pending is False
 
 
 def test_reload_config_from_disk_rolls_back_user_config_on_failure(
@@ -1238,18 +1240,33 @@ async def test_wait_for_session_clients_to_close_logs_timeout(
 
 
 @pytest.mark.asyncio
-async def test_reload_handler_defers_when_existing_reload_task_is_running() -> None:
+async def test_reload_handler_drops_request_when_existing_reload_task_is_running() -> None:
     manager = SessionManager()
     running_task = asyncio.create_task(asyncio.sleep(1))
     manager.reload_task = running_task
 
     manager._reload_handler()
 
-    assert manager.reload_pending is True
+    assert manager.reload_pending is False
     assert manager.reload_task is running_task
     running_task.cancel()
     with pytest.raises(asyncio.CancelledError):
         await running_task
+
+
+@pytest.mark.asyncio
+async def test_reload_profiles_clears_pending_when_debounce_is_cancelled() -> None:
+    manager = SessionManager()
+    manager.reload_pending = True
+
+    reload_task = asyncio.create_task(manager.reload_profiles())
+    await asyncio.sleep(0)
+    reload_task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await reload_task
+
+    assert manager.reload_pending is False
 
 
 @pytest.mark.asyncio

--- a/tests/test_toml.py
+++ b/tests/test_toml.py
@@ -63,6 +63,41 @@ def test_mapping_action_from_toml_parses_false_rapidfire_string_as_disabled() ->
     assert action.rapidfire_enabled is False
 
 
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("false", False),
+        ("off", False),
+        ("true", True),
+        ("yes", True),
+        (0, False),
+        (1, True),
+        ("not-a-boolean", False),
+    ],
+)
+def test_mapping_action_from_toml_coerces_profile_trigger_end(
+    value: object,
+    expected: bool,
+) -> None:
+    action = _parse_mapping_action_toml(
+        {
+            "action": "profile_enable",
+            "profile_name": "Gaming",
+            "deactivation": {"on_trigger_end": value},
+        }
+    )
+
+    if expected:
+        assert action.profile_deactivation == ProfileDeactivationPolicy(on_trigger_end=True)
+    else:
+        assert action.profile_deactivation is None
+        serialized = mapping_action_to_toml(
+            action,
+            rapidfire_warning_context="test config",
+        )
+        assert "deactivation" not in serialized
+
+
 def test_mapping_action_type_from_toml_can_passthrough_unknown_actions() -> None:
     logger = Mock()
 


### PR DESCRIPTION
## Summary
- Fail closed or warn on inconsistent state: strict security-policy booleans, finite float coercion, safer profile/window-rule parsing, and noncanonical `created_at` repair
- Profile bootstrap: seed Default without overwriting collisions (`Default_2.toml`…), adopt concurrently created defaults, and prepare mappings before grabs
- Macro editor/manager: read-only busy UI while loading/saving, fail closed on load errors, warn when rename cleanup leaves both names, block edits while saving
- Settings persistence: keep session values and warn when gamepad/recording settings cannot be written; debounce overlapping config reload (SIGHUP) signals
- Docs updated for profiles, macros, security, gamepad, actions, and troubleshooting

## Testing
- `./scripts/check.sh` (or `nix develop -c ./scripts/check.sh`)
- Covered by added/updated tests: coercion, security policy booleans, profile manager/default seeding, profile apply, recording settings, macro editor load/save, diagnostics dialog close, session manager core/commands, TOML/analog controls