### PR TITLE
Advertise BTN_TASK on virtual mouse

### DIFF
--- a/docs/ACTIONS.md
+++ b/docs/ACTIONS.md
@@ -198,8 +198,8 @@ Linux input key codes such as `key_playpause`, `key_play`, or `key_nextsong`.
 
 ### Mouse Buttons
 
-Map to a mouse button press: Left, Right, Middle, Side, Extra, Forward, or
-Back.
+Map to a mouse button press: Left, Right, Middle, Side, Extra, Forward, Back,
+or Task (`btn_task`).
 
 Mouse wheel directions can also be remapped from the device tab when the
 hardware profile contains wheel inputs. Keymasq treats each wheel tick as a

--- a/docs/DAEMON_SESSION_INTEGRATION_TEST.md
+++ b/docs/DAEMON_SESSION_INTEGRATION_TEST.md
@@ -26,7 +26,7 @@ coverage. It verifies that the core runtime classes still work together:
 - profile toggle, priority override, passthrough override, and held-output profile change
 - temporary profile activations across direct mappings, temporary toggles, superkeys, overload
   superkeys, combos, and combo-bound overload superkeys
-- mouse button, relative movement, wheel, and mouse combo output
+- standard and `BTN_TASK` mouse buttons, relative movement, wheel, and mouse combo output
 - gamepad button and analog axis output
 - emergency reset
 - capture, combo capture, recording save, and playback

--- a/keymasq/keymasqd/runtime/outputs.py
+++ b/keymasq/keymasqd/runtime/outputs.py
@@ -105,6 +105,7 @@ class _Ecodes(Protocol):
     BTN_EXTRA: Final[int]
     BTN_FORWARD: Final[int]
     BTN_BACK: Final[int]
+    BTN_TASK: Final[int]
     REL_X: Final[int]
     REL_Y: Final[int]
     REL_WHEEL: Final[int]
@@ -398,6 +399,7 @@ def create_global_uinputs(
                 evdev_mod.ecodes.BTN_EXTRA,
                 evdev_mod.ecodes.BTN_FORWARD,
                 evdev_mod.ecodes.BTN_BACK,
+                evdev_mod.ecodes.BTN_TASK,
             ],
             evdev_mod.ecodes.EV_REL: [
                 evdev_mod.ecodes.REL_X,

--- a/nix/daemon-session-integration-test/fixtures/profiles/core-smoke.toml
+++ b/nix/daemon-session-integration-test/fixtures/profiles/core-smoke.toml
@@ -47,6 +47,10 @@ action = "mouse_move_rel"
 x = 12
 y = -7
 
+[devices."$HARDWARE_ID".mapping.key_0]
+action = "mouse"
+target = "btn_task"
+
 [devices."$HARDWARE_ID".mapping.key_r]
 action = "keyboard"
 target = "key_i"

--- a/nix/daemon-session-integration-test/scenarios/mouse_output.py
+++ b/nix/daemon-session-integration-test/scenarios/mouse_output.py
@@ -5,11 +5,28 @@ from support import ScenarioContext
 
 
 def run(ctx: ScenarioContext) -> None:
+    if ctx.mouse_output is None:
+        raise AssertionError("mouse output is not available")
+    mouse_key_caps = set(ctx.mouse_output.capabilities().get(evdev.ecodes.EV_KEY, []))
+    if evdev.ecodes.BTN_TASK not in mouse_key_caps:
+        raise AssertionError(
+            f"mouse output does not advertise BTN_TASK ({evdev.ecodes.BTN_TASK}): "
+            f"{sorted(mouse_key_caps)}"
+        )
+
     ctx.tap_source(evdev.ecodes.KEY_O)
     ctx.expect_mouse_events(
         [
             (evdev.ecodes.EV_KEY, evdev.ecodes.BTN_LEFT, 1),
             (evdev.ecodes.EV_KEY, evdev.ecodes.BTN_LEFT, 0),
+        ]
+    )
+
+    ctx.tap_source(evdev.ecodes.KEY_0)
+    ctx.expect_mouse_events(
+        [
+            (evdev.ecodes.EV_KEY, evdev.ecodes.BTN_TASK, 1),
+            (evdev.ecodes.EV_KEY, evdev.ecodes.BTN_TASK, 0),
         ]
     )
 

--- a/nix/daemon-session-integration-test/support.py
+++ b/nix/daemon-session-integration-test/support.py
@@ -211,7 +211,7 @@ class ScenarioContext:
         source_keys = [
             getattr(evdev.ecodes, f"KEY_{letter}") for letter in "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
         ]
-        source_keys.append(evdev.ecodes.KEY_SPACE)
+        source_keys.extend((evdev.ecodes.KEY_0, evdev.ecodes.KEY_SPACE))
         source_keys.extend(getattr(evdev.ecodes, f"KEY_F{index}") for index in range(1, 25))
         device = evdev.UInput(
             events={
@@ -407,7 +407,7 @@ class ScenarioContext:
         primary_source_path: str,
         secondary_source_path: str,
     ) -> dict[str, str]:
-        primary_buttons = list("abcdefghijklmnopqrstuvwxyz") + ["space"] + [
+        primary_buttons = list("abcdefghijklmnopqrstuvwxyz") + ["0", "space"] + [
             f"f{index}" for index in range(1, 25)
         ]
         secondary_buttons = list("abcdefghijklmnopqrstuvwxyz") + ["f13", "f14"]

--- a/tests/keymasqd/test_device_manager_runtime_recovery.py
+++ b/tests/keymasqd/test_device_manager_runtime_recovery.py
@@ -305,6 +305,17 @@ class TestDeviceManagerHelpers:
         assert created[1].kwargs["name"] == "keymasq-test-mouse"
         assert created[1].kwargs["vendor"] == 0x4B46
         assert created[1].kwargs["product"] == 0x1002
+        mouse_key_caps = set(created[1].kwargs["events"][evdev.ecodes.EV_KEY])
+        assert mouse_key_caps == {
+            evdev.ecodes.BTN_LEFT,
+            evdev.ecodes.BTN_RIGHT,
+            evdev.ecodes.BTN_MIDDLE,
+            evdev.ecodes.BTN_SIDE,
+            evdev.ecodes.BTN_EXTRA,
+            evdev.ecodes.BTN_FORWARD,
+            evdev.ecodes.BTN_BACK,
+            evdev.ecodes.BTN_TASK,
+        }
         mouse_rel_caps = created[1].kwargs["events"][evdev.ecodes.EV_REL]
         assert evdev.ecodes.REL_WHEEL in mouse_rel_caps
         rel_wheel_hi_res = getattr(evdev.ecodes, "REL_WHEEL_HI_RES", None)


### PR DESCRIPTION
## Summary

- advertise BTN_TASK on the global virtual mouse
- verify code 279 capability and press/release output in the daemon/session VM
- document BTN_TASK mouse output support

## Tests

- `./scripts/check.sh`
- `./scripts/integration.sh daemon-session`