### PR TITLE
Edit individual macro gaps on the timeline

### DIFF
--- a/docs/MACROS.md
+++ b/docs/MACROS.md
@@ -505,6 +505,33 @@ logs the full call chain. If a macro tries to call a name already present in
 its active parent chain, Keymasq stops the call tree and logs the attempted
 cycle. This runtime check does not scan or rewrite saved macros.
 
+### Editing individual gaps
+
+Gap controls stay hidden while Move is locked. Double-click empty time between
+two actions to open the gap editor directly. Unlock Move to make gaps appear on
+hover; a single click on a highlighted gap then opens the editor. Right-clicking
+empty space still opens the event insertion menu.
+
+Inside an event track, the gap belongs to that input type. Keyboard events use
+the next keyboard action by start time, regardless of which temporary sub-lane
+the renderer uses to display parallel actions. Mouse-button, gamepad,
+mouse-move, and control tracks follow the same rule. Activity in other tracks
+does not affect the gap. Use the timeline ruler to select a macro-wide gap.
+
+Cancel, press Escape, click elsewhere, or lock Move again to close the gap
+editor and clear its highlight.
+
+Choose **Next action only** to move just the action after the gap. Track gaps
+also offer **Following actions in this track**, which leaves other tracks
+unchanged. Choose **Everything after this time** to move the rest of the macro
+together.
+
+For macro-wide ruler gaps, actions that start together count as one step. The
+gap starts after the last active editable action ends. Recorded mouse-movement
+samples, key-repeat markers, and other raw passthrough events do not split ruler
+gaps. A negative value moves the next step into an overlap. Select an overlap
+from the timeline ruler when there is no empty interval to click.
+
 ### Timing Tools
 
 The **Timing Tools** menu provides bulk adjustments to your macro's timing:

--- a/keymasq/gui/widgets/macro_editor/controller/timing.py
+++ b/keymasq/gui/widgets/macro_editor/controller/timing.py
@@ -197,6 +197,17 @@ class TimelineControllerMixin:
         move_scope: GapMoveScope,
     ) -> None:
         previous_duration_us = self._duration_us
+        previous_content_end_us = timing_ops.compute_duration_us(
+            self._events,
+            self._rel_events,
+            self._passthrough_events,
+            self._synthetic_moves,
+            self._control_events,
+        )
+        trailing_duration_us = max(
+            0,
+            previous_duration_us - previous_content_end_us,
+        )
         if move_scope == "track":
             edit_gap = set_timeline_gap_track_following
         elif move_scope == "timeline":
@@ -221,11 +232,10 @@ class TimelineControllerMixin:
             self._synthetic_moves,
             self._control_events,
         )
-        duration_delta_us = delta_us if move_scope == "timeline" else 0
-        self._duration_us = max(
-            content_end_us,
-            max(0, previous_duration_us + duration_delta_us),
-        )
+        if move_scope == "timeline":
+            self._duration_us = content_end_us + trailing_duration_us
+        else:
+            self._duration_us = max(content_end_us, previous_duration_us)
         self._timeline.clear_gap_selection()
         self._refresh_after_timing_edit(recompute_duration=False)
 

--- a/keymasq/gui/widgets/macro_editor/controller/timing.py
+++ b/keymasq/gui/widgets/macro_editor/controller/timing.py
@@ -3,6 +3,7 @@
 # pyright: reportAttributeAccessIssue=false, reportUnknownMemberType=false
 
 import math
+from typing import Literal
 
 import evdev
 import gi
@@ -24,6 +25,8 @@ from keymasq.gui.widgets.macro_editor.model import (
     EditableMove,
 )
 from keymasq.gui.widgets.macro_editor.timeline import TimelineWidget
+
+type GapMoveScope = Literal["next", "track", "timeline"]
 
 
 class TimelineControllerMixin:
@@ -191,7 +194,7 @@ class TimelineControllerMixin:
         gap: TimelineGap,
         target_us: int,
         *,
-        move_scope: str,
+        move_scope: GapMoveScope,
     ) -> None:
         previous_duration_us = self._duration_us
         if move_scope == "track":

--- a/keymasq/gui/widgets/macro_editor/controller/timing.py
+++ b/keymasq/gui/widgets/macro_editor/controller/timing.py
@@ -12,6 +12,12 @@ gi.require_version("Gtk", "4.0")
 from gi.repository import Gtk  # pyright: ignore[reportAttributeAccessIssue]
 
 from keymasq.gui.widgets.macro_editor import timing_ops
+from keymasq.gui.widgets.macro_editor.gaps import (
+    TimelineGap,
+    set_timeline_gap_and_following,
+    set_timeline_gap_next_action,
+    set_timeline_gap_track_following,
+)
 from keymasq.gui.widgets.macro_editor.model import (
     EditableControl,
     EditableEvent,
@@ -37,6 +43,8 @@ class TimelineControllerMixin:
         )
         self._stats_label.set_label(f"{duration_s:.3f}s · {event_count} events")
         self._update_exec_summary_label()
+        if hasattr(self, "_timeline"):
+            self._timeline.refresh_gaps()
 
     def _update_exec_summary_label(self) -> None:
         if not hasattr(self, "_exec_summary_label"):
@@ -176,6 +184,33 @@ class TimelineControllerMixin:
         if selected_obj is not None:
             self._on_selection_changed(selected_obj)
         self._sync_close_guard()
+
+    def _edit_timeline_gap(
+        self,
+        gap: TimelineGap,
+        target_us: int,
+        *,
+        move_scope: str,
+    ) -> None:
+        if move_scope == "track":
+            edit_gap = set_timeline_gap_track_following
+        elif move_scope == "timeline":
+            edit_gap = set_timeline_gap_and_following
+        else:
+            edit_gap = set_timeline_gap_next_action
+        delta_us = edit_gap(
+            self._events,
+            self._rel_events,
+            self._passthrough_events,
+            self._synthetic_moves,
+            self._control_events,
+            gap,
+            target_us,
+        )
+        if delta_us == 0:
+            return
+        self._timeline.clear_gap_selection()
+        self._refresh_after_timing_edit()
 
     def _build_time_mapping_with_gap_limits(
         self,

--- a/keymasq/gui/widgets/macro_editor/controller/timing.py
+++ b/keymasq/gui/widgets/macro_editor/controller/timing.py
@@ -175,9 +175,10 @@ class TimelineControllerMixin:
             self._control_events,
         )
 
-    def _refresh_after_timing_edit(self) -> None:
+    def _refresh_after_timing_edit(self, *, recompute_duration: bool = True) -> None:
         selected_obj = self._timeline._selected
-        self._recompute_duration()
+        if recompute_duration:
+            self._recompute_duration()
         self._update_stats()
         self._update_canvas_width()
         self._timeline.queue_draw()
@@ -192,6 +193,7 @@ class TimelineControllerMixin:
         *,
         move_scope: str,
     ) -> None:
+        previous_duration_us = self._duration_us
         if move_scope == "track":
             edit_gap = set_timeline_gap_track_following
         elif move_scope == "timeline":
@@ -209,8 +211,20 @@ class TimelineControllerMixin:
         )
         if delta_us == 0:
             return
+        content_end_us = timing_ops.compute_duration_us(
+            self._events,
+            self._rel_events,
+            self._passthrough_events,
+            self._synthetic_moves,
+            self._control_events,
+        )
+        duration_delta_us = delta_us if move_scope == "timeline" else 0
+        self._duration_us = max(
+            content_end_us,
+            max(0, previous_duration_us + duration_delta_us),
+        )
         self._timeline.clear_gap_selection()
