### PR TITLE
Serialize cross-device combo action transitions

### DIFF
--- a/keymasq/keymasqd/device_manager.py
+++ b/keymasq/keymasqd/device_manager.py
@@ -335,7 +335,7 @@ class DeviceManager(CursorManagerMixin, MacroManagerMixin, ComboManagerMixin):
         )
         async with self._op_lock:
             self.device_inspector_state.reset()
-            await self._refresh_combo_runtime_unlocked()
+            await self._refresh_combo_runtime()
 
     async def emergency_reset(self) -> JsonObject:
         await self.release_all_devices()
@@ -442,7 +442,7 @@ class DeviceManager(CursorManagerMixin, MacroManagerMixin, ComboManagerMixin):
             transition = self.device_inspector_state.stop(hardware_id)
             if transition.reset_runtime:
                 await self._reset_device_inspector_runtime_unlocked(transition.hardware_id)
-                await self._refresh_combo_runtime_unlocked()
+                await self._refresh_combo_runtime()
             self._broadcast_device_inspector_status(transition.hardware_id, "stop")
             return transition.response()
 
@@ -450,7 +450,7 @@ class DeviceManager(CursorManagerMixin, MacroManagerMixin, ComboManagerMixin):
         async with self._op_lock:
             transition = self.device_inspector_state.enable_suppression(hardware_id)
             await self._reset_device_inspector_runtime_unlocked(transition.hardware_id)
-            await self._refresh_combo_runtime_unlocked()
+            await self._refresh_combo_runtime()
             self._broadcast_device_inspector_status(transition.hardware_id, "enable_suppression")
             return transition.response()
 
@@ -463,7 +463,7 @@ class DeviceManager(CursorManagerMixin, MacroManagerMixin, ComboManagerMixin):
             transition = self.device_inspector_state.disable_suppression(hardware_id)
             if transition.reset_runtime:
                 await self._reset_device_inspector_runtime_unlocked(transition.hardware_id)
-                await self._refresh_combo_runtime_unlocked()
+                await self._refresh_combo_runtime()
             self._broadcast_device_inspector_status(transition.hardware_id, reason)
             return transition.response(reason=str(reason or ""))
 

--- a/keymasq/keymasqd/runtime/combo/actions.py
+++ b/keymasq/keymasqd/runtime/combo/actions.py
@@ -548,7 +548,10 @@ async def _start_combo_action_instance(
         )
         return
 
