### PR TITLE
Enforce superkey tap timeout

### DIFF
--- a/docs/SUPERKEYS.md
+++ b/docs/SUPERKEYS.md
@@ -179,6 +179,13 @@ The **Timing** section only matters in pattern mode.
 | **Double Tap Window** | Time between taps for a double tap. | 300 ms | 50-1000 ms |
 | **Hold Threshold** | Time before Hold or Tap + Hold activates. | 300 ms | 50-2000 ms |
 
+Each press in a Tap or Double Tap must be released within **Tap Timeout**.
+Releasing after Tap Timeout but before Hold Threshold does not trigger a slot.
+Once Hold or Tap + Hold activates, that held gesture wins even when Tap Timeout
+is configured to be longer than Hold Threshold. If a valid first tap is
+followed by a second press that is too long to be a tap and too short to become
+a held gesture, the original Tap still fires.
+
 Overload mode ignores these timing values because it does not do gesture
 recognition.
 

--- a/keymasq/keymasqd/superkey_state.py
+++ b/keymasq/keymasqd/superkey_state.py
@@ -1,6 +1,7 @@
 import asyncio
 import contextlib
 import logging
+import time
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 from enum import Enum
@@ -196,6 +197,7 @@ class SuperkeyMachine:
         action_deps: "ActionExecutionDeps | None" = None,
         await_action_tasks: bool = True,
         repeat_path_recorder: Callable[[str], None] | None = None,
+        monotonic_clock: Callable[[], float] = time.monotonic,
     ) -> None:
         self.config = config
         self.event_name = event_name
@@ -215,8 +217,10 @@ class SuperkeyMachine:
         self.action_deps = action_deps or _default_action_deps()
         self.await_action_tasks = await_action_tasks
         self.repeat_path_recorder = repeat_path_recorder
+        self._monotonic_clock = monotonic_clock
 
         self.state = SuperkeyState.IDLE
+        self._press_started_at: float | None = None
         self._hold_task: asyncio.Task[None] | None = None
         self._double_tap_task: asyncio.Task[None] | None = None
         self._rapidfire_tasks: list[asyncio.Task[None]] = []
@@ -240,6 +244,7 @@ class SuperkeyMachine:
 
     async def stop(self) -> None:
         self._running = False
+        self._press_started_at = None
         self._action_runtime.stop()
         self._rapidfire_active = False
         if self._hold_task:
@@ -275,6 +280,7 @@ class SuperkeyMachine:
 
     async def _transition_to_down_wait(self) -> None:
         self.state = SuperkeyState.DOWN_WAIT
+        self._press_started_at = self._monotonic_clock()
 
         if self.config.hold_actions:
             self._hold_task = asyncio.create_task(self._hold_timeout())
@@ -295,10 +301,12 @@ class SuperkeyMachine:
             pass
 
     async def _start_holding(self) -> None:
+        self._press_started_at = None
         self.state = SuperkeyState.HOLDING
         await self._emit_hold_down()
 
     async def _start_tap_holding(self) -> None:
+        self._press_started_at = None
         if not self.config.tap_hold_actions:
             await self._start_holding()
             return
@@ -307,9 +315,14 @@ class SuperkeyMachine:
         await self._emit_tap_hold_down()
 
     async def _on_first_up(self) -> None:
+        is_tap = self._release_qualifies_as_tap()
         if self._hold_task:
             self._hold_task.cancel()
             self._hold_task = None
+
+        if not is_tap:
+            self.state = SuperkeyState.IDLE
+            return
 
         # Tap+hold uses the same second-press window as double tap. Without
         # this branch, a quick tap followed by a held second press falls back
@@ -344,21 +357,35 @@ class SuperkeyMachine:
             self._double_tap_task = None
 
         self.state = SuperkeyState.DOWN_WAIT_2
+        self._press_started_at = self._monotonic_clock()
 
         if self.config.tap_hold_actions or self.config.hold_actions:
             self._hold_task = asyncio.create_task(self._hold_timeout())
 
     async def _on_second_up(self) -> None:
+        is_tap = self._release_qualifies_as_tap()
         if self._hold_task:
             self._hold_task.cancel()
             self._hold_task = None
 
-        if self.config.double_tap_actions:
+        if is_tap and self.config.double_tap_actions:
             await self._emit_double_tap()
         elif self.config.tap_actions:
