### PR TITLE
Neutralize active input runtime before suspend

### DIFF
--- a/docs/DEPENDENCIES.md
+++ b/docs/DEPENDENCIES.md
@@ -49,7 +49,7 @@ What they are used for:
 
 - `PyGObject`: GTK4 / libadwaita GUI
 - `dbus-next`: session D-Bus access for notifications and compositor/session
-  integrations
+  integrations, plus system D-Bus access to logind for pre-suspend output cleanup
 - `evdev`: input device access, recording, capture, and remap runtime
 - `python-xlib`: X11 listener support, including cursor position read/write
 - `tomli-w`: writing profile, hardware, and superkey TOML files
@@ -165,6 +165,12 @@ differentiator is the compositor/session environment itself.
 
 `slurp` is not a universal base runtime dependency. It is a GUI Capture helper
 for supported Wayland environments.
+
+### Suspend cleanup
+
+When systemd-logind is available, `keymasqd` uses its system D-Bus API to run
+output cleanup before suspend. The daemon continues normally when logind or the
+system bus is unavailable.
 
 ### Browser GUI backend
 

--- a/docs/DEPENDENCIES.md
+++ b/docs/DEPENDENCIES.md
@@ -171,7 +171,9 @@ for supported Wayland environments.
 When systemd-logind is available, `keymasqd` uses its system D-Bus API to pause
 input processing, neutralize active runtime state, and release tracked outputs
 before suspend. Input processing resumes after logind announces wake-up. The
-daemon continues normally when logind or the system bus is unavailable.
+daemon continues normally when logind or the system bus is unavailable at
+startup. After a successful connection, it reconnects if logind or the system
+bus restarts.
 
 ### Browser GUI backend
 

--- a/docs/DEPENDENCIES.md
+++ b/docs/DEPENDENCIES.md
@@ -168,9 +168,10 @@ for supported Wayland environments.
 
 ### Suspend cleanup
 
-When systemd-logind is available, `keymasqd` uses its system D-Bus API to run
-output cleanup before suspend. The daemon continues normally when logind or the
-system bus is unavailable.
+When systemd-logind is available, `keymasqd` uses its system D-Bus API to pause
+input processing, neutralize active runtime state, and release tracked outputs
+before suspend. Input processing resumes after logind announces wake-up. The
+daemon continues normally when logind or the system bus is unavailable.
 
 ### Browser GUI backend
 

--- a/keymasq/keymasqd/daemon.py
+++ b/keymasq/keymasqd/daemon.py
@@ -78,7 +78,9 @@ class Daemon:
         self.macro_store = MacroStore(STATE_DIR / "macros")
         self.capture_manager = CaptureManager()
         self.sleep_coordinator = LogindSleepCoordinator(
-            self.device_manager.cancel_macro_playback_and_release_outputs,
+            self.device_manager.neutralize_runtime,
+            pause_runtime=self.device_manager.pause_runtime_input,
+            resume_runtime=self.device_manager.resume_runtime_input,
         )
         self.socket_server: SocketServer | None = None
         self.running = False

--- a/keymasq/keymasqd/daemon.py
+++ b/keymasq/keymasqd/daemon.py
@@ -45,6 +45,7 @@ from keymasq.keymasqd.device_manager import DeviceManager
 from keymasq.keymasqd.macro_store import MacroStore
 from keymasq.keymasqd.recording import RecordingManager
 from keymasq.keymasqd.runtime import source_hiding
+from keymasq.keymasqd.sleep import LogindSleepCoordinator
 from keymasq.keymasqd.socket_server import ClientContext, SocketServer
 from keymasq.keymasqd.timer_precision import set_timer_slack_ns
 
@@ -76,6 +77,9 @@ class Daemon:
         self.recording_manager = RecordingManager()
         self.macro_store = MacroStore(STATE_DIR / "macros")
         self.capture_manager = CaptureManager()
+        self.sleep_coordinator = LogindSleepCoordinator(
+            self.device_manager.cancel_macro_playback_and_release_outputs,
+        )
         self.socket_server: SocketServer | None = None
         self.running = False
         self._shutdown_event = asyncio.Event()
@@ -136,6 +140,7 @@ class Daemon:
             self.device_manager.initialize_output_devices()
             await self.socket_server.start()
             await self.device_manager.start_topology_watcher()
+            await self.sleep_coordinator.start()
 
             sd_notify("READY=1")
 
@@ -150,6 +155,11 @@ class Daemon:
         sd_notify("STOPPING=1")
         log.info("Stopping keymasqd")
         self.running = False
+
+        await self._run_async_cleanup(
+            "stop logind sleep coordination",
+            self.sleep_coordinator.stop,
+        )
 
         if self.socket_server:
             await self._run_async_cleanup("stop socket server", self.socket_server.stop)

--- a/keymasq/keymasqd/device_manager.py
+++ b/keymasq/keymasqd/device_manager.py
@@ -59,6 +59,7 @@ from keymasq.keymasqd.runtime.grab.state import (
     GrabRuntimeState,
 )
 from keymasq.keymasqd.runtime.grabbed_device.device import GrabbedDevice