-    await drain_action_tasks(handle)
+    # Emergency reset tears down combo state itself. Its observed task must run
+    # after the current combo transition releases the ordering lock.
+    if action.action_type != ActionType.EMERGENCY_RESET:
+        await drain_action_tasks(handle)
 
 
 async def _pulse_combo_action_instance(

--- a/keymasq/keymasqd/runtime/combo/events.py
+++ b/keymasq/keymasqd/runtime/combo/events.py
@@ -228,6 +228,8 @@ async def process_runtime_combo_event(
         evdev=str_value_fn(payload.get("evdev"), ""),
         source=str_value_fn(payload.get("source"), ""),
     )
+    # Grabbed devices have independent read-loop tasks. Keep the decision and
+    # every resulting action transition ordered as one runtime transaction.
     async with manager.combo_state.runtime_lock:
         held_modifiers = (
             held_combo_modifier_bindings_for_scope(
@@ -245,15 +247,14 @@ async def process_runtime_combo_event(
         )
         if decision.recall_events:
             emit_combo_recalls(manager, decision.recall_events)
-    if decision.action_transition is not None:
-        await apply_combo_action_transition(
-            manager,
-            decision.action_transition,
-            deps=deps,
-        )
-    for transition in decision.extra_action_transitions:
-        await apply_combo_action_transition(manager, transition, deps=deps)
-    async with manager.combo_state.runtime_lock:
+        if decision.action_transition is not None:
+            await apply_combo_action_transition(
+                manager,
+                decision.action_transition,
+                deps=deps,
+            )
+        for transition in decision.extra_action_transitions:
+            await apply_combo_action_transition(manager, transition, deps=deps)
         refresh_combo_timeout_watchdog(manager, deps=deps)
     if (
         decision.consume_current_event

--- a/keymasq/keymasqd/runtime/combo/events.py
+++ b/keymasq/keymasqd/runtime/combo/events.py
@@ -228,25 +228,27 @@ async def process_runtime_combo_event(
         evdev=str_value_fn(payload.get("evdev"), ""),
         source=str_value_fn(payload.get("source"), ""),
     )
-    # Grabbed devices have independent read-loop tasks. Keep the decision and
-    # every resulting action transition ordered as one runtime transaction.
-    async with manager.combo_state.runtime_lock:
-        held_modifiers = (
-            held_combo_modifier_bindings_for_scope(
-                manager,
-                binding.hardware_id,
-                binding.source,
+    # Grabbed devices have independent read-loop tasks. Serialize the full
+    # decision/action sequence, but do not hold the state lock while an action
+    # waits for asynchronous startup work.
+    async with manager.combo_state.transition_lock:
+        async with manager.combo_state.runtime_lock:
+            held_modifiers = (
+                held_combo_modifier_bindings_for_scope(
+                    manager,
+                    binding.hardware_id,
+                    binding.source,
+                )
+                if value == 1 and not is_combo_pulse_evdev(binding.evdev)
+                else ()
             )
-            if value == 1 and not is_combo_pulse_evdev(binding.evdev)
-            else ()
-        )
-        decision = manager.combo_state.progression.handle(
-            binding,
-            value,
-            held_bindings=held_modifiers,
-        )
-        if decision.recall_events:
-            emit_combo_recalls(manager, decision.recall_events)
+            decision = manager.combo_state.progression.handle(
+                binding,
+                value,
+                held_bindings=held_modifiers,
+            )
+            if decision.recall_events:
+                emit_combo_recalls(manager, decision.recall_events)
         if decision.action_transition is not None:
             await apply_combo_action_transition(
                 manager,
@@ -255,7 +257,8 @@ async def process_runtime_combo_event(
             )
         for transition in decision.extra_action_transitions:
             await apply_combo_action_transition(manager, transition, deps=deps)
-        refresh_combo_timeout_watchdog(manager, deps=deps)
+        async with manager.combo_state.runtime_lock:
+            refresh_combo_timeout_watchdog(manager, deps=deps)
     if (
         decision.consume_current_event
         or decision.passthrough_current_event

--- a/keymasq/keymasqd/runtime/combo/events.py
+++ b/keymasq/keymasqd/runtime/combo/events.py
@@ -228,9 +228,10 @@ async def process_runtime_combo_event(
         evdev=str_value_fn(payload.get("evdev"), ""),
         source=str_value_fn(payload.get("source"), ""),
     )
-    # Grabbed devices have independent read-loop tasks. Serialize the full
-    # decision/action sequence, but do not hold the state lock while an action
-    # waits for asynchronous startup work.
+    # Grabbed devices have independent read-loop tasks, so this lock must cover
+    # action startup as well as the engine decision. Startup never waits for a
+    # later input event: for hold macros it waits only until play_macro has
+    # registered the separate long-running playback task.
     async with manager.combo_state.transition_lock:
         async with manager.combo_state.runtime_lock:
             held_modifiers = (

--- a/keymasq/keymasqd/runtime/combo/lifecycle.py
+++ b/keymasq/keymasqd/runtime/combo/lifecycle.py
@@ -13,8 +13,9 @@ async def clear_combo_runtime(
     *,
     deps: ComboRuntimeDeps,
 ) -> None:
-    async with manager.combo_state.runtime_lock:
-        await clear_combo_runtime_unlocked(manager, deps=deps)
+    async with manager.combo_state.transition_lock:
+        async with manager.combo_state.runtime_lock:
+            await clear_combo_runtime_unlocked(manager, deps=deps)
 
 
 async def clear_combo_runtime_unlocked(
@@ -42,12 +43,13 @@ async def clear_combo_runtime_except(
     *,
     deps: ComboRuntimeDeps,
 ) -> None:
-    async with manager.combo_state.runtime_lock:
-        await clear_combo_runtime_except_unlocked(
-            manager,
-            preserve_combo_ids,
-            deps=deps,
-        )
+    async with manager.combo_state.transition_lock:
+        async with manager.combo_state.runtime_lock:
+            await clear_combo_runtime_except_unlocked(
+                manager,
+                preserve_combo_ids,
+                deps=deps,
+            )
 
 
 async def clear_combo_runtime_except_unlocked(
@@ -85,13 +87,14 @@ async def clear_combo_runtime_for_binding_scope(
     *,
     deps: ComboRuntimeDeps,
 ) -> None:
-    async with manager.combo_state.runtime_lock:
-        await clear_combo_runtime_for_binding_scope_unlocked(
-            manager,
-            hardware_id,
-            source,
-            deps=deps,
-        )
+    async with manager.combo_state.transition_lock:
+        async with manager.combo_state.runtime_lock:
+            await clear_combo_runtime_for_binding_scope_unlocked(
+                manager,
+                hardware_id,
+                source,
+                deps=deps,
+            )
 
 
 async def clear_combo_runtime_for_binding_scope_unlocked(
@@ -159,11 +162,12 @@ async def combo_timeout_watchdog(
 ) -> None:
     try:
         await deps.asyncio_mod.sleep(max(0.0, deadline - time.monotonic()))
-        async with manager.combo_state.runtime_lock:
-            manager.combo_state.progression.engine.expire_timeouts(time.monotonic())
-            if manager.combo_state.timeout_task is deps.asyncio_mod.current_task():
-                manager.combo_state.timeout_task = None
-            refresh_combo_timeout_watchdog(manager, deps=deps)
+        async with manager.combo_state.transition_lock:
+            async with manager.combo_state.runtime_lock:
+                manager.combo_state.progression.engine.expire_timeouts(time.monotonic())
+                if manager.combo_state.timeout_task is deps.asyncio_mod.current_task():
+                    manager.combo_state.timeout_task = None
+                refresh_combo_timeout_watchdog(manager, deps=deps)
     except deps.asyncio_mod.CancelledError:
         raise
 

--- a/keymasq/keymasqd/runtime/combo/state.py
+++ b/keymasq/keymasqd/runtime/combo/state.py
@@ -57,6 +57,7 @@ class ComboRuntimeState:
     capture_queues: dict[str, ComboCaptureQueueState] = field(default_factory=dict)
     active_combos: list[RuntimeCombo] = field(default_factory=list)
     progression: ComboProgressionMachine = field(default_factory=ComboProgressionMachine)
+    transition_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
     runtime_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
     timeout_task: asyncio.Task[None] | None = None
     active_actions: dict[str, ComboActionState] = field(default_factory=dict)

--- a/keymasq/keymasqd/runtime/manager_combos.py
+++ b/keymasq/keymasqd/runtime/manager_combos.py
@@ -207,26 +207,28 @@ class ComboManagerMixin:
         preserve_combo_ids: set[str] | None = None,
     ) -> list[RuntimeCombo]:
         active_combos = self._with_emergency_cancel_combos(self._configured_combos)
-        self.combo_state.active_combos = active_combos
-        if preserve_combo_ids is None:
-            await lifecycle.clear_combo_runtime(self, deps=combo_runtime_deps())
-        else:
-            await lifecycle.clear_combo_runtime_except(
-                self,
-                preserve_combo_ids,
-                deps=combo_runtime_deps(),
-            )
-        async with self.combo_state.runtime_lock:
-            if preserve_combo_ids is None:
-                self.combo_state.progression.engine.set_combos(active_combos)
-            else:
-                self.combo_state.progression.engine.set_combos(
-                    active_combos,
-                    preserve_candidate_ids=preserve_combo_ids,
-                )
-            recall.prime_combo_engine_with_held_bindings(self)
-            lifecycle.refresh_combo_timeout_watchdog(self, deps=combo_runtime_deps())
-            return active_combos
+        deps = combo_runtime_deps()
+        async with self.combo_state.transition_lock:
+            async with self.combo_state.runtime_lock:
+                self.combo_state.active_combos = active_combos
+                if preserve_combo_ids is None:
+                    await lifecycle.clear_combo_runtime_unlocked(self, deps=deps)
+                else:
+                    await lifecycle.clear_combo_runtime_except_unlocked(
+                        self,
+                        preserve_combo_ids,
+                        deps=deps,
+                    )
+                if preserve_combo_ids is None:
+                    self.combo_state.progression.engine.set_combos(active_combos)
+                else:
+                    self.combo_state.progression.engine.set_combos(
+                        active_combos,
+                        preserve_candidate_ids=preserve_combo_ids,
+                    )
+                recall.prime_combo_engine_with_held_bindings(self)
+                lifecycle.refresh_combo_timeout_watchdog(self, deps=deps)
+                return active_combos
 
     async def _refresh_combo_runtime_preserving_unchanged(
         self: Any,

--- a/keymasq/keymasqd/runtime/manager_combos.py
+++ b/keymasq/keymasqd/runtime/manager_combos.py
@@ -191,7 +191,7 @@ class ComboManagerMixin:
                 source_button_prefix="combo:",
             )
             self._configured_combos = parsed
-            active_combos = await self._refresh_combo_runtime_unlocked(
+            active_combos = await self._refresh_combo_runtime(
                 preserve_combo_ids=preserve_combo_ids,
             )
             log.info(
@@ -201,7 +201,7 @@ class ComboManagerMixin:
             )
             return {"updated": True, "combo_count": len(active_combos)}
 
-    async def _refresh_combo_runtime_unlocked(
+    async def _refresh_combo_runtime(
         self: Any,
         *,
         preserve_combo_ids: set[str] | None = None,
@@ -237,7 +237,7 @@ class ComboManagerMixin:
             combo_runtime_signatures(self.combo_state.active_combos),
             self._with_emergency_cancel_combos(self._configured_combos),
         )
-        return await self._refresh_combo_runtime_unlocked(
+        return await self._refresh_combo_runtime(
             preserve_combo_ids=unchanged_ids if unchanged_ids else None,
         )
 

--- a/nix/daemon-session-integration-test/fixtures/profiles/core-smoke.toml
+++ b/nix/daemon-session-integration-test/fixtures/profiles/core-smoke.toml
@@ -255,6 +255,17 @@ steps = [
 action = { action = "keyboard", target = "key_f10" }
 
 [[combos]]
+id = "integration-cross-device-transition-order"
+name = "Integration cross-device transition order"
+steps = [
+  { events = [
+    { evdev = "key_f24", hardware_id = "$HARDWARE_ID" },
+    { evdev = "key_h", hardware_id = "$SECOND_HARDWARE_ID" },
+  ] },
+]
+action = { action = "superkey", superkey_name = "$COMBO_SERIALIZATION_SUPERKEY_NAME" }
+
+[[combos]]
 id = "integration-profile-lifetime"
 name = "Integration profile lifetime"
 steps = [

--- a/nix/daemon-session-integration-test/fixtures/superkeys/combo-serialization-superkey.toml
+++ b/nix/daemon-session-integration-test/fixtures/superkeys/combo-serialization-superkey.toml
@@ -1,0 +1,7 @@
+name = "$COMBO_SERIALIZATION_SUPERKEY_NAME"
+mode = "overload"
+
+[actions]
+overload = [
+  { action = "keyboard", target = "key_f11", tap_enabled = true, tap_hold_ms = 5000 },
+]

--- a/nix/daemon-session-integration-test/scenarios/__init__.py
+++ b/nix/daemon-session-integration-test/scenarios/__init__.py
@@ -15,6 +15,7 @@ from . import (
     analog_trigger_deadzone,
     cancel_macro_playback,
     combo_chord,
+    combo_cross_device_transition_order,
     combo_negative_timeout,
     combo_prefix_overlap,
     combo_superkey,
@@ -67,6 +68,10 @@ SCENARIOS = [
         superkey_overload_multi_action.run,
     ),
     ScenarioCase("combo chord", combo_chord.run),
+    ScenarioCase(
+        "combo cross-device transition order",
+        combo_cross_device_transition_order.run,
+    ),
     ScenarioCase("combo bound to superkey", combo_superkey.run),
     ScenarioCase("combo superkey recall and restore", combo_superkey_recall_restore.run),
     ScenarioCase("multi-step combo", multi_step_combo.run),

--- a/nix/daemon-session-integration-test/scenarios/combo_cross_device_transition_order.py
+++ b/nix/daemon-session-integration-test/scenarios/combo_cross_device_transition_order.py
@@ -1,0 +1,19 @@
+import time
+
+import evdev
+from support import ScenarioContext
+
+
+def run(ctx: ScenarioContext) -> None:
+    for _ in range(10):
+        ctx.source_key(evdev.ecodes.KEY_F24, 1)
+        ctx.secondary_key(evdev.ecodes.KEY_H, 1)
+        ctx.expect_keys([(evdev.ecodes.KEY_F11, 1)], timeout_s=1.0)
+
+        # Release the binding owned by the other evdev task while the long tap
+        # child is held, then require its release without waiting for timeout.
+        ctx.source_key(evdev.ecodes.KEY_F24, 0)
+        ctx.secondary_key(evdev.ecodes.KEY_H, 0)
+
+        ctx.expect_keys([(evdev.ecodes.KEY_F11, 0)], timeout_s=1.0)
+        time.sleep(0.01)

--- a/nix/daemon-session-integration-test/support.py
+++ b/nix/daemon-session-integration-test/support.py
@@ -31,6 +31,7 @@ MACRO_NAME = "integration-macro"
 LONG_MACRO_NAME = "integration-hold-macro"
 SUPERKEY_NAME = "integration-tap-superkey"
 COMBO_SUPERKEY_NAME = "integration-combo-superkey"
+COMBO_SERIALIZATION_SUPERKEY_NAME = "integration-combo-serialization-superkey"
 OVERLOAD_SUPERKEY_NAME = "integration-overload-superkey"
 PROFILE_LIFETIME_HOLD_SUPERKEY_NAME = "integration-profile-lifetime-hold-superkey"
 PROFILE_LIFETIME_OVERLOAD_SUPERKEY_NAME = "integration-profile-lifetime-overload-superkey"
@@ -296,6 +297,11 @@ class ScenarioContext:
             values,
         )
         self.write_fixture(
+            superkeys_dir / "integration-combo-serialization-superkey.toml",
+            "superkeys/combo-serialization-superkey.toml",
+            values,
+        )
+        self.write_fixture(
             superkeys_dir / "integration-overload-superkey.toml",
             "superkeys/overload-superkey.toml",
             values,
@@ -423,6 +429,7 @@ class ScenarioContext:
             "LONG_MACRO_NAME": LONG_MACRO_NAME,
             "SUPERKEY_NAME": SUPERKEY_NAME,
             "COMBO_SUPERKEY_NAME": COMBO_SUPERKEY_NAME,
+            "COMBO_SERIALIZATION_SUPERKEY_NAME": COMBO_SERIALIZATION_SUPERKEY_NAME,
             "OVERLOAD_SUPERKEY_NAME": OVERLOAD_SUPERKEY_NAME,
             "PROFILE_LIFETIME_HOLD_SUPERKEY_NAME": (
                 PROFILE_LIFETIME_HOLD_SUPERKEY_NAME

--- a/tests/keymasqd/test_device_manager_combo_runtime.py
+++ b/tests/keymasqd/test_device_manager_combo_runtime.py
@@ -632,33 +632,42 @@ class TestCombos:
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
-        "superkey_payload",
+        ("superkey_payload", "expected_writes"),
         [
-            {
-                "name": "overload-start-order",
-                "mode": "overload",
-                "overload_actions": [
-                    {
-                        "action": "macro",
-                        "macro_name": "held-child",
-                        "macro_loop_mode": "hold",
-                    }
+            (
+                {
+                    "name": "overload-start-order",
+                    "mode": "overload",
+                    "overload_actions": [
+                        {
+                            "action": "macro",
+                            "macro_name": "held-child",
+                            "macro_loop_mode": "hold",
+                        }
+                    ],
+                },
+                [],
+            ),
+            (
+                {
+                    "name": "split-overload-start-order",
+                    "mode": "overload",
+                    "overload_actions": [
+                        {
+                            "action": "macro",
+                            "macro_name": "held-child",
+                            "macro_loop_mode": "hold",
+                        }
+                    ],
+                    "overload_up_actions": [
+                        {"action": "keyboard", "target": "key_f6"},
+                    ],
+                },
+                [
+                    (evdev.ecodes.EV_KEY, evdev.ecodes.KEY_F6, 1),
+                    (evdev.ecodes.EV_KEY, evdev.ecodes.KEY_F6, 0),
                 ],
-            },
-            {
-                "name": "split-overload-start-order",
-                "mode": "overload",
-                "overload_actions": [
-                    {
-                        "action": "macro",
-                        "macro_name": "held-child",
-                        "macro_loop_mode": "hold",
-                    }
-                ],
-                "overload_up_actions": [
-                    {"action": "keyboard", "target": "key_f6"},
-                ],
-            },
+            ),
         ],
         ids=("overload", "split-overload"),
     )
@@ -666,9 +675,11 @@ class TestCombos:
         self,
         monkeypatch: pytest.MonkeyPatch,
         superkey_payload: dict[str, object],
+        expected_writes: list[tuple[int, int, int]],
     ) -> None:
         manager = DeviceManager()
-        manager.output_state.keyboard_uinput = FakeUInput()
+        keyboard_uinput = FakeUInput()
+        manager.output_state.keyboard_uinput = keyboard_uinput
         press_started = asyncio.Event()
         allow_press = asyncio.Event()
         trigger_values: list[int] = []
@@ -764,6 +775,7 @@ class TestCombos:
             await asyncio.wait_for(release_task, timeout=1.0)
 
             assert trigger_values == [1, 0]
+            assert keyboard_uinput.writes == expected_writes
             assert manager.combo_state.active_actions == {}
         finally:
             allow_press.set()
@@ -772,6 +784,63 @@ class TestCombos:
                     task.cancel()
                     await asyncio.gather(task, return_exceptions=True)
             await lifecycle.clear_combo_runtime(manager, deps=combo_runtime_deps())
+
+    @pytest.mark.asyncio
+    async def test_runtime_combo_emergency_reset_does_not_deadlock_transition(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        manager = DeviceManager()
+        reset_finished = asyncio.Event()
+
+        async def emergency_reset() -> dict[str, object]:
+            await lifecycle.clear_combo_runtime(manager, deps=combo_runtime_deps())
+            reset_finished.set()
+            return {"status": "ok"}
+
+        manager.emergency_reset = emergency_reset  # type: ignore[method-assign]
+        await manager.set_combos(
+            [
+                {
+                    "id": "combo-emergency-reset",
+                    "name": "Emergency Reset",
+                    "steps": [
+                        {
+                            "events": [
+                                {
+                                    "hardware_id": "1234:5678",
+                                    "source": "kbd",
+                                    "evdev": "key_f13",
+                                }
+                            ]
+                        }
+                    ],
+                    "action": {"action": "emergency_reset"},
+                }
+            ]
+        )
+
+        monkeypatch.setattr(devices, "resolve_stable_path", lambda path: path)
+        monkeypatch.setattr(devices, "get_interface_id", lambda _path: "kbd")
+
+        await asyncio.wait_for(
+            events.on_device_event(
+                manager,
+                "1234:5678",
+                "/dev/input/by-id/test-kbd",
+                evdev.ecodes.EV_KEY,
+                evdev.ecodes.KEY_F13,
+                1,
+                None,
+                "kbd",
+                **combo_event_runtime_kwargs(),
+            ),
+            timeout=1.0,
+        )
+        await asyncio.wait_for(reset_finished.wait(), timeout=1.0)
+
+        assert manager.combo_state.active_actions == {}
+        assert manager.combo_state.timeout_task is None
 
     @pytest.mark.asyncio
     async def test_runtime_combo_release_waits_for_repeat_start(

--- a/tests/keymasqd/test_device_manager_combo_runtime.py
+++ b/tests/keymasqd/test_device_manager_combo_runtime.py
@@ -6,7 +6,10 @@ import evdev
 import pytest
 
 from keymasq.common import devices
+from keymasq.common.model.actions import MappingAction
+from keymasq.common.model.core import ActionType
 from keymasq.keymasqd.device_manager import DeviceManager
+from keymasq.keymasqd.runtime import repeat
 from keymasq.keymasqd.runtime.combo import events, lifecycle
 from keymasq.keymasqd.runtime.grabbed_device.event import pipeline
 from tests.keymasqd.device_manager_support import (
@@ -563,6 +566,7 @@ class TestCombos:
             fire_and_observe_fn=delayed_fire_and_observe,
         )
         press_b_task = None
+        release_b_task = None
         try:
             await events.on_device_event(
                 manager,
@@ -590,19 +594,25 @@ class TestCombos:
             )
             await asyncio.wait_for(action_task_waiting.wait(), timeout=1.0)
 
-            await events.on_device_event(
-                manager,
-                "1234:5678",
-                "/dev/input/by-id/test-kbd-b",
-                evdev.ecodes.EV_KEY,
-                evdev.ecodes.KEY_B,
-                0,
-                None,
-                "kbd-b",
-                **kwargs,
+            release_b_task = asyncio.create_task(
+                events.on_device_event(
+                    manager,
+                    "1234:5678",
+                    "/dev/input/by-id/test-kbd-b",
+                    evdev.ecodes.EV_KEY,
+                    evdev.ecodes.KEY_B,
+                    0,
+                    None,
+                    "kbd-b",
+                    **kwargs,
+                )
             )
+            await asyncio.sleep(0)
+            assert not release_b_task.done()
+
             release_action_task.set()
             await asyncio.wait_for(press_b_task, timeout=1.0)
+            await asyncio.wait_for(release_b_task, timeout=1.0)
             await asyncio.gather(*action_tasks, return_exceptions=True)
 
             assert manager.combo_state.active_actions == {}
@@ -611,7 +621,361 @@ class TestCombos:
             if press_b_task is not None and not press_b_task.done():
                 press_b_task.cancel()
                 await asyncio.gather(press_b_task, return_exceptions=True)
+            if release_b_task is not None and not release_b_task.done():
+                release_b_task.cancel()
+                await asyncio.gather(release_b_task, return_exceptions=True)
             await lifecycle.clear_combo_runtime(manager, deps=combo_runtime_deps())
+            for task in action_tasks:
+                if not task.done():
+                    task.cancel()
+                await asyncio.gather(task, return_exceptions=True)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "superkey_payload",
+        [
+            {
+                "name": "overload-start-order",
+                "mode": "overload",
+                "overload_actions": [
+                    {
+                        "action": "macro",
+                        "macro_name": "held-child",
+                        "macro_loop_mode": "hold",
+                    }
+                ],
+            },
+            {
+                "name": "split-overload-start-order",
+                "mode": "overload",
+                "overload_actions": [
+                    {
+                        "action": "macro",
+                        "macro_name": "held-child",
+                        "macro_loop_mode": "hold",
+                    }
+                ],
+                "overload_up_actions": [
+                    {"action": "keyboard", "target": "key_f6"},
+                ],
+            },
+        ],
+        ids=("overload", "split-overload"),
+    )
+    async def test_runtime_combo_release_waits_for_overload_start(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        superkey_payload: dict[str, object],
+    ) -> None:
+        manager = DeviceManager()
+        manager.output_state.keyboard_uinput = FakeUInput()
+        press_started = asyncio.Event()
+        allow_press = asyncio.Event()
+        trigger_values: list[int] = []
+
+        async def play_macro(**kwargs: object) -> dict[str, object]:
+            trigger_value = int(kwargs["trigger_value"])
+            trigger_values.append(trigger_value)
+            if trigger_value == 1:
+                press_started.set()
+                await allow_press.wait()
+            return {"status": "ok"}
+
+        manager.play_macro = play_macro  # type: ignore[method-assign]
+        await manager.set_combos(
+            [
+                {
+                    "id": "combo-cross-device-overload",
+                    "name": "Cross Device Overload",
+                    "steps": [
+                        {
+                            "events": [
+                                {
+                                    "hardware_id": "1234:5678",
+                                    "source": "kbd-a",
+                                    "evdev": "key_leftalt",
+                                },
+                                {
+                                    "hardware_id": "1234:5678",
+                                    "source": "kbd-b",
+                                    "evdev": "key_b",
+                                },
+                            ]
+                        }
+                    ],
+                    "action": {
+                        "action": "superkey",
+                        "superkey": superkey_payload,
+                    },
+                }
+            ]
+        )
+
+        monkeypatch.setattr(devices, "resolve_stable_path", lambda path: path)
+        monkeypatch.setattr(devices, "get_interface_id", lambda _path: "")
+        kwargs = combo_event_runtime_kwargs()
+        press_task = None
+        release_task = None
+        try:
+            await events.on_device_event(
+                manager,
+                "1234:5678",
+                "/dev/input/by-id/test-kbd-a",
+                evdev.ecodes.EV_KEY,
+                evdev.ecodes.KEY_LEFTALT,
+                1,
+                None,
+                "kbd-a",
+                **kwargs,
+            )
+            press_task = asyncio.create_task(
+                events.on_device_event(
+                    manager,
+                    "1234:5678",
+                    "/dev/input/by-id/test-kbd-b",
+                    evdev.ecodes.EV_KEY,
+                    evdev.ecodes.KEY_B,
+                    1,
+                    None,
+                    "kbd-b",
+                    **kwargs,
+                )
+            )
+            await asyncio.wait_for(press_started.wait(), timeout=1.0)
+
+            release_task = asyncio.create_task(
+                events.on_device_event(
+                    manager,
+                    "1234:5678",
+                    "/dev/input/by-id/test-kbd-a",
+                    evdev.ecodes.EV_KEY,
+                    evdev.ecodes.KEY_LEFTALT,
+                    0,
+                    None,
+                    "kbd-a",
+                    **kwargs,
+                )
+            )
+            await asyncio.sleep(0)
+            assert not release_task.done()
+
+            allow_press.set()
+            await asyncio.wait_for(press_task, timeout=1.0)
+            await asyncio.wait_for(release_task, timeout=1.0)
+
+            assert trigger_values == [1, 0]
+            assert manager.combo_state.active_actions == {}
+        finally:
+            allow_press.set()
+            for task in (press_task, release_task):
+                if task is not None and not task.done():
+                    task.cancel()
+                    await asyncio.gather(task, return_exceptions=True)
+            await lifecycle.clear_combo_runtime(manager, deps=combo_runtime_deps())
+
+    @pytest.mark.asyncio
+    async def test_runtime_combo_release_waits_for_repeat_start(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        manager = DeviceManager()
+        press_started = asyncio.Event()
+        allow_press = asyncio.Event()
+        trigger_values: list[int] = []
+
+        async def play_macro(**kwargs: object) -> dict[str, object]:
+            trigger_value = int(kwargs["trigger_value"])
+            trigger_values.append(trigger_value)
+            if trigger_value == 1:
+                press_started.set()
+                await allow_press.wait()
+            return {"status": "ok"}
+
+        manager.play_macro = play_macro  # type: ignore[method-assign]
+        repeat.remember_action(
+            manager.repeat_state,
+            MappingAction(
+                action_type=ActionType.MACRO,
+                macro_name="held-repeat",
+                macro_loop_mode="hold",
+            ),
+        )
+        await manager.set_combos(
+            [
+                {
+                    "id": "combo-cross-device-repeat",
+                    "name": "Cross Device Repeat",
+                    "steps": [
+                        {
+                            "events": [
+                                {
+                                    "hardware_id": "1234:5678",
+                                    "source": "kbd-a",
+                                    "evdev": "key_leftalt",
+                                },
+                                {
+                                    "hardware_id": "1234:5678",
+                                    "source": "kbd-b",
+                                    "evdev": "key_b",
+                                },
+                            ]
+                        }
+                    ],
+                    "action": {"action": "repeat", "repeat_categories": ["macro"]},
+                }
+            ]
+        )
+
+        monkeypatch.setattr(devices, "resolve_stable_path", lambda path: path)
+        monkeypatch.setattr(devices, "get_interface_id", lambda _path: "")
+        kwargs = combo_event_runtime_kwargs()
+        press_task = None
+        release_task = None
+        try:
+            await events.on_device_event(
+                manager,
+                "1234:5678",
+                "/dev/input/by-id/test-kbd-a",
+                evdev.ecodes.EV_KEY,
+                evdev.ecodes.KEY_LEFTALT,
+                1,
+                None,
+                "kbd-a",
+                **kwargs,
+            )
+            press_task = asyncio.create_task(
+                events.on_device_event(
+                    manager,
+                    "1234:5678",
+                    "/dev/input/by-id/test-kbd-b",
+                    evdev.ecodes.EV_KEY,
+                    evdev.ecodes.KEY_B,
+                    1,
+                    None,
+                    "kbd-b",
+                    **kwargs,
+                )
+            )
+            await asyncio.wait_for(press_started.wait(), timeout=1.0)
+
+            release_task = asyncio.create_task(
+                events.on_device_event(
+                    manager,
+                    "1234:5678",
+                    "/dev/input/by-id/test-kbd-a",
+                    evdev.ecodes.EV_KEY,
+                    evdev.ecodes.KEY_LEFTALT,
+                    0,
+                    None,
+                    "kbd-a",
+                    **kwargs,
+                )
+            )
+            await asyncio.sleep(0)
+            assert not release_task.done()
+
+            allow_press.set()
+            await asyncio.wait_for(press_task, timeout=1.0)
+            await asyncio.wait_for(release_task, timeout=1.0)
+
+            assert trigger_values == [1, 0]
+            assert manager.combo_state.active_actions == {}
+        finally:
+            allow_press.set()
+            for task in (press_task, release_task):
+                if task is not None and not task.done():
+                    task.cancel()
+                    await asyncio.gather(task, return_exceptions=True)
+            await lifecycle.clear_combo_runtime(manager, deps=combo_runtime_deps())
+
+    @pytest.mark.asyncio
+    async def test_runtime_combo_refresh_waits_for_action_start(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        manager = DeviceManager()
+        manager.output_state.keyboard_uinput = FakeUInput()
+        action_started = asyncio.Event()
+        allow_action = asyncio.Event()
+        action_tasks: list[asyncio.Task[object]] = []
+
+        def delayed_fire_and_observe(coro, _label):
+            async def runner():
+                try:
+                    action_started.set()
+                    await allow_action.wait()
+                    return await coro
+                finally:
+                    if not allow_action.is_set():
+                        close = getattr(coro, "close", None)
+                        if callable(close):
+                            close()
+
+            task = asyncio.create_task(runner())
+            action_tasks.append(task)
+            return task
+
+        combo_payload = {
+            "id": "combo-refresh-during-start",
+            "name": "Refresh During Start",
+            "steps": [
+                {
+                    "events": [
+                        {
+                            "hardware_id": "1234:5678",
+                            "source": "kbd",
+                            "evdev": "key_f13",
+                        }
+                    ]
+                }
+            ],
+            "action": {
+                "action": "keyboard",
+                "target": "key_f5",
+                "tap_enabled": True,
+                "tap_hold_ms": 10,
+            },
+        }
+        await manager.set_combos([combo_payload])
+        monkeypatch.setattr(devices, "resolve_stable_path", lambda path: path)
+        monkeypatch.setattr(devices, "get_interface_id", lambda _path: "kbd")
+        kwargs = combo_event_runtime_kwargs()
+        kwargs["deps"] = combo_runtime_deps(
+            fire_and_observe_fn=delayed_fire_and_observe,
+        )
+        press_task = asyncio.create_task(
+            events.on_device_event(
+                manager,
+                "1234:5678",
+                "/dev/input/by-id/test-kbd",
+                evdev.ecodes.EV_KEY,
+                evdev.ecodes.KEY_F13,
+                1,
+                None,
+                "kbd",
+                **kwargs,
+            )
+        )
+        refresh_task = None
+        try:
+            await asyncio.wait_for(action_started.wait(), timeout=1.0)
+            refresh_task = asyncio.create_task(manager.set_combos([]))
+            await asyncio.sleep(0)
+            assert not refresh_task.done()
+
+            allow_action.set()
+            await asyncio.wait_for(press_task, timeout=1.0)
+            await asyncio.wait_for(refresh_task, timeout=1.0)
+            await asyncio.gather(*action_tasks, return_exceptions=True)
+
+            assert manager.combo_state.active_actions == {}
+            assert manager.combo_state.active_combos == []
+        finally:
+            allow_action.set()
+            for task in (press_task, refresh_task):
+                if task is not None and not task.done():
+                    task.cancel()
+                    await asyncio.gather(task, return_exceptions=True)
             for task in action_tasks:
                 if not task.done():
                     task.cancel()

--- a/tests/keymasqd/test_device_manager_runtime_recovery.py
+++ b/tests/keymasqd/test_device_manager_runtime_recovery.py
@@ -1114,9 +1114,13 @@ class TestDeviceManagerHelpers:
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         manager = DeviceManager()
-        clear_combo_runtime = AsyncMock()
+        clear_combo_runtime_unlocked = AsyncMock()
         refresh_combo_timeout_watchdog = Mock()
-        monkeypatch.setattr(lifecycle, "clear_combo_runtime", clear_combo_runtime)
+        monkeypatch.setattr(
+            lifecycle,
+            "clear_combo_runtime_unlocked",
+            clear_combo_runtime_unlocked,
+        )
         monkeypatch.setattr(
             lifecycle,
             "refresh_combo_timeout_watchdog",
@@ -1152,7 +1156,7 @@ class TestDeviceManagerHelpers:
         assert result == {"updated": True, "combo_count": 1}
         assert len(manager.combo_state.active_combos) == 1
         assert manager.combo_state.active_combos[0].steps[0].timeout_ms == 250
-        clear_combo_runtime.assert_awaited_once()
+        clear_combo_runtime_unlocked.assert_awaited_once()
         refresh_combo_timeout_watchdog.assert_called_once()
 
     @pytest.mark.asyncio

--- a/tests/test_integration_runner.py
+++ b/tests/test_integration_runner.py
@@ -104,7 +104,7 @@ from runner import _scenario_key, selected_scenarios
 from scenarios import SCENARIOS
 
 keys = [_scenario_key(scenario.name) for scenario in SCENARIOS]
-assert len(SCENARIOS) == 48
+assert len(SCENARIOS) == 49
 assert len(keys) == len(set(keys))
 assert all(key and key.replace('-', '').isalnum() for key in keys)
 assert _scenario_key('simple 1->1 remap') == 'simple-1-1-remap'
@@ -145,7 +145,11 @@ def test_runner_lists_all_registered_scenarios_without_starting_context() -> Non
 
     assert result.returncode == 0, result.stderr
     lines = result.stdout.splitlines()
-    assert len(lines) == 48
+    assert len(lines) == 49
+    assert (
+        "combo-cross-device-transition-order\t"
+        "combo cross-device transition order"
+    ) in lines
     assert "simple-1-1-remap\tsimple 1->1 remap" in lines
     assert (
         "superkey-overload-multi-action-press-release\t"


### PR DESCRIPTION
## Summary

- keep combo progression and its action transitions in one `runtime_lock` transaction
- prevent releases from overtaking yielding action startup on another grabbed-device task
- add regressions for ordinary actions, overload and split-overload superkeys, repeat actions, and runtime refresh
- add a two-device daemon/session integration scenario

## Verification

- `./scripts/check.sh`
  - Ruff and formatting passed
  - basedpyright passed
  - pytest: 952 passed, 25 skipped
- `./scripts/integration.sh daemon-session --scenario combo-cross-device-transition-order`
- `git diff --check`