### PR TITLE
Add type-to-search across manager and selector dialogs

### DIFF
--- a/docs/ACTIONS.md
+++ b/docs/ACTIONS.md
@@ -457,6 +457,9 @@ so only a small allowlisted set of actions is available.
 Assign a [super key](SUPERKEYS.md) to this button. Select one from the Super
 Keys tab, then click **Map**.
 
+On the Super Keys and Macro tabs, start typing to focus the visible search box
+and filter the corresponding saved-action list immediately.
+
 Use **Open Super Keys…** to create or edit reusable super keys. Right-click a
 saved super key in the selector to open the Super Keys dialog with that super
 key selected.

--- a/docs/COMBOS.md
+++ b/docs/COMBOS.md
@@ -36,6 +36,13 @@ sending the keys to your apps.
 
 ![Choose the action to fire when the combo matches](assets/screenshots/keymasq_combo_select_action_dialog.png)
 
+In the **Active Combos** inspector, start typing to reveal its search field and
+filter the captured combo list immediately. Ctrl+F and the search button remain
+available as explicit alternatives.
+
+Combo searches match visible name, trigger, action, and profile details, or one
+individual device/source field; unrelated hidden metadata is not combined.
+
 ## How Combos Work
 
 ### Single-Step Combos

--- a/docs/COMBOS.md
+++ b/docs/COMBOS.md
@@ -36,9 +36,9 @@ sending the keys to your apps.
 
 ![Choose the action to fire when the combo matches](assets/screenshots/keymasq_combo_select_action_dialog.png)
 
-In the **Active Combos** inspector, start typing to reveal its search field and
-filter the captured combo list immediately. Ctrl+F and the search button remain
-available as explicit alternatives.
+In the **Combos** tab or **Active Combos** inspector, start typing to reveal the
+search field and filter the combo list immediately. Ctrl+F and the search button
+remain available as explicit alternatives.
 
 Combo searches match visible name, trigger, action, and profile details, or one
 individual device/source field; unrelated hidden metadata is not combined.

--- a/docs/GAMEPAD.md
+++ b/docs/GAMEPAD.md
@@ -256,6 +256,9 @@ Open **Analog Controls** from the GUI main menu. The dialog has two panels:
 - **Right panel**: edit the selected config's name, description, input
   type, mode, and mode-specific settings.
 
+Start typing while focus is outside an editor field to search the saved Analog
+Controls immediately. Ctrl+F and the search button provide the same filter.
+
 ![Analog Controls manager dialog](assets/screenshots/keymasq_analog_controls_manager.png)
 
 Use **Save** to apply changes. If you switch selection or close the dialog

--- a/docs/SUPERKEYS.md
+++ b/docs/SUPERKEYS.md
@@ -81,6 +81,9 @@ Open **Super Keys** from the GUI. The dialog has two panels:
 - **Right panel**: edit the selected super key's name, description, mode,
   actions, and timing.
 
+Start typing while focus is outside an editor field to search the saved Super
+Keys immediately. Ctrl+F and the search button provide the same filter.
+
 Use **Save** to apply changes. If you close the dialog or press Escape with
 unsaved edits, Keymasq asks whether to save, discard, or keep editing.
 

--- a/keymasq/gui/widgets/analog_control/dialog.py
+++ b/keymasq/gui/widgets/analog_control/dialog.py
@@ -30,6 +30,7 @@ from keymasq.gui.widgets.analog_control.options import (
 from keymasq.gui.widgets.analog_control.persistence import AnalogControlPersistence
 from keymasq.gui.widgets.analog_control.view import AnalogControlEditorView, OutputChoicesLoader
 from keymasq.gui.widgets.docs_links import actions_docs_url
+from keymasq.gui.widgets.fuzzy_search import start_search_from_keypress
 from keymasq.gui.widgets.gamepad_output_choices import virtual_gamepad_count
 from keymasq.gui.widgets.managed_editor.shell import (
     ManagedEditorCallbacks,
@@ -201,7 +202,13 @@ class AnalogControlDialog(Adw.Dialog):
         if keyval == Gdk.KEY_Escape:
             self._request_close()
             return True
-        return False
+        return start_search_from_keypress(
+            self,
+            self.shell.search_entry,
+            keyval,
+            state,
+            show_search=self.shell.show_search,
+        )
 
     def _on_key_released(
         self,

--- a/keymasq/gui/widgets/combo_inspector_window.py
+++ b/keymasq/gui/widgets/combo_inspector_window.py
@@ -24,13 +24,16 @@ from keymasq.gui.widgets.action_labels import describe_mapping_action_compact
 from keymasq.gui.widgets.action_payloads import mapping_action_from_payload
 from keymasq.gui.widgets.combo_list import SORT_ACTION, SORT_NAME, SORT_TRIGGER, SortableComboList
 from keymasq.gui.widgets.combo_presentation import (
+    ComboSearchDocument,
     combo_action_label,
     combo_default_name,
     combo_key_label,
-    combo_search_text,
+    combo_row_search_matches,
+    combo_search_document,
     combo_trigger_label,
     create_combo_summary_row,
 )
+from keymasq.gui.widgets.fuzzy_search import start_search_from_keypress
 
 
 @dataclass
@@ -45,7 +48,7 @@ class ComboInspectorItem:
     restore_trigger_keys: list[str] | None = None
     match_across_devices: bool = False
     step_tooltips: list[str] | None = None
-    search_text: str = ""
+    search_document: ComboSearchDocument = ComboSearchDocument()
 
 
 @dataclass
@@ -158,6 +161,7 @@ class ComboInspectorWindow(Adw.Window):
                 SORT_ACTION: lambda item: describe_mapping_action_compact(item.action),
             },
             create_row=self._create_combo_row,
+            search_matches=combo_row_search_matches,
         )
         self.search_entry = self._combo_list.search_entry
         self.section_label = self._combo_list.section_label
@@ -334,7 +338,7 @@ class ComboInspectorWindow(Adw.Window):
             step_tooltips=item.step_tooltips,
         )
         row._combo_id = item.combo_id  # type: ignore[attr-defined]
