### PR TITLE
Fix window rule capture and show full rule summaries

### DIFF
--- a/keymasq/gui/widgets/device_tab/tab.py
+++ b/keymasq/gui/widgets/device_tab/tab.py
@@ -82,8 +82,11 @@ class DeviceTab(
         self,
         payload: JsonDict,
         callback: SessionCallback,
+        timeout: float | None = None,
     ) -> object:
-        return session_request_async(payload, callback)
+        if timeout is None:
+            return session_request_async(payload, callback)
+        return session_request_async(payload, callback, timeout=timeout)
 
     def _create_key_selector_dialog(
         self,

--- a/keymasq/gui/widgets/profile_managed_tab.py
+++ b/keymasq/gui/widgets/profile_managed_tab.py
@@ -216,8 +216,15 @@ class ProfileManagedTab(
                 source_widget=self,
             )
 
-    def _request_session_async(self, payload: dict, callback) -> object:
-        return session_request_async(payload, callback)
+    def _request_session_async(
+        self,
+        payload: dict,
+        callback,
+        timeout: float | None = None,
+    ) -> object:
+        if timeout is None:
+            return session_request_async(payload, callback)
+        return session_request_async(payload, callback, timeout=timeout)
 
     def _notify_session_reload(self) -> bool:
         return notify_session_reload()

--- a/keymasq/gui/widgets/profile_tab/rules.py
+++ b/keymasq/gui/widgets/profile_tab/rules.py
@@ -486,15 +486,14 @@ class WindowRulesMixin:
 
     def _update_rules_label(self: Any) -> None:
         if not self._selected_profile:
-            self.rules_list_label.set_text("No profile selected")
+            self.window_rules_row.set_subtitle("No profile selected")
             return
 
         rules = self._selected_profile.config.window_rules
         if not rules:
-            self.rules_list_label.set_text("No rules - always active")
+            self.window_rules_row.set_subtitle("No rules - always active")
             return
 
-        parts = [f"{rule.field}={rule.pattern}" for rule in rules[:2]]
-        if len(rules) > 2:
-            parts.append(f"... (+{len(rules) - 2})")
-        self.rules_list_label.set_text(f"{', '.join(parts)} - conditional")
+        parts = [f"{rule.field}={rule.pattern}" for rule in rules]
+        parts[-1] = f"{parts[-1]} - conditional"
+        self.window_rules_row.set_subtitle("\n".join(parts))

--- a/keymasq/gui/widgets/profile_tab/settings.py
+++ b/keymasq/gui/widgets/profile_tab/settings.py
@@ -50,14 +50,14 @@ class ProfileSettingsMixin:
         priority_row.add_suffix(self.priority_spin)
         settings_group.add(priority_row)
 
-        self.window_rules_row = Adw.ActionRow(title="Window Rules")
+        self.window_rules_row = Adw.ActionRow(
+            title="Window Rules",
+            subtitle="No rules",
+            subtitle_lines=0,
+        )
         self.window_rules_row.set_tooltip_text(
             "Profiles are always active unless window rules are configured."
         )
-        self.rules_list_label = Gtk.Label(label="No rules")
-        self.rules_list_label.add_css_class("dim-label")
-        self.rules_list_label.set_valign(Gtk.Align.CENTER)
-        self.window_rules_row.add_suffix(self.rules_list_label)
         edit_rules_btn = Gtk.Button(label="Edit")
         edit_rules_btn.set_valign(Gtk.Align.CENTER)
         edit_rules_btn.connect("clicked", self._on_edit_window_rules)

--- a/tests/gui/test_profile_dialogs_and_actions.py
+++ b/tests/gui/test_profile_dialogs_and_actions.py
@@ -30,6 +30,92 @@ class TestProfileCreateDialog:
 
 
 class TestProfileManagedTab:
+    def test_window_rules_summary_wraps_all_rules_in_action_row_subtitle(self):
+        from pathlib import Path
+
+        from gi.repository import Gtk
+
+        from keymasq.common.model.profiles import ProfileConfig, WindowRule
+        from keymasq.gui.widgets.profile_managed_tab import ProfileManagedTab
+        from keymasq.session.profile.types import ProfileInfo
+
+        class ProfileManagerStub:
+            def list_profiles(self):
+                return []
+
+        tab = ProfileManagedTab(ProfileManagerStub(), demo_mode=True)
+        tab.settings_btn = Gtk.Button()
+        tab._setup_profile_settings()
+        tab._selected_profile = ProfileInfo(
+            Path("browser.toml"),
+            ProfileConfig(
+                name="browser",
+                window_rules=[
+                    WindowRule(field="class", pattern="brave\\-origin|librewolf"),
+                    WindowRule(
+                        field="title",
+                        pattern="Subscriptions\\ \\-\\ YouTube\\ \\-\\ Brave\\ Origin",
+                    ),
+                    WindowRule(field="tag", pattern="browser"),
+                ],
+            ),
+        )
+
+        tab._update_rules_label()
+
+        assert tab.window_rules_row.get_subtitle_lines() == 0
+        assert tab.window_rules_row.get_subtitle() == (
+            "class=brave\\-origin|librewolf\n"
+            "title=Subscriptions\\ \\-\\ YouTube\\ \\-\\ Brave\\ Origin\n"
+            "tag=browser - conditional"
+        )
+
+    def test_window_rule_capture_forwards_timeout_and_restores_ui(self, monkeypatch):
+        from keymasq.gui.widgets import profile_managed_tab as profile_managed_tab_module
+        from keymasq.gui.widgets.profile_managed_tab import ProfileManagedTab
+
+        class ProfileManagerStub:
+            def list_profiles(self):
+                return []
+
+        class LabelStub:
+            def __init__(self):
+                self.text = ""
+
+            def set_text(self, text):
+                self.text = text
+
+        class ButtonStub:
+            def __init__(self):
+                self.sensitive = False
+
+            def set_sensitive(self, sensitive):
+                self.sensitive = sensitive
+
+        requests = []
+
+        def session_request_async(payload, callback, timeout=5.0):
+            requests.append((payload, timeout))
+            callback({"status": "error", "message": "Capture unavailable"})
+
+        monkeypatch.setattr(
+            profile_managed_tab_module,
+            "session_request_async",
+            session_request_async,
+        )
+
+        tab = ProfileManagedTab(ProfileManagerStub())
+        tab._window_rule_capture_pending = True
+        tab._window_rule_capture_generation = 1
+        tab._window_rule_capture_status = LabelStub()
+        tab._window_rule_capture_btn = ButtonStub()
+
+        assert tab._capture_window_rules_after_delay() is False
+        assert requests == [({"command": "get_active_window"}, 5.0)]
+        assert tab._window_rule_capture_pending is False
+        assert tab._window_rule_capture_btn.sensitive is True
+        assert tab._window_rule_capture_status.text == "Capture unavailable"
+
     def test_lifecycle_macro_dropdown_reloads_on_macro_saved_event(self, monkeypatch):
         from keymasq.gui.widgets import profile_managed_tab as profile_managed_tab_module
         from keymasq.gui.widgets.profile_managed_tab import ProfileManagedTab

--- a/tests/gui/test_profile_dialogs_and_actions.py
+++ b/tests/gui/test_profile_dialogs_and_actions.py
@@ -93,8 +93,9 @@ class TestProfileManagedTab:
                 self.sensitive = sensitive
 
         requests = []
+        timeout_not_provided = object()
 
-        def session_request_async(payload, callback, timeout=5.0):
+        def session_request_async(payload, callback, timeout=timeout_not_provided):
             requests.append((payload, timeout))
             callback({"status": "error", "message": "Capture unavailable"})
 


### PR DESCRIPTION
## Summary

- forward explicit request timeouts through the shared profile and device-tab session wrappers so window capture completes
- display every configured window rule in an unlimited multiline `Adw.ActionRow` subtitle
- keep the Window Rules title readable and leave only the Edit button in the suffix area
- add regression coverage for capture error recovery and complete multiline summaries

## Root cause

The GUI boundary refactor introduced a wrapper around `session_request_async` that did not accept the capture flow's `timeout` argument. The delayed callback raised `TypeError` before sending IPC, leaving the dialog stuck on “Reading active window…”.

The settings row also rendered its rule summary as a suffix label with an unrestricted natural width. Long values squeezed the row title, and the summary omitted rules after the first two.

## Impact

Window capture now reaches the session service and restores the UI on errors. Long rule sets remain fully visible, wrap across lines, and are never shortened.

## Validation

- `./scripts/check.sh`
- ruff: passed
- basedpyright: passed
- stylelint: passed
- pytest: 639 passed