### PR TITLE
Run output cleanup before suspend through logind

### DIFF
--- a/docs/DEPENDENCIES.md
+++ b/docs/DEPENDENCIES.md
@@ -49,7 +49,7 @@ What they are used for:
 
 - `PyGObject`: GTK4 / libadwaita GUI
 - `dbus-next`: session D-Bus access for notifications and compositor/session
-  integrations
+  integrations, plus system D-Bus access to logind for pre-suspend output cleanup
 - `evdev`: input device access, recording, capture, and remap runtime
 - `python-xlib`: X11 listener support, including cursor position read/write
 - `tomli-w`: writing profile, hardware, and superkey TOML files
@@ -165,6 +165,12 @@ differentiator is the compositor/session environment itself.
 
 `slurp` is not a universal base runtime dependency. It is a GUI Capture helper
 for supported Wayland environments.
+
+### Suspend cleanup
+
+When systemd-logind is available, `keymasqd` uses its system D-Bus API to run
+output cleanup before suspend. The daemon continues normally when logind or the
+system bus is unavailable.
 
 ### Browser GUI backend
 

--- a/keymasq/keymasqd/daemon.py
+++ b/keymasq/keymasqd/daemon.py
@@ -45,6 +45,7 @@ from keymasq.keymasqd.device_manager import DeviceManager
 from keymasq.keymasqd.macro_store import MacroStore
 from keymasq.keymasqd.recording import RecordingManager
 from keymasq.keymasqd.runtime import source_hiding
+from keymasq.keymasqd.sleep import LogindSleepCoordinator
 from keymasq.keymasqd.socket_server import ClientContext, SocketServer
 from keymasq.keymasqd.timer_precision import set_timer_slack_ns
 
@@ -76,6 +77,9 @@ class Daemon:
         self.recording_manager = RecordingManager()
         self.macro_store = MacroStore(STATE_DIR / "macros")
         self.capture_manager = CaptureManager()
+        self.sleep_coordinator = LogindSleepCoordinator(
+            self.device_manager.cancel_macro_playback_and_release_outputs,
+        )
         self.socket_server: SocketServer | None = None
         self.running = False
         self._shutdown_event = asyncio.Event()
@@ -136,6 +140,7 @@ class Daemon:
             self.device_manager.initialize_output_devices()
             await self.socket_server.start()
             await self.device_manager.start_topology_watcher()
+            await self.sleep_coordinator.start()
 
             sd_notify("READY=1")
 
@@ -150,6 +155,11 @@ class Daemon:
         sd_notify("STOPPING=1")
         log.info("Stopping keymasqd")
         self.running = False
+
+        await self._run_async_cleanup(
+            "stop logind sleep coordination",
+            self.sleep_coordinator.stop,
+        )
 
         if self.socket_server:
             await self._run_async_cleanup("stop socket server", self.socket_server.stop)

--- a/keymasq/keymasqd/sleep.py
+++ b/keymasq/keymasqd/sleep.py
@@ -41,7 +41,7 @@ class LogindSleepCoordinator:
         self._bus: Any | None = None
         self._manager: Any | None = None
         self._inhibitor_fd: int | None = None
-        self._events: asyncio.Queue[bool] = asyncio.Queue()
+        self._events: asyncio.Queue[bool | None] = asyncio.Queue()
         self._worker: asyncio.Task[None] | None = None
         self._subscribed = False
 
@@ -76,13 +76,22 @@ class LogindSleepCoordinator:
         return True
 
     async def stop(self) -> None:
+        self._unsubscribe()
         worker = self._worker
         self._worker = None
-        if worker is not None:
-            worker.cancel()
-            with contextlib.suppress(asyncio.CancelledError):
+        try:
+            if worker is None:
+                return
+            self._events.put_nowait(None)
+            try:
                 await worker
-        await self._close_connection()
+            except asyncio.CancelledError:
+                worker.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await worker
+                raise
+        finally:
+            await self._close_connection()
 
     def _on_prepare_for_sleep(self, preparing: bool) -> None:
         self._events.put_nowait(bool(preparing))
@@ -90,6 +99,8 @@ class LogindSleepCoordinator:
     async def _run(self) -> None:
         while True:
             preparing = await self._events.get()