-        self._refresh_after_timing_edit()
+        self._refresh_after_timing_edit(recompute_duration=False)
 
     def _build_time_mapping_with_gap_limits(
         self,

--- a/keymasq/gui/widgets/macro_editor/gaps.py
+++ b/keymasq/gui/widgets/macro_editor/gaps.py
@@ -11,6 +11,7 @@ from keymasq.gui.widgets.macro_editor.model import (
     EditableEvent,
     EditableMove,
     MacroEvent,
+    _passthrough_track,
 )
 
 type GapItem = EditableEvent | EditableMove | EditableControl | MacroEvent
@@ -176,8 +177,11 @@ def set_timeline_gap_track_following(
     repeat_owners = _repeat_owners(events, passthrough_events)
     following_items = _track_items_at_or_after(
         events,
+        rel_events,
+        passthrough_events,
         moves,
         controls,
+        repeat_owners=repeat_owners,
         track=gap.track,
         at_us=gap.next_start_us,
     )
@@ -196,20 +200,29 @@ def set_timeline_gap_track_following(
 
 def _track_items_at_or_after(
     events: list[EditableEvent],
+    rel_events: list[MacroEvent],
+    passthrough_events: list[MacroEvent],
     moves: list[EditableMove],
     controls: list[EditableControl],
     *,
+    repeat_owners: dict[int, EditableEvent],
     track: str | None,
     at_us: int,
 ) -> tuple[GapItem, ...]:
     if track in {"keyboard", "mouse", "gamepad"}:
         items: list[GapItem] = [event for event in events if event.device_type == track]
     elif track == "movement":
-        items = list(moves)
+        items = [*moves, *rel_events]
     elif track == "control":
         items = list(controls)
     else:
         return ()
+    if track != "control":
+        items.extend(
+            event
+            for event in passthrough_events
+            if id(event) not in repeat_owners and _passthrough_track(event) == track
+        )
     return tuple(item for item in items if _item_start_us(item) >= at_us)
 
 

--- a/keymasq/gui/widgets/macro_editor/gaps.py
+++ b/keymasq/gui/widgets/macro_editor/gaps.py
@@ -1,0 +1,365 @@
+"""Step-gap calculations for the macro editor timeline."""
+
+from bisect import bisect_right
+from dataclasses import dataclass
+from typing import Literal
+
+import evdev
+
+from keymasq.gui.widgets.macro_editor.document import selection_order
+from keymasq.gui.widgets.macro_editor.model import (
+    EditableControl,
+    EditableEvent,
+    EditableMove,
+    MacroEvent,
+)
+
+type GapItem = EditableEvent | EditableMove | EditableControl | MacroEvent
+type GapScope = Literal["timeline", "track"]
+
+
+@dataclass(frozen=True, slots=True)
+class TimelineGap:
+    """Timing between one action step and the step that follows it."""
+
+    previous_step_start_us: int
+    previous_end_us: int
+    next_start_us: int
+    previous_items: tuple[GapItem, ...]
+    next_items: tuple[GapItem, ...]
+    scope: GapScope = "timeline"
+    track: str | None = None
+    following_items: tuple[GapItem, ...] = ()
+
+    @property
+    def duration_us(self) -> int:
+        return self.next_start_us - self.previous_end_us
+
+    @property
+    def minimum_us(self) -> int:
+        """Keep the next step at or after the preceding step's start."""
+        return self.previous_step_start_us - self.previous_end_us
+
+
+@dataclass(frozen=True, slots=True)
+class _TimelineStep:
+    start_us: int
+    end_us: int
+    items: tuple[GapItem, ...]
+
+
+def build_timeline_gaps(
+    events: list[EditableEvent],
+    moves: list[EditableMove],
+    controls: list[EditableControl],
+) -> list[TimelineGap]:
+    """Return ruler gaps between consecutive editable action groups."""
+    steps = _build_steps_from_items([*events, *moves, *controls])
+    if len(steps) < 2:
+        return []
+
+    gaps: list[TimelineGap] = []
+    previous_end_us = steps[0].end_us
+    frontier_items = steps[0].items
+    for index, step in enumerate(steps[1:], start=1):
+        previous_step = steps[index - 1]
+        gaps.append(
+            TimelineGap(
+                previous_step_start_us=previous_step.start_us,
+                previous_end_us=previous_end_us,
+                next_start_us=step.start_us,
+                previous_items=frontier_items,
+                next_items=step.items,
+            )
+        )
+        if step.end_us >= previous_end_us:
+            previous_end_us = step.end_us
+            frontier_items = step.items
+    return gaps
+
+
+def build_track_gaps(
+    items: list[GapItem],
+    *,
+    track: str,
+) -> list[TimelineGap]:
+    """Return gaps between chronological action steps in one semantic track."""
+    steps = _build_steps_from_items(items)
+    gaps: list[TimelineGap] = []
+    for index, step in enumerate(steps[1:], start=1):
+        previous = steps[index - 1]
+        following_items = tuple(
+            item for following_step in steps[index:] for item in following_step.items
+        )
+        gaps.append(
+            TimelineGap(
+                previous_step_start_us=previous.start_us,
+                previous_end_us=previous.end_us,
+                next_start_us=step.start_us,
+                previous_items=previous.items,
+                next_items=step.items,
+                scope="track",
+                track=track,
+                following_items=following_items,
+            )
+        )
+    return gaps
+
+
+def set_timeline_gap_next_action(
+    events: list[EditableEvent],
+    rel_events: list[MacroEvent],
+    passthrough_events: list[MacroEvent],
+    moves: list[EditableMove],
+    controls: list[EditableControl],
+    gap: TimelineGap,
+    target_us: int,
+) -> int:
+    """Set one gap by moving only the action step after it."""
+    normalized_target_us = max(gap.minimum_us, int(target_us))
+    delta_us = normalized_target_us - gap.duration_us
+    if delta_us == 0:
+        return 0
+
+    repeat_owners = _repeat_owners(events, passthrough_events)
+    _shift_items(
+        events,
+        rel_events,
+        passthrough_events,
+        moves,
+        controls,
+        items=gap.next_items,
+        delta_us=delta_us,
+        repeat_owners=repeat_owners,
+    )
+    return delta_us
+
+
+def set_timeline_gap_and_following(
+    events: list[EditableEvent],
+    rel_events: list[MacroEvent],
+    passthrough_events: list[MacroEvent],
+    moves: list[EditableMove],
+    controls: list[EditableControl],
+    gap: TimelineGap,
+    target_us: int,
+) -> int:
+    """Set one gap and shift every action from the following step onward."""
+    normalized_target_us = max(gap.minimum_us, int(target_us))
+    delta_us = normalized_target_us - gap.duration_us
+    if delta_us == 0:
+        return 0
+
+    repeat_owners = _repeat_owners(events, passthrough_events)
+    _shift_suffix(
+        events,
+        rel_events,
+        passthrough_events,
+        moves,
+        controls,
+        at_us=gap.next_start_us,
+        delta_us=delta_us,
+        repeat_owners=repeat_owners,
+    )
+    return delta_us
+
+
+def set_timeline_gap_track_following(
+    events: list[EditableEvent],
+    rel_events: list[MacroEvent],
+    passthrough_events: list[MacroEvent],
+    moves: list[EditableMove],
+    controls: list[EditableControl],
+    gap: TimelineGap,
+    target_us: int,
+) -> int:
+    """Set one track gap and move later actions from that semantic track."""
+    normalized_target_us = max(gap.minimum_us, int(target_us))
+    delta_us = normalized_target_us - gap.duration_us
+    if delta_us == 0:
+        return 0
+
+    repeat_owners = _repeat_owners(events, passthrough_events)
+    _shift_items(
+        events,
+        rel_events,
+        passthrough_events,
+        moves,
+        controls,
+        items=gap.following_items,
+        delta_us=delta_us,
+        repeat_owners=repeat_owners,
+    )
+    return delta_us
+
+
+def _build_steps_from_items(items: list[GapItem]) -> list[_TimelineStep]:
+    items.sort(key=lambda item: (_item_start_us(item), selection_order(item)))
+
+    groups: list[list[GapItem]] = []
+    for item in items:
+        if not groups or _item_start_us(groups[-1][0]) != _item_start_us(item):
+            groups.append([item])
+        else:
+            groups[-1].append(item)
+    return [
+        _TimelineStep(
+            start_us=_item_start_us(group[0]),
+            end_us=max(_item_end_us(item) for item in group),
+            items=tuple(group),
+        )
+        for group in groups
+    ]
+
+
+def _item_start_us(item: GapItem) -> int:
+    if isinstance(item, EditableEvent):
+        return max(0, int(item.press_t_us))
+    if isinstance(item, (EditableMove, EditableControl)):
+        return max(0, int(item.t_us))
+    return max(0, int(item.get("t_us", 0)))
+
+
+def _item_end_us(item: GapItem) -> int:
+    if isinstance(item, EditableEvent):
+        return max(item.press_t_us, int(item.release_t_us))
+    return _item_start_us(item)
+
+
+def _shift_items(
+    events: list[EditableEvent],
+    rel_events: list[MacroEvent],
+    passthrough_events: list[MacroEvent],
+    moves: list[EditableMove],
+    controls: list[EditableControl],
+    *,
+    items: tuple[GapItem, ...],
+    delta_us: int,
+    repeat_owners: dict[int, EditableEvent],
+) -> None:
+    item_ids = {id(item) for item in items}
+    shifted_owner_ids: set[int] = set()
+    for event in events:
+        if id(event) not in item_ids:
+            continue
+        shifted_owner_ids.add(id(event))
+        event.press_t_us += delta_us
+        event.release_t_us += delta_us
+    for event in rel_events:
+        if id(event) in item_ids:
+            event["t_us"] = int(event.get("t_us", 0)) + delta_us
+    for event in passthrough_events:
+        owner = repeat_owners.get(id(event))
+        if id(event) in item_ids or (owner is not None and id(owner) in shifted_owner_ids):
+            event["t_us"] = int(event.get("t_us", 0)) + delta_us
+    for move in moves:
+        if id(move) in item_ids:
+            move.t_us += delta_us
+    for control in controls:
+        if id(control) in item_ids:
+            control.t_us += delta_us
+    _sort_items(events, rel_events, passthrough_events, moves, controls)
+
+
+def _shift_suffix(
+    events: list[EditableEvent],
+    rel_events: list[MacroEvent],
+    passthrough_events: list[MacroEvent],
+    moves: list[EditableMove],
+    controls: list[EditableControl],
+    *,
+    at_us: int,
+    delta_us: int,
+    repeat_owners: dict[int, EditableEvent],
+) -> None:
+    shifted_owner_ids: set[int] = set()
+    for event in events:
+        if event.press_t_us < at_us:
+            continue
+        shifted_owner_ids.add(id(event))
+        event.press_t_us += delta_us
+        event.release_t_us += delta_us
+    for event in rel_events:
+        timestamp_us = int(event.get("t_us", 0))
+        if timestamp_us >= at_us:
+            event["t_us"] = timestamp_us + delta_us
+    for event in passthrough_events:
+        timestamp_us = int(event.get("t_us", 0))
+        owner = repeat_owners.get(id(event))
+        should_shift = (
+            id(owner) in shifted_owner_ids if owner is not None else timestamp_us >= at_us
+        )
+        if should_shift:
+            event["t_us"] = timestamp_us + delta_us
+    for move in moves:
+        if move.t_us >= at_us:
+            move.t_us += delta_us
+    for control in controls:
+        if control.t_us >= at_us:
+            control.t_us += delta_us
+    _sort_items(events, rel_events, passthrough_events, moves, controls)
+
+
+def _repeat_owners(
+    events: list[EditableEvent],
+    passthrough_events: list[MacroEvent],
+) -> dict[int, EditableEvent]:
+    owners_by_key: dict[tuple[str, int, str | None], list[EditableEvent]] = {}
+    for event in events:
+        if event.ev_type != evdev.ecodes.EV_KEY:
+            continue
+        owners_by_key.setdefault(_editable_key_identity(event), []).append(event)
+    for candidates in owners_by_key.values():
+        candidates.sort(key=lambda event: event.press_t_us)
+    starts_by_key = {
+        key: [event.press_t_us for event in candidates] for key, candidates in owners_by_key.items()
+    }
+
+    owners: dict[int, EditableEvent] = {}
+    for repeat in passthrough_events:
+        if not _is_repeat(repeat):
+            continue
+        timestamp_us = int(repeat.get("t_us", 0))
+        identity = _raw_key_identity(repeat)
+        candidates = owners_by_key.get(identity, ())
+        candidate_index = bisect_right(starts_by_key.get(identity, ()), timestamp_us) - 1
+        if candidate_index < 0:
+            continue
+        candidate = candidates[candidate_index]
+        if timestamp_us < candidate.release_t_us:
+            owners[id(repeat)] = candidate
+    return owners
+
+
+def _is_repeat(event: MacroEvent) -> bool:
+    return int(event.get("type", -1)) == evdev.ecodes.EV_KEY and int(event.get("value", -1)) == 2
+
+
+def _editable_key_identity(event: EditableEvent) -> tuple[str, int, str | None]:
+    return (
+        str(event.device_type),
+        int(event.code),
+        str(event.output_id).strip() if event.output_id else None,
+    )
+
+
+def _raw_key_identity(event: MacroEvent) -> tuple[str, int, str | None]:
+    device_type = str(event.get("device_type", "") or "")
+    output_id = (
+        str(event.get("output_id", "") or "").strip() or None if device_type == "gamepad" else None
+    )
+    return device_type, int(event.get("code", 0)), output_id
+
+
+def _sort_items(
+    events: list[EditableEvent],
+    rel_events: list[MacroEvent],
+    passthrough_events: list[MacroEvent],
+    moves: list[EditableMove],
+    controls: list[EditableControl],
+) -> None:
+    events.sort(key=lambda event: event.press_t_us)
+    rel_events.sort(key=lambda event: int(event.get("t_us", 0)))
+    passthrough_events.sort(key=lambda event: int(event.get("t_us", 0)))
+    moves.sort(key=lambda move: move.t_us)
+    controls.sort(key=lambda control: control.t_us)

--- a/keymasq/gui/widgets/macro_editor/gaps.py
+++ b/keymasq/gui/widgets/macro_editor/gaps.py
@@ -1,6 +1,5 @@
 """Step-gap calculations for the macro editor timeline."""
 
-from bisect import bisect_right
 from dataclasses import dataclass
 from typing import Literal
 
@@ -331,10 +330,14 @@ def _repeat_owners(
             continue
         owners_by_key.setdefault(_editable_key_identity(event), []).append(event)
     for candidates in owners_by_key.values():
-        candidates.sort(key=lambda event: event.press_t_us)
-    starts_by_key = {
-        key: [event.press_t_us for event in candidates] for key, candidates in owners_by_key.items()
-    }
+        candidates.sort(
+            key=lambda event: (
+                event.press_t_us,
+                event.original_press_order
+                if event.original_press_order is not None
+                else -1,
+            )
+        )
 
     owners: dict[int, EditableEvent] = {}
     for repeat in passthrough_events:
@@ -343,13 +346,38 @@ def _repeat_owners(
         timestamp_us = int(repeat.get("t_us", 0))
         identity = _raw_key_identity(repeat)
         candidates = owners_by_key.get(identity, ())
-        candidate_index = bisect_right(starts_by_key.get(identity, ()), timestamp_us) - 1
-        if candidate_index < 0:
-            continue
-        candidate = candidates[candidate_index]
-        if timestamp_us < candidate.release_t_us:
-            owners[id(repeat)] = candidate
+        repeat_order = _raw_original_order(repeat)
+        for candidate in reversed(candidates):
+            if _event_owns_repeat(candidate, timestamp_us, repeat_order):
+                owners[id(repeat)] = candidate
+                break
     return owners
+
+
+def _event_owns_repeat(
+    event: EditableEvent,
+    timestamp_us: int,
+    repeat_order: int | None,
+) -> bool:
+    if timestamp_us < event.press_t_us or timestamp_us > event.release_t_us:
+        return False
+    if (
+        timestamp_us == event.press_t_us
+        and repeat_order is not None
+        and event.original_press_order is not None
+        and repeat_order <= event.original_press_order
+    ):
+        return False
+    if timestamp_us != event.release_t_us:
+        return True
+    if repeat_order is None or event.original_release_order is None:
+        return False
+    return repeat_order < event.original_release_order
+
+
+def _raw_original_order(event: MacroEvent) -> int | None:
+    source, order, _priority = selection_order(event)
+    return order if source == 0 else None
 
 
 def _is_repeat(event: MacroEvent) -> bool:

--- a/keymasq/gui/widgets/macro_editor/gaps.py
+++ b/keymasq/gui/widgets/macro_editor/gaps.py
@@ -29,7 +29,6 @@ class TimelineGap:
     next_items: tuple[GapItem, ...]
     scope: GapScope = "timeline"
     track: str | None = None
-    following_items: tuple[GapItem, ...] = ()
 
     @property
     def duration_us(self) -> int:
@@ -88,9 +87,6 @@ def build_track_gaps(
     gaps: list[TimelineGap] = []
     for index, step in enumerate(steps[1:], start=1):
         previous = steps[index - 1]
-        following_items = tuple(
-            item for following_step in steps[index:] for item in following_step.items
-        )
         gaps.append(
             TimelineGap(
                 previous_step_start_us=previous.start_us,
@@ -100,7 +96,6 @@ def build_track_gaps(
                 next_items=step.items,
                 scope="track",
                 track=track,
-                following_items=following_items,
             )
         )
     return gaps
@@ -180,17 +175,43 @@ def set_timeline_gap_track_following(
         return 0
 
     repeat_owners = _repeat_owners(events, passthrough_events)
+    following_items = _track_items_at_or_after(
+        events,
+        moves,
+        controls,
+        track=gap.track,
+        at_us=gap.next_start_us,
+    )
     _shift_items(
         events,
         rel_events,
         passthrough_events,
         moves,
         controls,
-        items=gap.following_items,
+        items=following_items,
         delta_us=delta_us,
         repeat_owners=repeat_owners,
     )
     return delta_us
+
+
+def _track_items_at_or_after(
+    events: list[EditableEvent],
+    moves: list[EditableMove],
+    controls: list[EditableControl],
+    *,
+    track: str | None,
+    at_us: int,
+) -> tuple[GapItem, ...]:
+    if track in {"keyboard", "mouse", "gamepad"}:
+        items: list[GapItem] = [event for event in events if event.device_type == track]
+    elif track == "movement":
+        items = list(moves)
+    elif track == "control":
+        items = list(controls)
+    else:
+        return ()
+    return tuple(item for item in items if _item_start_us(item) >= at_us)
 
 
 def _build_steps_from_items(items: list[GapItem]) -> list[_TimelineStep]:

--- a/keymasq/gui/widgets/macro_editor/panel/chrome.py
+++ b/keymasq/gui/widgets/macro_editor/panel/chrome.py
@@ -125,7 +125,10 @@ class EditorChromeMixin:
 
         self._lock_btn = Gtk.ToggleButton(label="Lock Move")
         self._lock_btn.set_active(True)
-        self._lock_btn.set_tooltip_text("When locked, events cannot be dragged")
+        self._lock_btn.set_tooltip_text(
+            "Unlock to drag actions or click highlighted gaps; "
+            "double-click a hidden gap while locked"
+        )
         self._lock_btn.connect("toggled", self._on_move_lock_toggled)
         bar.append(self._lock_btn)
 
@@ -390,10 +393,12 @@ class EditorChromeMixin:
     def _on_move_lock_toggled(self, btn: Gtk.ToggleButton) -> None:
         self._drag_locked = btn.get_active()
         btn.set_label("Lock Move" if self._drag_locked else "Move Unlocked")
+        self._timeline.set_move_locked(self._drag_locked)
 
     def _on_erase_mode_toggled(self, btn: Gtk.ToggleButton) -> None:
         self._erase_mode = btn.get_active()
         if self._erase_mode:
+            self._timeline.clear_gap_selection()
             btn.add_css_class("destructive-action")
             self._timeline.set_cursor_from_name("crosshair")
         else:
@@ -421,6 +426,7 @@ class EditorChromeMixin:
         self._timeline._context_menu_x = None
         self._timeline._hover_x = None
         self._timeline._hover_y = None
+        self._timeline.clear_gap_selection()
 
         self._sync_macro_settings_controls()
         self._macro_capture_delay_spin.set_value(self._start_position_capture.delay_seconds)

--- a/keymasq/gui/widgets/macro_editor/timeline.py
+++ b/keymasq/gui/widgets/macro_editor/timeline.py
@@ -650,7 +650,7 @@ class TimelineWidget(Gtk.DrawingArea):
             Gtk.Adjustment(
                 value=gap.duration_us / 1000.0,
                 lower=gap.minimum_us / 1000.0,
-                upper=3_600_000.0,
+                upper=(2**63 - 1) / 1000.0,
                 step_increment=1.0,
                 page_increment=10.0,
             )

--- a/keymasq/gui/widgets/macro_editor/timeline.py
+++ b/keymasq/gui/widgets/macro_editor/timeline.py
@@ -4,12 +4,19 @@ import gi
 
 gi.require_version("Gtk", "4.0")
 
+from bisect import bisect_right
 from typing import Any
 
 import evdev
 from gi.repository import Gdk, GLib, Gtk  # pyright: ignore[reportAttributeAccessIssue]
 
 from keymasq.gui.widgets.macro_editor import timeline_render
+from keymasq.gui.widgets.macro_editor.gaps import (
+    GapItem,
+    TimelineGap,
+    build_timeline_gaps,
+    build_track_gaps,
+)
 from keymasq.gui.widgets.macro_editor.model import (
     EditableControl,
     EditableEvent,
@@ -59,6 +66,25 @@ class TimelineWidget(Gtk.DrawingArea):
         self._hover_x: float | None = None
         self._hover_y: float | None = None
         self._context_menu_x: float | None = None
+        self._gap_segments: list[TimelineGap] = []
+        self._gap_next_starts: list[int] = []
+        self._positive_gap_starts: list[int] = []
+        self._positive_gaps: list[TimelineGap] = []
+        self._track_gaps: dict[str, list[TimelineGap]] = {}
+        self._track_next_starts: dict[str, list[int]] = {}
+        self._track_positive_gaps: dict[str, list[TimelineGap]] = {}
+        self._track_positive_starts: dict[str, list[int]] = {}
+        self._hover_gap: TimelineGap | None = None
+        self._selected_gap: TimelineGap | None = None
+        self._suppressed_hover_gap: TimelineGap | None = None
+        self._gap_double_click_handled = False
+        self._gap_popover: Gtk.Popover | None = None
+        self._gap_spin: Gtk.SpinButton | None = None
+        self._gap_next_only_check: Gtk.CheckButton | None = None
+        self._gap_track_following_check: Gtk.CheckButton | None = None
+        self._gap_timeline_following_check: Gtk.CheckButton | None = None
+        self._gap_cancel_button: Gtk.Button | None = None
+        self._gap_apply_button: Gtk.Button | None = None
 
         # Lane assignment — recomputed before each draw
         self._kb_lanes: dict[int, int] = {}  # id(ev) -> lane index
@@ -73,6 +99,7 @@ class TimelineWidget(Gtk.DrawingArea):
         self._drag_move: EditableMove | None = None
         self._drag_control: EditableControl | None = None
         self._drag_selected_obj: object | None = None
+        self._drag_selected_gap: TimelineGap | None = None
         self._drag_orig_press: int = 0
         self._drag_orig_release: int = 0
         self._in_drag: bool = False
@@ -81,6 +108,7 @@ class TimelineWidget(Gtk.DrawingArea):
         # The drag delta is gesture-relative, so the scroll movement since
         # drag-begin has to be folded into the applied time delta.
         self._drag_start_x: float = 0.0
+        self._drag_start_y: float = 0.0
         self._drag_scroll_origin: float = 0.0
         self._drag_last_offset_x: float = 0.0
         self._autoscroll_velocity: float = 0.0
@@ -114,6 +142,11 @@ class TimelineWidget(Gtk.DrawingArea):
         drag.connect("drag-end", self._on_drag_end)
         self.add_controller(drag)
 
+        gap_click = Gtk.GestureClick.new()
+        gap_click.set_button(1)
+        gap_click.connect("pressed", self._on_gap_click_pressed)
+        self.add_controller(gap_click)
+
         # Right-click context menu
         right_click = Gtk.GestureClick.new()
         right_click.set_button(3)
@@ -145,6 +178,99 @@ class TimelineWidget(Gtk.DrawingArea):
 
     def set_scroll_offset(self, offset: float) -> None:
         self._scroll_offset = offset
+        self.queue_draw()
+
+    def refresh_gaps(self) -> None:
+        """Refresh cached action gaps after the editor document changes."""
+        if self._editor._drag_locked:
+            self._set_gap_segments([])
+            self._set_track_gaps({})
+            self._hover_gap = None
+            self._selected_gap = None
+            self._suppressed_hover_gap = None
+            self.queue_draw()
+            return
+        self._rebuild_gaps()
+
+    def _rebuild_gaps(self) -> None:
+        """Build the gap cache when an interaction needs it."""
+        self._set_gap_segments(
+            build_timeline_gaps(
+                self._editor._events,
+                self._editor._synthetic_moves,
+                self._editor._control_events,
+            )
+        )
+        track_items: dict[str, list[GapItem]] = {}
+        for event in self._editor._events:
+            if event.device_type in {"keyboard", "mouse", "gamepad"}:
+                track_items.setdefault(event.device_type, []).append(event)
+        track_items["movement"] = list(self._editor._synthetic_moves)
+        track_items["control"] = list(self._editor._control_events)
+        self._set_track_gaps(
+            {
+                track: build_track_gaps(
+                    items,
+                    track=track,
+                )
+                for track, items in track_items.items()
+            }
+        )
+        self._hover_gap = None
+        self._selected_gap = None
+        self._suppressed_hover_gap = None
+        self.queue_draw()
+
+    def _set_gap_segments(self, gaps: list[TimelineGap]) -> None:
+        self._gap_segments = gaps
+        self._gap_next_starts = [gap.next_start_us for gap in gaps]
+        self._positive_gaps = [gap for gap in gaps if gap.duration_us > 0]
+        self._positive_gap_starts = [gap.previous_end_us for gap in self._positive_gaps]
+
+    def _set_track_gaps(
+        self,
+        track_gaps: dict[str, list[TimelineGap]],
+    ) -> None:
+        self._track_gaps = track_gaps
+        self._track_next_starts = {
+            track: [gap.next_start_us for gap in gaps]
+            for track, gaps in track_gaps.items()
+        }
+        self._track_positive_gaps = {
+            track: sorted(
+                (gap for gap in gaps if gap.duration_us > 0),
+                key=lambda gap: gap.previous_end_us,
+            )
+            for track, gaps in track_gaps.items()
+        }
+        self._track_positive_starts = {
+            track: [gap.previous_end_us for gap in gaps]
+            for track, gaps in self._track_positive_gaps.items()
+        }
+
+    def set_move_locked(self, locked: bool) -> None:
+        """Update gap interaction state after the Move lock changes."""
+        self.clear_gap_selection(suppress_hover=True)
+        if locked:
+            self._set_gap_segments([])
+            self._set_track_gaps({})
+        else:
+            self._rebuild_gaps()
+        if not self._editor._erase_mode:
+            self.set_cursor_from_name(None)
+        self.queue_draw()
+
+    def _ensure_gap_cache(self) -> None:
+        if not self._gap_segments and not self._track_gaps:
+            self._rebuild_gaps()
+
+    def clear_gap_selection(self, *, suppress_hover: bool = False) -> None:
+        if suppress_hover:
+            self._suppressed_hover_gap = self._selected_gap or self._hover_gap
+        self._hover_gap = None
+        self._selected_gap = None
+        if self._gap_popover is not None:
+            self._gap_popover.popdown()
         self.queue_draw()
 
     # ------------------------------------------------------------------
@@ -232,6 +358,8 @@ class TimelineWidget(Gtk.DrawingArea):
             _hover_x=self._hover_x,
             _hover_y=self._hover_y,
             _context_menu_x=self._context_menu_x,
+            _hover_gap=self._hover_gap,
+            _selected_gap=self._selected_gap,
             events=self._editor._events,
             rel_events=self._editor._rel_events,
             passthrough_events=self._editor._passthrough_events,
@@ -395,6 +523,234 @@ class TimelineWidget(Gtk.DrawingArea):
                 return ev
         return self._hit_test_passthrough(track, x, y)
 
+    def _gap_track_at_y(self, y: float) -> str | None:
+        track = self._get_track_at_y(y)
+        if track in {"keyboard", "mouse", "gamepad"}:
+            return track
+        if track == "movement":
+            if y < self._wave_y + self.TRACK_HEIGHT / 2:
+                return "movement"
+            return "control"
+        return None
+
+    def _gap_at_position(self, x: float, y: float) -> TimelineGap | None:
+        if x < self.LABEL_WIDTH:
+            return None
+        timestamp_us = max(0, self._x_to_time_us(x))
+
+        if y >= self.RULER_HEIGHT:
+            track = self._gap_track_at_y(y)
+            if track is None:
+                return None
+            gaps = self._track_gaps.get(track, ())
+            positive_gaps = self._track_positive_gaps.get(track, ())
+            positive_starts = self._track_positive_starts.get(track, ())
+            positive_index = bisect_right(positive_starts, timestamp_us) - 1
+            if positive_index >= 0:
+                gap = positive_gaps[positive_index]
+                if gap.previous_end_us < timestamp_us < gap.next_start_us:
+                    return gap
+
+            tolerance_us = int(6.0 / max(self._pps, 1.0) * 1e6)
+            next_starts = self._track_next_starts.get(track, ())
+            index = bisect_right(next_starts, timestamp_us) - 1
+            for candidate_index in (index, index + 1):
+                if 0 <= candidate_index < len(gaps):
+                    gap = gaps[candidate_index]
+                    if abs(timestamp_us - gap.next_start_us) <= tolerance_us:
+                        return gap
+            return None
+
+        if not self._gap_segments:
+            return None
+        positive_index = bisect_right(self._positive_gap_starts, timestamp_us) - 1
+        if positive_index >= 0:
+            gap = self._positive_gaps[positive_index]
+            if gap.previous_end_us < timestamp_us < gap.next_start_us:
+                return gap
+
+        index = bisect_right(self._gap_next_starts, timestamp_us) - 1
+        if index >= 0:
+            gap = self._gap_segments[index]
+            if gap.next_start_us <= timestamp_us <= gap.previous_end_us:
+                return gap
+
+        tolerance_us = int(6.0 / max(self._pps, 1.0) * 1e6)
+        for candidate_index in (index, index + 1):
+            if 0 <= candidate_index < len(self._gap_segments):
+                gap = self._gap_segments[candidate_index]
+                if abs(timestamp_us - gap.next_start_us) <= tolerance_us:
+                    return gap
+        return None
+
+    def _gap_item_label(self, item: object) -> str:
+        if isinstance(item, EditableEvent):
+            if item.ev_type == evdev.ecodes.EV_KEY:
+                return _get_key_name(item.code)
+            return _get_event_name(item.ev_type, item.code)
+        if isinstance(item, EditableMove):
+            return "Mouse move"
+        if isinstance(item, EditableControl):
+            return {
+                "wait": "Wait",
+                "wait_random": "Random wait",
+                "exec_sync": "Run command",
+                "exec_async": "Run command",
+                "compositor_dispatch": "Compositor action",
+            }.get(item.mode, item.mode.replace("_", " ").capitalize())
+        if isinstance(item, dict):
+            if int(item.get("type", -1)) == evdev.ecodes.EV_REL:
+                return "Mouse movement"
+            title, _detail = _describe_passthrough_event(item)
+            return title
+        return "Action"
+
+    def _gap_step_label(self, items: tuple[object, ...]) -> str:
+        labels = list(dict.fromkeys(self._gap_item_label(item) for item in items))
+        if len(labels) <= 2:
+            return " + ".join(labels)
+        return f"{labels[0]} + {len(labels) - 1} more"
+
+    def _select_gap(self, gap: TimelineGap, x: float, y: float) -> None:
+        self._selected = None
+        self._selected_gap = gap
+        self._hover_gap = gap
+        self._suppressed_hover_gap = None
+        self._editor._on_selection_changed(None)
+        self.queue_draw()
+        self._show_gap_editor(gap, x, y)
+
+    def _show_gap_editor(self, gap: TimelineGap, x: float, y: float) -> None:
+        if self._gap_popover is not None:
+            self._gap_popover.popdown()
+
+        popover = Gtk.Popover()
+        self._gap_popover = popover
+
+        box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=8)
+        box.set_margin_top(10)
+        box.set_margin_bottom(10)
+        box.set_margin_start(10)
+        box.set_margin_end(10)
+
+        previous_label = self._gap_step_label(gap.previous_items)
+        next_label = self._gap_step_label(gap.next_items)
+        title = Gtk.Label(label=f"{previous_label} → {next_label}")
+        title.add_css_class("heading")
+        title.set_halign(Gtk.Align.START)
+        title.set_max_width_chars(38)
+        title.set_ellipsize(3)
+        box.append(title)
+
+        value_row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=6)
+        value_row.append(Gtk.Label(label="Gap:"))
+        spin = Gtk.SpinButton()
+        self._gap_spin = spin
+        spin.set_adjustment(
+            Gtk.Adjustment(
+                value=gap.duration_us / 1000.0,
+                lower=gap.minimum_us / 1000.0,
+                upper=3_600_000.0,
+                step_increment=1.0,
+                page_increment=10.0,
+            )
+        )
+        spin.set_digits(1)
+        spin.set_width_chars(8)
+        value_row.append(spin)
+        value_row.append(Gtk.Label(label="ms"))
+        box.append(value_row)
+
+        hint = Gtk.Label(label="Negative values create an overlap.")
+        hint.add_css_class("dim-label")
+        hint.add_css_class("caption")
+        hint.set_halign(Gtk.Align.START)
+        box.append(hint)
+
+        scope_label = Gtk.Label(label="Move:")
+        scope_label.set_halign(Gtk.Align.START)
+        box.append(scope_label)
+
+        next_only_check = Gtk.CheckButton(label="Next action only")
+        self._gap_next_only_check = next_only_check
+        next_only_check.set_active(True)
+        box.append(next_only_check)
+
+        track_following_check: Gtk.CheckButton | None = None
+        if gap.scope == "track":
+            track_check = Gtk.CheckButton(label="Following actions in this track")
+            track_check.set_group(next_only_check)
+            box.append(track_check)
+            track_following_check = track_check
+            self._gap_track_following_check = track_check
+
+        timeline_following_check = Gtk.CheckButton(label="Everything after this time")
+        self._gap_timeline_following_check = timeline_following_check
+        timeline_following_check.set_group(next_only_check)
+        box.append(timeline_following_check)
+
+        button_row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=6)
+        button_row.set_halign(Gtk.Align.END)
+        cancel_button = Gtk.Button(label="Cancel")
+        self._gap_cancel_button = cancel_button
+
+        def _cancel_gap(_button: Gtk.Button) -> None:
+            self.clear_gap_selection(suppress_hover=True)
+
+        cancel_button.connect("clicked", _cancel_gap)
+        button_row.append(cancel_button)
+        apply_button = Gtk.Button(label="Apply")
+        self._gap_apply_button = apply_button
+        apply_button.add_css_class("suggested-action")
+
+        def _apply_gap(_button: Gtk.Button) -> None:
+            target_us = int(round(spin.get_value() * 1000))
+            if track_following_check is not None and track_following_check.get_active():
+                move_scope = "track"
+            elif timeline_following_check.get_active():
+                move_scope = "timeline"
+            else:
+                move_scope = "next"
+            popover.popdown()
+            self._editor._edit_timeline_gap(
+                gap,
+                target_us,
+                move_scope=move_scope,
+            )
+
+        apply_button.connect("clicked", _apply_gap)
+        spin.connect("activate", _apply_gap)
+        button_row.append(apply_button)
+        box.append(button_row)
+
+        def _on_popover_closed(closed_popover: Gtk.Popover) -> None:
+            if self._gap_popover is closed_popover:
+                if self._selected_gap is gap:
+                    self._suppressed_hover_gap = gap
+                    self._selected_gap = None
+                if self._hover_gap is gap:
+                    self._hover_gap = None
+                self._gap_popover = None
+                self._gap_spin = None
+                self._gap_next_only_check = None
+                self._gap_track_following_check = None
+                self._gap_timeline_following_check = None
+                self._gap_cancel_button = None
+                self._gap_apply_button = None
+                self.queue_draw()
+            if closed_popover.get_parent() is self:
+                closed_popover.unparent()
+
+        popover.connect("closed", _on_popover_closed)
+        popover.set_child(box)
+        popover.set_parent(self)
+        rect = Gdk.Rectangle()
+        rect.x, rect.y, rect.width, rect.height = int(x), int(y), 1, 1
+        popover.set_pointing_to(rect)
+        if self.get_realized():
+            popover.popup()
+            spin.grab_focus()
+
     # ------------------------------------------------------------------
     # Gesture handlers
     # ------------------------------------------------------------------
@@ -469,11 +825,29 @@ class TimelineWidget(Gtk.DrawingArea):
         self._erase_x1 = None
         self._erase_pending = []
 
+    def _on_gap_click_pressed(
+        self,
+        _gesture: Gtk.GestureClick,
+        press_count: int,
+        x: float,
+        y: float,
+    ) -> None:
+        if press_count != 2 or self._editor._erase_mode or self._hit_test(x, y) is not None:
+            return
+        self._ensure_gap_cache()
+        gap = self._gap_at_position(x, y)
+        if gap is None:
+            return
+        self._gap_double_click_handled = True
+        self._select_gap(gap, x, y)
+
     def _on_drag_begin(self, gesture, start_x, start_y) -> None:
         # Always hit-test on press; actual movement only starts after threshold.
         hit = self._hit_test(start_x, start_y)
         self._drag_selected_obj = hit
+        self._drag_selected_gap = None
         self._drag_start_x = float(start_x)
+        self._drag_start_y = float(start_y)
         self._drag_scroll_origin = self._scroll_offset
         self._drag_last_offset_x = 0.0
         self._stop_autoscroll()
@@ -488,6 +862,10 @@ class TimelineWidget(Gtk.DrawingArea):
             self._drag_control = None
             self._in_drag = False
             return
+        if hit is not None:
+            self.clear_gap_selection()
+        elif not self._editor._drag_locked and self._gap_popover is None:
+            self._drag_selected_gap = self._gap_at_position(start_x, start_y)
         self._drag_event = hit if isinstance(hit, EditableEvent) else None
         self._drag_move = hit if isinstance(hit, EditableMove) else None
         self._drag_control = hit if isinstance(hit, EditableControl) else None
@@ -512,6 +890,11 @@ class TimelineWidget(Gtk.DrawingArea):
             self._drag_last_offset_x = float(offset_x)
             self._apply_erase_band()
             self._update_autoscroll(self._drag_start_x + float(offset_x))
+            return
+        if self._drag_selected_gap is not None:
+            if abs(offset_x) >= 4 or abs(offset_y) >= 4:
+                self._drag_selected_gap = None
+                self._in_drag = True
             return
         if (
             self._drag_event is None and self._drag_move is None and self._drag_control is None
@@ -655,13 +1038,26 @@ class TimelineWidget(Gtk.DrawingArea):
             self._editor._refresh_after_timing_edit()
         elif not self._in_drag:
             selected_obj = self._drag_selected_obj
-            if selected_obj is not self._selected:
+            selected_gap = self._drag_selected_gap
+            if self._gap_double_click_handled:
+                pass
+            elif selected_gap is not None:
+                self._select_gap(selected_gap, self._drag_start_x, self._drag_start_y)
+            else:
+                self.clear_gap_selection()
+            if (
+                not self._gap_double_click_handled
+                and selected_gap is None
+                and selected_obj is not self._selected
+            ):
                 self._selected = selected_obj
                 self._editor._on_selection_changed(selected_obj)
         self._drag_event = None
         self._drag_move = None
         self._drag_control = None
         self._drag_selected_obj = None
+        self._drag_selected_gap = None
+        self._gap_double_click_handled = False
         self._in_drag = False
         self.queue_draw()
 
@@ -710,11 +1106,30 @@ class TimelineWidget(Gtk.DrawingArea):
     def _on_pointer_motion(self, controller, x, y) -> None:
         self._hover_x = x
         self._hover_y = y
+        gaps_visible = not self._editor._erase_mode and not self._editor._drag_locked
+        candidate = (
+            self._gap_at_position(x, y)
+            if gaps_visible and self._hit_test(x, y) is None
+            else None
+        )
+        if candidate is not None and candidate == self._suppressed_hover_gap:
+            candidate = None
+        elif candidate != self._suppressed_hover_gap:
+            self._suppressed_hover_gap = None
+        self._hover_gap = candidate
+        if gaps_visible:
+            self.set_cursor_from_name("pointer" if self._hover_gap is not None else None)
+        elif not self._editor._erase_mode:
+            self.set_cursor_from_name(None)
         self.queue_draw()
 
     def _on_pointer_leave(self, controller) -> None:
         self._hover_x = None
         self._hover_y = None
+        self._hover_gap = None
+        self._suppressed_hover_gap = None
+        if not self._editor._erase_mode:
+            self.set_cursor_from_name(None)
         self.queue_draw()
 
     def _on_scroll(self, controller, dx, dy) -> bool:

--- a/keymasq/gui/widgets/macro_editor/timeline_render.py
+++ b/keymasq/gui/widgets/macro_editor/timeline_render.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 
 import evdev
 
+from keymasq.gui.widgets.macro_editor.gaps import TimelineGap
 from keymasq.gui.widgets.macro_editor.model import (
     EditableControl,
     EditableEvent,
@@ -34,6 +35,8 @@ class TimelineRenderState:
     _hover_x: float | None
     _hover_y: float | None
     _context_menu_x: float | None
+    _hover_gap: TimelineGap | None
+    _selected_gap: TimelineGap | None
     events: list[EditableEvent]
     rel_events: list[MacroEvent]
     passthrough_events: list[MacroEvent]
@@ -200,6 +203,7 @@ def draw(cr, state: TimelineRenderState, width: int, height: int) -> None:
     state._draw_passthrough_markers(cr, width)
     state._draw_synthetic_move_markers(cr, width)
     state._draw_control_markers(cr, width)
+    _draw_gap_feedback(cr, state, width, height)
     _draw_erase_band(cr, state, width)
     state._draw_labels(cr, height)
     state._draw_pointer_guide(cr, width, height)
@@ -816,11 +820,111 @@ def _draw_erase_band(cr, state: TimelineRenderState, width: int) -> None:
     cr.show_text(label)
 
 
+def _draw_gap_feedback(
+    cr,
+    state: TimelineRenderState,
+    width: int,
+    height: int,
+) -> None:
+    gap = state._selected_gap or state._hover_gap
+    if gap is None:
+        return
+
+    boundary_x = state._time_to_x(gap.previous_end_us)
+    next_x = state._time_to_x(gap.next_start_us)
+    x0 = max(min(boundary_x, next_x), float(state.LABEL_WIDTH))
+    x1 = min(max(boundary_x, next_x), float(width))
+    if x1 < state.LABEL_WIDTH or x0 > width:
+        return
+
+    selected = gap is state._selected_gap
+    overlap = gap.duration_us < 0
+    color = (1.0, 0.56, 0.24) if overlap else (0.48, 0.72, 1.0)
+    span_width = max(x1 - x0, 1.0)
+    feedback_y, feedback_h = _gap_feedback_bounds(state, gap, height)
+    feedback_bottom = feedback_y + feedback_h
+
+    cr.set_source_rgba(*color, 0.13 if selected else 0.08)
+    cr.rectangle(x0, feedback_y, span_width, feedback_h)
+    cr.fill()
+
+    cr.set_source_rgba(*color, 0.92 if selected else 0.68)
+    cr.set_line_width(1.5 if selected else 1.0)
+    for x in (boundary_x, next_x):
+        if state.LABEL_WIDTH <= x <= width:
+            cr.move_to(x + 0.5, feedback_y)
+            cr.line_to(x + 0.5, feedback_bottom)
+            cr.stroke()
+
+    hover_y = state._hover_y
+    bracket_y = (
+        float(hover_y)
+        if hover_y is not None and feedback_y <= hover_y <= feedback_bottom
+        else feedback_y + feedback_h / 2
+    )
+    bracket_y = min(max(bracket_y, feedback_y + 8.0), feedback_bottom - 8.0)
+    cr.move_to(x0, bracket_y + 0.5)
+    cr.line_to(x1, bracket_y + 0.5)
+    cr.stroke()
+    for x in (x0, x1):
+        cr.move_to(x + 0.5, bracket_y - 4.0)
+        cr.line_to(x + 0.5, bracket_y + 5.0)
+        cr.stroke()
+
+    label = _format_time_us(gap.duration_us)
+
+    cr.select_font_face("monospace", 0, 0)
+    cr.set_font_size(10)
+    extents = cr.text_extents(label)
+    pad_x = 6.0
+    pad_y = 3.0
+    bubble_w = extents[2] + pad_x * 2
+    bubble_h = extents[3] + pad_y * 2
+    bubble_x = (boundary_x + next_x - bubble_w) / 2
+    bubble_x = min(max(bubble_x, state.LABEL_WIDTH + 4.0), width - bubble_w - 4.0)
+    bubble_y = min(
+        max(bracket_y - bubble_h - 7.0, feedback_y + 2.0),
+        feedback_bottom - bubble_h - 2.0,
+    )
+
+    cr.set_source_rgba(0.08, 0.08, 0.08, 0.94)
+    cr.rectangle(bubble_x, bubble_y, bubble_w, bubble_h)
+    cr.fill()
+    cr.set_source_rgba(*color, 0.98)
+    cr.rectangle(bubble_x + 0.5, bubble_y + 0.5, bubble_w - 1.0, bubble_h - 1.0)
+    cr.stroke()
+    cr.move_to(bubble_x + pad_x - extents[0], bubble_y + pad_y - extents[1])
+    cr.show_text(label)
+
+
+def _gap_feedback_bounds(
+    state: TimelineRenderState,
+    gap: TimelineGap,
+    height: int,
+) -> tuple[float, float]:
+    if gap.scope != "track" or gap.track is None:
+        return float(state.RULER_HEIGHT), float(height - state.RULER_HEIGHT)
+
+    if gap.track == "keyboard":
+        return float(state._kb_y), float(state._kb_track_h)
+    if gap.track == "mouse":
+        return float(state._m_y), float(state._m_track_h)
+    if gap.track == "gamepad":
+        return float(state._g_y), float(state._g_track_h)
+    if gap.track == "movement":
+        return float(state._wave_y), state.TRACK_HEIGHT / 2
+    if gap.track == "control":
+        return state._wave_y + state.TRACK_HEIGHT / 2, state.TRACK_HEIGHT / 2
+    return float(state.RULER_HEIGHT), float(height - state.RULER_HEIGHT)
+
+
 def _draw_pointer_guide(cr, state: TimelineRenderState, width: int, height: int) -> None:
     if state._context_menu_x is not None:
         state._draw_vertical_guide(cr, width, height, float(state._context_menu_x))
 
     if state._hover_x is None or state._hover_y is None:
+        return
+    if state._hover_gap is not None:
         return
 
     x = float(state._hover_x)

--- a/tests/gui/test_macro_editor_gap_widget.py
+++ b/tests/gui/test_macro_editor_gap_widget.py
@@ -102,6 +102,54 @@ def test_timeline_gap_editor_can_move_next_and_later_actions(monkeypatch) -> Non
     assert [gap.duration_us for gap in timeline._gap_segments] == [100_000, 600_000]
 
 
+def test_gap_edit_preserves_explicit_trailing_duration(monkeypatch) -> None:
+    dialog = _build_macro_dialog(monkeypatch)
+    first = _key(evdev.ecodes.KEY_A, 0, 100_000)
+    second = _key(evdev.ecodes.KEY_B, 300_000, 400_000)
+    dialog._events = [first, second]
+    dialog._duration_us = 1_000_000
+    dialog._update_stats()
+    dialog._lock_btn.set_active(False)
+    gap = dialog._timeline._track_gaps["keyboard"][0]
+
+    dialog._edit_timeline_gap(gap, 100_000, move_scope="next")
+
+    assert dialog._duration_us == 1_000_000
+
+
+def test_timeline_gap_edit_moves_explicit_trailing_duration(monkeypatch) -> None:
+    dialog = _build_macro_dialog(monkeypatch)
+    first = _key(evdev.ecodes.KEY_A, 0, 100_000)
+    second = _key(evdev.ecodes.KEY_B, 300_000, 400_000)
+    dialog._events = [first, second]
+    dialog._duration_us = 1_000_000
+    dialog._update_stats()
+    dialog._lock_btn.set_active(False)
+    gap = dialog._timeline._track_gaps["keyboard"][0]
+
+    dialog._edit_timeline_gap(gap, 100_000, move_scope="timeline")
+
+    assert dialog._duration_us == 900_000
+
+
+def test_gap_editor_accepts_gaps_longer_than_one_hour(monkeypatch) -> None:
+    dialog = _build_macro_dialog(monkeypatch)
+    first = _key(evdev.ecodes.KEY_A, 0, 100_000)
+    second = _key(evdev.ecodes.KEY_B, 3_700_100_000, 3_700_200_000)
+    dialog._events = [first, second]
+    dialog._duration_us = second.release_t_us
+    dialog._update_stats()
+    dialog._lock_btn.set_active(False)
+    timeline = dialog._timeline
+    gap = timeline._track_gaps["keyboard"][0]
+
+    timeline._select_gap(gap, 100.0, timeline._kb_y + 12)
+
+    assert timeline._gap_spin is not None
+    assert timeline._gap_spin.get_value() == pytest.approx(3_700_000.0)
+    assert timeline._gap_spin.get_adjustment().get_upper() > 3_700_000.0
+
+
 def test_hover_uses_next_track_action_instead_of_rendered_sublane(
     monkeypatch,
 ) -> None:

--- a/tests/gui/test_macro_editor_gap_widget.py
+++ b/tests/gui/test_macro_editor_gap_widget.py
@@ -132,6 +132,32 @@ def test_timeline_gap_edit_moves_explicit_trailing_duration(monkeypatch) -> None
     assert dialog._duration_us == 900_000
 
 
+def test_timeline_gap_edit_does_not_add_silence_past_unchanged_hold(
+    monkeypatch,
+) -> None:
+    dialog = _build_macro_dialog(monkeypatch)
+    long_hold = _key(evdev.ecodes.KEY_LEFTCTRL, 0, 10_000_000)
+    nested_tap = _key(evdev.ecodes.KEY_A, 1_000_000, 1_100_000)
+    dialog._events = [long_hold, nested_tap]
+    dialog._duration_us = long_hold.release_t_us
+    dialog._update_stats()
+    dialog._lock_btn.set_active(False)
+    gap = dialog._timeline._gap_segments[0]
+
+    dialog._edit_timeline_gap(
+        gap,
+        gap.duration_us + 1_000_000,
+        move_scope="timeline",
+    )
+
+    assert (long_hold.press_t_us, long_hold.release_t_us) == (0, 10_000_000)
+    assert (nested_tap.press_t_us, nested_tap.release_t_us) == (
+        2_000_000,
+        2_100_000,
+    )
+    assert dialog._duration_us == 10_000_000
+
+
 def test_gap_editor_accepts_gaps_longer_than_one_hour(monkeypatch) -> None:
     dialog = _build_macro_dialog(monkeypatch)
     first = _key(evdev.ecodes.KEY_A, 0, 100_000)

--- a/tests/gui/test_macro_editor_gap_widget.py
+++ b/tests/gui/test_macro_editor_gap_widget.py
@@ -1,0 +1,301 @@
+# ruff: noqa: E402, I001
+
+import pytest
+
+gi = pytest.importorskip("gi")
+
+gi.require_version("Gtk", "4.0")
+gi.require_version("Adw", "1")
+
+import cairo
+import evdev
+
+from keymasq.gui.widgets.macro_editor.model import EditableControl, EditableEvent
+from tests.gui.macro_editor_dialog_support import _build_macro_dialog
+
+
+def _key(code: int, start_us: int, end_us: int) -> EditableEvent:
+    return EditableEvent(
+        device_type="keyboard",
+        ev_type=evdev.ecodes.EV_KEY,
+        code=code,
+        press_t_us=start_us,
+        release_t_us=end_us,
+    )
+
+
+def test_locked_timeline_hides_gaps_but_double_click_edits_next_action(
+    monkeypatch,
+) -> None:
+    dialog = _build_macro_dialog(monkeypatch)
+    first = _key(evdev.ecodes.KEY_A, 50_000, 100_000)
+    second = _key(evdev.ecodes.KEY_B, 300_000, 350_000)
+    third = _key(evdev.ecodes.KEY_C, 600_000, 650_000)
+    dialog._events = [first, second, third]
+    dialog._duration_us = 650_000
+    dialog._update_stats()
+    timeline = dialog._timeline
+
+    x = timeline._time_to_x(200_000)
+    y = timeline._kb_y + 12
+    timeline._on_pointer_motion(None, x, y)
+
+    assert timeline._gap_segments == []
+    assert timeline._hover_gap is None
+    state = timeline._build_render_state()
+    assert state._hover_gap is None
+
+    surface = cairo.ImageSurface(cairo.FORMAT_ARGB32, 800, 420)
+    context = cairo.Context(surface)
+    timeline._draw(None, context, 800, 420, None)
+
+    timeline._on_drag_begin(None, x, y)
+    timeline._on_drag_end(None, 0.0, 0.0)
+
+    assert timeline._selected_gap is None
+    assert timeline._gap_spin is None
+
+    timeline._on_gap_click_pressed(None, 2, x, y)
+
+    assert timeline._selected_gap is not None
+    assert timeline._selected is None
+    assert dialog._revealer.get_reveal_child() is False
+    assert timeline._gap_spin is not None
+    assert timeline._gap_spin.get_value() == pytest.approx(200.0)
+    assert timeline._gap_apply_button is not None
+
+    timeline._gap_spin.set_value(50.0)
+    timeline._gap_apply_button.emit("clicked")
+
+    assert (second.press_t_us, second.release_t_us) == (150_000, 200_000)
+    assert (third.press_t_us, third.release_t_us) == (600_000, 650_000)
+    assert dialog._duration_us == 650_000
+    assert timeline._selected_gap is None
+
+
+def test_timeline_gap_editor_can_move_next_and_later_actions(monkeypatch) -> None:
+    dialog = _build_macro_dialog(monkeypatch)
+    first = _key(evdev.ecodes.KEY_A, 0, 100_000)
+    second = _key(evdev.ecodes.KEY_B, 300_000, 400_000)
+    third = _key(evdev.ecodes.KEY_C, 1_000_000, 1_100_000)
+    dialog._events = [first, second, third]
+    dialog._duration_us = 1_100_000
+    dialog._update_stats()
+    timeline = dialog._timeline
+    dialog._lock_btn.set_active(False)
+    gap = timeline._track_gaps["keyboard"][0]
+
+    timeline._select_gap(gap, timeline._time_to_x(200_000), timeline._kb_y + 12)
+
+    assert timeline._gap_spin is not None
+    assert timeline._gap_next_only_check is not None
+    assert timeline._gap_next_only_check.get_active() is True
+    assert timeline._gap_track_following_check is not None
+    assert timeline._gap_timeline_following_check is not None
+    assert timeline._gap_apply_button is not None
+    timeline._gap_spin.set_value(100.0)
+    timeline._gap_timeline_following_check.set_active(True)
+    timeline._gap_apply_button.emit("clicked")
+
+    assert (second.press_t_us, second.release_t_us) == (200_000, 300_000)
+    assert (third.press_t_us, third.release_t_us) == (900_000, 1_000_000)
+    assert [gap.duration_us for gap in timeline._gap_segments] == [100_000, 600_000]
+
+
+def test_hover_uses_next_track_action_instead_of_rendered_sublane(
+    monkeypatch,
+) -> None:
+    dialog = _build_macro_dialog(monkeypatch)
+    long_hold = _key(evdev.ecodes.KEY_LEFTCTRL, 0, 1_000_000)
+    key_a = _key(evdev.ecodes.KEY_A, 100_000, 250_000)
+    parallel_key = _key(evdev.ecodes.KEY_S, 150_000, 180_000)
+    key_d = _key(evdev.ecodes.KEY_D, 300_000, 350_000)
+    key_w = _key(evdev.ecodes.KEY_W, 500_000, 550_000)
+    dialog._events = [long_hold, key_a, parallel_key, key_d, key_w]
+    dialog._duration_us = 1_000_000
+    dialog._update_stats()
+    timeline = dialog._timeline
+    dialog._lock_btn.set_active(False)
+
+    timeline._recompute_lanes()
+    lane_h = timeline._kb_track_h / timeline._kb_num_lanes
+    x = timeline._time_to_x(240_000)
+    empty_sublane_y = timeline._kb_y + lane_h * 2.5
+    timeline._on_pointer_motion(None, x, empty_sublane_y)
+
+    assert timeline._hover_gap is not None
+    assert timeline._hover_gap.scope == "track"
+    assert timeline._hover_gap.track == "keyboard"
+    assert timeline._hover_gap.previous_items == (parallel_key,)
+    assert timeline._hover_gap.next_items == (key_d,)
+    assert timeline._hover_gap.duration_us == 120_000
+
+    timeline._on_drag_begin(None, x, empty_sublane_y)
+    timeline._on_drag_end(None, 0.0, 0.0)
+    assert timeline._gap_spin is not None
+    assert timeline._gap_track_following_check is not None
+    assert timeline._gap_apply_button is not None
+    timeline._gap_spin.set_value(50.0)
+    timeline._gap_track_following_check.set_active(True)
+    timeline._gap_apply_button.emit("clicked")
+
+    assert (key_d.press_t_us, key_d.release_t_us) == (230_000, 280_000)
+    assert (key_w.press_t_us, key_w.release_t_us) == (430_000, 480_000)
+    assert (long_hold.press_t_us, long_hold.release_t_us) == (0, 1_000_000)
+    assert (key_a.press_t_us, key_a.release_t_us) == (100_000, 250_000)
+    assert (parallel_key.press_t_us, parallel_key.release_t_us) == (150_000, 180_000)
+
+
+def test_wait_controls_have_local_gaps_in_the_control_row(monkeypatch) -> None:
+    dialog = _build_macro_dialog(monkeypatch)
+    first_wait = EditableControl(mode="wait", t_us=100_000, duration_us=50_000)
+    second_wait = EditableControl(mode="wait", t_us=300_000, duration_us=50_000)
+    dialog._control_events = [first_wait, second_wait]
+    dialog._duration_us = 350_000
+    dialog._update_stats()
+    timeline = dialog._timeline
+    dialog._lock_btn.set_active(False)
+
+    timeline._on_pointer_motion(
+        None,
+        timeline._time_to_x(200_000),
+        timeline._wave_y + timeline.TRACK_HEIGHT * 0.75,
+    )
+
+    assert timeline._hover_gap is not None
+    assert timeline._hover_gap.scope == "track"
+    assert timeline._hover_gap.track == "control"
+    assert timeline._hover_gap.previous_items == (first_wait,)
+    assert timeline._hover_gap.next_items == (second_wait,)
+    assert timeline._hover_gap.duration_us == 200_000
+
+
+def test_ruler_gaps_ignore_raw_movement_and_passthrough_events(monkeypatch) -> None:
+    dialog = _build_macro_dialog(monkeypatch)
+    first = _key(evdev.ecodes.KEY_A, 0, 100_000)
+    second = _key(evdev.ecodes.KEY_B, 500_000, 600_000)
+    dialog._events = [first, second]
+    dialog._rel_events = [
+        {
+            "device_type": "mouse",
+            "type": evdev.ecodes.EV_REL,
+            "code": evdev.ecodes.REL_X,
+            "value": 4,
+            "t_us": 250_000,
+        }
+    ]
+    dialog._passthrough_events = [
+        {
+            "device_type": "keyboard",
+            "type": evdev.ecodes.EV_KEY,
+            "code": evdev.ecodes.KEY_A,
+            "value": 2,
+            "t_us": 50_000,
+        },
+        {
+            "device_type": "other",
+            "type": evdev.ecodes.EV_MSC,
+            "code": evdev.ecodes.MSC_SCAN,
+            "value": 1,
+            "t_us": 350_000,
+        },
+    ]
+    dialog._duration_us = 600_000
+    dialog._update_stats()
+    timeline = dialog._timeline
+    dialog._lock_btn.set_active(False)
+
+    timeline._on_pointer_motion(None, timeline._time_to_x(300_000), 10.0)
+
+    assert timeline._hover_gap is not None
+    assert timeline._hover_gap.scope == "timeline"
+    assert timeline._hover_gap.previous_items == (first,)
+    assert timeline._hover_gap.next_items == (second,)
+    assert timeline._hover_gap.duration_us == 400_000
+
+
+def test_unlocked_move_mode_shows_gaps_and_cancel_clears_the_display(monkeypatch) -> None:
+    dialog = _build_macro_dialog(monkeypatch)
+    first = _key(evdev.ecodes.KEY_A, 0, 100_000)
+    second = _key(evdev.ecodes.KEY_B, 300_000, 400_000)
+    dialog._events = [first, second]
+    dialog._duration_us = 400_000
+    dialog._update_stats()
+    timeline = dialog._timeline
+    dialog._lock_btn.set_active(False)
+
+    x = timeline._time_to_x(200_000)
+    y = timeline._kb_y + 12
+    timeline._on_pointer_motion(None, x, y)
+
+    assert timeline._hover_gap is not None
+    assert timeline._hover_gap.duration_us == 200_000
+
+    timeline._on_drag_begin(None, x, y)
+    timeline._on_drag_end(None, 0.0, 0.0)
+
+    assert timeline._selected_gap is not None
+    assert timeline._gap_cancel_button is not None
+    timeline._gap_cancel_button.emit("clicked")
+
+    assert timeline._selected_gap is None
+    assert timeline._hover_gap is None
+    timeline._on_pointer_motion(None, x, y)
+    assert timeline._hover_gap is None
+
+    dialog._lock_btn.set_active(True)
+    assert timeline._gap_segments == []
+    assert timeline._selected_gap is None
+
+
+def test_closing_gap_popover_clears_selection_and_widget_references(monkeypatch) -> None:
+    dialog = _build_macro_dialog(monkeypatch)
+    dialog._events = [
+        _key(evdev.ecodes.KEY_A, 0, 100_000),
+        _key(evdev.ecodes.KEY_B, 300_000, 400_000),
+    ]
+    dialog._duration_us = 400_000
+    dialog._update_stats()
+    timeline = dialog._timeline
+
+    timeline._on_gap_click_pressed(
+        None,
+        2,
+        timeline._time_to_x(200_000),
+        timeline._kb_y + 12,
+    )
+
+    popover = timeline._gap_popover
+    assert popover is not None
+    assert timeline._selected_gap is not None
+    popover.emit("closed")
+
+    assert timeline._gap_popover is None
+    assert timeline._gap_spin is None
+    assert timeline._gap_cancel_button is None
+    assert timeline._gap_apply_button is None
+    assert timeline._selected_gap is None
+    assert timeline._hover_gap is None
+
+
+def test_timeline_overlap_is_selectable_from_ruler(monkeypatch) -> None:
+    dialog = _build_macro_dialog(monkeypatch)
+    first = _key(evdev.ecodes.KEY_A, 0, 300_000)
+    second = _key(evdev.ecodes.KEY_B, 100_000, 180_000)
+    dialog._events = [first, second]
+    dialog._duration_us = 300_000
+    dialog._update_stats()
+    timeline = dialog._timeline
+    dialog._lock_btn.set_active(False)
+
+    overlap = timeline._gap_at_position(timeline._time_to_x(200_000), 10.0)
+
+    assert overlap is not None
+    assert overlap.duration_us == -200_000
+    assert (
+        timeline._gap_at_position(
+            timeline._time_to_x(200_000),
+            timeline._kb_y + 12,
+        )
+        is None
+    )

--- a/tests/gui/test_macro_editor_gaps.py
+++ b/tests/gui/test_macro_editor_gaps.py
@@ -124,6 +124,26 @@ def test_track_following_moves_only_later_events_from_that_track() -> None:
     assert (mouse_hold.press_t_us, mouse_hold.release_t_us) == (0, 1_000_000)
 
 
+def test_track_following_resolves_the_suffix_when_the_edit_is_applied() -> None:
+    key_a = _key(evdev.ecodes.KEY_A, 0, 100_000)
+    key_d = _key(evdev.ecodes.KEY_D, 300_000, 400_000)
+    gap = build_track_gaps([key_a, key_d], track="keyboard")[0]
+    later_key = _key(evdev.ecodes.KEY_W, 600_000, 700_000)
+
+    set_timeline_gap_track_following(
+        [key_a, key_d, later_key],
+        [],
+        [],
+        [],
+        [],
+        gap,
+        50_000,
+    )
+
+    assert (key_d.press_t_us, key_d.release_t_us) == (150_000, 250_000)
+    assert (later_key.press_t_us, later_key.release_t_us) == (450_000, 550_000)
+
+
 def test_setting_one_gap_and_following_moves_the_suffix_and_owned_repeats() -> None:
     first = _key(evdev.ecodes.KEY_A, 0, 100_000)
     second = _key(evdev.ecodes.KEY_B, 300_000, 500_000)

--- a/tests/gui/test_macro_editor_gaps.py
+++ b/tests/gui/test_macro_editor_gaps.py
@@ -7,7 +7,7 @@ from keymasq.gui.widgets.macro_editor.gaps import (
     set_timeline_gap_next_action,
     set_timeline_gap_track_following,
 )
-from keymasq.gui.widgets.macro_editor.model import EditableEvent, MacroEvent
+from keymasq.gui.widgets.macro_editor.model import EditableEvent, MacroEvent, parse_events
 
 
 def _key(code: int, start_us: int, end_us: int) -> EditableEvent:
@@ -241,3 +241,82 @@ def test_setting_one_gap_next_action_leaves_later_times_unchanged() -> None:
     )
     assert next(gap for gap in updated if gap.next_start_us == 150_000).duration_us == 50_000
     assert next(gap for gap in updated if gap.next_start_us == 800_000).duration_us == 450_000
+
+
+def test_repeat_ownership_uses_original_order_at_tied_boundaries() -> None:
+    raw_events: list[MacroEvent] = [
+        {
+            "device_type": "keyboard",
+            "type": evdev.ecodes.EV_KEY,
+            "code": evdev.ecodes.KEY_B,
+            "value": 1,
+            "t_us": 0,
+        },
+        {
+            "device_type": "keyboard",
+            "type": evdev.ecodes.EV_KEY,
+            "code": evdev.ecodes.KEY_B,
+            "value": 0,
+            "t_us": 100_000,
+        },
+        {
+            "device_type": "keyboard",
+            "type": evdev.ecodes.EV_KEY,
+            "code": evdev.ecodes.KEY_A,
+            "value": 1,
+            "t_us": 300_000,
+        },
+        {
+            "device_type": "keyboard",
+            "type": evdev.ecodes.EV_KEY,
+            "code": evdev.ecodes.KEY_A,
+            "value": 2,
+            "t_us": 400_000,
+        },
+        {
+            "device_type": "keyboard",
+            "type": evdev.ecodes.EV_KEY,
+            "code": evdev.ecodes.KEY_A,
+            "value": 0,
+            "t_us": 400_000,
+        },
+        {
+            "device_type": "keyboard",
+            "type": evdev.ecodes.EV_KEY,
+            "code": evdev.ecodes.KEY_A,
+            "value": 1,
+            "t_us": 400_000,
+        },
+        {
+            "device_type": "keyboard",
+            "type": evdev.ecodes.EV_KEY,
+            "code": evdev.ecodes.KEY_A,
+            "value": 2,
+            "t_us": 400_000,
+        },
+        {
+            "device_type": "keyboard",
+            "type": evdev.ecodes.EV_KEY,
+            "code": evdev.ecodes.KEY_A,
+            "value": 0,
+            "t_us": 500_000,
+        },
+    ]
+    events, rel_events, repeats, moves, controls = parse_events(raw_events)
+    gap = next(
+        gap
+        for gap in build_timeline_gaps(events, moves, controls)
+        if gap.next_start_us == 300_000
+    )
+
+    set_timeline_gap_next_action(
+        events,
+        rel_events,
+        repeats,
+        moves,
+        controls,
+        gap,
+        100_000,
+    )
+
+    assert [int(repeat["t_us"]) for repeat in repeats] == [300_000, 400_000]

--- a/tests/gui/test_macro_editor_gaps.py
+++ b/tests/gui/test_macro_editor_gaps.py
@@ -1,0 +1,223 @@
+import evdev
+
+from keymasq.gui.widgets.macro_editor.gaps import (
+    build_timeline_gaps,
+    build_track_gaps,
+    set_timeline_gap_and_following,
+    set_timeline_gap_next_action,
+    set_timeline_gap_track_following,
+)
+from keymasq.gui.widgets.macro_editor.model import EditableEvent, MacroEvent
+
+
+def _key(code: int, start_us: int, end_us: int) -> EditableEvent:
+    return EditableEvent(
+        device_type="keyboard",
+        ev_type=evdev.ecodes.EV_KEY,
+        code=code,
+        press_t_us=start_us,
+        release_t_us=end_us,
+    )
+
+
+def _mouse(code: int, start_us: int, end_us: int) -> EditableEvent:
+    return EditableEvent(
+        device_type="mouse",
+        ev_type=evdev.ecodes.EV_KEY,
+        code=code,
+        press_t_us=start_us,
+        release_t_us=end_us,
+    )
+
+
+def _repeat(code: int, t_us: int) -> MacroEvent:
+    return {
+        "device_type": "keyboard",
+        "type": evdev.ecodes.EV_KEY,
+        "code": code,
+        "value": 2,
+        "t_us": t_us,
+    }
+
+
+def _rel(t_us: int) -> MacroEvent:
+    return {
+        "device_type": "mouse",
+        "type": evdev.ecodes.EV_REL,
+        "code": evdev.ecodes.REL_X,
+        "value": 4,
+        "t_us": t_us,
+    }
+
+
+def test_timeline_gaps_group_chords_and_use_latest_active_end() -> None:
+    ctrl = _key(evdev.ecodes.KEY_LEFTCTRL, 0, 300_000)
+    key_a = _key(evdev.ecodes.KEY_A, 0, 80_000)
+    key_b = _key(evdev.ecodes.KEY_B, 100_000, 180_000)
+    key_c = _key(evdev.ecodes.KEY_C, 500_000, 580_000)
+
+    gaps = build_timeline_gaps([ctrl, key_a, key_b, key_c], [], [])
+
+    assert len(gaps) == 2
+    assert gaps[0].previous_items == (ctrl, key_a)
+    assert gaps[0].duration_us == -200_000
+    assert gaps[0].minimum_us == -300_000
+    assert gaps[1].previous_items == (ctrl, key_a)
+    assert gaps[1].previous_end_us == 300_000
+    assert gaps[1].duration_us == 200_000
+    assert gaps[1].minimum_us == -200_000
+
+
+def test_track_gap_ignores_holds_in_other_tracks() -> None:
+    key_a = _key(evdev.ecodes.KEY_A, 0, 100_000)
+    key_d = _key(evdev.ecodes.KEY_D, 300_000, 400_000)
+    mouse_hold = _mouse(evdev.ecodes.BTN_LEFT, 0, 1_000_000)
+
+    track_gap = build_track_gaps(
+        [key_a, key_d],
+        track="keyboard",
+    )[0]
+    global_gaps = build_timeline_gaps([key_a, key_d, mouse_hold], [], [])
+
+    assert track_gap.scope == "track"
+    assert track_gap.duration_us == 200_000
+    assert all(gap.duration_us <= 0 for gap in global_gaps)
+
+
+def test_track_gaps_follow_chronology_instead_of_rendered_sublanes() -> None:
+    long_hold = _key(evdev.ecodes.KEY_LEFTCTRL, 0, 1_000_000)
+    first = _key(evdev.ecodes.KEY_A, 100_000, 250_000)
+    parallel = _key(evdev.ecodes.KEY_S, 150_000, 180_000)
+    next_action = _key(evdev.ecodes.KEY_D, 300_000, 350_000)
+
+    gaps = build_track_gaps(
+        [long_hold, first, parallel, next_action],
+        track="keyboard",
+    )
+
+    gap_before_next = gaps[-1]
+    assert gap_before_next.previous_items == (parallel,)
+    assert gap_before_next.next_items == (next_action,)
+    assert gap_before_next.duration_us == 120_000
+
+
+def test_track_following_moves_only_later_events_from_that_track() -> None:
+    key_a = _key(evdev.ecodes.KEY_A, 0, 100_000)
+    key_d = _key(evdev.ecodes.KEY_D, 300_000, 400_000)
+    key_w = _key(evdev.ecodes.KEY_W, 600_000, 700_000)
+    overlapping_key = _key(evdev.ecodes.KEY_S, 50_000, 500_000)
+    mouse_hold = _mouse(evdev.ecodes.BTN_LEFT, 0, 1_000_000)
+    events = [key_a, overlapping_key, key_d, key_w, mouse_hold]
+    gap = build_track_gaps(
+        [key_a, key_d, key_w],
+        track="keyboard",
+    )[0]
+
+    assert (
+        set_timeline_gap_track_following(events, [], [], [], [], gap, 50_000)
+        == -150_000
+    )
+
+    assert (key_d.press_t_us, key_d.release_t_us) == (150_000, 250_000)
+    assert (key_w.press_t_us, key_w.release_t_us) == (450_000, 550_000)
+    assert (overlapping_key.press_t_us, overlapping_key.release_t_us) == (50_000, 500_000)
+    assert (mouse_hold.press_t_us, mouse_hold.release_t_us) == (0, 1_000_000)
+
+
+def test_setting_one_gap_and_following_moves_the_suffix_and_owned_repeats() -> None:
+    first = _key(evdev.ecodes.KEY_A, 0, 100_000)
+    second = _key(evdev.ecodes.KEY_B, 300_000, 500_000)
+    third = _key(evdev.ecodes.KEY_C, 800_000, 900_000)
+    first_repeat = _repeat(evdev.ecodes.KEY_A, 50_000)
+    second_repeat = _repeat(evdev.ecodes.KEY_B, 400_000)
+    movement = _rel(700_000)
+    passthrough = [first_repeat, second_repeat]
+    gaps = build_timeline_gaps(
+        [first, second, third],
+        [],
+        [],
+    )
+    gap_before_second = next(gap for gap in gaps if gap.next_start_us == 300_000)
+
+    assert (
+        set_timeline_gap_and_following(
+            [first, second, third],
+            [movement],
+            passthrough,
+            [],
+            [],
+            gap_before_second,
+            50_000,
+        )
+        == -150_000
+    )
+
+    assert (first.press_t_us, first.release_t_us) == (0, 100_000)
+    assert (second.press_t_us, second.release_t_us) == (150_000, 350_000)
+    assert (third.press_t_us, third.release_t_us) == (650_000, 750_000)
+    assert first_repeat["t_us"] == 50_000
+    assert second_repeat["t_us"] == 250_000
+    assert movement["t_us"] == 550_000
+
+    updated = build_timeline_gaps(
+        [first, second, third],
+        [],
+        [],
+    )
+    assert next(gap for gap in updated if gap.next_start_us == 150_000).duration_us == 50_000
+
+
+def test_setting_overlap_is_clamped_before_step_order_can_reverse() -> None:
+    first = _key(evdev.ecodes.KEY_A, 0, 100_000)
+    second = _key(evdev.ecodes.KEY_B, 300_000, 400_000)
+    gap = build_timeline_gaps([first, second], [], [])[0]
+
+    assert (
+        set_timeline_gap_next_action(
+            [first, second], [], [], [], [], gap, -500_000
+        )
+        == -300_000
+    )
+    assert second.press_t_us == first.press_t_us
+    assert second.release_t_us == 100_000
+
+
+def test_setting_one_gap_next_action_leaves_later_times_unchanged() -> None:
+    first = _key(evdev.ecodes.KEY_A, 0, 100_000)
+    second = _key(evdev.ecodes.KEY_B, 300_000, 500_000)
+    third = _key(evdev.ecodes.KEY_C, 800_000, 900_000)
+    second_repeat = _repeat(evdev.ecodes.KEY_B, 400_000)
+    movement = _rel(700_000)
+    passthrough = [second_repeat]
+    gaps = build_timeline_gaps(
+        [first, second, third],
+        [],
+        [],
+    )
+    gap_before_second = next(gap for gap in gaps if gap.next_start_us == 300_000)
+
+    assert (
+        set_timeline_gap_next_action(
+            [first, second, third],
+            [movement],
+            passthrough,
+            [],
+            [],
+            gap_before_second,
+            50_000,
+        )
+        == -150_000
+    )
+
+    assert (first.press_t_us, first.release_t_us) == (0, 100_000)
+    assert (second.press_t_us, second.release_t_us) == (150_000, 350_000)
+    assert second_repeat["t_us"] == 250_000
+    assert movement["t_us"] == 700_000
+    assert (third.press_t_us, third.release_t_us) == (800_000, 900_000)
+    updated = build_timeline_gaps(
+        [first, second, third],
+        [],
+        [],
+    )
+    assert next(gap for gap in updated if gap.next_start_us == 150_000).duration_us == 50_000
+    assert next(gap for gap in updated if gap.next_start_us == 800_000).duration_us == 450_000

--- a/tests/gui/test_macro_editor_gaps.py
+++ b/tests/gui/test_macro_editor_gaps.py
@@ -7,7 +7,12 @@ from keymasq.gui.widgets.macro_editor.gaps import (
     set_timeline_gap_next_action,
     set_timeline_gap_track_following,
 )
-from keymasq.gui.widgets.macro_editor.model import EditableEvent, MacroEvent, parse_events
+from keymasq.gui.widgets.macro_editor.model import (
+    EditableEvent,
+    EditableMove,
+    MacroEvent,
+    parse_events,
+)
 
 
 def _key(code: int, start_us: int, end_us: int) -> EditableEvent:
@@ -142,6 +147,56 @@ def test_track_following_resolves_the_suffix_when_the_edit_is_applied() -> None:
 
     assert (key_d.press_t_us, key_d.release_t_us) == (150_000, 250_000)
     assert (later_key.press_t_us, later_key.release_t_us) == (450_000, 550_000)
+
+
+def test_track_following_moves_unowned_raw_events_from_the_same_track() -> None:
+    key_a = _key(evdev.ecodes.KEY_A, 0, 400_000)
+    key_d = _key(evdev.ecodes.KEY_D, 300_000, 350_000)
+    gap = build_track_gaps([key_a, key_d], track="keyboard")[0]
+    owned_repeat = _repeat(evdev.ecodes.KEY_A, 350_000)
+    unowned_repeat = _repeat(evdev.ecodes.KEY_B, 320_000)
+    mouse_raw: MacroEvent = {
+        "device_type": "mouse",
+        "type": evdev.ecodes.EV_KEY,
+        "code": evdev.ecodes.BTN_RIGHT,
+        "value": 2,
+        "t_us": 330_000,
+    }
+
+    set_timeline_gap_track_following(
+        [key_a, key_d],
+        [],
+        [owned_repeat, unowned_repeat, mouse_raw],
+        [],
+        [],
+        gap,
+        -50_000,
+    )
+
+    assert (key_d.press_t_us, key_d.release_t_us) == (350_000, 400_000)
+    assert owned_repeat["t_us"] == 350_000
+    assert unowned_repeat["t_us"] == 370_000
+    assert mouse_raw["t_us"] == 330_000
+
+
+def test_movement_track_following_moves_later_raw_samples() -> None:
+    first = EditableMove(mode="rel", t_us=0, x=1, y=2)
+    second = EditableMove(mode="rel", t_us=300_000, x=3, y=4)
+    movement_sample = _rel(400_000)
+    gap = build_track_gaps([first, second], track="movement")[0]
+
+    set_timeline_gap_track_following(
+        [],
+        [movement_sample],
+        [],
+        [first, second],
+        [],
+        gap,
+        100_000,
+    )
+
+    assert second.t_us == 100_000
+    assert movement_sample["t_us"] == 200_000
 
 
 def test_setting_one_gap_and_following_moves_the_suffix_and_owned_repeats() -> None:


### PR DESCRIPTION
## Summary

- add a timeline-native editor for individual gaps without introducing a second macro editing mode
- provide semantic per-track gaps and macro-wide ruler gaps while ignoring raw movement and passthrough samples as ruler boundaries
- keep repeat markers and raw events aligned when timing changes move their owning action or the timeline suffix

Closes #233

## Testing

- [x] `./scripts/check.sh`
- [x] Required VM suites per `docs/VM_TESTING.md` ran and passed.
  - Suites run: `scripts/check-doc-screenshots`
  - Suites skipped, with reason: no daemon/session or compositor runtime suites apply to this GUI-only change
- [x] GUI changes: `scripts/check-doc-screenshots` passed, or the regenerated screenshots are part of this PR / not applicable
- [x] Other testing: 669 GUI tests passed, including new gap calculation and GTK interaction coverage

## Notes

- packaging impact: none
- service or security impact: none
- GUI impact: gap editing is integrated into the timeline Move mode; locked timelines retain a double-click shortcut on empty gaps