### PR TITLE
Add structured macro and command calls

### DIFF
--- a/docs/MACROS.md
+++ b/docs/MACROS.md
@@ -329,11 +329,6 @@ pressing a toggle trigger again lets the current macro pass complete and only
 prevents the next repeat. When it is disabled, stop input cancels playback
 immediately.
 
-When a Super Key runs a macro on press and another macro on hold, the press
-macro runs once to completion before the hold macro starts. The hold macro
-starts only if the physical trigger is still held afterward. Releasing the
-trigger while the press macro is running prevents the hold macro from starting.
-
 Macro duration is the minimum timeline length of one pass. If the pass reaches
 the end of its events before `duration_us`, playback waits until that duration
 has elapsed before looping or finishing. This trailing duration is scaled by

--- a/docs/MACROS.md
+++ b/docs/MACROS.md
@@ -329,6 +329,11 @@ pressing a toggle trigger again lets the current macro pass complete and only
 prevents the next repeat. When it is disabled, stop input cancels playback
 immediately.
 
+When a Super Key runs a macro on press and another macro on hold, the press
+macro runs once to completion before the hold macro starts. The hold macro
+starts only if the physical trigger is still held afterward. Releasing the
+trigger while the press macro is running prevents the hold macro from starting.
+
 Macro duration is the minimum timeline length of one pass. If the pass reaches
 the end of its events before `duration_us`, playback waits until that duration
 has elapsed before looping or finishing. This trailing duration is scaled by
@@ -420,8 +425,10 @@ The editor lets you insert several kinds of events into the timeline:
 | **Run command** | Run an external program. It can pause at the event, run in parallel and join at the end of the iteration, or detach from macro playback. |
 | **Compositor action** | Send a compositor dispatch through the active session listener. This uses the same Hyprland, Niri, KDE, or GNOME action picker as normal mappings. |
 
-Exec events use the configured timeout. A command that reaches it is killed by
-the session process. The three execution modes are:
+Waitable Exec events (**Wait for completion** and **Run in parallel**) use the
+configured timeout. A command that reaches it is killed by the session process.
+Detached commands instead use the session's default 300-second command timeout.
+The three execution modes are:
 
 - **Wait for completion** pauses the timeline at the command until it exits or
   times out.

--- a/docs/MACROS.md
+++ b/docs/MACROS.md
@@ -428,7 +428,7 @@ The three execution modes are:
 - **Wait for completion** pauses the timeline at the command until it exits or
   times out.
 - **Run in parallel** continues the timeline, then joins the command before the
-  parent iteration finishes. Count does not start its next iteration until all
+  parent iteration finishes. The next loop iteration does not start until all
   parallel commands finish. Canceling the macro kills the command.
 - **Run detached** continues the timeline and does not join or cancel the
   command. The command can outlive the macro.

--- a/docs/MACROS.md
+++ b/docs/MACROS.md
@@ -417,13 +417,22 @@ The editor lets you insert several kinds of events into the timeline:
 | **Absolute mouse movement** | Attempt to move the pointer to a screen coordinate with the older reset-and-offset virtual mouse action. Use it as a fallback when natural movement is unavailable. |
 | **Wait** | Pause macro playback for a fixed duration. The editor stores it at its timestamp and does not move later events. |
 | **Wait (random)** | Pause macro playback for a random duration in a configured range. The editor stores it at its timestamp and does not estimate the eventual delay. |
-| **Exec (synchronous)** | Run an external program and wait for it to finish before the macro continues. Macro playback is paused until the process exits. |
-| **Exec (asynchronous)** | Fire-and-forget an external program. The macro continues immediately — the launched process runs independently. |
+| **Run command** | Run an external program. It can pause at the event, run in parallel and join at the end of the iteration, or detach from macro playback. |
 | **Compositor action** | Send a compositor dispatch through the active session listener. This uses the same Hyprland, Niri, KDE, or GNOME action picker as normal mappings. |
 
-Exec events are powerful but be cautious: a synchronous exec that hangs will
-stall the macro indefinitely. Prefer asynchronous exec for anything that
-doesn't need to gate later events.
+Exec events use the configured timeout. A command that reaches it is killed by
+the session process. The three execution modes are:
+
+- **Wait for completion** pauses the timeline at the command until it exits or
+  times out.
+- **Run in parallel** continues the timeline, then joins the command before the
+  parent iteration finishes. Count does not start its next iteration until all
+  parallel commands finish. Canceling the macro kills the command.
+- **Run detached** continues the timeline and does not join or cancel the
+  command. The command can outlive the macro.
+
+The timeline context menu has one **Run Command** action. After inserting it,
+choose its execution mode in the event properties.
 
 Exec events are the recommended way to call existing hardware/vendor tooling
 from a macro. For example, DPI changes can be delegated to OpenRazer or
@@ -465,6 +474,34 @@ Wait controls appear as **W** or **WR** markers on the timeline. You can move
 them, edit their duration, or delete them at any time.
 
 ![Wait and random-wait controls on the macro timeline](assets/screenshots/macro_edit_wait_wait_random_markers.png)
+
+### Calling macros from macros
+
+A macro can call another saved macro from its timeline. Right-click the
+timeline at the desired time, choose **Call Macro**, then select the macro from
+the normal Macro Library selector. Choose **Run and wait** or **Run in parallel**
+in the event properties. The resulting **MW** or **MP** marker remains editable.
+
+- **Run and wait** pauses the parent at the marker until the child completes.
+  Later parent deadlines move back by the time spent in the child.
+- **Run in parallel** lets the parent timeline continue. It is still a child,
+  not a detached task: the parent iteration waits for it at the end before the
+  next Count/Hold/Toggle iteration can start.
+- Each call chooses its own Once, Count, or While Held playback, speed, and
+  mouse replay options. Toggle is intentionally a top-level trigger mode and
+  is not offered for child calls.
+- While Held children share the original trigger's lifecycle. If that key was
+  released before the call marker is reached, the child is skipped. Without a
+  key lifecycle, such as playback from the GUI or CLI, While Held runs once.
+- A child configured to cancel its current run also cancels its descendants.
+  Emergency macro cancellation cancels and reaps the entire call tree.
+
+Child names are resolved when the marker is reached, so edits to a saved child
+take effect without rebuilding the parent. Renaming or deleting a child does
+not rewrite callers. A missing or failed child aborts the parent call tree and
+logs the full call chain. If a macro tries to call a name already present in
+its active parent chain, Keymasq stops the call tree and logs the attempted
+cycle. This runtime check does not scan or rewrite saved macros.
 
 ### Timing Tools
 

--- a/docs/agents/macros.txt
+++ b/docs/agents/macros.txt
@@ -115,6 +115,11 @@ Semantic macro control events:
 {"device_type":"macro","type":0,"code":0,"value":0,"t_us":0,"macro_action":"mouse_move_abs","x":100,"y":200}
 {"device_type":"macro","type":0,"code":0,"value":0,"t_us":0,"macro_action":"mouse_move_rel","x":10,"y":0}
 {"device_type":"macro","type":0,"code":0,"value":0,"t_us":0,"macro_action":"mouse_move_natural_abs","x":100,"y":200,"speed":12000.0,"jitter":0.3,"curve":"natural","tolerance":2,"max_duration_ms":3000,"stop_on_failure":false}