-        row._search_text = item.search_text  # type: ignore[attr-defined]
+        row._combo_search_document = item.search_document  # type: ignore[attr-defined]
         return row
 
     def _on_search_clicked(self, _button: Gtk.Button) -> None:
@@ -353,7 +357,13 @@ class ComboInspectorWindow(Adw.Window):
         if keyval == Gdk.KEY_Escape and self.search_entry.get_visible():
             self._combo_list.hide_search()
             return True
-        return False
+        return start_search_from_keypress(
+            self,
+            self.search_entry,
+            keyval,
+            state,
+            show_search=self._combo_list.show_search,
+        )
 
     def _on_profiles_changed(self, _event: JsonDict) -> bool:
         self._request_snapshot()
@@ -486,7 +496,7 @@ def _profile_summary(active_profiles: list[str]) -> str:
 def _combo_item_from_payload(payload: JsonDict) -> ComboInspectorItem | None:
     steps: list[ComboStep] = []
     step_tooltips: list[str] = []
-    search_parts: list[str] = []
+    event_search_fields: list[str] = []
     for step_payload in _list_of_dicts(payload.get("steps")):
         events: list[ComboEvent] = []
         scope_lines: list[str] = []
@@ -499,12 +509,13 @@ def _combo_item_from_payload(payload: JsonDict) -> ComboInspectorItem | None:
             device_name = _text(event_payload.get("device_name"))
             events.append(ComboEvent(evdev=evdev, hardware_id=hardware_id, source=source or None))
             scope_lines.append(_event_scope_label(evdev, hardware_id, source, device_name))
-            search_parts.extend([evdev, hardware_id, source, device_name])
+            if device_name:
+                event_search_fields.append(device_name)
+                if source:
+                    event_search_fields.append(f"{device_name} {source}")
         if not events:
             continue
         timeout_ms = coerce_int(step_payload.get("timeout_ms"), None)
-        if timeout_ms is not None:
-            search_parts.append(f"{timeout_ms}ms")
         steps.append(ComboStep(events=events, timeout_ms=timeout_ms))
         step_tooltips.append("\n".join(scope_lines))
     if not steps:
@@ -543,12 +554,10 @@ def _combo_item_from_payload(payload: JsonDict) -> ComboInspectorItem | None:
         restore_trigger_keys=restore_trigger_keys,
         match_across_devices=match_across_devices,
         step_tooltips=step_tooltips,
-        search_text=" ".join(
-            [
-                combo_search_text(search_config, profile_name=profile_name),
-                " ".join(search_parts),
-                f"order {coerce_int(payload.get('order'), 0) + 1}",
-            ]
+        search_document=combo_search_document(
+            search_config,
+            profile_name=profile_name,
+            additional_event_fields=event_search_fields,
         ),
     )
 

--- a/keymasq/gui/widgets/combo_list.py
+++ b/keymasq/gui/widgets/combo_list.py
@@ -35,6 +35,7 @@ class SortableComboList[ItemT]:
         get_items: Callable[[], Iterable[ItemT]],
         sort_keys: Mapping[int, Callable[[ItemT], str]],
         create_row: Callable[[ItemT], Gtk.ListBoxRow],
+        search_matches: Callable[[str, Gtk.ListBoxRow], bool] | None = None,
         is_available: Callable[[], bool] | None = None,
         row_activated: Callable[[Gtk.ListBox, Gtk.ListBoxRow], None] | None = None,
         trailing_header_width: int | None = None,
@@ -44,6 +45,7 @@ class SortableComboList[ItemT]:
         self._get_items = get_items
         self._sort_keys = dict(sort_keys)
         self._create_row = create_row
+        self._search_matches = search_matches or self._default_search_matches
         self._is_available = is_available or (lambda: True)
         self._sort_column = SORT_NONE
         self._sort_ascending = True
@@ -70,6 +72,7 @@ class SortableComboList[ItemT]:
         install_listbox_fuzzy_filter(
             self.listbox,
             self.search_entry,
+            row_matches=self._search_matches,
             after_filter_changed=self._after_search_filter_changed,
         )
 
@@ -148,11 +151,11 @@ class SortableComboList[ItemT]:
 
     def visible_count(self) -> int:
         query = self.search_entry.get_text()
-        return sum(
-            1
-            for row in self.iter_rows()
-            if fuzzy_query_matches(query, getattr(row, "_search_text", ""))
-        )
+        return sum(1 for row in self.iter_rows() if self._search_matches(query, row))
+
+    @staticmethod
+    def _default_search_matches(query: str, row: Gtk.ListBoxRow) -> bool:
+        return fuzzy_query_matches(query, getattr(row, "_search_text", ""))
 
     def update_state(self, *, has_combos: bool | None = None) -> None:
         if not self._is_available():