+            if preparing is None:
+                return
             if preparing:
                 log.info(
                     "Received logind suspend signal; running pre-suspend output cleanup"
@@ -131,11 +142,7 @@ class LogindSleepCoordinator:
             log.debug("Failed to close logind sleep inhibitor", exc_info=True)
 
     async def _close_connection(self) -> None:
-        manager = self._manager
-        if manager is not None and self._subscribed:
-            with contextlib.suppress(Exception):
-                manager.off_prepare_for_sleep(self._on_prepare_for_sleep)
-        self._subscribed = False
+        self._unsubscribe()
         self._manager = None
         self._release_inhibitor()
 
@@ -144,3 +151,10 @@ class LogindSleepCoordinator:
         if bus is not None:
             with contextlib.suppress(Exception):
                 bus.disconnect()
+
+    def _unsubscribe(self) -> None:
+        manager = self._manager
+        if manager is not None and self._subscribed:
+            with contextlib.suppress(Exception):
+                manager.off_prepare_for_sleep(self._on_prepare_for_sleep)
+        self._subscribed = False

--- a/keymasq/keymasqd/sleep.py
+++ b/keymasq/keymasqd/sleep.py
@@ -1,0 +1,146 @@
+"""Coordinate keymasqd pre-suspend output cleanup with systemd-logind."""
+
+import asyncio
+import contextlib
+import logging
+import os
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+from dbus_next.aio.message_bus import MessageBus
+from dbus_next.constants import BusType
+
+log = logging.getLogger("keymasqd.sleep")
+
+LOGIN1_SERVICE = "org.freedesktop.login1"
+LOGIN1_PATH = "/org/freedesktop/login1"
+LOGIN1_MANAGER = "org.freedesktop.login1.Manager"
+SETUP_TIMEOUT_S = 2.0
+
+type AsyncCallback = Callable[[], Awaitable[object]]
+type BusFactory = Callable[[], Any]
+
+
+def _system_bus() -> MessageBus:
+    return MessageBus(bus_type=BusType.SYSTEM, negotiate_unix_fd=True)
+
+
+class LogindSleepCoordinator:
+    """Run one cleanup callback before logind suspends the machine."""
+
+    def __init__(
+        self,
+        prepare_for_sleep: AsyncCallback,
+        *,
+        bus_factory: BusFactory = _system_bus,
+        close_fd: Callable[[int], None] = os.close,
+    ) -> None:
+        self._prepare_for_sleep = prepare_for_sleep
+        self._bus_factory = bus_factory
+        self._close_fd = close_fd
+        self._bus: Any | None = None
+        self._manager: Any | None = None
+        self._inhibitor_fd: int | None = None
+        self._events: asyncio.Queue[bool] = asyncio.Queue()
+        self._worker: asyncio.Task[None] | None = None
+        self._subscribed = False
+
+    async def start(self) -> bool:
+        """Connect to logind, or return false when it is unavailable."""
+
+        if self._bus is not None:
+            return True
+
+        try:
+            async with asyncio.timeout(SETUP_TIMEOUT_S):
+                bus = await self._bus_factory().connect()
+                self._bus = bus
+                introspection = await bus.introspect(LOGIN1_SERVICE, LOGIN1_PATH)
+                proxy = bus.get_proxy_object(LOGIN1_SERVICE, LOGIN1_PATH, introspection)
+                manager = proxy.get_interface(LOGIN1_MANAGER)
+                self._manager = manager
+                manager.on_prepare_for_sleep(self._on_prepare_for_sleep)
+                self._subscribed = True
+                await self._acquire_inhibitor()
+        except Exception as exc:  # noqa: BLE001 - logind integration is optional.
+            log.warning(
+                "systemd-logind sleep notification is unavailable; "
+                "pre-suspend cleanup is disabled: %s",
+                exc,
+            )
+            await self._close_connection()
+            return False
+
+        self._worker = asyncio.create_task(self._run(), name="keymasqd-logind-sleep")
+        log.info("Enabled systemd-logind pre-suspend cleanup")
+        return True
+
+    async def stop(self) -> None:
+        worker = self._worker
+        self._worker = None
+        if worker is not None:
+            worker.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await worker
+        await self._close_connection()
+
+    def _on_prepare_for_sleep(self, preparing: bool) -> None:
+        self._events.put_nowait(bool(preparing))
+
+    async def _run(self) -> None:
+        while True:
+            preparing = await self._events.get()
+            if preparing:
+                log.info(
+                    "Received logind suspend signal; running pre-suspend output cleanup"
+                )
+                try:
+                    await self._prepare_for_sleep()
+                except Exception:
+                    log.exception("Pre-suspend cleanup failed")
+                finally:
+                    self._release_inhibitor()
+                continue
+
+            try:
+                await self._acquire_inhibitor()
+            except Exception:
+                log.exception("Failed to reacquire the logind sleep inhibitor after resume")
+
+    async def _acquire_inhibitor(self) -> None:
+        manager = self._manager
+        if manager is None or self._inhibitor_fd is not None:
+            return
+        self._inhibitor_fd = int(
+            await manager.call_inhibit(
+                "sleep",
+                "keymasqd",
+                "Release active remapped input state",
+                "delay",
+            )
+        )
+
+    def _release_inhibitor(self) -> None:
+        inhibitor_fd = self._inhibitor_fd
+        self._inhibitor_fd = None
+        if inhibitor_fd is None:
+            return
+        try:
+            self._close_fd(inhibitor_fd)
+        except OSError:
+            log.debug("Failed to close logind sleep inhibitor", exc_info=True)
+
+    async def _close_connection(self) -> None:
+        manager = self._manager
+        if manager is not None and self._subscribed:
+            with contextlib.suppress(Exception):
+                manager.off_prepare_for_sleep(self._on_prepare_for_sleep)
+        self._subscribed = False
+        self._manager = None
+        self._release_inhibitor()
+
+        bus = self._bus
+        self._bus = None
+        if bus is not None:
+            with contextlib.suppress(Exception):
+                bus.disconnect()

--- a/tests/keymasqd/daemon_support.py
+++ b/tests/keymasqd/daemon_support.py
@@ -39,6 +39,9 @@ def make_daemon_testbed(monkeypatch):
         grabbed_devices={},
         play_macro=AsyncMock(return_value={"played": True}),
         cancel_macro_playback=AsyncMock(return_value={"canceled": True}),
+        cancel_macro_playback_and_release_outputs=AsyncMock(
+            return_value={"canceled": True}
+        ),
         emergency_reset=AsyncMock(return_value={"reset": True}),
         set_diagnostics=AsyncMock(return_value={"status": "ok"}),
         start_device_inspector=AsyncMock(return_value={"status": "ok", "active": True}),
@@ -106,6 +109,10 @@ def make_daemon_testbed(monkeypatch):
     monkeypatch.setattr(daemon, "CaptureManager", lambda: capture_manager)
 
     daemon_instance = daemon.Daemon()
+    daemon_instance.sleep_coordinator = SimpleNamespace(
+        start=AsyncMock(return_value=True),
+        stop=AsyncMock(return_value=None),
+    )
     return daemon_instance, device_manager, recording_manager, macro_store, capture_manager
 
 

--- a/tests/keymasqd/test_daemon_capture_commands.py
+++ b/tests/keymasqd/test_daemon_capture_commands.py
@@ -1040,6 +1040,8 @@ async def test_start_offloads_macro_store_prep_to_thread(
     device_manager.shutdown_output_devices.assert_called_once()
     device_manager.start_topology_watcher.assert_awaited_once()
     device_manager.stop_topology_watcher.assert_awaited_once()
+    daemon.sleep_coordinator.start.assert_awaited_once()
+    daemon.sleep_coordinator.stop.assert_awaited_once()
     assert device_manager.broadcast_callback == fake_socket_server.broadcast_event
     assert recording_manager.broadcast_callback == fake_socket_server.broadcast_event
     assert recording_manager.macro_recording_time_limit == 23
@@ -1093,6 +1095,7 @@ async def test_stop_lets_socket_server_own_socket_path_cleanup(
 
     await daemon.stop()
 
+    daemon.sleep_coordinator.stop.assert_awaited_once()
     socket_server.stop.assert_awaited_once()
     cleanup_socket_path.assert_not_called()
     recording_manager.abort.assert_awaited_once()

--- a/tests/keymasqd/test_sleep.py
+++ b/tests/keymasqd/test_sleep.py
@@ -1,0 +1,148 @@
+import asyncio
+import logging
+from unittest.mock import AsyncMock
+
+import pytest
+
+from keymasq.keymasqd.sleep import (
+    LOGIN1_MANAGER,
+    LOGIN1_PATH,
+    LOGIN1_SERVICE,
+    LogindSleepCoordinator,
+)
+
+
+class _FakeLoginManager:
+    def __init__(self) -> None:
+        self.callback = None
+        self.inhibit_calls: list[tuple[str, str, str, str]] = []
+        self.fds = iter((41, 42))
+
+    def on_prepare_for_sleep(self, callback) -> None:
+        self.callback = callback
+
+    def off_prepare_for_sleep(self, callback) -> None:
+        assert callback == self.callback
+        self.callback = None
+
+    async def call_inhibit(self, *args: str) -> int:
+        self.inhibit_calls.append(args)
+        return next(self.fds)
+
+    def emit(self, preparing: bool) -> None:
+        assert self.callback is not None
+        self.callback(preparing)
+
+
+class _FakeBus:
+    def __init__(self, manager: _FakeLoginManager) -> None:
+        self.manager = manager
+        self.disconnected = False
+
+    async def connect(self):
+        return self
+
+    async def introspect(self, service: str, path: str):
+        assert (service, path) == (LOGIN1_SERVICE, LOGIN1_PATH)
+        return object()
+
+    def get_proxy_object(self, service: str, path: str, _introspection):
+        assert (service, path) == (LOGIN1_SERVICE, LOGIN1_PATH)
+        return self
+
+    def get_interface(self, interface: str):
+        assert interface == LOGIN1_MANAGER
+        return self.manager
+
+    def disconnect(self) -> None:
+        self.disconnected = True
+
+
+async def _flush_worker() -> None:
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+
+
+@pytest.mark.asyncio
+async def test_delay_inhibitor_surrounds_suspend_cleanup(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    manager = _FakeLoginManager()
+    bus = _FakeBus(manager)
+    actions: list[str] = []
+    prepare = AsyncMock(side_effect=lambda: actions.append("cleanup"))
+    closed_fds: list[int] = []
+
+    def close_fd(fd: int) -> None:
+        closed_fds.append(fd)
+        actions.append(f"close:{fd}")
+
+    coordinator = LogindSleepCoordinator(
+        prepare,
+        bus_factory=lambda: bus,
+        close_fd=close_fd,
+    )
+    caplog.set_level(logging.INFO, logger="keymasqd.sleep")
+
+    assert await coordinator.start() is True
+    assert manager.inhibit_calls == [
+        (
+            "sleep",
+            "keymasqd",
+            "Release active remapped input state",
+            "delay",
+        )
+    ]
+
+    manager.emit(True)
+    await _flush_worker()
+    prepare.assert_awaited_once()
+    assert closed_fds == [41]
+    assert actions == ["cleanup", "close:41"]
+    assert (
+        "Received logind suspend signal; running pre-suspend output cleanup"
+        in caplog.messages
+    )
+
+    manager.emit(False)
+    await _flush_worker()
+    assert len(manager.inhibit_calls) == 2
+
+    await coordinator.stop()
+    assert closed_fds == [41, 42]
+    assert manager.callback is None
+    assert bus.disconnected is True
+
+
+@pytest.mark.asyncio
+async def test_cleanup_failure_still_releases_delay_inhibitor() -> None:
+    manager = _FakeLoginManager()
+    bus = _FakeBus(manager)
+    closed_fds: list[int] = []
+    coordinator = LogindSleepCoordinator(
+        AsyncMock(side_effect=RuntimeError("cleanup failed")),
+        bus_factory=lambda: bus,
+        close_fd=closed_fds.append,
+    )
+
+    assert await coordinator.start() is True
+    manager.emit(True)
+    await _flush_worker()
+
+    assert closed_fds == [41]
+    await coordinator.stop()
+
+
+@pytest.mark.asyncio
+async def test_logind_unavailable_does_not_prevent_daemon_start() -> None:
+    class _UnavailableBus:
+        async def connect(self):
+            raise OSError("no system bus")
+
+    coordinator = LogindSleepCoordinator(
+        AsyncMock(),
+        bus_factory=_UnavailableBus,
+    )
+
+    assert await coordinator.start() is False
+    await coordinator.stop()

--- a/tests/keymasqd/test_sleep.py
+++ b/tests/keymasqd/test_sleep.py
@@ -134,6 +134,26 @@ async def test_cleanup_failure_still_releases_delay_inhibitor() -> None:
 
 
 @pytest.mark.asyncio
+async def test_stop_completes_queued_suspend_cleanup_before_closing_inhibitor() -> None:
+    manager = _FakeLoginManager()
+    bus = _FakeBus(manager)
+    prepare = AsyncMock()
+    closed_fds: list[int] = []
+    coordinator = LogindSleepCoordinator(
+        prepare,
+        bus_factory=lambda: bus,
+        close_fd=closed_fds.append,
+    )
+
+    assert await coordinator.start() is True
+    manager.emit(True)
+    await coordinator.stop()
+
+    prepare.assert_awaited_once()
+    assert closed_fds == [41]
+
+
+@pytest.mark.asyncio
 async def test_logind_unavailable_does_not_prevent_daemon_start() -> None:
     class _UnavailableBus:
         async def connect(self):


### PR DESCRIPTION
## Summary

- listen for logind `PrepareForSleep` signals while holding a delay inhibitor
- cancel active macro playback and release tracked outputs before suspend
- reacquire the inhibitor after resume and continue normally when logind is unavailable
- log receipt of the suspend signal before cleanup starts

## Validation

- `./scripts/check.sh` (`973 passed, 25 skipped`)
- `./scripts/integration.sh daemon-session`