+from keymasq.keymasqd.runtime.grabbed_device.event import pipeline
 from keymasq.keymasqd.runtime.macro.state import (
     DiagnosticRecorder,
     MacroRuntimeDeps,
@@ -170,6 +171,8 @@ class DeviceManager(CursorManagerMixin, MacroManagerMixin, ComboManagerMixin):
         self.macro_exec_timeout_max_ms = 30000
         self.macro_state = MacroRuntimeState()
         self._op_lock = asyncio.Lock()
+        self._neutralize_lock = asyncio.Lock()
+        self._runtime_input_paused = False
         self._initialize_cursor_runtime()
         self._diagnostics = diagnostics.DiagnosticsRuntime(log)
         self.diagnostics_state = self._diagnostics.state
@@ -336,6 +339,94 @@ class DeviceManager(CursorManagerMixin, MacroManagerMixin, ComboManagerMixin):
         async with self._op_lock:
             self.device_inspector_state.reset()
             await self._refresh_combo_runtime()
+
+    def runtime_input_paused(self) -> bool:
+        return self._runtime_input_paused
+
+    def pause_runtime_input(self) -> None:
+        self._runtime_input_paused = True
+
+    def resume_runtime_input(self) -> None:
+        self._runtime_input_paused = False
+
+    async def neutralize_runtime(self) -> JsonObject:
+        """Stop active input runtimes and release every tracked output."""
+
+        async with self._neutralize_lock:
+            was_paused = self._runtime_input_paused
+            self._runtime_input_paused = True
+            devices = [
+                device
+                for grabbed in list(self.grabbed_devices.values())
+                for device in list(grabbed)
+            ]
+            errors: list[Exception] = []
+            combo_deps = support.combo_runtime_deps()
+
+            async def attempt(label: str, cleanup: Callable[[], Awaitable[object]]) -> None:
+                try:
+                    await cleanup()
+                except Exception as exc:
+                    errors.append(exc)
+                    log.exception("Runtime neutralization failed while %s", label)
+
+            def attempt_sync(label: str, cleanup: Callable[[], object]) -> None:
+                try:
+                    cleanup()
+                except Exception as exc:
+                    errors.append(exc)
+                    log.exception("Runtime neutralization failed while %s", label)
+
+            try:
+                await attempt("cancelling macro playback", self.cancel_macro_playback)
+                await attempt(
+                    "clearing combo runtime",
+                    lambda: lifecycle.clear_combo_runtime(self, deps=combo_deps),
+                )
+                await attempt("cancelling cursor movement", self.cancel_cursor_move)
+
+                for device in devices:
+                    held_sources = set(device.state.held_source_keys)
+                    held_sources.update(device.state.held_source_actions)
+                    held_sources.update(device.state.combo_passthrough_held)
+                    device.state.quarantined_source_keys.update(held_sources)
+
+                    await attempt(
+                        f"resetting analog controls for {device.path}",
+                        device.reset_analog_controls,
+                    )
+                    await attempt(
+                        f"resetting superkeys for {device.path}",
+                        device.reset_superkeys,
+                    )
+
+                await attempt("cancelling teardown macro playback", self.cancel_macro_playback)
+
+                for device in devices:
+                    attempt_sync(
+                        f"ending held profile triggers for {device.path}",
+                        lambda device=device: pipeline.observe_profile_trigger_end_for_held_sources(
+                            device
+                        ),
+                    )
+                    device.state.repeat_active_actions.clear()
+                    device.state.passthrough_frame_output = None
+            finally:
+                attempt_sync(
+                    "releasing combo outputs",
+                    lambda: lifecycle.release_tracked_outputs(self, deps=combo_deps),
+                )
+                for device in devices:
+                    attempt_sync(
+                        f"releasing tracked outputs for {device.path}",
+                        device.release_tracked_outputs,
+                    )
+                if not was_paused:
+                    self._runtime_input_paused = False
+
+            if errors:
+                raise errors[0]
+            return {"status": "ok", "neutralized": True}
 
     async def emergency_reset(self) -> JsonObject:
         await self.release_all_devices()

--- a/keymasq/keymasqd/runtime/combo/actions.py
+++ b/keymasq/keymasqd/runtime/combo/actions.py
@@ -36,7 +36,12 @@ from keymasq.keymasqd.runtime.combo.state import (
     ComboRuntimeDeps,
     ResolveCodeFn,
 )
-from keymasq.keymasqd.runtime.grabbed_device.types import ActionExecutionDeps, ActionRuntime
+from keymasq.keymasqd.runtime.grabbed_device import outputs
+from keymasq.keymasqd.runtime.grabbed_device.types import (
+    ActionExecutionDeps,
+    ActionRuntime,
+    EvdevModule,
+)
 from keymasq.keymasqd.runtime.repeat import (
     SUPERKEY_SLOT_OVERLOAD,
     RepeatHistoryEntry,
@@ -649,21 +654,34 @@ async def stop_combo_action(
         action = state.action
         handle = state.execution_handle
         if runtime is not None and action is not None:
-            await action_runner.execute_action(
-                runtime,
-                action,
-                execution.synthetic_event(trigger_binding, 0),
-                source_button,
-                deps=execution.action_execution_deps(deps),
-                execution_handle=handle,
-                cancel_macro_playback=manager.cancel_macro_playback,
-                resolve_code_fn=deps.resolve_code_fn,
-            )
-            if execution.uses_tap_task(action):
-                await cancel_action_tasks(handle)
-            else:
-                await drain_action_tasks(handle)
-            runtime.stop()
+            release_completed = False
+            try:
+                await action_runner.execute_action(
+                    runtime,
+                    action,
+                    execution.synthetic_event(trigger_binding, 0),
+                    source_button,
+                    deps=execution.action_execution_deps(deps),
+                    execution_handle=handle,
+                    cancel_macro_playback=manager.cancel_macro_playback,
+                    resolve_code_fn=deps.resolve_code_fn,
+                )
+                if execution.uses_tap_task(action):
+                    await cancel_action_tasks(handle)
+                else:
+                    await drain_action_tasks(handle)
+                release_completed = True
+            finally:
+                try:
+                    await cancel_action_tasks(handle)
+                finally:
+                    runtime.stop()
+                    if not release_completed:
+                        outputs.release_all_keys(
+                            runtime,
+                            evdev_mod=cast(EvdevModule, deps.evdev_mod),
+                            uinput_writer=deps.uinput_writer,
+                        )
         restore_combo_trigger_bindings(manager, restore_bindings)
         return
     restore_combo_trigger_bindings(manager, restore_bindings)

--- a/keymasq/keymasqd/runtime/combo/lifecycle.py
+++ b/keymasq/keymasqd/runtime/combo/lifecycle.py
@@ -232,10 +232,9 @@ def release_tracked_outputs(
                 bucket,
                 held,
             )
-        finally:
+        else:
             held_keys.clear()
             manager.combo_state.superkey_output_refcounts.get(bucket, {}).clear()
-    _clear_tracked_outputs(manager)
 
 
 async def _cancel_timeout_watchdog(

--- a/keymasq/keymasqd/runtime/combo/lifecycle.py
+++ b/keymasq/keymasqd/runtime/combo/lifecycle.py
@@ -1,11 +1,14 @@
 """Topology cleanup and timeout lifecycle for the combo runtime."""
 
 import contextlib
+import logging
 import time
 
 from keymasq.keymasqd.runtime.combo.actions import stop_combo_action
 from keymasq.keymasqd.runtime.combo.recall import binding_matches_scope
 from keymasq.keymasqd.runtime.combo.state import ComboManager, ComboRuntimeDeps
+
+log = logging.getLogger("keymasqd.runtime.combo_lifecycle")
 
 
 async def clear_combo_runtime(
@@ -23,18 +26,35 @@ async def clear_combo_runtime_unlocked(
     *,
     deps: ComboRuntimeDeps,
 ) -> None:
+    errors: list[Exception] = []
     manager.combo_state.progression.engine.reset()
     for combo_id in list(manager.combo_state.active_actions):
-        await stop_combo_action(manager, combo_id, deps=deps)
+        try:
+            await stop_combo_action(manager, combo_id, deps=deps)
+        except Exception as exc:
+            errors.append(exc)
+            log.exception("Failed to stop combo action %s during runtime cleanup", combo_id)
     # Active actions perform their key-up transition. Cached machines still need
     # explicit teardown so their timers cannot outlive a runtime reset.
     machines = list(manager.combo_state.superkey_machines.values())
     manager.combo_state.superkey_machines.clear()
     manager.combo_state.superkey_machine_bindings.clear()
     for machine in machines:
-        await machine.stop()
-    _clear_tracked_outputs(manager)
-    await _cancel_timeout_watchdog(manager, deps=deps)
+        try:
+            await machine.stop()
+        except Exception as exc:
+            errors.append(exc)
+            log.exception("Failed to stop combo superkey during runtime cleanup")
+    try:
+        await _cancel_timeout_watchdog(manager, deps=deps)
+    except Exception as exc:
+        errors.append(exc)
+        log.exception("Failed to cancel combo timeout during runtime cleanup")
+    finally:
+        release_tracked_outputs(manager, deps=deps)
+
+    if errors:
+        raise errors[0]
 
 
 async def clear_combo_runtime_except(
@@ -177,6 +197,45 @@ def _clear_tracked_outputs(manager: ComboManager) -> None:
         held.clear()
     for refcounts in manager.combo_state.superkey_output_refcounts.values():
         refcounts.clear()
+
+
+def release_tracked_outputs(
+    manager: ComboManager,
+    *,
+    deps: ComboRuntimeDeps,
+) -> None:
+    """Release output keys still owned by the shared combo runtime."""
+
+    uinputs = {
+        "keyboard": manager.output_state.keyboard_uinput,
+        "mouse": manager.output_state.mouse_uinput,
+        "gamepad": manager.output_state.gamepad_uinput,
+    }
+    for bucket, held_keys in manager.combo_state.held_output_keys.items():
+        held = sorted(held_keys)
+        try:
+            writer = deps.uinput_writer(uinputs.get(bucket))
+            if writer is not None and held:
+                for code in held:
+                    writer.write(deps.evdev_mod.ecodes.EV_KEY, int(code), 0)
+                writer.syn()
+        except OSError:
+            log.debug(
+                "Failed to release combo-held outputs bucket=%s keys=%s",
+                bucket,
+                held,
+                exc_info=True,
+            )
+        except Exception:
+            log.exception(
+                "Unexpected failure releasing combo-held outputs bucket=%s keys=%s",
+                bucket,
+                held,
+            )
+        finally:
+            held_keys.clear()
+            manager.combo_state.superkey_output_refcounts.get(bucket, {}).clear()
+    _clear_tracked_outputs(manager)
 
 
 async def _cancel_timeout_watchdog(

--- a/keymasq/keymasqd/runtime/combo/lifecycle.py
+++ b/keymasq/keymasqd/runtime/combo/lifecycle.py
@@ -214,8 +214,17 @@ def release_tracked_outputs(
     for bucket, held_keys in manager.combo_state.held_output_keys.items():
         held = sorted(held_keys)
         try:
-            writer = deps.uinput_writer(uinputs.get(bucket))
-            if writer is not None and held:
+            uinput_dev = uinputs.get(bucket)
+            if bucket.startswith("gamepad:") and bucket not in uinputs:
+                target = manager.resolve_gamepad_output(
+                    bucket.removeprefix("gamepad:"),
+                    context=f"combo output cleanup {bucket}",
+                )
+                uinput_dev = getattr(target, "uinput", None)
+            writer = deps.uinput_writer(uinput_dev)
+            if writer is None:
+                continue
+            if held:
                 for code in held:
                     writer.write(deps.evdev_mod.ecodes.EV_KEY, int(code), 0)
                 writer.syn()

--- a/keymasq/keymasqd/runtime/grab/acquisition.py
+++ b/keymasq/keymasqd/runtime/grab/acquisition.py
@@ -228,6 +228,7 @@ def construct_grabbed_device(
         inspector_suppression_getter=manager.device_inspector_suppressed,
         inspector_suppressed_ids_getter=(manager.device_inspector_suppressed_hardware_ids_snapshot),
         inspector_suppression_disabler=manager.disable_device_inspector_suppression,
+        input_paused_getter=getattr(manager, "runtime_input_paused", None),
         profile_activation_recorder=manager.record_profile_action,
         profile_activation_trigger_start_observer=(manager.observe_profile_trigger_start),
         profile_activation_trigger_end_observer=manager.observe_profile_trigger_end,

--- a/keymasq/keymasqd/runtime/grabbed_device/device.py
+++ b/keymasq/keymasqd/runtime/grabbed_device/device.py
@@ -272,6 +272,7 @@ class GrabbedDevice:
         inspector_suppression_getter: DeviceInspectorSuppressionGetter | None = None,
         inspector_suppressed_ids_getter: DeviceInspectorSuppressedIdsGetter | None = None,
         inspector_suppression_disabler: DeviceInspectorSuppressionDisabler | None = None,
+        input_paused_getter: Callable[[], bool] | None = None,
         profile_activation_recorder: Callable[[str | None, str | None], None] | None = None,
         profile_activation_trigger_start_observer: Callable[[str | None], None] | None = None,
         profile_activation_trigger_end_observer: Callable[[str | None], None] | None = None,
@@ -326,6 +327,7 @@ class GrabbedDevice:
         self.inspector_suppression_getter = inspector_suppression_getter
         self.inspector_suppressed_ids_getter = inspector_suppressed_ids_getter
         self.inspector_suppression_disabler = inspector_suppression_disabler
+        self.input_paused_getter = input_paused_getter
         self.profile_activation_recorder = profile_activation_recorder
         self.profile_activation_trigger_start_observer = profile_activation_trigger_start_observer
         self.profile_activation_trigger_end_observer = profile_activation_trigger_end_observer
@@ -628,6 +630,7 @@ class GrabbedDevice:
         self.state.held_source_actions.clear()
         self.state.combo_passthrough_held.clear()
         self.state.combo_recalled_bindings.clear()
+        self.state.quarantined_source_keys.clear()
 
         await self._stop_force_feedback_proxy()
 

--- a/keymasq/keymasqd/runtime/grabbed_device/event/pipeline.py
+++ b/keymasq/keymasqd/runtime/grabbed_device/event/pipeline.py
@@ -211,6 +211,37 @@ def _observe_source_key_transition(
             observer(trigger_id)
 
 
+def _intercept_paused_or_quarantined_input(
+    device_runtime: GrabbedDeviceRuntime,
+    *,
+    event_class: EventClass,
+    event_name: str,
+    event_value: int,
+) -> str | None:
+    paused_getter = device_runtime.input_paused_getter
+    paused = bool(paused_getter and paused_getter())
+    quarantined = device_runtime.state.quarantined_source_keys
+
+    if event_class is not EventClass.KEY:
+        return "runtime_input_paused" if paused else None
+
+    if paused:
+        if event_value in {1, 2}:
+            quarantined.add(event_name)
+        elif event_value == 0:
+            quarantined.discard(event_name)
+        return "runtime_input_paused"
+
+    if event_name not in quarantined:
+        return None
+    if event_value == 1:
+        quarantined.discard(event_name)
+        return None
+    if event_value == 0:
+        quarantined.discard(event_name)
+    return "runtime_input_quarantined"
+
+
 def _finish_diagnostics(
     device_runtime: GrabbedDeviceRuntime,
     label: str,
@@ -242,6 +273,16 @@ async def process_event(
         evdev_mod=evdev_mod,
         analog_axis_bindings=device_runtime.analog_axis_bindings.keys(),
     )
+
+    paused_label = _intercept_paused_or_quarantined_input(
+        device_runtime,
+        event_class=event_class,
+        event_name=event_name,
+        event_value=int(event.value),
+    )
+    if paused_label is not None:
+        _finish_diagnostics(device_runtime, paused_label, started_ns, deps=deps)
+        return
 
     broadcast_inspector_event(
         device_runtime,

--- a/keymasq/keymasqd/runtime/grabbed_device/types.py
+++ b/keymasq/keymasqd/runtime/grabbed_device/types.py
@@ -184,6 +184,7 @@ class GrabbedDeviceState:
     repeat_active_actions: dict[str, MappingAction] = field(default_factory=dict)
     passthrough_frame_output: object | None = None
     held_source_keys: set[str] = field(default_factory=set)
+    quarantined_source_keys: set[str] = field(default_factory=set)
     combo_passthrough_held: set[str] = field(default_factory=set)
     combo_recalled_bindings: set[str] = field(default_factory=set)
     held_output_keys: dict[str, set[int]] = field(
@@ -309,6 +310,9 @@ class GrabbedDeviceRuntime(ActionRuntime, Protocol):
     def inspector_suppressed_ids_getter(
         self,
     ) -> DeviceInspectorSuppressedIdsGetter | None: ...
+
+    @property
+    def input_paused_getter(self) -> Callable[[], bool] | None: ...
 
     @property
     def inspector_suppression_disabler(

--- a/keymasq/keymasqd/runtime/manager_cursor.py
+++ b/keymasq/keymasqd/runtime/manager_cursor.py
@@ -22,6 +22,7 @@ class CursorManagerMixin:
 
     def _initialize_cursor_runtime(self) -> None:
         self._cursor_move_lock = asyncio.Lock()
+        self._cursor_move_cancel: asyncio.Event | None = None
         self._cursor_request_seq = 0
         self._cursor_position_waiters: dict[str, asyncio.Future[JsonObject]] = {}
 
@@ -110,6 +111,8 @@ class CursorManagerMixin:
         max_duration_ms: int,
     ) -> JsonObject:
         async with self._cursor_move_lock:
+            cancel_event = asyncio.Event()
+            self._cursor_move_cancel = cancel_event
             try:
                 return await natural_mouse.move_cursor_naturally(
                     uinput=cast(
@@ -127,6 +130,17 @@ class CursorManagerMixin:
                         max_duration_ms=int(max_duration_ms),
                     ),
                     asyncio_mod=adapters.ASYNCIO_RUNTIME,
+                    should_cancel=cancel_event.is_set,
                 )
             finally:
+                if self._cursor_move_cancel is cancel_event:
+                    self._cursor_move_cancel = None
                 await self.stop_cursor_position_tracking()
+
+    async def cancel_cursor_move(self) -> None:
+        cancel_event = self._cursor_move_cancel
+        if cancel_event is None:
+            return
+        cancel_event.set()
+        async with self._cursor_move_lock:
+            pass

--- a/keymasq/keymasqd/runtime/manager_cursor.py
+++ b/keymasq/keymasqd/runtime/manager_cursor.py
@@ -23,6 +23,7 @@ class CursorManagerMixin:
     def _initialize_cursor_runtime(self) -> None:
         self._cursor_move_lock = asyncio.Lock()
         self._cursor_move_cancel: asyncio.Event | None = None
+        self._cursor_move_cancel_generation = 0
         self._cursor_request_seq = 0
         self._cursor_position_waiters: dict[str, asyncio.Future[JsonObject]] = {}
 
@@ -110,7 +111,16 @@ class CursorManagerMixin:
         tolerance: int,
         max_duration_ms: int,
     ) -> JsonObject:
+        cancel_generation = self._cursor_move_cancel_generation
         async with self._cursor_move_lock:
+            if cancel_generation != self._cursor_move_cancel_generation:
+                return {
+                    "status": "error",
+                    "message": "Cursor move cancelled",
+                    "target_x": int(x),
+                    "target_y": int(y),
+                    "reached": False,
+                }
             cancel_event = asyncio.Event()
             self._cursor_move_cancel = cancel_event
             try:
@@ -138,9 +148,9 @@ class CursorManagerMixin:
                 await self.stop_cursor_position_tracking()
 
     async def cancel_cursor_move(self) -> None:
+        self._cursor_move_cancel_generation += 1
         cancel_event = self._cursor_move_cancel
-        if cancel_event is None:
-            return
-        cancel_event.set()
+        if cancel_event is not None:
+            cancel_event.set()
         async with self._cursor_move_lock:
             pass

--- a/keymasq/keymasqd/runtime/manager_macros.py
+++ b/keymasq/keymasqd/runtime/manager_macros.py
@@ -45,6 +45,9 @@ class MacroManagerMixin:
     ) -> None:
         raise NotImplementedError
 
+    def runtime_input_paused(self) -> bool:
+        raise NotImplementedError
+
     async def play_macro(
         self,
         playback_options: MacroPlaybackOptions | None = None,
@@ -71,6 +74,8 @@ class MacroManagerMixin:
                 playback_options.macro_name,
                 deps=deps,
             )
+        if int(playback_options.trigger_value) == 1 and self.runtime_input_paused():
+            return {"status": "error", "message": "Runtime input is paused"}
         return await playback.play_macro(
             self,
             playback_options,

--- a/keymasq/keymasqd/runtime/natural_mouse.py
+++ b/keymasq/keymasqd/runtime/natural_mouse.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import math
 import random
-from collections.abc import Awaitable
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from typing import Any, Protocol
 
@@ -65,14 +65,19 @@ async def move_cursor_naturally(
     get_cursor_position: CursorPositionGetter,
     config: NaturalMouseMoveConfig,
     asyncio_mod: _AsyncioModule,
+    should_cancel: Callable[[], bool] | None = None,
 ) -> dict[str, object]:
     if uinput is None:
         return {"status": "error", "message": "No mouse uinput device available"}
 
     config = config.normalized()
     target = (int(target_x), int(target_y))
+    if should_cancel is not None and should_cancel():
+        return _cancelled_result(target)
     tracking_hint_ms = config.max_duration_ms
     position = await get_cursor_position(tracking_hint_ms=tracking_hint_ms)
+    if should_cancel is not None and should_cancel():
+        return _cancelled_result(target)
     if position is None:
         return {
             "status": "error",
@@ -99,6 +104,8 @@ async def move_cursor_naturally(
     response_gain = 1.0
 
     while loop.time() <= deadline:
+        if should_cancel is not None and should_cancel():
+            return _cancelled_result(target)
         distance = distance_to_target(position, target)
         if distance <= config.tolerance_px:
             return _success_result(position, target, config.tolerance_px, emitted_frames)
@@ -154,6 +161,8 @@ async def move_cursor_naturally(
         emit_mouse_move(uinput, move_x, move_y)
         emitted_frames += 1
         await asyncio_mod.sleep(tick_s)
+        if should_cancel is not None and should_cancel():
+            return _cancelled_result(target)
 
         remaining_ms = max(1, int((deadline - loop.time()) * 1000.0))
         next_position = await get_cursor_position(tracking_hint_ms=remaining_ms)
@@ -211,6 +220,16 @@ async def move_cursor_naturally(
         "tolerance": int(config.tolerance_px),
         "reached": False,
         "frames": emitted_frames,
+    }
+
+
+def _cancelled_result(target: tuple[int, int]) -> dict[str, object]:
+    return {
+        "status": "error",
+        "message": "Cursor move cancelled",
+        "target_x": target[0],
+        "target_y": target[1],
+        "reached": False,
     }
 
 

--- a/keymasq/keymasqd/sleep.py
+++ b/keymasq/keymasqd/sleep.py
@@ -142,6 +142,7 @@ class LogindSleepCoordinator:
                 await self._acquire_inhibitor()
             except Exception:
                 log.exception("Failed to reacquire the logind sleep inhibitor after resume")
+                self._connection_refresh.set()
 
     async def _connect(self) -> None:
         async with asyncio.timeout(SETUP_TIMEOUT_S):

--- a/keymasq/keymasqd/sleep.py
+++ b/keymasq/keymasqd/sleep.py
@@ -41,7 +41,7 @@ class LogindSleepCoordinator:
         self._bus: Any | None = None
         self._manager: Any | None = None
         self._inhibitor_fd: int | None = None
-        self._events: asyncio.Queue[bool] = asyncio.Queue()
+        self._events: asyncio.Queue[bool | None] = asyncio.Queue()
         self._worker: asyncio.Task[None] | None = None
         self._subscribed = False
 
@@ -76,13 +76,22 @@ class LogindSleepCoordinator:
         return True
 
     async def stop(self) -> None:
+        self._unsubscribe()
         worker = self._worker
         self._worker = None
-        if worker is not None:
-            worker.cancel()
-            with contextlib.suppress(asyncio.CancelledError):
+        try:
+            if worker is None:
+                return
+            self._events.put_nowait(None)
+            try:
                 await worker
-        await self._close_connection()
+            except asyncio.CancelledError:
+                worker.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await worker
+                raise
+        finally:
+            await self._close_connection()
 
     def _on_prepare_for_sleep(self, preparing: bool) -> None:
         self._events.put_nowait(bool(preparing))
@@ -90,6 +99,8 @@ class LogindSleepCoordinator:
     async def _run(self) -> None:
         while True:
             preparing = await self._events.get()
+            if preparing is None:
+                return
             if preparing:
                 log.info(
                     "Received logind suspend signal; running pre-suspend output cleanup"
@@ -131,11 +142,7 @@ class LogindSleepCoordinator:
             log.debug("Failed to close logind sleep inhibitor", exc_info=True)
 
     async def _close_connection(self) -> None:
-        manager = self._manager
-        if manager is not None and self._subscribed:
-            with contextlib.suppress(Exception):
-                manager.off_prepare_for_sleep(self._on_prepare_for_sleep)
-        self._subscribed = False
+        self._unsubscribe()
         self._manager = None
         self._release_inhibitor()
 
@@ -144,3 +151,10 @@ class LogindSleepCoordinator:
         if bus is not None:
             with contextlib.suppress(Exception):
                 bus.disconnect()
+
+    def _unsubscribe(self) -> None:
+        manager = self._manager
+        if manager is not None and self._subscribed:
+            with contextlib.suppress(Exception):
+                manager.off_prepare_for_sleep(self._on_prepare_for_sleep)
+        self._subscribed = False

--- a/keymasq/keymasqd/sleep.py
+++ b/keymasq/keymasqd/sleep.py
@@ -18,11 +18,16 @@ LOGIN1_MANAGER = "org.freedesktop.login1.Manager"
 SETUP_TIMEOUT_S = 2.0
 
 type AsyncCallback = Callable[[], Awaitable[object]]
+type SyncCallback = Callable[[], object]
 type BusFactory = Callable[[], Any]
 
 
 def _system_bus() -> MessageBus:
     return MessageBus(bus_type=BusType.SYSTEM, negotiate_unix_fd=True)
+
+
+def _noop() -> None:
+    return None
 
 
 class LogindSleepCoordinator:
@@ -32,10 +37,14 @@ class LogindSleepCoordinator:
         self,
         prepare_for_sleep: AsyncCallback,
         *,
+        pause_runtime: SyncCallback = _noop,
+        resume_runtime: SyncCallback = _noop,
         bus_factory: BusFactory = _system_bus,
         close_fd: Callable[[int], None] = os.close,
     ) -> None:
         self._prepare_for_sleep = prepare_for_sleep
+        self._pause_runtime = pause_runtime
+        self._resume_runtime = resume_runtime
         self._bus_factory = bus_factory
         self._close_fd = close_fd
         self._bus: Any | None = None
@@ -44,6 +53,7 @@ class LogindSleepCoordinator:
         self._events: asyncio.Queue[bool | None] = asyncio.Queue()
         self._worker: asyncio.Task[None] | None = None
         self._subscribed = False
+        self._runtime_paused = False
 
     async def start(self) -> bool:
         """Connect to logind, or return false when it is unavailable."""
@@ -91,9 +101,12 @@ class LogindSleepCoordinator:
                     await worker
                 raise
         finally:
+            self._resume_runtime_safely()
             await self._close_connection()
 
     def _on_prepare_for_sleep(self, preparing: bool) -> None:
+        if preparing:
+            self._pause_runtime_safely()
         self._events.put_nowait(bool(preparing))
 
     async def _run(self) -> None:
@@ -103,7 +116,7 @@ class LogindSleepCoordinator:
                 return
             if preparing:
                 log.info(
-                    "Received logind suspend signal; running pre-suspend output cleanup"
+                    "Received logind suspend signal; neutralizing input runtime before suspend"
                 )
                 try:
                     await self._prepare_for_sleep()
@@ -113,10 +126,31 @@ class LogindSleepCoordinator:
                     self._release_inhibitor()
                 continue
 
+            self._resume_runtime_safely()
             try:
                 await self._acquire_inhibitor()
             except Exception:
                 log.exception("Failed to reacquire the logind sleep inhibitor after resume")
+
+    def _pause_runtime_safely(self) -> None:
+        if self._runtime_paused:
+            return
+        try:
+            self._pause_runtime()
+        except Exception:
+            log.exception("Failed to pause input processing for suspend")
+        else:
+            self._runtime_paused = True
+
+    def _resume_runtime_safely(self) -> None:
+        if not self._runtime_paused:
+            return
+        try:
+            self._resume_runtime()
+        except Exception:
+            log.exception("Failed to resume input processing after suspend")
+        else:
+            self._runtime_paused = False
 
     async def _acquire_inhibitor(self) -> None:
         manager = self._manager

--- a/keymasq/keymasqd/sleep.py
+++ b/keymasq/keymasqd/sleep.py
@@ -15,7 +15,11 @@ log = logging.getLogger("keymasqd.sleep")
 LOGIN1_SERVICE = "org.freedesktop.login1"
 LOGIN1_PATH = "/org/freedesktop/login1"
 LOGIN1_MANAGER = "org.freedesktop.login1.Manager"
+DBUS_SERVICE = "org.freedesktop.DBus"
+DBUS_PATH = "/org/freedesktop/DBus"
+DBUS_INTERFACE = "org.freedesktop.DBus"
 SETUP_TIMEOUT_S = 2.0
+RECONNECT_DELAY_S = 1.0
 
 type AsyncCallback = Callable[[], Awaitable[object]]
 type SyncCallback = Callable[[], object]
@@ -49,10 +53,14 @@ class LogindSleepCoordinator:
         self._close_fd = close_fd
         self._bus: Any | None = None
         self._manager: Any | None = None
+        self._dbus_manager: Any | None = None
         self._inhibitor_fd: int | None = None
         self._events: asyncio.Queue[bool | None] = asyncio.Queue()
         self._worker: asyncio.Task[None] | None = None
+        self._connection_supervisor: asyncio.Task[None] | None = None
+        self._connection_refresh = asyncio.Event()
         self._subscribed = False
+        self._dbus_subscribed = False
         self._runtime_paused = False
 
     async def start(self) -> bool:
@@ -61,17 +69,9 @@ class LogindSleepCoordinator:
         if self._bus is not None:
             return True
 
+        self._connection_refresh.clear()
         try:
-            async with asyncio.timeout(SETUP_TIMEOUT_S):
-                bus = await self._bus_factory().connect()
-                self._bus = bus
-                introspection = await bus.introspect(LOGIN1_SERVICE, LOGIN1_PATH)
-                proxy = bus.get_proxy_object(LOGIN1_SERVICE, LOGIN1_PATH, introspection)
-                manager = proxy.get_interface(LOGIN1_MANAGER)
-                self._manager = manager
-                manager.on_prepare_for_sleep(self._on_prepare_for_sleep)
-                self._subscribed = True
-                await self._acquire_inhibitor()
+            await self._connect()
         except Exception as exc:  # noqa: BLE001 - logind integration is optional.
             log.warning(
                 "systemd-logind sleep notification is unavailable; "
@@ -82,10 +82,21 @@ class LogindSleepCoordinator:
             return False
 
         self._worker = asyncio.create_task(self._run(), name="keymasqd-logind-sleep")
+        self._connection_supervisor = asyncio.create_task(
+            self._supervise_connection(),
+            name="keymasqd-logind-connection",
+        )
         log.info("Enabled systemd-logind pre-suspend cleanup")
         return True
 
     async def stop(self) -> None:
+        supervisor = self._connection_supervisor
+        self._connection_supervisor = None
+        if supervisor is not None:
+            supervisor.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await supervisor
+
         self._unsubscribe()
         worker = self._worker
         self._worker = None
@@ -131,6 +142,80 @@ class LogindSleepCoordinator:
                 await self._acquire_inhibitor()
             except Exception:
                 log.exception("Failed to reacquire the logind sleep inhibitor after resume")
+
+    async def _connect(self) -> None:
+        async with asyncio.timeout(SETUP_TIMEOUT_S):
+            bus = await self._bus_factory().connect()
+            self._bus = bus
+
+            dbus_introspection = await bus.introspect(DBUS_SERVICE, DBUS_PATH)
+            dbus_proxy = bus.get_proxy_object(
+                DBUS_SERVICE,
+                DBUS_PATH,
+                dbus_introspection,
+            )
+            dbus_manager = dbus_proxy.get_interface(DBUS_INTERFACE)
+            self._dbus_manager = dbus_manager
+            dbus_manager.on_name_owner_changed(self._on_name_owner_changed)
+            self._dbus_subscribed = True
+
+            introspection = await bus.introspect(LOGIN1_SERVICE, LOGIN1_PATH)
+            proxy = bus.get_proxy_object(LOGIN1_SERVICE, LOGIN1_PATH, introspection)
+            manager = proxy.get_interface(LOGIN1_MANAGER)
+            self._manager = manager
+            manager.on_prepare_for_sleep(self._on_prepare_for_sleep)
+            self._subscribed = True
+            await self._acquire_inhibitor()
+
+    async def _supervise_connection(self) -> None:
+        while True:
+            bus = self._bus
+            if bus is None:
+                return
+
+            waiters = (
+                asyncio.create_task(self._connection_refresh.wait()),
+                asyncio.create_task(bus.wait_for_disconnect()),
+            )
+            try:
+                await asyncio.wait(
+                    waiters,
+                    return_when=asyncio.FIRST_COMPLETED,
+                )
+            finally:
+                for waiter in waiters:
+                    waiter.cancel()
+                await asyncio.gather(*waiters, return_exceptions=True)
+
+            self._connection_refresh.clear()
+            self._events.put_nowait(False)
+            await self._close_connection()
+
+            while True:
+                try:
+                    await self._connect()
+                except Exception as exc:  # noqa: BLE001 - retry runtime connection loss.
+                    log.warning(
+                        "Failed to restore systemd-logind sleep coordination; "
+                        "retrying in %.1fs: %s",
+                        RECONNECT_DELAY_S,
+                        exc,
+                    )
+                    await self._close_connection()
+                    await asyncio.sleep(RECONNECT_DELAY_S)
+                    continue
+
+                log.info("Restored systemd-logind sleep coordination")
+                break
+
+    def _on_name_owner_changed(
+        self,
+        name: str,
+        old_owner: str,
+        new_owner: str,
+    ) -> None:
+        if name == LOGIN1_SERVICE and old_owner != new_owner:
+            self._connection_refresh.set()
 
     def _pause_runtime_safely(self) -> None:
         if self._runtime_paused:
@@ -178,6 +263,7 @@ class LogindSleepCoordinator:
     async def _close_connection(self) -> None:
         self._unsubscribe()
         self._manager = None
+        self._dbus_manager = None
         self._release_inhibitor()
 
         bus = self._bus
@@ -192,3 +278,9 @@ class LogindSleepCoordinator:
             with contextlib.suppress(Exception):
                 manager.off_prepare_for_sleep(self._on_prepare_for_sleep)
         self._subscribed = False
+
+        dbus_manager = self._dbus_manager
+        if dbus_manager is not None and self._dbus_subscribed:
+            with contextlib.suppress(Exception):
+                dbus_manager.off_name_owner_changed(self._on_name_owner_changed)
+        self._dbus_subscribed = False

--- a/keymasq/keymasqd/sleep.py
+++ b/keymasq/keymasqd/sleep.py
@@ -1,0 +1,146 @@
+"""Coordinate keymasqd pre-suspend output cleanup with systemd-logind."""
+
+import asyncio
+import contextlib
+import logging
+import os
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+from dbus_next.aio.message_bus import MessageBus
+from dbus_next.constants import BusType
+
+log = logging.getLogger("keymasqd.sleep")
+
+LOGIN1_SERVICE = "org.freedesktop.login1"
+LOGIN1_PATH = "/org/freedesktop/login1"
+LOGIN1_MANAGER = "org.freedesktop.login1.Manager"
+SETUP_TIMEOUT_S = 2.0
+
+type AsyncCallback = Callable[[], Awaitable[object]]
+type BusFactory = Callable[[], Any]
+
+
+def _system_bus() -> MessageBus:
+    return MessageBus(bus_type=BusType.SYSTEM, negotiate_unix_fd=True)
+
+
+class LogindSleepCoordinator:
+    """Run one cleanup callback before logind suspends the machine."""
+
+    def __init__(
+        self,
+        prepare_for_sleep: AsyncCallback,
+        *,
+        bus_factory: BusFactory = _system_bus,
+        close_fd: Callable[[int], None] = os.close,
+    ) -> None:
+        self._prepare_for_sleep = prepare_for_sleep
+        self._bus_factory = bus_factory
+        self._close_fd = close_fd
+        self._bus: Any | None = None
+        self._manager: Any | None = None
+        self._inhibitor_fd: int | None = None
+        self._events: asyncio.Queue[bool] = asyncio.Queue()
+        self._worker: asyncio.Task[None] | None = None
+        self._subscribed = False
+
+    async def start(self) -> bool:
+        """Connect to logind, or return false when it is unavailable."""
+
+        if self._bus is not None:
+            return True
+
+        try:
+            async with asyncio.timeout(SETUP_TIMEOUT_S):
+                bus = await self._bus_factory().connect()
+                self._bus = bus
+                introspection = await bus.introspect(LOGIN1_SERVICE, LOGIN1_PATH)
+                proxy = bus.get_proxy_object(LOGIN1_SERVICE, LOGIN1_PATH, introspection)
+                manager = proxy.get_interface(LOGIN1_MANAGER)
+                self._manager = manager
+                manager.on_prepare_for_sleep(self._on_prepare_for_sleep)
+                self._subscribed = True
+                await self._acquire_inhibitor()
+        except Exception as exc:  # noqa: BLE001 - logind integration is optional.
+            log.warning(
+                "systemd-logind sleep notification is unavailable; "
+                "pre-suspend cleanup is disabled: %s",
+                exc,
+            )
+            await self._close_connection()
+            return False
+
+        self._worker = asyncio.create_task(self._run(), name="keymasqd-logind-sleep")
+        log.info("Enabled systemd-logind pre-suspend cleanup")
+        return True
+
+    async def stop(self) -> None:
+        worker = self._worker
+        self._worker = None
+        if worker is not None:
+            worker.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await worker
+        await self._close_connection()
+
+    def _on_prepare_for_sleep(self, preparing: bool) -> None:
+        self._events.put_nowait(bool(preparing))
+
+    async def _run(self) -> None:
+        while True:
+            preparing = await self._events.get()
+            if preparing:
+                log.info(
+                    "Received logind suspend signal; running pre-suspend output cleanup"
+                )
+                try:
+                    await self._prepare_for_sleep()
+                except Exception:
+                    log.exception("Pre-suspend cleanup failed")
+                finally:
+                    self._release_inhibitor()
+                continue
+
+            try:
+                await self._acquire_inhibitor()
+            except Exception:
+                log.exception("Failed to reacquire the logind sleep inhibitor after resume")
+
+    async def _acquire_inhibitor(self) -> None:
+        manager = self._manager
+        if manager is None or self._inhibitor_fd is not None:
+            return
+        self._inhibitor_fd = int(
+            await manager.call_inhibit(
+                "sleep",
+                "keymasqd",
+                "Release active remapped input state",
+                "delay",
+            )
+        )
+
+    def _release_inhibitor(self) -> None:
+        inhibitor_fd = self._inhibitor_fd
+        self._inhibitor_fd = None
+        if inhibitor_fd is None:
+            return
+        try:
+            self._close_fd(inhibitor_fd)
+        except OSError:
+            log.debug("Failed to close logind sleep inhibitor", exc_info=True)
+
+    async def _close_connection(self) -> None:
+        manager = self._manager
+        if manager is not None and self._subscribed:
+            with contextlib.suppress(Exception):
+                manager.off_prepare_for_sleep(self._on_prepare_for_sleep)
+        self._subscribed = False
+        self._manager = None
+        self._release_inhibitor()
+
+        bus = self._bus
+        self._bus = None
+        if bus is not None:
+            with contextlib.suppress(Exception):
+                bus.disconnect()

--- a/tests/keymasqd/daemon_support.py
+++ b/tests/keymasqd/daemon_support.py
@@ -39,6 +39,9 @@ def make_daemon_testbed(monkeypatch):
         grabbed_devices={},
         play_macro=AsyncMock(return_value={"played": True}),
         cancel_macro_playback=AsyncMock(return_value={"canceled": True}),
+        cancel_macro_playback_and_release_outputs=AsyncMock(
+            return_value={"canceled": True}
+        ),
         emergency_reset=AsyncMock(return_value={"reset": True}),
         set_diagnostics=AsyncMock(return_value={"status": "ok"}),
         start_device_inspector=AsyncMock(return_value={"status": "ok", "active": True}),
@@ -106,6 +109,10 @@ def make_daemon_testbed(monkeypatch):
     monkeypatch.setattr(daemon, "CaptureManager", lambda: capture_manager)
 
     daemon_instance = daemon.Daemon()
+    daemon_instance.sleep_coordinator = SimpleNamespace(
+        start=AsyncMock(return_value=True),
+        stop=AsyncMock(return_value=None),
+    )
     return daemon_instance, device_manager, recording_manager, macro_store, capture_manager
 
 

--- a/tests/keymasqd/daemon_support.py
+++ b/tests/keymasqd/daemon_support.py
@@ -39,9 +39,10 @@ def make_daemon_testbed(monkeypatch):
         grabbed_devices={},
         play_macro=AsyncMock(return_value={"played": True}),
         cancel_macro_playback=AsyncMock(return_value={"canceled": True}),
-        cancel_macro_playback_and_release_outputs=AsyncMock(
-            return_value={"canceled": True}
-        ),
+        cancel_macro_playback_and_release_outputs=AsyncMock(return_value={"canceled": True}),
+        neutralize_runtime=AsyncMock(return_value={"neutralized": True}),
+        pause_runtime_input=Mock(),
+        resume_runtime_input=Mock(),
         emergency_reset=AsyncMock(return_value={"reset": True}),
         set_diagnostics=AsyncMock(return_value={"status": "ok"}),
         start_device_inspector=AsyncMock(return_value={"status": "ok", "active": True}),

--- a/tests/keymasqd/test_combo_action_dispatch.py
+++ b/tests/keymasqd/test_combo_action_dispatch.py
@@ -89,9 +89,28 @@ class TestComboActionDispatch:
         manager.output_state.keyboard_uinput = keyboard
         lifecycle.release_tracked_outputs(manager, deps=combo_runtime_deps())
 
-        assert keyboard.writes == [
-            (evdev.ecodes.EV_KEY, evdev.ecodes.KEY_F13, 0)
-        ]
+        assert keyboard.writes == [(evdev.ecodes.EV_KEY, evdev.ecodes.KEY_F13, 0)]
+        assert held == set()
+        assert refcounts == {}
+
+    def test_combo_output_release_resolves_routed_gamepad_for_retry(self) -> None:
+        manager = DeviceManager()
+        bucket = "gamepad:virtual-gamepad-2"
+        held = manager.combo_state.held_output_keys.setdefault(bucket, set())
+        refcounts = manager.combo_state.superkey_output_refcounts.setdefault(bucket, {})
+        held.add(evdev.ecodes.BTN_SOUTH)
+        refcounts[evdev.ecodes.BTN_SOUTH] = 1
+
+        lifecycle.release_tracked_outputs(manager, deps=combo_runtime_deps())
+
+        assert held == {evdev.ecodes.BTN_SOUTH}
+        assert refcounts == {evdev.ecodes.BTN_SOUTH: 1}
+
+        gamepad = FakeUInput()
+        manager.output_state.virtual_gamepad_uinputs["virtual-gamepad-2"] = gamepad
+        lifecycle.release_tracked_outputs(manager, deps=combo_runtime_deps())
+
+        assert gamepad.writes == [(evdev.ecodes.EV_KEY, evdev.ecodes.BTN_SOUTH, 0)]
         assert held == set()
         assert refcounts == {}
 

--- a/tests/keymasqd/test_combo_action_dispatch.py
+++ b/tests/keymasqd/test_combo_action_dispatch.py
@@ -180,6 +180,50 @@ class TestComboActionDispatch:
         ]
 
     @pytest.mark.asyncio
+    async def test_combo_stop_releases_tracked_output_when_release_action_fails(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        manager = DeviceManager()
+        keyboard = FakeUInput()
+        manager.output_state.keyboard_uinput = keyboard
+        binding = RuntimeComboBinding(
+            hardware_id="1234:5678",
+            source="kbd",
+            evdev="key_a",
+        )
+        action = MappingAction(action_type=ActionType.KEYBOARD, target="key_f13")
+
+        await actions.start_combo_action(
+            manager,
+            "combo-key",
+            action,
+            binding,
+            (binding,),
+            deps=combo_runtime_deps(),
+        )
+        runtime = manager.combo_state.active_actions["combo-key"].action_runtime
+        monkeypatch.setattr(
+            actions.action_runner,
+            "execute_action",
+            AsyncMock(side_effect=RuntimeError("release failed")),
+        )
+
+        with pytest.raises(RuntimeError, match="release failed"):
+            await actions.stop_combo_action(
+                manager,
+                "combo-key",
+                deps=combo_runtime_deps(),
+            )
+
+        assert keyboard.writes == [
+            (evdev.ecodes.EV_KEY, evdev.ecodes.KEY_F13, 1),
+            (evdev.ecodes.EV_KEY, evdev.ecodes.KEY_F13, 0),
+        ]
+        assert runtime is not None
+        assert runtime.running is False
+
+    @pytest.mark.asyncio
     async def test_combo_repeat_replays_last_combo_action_and_releases_child(self) -> None:
         manager = DeviceManager()
         manager.output_state.keyboard_uinput = FakeUInput()

--- a/tests/keymasqd/test_combo_action_dispatch.py
+++ b/tests/keymasqd/test_combo_action_dispatch.py
@@ -64,7 +64,37 @@ class FakeComboDevice:
         return set()
 
 
+class FailingUInput(FakeUInput):
+    def write(self, event_type: int, code: int, value: int) -> None:
+        raise OSError("uinput disconnected")
+
+
 class TestComboActionDispatch:
+    def test_combo_output_release_keeps_tracking_for_retry_after_write_failure(
+        self,
+    ) -> None:
+        manager = DeviceManager()
+        manager.output_state.keyboard_uinput = FailingUInput()
+        held = manager.combo_state.held_output_keys["keyboard"]
+        refcounts = manager.combo_state.superkey_output_refcounts["keyboard"]
+        held.add(evdev.ecodes.KEY_F13)
+        refcounts[evdev.ecodes.KEY_F13] = 1
+
+        lifecycle.release_tracked_outputs(manager, deps=combo_runtime_deps())
+
+        assert held == {evdev.ecodes.KEY_F13}
+        assert refcounts == {evdev.ecodes.KEY_F13: 1}
+
+        keyboard = FakeUInput()
+        manager.output_state.keyboard_uinput = keyboard
+        lifecycle.release_tracked_outputs(manager, deps=combo_runtime_deps())
+
+        assert keyboard.writes == [
+            (evdev.ecodes.EV_KEY, evdev.ecodes.KEY_F13, 0)
+        ]
+        assert held == set()
+        assert refcounts == {}
+
     def test_combo_payload_handles_list_style_evdev_aliases(self) -> None:
         evdev_mod = SimpleNamespace(
             ecodes=SimpleNamespace(

--- a/tests/keymasqd/test_daemon_capture_commands.py
+++ b/tests/keymasqd/test_daemon_capture_commands.py
@@ -1040,6 +1040,8 @@ async def test_start_offloads_macro_store_prep_to_thread(
     device_manager.shutdown_output_devices.assert_called_once()
     device_manager.start_topology_watcher.assert_awaited_once()
     device_manager.stop_topology_watcher.assert_awaited_once()
+    daemon.sleep_coordinator.start.assert_awaited_once()
+    daemon.sleep_coordinator.stop.assert_awaited_once()
     assert device_manager.broadcast_callback == fake_socket_server.broadcast_event
     assert recording_manager.broadcast_callback == fake_socket_server.broadcast_event
     assert recording_manager.macro_recording_time_limit == 23
@@ -1093,6 +1095,7 @@ async def test_stop_lets_socket_server_own_socket_path_cleanup(
 
     await daemon.stop()
 
+    daemon.sleep_coordinator.stop.assert_awaited_once()
     socket_server.stop.assert_awaited_once()
     cleanup_socket_path.assert_not_called()
     recording_manager.abort.assert_awaited_once()

--- a/tests/keymasqd/test_device_manager_core.py
+++ b/tests/keymasqd/test_device_manager_core.py
@@ -221,6 +221,40 @@ async def test_cancel_cursor_move_waits_for_active_move_to_stop(
 
 
 @pytest.mark.asyncio
+async def test_cancel_cursor_move_cancels_a_move_waiting_on_the_lock(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = DeviceManager()
+    move_started = asyncio.Event()
+    move_calls: list[int] = []
+
+    async def move_cursor_naturally(**kwargs: object) -> JsonObject:
+        move_calls.append(cast(int, kwargs["target_x"]))
+        should_cancel = cast(Callable[[], bool], kwargs["should_cancel"])
+        move_started.set()
+        while not should_cancel():
+            await asyncio.sleep(0)
+        return {"status": "error", "message": "Cursor move cancelled"}
+
+    monkeypatch.setattr(
+        manager_cursor.natural_mouse,
+        "move_cursor_naturally",
+        move_cursor_naturally,
+    )
+
+    active = asyncio.create_task(manager.move_cursor_natural(10, 20, 5000, 0, "linear", 1, 500))
+    await move_started.wait()
+    queued = asyncio.create_task(manager.move_cursor_natural(30, 40, 5000, 0, "linear", 1, 500))
+    await asyncio.sleep(0)
+
+    await manager.cancel_cursor_move()
+
+    assert (await active)["message"] == "Cursor move cancelled"
+    assert (await queued)["message"] == "Cursor move cancelled"
+    assert move_calls == [10]
+
+
+@pytest.mark.asyncio
 async def test_neutralize_runtime_clears_active_runtime_and_releases_outputs(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/keymasqd/test_device_manager_core.py
+++ b/tests/keymasqd/test_device_manager_core.py
@@ -3,6 +3,7 @@ import errno
 import logging
 import os
 from collections import deque
+from collections.abc import Callable
 from types import SimpleNamespace
 from typing import cast
 from unittest.mock import AsyncMock, Mock
@@ -11,7 +12,8 @@ import evdev
 import pytest
 
 from keymasq.common.ipc import CommandType
-from keymasq.common.model.core import DeviceType
+from keymasq.common.model.actions import MappingAction
+from keymasq.common.model.core import ActionType, DeviceType
 from keymasq.common.types import JsonObject
 from keymasq.keymasqd import device_manager
 from keymasq.keymasqd.device_manager import DeviceManager
@@ -27,7 +29,7 @@ from keymasq.keymasqd.runtime.combo import events, lifecycle
 from keymasq.keymasqd.runtime.grab import acquisition, planning, release
 from keymasq.keymasqd.runtime.grab.state import DesiredGrabConfig, GrabDeviceDeps, GrabRequest
 from keymasq.keymasqd.runtime.macro import controls, mouse
-from tests.keymasqd.device_manager_support import FakeUInput
+from tests.keymasqd.device_manager_support import FakeUInput, make_grabbed_device
 
 
 @pytest.mark.asyncio
@@ -188,6 +190,132 @@ async def test_move_cursor_natural_stops_cursor_tracking_after_failure(
     with pytest.raises(RuntimeError, match="move failed"):
         await manager.move_cursor_natural(10, 20, 5000, 0, "linear", 1, 500)
     broadcast.assert_awaited_once_with(CommandType.CURSOR_POSITION_TRACKING_STOP, {})
+
+
+@pytest.mark.asyncio
+async def test_cancel_cursor_move_waits_for_active_move_to_stop(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = DeviceManager()
+    move_started = asyncio.Event()
+
+    async def move_cursor_naturally(**kwargs: object) -> JsonObject:
+        should_cancel = cast(Callable[[], bool], kwargs["should_cancel"])
+        move_started.set()
+        while not should_cancel():
+            await asyncio.sleep(0)
+        return {"status": "error", "message": "Cursor move cancelled"}
+
+    monkeypatch.setattr(
+        manager_cursor.natural_mouse,
+        "move_cursor_naturally",
+        move_cursor_naturally,
+    )
+
+    move_task = asyncio.create_task(manager.move_cursor_natural(10, 20, 5000, 0, "linear", 1, 500))
+    await move_started.wait()
+
+    await manager.cancel_cursor_move()
+
+    assert (await move_task)["message"] == "Cursor move cancelled"
+
+
+@pytest.mark.asyncio
+async def test_neutralize_runtime_clears_active_runtime_and_releases_outputs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = DeviceManager()
+    keyboard = FakeUInput()
+    trigger_ends: list[str | None] = []
+    device = make_grabbed_device(
+        monkeypatch,
+        keyboard_uinput=keyboard,
+        profile_activation_trigger_end_observer=trigger_ends.append,
+    )
+    manager.grabbed_devices[device.hardware_id] = [device]
+    manager.output_state.keyboard_uinput = keyboard  # type: ignore[assignment]
+
+    device.state.held_source_keys.update({"key_a", "key_b"})
+    device.state.held_source_actions["key_b"] = MappingAction(
+        action_type=ActionType.KEYBOARD,
+        target="key_f13",
+    )
+    device.state.held_profile_trigger_events.add("key_c")
+    device.state.repeat_active_actions["key_r"] = MappingAction(
+        action_type=ActionType.REPEAT,
+    )
+    device.state.passthrough_frame_output = object()
+    device.state.held_output_keys["keyboard"].add(evdev.ecodes.KEY_F13)
+    manager.combo_state.held_output_keys["keyboard"].add(evdev.ecodes.KEY_F14)
+    manager.combo_state.superkey_output_refcounts["keyboard"][evdev.ecodes.KEY_F14] = 1
+
+    cancel_macros = AsyncMock(return_value={"status": "ok"})
+    clear_combos = AsyncMock()
+    cancel_cursor = AsyncMock()
+    reset_analog = AsyncMock()
+    reset_superkeys = AsyncMock()
+    monkeypatch.setattr(manager, "cancel_macro_playback", cancel_macros)
+    monkeypatch.setattr(lifecycle, "clear_combo_runtime", clear_combos)
+    monkeypatch.setattr(manager, "cancel_cursor_move", cancel_cursor)
+    monkeypatch.setattr(device, "reset_analog_controls", reset_analog)
+    monkeypatch.setattr(device, "reset_superkeys", reset_superkeys)
+    manager.pause_runtime_input()
+
+    result = await manager.neutralize_runtime()
+
+    assert result == {"status": "ok", "neutralized": True}
+    assert manager.runtime_input_paused() is True
+    assert cancel_macros.await_count == 2
+    clear_combos.assert_awaited_once()
+    cancel_cursor.assert_awaited_once()
+    reset_analog.assert_awaited_once()
+    reset_superkeys.assert_awaited_once()
+    assert trigger_ends == [
+        f"{device.hardware_id}:key_a",
+        f"{device.hardware_id}:key_b",
+        f"{device.hardware_id}:key_c",
+    ]
+    assert device.state.quarantined_source_keys == {"key_a", "key_b"}
+    assert device.state.repeat_active_actions == {}
+    assert device.state.passthrough_frame_output is None
+    assert keyboard.writes == [
+        (evdev.ecodes.EV_KEY, evdev.ecodes.KEY_F14, 0),
+        (evdev.ecodes.EV_KEY, evdev.ecodes.KEY_F13, 0),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_neutralize_runtime_continues_cleanup_after_failures(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = DeviceManager()
+    device = make_grabbed_device(monkeypatch)
+    manager.grabbed_devices[device.hardware_id] = [device]
+    first_error = RuntimeError("macro cancellation failed")
+    cancel_macros = AsyncMock(side_effect=[first_error, {"status": "ok"}])
+    reset_analog = AsyncMock(side_effect=RuntimeError("analog reset failed"))
+    reset_superkeys = AsyncMock()
+    release_outputs = Mock()
+    monkeypatch.setattr(manager, "cancel_macro_playback", cancel_macros)
+    monkeypatch.setattr(
+        lifecycle,
+        "clear_combo_runtime",
+        AsyncMock(side_effect=RuntimeError("combo reset failed")),
+    )
+    monkeypatch.setattr(manager, "cancel_cursor_move", AsyncMock())
+    monkeypatch.setattr(device, "reset_analog_controls", reset_analog)
+    monkeypatch.setattr(device, "reset_superkeys", reset_superkeys)
+    monkeypatch.setattr(device, "release_tracked_outputs", release_outputs)
+
+    with pytest.raises(RuntimeError, match="macro cancellation failed") as excinfo:
+        await manager.neutralize_runtime()
+
+    assert excinfo.value is first_error
+    assert cancel_macros.await_count == 2
+    reset_analog.assert_awaited_once()
+    reset_superkeys.assert_awaited_once()
+    release_outputs.assert_called_once()
+    assert manager.runtime_input_paused() is False
 
 
 @pytest.mark.asyncio

--- a/tests/keymasqd/test_grabbed_device_runtime_helpers.py
+++ b/tests/keymasqd/test_grabbed_device_runtime_helpers.py
@@ -70,6 +70,62 @@ class _CountingUInput(FakeUInput):
 
 
 class TestGrabbedDeviceHelpers:
+    @pytest.mark.asyncio
+    async def test_paused_runtime_quarantines_held_key_until_release(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        paused = True
+        passthrough = FakeUInput()
+        device = make_grabbed_device(
+            monkeypatch,
+            input_paused_getter=lambda: paused,
+            passthrough_uinput=passthrough,
+        )
+        press = evdev.InputEvent(0, 0, evdev.ecodes.EV_KEY, evdev.ecodes.KEY_A, 1)
+        repeat_event = evdev.InputEvent(0, 0, evdev.ecodes.EV_KEY, evdev.ecodes.KEY_A, 2)
+        release = evdev.InputEvent(0, 0, evdev.ecodes.EV_KEY, evdev.ecodes.KEY_A, 0)
+
+        await pipeline.process_event(device, press, deps=grabbed_event_processing_deps())
+        assert device.state.quarantined_source_keys == {"key_a"}
+
+        paused = False
+        await pipeline.process_event(
+            device,
+            repeat_event,
+            deps=grabbed_event_processing_deps(),
+        )
+        await pipeline.process_event(device, release, deps=grabbed_event_processing_deps())
+
+        assert passthrough.writes == []
+        assert device.state.quarantined_source_keys == set()
+
+        await pipeline.process_event(device, press, deps=grabbed_event_processing_deps())
+
+        assert passthrough.writes == [(evdev.ecodes.EV_KEY, evdev.ecodes.KEY_A, 1)]
+
+    @pytest.mark.asyncio
+    async def test_fresh_press_rearms_key_when_suspend_release_was_missed(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        passthrough = FakeUInput()
+        device = make_grabbed_device(
+            monkeypatch,
+            input_paused_getter=lambda: False,
+            passthrough_uinput=passthrough,
+        )
+        device.state.quarantined_source_keys.add("key_a")
+
+        await pipeline.process_event(
+            device,
+            evdev.InputEvent(0, 0, evdev.ecodes.EV_KEY, evdev.ecodes.KEY_A, 1),
+            deps=grabbed_event_processing_deps(),
+        )
+
+        assert device.state.quarantined_source_keys == set()
+        assert passthrough.writes == [(evdev.ecodes.EV_KEY, evdev.ecodes.KEY_A, 1)]
+
     def test_event_name_helpers_handle_missing_ecode_tables(self) -> None:
         evdev_mod = SimpleNamespace(ecodes=SimpleNamespace(EV_KEY=evdev.ecodes.EV_KEY))
         event = SimpleNamespace(type=evdev.ecodes.EV_KEY, code=evdev.ecodes.KEY_A, value=1)

--- a/tests/keymasqd/test_macro_backend_recording.py
+++ b/tests/keymasqd/test_macro_backend_recording.py
@@ -786,6 +786,36 @@ async def test_stored_macro_playback_uses_revision_snapshot(
 
 
 @pytest.mark.asyncio
+async def test_stored_macro_does_not_start_if_runtime_pauses_during_load(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manager = DeviceManager()
+    manager.output_state.keyboard_uinput = MagicMock()
+
+    async def load_stored_macro(
+        _macro_name: str,
+        *,
+        deps: MacroRuntimeDeps,
+    ) -> MacroEventSource:
+        del deps
+        manager.pause_runtime_input()
+        return MacroEventSource(
+            event_count=1,
+            duration_us=0,
+            iter_events=lambda: iter(
+                [{"t_us": 0, "type": evdev.ecodes.EV_KEY, "code": 30, "value": 1}]
+            ),
+        )
+
+    monkeypatch.setattr(manager, "_stored_macro_event_source", load_stored_macro)
+
+    result = await manager.play_macro(macro_name="stored")
+
+    assert result == {"status": "error", "message": "Runtime input is paused"}
+    assert manager.macro_state.tasks == {}
+
+
+@pytest.mark.asyncio
 async def test_short_stored_macro_streams_once_then_reuses_cached_events(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/keymasqd/test_sleep.py
+++ b/tests/keymasqd/test_sleep.py
@@ -16,10 +16,16 @@ from keymasq.keymasqd.sleep import (
 
 
 class _FakeLoginManager:
-    def __init__(self, fds: tuple[int, ...] = (41, 42)) -> None:
+    def __init__(
+        self,
+        fds: tuple[int, ...] = (41, 42),
+        *,
+        fail_on_inhibit_calls: frozenset[int] = frozenset(),
+    ) -> None:
         self.callback = None
         self.inhibit_calls: list[tuple[str, str, str, str]] = []
         self.fds = iter(fds)
+        self.fail_on_inhibit_calls = fail_on_inhibit_calls
 
     def on_prepare_for_sleep(self, callback) -> None:
         self.callback = callback
@@ -30,6 +36,8 @@ class _FakeLoginManager:
 
     async def call_inhibit(self, *args: str) -> int:
         self.inhibit_calls.append(args)
+        if len(self.inhibit_calls) in self.fail_on_inhibit_calls:
+            raise OSError("transient inhibit failure")
         return next(self.fds)
 
     def emit(self, preparing: bool) -> None:
@@ -268,6 +276,33 @@ async def test_bus_disconnect_resumes_input_and_reconnects() -> None:
 
     assert second_manager.callback is not None
     await coordinator.stop()
+
+
+@pytest.mark.asyncio
+async def test_resume_inhibitor_failure_reconnects_and_retries() -> None:
+    first_manager = _FakeLoginManager((41,), fail_on_inhibit_calls=frozenset({2}))
+    second_manager = _FakeLoginManager((42,))
+    first_bus = _FakeBus(first_manager)
+    second_bus = _FakeBus(second_manager)
+    buses = iter((first_bus, second_bus))
+    closed_fds: list[int] = []
+    coordinator = LogindSleepCoordinator(
+        AsyncMock(),
+        bus_factory=lambda: next(buses),
+        close_fd=closed_fds.append,
+    )
+
+    assert await coordinator.start() is True
+    first_manager.emit(True)
+    await _flush_worker()
+    first_manager.emit(False)
+    await _wait_until(lambda: len(first_manager.inhibit_calls) == 2)
+    await _wait_until(lambda: len(second_manager.inhibit_calls) == 1)
+
+    assert first_bus.disconnected is True
+    assert second_manager.callback is not None
+    await coordinator.stop()
+    assert closed_fds == [41, 42]
 
 
 @pytest.mark.asyncio

--- a/tests/keymasqd/test_sleep.py
+++ b/tests/keymasqd/test_sleep.py
@@ -1,0 +1,148 @@
+import asyncio
+import logging
+from unittest.mock import AsyncMock
+
+import pytest
+
+from keymasq.keymasqd.sleep import (
+    LOGIN1_MANAGER,
+    LOGIN1_PATH,
+    LOGIN1_SERVICE,
+    LogindSleepCoordinator,
+)
+
+
+class _FakeLoginManager:
+    def __init__(self) -> None:
+        self.callback = None
+        self.inhibit_calls: list[tuple[str, str, str, str]] = []
+        self.fds = iter((41, 42))
+
+    def on_prepare_for_sleep(self, callback) -> None:
+        self.callback = callback
+
+    def off_prepare_for_sleep(self, callback) -> None:
+        assert callback == self.callback
+        self.callback = None
+
+    async def call_inhibit(self, *args: str) -> int:
+        self.inhibit_calls.append(args)
+        return next(self.fds)
+
+    def emit(self, preparing: bool) -> None:
+        assert self.callback is not None
+        self.callback(preparing)
+
+
+class _FakeBus:
+    def __init__(self, manager: _FakeLoginManager) -> None:
+        self.manager = manager
+        self.disconnected = False
+
+    async def connect(self):
+        return self
+
+    async def introspect(self, service: str, path: str):
+        assert (service, path) == (LOGIN1_SERVICE, LOGIN1_PATH)
+        return object()
+
+    def get_proxy_object(self, service: str, path: str, _introspection):
+        assert (service, path) == (LOGIN1_SERVICE, LOGIN1_PATH)
+        return self
+
+    def get_interface(self, interface: str):
+        assert interface == LOGIN1_MANAGER
+        return self.manager
+
+    def disconnect(self) -> None:
+        self.disconnected = True
+
+
+async def _flush_worker() -> None:
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+
+
+@pytest.mark.asyncio
+async def test_delay_inhibitor_surrounds_suspend_cleanup(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    manager = _FakeLoginManager()
+    bus = _FakeBus(manager)
+    actions: list[str] = []
+    prepare = AsyncMock(side_effect=lambda: actions.append("cleanup"))
+    closed_fds: list[int] = []
+
+    def close_fd(fd: int) -> None:
+        closed_fds.append(fd)
+        actions.append(f"close:{fd}")
+
+    coordinator = LogindSleepCoordinator(
+        prepare,
+        bus_factory=lambda: bus,
+        close_fd=close_fd,
+    )
+    caplog.set_level(logging.INFO, logger="keymasqd.sleep")
+
+    assert await coordinator.start() is True
+    assert manager.inhibit_calls == [
+        (
+            "sleep",
+            "keymasqd",
+            "Release active remapped input state",
+            "delay",
+        )
+    ]
+
+    manager.emit(True)
+    await _flush_worker()
+    prepare.assert_awaited_once()
+    assert closed_fds == [41]
+    assert actions == ["cleanup", "close:41"]
+    assert (
+        "Received logind suspend signal; running pre-suspend output cleanup"
+        in caplog.messages
+    )
+
+    manager.emit(False)
+    await _flush_worker()
+    assert len(manager.inhibit_calls) == 2
+
+    await coordinator.stop()
+    assert closed_fds == [41, 42]
+    assert manager.callback is None
+    assert bus.disconnected is True
+
+
+@pytest.mark.asyncio
+async def test_cleanup_failure_still_releases_delay_inhibitor() -> None:
+    manager = _FakeLoginManager()
+    bus = _FakeBus(manager)
+    closed_fds: list[int] = []
+    coordinator = LogindSleepCoordinator(
+        AsyncMock(side_effect=RuntimeError("cleanup failed")),
+        bus_factory=lambda: bus,
+        close_fd=closed_fds.append,
+    )
+
+    assert await coordinator.start() is True
+    manager.emit(True)
+    await _flush_worker()
+
+    assert closed_fds == [41]
+    await coordinator.stop()
+
+
+@pytest.mark.asyncio
+async def test_logind_unavailable_does_not_prevent_daemon_start() -> None:
+    class _UnavailableBus:
+        async def connect(self):
+            raise OSError("no system bus")
+
+    coordinator = LogindSleepCoordinator(
+        AsyncMock(),
+        bus_factory=_UnavailableBus,
+    )
+
+    assert await coordinator.start() is False
+    await coordinator.stop()

--- a/tests/keymasqd/test_sleep.py
+++ b/tests/keymasqd/test_sleep.py
@@ -73,12 +73,20 @@ async def test_delay_inhibitor_surrounds_suspend_cleanup(
     prepare = AsyncMock(side_effect=lambda: actions.append("cleanup"))
     closed_fds: list[int] = []
 
+    def pause_runtime() -> None:
+        actions.append("pause")
+
+    def resume_runtime() -> None:
+        actions.append("resume")
+
     def close_fd(fd: int) -> None:
         closed_fds.append(fd)
         actions.append(f"close:{fd}")
 
     coordinator = LogindSleepCoordinator(
         prepare,
+        pause_runtime=pause_runtime,
+        resume_runtime=resume_runtime,
         bus_factory=lambda: bus,
         close_fd=close_fd,
     )
@@ -98,15 +106,16 @@ async def test_delay_inhibitor_surrounds_suspend_cleanup(
     await _flush_worker()
     prepare.assert_awaited_once()
     assert closed_fds == [41]
-    assert actions == ["cleanup", "close:41"]
+    assert actions == ["pause", "cleanup", "close:41"]
     assert (
-        "Received logind suspend signal; running pre-suspend output cleanup"
+        "Received logind suspend signal; neutralizing input runtime before suspend"
         in caplog.messages
     )
 
     manager.emit(False)
     await _flush_worker()
     assert len(manager.inhibit_calls) == 2
+    assert actions == ["pause", "cleanup", "close:41", "resume"]
 
     await coordinator.stop()
     assert closed_fds == [41, 42]
@@ -139,8 +148,11 @@ async def test_stop_completes_queued_suspend_cleanup_before_closing_inhibitor() 
     bus = _FakeBus(manager)
     prepare = AsyncMock()
     closed_fds: list[int] = []
+    runtime_events: list[str] = []
     coordinator = LogindSleepCoordinator(
         prepare,
+        pause_runtime=lambda: runtime_events.append("pause"),
+        resume_runtime=lambda: runtime_events.append("resume"),
         bus_factory=lambda: bus,
         close_fd=closed_fds.append,
     )
@@ -151,6 +163,7 @@ async def test_stop_completes_queued_suspend_cleanup_before_closing_inhibitor() 
 
     prepare.assert_awaited_once()
     assert closed_fds == [41]
+    assert runtime_events == ["pause", "resume"]
 
 
 @pytest.mark.asyncio

--- a/tests/keymasqd/test_sleep.py
+++ b/tests/keymasqd/test_sleep.py
@@ -5,6 +5,9 @@ from unittest.mock import AsyncMock
 import pytest
 
 from keymasq.keymasqd.sleep import (
+    DBUS_INTERFACE,
+    DBUS_PATH,
+    DBUS_SERVICE,
     LOGIN1_MANAGER,
     LOGIN1_PATH,
     LOGIN1_SERVICE,
@@ -13,10 +16,10 @@ from keymasq.keymasqd.sleep import (
 
 
 class _FakeLoginManager:
-    def __init__(self) -> None:
+    def __init__(self, fds: tuple[int, ...] = (41, 42)) -> None:
         self.callback = None
         self.inhibit_calls: list[tuple[str, str, str, str]] = []
-        self.fds = iter((41, 42))
+        self.fds = iter(fds)
 
     def on_prepare_for_sleep(self, callback) -> None:
         self.callback = callback
@@ -34,33 +37,77 @@ class _FakeLoginManager:
         self.callback(preparing)
 
 
+class _FakeDBusManager:
+    def __init__(self) -> None:
+        self.callback = None
+
+    def on_name_owner_changed(self, callback) -> None:
+        self.callback = callback
+
+    def off_name_owner_changed(self, callback) -> None:
+        assert callback == self.callback
+        self.callback = None
+
+    def emit(self, name: str, old_owner: str, new_owner: str) -> None:
+        assert self.callback is not None
+        self.callback(name, old_owner, new_owner)
+
+
+class _FakeProxy:
+    def __init__(self, interface: str, implementation: object) -> None:
+        self.interface = interface
+        self.implementation = implementation
+
+    def get_interface(self, interface: str):
+        assert interface == self.interface
+        return self.implementation
+
+
 class _FakeBus:
     def __init__(self, manager: _FakeLoginManager) -> None:
         self.manager = manager
+        self.dbus_manager = _FakeDBusManager()
         self.disconnected = False
+        self.disconnect_event = asyncio.Event()
 
     async def connect(self):
         return self
 
     async def introspect(self, service: str, path: str):
-        assert (service, path) == (LOGIN1_SERVICE, LOGIN1_PATH)
+        assert (service, path) in {
+            (DBUS_SERVICE, DBUS_PATH),
+            (LOGIN1_SERVICE, LOGIN1_PATH),
+        }
         return object()
 
     def get_proxy_object(self, service: str, path: str, _introspection):
+        if (service, path) == (DBUS_SERVICE, DBUS_PATH):
+            return _FakeProxy(DBUS_INTERFACE, self.dbus_manager)
         assert (service, path) == (LOGIN1_SERVICE, LOGIN1_PATH)
-        return self
+        return _FakeProxy(LOGIN1_MANAGER, self.manager)
 
-    def get_interface(self, interface: str):
-        assert interface == LOGIN1_MANAGER
-        return self.manager
+    async def wait_for_disconnect(self) -> None:
+        await self.disconnect_event.wait()
+
+    def drop(self) -> None:
+        self.disconnect_event.set()
 
     def disconnect(self) -> None:
         self.disconnected = True
+        self.disconnect_event.set()
 
 
 async def _flush_worker() -> None:
     await asyncio.sleep(0)
     await asyncio.sleep(0)
+
+
+async def _wait_until(predicate) -> None:
+    for _ in range(100):
+        if predicate():
+            return
+        await asyncio.sleep(0)
+    raise AssertionError("condition was not reached")
 
 
 @pytest.mark.asyncio
@@ -120,6 +167,7 @@ async def test_delay_inhibitor_surrounds_suspend_cleanup(
     await coordinator.stop()
     assert closed_fds == [41, 42]
     assert manager.callback is None
+    assert bus.dbus_manager.callback is None
     assert bus.disconnected is True
 
 
@@ -164,6 +212,62 @@ async def test_stop_completes_queued_suspend_cleanup_before_closing_inhibitor() 
     prepare.assert_awaited_once()
     assert closed_fds == [41]
     assert runtime_events == ["pause", "resume"]
+
+
+@pytest.mark.asyncio
+async def test_logind_restart_reconnects_and_reacquires_inhibitor() -> None:
+    first_manager = _FakeLoginManager((41,))
+    second_manager = _FakeLoginManager((42,))
+    first_bus = _FakeBus(first_manager)
+    second_bus = _FakeBus(second_manager)
+    buses = iter((first_bus, second_bus))
+    closed_fds: list[int] = []
+    coordinator = LogindSleepCoordinator(
+        AsyncMock(),
+        bus_factory=lambda: next(buses),
+        close_fd=closed_fds.append,
+    )
+
+    assert await coordinator.start() is True
+    first_bus.dbus_manager.emit(LOGIN1_SERVICE, ":1.10", ":1.11")
+    await _wait_until(lambda: len(second_manager.inhibit_calls) == 1)
+
+    assert first_bus.disconnected is True
+    assert first_manager.callback is None
+    assert closed_fds == [41]
+    assert second_manager.callback is not None
+
+    await coordinator.stop()
+    assert closed_fds == [41, 42]
+
+
+@pytest.mark.asyncio
+async def test_bus_disconnect_resumes_input_and_reconnects() -> None:
+    first_manager = _FakeLoginManager((41,))
+    second_manager = _FakeLoginManager((42,))
+    first_bus = _FakeBus(first_manager)
+    second_bus = _FakeBus(second_manager)
+    buses = iter((first_bus, second_bus))
+    runtime_events: list[str] = []
+    coordinator = LogindSleepCoordinator(
+        AsyncMock(),
+        pause_runtime=lambda: runtime_events.append("pause"),
+        resume_runtime=lambda: runtime_events.append("resume"),
+        bus_factory=lambda: next(buses),
+        close_fd=lambda _fd: None,
+    )
+
+    assert await coordinator.start() is True
+    first_manager.emit(True)
+    await _flush_worker()
+    assert runtime_events == ["pause"]
+
+    first_bus.drop()
+    await _wait_until(lambda: len(second_manager.inhibit_calls) == 1)
+    await _wait_until(lambda: runtime_events == ["pause", "resume"])
+
+    assert second_manager.callback is not None
+    await coordinator.stop()
 
 
 @pytest.mark.asyncio

--- a/tests/keymasqd/test_sleep.py
+++ b/tests/keymasqd/test_sleep.py
@@ -134,6 +134,26 @@ async def test_cleanup_failure_still_releases_delay_inhibitor() -> None:
 
 
 @pytest.mark.asyncio
+async def test_stop_completes_queued_suspend_cleanup_before_closing_inhibitor() -> None:
+    manager = _FakeLoginManager()
+    bus = _FakeBus(manager)
+    prepare = AsyncMock()
+    closed_fds: list[int] = []
+    coordinator = LogindSleepCoordinator(
+        prepare,
+        bus_factory=lambda: bus,
+        close_fd=closed_fds.append,
+    )
+
+    assert await coordinator.start() is True
+    manager.emit(True)
+    await coordinator.stop()
+
+    prepare.assert_awaited_once()
+    assert closed_fds == [41]
+
+
+@pytest.mark.asyncio
 async def test_logind_unavailable_does_not_prevent_daemon_start() -> None:
     class _UnavailableBus:
         async def connect(self):


### PR DESCRIPTION
## Summary

- listen for systemd-logind sleep signals while holding a delay inhibitor
- pause grabbed-device dispatch and neutralize macros, combos, cursor movement, analog controls, superkeys, profile triggers, repeat state, and tracked outputs
- quarantine held source keys across resume so missed releases cannot leave synthetic outputs stuck
- keep cleanup failure-contained and log when suspend cleanup starts

## Testing

- `./scripts/check.sh`
- `./scripts/integration.sh daemon-session`

Replaces the closed #250.