--- a/keymasq/gui/widgets/combo_presentation.py
+++ b/keymasq/gui/widgets/combo_presentation.py
@@ -230,9 +230,9 @@ def combo_search_document(
 def combo_search_matches(query: str, document: ComboSearchDocument) -> bool:
     if fuzzy_query_matches(query, ""):
         return True
-    return any(
-        fuzzy_query_matches(query, field)
-        for field in (*document.visible_fields, *document.supplemental_fields)
+    visible_text = " ".join(document.visible_fields)
+    return fuzzy_query_matches(query, visible_text) or any(
+        fuzzy_query_matches(query, field) for field in document.supplemental_fields
     )
 
 

--- a/keymasq/gui/widgets/combo_presentation.py
+++ b/keymasq/gui/widgets/combo_presentation.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
+from dataclasses import dataclass
 
 import gi
 
@@ -13,7 +14,14 @@ from keymasq.common.model.actions import MappingAction
 from keymasq.common.model.core import ActionType
 from keymasq.common.model.profiles import ComboConfig, ComboEvent, ComboStep
 from keymasq.gui.widgets.action_labels import describe_mapping_action_compact
+from keymasq.gui.widgets.fuzzy_search import fuzzy_query_matches
 from keymasq.gui.widgets.key_selector.targets import EVDEV_TO_GAMEPAD, EVDEV_TO_KEY
+
+
+@dataclass(frozen=True)
+class ComboSearchDocument:
+    visible_fields: tuple[str, ...] = ()
+    supplemental_fields: tuple[str, ...] = ()
 
 
 def sort_combo_keys(keys: list[str]) -> list[str]:
@@ -174,25 +182,65 @@ def combo_default_name(combo: ComboConfig) -> str:
     return "Combo"
 
 
-def combo_search_text(combo: ComboConfig, *, profile_name: str = "") -> str:
-    parts = [
+def combo_search_document(
+    combo: ComboConfig,
+    *,
+    profile_name: str = "",
+    additional_event_fields: Sequence[str] = (),
+) -> ComboSearchDocument:
+    visible_parts = [
         combo.name or combo_default_name(combo),
         combo_trigger_label(combo.steps),
         describe_mapping_action_compact(combo.action),
         profile_name,
     ]
+    supplemental_fields: list[str] = []
     for step in combo.steps:
         if step.timeout_ms is not None:
-            parts.append(f"{int(step.timeout_ms)}ms")
+            supplemental_fields.append(f"timeout {int(step.timeout_ms)}ms")
         for event in step.events:
-            parts.extend([event.evdev, event.hardware_id, event.source or ""])
+            supplemental_fields.extend(
+                field
+                for field in (
+                    f"{combo_key_label(event.evdev)} {event.evdev}",
+                    event.hardware_id,
+                    event.source or "",
+                )
+                if field.strip()
+            )
     if combo.recall_trigger_keys:
-        parts.append("recall trigger keys")
+        supplemental_fields.append("recall trigger keys")
     if combo.restore_trigger_keys:
-        parts.extend(combo.restore_trigger_keys)
+        supplemental_fields.append(
+            "restore trigger keys " + " ".join(combo.restore_trigger_keys)
+        )
     if combo.match_across_devices:
-        parts.append("any device across devices")
-    return " ".join(str(part) for part in parts if str(part or "").strip())
+        supplemental_fields.append("any device across devices")
+    supplemental_fields.extend(
+        str(field) for field in additional_event_fields if str(field or "").strip()
+    )
+    return ComboSearchDocument(
+        visible_fields=tuple(
+            str(part) for part in visible_parts if str(part or "").strip()
+        ),
+        supplemental_fields=tuple(supplemental_fields),
+    )
+
+
+def combo_search_matches(query: str, document: ComboSearchDocument) -> bool:
+    if fuzzy_query_matches(query, ""):
+        return True
+    return any(
+        fuzzy_query_matches(query, field)
+        for field in (*document.visible_fields, *document.supplemental_fields)
+    )
+
+
+def combo_row_search_matches(query: str, row: Gtk.ListBoxRow) -> bool:
+    document = getattr(row, "_combo_search_document", None)
+    if not isinstance(document, ComboSearchDocument):
+        return fuzzy_query_matches(query, "")
+    return combo_search_matches(query, document)
 
 
 def create_combo_summary_row(

--- a/keymasq/gui/widgets/combo_tab.py
+++ b/keymasq/gui/widgets/combo_tab.py
@@ -21,6 +21,7 @@ from keymasq.gui.widgets.combo_presentation import (
     combo_trigger_label,
     create_combo_summary_row,
 )
+from keymasq.gui.widgets.fuzzy_search import start_search_from_keypress
 from keymasq.gui.widgets.profile_managed_tab import ProfileManagedTab
 from keymasq.session.profile.manager import ProfileManager
 from keymasq.session.profile.types import ProfileInfo
@@ -223,7 +224,13 @@ class ComboTab(ProfileManagedTab):
         if keyval == Gdk.KEY_Escape and self.search_entry.get_visible():
             self._combo_list.hide_search()
             return True
-        return False
+        return start_search_from_keypress(
+            self,
+            self.search_entry,
+            keyval,
+            state,
+            show_search=self._combo_list.show_search,
+        )
 
     def _on_inspect_combos_clicked(self, _button: Gtk.Button) -> None:
         root = self.main_window or self.get_root()

--- a/keymasq/gui/widgets/combo_tab.py
+++ b/keymasq/gui/widgets/combo_tab.py
@@ -16,7 +16,8 @@ from keymasq.gui.widgets.combo_editor_dialog import ComboEditorDialog, combo_tri
 from keymasq.gui.widgets.combo_list import SORT_ACTION, SORT_NAME, SORT_TRIGGER, SortableComboList
 from keymasq.gui.widgets.combo_presentation import (
     combo_default_name,
-    combo_search_text,
+    combo_row_search_matches,
+    combo_search_document,
     combo_trigger_label,
     create_combo_summary_row,
 )
@@ -132,6 +133,7 @@ class ComboTab(ProfileManagedTab):
                 SORT_ACTION: lambda combo: describe_mapping_action_compact(combo.action),
             },
             create_row=self._create_combo_row,
+            search_matches=combo_row_search_matches,
             is_available=lambda: self._selected_profile is not None,
             row_activated=self._on_row_activated,
             trailing_header_width=36,
@@ -199,7 +201,7 @@ class ComboTab(ProfileManagedTab):
             trailing_widget=delete_button,
         )
         row._combo_id = combo.id  # type: ignore[attr-defined]
-        row._search_text = combo_search_text(  # type: ignore[attr-defined]
+        row._combo_search_document = combo_search_document(  # type: ignore[attr-defined]
             combo,
             profile_name=self.selected_profile_name() or "",
         )

--- a/keymasq/gui/widgets/fuzzy_search.py
+++ b/keymasq/gui/widgets/fuzzy_search.py
@@ -3,13 +3,20 @@ from collections.abc import Callable, Mapping
 
 import gi
 
+gi.require_version("Gdk", "4.0")
 gi.require_version("Gtk", "4.0")
 
-from gi.repository import Gtk  # pyright: ignore[reportAttributeAccessIssue]
+from gi.repository import Gdk, Gtk  # pyright: ignore[reportAttributeAccessIssue]
 
 from keymasq.common.model.superkeys import SuperkeyConfig
 
 _TOKEN_RE = re.compile(r"\w+", re.UNICODE)
+_SEARCH_BLOCKING_MODIFIERS = (
+    Gdk.ModifierType.CONTROL_MASK
+    | Gdk.ModifierType.ALT_MASK
+    | Gdk.ModifierType.SUPER_MASK
+    | Gdk.ModifierType.META_MASK
+)
 
 
 def _normalize_search_text(value: object) -> str:
@@ -100,18 +107,71 @@ def superkey_search_text(config: SuperkeyConfig | None, name: str) -> str:
     )
 
 
+def start_search_from_keypress(
+    owner: Gtk.Widget,
+    search_entry: Gtk.SearchEntry,
+    keyval: int,
+    state: Gdk.ModifierType | int,
+    *,
+    show_search: Callable[[], None] | None = None,
+) -> bool:
+    """Start a search with an unmodified printable key.
+
+    Existing text inputs retain normal typing behavior. This lets dialogs use
+    type-to-search without stealing input from editor fields.
+    """
+    if state & _SEARCH_BLOCKING_MODIFIERS:
+        return False
+    if _text_input_has_focus(owner):
+        return False
+
+    unicode_value = Gdk.keyval_to_unicode(keyval)
+    if not unicode_value:
+        return False
+    char = chr(unicode_value)
+    if not char.isprintable() or char.isspace():
+        return False
+
+    search_was_visible = search_entry.get_visible()
+    existing_text = search_entry.get_text() if search_was_visible else ""
+    if search_was_visible:
+        search_entry.grab_focus()
+    elif show_search is not None:
+        show_search()
+    else:
+        return False
+    if not search_entry.get_visible():
+        return False
+    search_entry.set_text(existing_text + char)
+    search_entry.set_position(-1)
+    return True
+
+
+def _text_input_has_focus(owner: Gtk.Widget) -> bool:
+    root = owner.get_root()
+    focus = root.get_focus() if root is not None else None
+    while focus is not None:
+        if isinstance(focus, Gtk.Editable | Gtk.TextView):
+            return True
+        focus = focus.get_parent()
+    return False
+
+
 def install_listbox_fuzzy_filter(
     listbox: Gtk.ListBox,
     search_entry: Gtk.Editable,
     *,
     row_text_attr: str = "_search_text",
     row_text: Callable[[Gtk.ListBoxRow], object] | None = None,
+    row_matches: Callable[[str, Gtk.ListBoxRow], bool] | None = None,
     before_filter_changed: Callable[[], None] | None = None,
     after_filter_changed: Callable[[], None] | None = None,
 ) -> None:
     state = {"query": search_entry.get_text()}
 
     def filter_row(row: Gtk.ListBoxRow) -> bool:
+        if row_matches is not None:
+            return row_matches(state["query"], row)
         text = row_text(row) if row_text is not None else getattr(row, row_text_attr, "")
         return fuzzy_query_matches(state["query"], text)
 

--- a/keymasq/gui/widgets/key_selector/dialog.py
+++ b/keymasq/gui/widgets/key_selector/dialog.py
@@ -8,7 +8,7 @@ import gi
 gi.require_version("Gtk", "4.0")
 gi.require_version("Adw", "1")
 
-from gi.repository import Adw, GObject, Gtk  # pyright: ignore[reportAttributeAccessIssue]
+from gi.repository import Adw, Gdk, GObject, Gtk  # pyright: ignore[reportAttributeAccessIssue]
 
 from keymasq.common.model.actions import (
     DEFAULT_NATURAL_MOUSE_MOVE_CURVE,
@@ -30,6 +30,7 @@ from keymasq.gui.widgets.compositor_actions import (
     build_compositor_action_pages,
     compositor_action_tab_name,
 )
+from keymasq.gui.widgets.fuzzy_search import start_search_from_keypress
 from keymasq.gui.widgets.mouse_move_units import speed_kpx_s_to_px_s
 from keymasq.gui.widgets.position_capture import PositionCallback, PositionCaptureController
 
@@ -435,8 +436,27 @@ class KeySelectorDialog(
         main_box.append(frame)
         self.set_child(main_box)
 
+        search_key_controller = Gtk.EventControllerKey()
+        search_key_controller.connect("key-pressed", self._on_search_key_pressed)
+        self.add_controller(search_key_controller)
+
         self.stack.connect("notify::visible-child", self._on_tab_changed)
         self._on_tab_changed(self.stack, None)
+
+    def _on_search_key_pressed(
+        self,
+        _controller: Gtk.EventControllerKey,
+        keyval: int,
+        _keycode: int,
+        state: Gdk.ModifierType,
+    ) -> bool:
+        search_entry = {
+            "macro": getattr(self, "_macro_search_entry", None),
+            "superkey": getattr(self, "_superkey_search_entry", None),
+        }.get(self.stack.get_visible_child_name())
+        if search_entry is None:
+            return False
+        return start_search_from_keypress(self, search_entry, keyval, state)
 
     def _on_cancel_clicked(self, _button: Gtk.Button) -> None:
         self.close()

--- a/keymasq/gui/widgets/macro_manager/view.py
+++ b/keymasq/gui/widgets/macro_manager/view.py
@@ -9,7 +9,10 @@ gi.require_version("Gtk", "4.0")
 from gi.repository import Gdk, Gtk  # pyright: ignore[reportAttributeAccessIssue]
 
 from keymasq.common.model.actions import MAX_MACRO_RECORDING_SLOTS
-from keymasq.gui.widgets.fuzzy_search import install_listbox_fuzzy_filter
+from keymasq.gui.widgets.fuzzy_search import (
+    install_listbox_fuzzy_filter,
+    start_search_from_keypress,
+)
 
 
 class ManagerViewMixin:
@@ -160,31 +163,12 @@ class ManagerViewMixin:
         if keyval == Gdk.KEY_Escape and self._search_entry.get_visible():
             self._hide_search()
             return True
-        if state & (
-            Gdk.ModifierType.CONTROL_MASK
-            | Gdk.ModifierType.ALT_MASK
-            | Gdk.ModifierType.SUPER_MASK
-            | Gdk.ModifierType.META_MASK
-        ):
-            return False
-        if self._search_focused():
-            return False
-        unicode_value = Gdk.keyval_to_unicode(keyval)
-        if not unicode_value:
-            return False
-        char = chr(unicode_value)
-        if not char.isprintable() or char.isspace():
-            return False
-        self._show_search()
-        self._search_entry.set_text(char)
-        self._search_entry.set_position(-1)
-        return True
-
-    def _search_focused(self) -> bool:
-        root = self.get_root()
-        focus = root.get_focus() if root is not None else None
-        return focus is not None and (
-            focus is self._search_entry or focus.is_ancestor(self._search_entry)
+        return start_search_from_keypress(
+            self,
+            self._search_entry,
+            keyval,
+            state,
+            show_search=self._show_search,
         )
 
     def _show_search(self) -> None:

--- a/keymasq/gui/widgets/superkey_editor/dialog.py
+++ b/keymasq/gui/widgets/superkey_editor/dialog.py
@@ -20,7 +20,7 @@ from keymasq.common.model.actions import MappingAction
 from keymasq.common.model.superkeys import SuperkeyAction, SuperkeyConfig
 from keymasq.gui.widgets.action_sequence import ActionSequenceDialog, ActionSequenceMode
 from keymasq.gui.widgets.docs_links import docs_page_url
-from keymasq.gui.widgets.fuzzy_search import superkey_search_text
+from keymasq.gui.widgets.fuzzy_search import start_search_from_keypress, superkey_search_text
 from keymasq.gui.widgets.managed_editor.shell import (
     ManagedEditorCallbacks,
     ManagedEditorLabels,
@@ -150,7 +150,13 @@ class SuperkeyDialog(Adw.Dialog):
         if keyval == Gdk.KEY_Escape:
             self._request_close()
             return True
-        return False
+        return start_search_from_keypress(
+            self,
+            self.shell.search_entry,
+            keyval,
+            state,
+            show_search=self.shell.show_search,
+        )
 
     def do_close_attempt(self) -> None:
         self._request_close()

--- a/tests/gui/test_combo_inspector_window.py
+++ b/tests/gui/test_combo_inspector_window.py
@@ -199,7 +199,7 @@ def test_combo_inspector_search_scopes_visible_and_runtime_fields(monkeypatch) -
     window.search_entry.set_text("movetoworkspace 4")
     assert visible_combo_ids() == ["workspace-4"]
 
-    window.search_entry.set_text("test t3")
+    window.search_entry.set_text("keyboard controller")
     assert visible_combo_ids() == []
     assert window.section_label.get_text() == "No matching active combos."
 

--- a/tests/gui/test_combo_inspector_window.py
+++ b/tests/gui/test_combo_inspector_window.py
@@ -3,11 +3,12 @@ import pytest
 from tests.gui.support import SessionIpcHarness, collect_listbox_row_labels
 
 gi = pytest.importorskip("gi")
+gi.require_version("Gdk", "4.0")
 gi.require_version("Gtk", "4.0")
 
 
 def test_combo_inspector_window_renders_snapshot_and_search(monkeypatch) -> None:
-    from gi.repository import Gtk
+    from gi.repository import Gdk, Gtk
 
     from keymasq.gui.widgets import combo_inspector_window as inspector_module
     from keymasq.gui.widgets.combo_inspector_window import ComboInspectorWindow
@@ -87,6 +88,19 @@ def test_combo_inspector_window_renders_snapshot_and_search(monkeypatch) -> None
 
     assert collect_listbox_row_labels(window.combo_listbox) == ["Quick Save"]
 
+    assert (
+        window._on_key_pressed(
+            Gtk.EventControllerKey(),
+            Gdk.KEY_q,
+            0,
+            Gdk.ModifierType(0),
+        )
+        is True
+    )
+    assert window.search_entry.get_visible() is True
+    assert window.search_entry.get_text() == "q"
+    window._combo_list.hide_search()
+
     window.search_button.emit("clicked")
     assert window.search_entry.get_visible() is True
 
@@ -129,6 +143,70 @@ def test_combo_inspector_window_renders_snapshot_and_search(monkeypatch) -> None
     assert session.callbacks["profiles_changed"] == []
     assert session.callbacks["runtime_reset"] == []
     assert session.callbacks["keymasqd_status"] == []
+
+
+def test_combo_inspector_search_scopes_visible_and_runtime_fields(monkeypatch) -> None:
+    from gi.repository import Gtk
+
+    from keymasq.gui.widgets import combo_inspector_window as inspector_module
+    from keymasq.gui.widgets.combo_inspector_window import ComboInspectorWindow
+
+    def workspace_combo(workspace: int) -> dict[str, object]:
+        suffix = f" {workspace}" if workspace > 1 else ""
+        return {
+            "id": f"workspace-{workspace}",
+            "name": f"movetoworkspace{suffix}",
+            "profile_name": "Desktop",
+            "order": workspace - 1,
+            "steps": [
+                {
+                    "events": [
+                        {
+                            "evdev": f"key_f{workspace + 4}",
+                            "hardware_id": "t3-controller-4",
+                            "source": "kbd",
+                            "device_name": "Test Keyboard",
+                        }
+                    ]
+                }
+            ],
+            "action": {
+                "action": "compositor_dispatch",
+                "dispatcher": "movetoworkspace",
+                "args": str(workspace),
+            },
+        }
+
+    snapshot = {
+        "status": "ok",
+        "active_profiles": ["Desktop"],
+        "combos": [workspace_combo(workspace) for workspace in range(1, 7)],
+    }
+
+    def request_handler(_payload, callback, _timeout):
+        callback(snapshot)
+
+    SessionIpcHarness(request_handler=request_handler).install(monkeypatch, inspector_module)
+    window = ComboInspectorWindow(Gtk.Window())
+
+    def visible_combo_ids() -> list[str]:
+        return [
+            row._combo_id
+            for row in window._combo_list.iter_rows()
+            if row.get_child_visible()
+        ]
+
+    window.search_entry.set_text("movetoworkspace 4")
+    assert visible_combo_ids() == ["workspace-4"]
+
+    window.search_entry.set_text("test t3")
+    assert visible_combo_ids() == []
+    assert window.section_label.get_text() == "No matching active combos."
+
+    window.search_entry.set_text("")
+    assert visible_combo_ids() == [f"workspace-{workspace}" for workspace in range(1, 7)]
+
+    window._finalize()
 
 
 def test_combo_inspector_window_ignores_stale_snapshot_responses(monkeypatch) -> None:

--- a/tests/gui/test_combo_presentation.py
+++ b/tests/gui/test_combo_presentation.py
@@ -133,7 +133,9 @@ def test_combo_search_keeps_runtime_device_fields_scoped() -> None:
     )
 
     assert combo_search_matches("test kbd", document)
-    assert not combo_search_matches("test t3", document)
+    assert combo_search_matches("quick f5", document)
+    assert combo_search_matches("quick desktop", document)
+    assert not combo_search_matches("keyboard controller", document)
     assert not combo_search_matches("quick t3", document)
     assert combo_search_matches("qs", document)
 

--- a/tests/gui/test_combo_presentation.py
+++ b/tests/gui/test_combo_presentation.py
@@ -56,3 +56,94 @@ def test_create_combo_summary_row_supports_readonly_and_trailing_widget() -> Non
 
     pills = [label for label in labels if "combo-step-pill" in set(label.get_css_classes())]
     assert [pill.get_tooltip_text() for pill in pills] == ["Keyboard chord", "Follow-up key"]
+
+
+def test_combo_search_does_not_mix_visible_terms_with_hidden_metadata() -> None:
+    from keymasq.common.model.actions import MappingAction
+    from keymasq.common.model.core import ActionType
+    from keymasq.common.model.profiles import ComboConfig, ComboEvent, ComboStep
+    from keymasq.gui.widgets.combo_presentation import (
+        combo_search_document,
+        combo_search_matches,
+    )
+
+    documents = []
+    for workspace in range(1, 7):
+        suffix = f" {workspace}" if workspace > 1 else ""
+        combo = ComboConfig(
+            id=f"workspace-{workspace}",
+            name=f"movetoworkspace{suffix}",
+            steps=[
+                ComboStep(
+                    events=[
+                        ComboEvent(
+                            evdev=f"key_f{workspace + 4}",
+                            hardware_id="shared-device-4",
+                            source="kbd",
+                        )
+                    ]
+                )
+            ],
+            action=MappingAction(
+                action_type=ActionType.COMPOSITOR_DISPATCH,
+                compositor_dispatcher="movetoworkspace",
+                compositor_args=str(workspace),
+            ),
+        )
+        documents.append(combo_search_document(combo, profile_name="Desktop"))
+
+    matching_workspaces = [
+        workspace
+        for workspace, document in enumerate(documents, start=1)
+        if combo_search_matches("movetoworkspace 4", document)
+    ]
+
+    assert matching_workspaces == [4]
+
+
+def test_combo_search_keeps_runtime_device_fields_scoped() -> None:
+    from keymasq.common.model.actions import MappingAction
+    from keymasq.common.model.core import ActionType
+    from keymasq.common.model.profiles import ComboConfig, ComboEvent, ComboStep
+    from keymasq.gui.widgets.combo_presentation import (
+        combo_search_document,
+        combo_search_matches,
+    )
+
+    combo = ComboConfig(
+        id="quick-save",
+        name="Quick Save",
+        steps=[
+            ComboStep(
+                events=[
+                    ComboEvent(
+                        evdev="key_s",
+                        hardware_id="t3-controller",
+                        source="kbd",
+                    )
+                ]
+            )
+        ],
+        action=MappingAction(action_type=ActionType.KEYBOARD, target="key_f5"),
+    )
+    document = combo_search_document(
+        combo,
+        profile_name="Desktop",
+        additional_event_fields=["Test Keyboard", "Test Keyboard kbd"],
+    )
+
+    assert combo_search_matches("test kbd", document)
+    assert not combo_search_matches("test t3", document)
+    assert not combo_search_matches("quick t3", document)
+    assert combo_search_matches("qs", document)
+
+
+def test_combo_row_without_search_document_is_visible_for_an_empty_query() -> None:
+    from gi.repository import Gtk
+
+    from keymasq.gui.widgets.combo_presentation import combo_row_search_matches
+
+    row = Gtk.ListBoxRow()
+
+    assert combo_row_search_matches("", row)
+    assert not combo_row_search_matches("quick", row)

--- a/tests/gui/test_combo_tab_widget.py
+++ b/tests/gui/test_combo_tab_widget.py
@@ -569,7 +569,7 @@ class TestComboTabWidget:
         profile_manager = ProfileManager()
         profile_manager.save_profile(
             ProfileConfig(
-                name="Desktop",
+                name="Office",
                 enabled=True,
                 is_permanent=True,
                 combos=[
@@ -610,7 +610,7 @@ class TestComboTabWidget:
         )
 
         tab = ComboTab(profile_manager=profile_manager, demo_mode=True)
-        tab.refresh_profiles(preferred_profile_name="Desktop", publish_selection=False)
+        tab.refresh_profiles(preferred_profile_name="Office", publish_selection=False)
 
         assert tab.search_entry.get_visible() is False
         assert (
@@ -624,6 +624,7 @@ class TestComboTabWidget:
         )
         assert tab.search_entry.get_visible() is True
         assert tab.search_entry.get_text() == "m"
+        assert tab._combo_list.visible_count() == 1
 
         tab.search_entry.set_text("mouse")
         assert tab._combo_list.visible_count() == 1

--- a/tests/gui/test_combo_tab_widget.py
+++ b/tests/gui/test_combo_tab_widget.py
@@ -558,6 +558,8 @@ class TestComboTabWidget:
         assert opened == ["combo-c"]
 
     def test_combo_tab_search_filters_rows(self, temp_config_dir):
+        from gi.repository import Gdk, Gtk
+
         from keymasq.common.model.core import ActionType
         from keymasq.common.model.profiles import ComboConfig, ComboEvent, ComboStep, ProfileConfig
         from keymasq.common.model.actions import MappingAction
@@ -611,8 +613,17 @@ class TestComboTabWidget:
         tab.refresh_profiles(preferred_profile_name="Desktop", publish_selection=False)
 
         assert tab.search_entry.get_visible() is False
-        tab.search_button.emit("clicked")
+        assert (
+            tab._on_key_pressed(
+                Gtk.EventControllerKey(),
+                Gdk.KEY_m,
+                0,
+                Gdk.ModifierType(0),
+            )
+            is True
+        )
         assert tab.search_entry.get_visible() is True
+        assert tab.search_entry.get_text() == "m"
 
         tab.search_entry.set_text("mouse")
         assert tab._combo_list.visible_count() == 1
@@ -636,6 +647,17 @@ class TestComboTabWidget:
 
         tab._combo_list.show_search()
         assert tab.search_entry.get_visible() is False
+        assert (
+            tab._on_key_pressed(
+                Gtk.EventControllerKey(),
+                Gdk.KEY_m,
+                0,
+                Gdk.ModifierType(0),
+            )
+            is False
+        )
+        assert tab.search_entry.get_visible() is False
+        assert tab.search_entry.get_text() == ""
 
         tab.search_entry.set_visible(True)
         tab.search_entry.set_text("stale")

--- a/tests/gui/test_fuzzy_search.py
+++ b/tests/gui/test_fuzzy_search.py
@@ -27,6 +27,114 @@ def test_fuzzy_query_matches_substrings_and_abbreviations() -> None:
     )
 
 
+def test_type_to_search_does_not_steal_from_text_inputs() -> None:
+    gi.require_version("Gdk", "4.0")
+    gi.require_version("Gtk", "4.0")
+    from gi.repository import Gdk, Gtk
+
+    from keymasq.gui.widgets.fuzzy_search import start_search_from_keypress
+
+    owner = Gtk.Window()
+    editor = Gtk.Entry()
+    owner.set_child(editor)
+    editor.grab_focus()
+    search_entry = Gtk.SearchEntry()
+
+    handled = start_search_from_keypress(
+        owner,
+        search_entry,
+        Gdk.KEY_a,
+        Gdk.ModifierType(0),
+    )
+
+    assert handled is False
+    assert search_entry.get_text() == ""
+
+
+def test_type_to_search_appends_to_a_visible_unfocused_query() -> None:
+    gi.require_version("Gdk", "4.0")
+    gi.require_version("Gtk", "4.0")
+    from gi.repository import Gdk, Gtk
+
+    from keymasq.gui.widgets.fuzzy_search import start_search_from_keypress
+
+    owner = Gtk.Window()
+    content = Gtk.Box()
+    search_entry = Gtk.SearchEntry()
+    search_entry.set_text("existing")
+    other_button = Gtk.Button()
+    content.append(search_entry)
+    content.append(other_button)
+    owner.set_child(content)
+    other_button.grab_focus()
+
+    handled = start_search_from_keypress(
+        owner,
+        search_entry,
+        Gdk.KEY_q,
+        Gdk.ModifierType(0),
+        show_search=lambda: pytest.fail("visible search must not be reselected"),
+    )
+
+    assert handled is True
+    assert search_entry.get_text() == "existingq"
+
+
+def test_type_to_search_does_not_mutate_a_hidden_entry_when_show_declines() -> None:
+    gi.require_version("Gdk", "4.0")
+    gi.require_version("Gtk", "4.0")
+    from gi.repository import Gdk, Gtk
+
+    from keymasq.gui.widgets.fuzzy_search import start_search_from_keypress
+
+    owner = Gtk.Window()
+    search_entry = Gtk.SearchEntry()
+    search_entry.set_visible(False)
+    owner.set_child(search_entry)
+
+    handled = start_search_from_keypress(
+        owner,
+        search_entry,
+        Gdk.KEY_q,
+        Gdk.ModifierType(0),
+        show_search=lambda: None,
+    )
+
+    assert handled is False
+    assert search_entry.get_text() == ""
+
+
+def test_type_to_search_ignores_space_and_modified_keys() -> None:
+    gi.require_version("Gdk", "4.0")
+    gi.require_version("Gtk", "4.0")
+    from gi.repository import Gdk, Gtk
+
+    from keymasq.gui.widgets.fuzzy_search import start_search_from_keypress
+
+    owner = Gtk.Window()
+    content = Gtk.Box()
+    search_entry = Gtk.SearchEntry()
+    other_button = Gtk.Button()
+    content.append(search_entry)
+    content.append(other_button)
+    owner.set_child(content)
+    other_button.grab_focus()
+
+    assert not start_search_from_keypress(
+        owner,
+        search_entry,
+        Gdk.KEY_space,
+        Gdk.ModifierType(0),
+    )
+    assert not start_search_from_keypress(
+        owner,
+        search_entry,
+        Gdk.KEY_q,
+        Gdk.ModifierType.CONTROL_MASK,
+    )
+    assert search_entry.get_text() == ""
+
+
 def test_macro_manager_search_entry_filters_against_row_metadata(monkeypatch) -> None:
     gi.require_version("Gtk", "4.0")
     from gi.repository import GLib, Gtk
@@ -100,12 +208,12 @@ def test_key_selector_macro_search_clears_hidden_selection(monkeypatch) -> None:
     gi.require_version("Gtk", "4.0")
     from gi.repository import Gtk
 
-    import keymasq.gui.widgets.key_selector.macro_tab as key_selector_dialog_module
+    import keymasq.gui.widgets.key_selector.macro_tab as macro_tab_module
     from keymasq.gui.widgets.key_selector.dialog import KeySelectorDialog
 
-    monkeypatch.setattr(key_selector_dialog_module.GLib, "idle_add", lambda callback, *args: 0)
+    monkeypatch.setattr(macro_tab_module.GLib, "idle_add", lambda callback, *args: 0)
     monkeypatch.setattr(
-        key_selector_dialog_module,
+        macro_tab_module,
         "session_request_async",
         lambda _payload, _callback: None,
     )
@@ -134,6 +242,58 @@ def test_key_selector_macro_search_clears_hidden_selection(monkeypatch) -> None:
 
     assert dialog._selected_macro is None
     assert dialog.map_btn.get_sensitive() is False
+
+
+def test_key_selector_typing_searches_active_saved_action_tab(monkeypatch) -> None:
+    gi.require_version("Gdk", "4.0")
+    gi.require_version("Gtk", "4.0")
+    from gi.repository import Gdk, Gtk
+
+    import keymasq.gui.widgets.key_selector.macro_tab as macro_tab_module
+    from keymasq.gui.widgets.key_selector.dialog import KeySelectorDialog
+
+    monkeypatch.setattr(macro_tab_module.GLib, "idle_add", lambda callback, *args: 0)
+    monkeypatch.setattr(
+        macro_tab_module,
+        "session_request_async",
+        lambda _payload, _callback: None,
+    )
+    dialog = KeySelectorDialog(Gtk.Window(), "Back")
+
+    dialog.stack.set_visible_child_name("macro")
+    assert (
+        dialog._on_search_key_pressed(
+            Gtk.EventControllerKey(),
+            Gdk.KEY_m,
+            0,
+            Gdk.ModifierType(0),
+        )
+        is True
+    )
+    assert dialog._macro_search_entry.get_text() == "m"
+
+    dialog.stack.set_visible_child_name("superkey")
+    assert (
+        dialog._on_search_key_pressed(
+            Gtk.EventControllerKey(),
+            Gdk.KEY_s,
+            0,
+            Gdk.ModifierType(0),
+        )
+        is True
+    )
+    assert dialog._superkey_search_entry.get_text() == "s"
+
+    dialog.stack.set_visible_child_name("keyboard")
+    assert (
+        dialog._on_search_key_pressed(
+            Gtk.EventControllerKey(),
+            Gdk.KEY_k,
+            0,
+            Gdk.ModifierType(0),
+        )
+        is False
+    )
 
 
 def test_key_selector_macro_refresh_clears_missing_selection(monkeypatch) -> None:
@@ -465,6 +625,18 @@ def test_superkey_dialog_search_is_revealed_by_button_and_ctrl_f(
     assert handled is True
     assert dialog.shell.search_entry.get_visible() is True
 
+    dialog.shell.hide_search()
+    handled = dialog._on_key_pressed(
+        Gtk.EventControllerKey(),
+        Gdk.KEY_s,
+        0,
+        Gdk.ModifierType(0),
+    )
+
+    assert handled is True
+    assert dialog.shell.search_entry.get_visible() is True
+    assert dialog.shell.search_entry.get_text() == "s"
+
 
 def test_analog_control_dialog_search_is_revealed_by_button_and_ctrl_f(
     temp_config_dir,
@@ -493,3 +665,15 @@ def test_analog_control_dialog_search_is_revealed_by_button_and_ctrl_f(
 
     assert handled is True
     assert dialog.shell.search_entry.get_visible() is True
+
+    dialog.shell.hide_search()
+    handled = dialog._on_key_pressed(
+        Gtk.EventControllerKey(),
+        Gdk.KEY_a,
+        0,
+        Gdk.ModifierType(0),
+    )
+
+    assert handled is True
+    assert dialog.shell.search_entry.get_visible() is True
+    assert dialog.shell.search_entry.get_text() == "a"


### PR DESCRIPTION
## Summary
- Shared `start_search_from_keypress` for type-to-search without stealing editor focus
- Wired into Super Keys, Analog Controls, macro manager, key selector (macro/superkey tabs), and Active Combos inspector
- Combo search uses field-scoped documents so visible/runtime terms are not mixed with unrelated metadata
- Docs updated for Super Keys, Analog Controls, Actions, and Combos

## Testing
- `tests/gui/test_fuzzy_search.py` (type-to-search, key selector, superkey/analog dialogs)
- `tests/gui/test_combo_presentation.py` (scoped combo search matching)
- `tests/gui/test_combo_inspector_window.py` (inspector type-to-search and field scoping)
- Full `./scripts/check.sh full`