### PR TITLE
Scope macro cancellation cleanup to the emergency escape hatch

### DIFF
--- a/docs/COMBOS.md
+++ b/docs/COMBOS.md
@@ -275,8 +275,9 @@ secondary click can remove that click **everywhere**.
 `Ctrl+Alt+Esc` is reserved by default as Keymasq's emergency combo on grabbed
 keyboards. The daemon injects it into the active combo set, and the GUI rejects
 that exact trigger while the safety combo is enabled. One tap cancels macro
-playback after a 200 ms double-tap window; a double tap releases all grabbed
-devices and asks the session to reapply active profiles.
+playback and releases tracked held outputs after a 200 ms double-tap window; a
+double tap releases all grabbed devices and asks the session to reapply active
+profiles.
 
 ## Overlap And Conflicts
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -329,9 +329,10 @@ This does not enable macro recording; macro recording still requires the
 **Settings > Macro recording**.
 
 `Ctrl+Alt+Esc` is reserved by default as an emergency combo while Keymasq has a
-keyboard grabbed. One tap cancels macro playback; a double tap releases all
-grabbed devices and asks the session to reapply active profiles. You can
-disable it if you really need that exact combo:
+keyboard grabbed. One tap cancels macro playback and releases tracked held
+outputs; a double tap releases all grabbed devices and asks the session to
+reapply active profiles. You can disable it if you really need that exact
+combo:
 
 ```toml
 [gui]

--- a/docs/MACROS.md
+++ b/docs/MACROS.md
@@ -68,10 +68,11 @@ bind **Cancel Macro Playback** — it immediately stops every running macro and
 is a useful safety net.
 
 When Keymasq has grabbed a keyboard, `Ctrl+Alt+Esc` is also reserved as an
-emergency combo. Tap it once to cancel all macro playback after a 200 ms
-double-tap window. Double-tap it to run a full daemon runtime reset, release
-grabbed devices, and let the session reapply active profiles. It is injected
-by `keymasqd` and does not need to be added to your profiles.
+emergency combo. Tap it once to cancel all macro playback and release tracked
+held outputs after a 200 ms double-tap window. Double-tap it to run a full
+daemon runtime reset, release grabbed devices, and let the session reapply
+active profiles. It is injected by `keymasqd` and does not need to be added to
+your profiles.
 
 **How to record:**
 
@@ -540,9 +541,9 @@ could be misused as a keylogger.
   directly.
 
 - **Emergency playback cancellation** is enabled by default. Tap `Ctrl+Alt+Esc`
-  on a keyboard grabbed by Keymasq to cancel all running macro playback after
-  a 200 ms double-tap window. Double-tap it to release all grabbed devices and
-  rebuild the active runtime mappings.
+  on a keyboard grabbed by Keymasq to cancel all running macro playback and
+  release tracked held outputs after a 200 ms double-tap window. Double-tap it
+  to release all grabbed devices and rebuild the active runtime mappings.
 
 **Optional security settings** (in `/etc/keymasq/security.toml`). Most users
 do not need to change these — they are intended for system administrators:

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -407,8 +407,8 @@ When `emergency_cancel_combo_enabled = true`:
 
 - the daemon injects `Ctrl+Alt+Esc` into active keyboard combo runtime state
 - the GUI rejects attempts to save that exact combo trigger
-- tapping the combo cancels all running macro playback directly in `keymasqd`
-  after a 200 ms double-tap window
+- tapping the combo cancels all running macro playback and releases tracked
+  held outputs directly in `keymasqd` after a 200 ms double-tap window
 - double-tapping the combo runs a daemon runtime reset, releases all grabbed
   devices, broadcasts `runtime_reset`, and lets the session reapply profiles
 

--- a/keymasq/keymasqd/combo_engine.py
+++ b/keymasq/keymasqd/combo_engine.py
@@ -37,6 +37,7 @@ class RuntimeCombo:
     recall_trigger_keys: bool = False
     restore_trigger_keys: list[str] = field(default_factory=list)
     match_across_devices: bool = False
+    release_outputs_on_cancel: bool = False
 
 
 @dataclass(frozen=True)

--- a/keymasq/keymasqd/runtime/combo/superkeys.py
+++ b/keymasq/keymasqd/runtime/combo/superkeys.py
@@ -49,6 +49,13 @@ def effective_config(
     )
 
 
+def releases_outputs_on_cancel(manager: ComboManager, combo_id: str) -> bool:
+    return any(
+        combo.id == combo_id and combo.release_outputs_on_cancel
+        for combo in manager.combo_state.active_combos
+    )
+
+
 async def build_machine(
     manager: ComboManager,
     combo_id: str,
@@ -64,6 +71,11 @@ async def build_machine(
         return None
 
     trigger_name = f"combo:{combo_id}"
+    cancel_macro_playback = (
+        manager.cancel_macro_playback_and_release_outputs
+        if releases_outputs_on_cancel(manager, combo_id)
+        else manager.cancel_macro_playback
+    )
     machine_bindings = tuple(ordered_unique_bindings(trigger_bindings or (trigger_binding,)))
     existing = manager.combo_state.superkey_machines.get(combo_id)
     if existing is not None:
@@ -82,7 +94,7 @@ async def build_machine(
         payload = dict(data)
         action_type = str(payload.get("action_type", "") or "")
         if action_type == ActionType.CANCEL_MACRO_PLAYBACK.value:
-            await manager.cancel_macro_playback()
+            await cancel_macro_playback()
             return
         if action_type == ActionType.EMERGENCY_RESET.value:
             deps.fire_and_observe_fn(
@@ -131,7 +143,7 @@ async def build_machine(
         ),
         macro_player=manager.play_macro,
         emergency_resetter=manager.emergency_reset,
-        cancel_macro_playback=manager.cancel_macro_playback,
+        cancel_macro_playback=cancel_macro_playback,
         action_deps=action_execution_deps(deps),
         await_action_tasks=False,
         repeat_path_recorder=repeat_path_recorder,

--- a/keymasq/keymasqd/runtime/macro/cleanup.py
+++ b/keymasq/keymasqd/runtime/macro/cleanup.py
@@ -63,9 +63,6 @@ async def cancel_macro_playback(
 
     running_ids = running_macro_instance_ids(manager.macro_state)
     cancelled = await cancel_instances_fn(manager, running_ids, deps=deps)
-    for devices in manager.grabbed_devices.values():
-        for device in devices:
-            device.release_tracked_outputs()
     controls.complete_all_macro_exec_waiters(manager, -1)
     manager.macro_state.mouse_inhibit_count = 0
     end_suppression_fn(manager)

--- a/keymasq/keymasqd/runtime/manager_combos.py
+++ b/keymasq/keymasqd/runtime/manager_combos.py
@@ -74,6 +74,7 @@ def combo_runtime_signature(combo: RuntimeCombo) -> tuple[object, ...]:
         bool(combo.recall_trigger_keys),
         tuple(combo.restore_trigger_keys),
         bool(combo.match_across_devices),
+        bool(combo.release_outputs_on_cancel),
     )
 
 
@@ -306,6 +307,7 @@ class ComboManagerMixin:
             profile_name=EMERGENCY_CANCEL_COMBO_PROFILE,
             recall_trigger_keys=True,
             restore_trigger_keys=[],
+            release_outputs_on_cancel=True,
         )
 
     def _is_emergency_cancel_duplicate(

--- a/keymasq/keymasqd/runtime/manager_macros.py
+++ b/keymasq/keymasqd/runtime/manager_macros.py
@@ -28,6 +28,7 @@ class MacroManagerMixin:
 
     macro_store: Any | None
     macro_state: MacroRuntimeState
+    grabbed_devices: dict[str, list[Any]]
 
     def _initialize_macro_runtime(self, deps_factory: MacroRuntimeDepsFactory) -> None:
         self._macro_runtime_deps_factory = deps_factory
@@ -138,6 +139,15 @@ class MacroManagerMixin:
                 CommandType.MACRO_PLAYBACK_CANCELLED,
                 {"reason": "cancel_macro_playback", "cancelled": True},
             )
+        return result
+
+    async def cancel_macro_playback_and_release_outputs(self) -> JsonObject:
+        """Cancel macros, then neutralize outputs tracked by grabbed devices."""
+
+        result = await self.cancel_macro_playback()
+        for devices in self.grabbed_devices.values():
+            for device in devices:
+                device.release_tracked_outputs()
         return result
 
     def complete_macro_exec_wait(self, wait_id: str, returncode: int) -> JsonObject:

--- a/keymasq/keymasqd/runtime/manager_macros.py
+++ b/keymasq/keymasqd/runtime/manager_macros.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 import time
 from collections.abc import Callable, Iterator
 from functools import partial
@@ -21,6 +22,8 @@ from keymasq.keymasqd.runtime.macro.state import (
 )
 
 type MacroRuntimeDepsFactory = Callable[[], MacroRuntimeDeps]
+
+log = logging.getLogger("keymasqd.devices")
 
 
 class MacroManagerMixin:
@@ -144,11 +147,23 @@ class MacroManagerMixin:
     async def cancel_macro_playback_and_release_outputs(self) -> JsonObject:
         """Cancel macros, then neutralize outputs tracked by grabbed devices."""
 
-        result = await self.cancel_macro_playback()
-        for devices in self.grabbed_devices.values():
-            for device in devices:
-                device.release_tracked_outputs()
-        return result
+        try:
+            return await self.cancel_macro_playback()
+        finally:
+            for devices in self.grabbed_devices.values():
+                for device in devices:
+                    try:
+                        device.release_tracked_outputs()
+                    except OSError:
+                        log.debug(
+                            "Failed to release tracked outputs during emergency macro cancel",
+                            exc_info=True,
+                        )
+                    except Exception:
+                        log.exception(
+                            "Unexpected failure releasing tracked outputs during "
+                            "emergency macro cancel"
+                        )
 
     def complete_macro_exec_wait(self, wait_id: str, returncode: int) -> JsonObject:
         return controls.complete_macro_exec_wait(self, wait_id, returncode)

--- a/tests/keymasqd/test_device_manager_combo_matching.py
+++ b/tests/keymasqd/test_device_manager_combo_matching.py
@@ -152,7 +152,8 @@ class TestCombos:
         assert combo.match_across_devices is True
         assert binding.hardware_id == ""
         assert binding.source == ""
-        assert combo_runtime_signature(combo)[-1] is True
+        assert combo_runtime_signature(combo)[-2] is True
+        assert combo_runtime_signature(combo)[-1] is False
 
     @pytest.mark.asyncio
     async def test_set_combos_allows_omitted_hardware_id_as_wildcard(self):

--- a/tests/keymasqd/test_device_manager_combo_state.py
+++ b/tests/keymasqd/test_device_manager_combo_state.py
@@ -59,6 +59,7 @@ class TestCombos:
             ActionType.EMERGENCY_RESET.value,
         ]
         assert combo.recall_trigger_keys is True
+        assert combo.release_outputs_on_cancel is True
         assert [
             (binding.hardware_id, binding.evdev, binding.source)
             for binding in combo.steps[0].bindings
@@ -131,9 +132,12 @@ class TestCombos:
         ]
 
     @pytest.mark.asyncio
-    async def test_emergency_cancel_combo_calls_daemon_cancel(self, monkeypatch):
+    async def test_emergency_cancel_combo_cancels_macros_and_releases_outputs(
+        self, monkeypatch
+    ):
         manager = DeviceManager()
         manager.cancel_macro_playback = AsyncMock(return_value={"cancelled": True})  # type: ignore[method-assign]
+        release_tracked_outputs = Mock()
         manager.grabbed_devices = {
             "1234:5678": [
                 SimpleNamespace(
@@ -142,6 +146,7 @@ class TestCombos:
                     interface_id="kbd",
                     combo_passthrough_binding_active=lambda _evdev: True,
                     emit_combo_release=Mock(),
+                    release_tracked_outputs=release_tracked_outputs,
                 )
             ]
         }
@@ -198,6 +203,7 @@ class TestCombos:
 
         assert decision is not None and decision.consume_current_event is True
         manager.cancel_macro_playback.assert_awaited_once()
+        release_tracked_outputs.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_emergency_cancel_combo_double_tap_resets_runtime(self):

--- a/tests/keymasqd/test_device_manager_combo_state.py
+++ b/tests/keymasqd/test_device_manager_combo_state.py
@@ -206,6 +206,48 @@ class TestCombos:
         release_tracked_outputs.assert_called_once()
 
     @pytest.mark.asyncio
+    async def test_user_cancel_combo_preserves_grabbed_device_outputs(self):
+        manager = DeviceManager()
+        manager.emergency_cancel_combo_enabled = False
+        manager.cancel_macro_playback = AsyncMock(return_value={"cancelled": True})  # type: ignore[method-assign]
+        release_tracked_outputs = Mock()
+        manager.grabbed_devices = {
+            "1234:5678": [SimpleNamespace(release_tracked_outputs=release_tracked_outputs)]
+        }
+        await manager.set_combos(
+            [
+                {
+                    "id": "user-cancel",
+                    "name": "User cancel",
+                    "steps": [
+                        {
+                            "events": [
+                                {"hardware_id": "1234:5678", "evdev": "key_f13"},
+                            ]
+                        }
+                    ],
+                    "action": {"action": ActionType.CANCEL_MACRO_PLAYBACK.value},
+                }
+            ]
+        )
+        combo = manager.combo_state.active_combos[0]
+        assert combo.action is not None
+        binding = combo.steps[0].bindings[0]
+
+        await actions.start_combo_action(
+            manager,
+            combo.id,
+            combo.action,
+            binding,
+            combo.steps[0].bindings,
+            deps=combo_runtime_deps(),
+        )
+        await asyncio.sleep(0)
+
+        manager.cancel_macro_playback.assert_awaited_once()
+        release_tracked_outputs.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_emergency_cancel_combo_double_tap_resets_runtime(self):
         manager = DeviceManager()
         manager.cancel_macro_playback = AsyncMock(return_value={"cancelled": True})  # type: ignore[method-assign]

--- a/tests/keymasqd/test_macro_backend_loops.py
+++ b/tests/keymasqd/test_macro_backend_loops.py
@@ -22,6 +22,11 @@ async def _wait_for_no_running_macros(manager: DeviceManager) -> None:
         await asyncio.sleep(0.005)
 
 
+async def _wait_for_running_macros(manager: DeviceManager) -> None:
+    while not loops.running_macro_instance_ids(manager.macro_state):
+        await asyncio.sleep(0.005)
+
+
 @pytest.mark.asyncio
 async def test_recording_manager_start_opens_extra_devices_via_to_thread(monkeypatch) -> None:
     broadcast_callback = AsyncMock()
@@ -513,7 +518,7 @@ async def test_cancel_macro_playback_preserves_grabbed_device_outputs() -> None:
         ],
         macro_name="active_cancel",
     )
-    await asyncio.sleep(0.01)
+    await asyncio.wait_for(_wait_for_running_macros(manager), timeout=0.5)
 
     result = await manager.cancel_macro_playback()
 

--- a/tests/keymasqd/test_macro_backend_loops.py
+++ b/tests/keymasqd/test_macro_backend_loops.py
@@ -490,15 +490,53 @@ async def test_cancel_macro_playback_cancels_all_running_instances() -> None:
 @pytest.mark.asyncio
 async def test_cancel_macro_playback_preserves_grabbed_device_outputs() -> None:
     manager = DeviceManager()
+    manager.output_state.keyboard_uinput = MagicMock()
     device = MagicMock()
     manager.grabbed_devices = {"hw": [device]}
+
+    await manager.play_macro(
+        macro_events=[
+            {
+                "t_us": 0,
+                "type": evdev.ecodes.EV_KEY,
+                "code": evdev.ecodes.KEY_J,
+                "value": 1,
+                "device_type": "keyboard",
+            },
+            {
+                "t_us": 2_000_000,
+                "type": evdev.ecodes.EV_KEY,
+                "code": evdev.ecodes.KEY_J,
+                "value": 0,
+                "device_type": "keyboard",
+            },
+        ],
+        macro_name="active_cancel",
+    )
+    await asyncio.sleep(0.01)
 
     result = await manager.cancel_macro_playback()
 
     assert result["status"] == "ok"
-    assert result["cancelled"] is False
+    assert result["cancelled"] is True
     device.release_tracked_outputs.assert_not_called()
     assert loops.running_macro_instance_ids(manager.macro_state) == []
+
+
+@pytest.mark.asyncio
+async def test_emergency_macro_cancel_releases_every_device_when_cancellation_fails() -> None:
+    manager = DeviceManager()
+    first = MagicMock()
+    second = MagicMock()
+    first.release_tracked_outputs.side_effect = RuntimeError("first device failed")
+    manager.grabbed_devices = {"hw": [first, second]}
+    manager.cancel_macro_playback = AsyncMock(side_effect=ValueError("cancel failed"))  # type: ignore[method-assign]
+
+    with pytest.raises(ValueError, match="cancel failed"):
+        await manager.cancel_macro_playback_and_release_outputs()
+
+    first.release_tracked_outputs.assert_called_once()
+    second.release_tracked_outputs.assert_called_once()
 
 
 def test_profile_macro_roundtrip_and_special_actions(temp_config_dir, monkeypatch) -> None:

--- a/tests/keymasqd/test_macro_backend_loops.py
+++ b/tests/keymasqd/test_macro_backend_loops.py
@@ -488,7 +488,7 @@ async def test_cancel_macro_playback_cancels_all_running_instances() -> None:
 
 
 @pytest.mark.asyncio
-async def test_cancel_macro_playback_releases_tracked_outputs() -> None:
+async def test_cancel_macro_playback_preserves_grabbed_device_outputs() -> None:
     manager = DeviceManager()
     device = MagicMock()
     manager.grabbed_devices = {"hw": [device]}
@@ -496,7 +496,8 @@ async def test_cancel_macro_playback_releases_tracked_outputs() -> None:
     result = await manager.cancel_macro_playback()
 
     assert result["status"] == "ok"
-    device.release_tracked_outputs.assert_called_once()
+    assert result["cancelled"] is False
+    device.release_tracked_outputs.assert_not_called()
     assert loops.running_macro_instance_ids(manager.macro_state) == []
 
 


### PR DESCRIPTION
## Summary

- keep ordinary macro cancellation scoped to macro-owned outputs
- preserve the built-in `Ctrl+Alt+Esc` single-tap behavior that also releases outputs tracked by grabbed devices
- keep the double-tap emergency reset as the more destructive ungrab-and-reapply path
- document and test the three distinct cancellation levels

## Root cause

The shared macro cancellation routine also called `release_tracked_outputs()` on every grabbed device. Because the CLI, mapped cancel actions, and the built-in escape hatch all used that routine, ordinary macro cancellation released physically held mappings and cleared unrelated device runtime state.

The daemon-injected emergency combo now carries an internal runtime marker that selects a dedicated cancel-and-release callback. User-defined cancel actions and `keymasq macros cancel` continue to use plain macro cancellation.

## Validation

- `./scripts/check.sh`
  - ruff: passed
  - formatting: passed
  - basedpyright: passed
  - pytest: 941 passed, 25 skipped
- focused cancellation and emergency-combo tests: 8 passed