+            # The first tap was deferred while waiting for a second gesture.
+            # If that second press is too long to be a tap, preserve the
+            # already-recognized first tap instead of dropping both presses.
             await self._emit_tap()
 
         self.state = SuperkeyState.IDLE
+
+    def _release_qualifies_as_tap(self) -> bool:
+        started_at = self._press_started_at
+        self._press_started_at = None
+        if started_at is None:
+            return False
+
+        elapsed_ms = max(0.0, self._monotonic_clock() - started_at) * 1000.0
+        return elapsed_ms <= max(0, self.config.tap_timeout_ms)
 
     async def _on_hold_release(self) -> None:
         self._rapidfire_active = False

--- a/nix/daemon-session-integration-test/fixtures/superkeys/combo-superkey.toml
+++ b/nix/daemon-session-integration-test/fixtures/superkeys/combo-superkey.toml
@@ -2,9 +2,9 @@ name = "$COMBO_SUPERKEY_NAME"
 mode = "pattern"
 
 [timing]
-tap_timeout_ms = 80
+tap_timeout_ms = 250
 double_tap_window_ms = 120
-hold_threshold_ms = 120
+hold_threshold_ms = 300
 
 [actions]
 tap = [{ action = "keyboard", target = "key_r" }]

--- a/nix/daemon-session-integration-test/scenarios/superkey_tap.py
+++ b/nix/daemon-session-integration-test/scenarios/superkey_tap.py
@@ -3,5 +3,15 @@ from support import ScenarioContext
 
 
 def run(ctx: ScenarioContext) -> None:
-    ctx.tap_source(evdev.ecodes.KEY_B)
+    ctx.subtest("superkey release within tap timeout emits tap", lambda: _quick_tap(ctx))
+    ctx.subtest("superkey release after tap timeout emits nothing", lambda: _slow_tap(ctx))
+
+
+def _quick_tap(ctx: ScenarioContext) -> None:
+    ctx.tap_source(evdev.ecodes.KEY_B, pause_s=0.05)
     ctx.expect_keys([(evdev.ecodes.KEY_W, 1), (evdev.ecodes.KEY_W, 0)])
+
+
+def _slow_tap(ctx: ScenarioContext) -> None:
+    ctx.tap_source(evdev.ecodes.KEY_B, pause_s=0.15)
+    ctx.expect_no_keyboard_events()

--- a/tests/test_superkey_state.py
+++ b/tests/test_superkey_state.py
@@ -13,6 +13,17 @@ from keymasq.keymasqd.superkey_state import (
 )
 
 