+{"device_type":"macro","type":0,"code":0,"value":0,"t_us":0,"macro_action":"exec_sync","command":"echo ready","timeout_ms":30000,"inhibit_mouse":false}
+{"device_type":"macro","type":0,"code":0,"value":0,"t_us":0,"macro_action":"exec_parallel","command":"sleep 1","timeout_ms":30000,"inhibit_mouse":false}
+{"device_type":"macro","type":0,"code":0,"value":0,"t_us":0,"macro_action":"exec_async","command":"notify-send done"}
+{"device_type":"macro","type":0,"code":0,"value":0,"t_us":0,"macro_action":"macro_sync","macro_name":"child","loop_mode":"none","loop_count":1,"loop_stop_behavior":"finish_run","speed":1.0,"replay_mouse_movement":true,"replay_mouse_clicks":true}
+{"device_type":"macro","type":0,"code":0,"value":0,"t_us":0,"macro_action":"macro_parallel","macro_name":"child","loop_mode":"hold","loop_count":1,"loop_stop_behavior":"cancel_run","speed":1.0,"replay_mouse_movement":true,"replay_mouse_clicks":true}
 ```
 
 Recorded macro start positioning is represented as the first
@@ -128,6 +133,23 @@ stops before later events execute.
 
 Loop modes for saved macros: `none`, `count`, `hold`, `toggle`.
 Stop behavior for `hold` and `toggle`: `finish_run` or `cancel_run`.
+
+Macro call events dynamically resolve `macro_name`. `macro_sync` blocks the
+parent at the call site; `macro_parallel` continues the parent timeline but joins
+the child before the parent iteration completes. Child `loop_mode` accepts
+`none`, `count`, or `hold`; nested toggle is treated as `none`. Hold inherits
+the root key lifecycle and is treated as one run when playback has no source.
+Parallel children never detach from the parent. Child failures abort the call
+tree and log the dynamic call chain. Before spawning a child, the runtime
+rejects its name if that name already appears in the active parent chain. The
+failure includes the attempted cycle and aborts the call tree. Keymasq does not
+scan saved macros or impose a separate depth limit.
+
+Exec modes: `exec_sync` waits at the event; `exec_parallel` continues the
+timeline and joins before the parent iteration completes; `exec_async` is
+detached and can outlive the macro. `exec_sync` and `exec_parallel` share the
+same `timeout_ms` policy and optional `inhibit_mouse` behavior. Canceling a
+joined command kills its session-owned process group.
 
 ## Binding a macro from a profile
 

--- a/keymasq/gui/widgets/key_selector/dialog.py
+++ b/keymasq/gui/widgets/key_selector/dialog.py
@@ -93,6 +93,7 @@ class KeySelectorDialog(
         allow_rapidfire: bool = True,
         allow_tap: bool = True,
         allow_macro_options: bool = True,
+        macro_library_only: bool = False,
         source_type: str = "button",
         analog_input_type: str | None = None,
         allowed_tabs: set[str] | list[str] | tuple[str, ...] | None = None,
@@ -103,10 +104,13 @@ class KeySelectorDialog(
         include_mouse_move_controls: bool | None = None,
         include_mouse_move_failure_controls: bool = False,
         mouse_move_commit_label: str = "Map Move",
+        dialog_title: str | None = None,
     ):
-        super().__init__(title=f"Map: {button_label}", content_width=570, content_height=580)
+        resolved_title = dialog_title or f"Map: {button_label}"
+        super().__init__(title=resolved_title, content_width=570, content_height=580)
         self._parent = parent
         self._button_label = button_label
+        self._dialog_title = resolved_title
         self._current_action = current_action
         self._allow_passthrough = allow_passthrough
         self._allow_clear_mapping = allow_clear_mapping
@@ -116,6 +120,7 @@ class KeySelectorDialog(
         self._allow_rapidfire = allow_rapidfire
         self._allow_tap = allow_tap
         self._allow_macro_options = allow_macro_options
+        self._macro_library_only = bool(macro_library_only)
         self._source_type = str(source_type or "button")
         self._allowed_tabs = set(allowed_tabs) if allowed_tabs is not None else None
         self._initial_tab = initial_tab
@@ -351,7 +356,7 @@ class KeySelectorDialog(
         title_row.set_margin_top(12)
         title_row.set_margin_bottom(6)
 
-        title_label = Gtk.Label(label=f"Map: {self._button_label}")
+        title_label = Gtk.Label(label=self._dialog_title)
         title_label.add_css_class("title-3")
         title_label.set_halign(Gtk.Align.CENTER)
         title_row.append(title_label)
@@ -584,9 +589,15 @@ class KeySelectorDialog(
         self.map_btn.set_visible(
             is_superkey or is_analog_control or is_type or is_macro or is_profile or is_mouse_move
         )
-        self.map_btn.set_label(self._mouse_move_commit_label if is_mouse_move else "Map")
+        self.map_btn.set_label(
+            self._mouse_move_commit_label
+            if is_mouse_move
+            else "Select Macro"
+            if is_macro and self._macro_library_only
+            else "Map"
+        )
         if self._cancel_macro_playback_btn is not None:
-            self._cancel_macro_playback_btn.set_visible(is_macro)
+            self._cancel_macro_playback_btn.set_visible(is_macro and not self._macro_library_only)
         if is_superkey:
             self.map_btn.set_sensitive(self._selected_superkey is not None)
         elif is_analog_control:

--- a/keymasq/gui/widgets/key_selector/macro_tab.py
+++ b/keymasq/gui/widgets/key_selector/macro_tab.py
@@ -94,9 +94,9 @@ class MacroTabMixin:
     def _build_macro_tab(self) -> Gtk.Widget:
         outer = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=0)
 
-        outer.append(self._build_macro_slot_console())
-
-        outer.append(Gtk.Separator())
+        if not self._macro_library_only:
+            outer.append(self._build_macro_slot_console())
+            outer.append(Gtk.Separator())
 
         library_label = Gtk.Label(label="Macro Library")
         library_label.add_css_class("dim-label")

--- a/keymasq/gui/widgets/macro_editor/add_popovers.py
+++ b/keymasq/gui/widgets/macro_editor/add_popovers.py
@@ -139,6 +139,71 @@ class MacroEditorAddPopoversMixin:
         self._refresh_after_timing_edit()
         self._on_selection_changed(control)
 
+    def _present_macro_call_dialog(
+        self,
+        *,
+        mode: str = "macro_sync",
+        default_t_us: int | None = None,
+        control: EditableControl | None = None,
+    ) -> None:
+        """Select a called macro through the shared macro library dialog."""
+
+        from keymasq.gui.widgets.key_selector.dialog import KeySelectorDialog
+
+        current_action = None
+        if control is not None and control.macro_name:
+            current_action = MappingAction(
+                action_type=ActionType.MACRO,
+                macro_name=control.macro_name,
+                macro_replay_mouse_movement=control.macro_replay_mouse_movement,
+                macro_replay_mouse_clicks=control.macro_replay_mouse_clicks,
+                macro_speed=control.macro_speed,
+            )
+        dialog = KeySelectorDialog(
+            self._parent,
+            "Macro Call",
+            current_action,
+            allow_passthrough=False,
+            allow_clear_mapping=False,
+            allow_suppress=False,
+            allow_superkey=False,
+            allow_repeat=False,
+            allow_rapidfire=False,
+            allow_tap=False,
+            allowed_tabs={"macro"},
+            initial_tab="macro",
+            macro_library_only=True,
+            dialog_title="Choose Macro",
+        )
+        dialog.connect(
+            "key-selected",
+            self._on_macro_call_selected,
+            mode,
+            self._default_insert_time_us(default_t_us),
+            control,
+        )
+        dialog.present(self._parent)
+
+    def _on_macro_call_selected(
+        self,
+        _dialog: Gtk.Widget,
+        action: MappingAction | None,
+        mode: str,
+        default_t_us: int,
+        control: EditableControl | None,
+    ) -> None:
+        if action is None or action.action_type != ActionType.MACRO or not action.macro_name:
+            return
+        target = control or EditableControl(mode=mode, t_us=max(0, int(default_t_us)))
+        target.macro_name = action.macro_name
+        target.macro_replay_mouse_movement = action.macro_replay_mouse_movement
+        target.macro_replay_mouse_clicks = action.macro_replay_mouse_clicks
+        target.macro_speed = max(0.01, action.macro_speed)
+        if control is None:
+            self._insert_control_event(target)
+        else:
+            self._refresh_after_control_change(target)
+
     def _present_compositor_action_dialog(
         self,
         default_t_us: int | None = None,
@@ -242,6 +307,7 @@ class MacroEditorAddPopoversMixin:
             "wait": "Insert Wait (Fixed)",
             "wait_random": "Insert Wait (Random)",
             "exec_sync": "Insert Exec Sync",
+            "exec_parallel": "Insert Exec Parallel",
             "exec_async": "Insert Exec Async",
         }.get(control_mode, "Insert Control")
 
@@ -303,7 +369,7 @@ class MacroEditorAddPopoversMixin:
             max_spin_widget.set_width_chars(7)
             row.append(max_spin_widget)
             box.append(row)
-        elif control_mode in {"exec_sync", "exec_async"}:
+        elif control_mode in {"exec_sync", "exec_parallel", "exec_async"}:
             cmd_row = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=4)
             cmd_label = Gtk.Label(label="Command:")
             cmd_label.set_halign(Gtk.Align.START)
@@ -314,7 +380,7 @@ class MacroEditorAddPopoversMixin:
             cmd_row.append(cmd_entry_widget)
             box.append(cmd_row)
 
-            if control_mode == "exec_sync":
+            if control_mode in {"exec_sync", "exec_parallel"}:
                 row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=8)
                 row.append(Gtk.Label(label="Timeout (ms):"))
                 timeout_spin_widget = Gtk.SpinButton()
@@ -364,10 +430,13 @@ class MacroEditorAddPopoversMixin:
                 mx = max(mn, int(max_spin.get_value() * 1000))
                 control.min_us = mn
                 control.max_us = mx
-            elif control_mode in {"exec_sync", "exec_async"} and cmd_entry is not None:
+            elif (
+                control_mode in {"exec_sync", "exec_parallel", "exec_async"}
+                and cmd_entry is not None
+            ):
                 command = cmd_entry.get_text().strip()
                 control.command = command
-                if control_mode == "exec_sync":
+                if control_mode in {"exec_sync", "exec_parallel"}:
                     control.timeout_ms = (
                         max(1, int(timeout_spin.get_value())) if timeout_spin is not None else 30000
                     )

--- a/keymasq/gui/widgets/macro_editor/controller/timing.py
+++ b/keymasq/gui/widgets/macro_editor/controller/timing.py
@@ -42,13 +42,15 @@ class TimelineControllerMixin:
         if not hasattr(self, "_exec_summary_label"):
             return
         sync_count = sum(1 for c in self._control_events if c.mode == "exec_sync")
+        parallel_count = sum(1 for c in self._control_events if c.mode == "exec_parallel")
         async_count = sum(1 for c in self._control_events if c.mode == "exec_async")
-        total = sync_count + async_count
+        total = sync_count + parallel_count + async_count
         if total == 0:
             self._exec_summary_label.set_label("Exec actions: none")
             return
         self._exec_summary_label.set_label(
-            f"Exec actions: {total} (sync {sync_count}, async {async_count})"
+            f"Exec actions: {total} "
+            f"(wait {sync_count}, parallel {parallel_count}, detached {async_count})"
         )
 
     def _timeline_end_us(self) -> int:

--- a/keymasq/gui/widgets/macro_editor/model.py
+++ b/keymasq/gui/widgets/macro_editor/model.py
@@ -7,6 +7,7 @@ import evdev
 
 from keymasq.common.coercion import bool_value, coerce_float, coerce_int
 from keymasq.common.model.actions import (
+    DEFAULT_MACRO_LOOP_STOP_BEHAVIOR,
     DEFAULT_NATURAL_MOUSE_MOVE_CURVE,
     DEFAULT_NATURAL_MOUSE_MOVE_JITTER,
     DEFAULT_NATURAL_MOUSE_MOVE_MAX_DURATION_MS,
@@ -110,8 +111,11 @@ _CONTROL_MACRO_ACTIONS = {
     "wait",
     "wait_random",
     "exec_sync",
+    "exec_parallel",
     "exec_async",
     "compositor_dispatch",
+    "macro_sync",
+    "macro_parallel",
 }
 
 # ---------------------------------------------------------------------------
@@ -149,7 +153,7 @@ class EditableMove:
 
 @dataclass
 class EditableControl:
-    mode: str  # wait | wait_random | exec_sync | exec_async | compositor_dispatch
+    mode: str
     t_us: int
     duration_us: int = 0
     min_us: int = 0
@@ -160,6 +164,13 @@ class EditableControl:
     compositor_id: str = ""
     compositor_dispatcher: str = ""
     compositor_args: str = ""
+    macro_name: str = ""
+    macro_replay_mouse_movement: bool = True
+    macro_replay_mouse_clicks: bool = True
+    macro_speed: float = 1.0
+    macro_loop_mode: str = "none"
+    macro_loop_count: int = 1
+    macro_loop_stop_behavior: str = DEFAULT_MACRO_LOOP_STOP_BEHAVIOR
     original_order: int | None = None
 
 
@@ -310,6 +321,16 @@ def parse_events(
                     compositor_id=str(ev.get("compositor", "") or ""),
                     compositor_dispatcher=str(ev.get("dispatcher", "") or ""),
                     compositor_args=str(ev.get("args", "") or ""),
+                    macro_name=str(ev.get("macro_name", "") or ""),
+                    macro_replay_mouse_movement=bool_value(ev.get("replay_mouse_movement", True)),
+                    macro_replay_mouse_clicks=bool_value(ev.get("replay_mouse_clicks", True)),
+                    macro_speed=max(0.01, coerce_float(ev.get("speed"), 1.0)),
+                    macro_loop_mode=str(ev.get("loop_mode", "none") or "none"),
+                    macro_loop_count=max(1, coerce_int(ev.get("loop_count"), 1)),
+                    macro_loop_stop_behavior=str(
+                        ev.get("loop_stop_behavior", DEFAULT_MACRO_LOOP_STOP_BEHAVIOR)
+                        or DEFAULT_MACRO_LOOP_STOP_BEHAVIOR
+                    ),
                     original_order=original_order,
                 )
             )
@@ -478,9 +499,9 @@ def reconstruct_events(
         elif control.mode == "wait_random":
             control_event["min_us"] = int(control.min_us)
             control_event["max_us"] = int(control.max_us)
-        elif control.mode in {"exec_sync", "exec_async"}:
+        elif control.mode in {"exec_sync", "exec_parallel", "exec_async"}:
             control_event["command"] = str(control.command)
-            if control.mode == "exec_sync":
+            if control.mode in {"exec_sync", "exec_parallel"}:
                 control_event["timeout_ms"] = int(control.timeout_ms)
                 control_event["inhibit_mouse"] = bool(control.inhibit_mouse)
         elif control.mode == "compositor_dispatch":
@@ -488,6 +509,16 @@ def reconstruct_events(
                 control_event["compositor"] = str(control.compositor_id)
             control_event["dispatcher"] = str(control.compositor_dispatcher)
             control_event["args"] = str(control.compositor_args)
+        elif control.mode in {"macro_sync", "macro_parallel"}:
+            control_event["macro_name"] = str(control.macro_name)
+            control_event["replay_mouse_movement"] = bool(control.macro_replay_mouse_movement)
+            control_event["replay_mouse_clicks"] = bool(control.macro_replay_mouse_clicks)
+            control_event["speed"] = max(0.01, float(control.macro_speed))
+            control_event["loop_mode"] = str(control.macro_loop_mode)
+            control_event["loop_count"] = max(1, int(control.macro_loop_count))
+            control_event["loop_stop_behavior"] = str(
+                control.macro_loop_stop_behavior or DEFAULT_MACRO_LOOP_STOP_BEHAVIOR
+            )
         if control.original_order is not None:
             control_event = _with_editor_order(control_event, control.original_order)
         raw.append(control_event)

--- a/keymasq/gui/widgets/macro_editor/panel/controls.py
+++ b/keymasq/gui/widgets/macro_editor/panel/controls.py
@@ -25,6 +25,7 @@ class ControlEditorState:
     mode_label: str
     change_label: str
     show_change: bool
+    title_context: str = ""
     show_ab: bool = False
     a_label: str = "A:"
     a_value_ms: float = 0.0
@@ -34,11 +35,21 @@ class ControlEditorState:
     show_b: bool = False
     show_command: bool = False
     command: str = ""
+    show_exec_mode: bool = False
+    exec_mode: str = "exec_sync"
     show_sync: bool = False
     timeout_ms: int = 1
     inhibit_mouse: bool = False
     show_timeout_hint: bool = False
     timeout_hint: str = ""
+    show_macro: bool = False
+    macro_wait: bool = True
+    macro_loop_mode: str = "none"
+    macro_loop_count: int = 1
+    macro_loop_stop_behavior: str = "finish_run"
+    macro_speed: float = 1.0
+    macro_replay_mouse_movement: bool = True
+    macro_replay_mouse_clicks: bool = True
 
 
 def timeout_policy_hint(timeout_ms: int, max_timeout_ms: int) -> str:
@@ -85,22 +96,51 @@ def control_editor_state(
             b_value_ms=max(0.0, control.max_us / 1000.0),
             show_b=True,
         )
-    if control.mode == "exec_async":
+    if control.mode in {"exec_sync", "exec_parallel", "exec_async"}:
+        tracked = control.mode != "exec_async"
+        detail = {
+            "exec_sync": "Wait for completion",
+            "exec_parallel": "Run in parallel",
+            "exec_async": "Run detached",
+        }[control.mode]
         return replace(
             base,
+            title="Run Command",
+            detail=detail,
+            mode_label="Shell command",
             show_command=True,
             command=control.command,
-        )
-    if control.mode == "exec_sync":
-        return replace(
-            base,
-            show_command=True,
-            command=control.command,
-            show_sync=True,
+            show_exec_mode=True,
+            exec_mode=control.mode,
+            show_sync=tracked,
             timeout_ms=max(1, int(control.timeout_ms)),
             inhibit_mouse=bool(control.inhibit_mouse),
-            show_timeout_hint=True,
+            show_timeout_hint=tracked,
             timeout_hint=timeout_policy_hint(int(control.timeout_ms), max_timeout_ms),
+        )
+    if control.mode in {"macro_sync", "macro_parallel"}:
+        call_label = "Run and wait" if control.mode == "macro_sync" else "Run in parallel"
+        loop_label = {
+            "none": "once",
+            "count": f"{max(1, control.macro_loop_count)} times",
+            "hold": "while held",
+        }.get(control.macro_loop_mode, "once")
+        return replace(
+            base,
+            title="Macro Call",
+            detail=f"{call_label}, {loop_label}",
+            title_context=control.macro_name or "<missing macro>",
+            mode_label="Saved macro",
+            change_label="Change Macro...",
+            show_change=True,
+            show_macro=True,
+            macro_wait=control.mode == "macro_sync",
+            macro_loop_mode=control.macro_loop_mode,
+            macro_loop_count=max(1, int(control.macro_loop_count)),
+            macro_loop_stop_behavior=control.macro_loop_stop_behavior,
+            macro_speed=max(0.01, float(control.macro_speed)),
+            macro_replay_mouse_movement=bool(control.macro_replay_mouse_movement),
+            macro_replay_mouse_clicks=bool(control.macro_replay_mouse_clicks),
         )
     return base
 
@@ -152,6 +192,17 @@ class ControlEditorMixin:
         control_cmd_row.append(self._control_cmd_entry)
         control_row.append(control_cmd_row)
 
+        control_exec_mode_row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=8)
+        control_exec_mode_row.append(Gtk.Label(label="Run:"))
+        self._control_exec_mode_dropdown = Gtk.DropDown.new_from_strings(
+            ["Wait for completion", "Run in parallel", "Run detached"]
+        )
+        self._control_exec_mode_dropdown.connect(
+            "notify::selected", self._on_control_exec_mode_changed
+        )
+        control_exec_mode_row.append(self._control_exec_mode_dropdown)
+        control_row.append(control_exec_mode_row)
+
         control_sync_row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=8)
         control_sync_row.append(Gtk.Label(label="Timeout (ms):"))
         self._control_timeout_spin = Gtk.SpinButton()
@@ -177,17 +228,86 @@ class ControlEditorMixin:
         self._control_timeout_hint_label.set_halign(Gtk.Align.START)
         control_row.append(self._control_timeout_hint_label)
 
+        macro_call_row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=8)
+        macro_call_row.append(Gtk.Label(label="Call:"))
+        self._control_macro_call_dropdown = Gtk.DropDown.new_from_strings(
+            ["Run and wait", "Run in parallel"]
+        )
+        self._control_macro_call_dropdown.connect(
+            "notify::selected", self._on_control_macro_call_changed
+        )
+        macro_call_row.append(self._control_macro_call_dropdown)
+        macro_call_row.append(Gtk.Label(label="Playback:"))
+        self._control_macro_loop_dropdown = Gtk.DropDown.new_from_strings(
+            ["Once", "Count", "While held"]
+        )
+        self._control_macro_loop_dropdown.connect(
+            "notify::selected", self._on_control_macro_loop_changed
+        )
+        macro_call_row.append(self._control_macro_loop_dropdown)
+        self._control_macro_count_spin = Gtk.SpinButton()
+        self._control_macro_count_spin.set_adjustment(
+            Gtk.Adjustment(value=1, lower=1, upper=1000000, step_increment=1)
+        )
+        self._control_macro_count_spin.connect(
+            "value-changed", self._on_control_macro_count_changed
+        )
+        macro_call_row.append(self._control_macro_count_spin)
+        control_row.append(macro_call_row)
+
+        macro_options_row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=8)
+        macro_options_row.append(Gtk.Label(label="Speed:"))
+        self._control_macro_speed_spin = Gtk.SpinButton()
+        self._control_macro_speed_spin.set_adjustment(
+            Gtk.Adjustment(value=1.0, lower=0.1, upper=10.0, step_increment=0.1)
+        )
+        self._control_macro_speed_spin.set_digits(1)
+        self._control_macro_speed_spin.connect(
+            "value-changed", self._on_control_macro_speed_changed
+        )
+        macro_options_row.append(self._control_macro_speed_spin)
+        self._control_macro_movement_check = Gtk.CheckButton(label="Mouse movement")
+        self._control_macro_movement_check.connect(
+            "toggled", self._on_control_macro_movement_changed
+        )
+        macro_options_row.append(self._control_macro_movement_check)
+        self._control_macro_clicks_check = Gtk.CheckButton(label="Mouse clicks")
+        self._control_macro_clicks_check.connect("toggled", self._on_control_macro_clicks_changed)
+        macro_options_row.append(self._control_macro_clicks_check)
+        control_row.append(macro_options_row)
+
+        macro_stop_row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=8)
+        macro_stop_row.append(Gtk.Label(label="On release:"))
+        self._control_macro_stop_dropdown = Gtk.DropDown.new_from_strings(
+            ["Finish current run", "Cancel current run"]
+        )
+        self._control_macro_stop_dropdown.connect(
+            "notify::selected", self._on_control_macro_stop_changed
+        )
+        macro_stop_row.append(self._control_macro_stop_dropdown)
+        control_row.append(macro_stop_row)
+
         panel.append(control_row)
         self._control_row = control_row
         self._control_ab_row = control_ab_row
         self._control_cmd_row = control_cmd_row
+        self._control_exec_mode_row = control_exec_mode_row
         self._control_sync_row = control_sync_row
         self._control_timeout_hint_label.set_visible(False)
+        self._control_macro_call_row = macro_call_row
+        self._control_macro_options_row = macro_options_row
+        self._control_macro_stop_row = macro_stop_row
+        macro_call_row.set_visible(False)
+        macro_options_row.set_visible(False)
+        macro_stop_row.set_visible(False)
         self._control_row.set_visible(False)
 
     def _show_control_properties(self, control: EditableControl) -> None:
         state = control_editor_state(control, self._macro_exec_timeout_max_ms)
-        self._prop_title.set_label(state.title)
+        self._prop_title.set_label(f"{state.title}:" if state.title_context else state.title)
+        self._prop_context_label.set_label(state.title_context)
+        self._prop_context_label.set_tooltip_text(state.title_context or None)
+        self._prop_context_label.set_visible(bool(state.title_context))
         self._key_info_label.set_label(state.detail)
         self._press_label.set_label("At:")
         self._duration_text_label.set_visible(False)
@@ -205,6 +325,7 @@ class ControlEditorMixin:
         try:
             self._press_spin.set_value(control.t_us / 1000)
             self._control_mode_label.set_label(state.mode_label)
+            self._control_mode_label.set_visible(not state.show_macro)
             self._control_a_label.set_label(state.a_label)
             self._control_a_label.set_visible(state.show_a)
             self._control_a_spin.set_visible(state.show_a)
@@ -215,15 +336,40 @@ class ControlEditorMixin:
             self._control_b_spin.set_value(state.b_value_ms)
             self._control_ab_row.set_visible(state.show_ab)
             self._control_cmd_row.set_visible(state.show_command)
+            self._control_exec_mode_row.set_visible(state.show_exec_mode)
             self._control_sync_row.set_visible(state.show_sync)
             self._control_timeout_hint_label.set_visible(state.show_timeout_hint)
+            self._control_macro_call_row.set_visible(state.show_macro)
+            self._control_macro_options_row.set_visible(state.show_macro)
+            self._control_macro_stop_row.set_visible(
+                state.show_macro and state.macro_loop_mode == "hold"
+            )
             if state.show_command:
                 _set_entry_text_if_needed(self._control_cmd_entry, state.command)
+            if state.show_exec_mode:
+                self._control_exec_mode_dropdown.set_selected(
+                    {"exec_sync": 0, "exec_parallel": 1, "exec_async": 2}.get(
+                        state.exec_mode, 0
+                    )
+                )
             if state.show_sync:
                 self._control_timeout_spin.set_value(state.timeout_ms)
                 self._control_inhibit_check.set_active(state.inhibit_mouse)
             if state.show_timeout_hint:
                 self._control_timeout_hint_label.set_label(state.timeout_hint)
+            if state.show_macro:
+                self._control_macro_call_dropdown.set_selected(0 if state.macro_wait else 1)
+                self._control_macro_loop_dropdown.set_selected(
+                    {"none": 0, "count": 1, "hold": 2}.get(state.macro_loop_mode, 0)
+                )
+                self._control_macro_count_spin.set_visible(state.macro_loop_mode == "count")
+                self._control_macro_count_spin.set_value(state.macro_loop_count)
+                self._control_macro_stop_dropdown.set_selected(
+                    1 if state.macro_loop_stop_behavior == "cancel_run" else 0
+                )
+                self._control_macro_speed_spin.set_value(state.macro_speed)
+                self._control_macro_movement_check.set_active(state.macro_replay_mouse_movement)
+                self._control_macro_clicks_check.set_active(state.macro_replay_mouse_clicks)
         finally:
             self._updating_props = False
         self._update_selected_move_capture_controls(None)
@@ -274,10 +420,25 @@ class ControlEditorMixin:
         selected_obj = self._timeline._selected
         if not isinstance(selected_obj, EditableControl):
             return
-        if selected_obj.mode in {"exec_sync", "exec_async"}:
+        if selected_obj.mode in {"exec_sync", "exec_parallel", "exec_async"}:
             # Rebuilding the panel here would drop focus from the command entry.
             selected_obj.command = entry.get_text()
             self._sync_close_guard()
+
+    def _on_control_exec_mode_changed(self, dropdown: Gtk.DropDown, _param) -> None:
+        if self._updating_props:
+            return
+        selected_obj = self._timeline._selected
+        if not isinstance(selected_obj, EditableControl) or selected_obj.mode not in {
+            "exec_sync",
+            "exec_parallel",
+            "exec_async",
+        }:
+            return
+        selected_obj.mode = {0: "exec_sync", 1: "exec_parallel", 2: "exec_async"}.get(
+            dropdown.get_selected(), "exec_sync"
+        )
+        self._refresh_after_control_change(selected_obj)
 
     def _on_control_timeout_changed(self, spin: Gtk.SpinButton) -> None:
         if self._updating_props:
@@ -285,7 +446,7 @@ class ControlEditorMixin:
         selected_obj = self._timeline._selected
         if not isinstance(selected_obj, EditableControl):
             return
-        if selected_obj.mode == "exec_sync":
+        if selected_obj.mode in {"exec_sync", "exec_parallel"}:
             selected_obj.timeout_ms = max(1, int(spin.get_value()))
             self._update_timeout_clamp_hint(selected_obj.timeout_ms)
             self._refresh_after_control_change(selected_obj)
@@ -296,6 +457,61 @@ class ControlEditorMixin:
         selected_obj = self._timeline._selected
         if not isinstance(selected_obj, EditableControl):
             return
-        if selected_obj.mode == "exec_sync":
+        if selected_obj.mode in {"exec_sync", "exec_parallel"}:
             selected_obj.inhibit_mouse = bool(check.get_active())
             self._refresh_after_control_change(selected_obj)
+
+    def _selected_macro_control(self) -> EditableControl | None:
+        selected = self._timeline._selected
+        if isinstance(selected, EditableControl) and selected.mode in {
+            "macro_sync",
+            "macro_parallel",
+        }:
+            return selected
+        return None
+
+    def _on_control_macro_call_changed(self, dropdown: Gtk.DropDown, _param) -> None:
+        if self._updating_props or (control := self._selected_macro_control()) is None:
+            return
+        control.mode = "macro_sync" if dropdown.get_selected() == 0 else "macro_parallel"
+        self._refresh_after_control_change(control)
+
+    def _on_control_macro_loop_changed(self, dropdown: Gtk.DropDown, _param) -> None:
+        if self._updating_props or (control := self._selected_macro_control()) is None:
+            return
+        control.macro_loop_mode = {0: "none", 1: "count", 2: "hold"}.get(
+            dropdown.get_selected(), "none"
+        )
+        self._refresh_after_control_change(control)
+
+    def _on_control_macro_count_changed(self, spin: Gtk.SpinButton) -> None:
+        if self._updating_props or (control := self._selected_macro_control()) is None:
+            return
+        control.macro_loop_count = max(1, spin.get_value_as_int())
+        self._refresh_after_control_change(control)
+
+    def _on_control_macro_stop_changed(self, dropdown: Gtk.DropDown, _param) -> None:
+        if self._updating_props or (control := self._selected_macro_control()) is None:
+            return
+        control.macro_loop_stop_behavior = (
+            "cancel_run" if dropdown.get_selected() == 1 else "finish_run"
+        )
+        self._refresh_after_control_change(control)
+
+    def _on_control_macro_speed_changed(self, spin: Gtk.SpinButton) -> None:
+        if self._updating_props or (control := self._selected_macro_control()) is None:
+            return
+        control.macro_speed = max(0.01, spin.get_value())
+        self._refresh_after_control_change(control)
+
+    def _on_control_macro_movement_changed(self, check: Gtk.CheckButton) -> None:
+        if self._updating_props or (control := self._selected_macro_control()) is None:
+            return
+        control.macro_replay_mouse_movement = bool(check.get_active())
+        self._refresh_after_control_change(control)
+
+    def _on_control_macro_clicks_changed(self, check: Gtk.CheckButton) -> None:
+        if self._updating_props or (control := self._selected_macro_control()) is None:
+            return
+        control.macro_replay_mouse_clicks = bool(check.get_active())
+        self._refresh_after_control_change(control)

--- a/keymasq/gui/widgets/macro_editor/panel/controls.py
+++ b/keymasq/gui/widgets/macro_editor/panel/controls.py
@@ -249,6 +249,8 @@ class ControlEditorMixin:
         self._control_macro_count_spin.set_adjustment(
             Gtk.Adjustment(value=1, lower=1, upper=1000000, step_increment=1)
         )
+        self._control_macro_count_spin.set_digits(0)
+        self._control_macro_count_spin.set_width_chars(7)
         self._control_macro_count_spin.connect(
             "value-changed", self._on_control_macro_count_changed
         )

--- a/keymasq/gui/widgets/macro_editor/panel/properties.py
+++ b/keymasq/gui/widgets/macro_editor/panel/properties.py
@@ -7,7 +7,7 @@ import gi
 gi.require_version("Gtk", "4.0")
 
 import evdev
-from gi.repository import Gtk  # pyright: ignore[reportAttributeAccessIssue]
+from gi.repository import Gtk, Pango  # pyright: ignore[reportAttributeAccessIssue]
 
 from keymasq.common.gamepad_axes import (
     clamp_gamepad_axis_value,
@@ -54,8 +54,15 @@ class EventPropertiesMixin:
         self._prop_title = Gtk.Label()
         self._prop_title.add_css_class("heading")
         self._prop_title.set_halign(Gtk.Align.START)
-        self._prop_title.set_hexpand(True)
         title_row.append(self._prop_title)
+        self._prop_context_label = Gtk.Label()
+        self._prop_context_label.add_css_class("heading")
+        self._prop_context_label.add_css_class("dim-label")
+        self._prop_context_label.set_halign(Gtk.Align.START)
+        self._prop_context_label.set_hexpand(True)
+        self._prop_context_label.set_ellipsize(Pango.EllipsizeMode.END)
+        self._prop_context_label.set_visible(False)
+        title_row.append(self._prop_context_label)
         panel.append(title_row)
 
         timing_row = Gtk.Box(
@@ -240,12 +247,14 @@ class EventPropertiesMixin:
 
     def _on_selection_changed(self, selected_obj: object | None) -> None:
         if selected_obj is None:
+            self._prop_context_label.set_visible(False)
             self._cancel_capture_selected_move("")
             self._revealer.set_reveal_child(False)
             self._update_selected_move_capture_controls(None)
             return
 
         self._revealer.set_reveal_child(True)
+        self._prop_context_label.set_visible(False)
         if not isinstance(selected_obj, EditableMove) or selected_obj.mode not in {
             "abs",
             "natural",
@@ -540,6 +549,9 @@ class EventPropertiesMixin:
         ev = self._timeline._selected
         if isinstance(ev, EditableControl) and ev.mode == "compositor_dispatch":
             self._present_compositor_action_dialog(control=ev)
+            return
+        if isinstance(ev, EditableControl) and ev.mode in {"macro_sync", "macro_parallel"}:
+            self._present_macro_call_dialog(control=ev)
             return
         if isinstance(ev, EditableMove):
             self._present_mouse_move_dialog(move=ev)

--- a/keymasq/gui/widgets/macro_editor/timeline.py
+++ b/keymasq/gui/widgets/macro_editor/timeline.py
@@ -844,10 +844,10 @@ class TimelineWidget(Gtk.DrawingArea):
             wait_random_btn.connect("clicked", _insert_wait_random)
             box.append(wait_random_btn)
 
-            exec_sync_btn = Gtk.Button(label=f"Insert Exec Sync at {t_label}")
-            exec_sync_btn.add_css_class("flat")
+            exec_btn = Gtk.Button(label=f"Run Command at {t_label}")
+            exec_btn.add_css_class("flat")
 
-            def _insert_exec_sync(_b, _t=t_us, _p=popover):
+            def _insert_exec(_b, _t=t_us, _p=popover):
                 _p.popdown()
                 control = EditableControl(
                     mode="exec_sync",
@@ -858,19 +858,21 @@ class TimelineWidget(Gtk.DrawingArea):
                 )
                 self._editor._insert_control_event(control)
 
-            exec_sync_btn.connect("clicked", _insert_exec_sync)
-            box.append(exec_sync_btn)
+            exec_btn.connect("clicked", _insert_exec)
+            box.append(exec_btn)
 
-            exec_async_btn = Gtk.Button(label=f"Insert Exec Async at {t_label}")
-            exec_async_btn.add_css_class("flat")
+            macro_btn = Gtk.Button(label=f"Call Macro at {t_label}")
+            macro_btn.add_css_class("flat")
 
-            def _insert_exec_async(_b, _t=t_us, _p=popover):
+            def _insert_macro(_b, _t=t_us, _p=popover):
                 _p.popdown()
-                control = EditableControl(mode="exec_async", t_us=int(_t), command="")
-                self._editor._insert_control_event(control)
+                self._editor._present_macro_call_dialog(
+                    mode="macro_sync",
+                    default_t_us=_t,
+                )
 
-            exec_async_btn.connect("clicked", _insert_exec_async)
-            box.append(exec_async_btn)
+            macro_btn.connect("clicked", _insert_macro)
+            box.append(macro_btn)
 
             compositor_btn = Gtk.Button(label=f"Insert Compositor Action at {t_label}")
             compositor_btn.add_css_class("flat")
@@ -960,6 +962,10 @@ class TimelineWidget(Gtk.DrawingArea):
             label = (
                 "Compositor Action"
                 if ev.mode == "compositor_dispatch"
+                else f"Macro Call {ev.macro_name}"
+                if ev.mode in {"macro_sync", "macro_parallel"}
+                else "Run Command"
+                if ev.mode in {"exec_sync", "exec_parallel", "exec_async"}
                 else ev.mode.replace("_", " ").title()
             )
             del_control_btn = Gtk.Button(label=f"Delete {label}")

--- a/keymasq/gui/widgets/macro_editor/timeline_render.py
+++ b/keymasq/gui/widgets/macro_editor/timeline_render.py
@@ -704,12 +704,21 @@ def _draw_control_markers(cr, state: TimelineRenderState, width: int) -> None:
         elif control.mode == "exec_sync":
             rgba = (1.00, 0.62, 0.12, 0.95)
             label = "XS"
+        elif control.mode == "exec_parallel":
+            rgba = (0.98, 0.56, 0.13, 0.95)
+            label = "XP"
         elif control.mode == "exec_async":
             rgba = (0.95, 0.50, 0.15, 0.95)
             label = "XA"
         elif control.mode == "compositor_dispatch":
             rgba = (0.70, 0.45, 1.00, 0.95)
             label = "C"
+        elif control.mode == "macro_sync":
+            rgba = (0.30, 0.72, 1.00, 0.95)
+            label = "MW"
+        elif control.mode == "macro_parallel":
+            rgba = (0.25, 0.88, 0.75, 0.95)
+            label = "MP"
         else:
             rgba = (0.65, 0.65, 0.65, 0.95)
             label = "?"

--- a/keymasq/keymasqd/runtime/macro/cleanup.py
+++ b/keymasq/keymasqd/runtime/macro/cleanup.py
@@ -23,7 +23,7 @@ async def cancel_macro_instances(
     """Cancel selected tasks after synchronously neutralizing their outputs."""
 
     asyncio_mod = deps.asyncio_mod
-    unique_ids = list(dict.fromkeys(int(instance_id) for instance_id in instance_ids))
+    unique_ids = manager.macro_state.descendant_instance_ids(instance_ids)
     if not unique_ids:
         return 0
 

--- a/keymasq/keymasqd/runtime/macro/controls.py
+++ b/keymasq/keymasqd/runtime/macro/controls.py
@@ -92,8 +92,8 @@ async def run_macro_control_action(
             )
         return 0.0
 
-    if action_type == "exec_sync":
-        return await _run_exec_sync(
+    if action_type in {"exec_sync", "exec_parallel"}:
+        return await _run_exec_wait(
             manager,
             event,
             renew_mouse_suppression=renew_mouse_suppression,
@@ -143,7 +143,7 @@ async def _sleep_control_action(
     return max(0.0, loop.time() - started_at)
 
 
-async def _run_exec_sync(
+async def _run_exec_wait(
     manager: MacroManager,
     event: dict[str, object],
     *,
@@ -180,11 +180,13 @@ async def _run_exec_sync(
         )
 
     wait_id = uuid.uuid4().hex
+    command_started = False
     try:
         waiter = loop.create_future()
         manager.macro_state.exec_waiters[wait_id] = waiter
 
         if manager.broadcast_callback:
+            command_started = True
             await manager.broadcast_callback(
                 CommandType.ACTION_TRIGGER,
                 {
@@ -199,6 +201,17 @@ async def _run_exec_sync(
                     waiter,
                     timeout=max(0.1, timeout_ms / 1000.0),
                 )
+    except asyncio_mod.CancelledError:
+        if command_started and manager.broadcast_callback:
+            with contextlib.suppress(Exception):
+                await manager.broadcast_callback(
+                    CommandType.ACTION_TRIGGER,
+                    {
+                        "action_type": "exec",
+                        "macro_exec_cancel_id": wait_id,
+                    },
+                )
+        raise
     finally:
         manager.macro_state.exec_waiters.pop(wait_id, None)
         if inhibit_mouse:

--- a/keymasq/keymasqd/runtime/macro/exceptions.py
+++ b/keymasq/keymasqd/runtime/macro/exceptions.py
@@ -1,0 +1,9 @@
+"""Expected and unexpected failures from nested macro playback."""
+
+
+class MacroCallError(RuntimeError):
+    """A macro call cannot run because its configured target is invalid."""
+
+
+class MacroChildPlaybackError(RuntimeError):
+    """A child invocation failed unexpectedly, with its call chain attached."""

--- a/keymasq/keymasqd/runtime/macro/playback.py
+++ b/keymasq/keymasqd/runtime/macro/playback.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
+import asyncio
 from typing import Any
 
 from keymasq.common.model.actions import normalize_macro_loop_stop_behavior
 from keymasq.keymasqd.runtime.macro import cleanup, loops, scheduler
 from keymasq.keymasqd.runtime.macro.events import list_macro_event_source
+from keymasq.keymasqd.runtime.macro.exceptions import MacroCallError
 from keymasq.keymasqd.runtime.macro.options import MacroPlaybackOptions
 from keymasq.keymasqd.runtime.macro.state import MacroEventSource, MacroRuntimeDeps
 
@@ -36,6 +38,8 @@ async def play_macro(
     source_key = (str(playback_options.source_device), str(playback_options.source_button))
 
     if int(playback_options.trigger_value) == 0:
+        if source_key[0] or source_key[1]:
+            manager.macro_state.mark_source_released(source_key)
         hold_instances = loops.find_matching_macro_instances(
             manager.macro_state,
             loop_mode="hold",
@@ -59,6 +63,9 @@ async def play_macro(
             cancelled = await _stop_loop_instances(manager, toggle_instances, deps=deps)
             return {"status": "ok", "cancelled": cancelled > 0}
 
+    if normalized_loop == "hold" and not (source_key[0] or source_key[1]):
+        normalized_loop = "none"
+
     if normalized_loop == "hold" and loops.find_matching_macro_instances(
         manager.macro_state,
         loop_mode="hold",
@@ -73,24 +80,95 @@ async def play_macro(
     if event_source.event_count <= 0:
         return {"status": "ok"}
 
+    _start_macro_instance(
+        manager,
+        playback_options,
+        macro_event_source=event_source,
+        normalized_loop=normalized_loop,
+        normalized_loop_stop_behavior=normalized_loop_stop_behavior,
+        loop_count=count,
+        source_key=source_key,
+        deps=deps,
+    )
+
+    return {"status": "ok"}
+
+
+def start_child_macro(
+    manager: MacroManager,
+    playback_options: MacroPlaybackOptions,
+    *,
+    parent_instance_id: int,
+    macro_event_source: MacroEventSource,
+    deps: MacroRuntimeDeps,
+) -> asyncio.Task[None] | None:
+    """Start a structured child invocation and return its join handle."""
+
+    source_available, source_active = manager.macro_state.source_lifecycle(parent_instance_id)
+    normalized_loop = loops.normalize_loop_mode(playback_options.loop_mode)
+    if normalized_loop == "toggle":
+        normalized_loop = "none"
+    if normalized_loop == "hold":
+        if not source_available:
+            normalized_loop = "none"
+        elif not source_active:
+            return None
+
+    macro_name = str(playback_options.macro_name or "")
+    if manager.macro_state.call_chain_contains(parent_instance_id, macro_name):
+        raise MacroCallError("recursive macro call blocked")
+
+    parent_meta = manager.macro_state.instance_meta.get(parent_instance_id, {})
+    source_key = (
+        str(parent_meta.get("source_device", "")),
+        str(parent_meta.get("source_button", "")),
+    )
+    return _start_macro_instance(
+        manager,
+        playback_options,
+        macro_event_source=macro_event_source,
+        normalized_loop=normalized_loop,
+        normalized_loop_stop_behavior=normalize_macro_loop_stop_behavior(
+            playback_options.loop_stop_behavior
+        ),
+        loop_count=max(1, int(playback_options.loop_count or 1)),
+        source_key=source_key,
+        deps=deps,
+        parent_instance_id=parent_instance_id,
+    )
+
+
+def _start_macro_instance(
+    manager: MacroManager,
+    playback_options: MacroPlaybackOptions,
+    *,
+    macro_event_source: MacroEventSource,
+    normalized_loop: str,
+    normalized_loop_stop_behavior: str,
+    loop_count: int,
+    source_key: tuple[str, str],
+    deps: MacroRuntimeDeps,
+    parent_instance_id: int | None = None,
+) -> asyncio.Task[None]:
     instance_id = manager.macro_state.allocate_instance(
         loop_mode=normalized_loop,
         source_key=source_key,
         macro_name=str(playback_options.macro_name or ""),
         loop_stop_behavior=normalized_loop_stop_behavior,
+        parent_instance_id=parent_instance_id,
     )
     task = deps.asyncio_mod.create_task(
         scheduler.play_macro_task(
             manager,
             instance_id=instance_id,
             macro_events=playback_options.macro_events,
-            macro_event_source=event_source,
+            macro_event_source=macro_event_source,
             macro_name=playback_options.macro_name,
             replay_mouse_movement=playback_options.replay_mouse_movement,
             replay_mouse_clicks=playback_options.replay_mouse_clicks,
             speed=max(0.01, playback_options.speed),
             loop_mode=normalized_loop,
-            loop_count=count,
+            loop_count=loop_count,
             move_to_start=playback_options.move_to_start,
             start_x=int(playback_options.start_x),
             start_y=int(playback_options.start_y),
@@ -99,8 +177,7 @@ async def play_macro(
         )
     )
     manager.macro_state.tasks[instance_id] = task
-
-    return {"status": "ok"}
+    return task
 
 
 async def _stop_loop_instances(

--- a/keymasq/keymasqd/runtime/macro/scheduler.py
+++ b/keymasq/keymasqd/runtime/macro/scheduler.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import asyncio
+import contextlib
 import time
 from collections.abc import Awaitable, Callable
 from typing import Any, cast
@@ -14,6 +16,10 @@ from keymasq.keymasqd.runtime.macro import controls, events, mouse, outputs
 from keymasq.keymasqd.runtime.macro.cache import (
     MAX_CACHEABLE_MACRO_RUNTIME_US,
     MacroCacheCandidate,
+)
+from keymasq.keymasqd.runtime.macro.exceptions import (
+    MacroCallError,
+    MacroChildPlaybackError,
 )
 from keymasq.keymasqd.runtime.macro.loops import (
     MacroLoopStateMachine,
@@ -32,6 +38,8 @@ type RuntimeAction = Callable[..., None]
 
 _MOUSE_BUTTON_CODES = frozenset(range(0x110, 0x118))
 _SEMANTIC_MOUSE_ACTIONS = frozenset({"mouse_move_abs", "mouse_move_rel", "mouse_move_natural_abs"})
+_MACRO_CALL_ACTIONS = frozenset({"macro_sync", "macro_parallel"})
+_PARALLEL_CONTROL_ACTIONS = frozenset({"exec_parallel"})
 
 
 async def play_macro_task(
@@ -122,44 +130,51 @@ async def play_macro_task(
                 await manager.set_cursor_position(int(start_x), int(start_y))
 
             timeline = MacroPlaybackTimeline(event_loop.time(), speed_factor)
-            stop_current_run = await _play_iteration(
-                manager,
-                instance_id=instance_id,
-                macro_event_source=macro_event_source,
-                macro_name=macro_name,
-                replay_mouse_movement=replay_mouse_movement,
-                replay_mouse_clicks=replay_mouse_clicks,
-                block_mouse_movement=block_mouse_movement,
-                timeline=timeline,
-                event_loop=event_loop,
-                deps=deps,
-                control_action_fn=control_action,
-                renew_mouse_suppression_fn=renew_mouse_suppression,
-                diagnostic_initial_load_us=diagnostic_initial_load_us,
-                cached_events=cached_events,
-                verify_cached_revision=verify_cached_revision,
-                cache_candidate=cache_candidate,
-            )
-            if diagnostic_initial_load_us is not None:
-                diagnostic_initial_load_us = 0.0
-            if cached_events is not None:
-                verify_cached_revision = True
-            if stop_current_run:
-                break
-
-            if instance_id not in manager.macro_state.cancel_instance_ids:
-                remaining = timeline.nominal_end_delay(
-                    macro_duration_us,
-                    now_s=event_loop.time(),
+            parallel_tasks: set[asyncio.Task[Any]] = set()
+            try:
+                stop_current_run = await _play_iteration(
+                    manager,
+                    instance_id=instance_id,
+                    macro_event_source=macro_event_source,
+                    macro_name=macro_name,
+                    replay_mouse_movement=replay_mouse_movement,
+                    replay_mouse_clicks=replay_mouse_clicks,
+                    block_mouse_movement=block_mouse_movement,
+                    timeline=timeline,
+                    event_loop=event_loop,
+                    deps=deps,
+                    control_action_fn=control_action,
+                    renew_mouse_suppression_fn=renew_mouse_suppression,
+                    diagnostic_initial_load_us=diagnostic_initial_load_us,
+                    cached_events=cached_events,
+                    verify_cached_revision=verify_cached_revision,
+                    cache_candidate=cache_candidate,
+                    parallel_tasks=parallel_tasks,
                 )
-                if remaining >= 0.0005:
-                    if block_mouse_movement:
-                        renew_mouse_suppression(
-                            manager,
-                            timeout_s=remaining + 1.0,
-                            deps=deps,
-                        )
-                    await asyncio_mod.sleep(remaining)
+                if diagnostic_initial_load_us is not None:
+                    diagnostic_initial_load_us = 0.0
+                if cached_events is not None:
+                    verify_cached_revision = True
+                if stop_current_run:
+                    break
+
+                if instance_id not in manager.macro_state.cancel_instance_ids:
+                    remaining = timeline.nominal_end_delay(
+                        macro_duration_us,
+                        now_s=event_loop.time(),
+                    )
+                    if remaining >= 0.0005:
+                        if block_mouse_movement:
+                            renew_mouse_suppression(
+                                manager,
+                                timeout_s=remaining + 1.0,
+                                deps=deps,
+                            )
+                        await asyncio_mod.sleep(remaining)
+
+                await _join_parallel_tasks(parallel_tasks, asyncio_mod=asyncio_mod)
+            finally:
+                await _cancel_parallel_tasks(parallel_tasks, asyncio_mod=asyncio_mod)
 
             iteration_elapsed_us = (
                 max(0, time.perf_counter_ns() - iteration_started_ns) / 1000.0
@@ -192,14 +207,28 @@ async def play_macro_task(
             if not loop_state.should_continue():
                 break
     except asyncio_mod.CancelledError:
-        pass
+        raise
+    except MacroCallError as exc:
+        if _is_child_instance(manager, instance_id):
+            raise
+        deps.log.error("Macro playback aborted: %s", exc)
     except MacroFileChangedError:
+        if _is_child_instance(manager, instance_id):
+            raise MacroCallError(
+                f"{manager.macro_state.call_chain(instance_id)}: macro was modified or removed"
+            ) from None
         deps.log.debug(
             "Macro playback ended because %s was modified or removed",
             macro_name or "<unnamed>",
         )
-    except Exception:
-        deps.log.exception("Macro playback aborted")
+    except Exception as exc:
+        if _is_child_instance(manager, instance_id):
+            if isinstance(exc, MacroChildPlaybackError):
+                raise
+            raise MacroChildPlaybackError(
+                f"{manager.macro_state.call_chain(instance_id)}: {exc}"
+            ) from exc
+        deps.log.exception("Macro playback aborted: %s", exc)
     finally:
         if cache_candidate is not None:
             cache_candidate.discard()
@@ -230,6 +259,7 @@ async def _play_iteration(
     cached_events: tuple[dict[str, object], ...] | None,
     verify_cached_revision: bool,
     cache_candidate: MacroCacheCandidate | None,
+    parallel_tasks: set[asyncio.Task[Any]],
 ) -> bool:
     """Replay one source iteration; return true when a semantic move aborts it."""
 
@@ -242,6 +272,7 @@ async def _play_iteration(
         cached_events=cached_events,
         verify_cached_revision=verify_cached_revision,
     ):
+        _raise_finished_parallel_errors(parallel_tasks)
         if instance_id in manager.macro_state.cancel_instance_ids:
             break
         if cache_candidate is not None:
@@ -254,8 +285,46 @@ async def _play_iteration(
         remaining = timeline.event_delay(timestamp_us, now_s=event_loop.time())
         if remaining >= 0.0005:
             await asyncio_mod.sleep(remaining)
+            _raise_finished_parallel_errors(parallel_tasks)
 
         action_type = str(event.get("macro_action", "") or "")
+        if action_type in _MACRO_CALL_ACTIONS:
+            await asyncio_mod.sleep(0)
+            child_name = deps.str_value_fn(event.get("macro_name"), "").strip()
+            try:
+                child_task = await manager.start_macro_child(
+                    instance_id,
+                    event,
+                    deps=deps,
+                )
+            except MacroCallError as exc:
+                chain = manager.macro_state.call_chain(instance_id, child_name or "<missing>")
+                raise MacroCallError(f"{chain}: {exc}") from None
+            except Exception as exc:
+                chain = manager.macro_state.call_chain(instance_id, child_name or "<missing>")
+                raise MacroChildPlaybackError(f"{chain}: {exc}") from exc
+            if child_task is None:
+                continue
+            if action_type == "macro_sync":
+                started_at = event_loop.time()
+                await _await_child(child_task, asyncio_mod=asyncio_mod)
+                timeline.extend_for_blocking_action(event_loop.time() - started_at)
+            else:
+                parallel_tasks.add(child_task)
+            continue
+        if action_type in _PARALLEL_CONTROL_ACTIONS:
+            task = asyncio_mod.create_task(
+                control_action_fn(
+                    manager,
+                    event,
+                    renew_mouse_suppression=block_mouse_movement,
+                    deps=deps,
+                )
+            )
+            parallel_tasks.add(task)
+            await asyncio_mod.sleep(0)
+            _raise_finished_parallel_errors(parallel_tasks)
+            continue
         if action_type in _SEMANTIC_MOUSE_ACTIONS:
             should_stop = await _run_semantic_mouse_action(
                 manager,
@@ -313,6 +382,63 @@ async def _play_iteration(
             deps=deps,
         )
     return False
+
+
+def _is_child_instance(manager: MacroManager, instance_id: int) -> bool:
+    meta = manager.macro_state.instance_meta.get(instance_id, {})
+    return meta.get("parent_instance_id") is not None
+
+
+def _raise_finished_parallel_errors(tasks: set[asyncio.Task[Any]]) -> None:
+    for task in tuple(tasks):
+        if not task.done():
+            continue
+        tasks.discard(task)
+        if task.cancelled():
+            continue
+        error = task.exception()
+        if error is not None:
+            raise error
+
+
+async def _await_child(child: asyncio.Task[None], *, asyncio_mod: Any) -> None:
+    try:
+        await child
+    except asyncio_mod.CancelledError:
+        current = asyncio_mod.current_task()
+        if current is not None and current.cancelling():
+            raise
+
+
+async def _join_parallel_tasks(
+    tasks: set[asyncio.Task[Any]],
+    *,
+    asyncio_mod: Any,
+) -> None:
+    if not tasks:
+        return
+    results = await asyncio_mod.gather(*tuple(tasks), return_exceptions=True)
+    tasks.clear()
+    for result in results:
+        if isinstance(result, asyncio_mod.CancelledError):
+            continue
+        if isinstance(result, BaseException):
+            raise result
+
+
+async def _cancel_parallel_tasks(
+    tasks: set[asyncio.Task[Any]],
+    *,
+    asyncio_mod: Any,
+) -> None:
+    all_tasks = tuple(tasks)
+    pending = [task for task in all_tasks if not task.done()]
+    tasks.clear()
+    for task in pending:
+        task.cancel()
+    if all_tasks:
+        with contextlib.suppress(Exception):
+            await asyncio_mod.gather(*all_tasks, return_exceptions=True)
 
 
 async def _run_semantic_mouse_action(

--- a/keymasq/keymasqd/runtime/macro/state.py
+++ b/keymasq/keymasqd/runtime/macro/state.py
@@ -50,6 +50,7 @@ class MacroRuntimeState:
     mouse_rel_suppressed: bool = False
     mouse_rel_suppression_watchdog_task: asyncio.Task[None] | None = None
     replay_cache: MacroReplayCache = field(default_factory=MacroReplayCache)
+    instance_children: dict[int, set[int]] = field(default_factory=dict)
 
     def allocate_instance(
         self,
@@ -58,6 +59,7 @@ class MacroRuntimeState:
         source_key: tuple[str, str],
         macro_name: str,
         loop_stop_behavior: str,
+        parent_instance_id: int | None = None,
     ) -> int:
         """Allocate and initialize one playback instance before its task starts."""
 
@@ -65,7 +67,13 @@ class MacroRuntimeState:
         instance_id = self.instance_seq
         self.instance_held[instance_id] = set()
         self.instance_held_abs[instance_id] = set()
+        self.instance_children[instance_id] = set()
         self.cancel_instance_ids.discard(instance_id)
+        parent_meta = self.instance_meta.get(parent_instance_id or -1, {})
+        raw_root_instance_id = parent_meta.get("root_instance_id")
+        root_instance_id = (
+            raw_root_instance_id if isinstance(raw_root_instance_id, int) else instance_id
+        )
         self.instance_meta[instance_id] = {
             "loop_mode": loop_mode,
             "source_device": source_key[0],
@@ -73,15 +81,94 @@ class MacroRuntimeState:
             "macro_name": macro_name,
             "loop_active": loop_mode in {"hold", "toggle"},
             "loop_stop_behavior": loop_stop_behavior,
+            "parent_instance_id": parent_instance_id,
+            "root_instance_id": root_instance_id,
         }
+        if parent_instance_id is None:
+            self.instance_meta[instance_id]["source_lifecycle_available"] = bool(
+                source_key[0] or source_key[1]
+            )
+            self.instance_meta[instance_id]["source_lifecycle_active"] = True
+        else:
+            self.instance_children.setdefault(parent_instance_id, set()).add(instance_id)
         return instance_id
+
+    def mark_source_released(self, source_key: tuple[str, str]) -> None:
+        """End the trigger lifecycle for every active root from one source."""
+
+        for meta in self.instance_meta.values():
+            if meta.get("parent_instance_id") is not None:
+                continue
+            if (
+                meta.get("source_device") == source_key[0]
+                and meta.get("source_button") == source_key[1]
+            ):
+                meta["source_lifecycle_active"] = False
+
+    def source_lifecycle(self, instance_id: int) -> tuple[bool, bool]:
+        """Return whether a root has a trigger source and whether it remains held."""
+
+        meta = self.instance_meta.get(instance_id, {})
+        raw_root_id = meta.get("root_instance_id")
+        root_id = raw_root_id if isinstance(raw_root_id, int) else instance_id
+        root_meta = self.instance_meta.get(root_id, {})
+        return (
+            bool(root_meta.get("source_lifecycle_available", False)),
+            bool(root_meta.get("source_lifecycle_active", False)),
+        )
+
+    def descendant_instance_ids(self, instance_ids: list[int]) -> list[int]:
+        """Expand instance IDs to their complete, currently-known subtrees."""
+
+        expanded: list[int] = []
+        pending = list(dict.fromkeys(int(value) for value in instance_ids))
+        seen: set[int] = set()
+        while pending:
+            instance_id = pending.pop()
+            if instance_id in seen:
+                continue
+            seen.add(instance_id)
+            expanded.append(instance_id)
+            pending.extend(self.instance_children.get(instance_id, ()))
+        return expanded
+
+    def call_chain(self, instance_id: int, child_name: str | None = None) -> str:
+        """Format the active parent chain for diagnostics."""
+
+        names: list[str] = []
+        current: int | None = instance_id
+        while current is not None:
+            meta = self.instance_meta.get(current, {})
+            names.append(str(meta.get("macro_name") or "<unnamed>"))
+            raw_parent = meta.get("parent_instance_id")
+            current = int(raw_parent) if isinstance(raw_parent, int) else None
+        names.reverse()
+        if child_name:
+            names.append(child_name)
+        return " -> ".join(names)
+
+    def call_chain_contains(self, instance_id: int, macro_name: str) -> bool:
+        """Return whether a macro name already appears among active ancestors."""
+
+        current: int | None = instance_id
+        while current is not None:
+            meta = self.instance_meta.get(current, {})
+            if str(meta.get("macro_name") or "") == macro_name:
+                return True
+            raw_parent = meta.get("parent_instance_id")
+            current = raw_parent if isinstance(raw_parent, int) else None
+        return False
 
     def forget_instance(self, instance_id: int) -> None:
         """Remove scheduler metadata after cleanup has released held outputs."""
 
         self.cancel_instance_ids.discard(instance_id)
         self.tasks.pop(instance_id, None)
-        self.instance_meta.pop(instance_id, None)
+        meta = self.instance_meta.pop(instance_id, None) or {}
+        raw_parent = meta.get("parent_instance_id")
+        if isinstance(raw_parent, int):
+            self.instance_children.get(raw_parent, set()).discard(instance_id)
+        self.instance_children.pop(instance_id, None)
 
 
 @dataclass(frozen=True)

--- a/keymasq/keymasqd/runtime/manager_macros.py
+++ b/keymasq/keymasqd/runtime/manager_macros.py
@@ -7,10 +7,12 @@ from collections.abc import Callable, Iterator
 from functools import partial
 from typing import Any, cast
 
-from keymasq.common.coercion import coerce_int
+from keymasq.common.coercion import coerce_bool, coerce_float, coerce_int, coerce_str
 from keymasq.common.ipc import CommandType
+from keymasq.common.model.actions import DEFAULT_MACRO_LOOP_STOP_BEHAVIOR
 from keymasq.common.types import JsonObject
 from keymasq.keymasqd.runtime.macro import cleanup, controls, playback
+from keymasq.keymasqd.runtime.macro.exceptions import MacroCallError
 from keymasq.keymasqd.runtime.macro.options import (
     MacroPlaybackOptions,
     macro_playback_options_from_mapping,
@@ -130,6 +132,59 @@ class MacroManagerMixin:
                 snapshot_revision.verify_unchanged if snapshot_revision is not None else None
             ),
             begin_cache_candidate=begin_cache_candidate,
+        )
+
+    async def start_macro_child(
+        self,
+        parent_instance_id: int,
+        event: dict[str, object],
+        *,
+        deps: MacroRuntimeDeps,
+    ) -> asyncio.Task[None] | None:
+        """Resolve and start one dynamic child-macro timeline event."""
+
+        macro_name = coerce_str(event.get("macro_name", "")).strip()
+        if not macro_name:
+            raise MacroCallError("macro call event has no macro name")
+        store = self.macro_store
+        if store is None:
+            raise MacroCallError("macro storage is unavailable")
+
+        try:
+            meta = cast(JsonObject, await asyncio.to_thread(store.get_meta, macro_name))
+            event_source = await self._stored_macro_event_source(macro_name, deps=deps)
+        except FileNotFoundError as exc:
+            raise MacroCallError(f"Macro '{macro_name}' not found") from exc
+        if event_source is None:
+            raise MacroCallError(f"Macro '{macro_name}' not found")
+        if event_source.event_count <= 0:
+            return None
+
+        options = MacroPlaybackOptions(
+            macro_name=macro_name,
+            replay_mouse_movement=coerce_bool(event.get("replay_mouse_movement"), True),
+            replay_mouse_clicks=coerce_bool(event.get("replay_mouse_clicks"), True),
+            speed=max(0.01, coerce_float(event.get("speed"), 1.0)),
+            loop_mode=coerce_str(event.get("loop_mode"), "none") or "none",
+            loop_count=max(1, coerce_int(event.get("loop_count"), 1)),
+            loop_stop_behavior=(
+                coerce_str(
+                    event.get("loop_stop_behavior"),
+                    DEFAULT_MACRO_LOOP_STOP_BEHAVIOR,
+                )
+                or DEFAULT_MACRO_LOOP_STOP_BEHAVIOR
+            ),
+            move_to_start=coerce_bool(meta.get("move_to_start"), False),
+            start_x=coerce_int(meta.get("start_x"), 0),
+            start_y=coerce_int(meta.get("start_y"), 0),
+            block_mouse_movement=coerce_bool(meta.get("block_mouse_movement"), False),
+        )
+        return playback.start_child_macro(
+            self,
+            options,
+            parent_instance_id=parent_instance_id,
+            macro_event_source=event_source,
+            deps=deps,
         )
 
     async def cancel_macro_playback(self) -> JsonObject:

--- a/keymasq/session/action_handler.py
+++ b/keymasq/session/action_handler.py
@@ -30,6 +30,7 @@ async def _kill_and_drain_process(process: asyncio.subprocess.Process) -> None:
 class ActionHandler:
     def __init__(self) -> None:
         self._background_tasks: set[asyncio.Task[int]] = set()
+        self._tracked_command_tasks: dict[str, asyncio.Task[object]] = {}
 
     async def handle_action(self, data: JsonObject) -> None:
         action_type = data.get("action_type")
@@ -90,6 +91,25 @@ class ActionHandler:
         )
         self._background_tasks.add(task)
         task.add_done_callback(self._handle_background_task_done)
+
+    def track_command(self, command_id: str) -> None:
+        """Associate the current session event task with a macro command."""
+
+        task = asyncio.current_task()
+        if task is not None:
+            self._tracked_command_tasks[command_id] = task
+
+    def untrack_command(self, command_id: str) -> None:
+        task = asyncio.current_task()
+        if self._tracked_command_tasks.get(command_id) is task:
+            self._tracked_command_tasks.pop(command_id, None)
+
+    def cancel_tracked_command(self, command_id: str) -> bool:
+        task = self._tracked_command_tasks.get(command_id)
+        if task is None or task.done():
+            return False
+        task.cancel()
+        return True
 
     def _handle_background_task_done(self, task: asyncio.Task[int]) -> None:
         self._background_tasks.discard(task)

--- a/keymasq/session/manager/events.py
+++ b/keymasq/session/manager/events.py
@@ -696,6 +696,13 @@ async def handle_profile_deactivate_requested(
 
 
 async def handle_exec_trigger(manager: "SessionManager", data: JsonObject) -> None:
+    cancel_id = str(data.get("macro_exec_cancel_id", "") or "").strip()
+    action_handler = manager.action_handler
+    if cancel_id:
+        if action_handler is not None:
+            action_handler.cancel_tracked_command(cancel_id)
+        return
+
     cmd = str(data.get("cmd", "") or "").strip()
     if not cmd:
         return
@@ -703,7 +710,6 @@ async def handle_exec_trigger(manager: "SessionManager", data: JsonObject) -> No
     wait_id = str(data.get("macro_exec_wait_id", "") or "").strip()
     is_async = bool(data.get("macro_exec_async", False))
 
-    action_handler = manager.action_handler
     if action_handler is None:
         return
 
@@ -714,21 +720,25 @@ async def handle_exec_trigger(manager: "SessionManager", data: JsonObject) -> No
             coerce_int(data.get("macro_exec_timeout_ms"), policy_timeout_ms),
         )
         timeout_ms = min(timeout_ms, policy_timeout_ms)
-        returncode = await action_handler.execute_command(
-            cmd,
-            timeout_s=timeout_ms / 1000.0,
-        )
+        action_handler.track_command(wait_id)
         try:
-            await manager.client.send_command(
-                Command(
-                    command=CommandType.MACRO_EXEC_COMPLETE,
-                    data={"wait_id": wait_id, "returncode": int(returncode)},
-                )
+            returncode = await action_handler.execute_command(
+                cmd,
+                timeout_s=timeout_ms / 1000.0,
             )
-        except OSError:
-            log.debug("Failed to report macro exec completion", exc_info=True)
-        except Exception:
-            log.exception("Unexpected failure reporting macro exec completion")
+            try:
+                await manager.client.send_command(
+                    Command(
+                        command=CommandType.MACRO_EXEC_COMPLETE,
+                        data={"wait_id": wait_id, "returncode": int(returncode)},
+                    )
+                )
+            except OSError:
+                log.debug("Failed to report macro exec completion", exc_info=True)
+            except Exception:
+                log.exception("Unexpected failure reporting macro exec completion")
+        finally:
+            action_handler.untrack_command(wait_id)
         return
 
     if is_async:

--- a/tests/gui/test_macro_editor_dialog_widget.py
+++ b/tests/gui/test_macro_editor_dialog_widget.py
@@ -158,7 +158,9 @@ def test_macro_editor_initial_state_load_applies_macro_fields(monkeypatch) -> No
     assert len(dialog._control_events) == 1
     assert dialog._duration_us == 25000
     assert dialog._stats_label.get_label() == "0.025s · 4 events"
-    assert dialog._exec_summary_label.get_label() == "Exec actions: 1 (sync 1, async 0)"
+    assert dialog._exec_summary_label.get_label() == (
+        "Exec actions: 1 (wait 1, parallel 0, detached 0)"
+    )
     assert dialog._control_timeout_spin.get_adjustment().get_upper() == 45000
     assert dialog._name_entry.get_text() == "demo_macro"
     assert (
@@ -551,6 +553,26 @@ def test_macro_editor_compositor_control_selection_shows_action(monkeypatch) -> 
     assert dialog._control_sync_row.get_visible() is False
 
 
+def test_macro_call_selection_shows_called_macro_in_heading(monkeypatch) -> None:
+    dialog = _build_macro_dialog(monkeypatch)
+    control = EditableControl(
+        mode="macro_parallel",
+        t_us=12_000,
+        macro_name="a2",
+        macro_loop_mode="count",
+        macro_loop_count=6,
+    )
+    dialog._timeline._selected = control
+
+    dialog._on_selection_changed(control)
+
+    assert dialog._prop_title.get_label() == "Macro Call:"
+    assert dialog._prop_context_label.get_label() == "a2"
+    assert dialog._prop_context_label.get_visible() is True
+    assert dialog._control_mode_label.get_visible() is False
+    assert dialog._key_info_label.get_label() == "Run in parallel, 6 times"
+
+
 def test_macro_editor_abs_move_capture_updates_selected_move(monkeypatch) -> None:
     dialog = _build_macro_dialog(monkeypatch, slurp_available=True)
     move = EditableMove(mode="abs", t_us=5000, x=10, y=20)
@@ -675,7 +697,11 @@ def test_set_entry_text_if_needed_skips_redundant_updates() -> None:
 def test_macro_editor_exec_command_edit_does_not_refresh_control_panel(monkeypatch) -> None:
     dialog = _build_macro_dialog(monkeypatch)
 
-    for mode, command_text in (("exec_sync", "echo hi"), ("exec_async", "printf 'x'")):
+    for mode, command_text in (
+        ("exec_sync", "echo hi"),
+        ("exec_parallel", "sleep 1"),
+        ("exec_async", "printf 'x'"),
+    ):
         control = EditableControl(mode=mode, t_us=5000, command="")
         dialog._control_events = [control]
         dialog._timeline._selected = control
@@ -693,6 +719,45 @@ def test_macro_editor_exec_command_edit_does_not_refresh_control_panel(monkeypat
 
         assert control.command == command_text
         assert dialog._control_cmd_entry.get_text() == command_text
+
+
+def test_macro_editor_exec_mode_switch_updates_event_and_sync_options(monkeypatch) -> None:
+    dialog = _build_macro_dialog(monkeypatch)
+    control = EditableControl(
+        mode="exec_sync",
+        t_us=5000,
+        command="sleep 1",
+        timeout_ms=1200,
+        inhibit_mouse=True,
+    )
+    dialog._control_events = [control]
+    dialog._timeline._selected = control
+    dialog._on_selection_changed(control)
+
+    assert dialog._control_exec_mode_row.get_visible() is True
+    assert dialog._control_exec_mode_dropdown.get_selected() == 0
+    assert dialog._control_sync_row.get_visible() is True
+
+    dialog._control_exec_mode_dropdown.set_selected(1)
+
+    assert control.mode == "exec_parallel"
+    assert dialog._control_exec_mode_dropdown.get_selected() == 1
+    assert dialog._control_sync_row.get_visible() is True
+    assert dialog._control_timeout_hint_label.get_visible() is True
+
+    dialog._control_exec_mode_dropdown.set_selected(2)
+
+    assert control.mode == "exec_async"
+    assert dialog._control_exec_mode_dropdown.get_selected() == 2
+    assert dialog._control_sync_row.get_visible() is False
+    assert dialog._control_timeout_hint_label.get_visible() is False
+
+    dialog._control_exec_mode_dropdown.set_selected(0)
+
+    assert control.mode == "exec_sync"
+    assert control.timeout_ms == 1200
+    assert control.inhibit_mouse is True
+    assert dialog._control_sync_row.get_visible() is True
 
 
 def test_macro_editor_loop_and_capture_start_position_controls(monkeypatch) -> None:
@@ -2281,6 +2346,32 @@ def test_macro_editor_erase_mode_right_press_defers_context_menu(monkeypatch) ->
     dialog._erase_btn.set_active(False)
     timeline._on_right_drag_begin(None, 40.0, timeline._kb_y + 5.0)
     assert timeline._erase_track is None
+
+
+def test_macro_editor_context_menu_has_one_command_and_macro_call_action(monkeypatch) -> None:
+    dialog = _build_macro_dialog(monkeypatch)
+    timeline = dialog._timeline
+    popovers: list[Gtk.Popover] = []
+    monkeypatch.setattr(Gtk.Popover, "popup", lambda popover: popovers.append(popover))
+
+    timeline._on_right_click(None, 1, 50.0, timeline._kb_y + 5.0)
+
+    assert len(popovers) == 1
+    buttons = collect_widgets(popovers[0].get_child(), Gtk.Button)
+    labels = [button.get_label() or "" for button in buttons]
+    command_labels = [label for label in labels if label.startswith("Run Command at ")]
+    macro_labels = [label for label in labels if label.startswith("Call Macro at ")]
+    assert len(command_labels) == 1
+    assert len(macro_labels) == 1
+    assert not any("Exec Sync" in label or "Exec Async" in label for label in labels)
+    assert not any("Macro and Wait" in label or "Macro in Parallel" in label for label in labels)
+
+    command_button = next(button for button in buttons if button.get_label() in command_labels)
+    command_button.emit("clicked")
+
+    assert len(dialog._control_events) == 1
+    assert dialog._control_events[0].mode == "exec_sync"
+    assert dialog._control_exec_mode_row.get_visible() is True
 
 
 def test_macro_editor_erase_mode_click_still_selects_and_never_moves(monkeypatch) -> None:

--- a/tests/gui/test_macro_editor_panel_state.py
+++ b/tests/gui/test_macro_editor_panel_state.py
@@ -73,15 +73,38 @@ def test_control_editor_state_resolves_command_policy() -> None:
         ),
         30_000,
     )
+    parallel_command = control_editor_state(
+        EditableControl(
+            mode="exec_parallel",
+            t_us=0,
+            command="sleep 2",
+            timeout_ms=15_000,
+            inhibit_mouse=True,
+        ),
+        30_000,
+    )
 
     assert async_command.show_command is True
     assert async_command.command == "notify-send done"
+    assert async_command.title == "Run Command"
+    assert async_command.detail == "Run detached"
+    assert async_command.show_exec_mode is True
+    assert async_command.exec_mode == "exec_async"
     assert async_command.show_sync is False
     assert sync_command.show_command is True
+    assert sync_command.title == "Run Command"
+    assert sync_command.detail == "Wait for completion"
+    assert sync_command.show_exec_mode is True
+    assert sync_command.exec_mode == "exec_sync"
     assert sync_command.show_sync is True
     assert sync_command.timeout_ms == 45_000
     assert sync_command.inhibit_mouse is True
     assert sync_command.timeout_hint == "Runtime clamp: 45000ms -> 30000ms"
+    assert parallel_command.detail == "Run in parallel"
+    assert parallel_command.exec_mode == "exec_parallel"
+    assert parallel_command.show_sync is True
+    assert parallel_command.timeout_ms == 15_000
+    assert parallel_command.inhibit_mouse is True
     assert timeout_policy_hint(1_000, 30_000) == "Policy max timeout: 30000ms"
 
 
@@ -101,3 +124,30 @@ def test_control_editor_state_resolves_compositor_action() -> None:
     assert state.show_change is True
     assert state.change_label == "Change Action..."
     assert "workspace" in state.detail
+
+
+def test_control_editor_state_resolves_macro_call() -> None:
+    state = control_editor_state(
+        EditableControl(
+            mode="macro_parallel",
+            t_us=0,
+            macro_name="child",
+            macro_speed=1.5,
+            macro_loop_mode="hold",
+            macro_loop_stop_behavior="cancel_run",
+            macro_replay_mouse_movement=False,
+        ),
+        30_000,
+    )
+
+    assert state.title == "Macro Call"
+    assert state.title_context == "child"
+    assert state.detail == "Run in parallel, while held"
+    assert state.show_change is True
+    assert state.change_label == "Change Macro..."
+    assert state.show_macro is True
+    assert state.macro_wait is False
+    assert state.macro_loop_mode == "hold"
+    assert state.macro_loop_stop_behavior == "cancel_run"
+    assert state.macro_speed == 1.5
+    assert state.macro_replay_mouse_movement is False

--- a/tests/gui/test_macro_editor_parser.py
+++ b/tests/gui/test_macro_editor_parser.py
@@ -344,6 +344,64 @@ def test_parse_reconstruct_compositor_macro_action() -> None:
     assert rebuilt == raw
 
 
+def test_parse_reconstruct_macro_call_actions() -> None:
+    raw = [
+        {
+            "device_type": "macro",
+            "type": 0,
+            "code": 0,
+            "value": 0,
+            "t_us": 12_000,
+            "macro_action": "macro_parallel",
+            "macro_name": "child",
+            "replay_mouse_movement": False,
+            "replay_mouse_clicks": True,
+            "speed": 1.5,
+            "loop_mode": "count",
+            "loop_count": 3,
+            "loop_stop_behavior": "cancel_run",
+        }
+    ]
+
+    editable, rel_events, passthrough, moves, controls = parse_events(raw)
+    rebuilt = reconstruct_events(editable, rel_events, passthrough, moves, controls)
+
+    assert len(controls) == 1
+    control = controls[0]
+    assert control.mode == "macro_parallel"
+    assert control.macro_name == "child"
+    assert control.macro_replay_mouse_movement is False
+    assert control.macro_speed == 1.5
+    assert control.macro_loop_mode == "count"
+    assert control.macro_loop_count == 3
+    assert rebuilt == raw
+
+
+def test_parse_reconstruct_parallel_exec_action() -> None:
+    raw = [
+        {
+            "device_type": "macro",
+            "type": 0,
+            "code": 0,
+            "value": 0,
+            "t_us": 12_000,
+            "macro_action": "exec_parallel",
+            "command": "sleep 1",
+            "timeout_ms": 2500,
+            "inhibit_mouse": True,
+        }
+    ]
+
+    editable, rel_events, passthrough, moves, controls = parse_events(raw)
+    rebuilt = reconstruct_events(editable, rel_events, passthrough, moves, controls)
+
+    assert len(controls) == 1
+    assert controls[0].mode == "exec_parallel"
+    assert controls[0].timeout_ms == 2500
+    assert controls[0].inhibit_mouse is True
+    assert rebuilt == raw
+
+
 def test_unmatched_key_press_is_classified_for_keyboard_track() -> None:
     raw = [
         {

--- a/tests/keymasqd/test_device_manager_core.py
+++ b/tests/keymasqd/test_device_manager_core.py
@@ -3532,8 +3532,13 @@ class TestMacroControlActions:
         }
         assert result == 0.0
 
+    @pytest.mark.parametrize("action_type", ["exec_sync", "exec_parallel"])
     @pytest.mark.asyncio
-    async def test_run_macro_control_action_exec_sync_wait_id_and_cleanup(self, monkeypatch):
+    async def test_run_macro_control_action_exec_wait_id_timeout_and_cleanup(
+        self,
+        monkeypatch,
+        action_type,
+    ):
         manager = DeviceManager()
         clock = {"now": 30.0}
         callback = AsyncMock()
@@ -3569,7 +3574,7 @@ class TestMacroControlActions:
         result = await controls.run_macro_control_action(
             manager,
             {
-                "macro_action": "exec_sync",
+                "macro_action": action_type,
                 "command": "echo hi",
                 "inhibit_mouse": True,
                 "timeout_ms": 100,
@@ -3588,6 +3593,44 @@ class TestMacroControlActions:
         assert called_data["macro_exec_timeout_ms"] == 100
         assert called_data["macro_exec_wait_id"]
         assert result == pytest.approx(0.025)
+
+    @pytest.mark.asyncio
+    async def test_run_macro_control_action_cancellation_requests_process_cancel(self):
+        manager = DeviceManager()
+        started = asyncio.Event()
+        broadcasts: list[tuple[CommandType, dict[str, object]]] = []
+
+        async def cb(command: CommandType, data: dict[str, object]) -> None:
+            broadcasts.append((command, data))
+            if data.get("macro_exec_wait_id"):
+                started.set()
+
+        manager.broadcast_callback = cb
+        task = asyncio.create_task(
+            controls.run_macro_control_action(
+                manager,
+                {
+                    "macro_action": "exec_parallel",
+                    "command": "sleep 30",
+                    "timeout_ms": 30_000,
+                },
+                deps=device_manager._macro_runtime_deps(),
+            )
+        )
+
+        await asyncio.wait_for(started.wait(), timeout=1.0)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        assert len(broadcasts) == 2
+        start_data = broadcasts[0][1]
+        cancel_data = broadcasts[1][1]
+        assert cancel_data == {
+            "action_type": "exec",
+            "macro_exec_cancel_id": start_data["macro_exec_wait_id"],
+        }
+        assert manager.macro_state.exec_waiters == {}
 
 
 class TestReleaseScheduling:

--- a/tests/keymasqd/test_macro_backend_recording.py
+++ b/tests/keymasqd/test_macro_backend_recording.py
@@ -2102,3 +2102,58 @@ async def test_play_macro_wait_control_actions_shift_later_deadlines(
     )
 
     assert sleep_calls == [pytest.approx(0.3), 0]
+
+
+@pytest.mark.asyncio
+async def test_play_macro_parallel_exec_continues_timeline_and_joins_at_end() -> None:
+    manager = DeviceManager()
+    manager.output_state.keyboard_uinput = MagicMock()
+    command_started = asyncio.Event()
+    finish_command = asyncio.Event()
+
+    async def run_control_action(*_args: object, **_kwargs: object) -> float:
+        command_started.set()
+        await finish_command.wait()
+        return 0.0
+
+    task = asyncio.create_task(
+        scheduler.play_macro_task(
+            manager,
+            instance_id=1,
+            macro_events=[
+                {"t_us": 0, "macro_action": "exec_parallel", "command": "sleep 1"},
+                {
+                    "t_us": 0,
+                    "type": evdev.ecodes.EV_KEY,
+                    "code": evdev.ecodes.KEY_A,
+                    "value": 1,
+                    "device_type": "keyboard",
+                },
+            ],
+            macro_name="parallel_exec",
+            replay_mouse_movement=True,
+            replay_mouse_clicks=True,
+            speed=1.0,
+            loop_mode="none",
+            loop_count=1,
+            move_to_start=False,
+            start_x=0,
+            start_y=0,
+            block_mouse_movement=False,
+            deps=device_manager._macro_runtime_deps(),
+            control_action_fn=run_control_action,
+        )
+    )
+
+    await asyncio.wait_for(command_started.wait(), timeout=1.0)
+    await asyncio.sleep(0)
+
+    manager.output_state.keyboard_uinput.write.assert_called_once_with(
+        evdev.ecodes.EV_KEY,
+        evdev.ecodes.KEY_A,
+        1,
+    )
+    assert task.done() is False
+
+    finish_command.set()
+    await asyncio.wait_for(task, timeout=1.0)

--- a/tests/keymasqd/test_macro_backend_recording.py
+++ b/tests/keymasqd/test_macro_backend_recording.py
@@ -2146,7 +2146,12 @@ async def test_play_macro_parallel_exec_continues_timeline_and_joins_at_end() ->
     )
 
     await asyncio.wait_for(command_started.wait(), timeout=1.0)
-    await asyncio.sleep(0)
+
+    async def _wait_for_key_write() -> None:
+        while not manager.output_state.keyboard_uinput.write.called:
+            await asyncio.sleep(0)
+
+    await asyncio.wait_for(_wait_for_key_write(), timeout=1.0)
 
     manager.output_state.keyboard_uinput.write.assert_called_once_with(
         evdev.ecodes.EV_KEY,

--- a/tests/keymasqd/test_macro_meta_macros.py
+++ b/tests/keymasqd/test_macro_meta_macros.py
@@ -1,0 +1,405 @@
+import asyncio
+import logging
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import evdev
+import pytest
+
+from keymasq.keymasqd.device_manager import DeviceManager
+from keymasq.keymasqd.macro_store import MacroStore
+from keymasq.keymasqd.runtime.macro import loops
+
+
+def _key_event(code: int, value: int, t_us: int) -> dict[str, object]:
+    return {
+        "t_us": t_us,
+        "device_type": "keyboard",
+        "type": evdev.ecodes.EV_KEY,
+        "code": code,
+        "value": value,
+    }
+
+
+async def _wait_for_no_running_macros(manager: DeviceManager) -> None:
+    while loops.running_macro_instance_ids(manager.macro_state):
+        await asyncio.sleep(0.005)
+
+
+def _manager_with_store(tmp_path: Path) -> tuple[DeviceManager, MacroStore]:
+    manager = DeviceManager()
+    manager.output_state.keyboard_uinput = MagicMock()
+    store = MacroStore(tmp_path / "macros")
+    manager.macro_store = store
+    return manager, store
+
+
+@pytest.mark.asyncio
+async def test_sync_child_blocks_later_parent_events(tmp_path: Path) -> None:
+    manager, store = _manager_with_store(tmp_path)
+    store.create(
+        {
+            "name": "child",
+            "events": [
+                _key_event(evdev.ecodes.KEY_B, 1, 0),
+                _key_event(evdev.ecodes.KEY_B, 0, 20_000),
+            ],
+        }
+    )
+
+    await manager.play_macro(
+        macro_name="parent",
+        load_stored_macro=False,
+        macro_events=[
+            {"t_us": 0, "macro_action": "macro_sync", "macro_name": "child"},
+            _key_event(evdev.ecodes.KEY_A, 1, 0),
+        ],
+    )
+    await _wait_for_no_running_macros(manager)
+
+    writes = [call.args for call in manager.output_state.keyboard_uinput.write.call_args_list]
+    assert writes.index((evdev.ecodes.EV_KEY, evdev.ecodes.KEY_B, 0)) < writes.index(
+        (evdev.ecodes.EV_KEY, evdev.ecodes.KEY_A, 1)
+    )
+
+
+@pytest.mark.asyncio
+async def test_parallel_children_join_each_parent_count_iteration(tmp_path: Path) -> None:
+    manager, store = _manager_with_store(tmp_path)
+    store.create(
+        {
+            "name": "child",
+            "events": [
+                _key_event(evdev.ecodes.KEY_B, 1, 0),
+                _key_event(evdev.ecodes.KEY_B, 0, 20_000),
+            ],
+        }
+    )
+
+    await manager.play_macro(
+        macro_name="parent",
+        load_stored_macro=False,
+        loop_mode="count",
+        loop_count=2,
+        macro_events=[
+            {"t_us": 0, "macro_action": "macro_parallel", "macro_name": "child"},
+            _key_event(evdev.ecodes.KEY_A, 1, 1_000),
+        ],
+    )
+    await _wait_for_no_running_macros(manager)
+
+    writes = [call.args for call in manager.output_state.keyboard_uinput.write.call_args_list]
+    a_presses = [
+        index
+        for index, event in enumerate(writes)
+        if event == (evdev.ecodes.EV_KEY, evdev.ecodes.KEY_A, 1)
+    ]
+    b_releases = [
+        index
+        for index, event in enumerate(writes)
+        if event == (evdev.ecodes.EV_KEY, evdev.ecodes.KEY_B, 0)
+    ]
+    assert len(a_presses) == 2
+    assert len(b_releases) == 2
+    assert b_releases[0] < a_presses[1]
+
+
+@pytest.mark.asyncio
+async def test_hold_child_is_skipped_if_source_released_before_call(tmp_path: Path) -> None:
+    manager, store = _manager_with_store(tmp_path)
+    store.create(
+        {
+            "name": "held child",
+            "events": [_key_event(evdev.ecodes.KEY_C, 1, 0)],
+        }
+    )
+
+    await manager.play_macro(
+        macro_name="parent",
+        load_stored_macro=False,
+        source_device="kbd",
+        source_button="key_f13",
+        macro_events=[
+            {"t_us": 0, "macro_action": "wait", "duration_us": 30_000},
+            {
+                "t_us": 0,
+                "macro_action": "macro_sync",
+                "macro_name": "held child",
+                "loop_mode": "hold",
+            },
+        ],
+    )
+    await asyncio.sleep(0.005)
+    await manager.play_macro(
+        macro_name="parent",
+        load_stored_macro=False,
+        source_device="kbd",
+        source_button="key_f13",
+        trigger_value=0,
+    )
+    await _wait_for_no_running_macros(manager)
+
+    manager.output_state.keyboard_uinput.write.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_source_less_hold_child_runs_once(tmp_path: Path) -> None:
+    manager, store = _manager_with_store(tmp_path)
+    store.create(
+        {
+            "name": "held child",
+            "events": [
+                _key_event(evdev.ecodes.KEY_D, 1, 0),
+                _key_event(evdev.ecodes.KEY_D, 0, 1_000),
+            ],
+        }
+    )
+
+    await manager.play_macro(
+        macro_name="parent",
+        load_stored_macro=False,
+        macro_events=[
+            {
+                "t_us": 0,
+                "macro_action": "macro_sync",
+                "macro_name": "held child",
+                "loop_mode": "hold",
+            }
+        ],
+    )
+    await _wait_for_no_running_macros(manager)
+
+    writes = [call.args for call in manager.output_state.keyboard_uinput.write.call_args_list]
+    assert writes.count((evdev.ecodes.EV_KEY, evdev.ecodes.KEY_D, 1)) == 1
+
+
+@pytest.mark.parametrize(
+    ("loop_mode", "loop_count", "expected_presses"),
+    [("count", 3, 3), ("toggle", 99, 1)],
+)
+@pytest.mark.asyncio
+async def test_child_count_is_explicit_and_nested_toggle_runs_once(
+    tmp_path: Path,
+    loop_mode: str,
+    loop_count: int,
+    expected_presses: int,
+) -> None:
+    manager, store = _manager_with_store(tmp_path)
+    store.create(
+        {
+            "name": "child",
+            "events": [
+                _key_event(evdev.ecodes.KEY_G, 1, 0),
+                _key_event(evdev.ecodes.KEY_G, 0, 1_000),
+            ],
+        }
+    )
+
+    await manager.play_macro(
+        macro_name="parent",
+        load_stored_macro=False,
+        macro_events=[
+            {
+                "t_us": 0,
+                "macro_action": "macro_sync",
+                "macro_name": "child",
+                "loop_mode": loop_mode,
+                "loop_count": loop_count,
+            }
+        ],
+    )
+    await _wait_for_no_running_macros(manager)
+
+    writes = [call.args for call in manager.output_state.keyboard_uinput.write.call_args_list]
+    assert writes.count((evdev.ecodes.EV_KEY, evdev.ecodes.KEY_G, 1)) == expected_presses
+
+
+@pytest.mark.asyncio
+async def test_source_less_top_level_hold_runs_once() -> None:
+    manager = DeviceManager()
+    manager.output_state.keyboard_uinput = MagicMock()
+
+    await manager.play_macro(
+        macro_name="source-less hold",
+        load_stored_macro=False,
+        loop_mode="hold",
+        macro_events=[
+            _key_event(evdev.ecodes.KEY_H, 1, 0),
+            _key_event(evdev.ecodes.KEY_H, 0, 1_000),
+        ],
+    )
+    await _wait_for_no_running_macros(manager)
+
+    writes = [call.args for call in manager.output_state.keyboard_uinput.write.call_args_list]
+    assert writes.count((evdev.ecodes.EV_KEY, evdev.ecodes.KEY_H, 1)) == 1
+
+
+@pytest.mark.asyncio
+async def test_missing_child_aborts_parent_and_logs_call_chain(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    manager, _store = _manager_with_store(tmp_path)
+    caplog.set_level(logging.ERROR, logger="keymasqd.devices")
+
+    await manager.play_macro(
+        macro_name="parent",
+        load_stored_macro=False,
+        macro_events=[
+            {"t_us": 0, "macro_action": "macro_sync", "macro_name": "missing"},
+            _key_event(evdev.ecodes.KEY_E, 1, 1_000),
+        ],
+    )
+    await _wait_for_no_running_macros(manager)
+
+    manager.output_state.keyboard_uinput.write.assert_not_called()
+    assert "parent -> missing" in caplog.text
+    assert "Traceback" not in caplog.text
+    assert all(record.exc_info is None for record in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_parallel_child_failure_stops_later_parent_event(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    manager, store = _manager_with_store(tmp_path)
+    store.create(
+        {
+            "name": "failing child",
+            "events": [{"t_us": 0, "macro_action": "macro_sync", "macro_name": "missing"}],
+        }
+    )
+    caplog.set_level(logging.ERROR, logger="keymasqd.devices")
+
+    await manager.play_macro(
+        macro_name="parent",
+        load_stored_macro=False,
+        macro_events=[
+            {
+                "t_us": 0,
+                "macro_action": "macro_parallel",
+                "macro_name": "failing child",
+            },
+            _key_event(evdev.ecodes.KEY_F, 1, 30_000),
+        ],
+    )
+    await _wait_for_no_running_macros(manager)
+
+    manager.output_state.keyboard_uinput.write.assert_not_called()
+    assert "parent -> failing child -> missing" in caplog.text
+
+
+@pytest.mark.parametrize("macro_action", ["macro_sync", "macro_parallel"])
+@pytest.mark.asyncio
+async def test_direct_recursive_call_is_blocked(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+    macro_action: str,
+) -> None:
+    manager, store = _manager_with_store(tmp_path)
+    store.create(
+        {
+            "name": "A",
+            "events": [
+                {"t_us": 0, "macro_action": macro_action, "macro_name": "A"},
+                _key_event(evdev.ecodes.KEY_A, 1, 1_000),
+            ],
+        }
+    )
+    caplog.set_level(logging.ERROR, logger="keymasqd.devices")
+
+    await manager.play_macro(macro_name="A")
+    await _wait_for_no_running_macros(manager)
+
+    manager.output_state.keyboard_uinput.write.assert_not_called()
+    assert "A -> A: recursive macro call blocked" in caplog.text
+    assert "Traceback" not in caplog.text
+    assert all(record.exc_info is None for record in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_indirect_recursive_call_logs_complete_cycle(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    manager, store = _manager_with_store(tmp_path)
+    store.create(
+        {
+            "name": "A",
+            "events": [{"t_us": 0, "macro_action": "macro_sync", "macro_name": "B"}],
+        }
+    )
+    store.create(
+        {
+            "name": "B",
+            "events": [{"t_us": 0, "macro_action": "macro_parallel", "macro_name": "C"}],
+        }
+    )
+    store.create(
+        {
+            "name": "C",
+            "events": [{"t_us": 0, "macro_action": "macro_sync", "macro_name": "A"}],
+        }
+    )
+    caplog.set_level(logging.ERROR, logger="keymasqd.devices")
+
+    await manager.play_macro(macro_name="A")
+    await _wait_for_no_running_macros(manager)
+
+    assert "A -> B -> C -> A: recursive macro call blocked" in caplog.text
+    assert "Traceback" not in caplog.text
+    assert all(record.exc_info is None for record in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_unexpected_child_start_failure_keeps_traceback(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager, _store = _manager_with_store(tmp_path)
+
+    async def fail_to_start_child(*_args: object, **_kwargs: object) -> None:
+        raise RuntimeError("unexpected child failure")
+
+    monkeypatch.setattr(manager, "start_macro_child", fail_to_start_child)
+    caplog.set_level(logging.ERROR, logger="keymasqd.devices")
+
+    await manager.play_macro(
+        macro_name="parent",
+        load_stored_macro=False,
+        macro_events=[{"t_us": 0, "macro_action": "macro_sync", "macro_name": "child"}],
+    )
+    await _wait_for_no_running_macros(manager)
+
+    record = next(record for record in caplog.records if "Macro playback aborted" in record.message)
+    assert "parent -> child: unexpected child failure" in record.message
+    assert record.exc_info is not None
+
+
+@pytest.mark.asyncio
+async def test_repeated_non_recursive_calls_remain_allowed(tmp_path: Path) -> None:
+    manager, store = _manager_with_store(tmp_path)
+    store.create(
+        {
+            "name": "B",
+            "events": [
+                _key_event(evdev.ecodes.KEY_B, 1, 0),
+                _key_event(evdev.ecodes.KEY_B, 0, 1_000),
+            ],
+        }
+    )
+
+    await manager.play_macro(
+        macro_name="A",
+        load_stored_macro=False,
+        macro_events=[
+            {"t_us": 0, "macro_action": "macro_sync", "macro_name": "B"},
+            {"t_us": 1_000, "macro_action": "macro_sync", "macro_name": "B"},
+        ],
+    )
+    await _wait_for_no_running_macros(manager)
+
+    writes = [call.args for call in manager.output_state.keyboard_uinput.write.call_args_list]
+    assert writes.count((evdev.ecodes.EV_KEY, evdev.ecodes.KEY_B, 1)) == 2

--- a/tests/keymasqd/test_macro_meta_macros.py
+++ b/tests/keymasqd/test_macro_meta_macros.py
@@ -21,8 +21,17 @@ def _key_event(code: int, value: int, t_us: int) -> dict[str, object]:
     }
 
 
-async def _wait_for_no_running_macros(manager: DeviceManager) -> None:
+async def _wait_for_no_running_macros(
+    manager: DeviceManager,
+    timeout_s: float = 5.0,
+) -> None:
+    deadline = asyncio.get_running_loop().time() + timeout_s
     while loops.running_macro_instance_ids(manager.macro_state):
+        if asyncio.get_running_loop().time() >= deadline:
+            raise AssertionError(
+                "macro instances still running: "
+                f"{loops.running_macro_instance_ids(manager.macro_state)}"
+            )
         await asyncio.sleep(0.005)
 
 

--- a/tests/keymasqd/test_macro_runtime_state.py
+++ b/tests/keymasqd/test_macro_runtime_state.py
@@ -69,6 +69,10 @@ def test_macro_runtime_state_allocates_explicit_instance_metadata() -> None:
         "macro_name": "hold action",
         "loop_active": True,
         "loop_stop_behavior": "finish_run",
+        "parent_instance_id": None,
+        "root_instance_id": 1,
+        "source_lifecycle_available": True,
+        "source_lifecycle_active": True,
     }
 
 

--- a/tests/test_session_manager_events.py
+++ b/tests/test_session_manager_events.py
@@ -483,7 +483,7 @@ async def test_handle_event_high_exec_ref_schedules_command_without_numeric_spli
 
 
 @pytest.mark.asyncio
-async def test_handle_event_macro_async_exec_uses_exec_trigger_path() -> None:
+async def test_handle_event_detached_macro_exec_uses_exec_trigger_path() -> None:
     manager = SessionManager()
     manager.action_handler.handle_action = AsyncMock()
     manager.action_handler.execute_command_sync = Mock()
@@ -581,6 +581,45 @@ async def test_handle_event_macro_sync_exec_clamps_timeout_to_session_policy() -
         "echo macro",
         timeout_s=0.75,
     )
+
+
+@pytest.mark.asyncio
+async def test_handle_exec_trigger_cancels_tracked_macro_command() -> None:
+    manager = SessionManager()
+    started = asyncio.Event()
+    cancelled = asyncio.Event()
+
+    async def _execute_command(_cmd: str, *, timeout_s: float = 300.0) -> int:
+        started.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            cancelled.set()
+            raise
+        return 0
+
+    manager.action_handler.execute_command = AsyncMock(side_effect=_execute_command)
+    command_task = asyncio.create_task(
+        session_events_module.handle_exec_trigger(
+            manager,
+            {
+                "cmd": "sleep 30",
+                "macro_exec_wait_id": "wait-1",
+                "macro_exec_timeout_ms": 30_000,
+            },
+        )
+    )
+    await asyncio.wait_for(started.wait(), timeout=1.0)
+
+    await session_events_module.handle_exec_trigger(
+        manager,
+        {"macro_exec_cancel_id": "wait-1"},
+    )
+
+    with pytest.raises(asyncio.CancelledError):
+        await command_task
+    assert cancelled.is_set()
+    assert manager.action_handler._tracked_command_tasks == {}  # pyright: ignore[reportPrivateUsage]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- add saved macro calls with wait and joined-parallel execution
- propagate key lifecycle, cancellation, playback options, and recursion detection through child call trees
- add joined parallel command execution while retaining explicit detached commands
- expose macro calls and all command execution modes in the timeline editor

Closes #232

## Verification

- ./scripts/check.sh
- 2724 passed, 25 skipped