+class _ManualClock:
+    def __init__(self) -> None:
+        self.now = 0.0
+
+    def __call__(self) -> float:
+        return self.now
+
+    def advance_ms(self, milliseconds: int) -> None:
+        self.now += milliseconds / 1000.0
+
+
 @pytest.mark.asyncio
 async def test_default_action_deps_observes_background_task_exceptions(
     caplog: pytest.LogCaptureFixture,
@@ -64,6 +75,127 @@ async def test_double_tap_action_fires_on_second_tap() -> None:
     assert (evdev.ecodes.EV_KEY, evdev.ecodes.KEY_B, 1) in writes
     assert (evdev.ecodes.EV_KEY, evdev.ecodes.KEY_B, 0) in writes
     assert (evdev.ecodes.EV_KEY, evdev.ecodes.KEY_A, 1) not in writes
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(("press_duration_ms", "expected_values"), [(99, [1, 0]), (101, [])])
+async def test_tap_timeout_bounds_single_tap(
+    press_duration_ms: int,
+    expected_values: list[int],
+) -> None:
+    clock = _ManualClock()
+    keyboard_uinput = MagicMock()
+    machine = SuperkeyMachine(
+        config=SuperkeyConfig(
+            name="tap_timeout",
+            tap_timeout_ms=100,
+            tap_actions=[SuperkeyActionData(action_type="keyboard", target="key_a")],
+        ),
+        event_name="btn_side",
+        keyboard_uinput=keyboard_uinput,
+        mouse_uinput=MagicMock(),
+        gamepad_uinput=MagicMock(),
+        monotonic_clock=clock,
+    )
+
+    await machine.on_down()
+    clock.advance_ms(press_duration_ms)
+    await machine.on_up()
+
+    assert [
+        call.args[2]
+        for call in keyboard_uinput.write.call_args_list
+        if call.args[:2] == (evdev.ecodes.EV_KEY, evdev.ecodes.KEY_A)
+    ] == expected_values
+
+
+@pytest.mark.asyncio
+async def test_release_between_tap_timeout_and_hold_threshold_does_nothing() -> None:
+    clock = _ManualClock()
+    keyboard_uinput = MagicMock()
+    machine = SuperkeyMachine(
+        config=SuperkeyConfig(
+            name="tap_hold_gap",
+            tap_timeout_ms=100,
+            hold_threshold_ms=300,
+            tap_actions=[SuperkeyActionData(action_type="keyboard", target="key_a")],
+            hold_actions=[SuperkeyActionData(action_type="keyboard", target="key_b")],
+        ),
+        event_name="btn_side",
+        keyboard_uinput=keyboard_uinput,
+        mouse_uinput=MagicMock(),
+        gamepad_uinput=MagicMock(),
+        monotonic_clock=clock,
+    )
+
+    await machine.on_down()
+    clock.advance_ms(200)
+    await machine.on_up()
+
+    assert keyboard_uinput.write.call_args_list == []
+    assert machine.state.value == "idle"
+
+
+@pytest.mark.asyncio
+async def test_hold_wins_when_it_activates_before_tap_timeout() -> None:
+    keyboard_uinput = MagicMock()
+    machine = SuperkeyMachine(
+        config=SuperkeyConfig(
+            name="hold_before_tap_timeout",
+            tap_timeout_ms=1000,
+            hold_threshold_ms=0,
+            tap_actions=[SuperkeyActionData(action_type="keyboard", target="key_a")],
+            hold_actions=[SuperkeyActionData(action_type="keyboard", target="key_b")],
+        ),
+        event_name="btn_side",
+        keyboard_uinput=keyboard_uinput,
+        mouse_uinput=MagicMock(),
+        gamepad_uinput=MagicMock(),
+    )
+
+    await machine.on_down()
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+    await machine.on_up()
+
+    assert [tuple(call.args) for call in keyboard_uinput.write.call_args_list] == [
+        (evdev.ecodes.EV_KEY, evdev.ecodes.KEY_B, 1),
+        (evdev.ecodes.EV_KEY, evdev.ecodes.KEY_B, 0),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_slow_second_press_preserves_first_tap() -> None:
+    clock = _ManualClock()
+    keyboard_uinput = MagicMock()
+    machine = SuperkeyMachine(
+        config=SuperkeyConfig(
+            name="slow_second_press",
+            tap_timeout_ms=100,
+            double_tap_window_ms=500,
+            hold_threshold_ms=300,
+            tap_actions=[SuperkeyActionData(action_type="keyboard", target="key_a")],
+            double_tap_actions=[SuperkeyActionData(action_type="keyboard", target="key_b")],
+            tap_hold_actions=[SuperkeyActionData(action_type="keyboard", target="key_c")],
+        ),
+        event_name="btn_side",
+        keyboard_uinput=keyboard_uinput,
+        mouse_uinput=MagicMock(),
+        gamepad_uinput=MagicMock(),
+        monotonic_clock=clock,
+    )
+
+    await machine.on_down()
+    clock.advance_ms(50)
+    await machine.on_up()
+    await machine.on_down()
+    clock.advance_ms(150)
+    await machine.on_up()
+
+    assert [tuple(call.args) for call in keyboard_uinput.write.call_args_list] == [
+        (evdev.ecodes.EV_KEY, evdev.ecodes.KEY_A, 1),
+        (evdev.ecodes.EV_KEY, evdev.ecodes.KEY_A, 0),
+    ]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- enforce `tap_timeout_ms` for each pattern-mode tap using a monotonic clock
- reject releases in the gap between Tap Timeout and Hold Threshold while preserving an already-valid first tap after a slow second press
- document the timing rules and add deterministic state-machine regression coverage

## Root cause

`tap_timeout_ms` was persisted, sent to the daemon, and exposed in the GUI, but the Super Key state machine never consulted it when classifying releases.

## Impact

The Tap Timeout control now matches its documented behavior. Hold and Tap + Hold still win once their threshold activates, and overload mode remains unchanged.

## Validation

- `./scripts/check.sh`
- ruff, formatting, basedpyright, and stylelint passed
- 2695 tests passed, 25 skipped