### PR TITLE
Add configurable virtual controller templates and flight stick outputs

### DIFF
--- a/docs/ACTIONS.md
+++ b/docs/ACTIONS.md
@@ -293,8 +293,10 @@ controller diagram. It accepts an evdev button name (such as `btn_c` or
 `btn_trigger_happy1`) or a numeric key code (decimal or `0x`-prefixed), and
 routes through the same output selected above. This is an advanced option: the
 chosen output must actually support the button code for it to emit. Hardware
-gamepad outputs expose whatever buttons the physical device advertises, while
-the virtual gamepad outputs advertise the standard Xbox 360 button set.
+gamepad outputs expose whatever buttons the physical device advertises. The
+built-in Xbox outputs advertise the standard Xbox 360 button set, while
+template-backed outputs advertise their declared buttons and show their
+control labels in the mapper.
 
 Gamepad actions can route to a specific output with `output_id`. Use
 `virtual-gamepad-1` through `virtual-gamepad-4` for configured virtual Xbox
@@ -306,15 +308,17 @@ configured output, it logs a warning and drops the gamepad event.
 Analog axis actions use `action = "gamepad_axis"`, a target such as `abs_x`
 or `abs_rz`, and a raw evdev `value`. Stick axes accept `-32768..32767`;
 trigger axes accept `0..255`. Releasing the source input returns the axis to
-neutral `0`. LT and RT are axis actions (`abs_z` and `abs_rz`); `gamepad`
-actions are button-only.
+the selected output template's declared rest value (`0` for the built-in Xbox
+axes). LT and RT are axis actions (`abs_z` and `abs_rz`); `gamepad` actions are
+button-only.
 
 To target an axis outside the template, pick **Custom** in the axis dropdown
 and enter an evdev axis name (such as `abs_hat0x`, `abs_hat0y`, `abs_throttle`,
 or `abs_rudder`) or a numeric code, then enter the raw value to send. As with
 custom buttons, the chosen output must support the axis for it to emit; the
-virtual gamepad outputs include the standard stick, trigger, and `abs_hat0`
-axes.
+built-in Xbox outputs include the standard stick, trigger, and `abs_hat0`
+axes. Template-backed outputs include exactly the axes declared by their
+template.
 
 ## Analog Controls
 

--- a/docs/ACTIONS.md
+++ b/docs/ACTIONS.md
@@ -306,11 +306,14 @@ exists. Explicit targets never fall back: if the daemon cannot route to the
 configured output, it logs a warning and drops the gamepad event.
 
 Analog axis actions use `action = "gamepad_axis"`, a target such as `abs_x`
-or `abs_rz`, and a raw evdev `value`. Stick axes accept `-32768..32767`;
-trigger axes accept `0..255`. Releasing the source input returns the axis to
-the selected output template's declared rest value (`0` for the built-in Xbox
-axes). LT and RT are axis actions (`abs_z` and `abs_rz`); `gamepad` actions are
-button-only.
+or `abs_rz`, and a raw evdev `value`. Built-in Xbox stick axes accept
+`-32768..32767`; trigger axes accept `0..255`. Other virtual outputs use their
+template's ranges. Releasing the source input returns a virtual axis to the
+selected output's declared rest value. The built-in Xbox axes declare `0`.
+Direct axis actions targeting physical hardware currently release to `0`;
+using learned or advertised target metadata is supported by
+[analog-control mappings](GAMEPAD.md#analog-output).
+LT and RT are axis actions (`abs_z` and `abs_rz`); `gamepad` actions are button-only.
 
 To target an axis outside the template, pick **Custom** in the axis dropdown
 and enter an evdev axis name (such as `abs_hat0x`, `abs_hat0y`, `abs_throttle`,

--- a/docs/ANALOG_CONTROLS.md
+++ b/docs/ANALOG_CONTROLS.md
@@ -136,6 +136,10 @@ per-control flags.
 
 Virtual Xbox gamepads also accept the legacy left/right stick and trigger
 targets. Their individual axes can be selected with `target = "axis"`.
+Template-backed virtual devices expose paired X/Y or RX/RY sticks through
+`target_analog_id`. For 1D controls, each advertised template axis is available
+through `target = "axis"`, including individual stick components, twist,
+throttle, hats, and custom axes. Existing named axis targets remain readable.
 
 ### Individual axis routing
 
@@ -144,7 +148,9 @@ The editor's **Output Axis** dropdown lists axes on the selected destination.
 raw rest override. Saved unavailable selections remain visible and are not
 silently replaced. With the default same-device output, the editor offers
 standard axes; availability and neutral are resolved against the bound device
-at runtime. Select a specific hardware output to choose its custom axes.
+at runtime. Select a specific hardware or template output to choose its custom
+axes. Template outputs use their configured ranges and rest values. For example,
+the built-in flight stick centers Stick X at 511 and releases Throttle at 255.
 
 For example, a trigger can drive the negative half of a stick:
 

--- a/docs/GAMEPAD.md
+++ b/docs/GAMEPAD.md
@@ -409,6 +409,11 @@ When applying changes, Keymasq prepares replacement outputs before removing the
 old ones. If creating or initializing a replacement fails, the existing outputs
 and their configuration remain available.
 
+Applying changes from the GUI requires the session service. If the Apply response
+is lost, the dialog checks the service's current configuration. It keeps the edits
+unapplied when it cannot confirm them, instead of saving an unconfirmed candidate
+to disk. Retry once the service responds.
+
 Use **Customize** on a built-in template, or **Duplicate** on a custom template,
 to create an editable copy. Copies receive an unused ID that can be changed before
 saving. **New template** lets you start from the gamepad or flight stick. The
@@ -425,6 +430,9 @@ resolution are under **Advanced**; the Linux device name, USB IDs, and bus type 
 identity**. Validation errors keep the editor open with your changes intact.
 Axis metadata must fit signed 32-bit integers. Linux aliases for the same button
 or axis count as one event code and cannot define separate controls.
+Output IDs cannot use the reserved `same-device` routing identifier or numbered
+`virtual-gamepad-N` IDs. Axis IDs must also produce unique analog-control IDs:
+the generated X/Y stick ID `x__y`, for example, cannot also name a standalone axis.
 
 A template defines:
 

--- a/docs/GAMEPAD.md
+++ b/docs/GAMEPAD.md
@@ -223,9 +223,10 @@ controller, or pass through with adjusted tuning.
 - **Output Axis** — for 1D controls, choose `Same Axis` or an individual
   supported destination axis, including components of a stick
 - **Output Control** — for sticks, preserve the source side, force `Left` or
-  `Right`, or select a learned stick on physical hardware
-- Physical stick outputs use the target stick's hardware range and center
-  when available; virtual gamepad sticks use the standard Xbox stick range
+  `Right`, or select a learned hardware or template stick
+- Physical and template-backed virtual outputs use the target axis ranges and
+  rest values when available. The built-in standard gamepad uses its standard
+  stick range.
 - **Output Deadzone** — values below this are sent as centered/released
 - **Output Rest** — manual release value when **Use Axis Neutral** is disabled
 - **Output Direction** — `Min`, `Max`, or `Both` (1D axes):
@@ -314,12 +315,18 @@ analog_control_names = ["WASD", "Mouse Wheel"]
 
 ## Game Compatibility
 
-The virtual gamepad appears as a standard Linux gamepad:
+The built-in Xbox output appears as a standard Xbox 360 controller:
 
 - **SDL2/SDL3** — full support
 - **Steam Input** — full support
 - **Wine/Proton** — works via evdev translation
 - **Native Linux games** — works with evdev-compatible games
+
+Template-backed joysticks are exposed through Linux evdev and SDL's joystick
+API. Games launched through Steam can open them directly, including through
+Wine/Proton when the game supports a joystick. Steam Input itself does not
+provide remapping for flight sticks and wheels, so do not expect a joystick
+template in Steam's gamepad configurator.
 
 Use [jstest-gtk](https://github.com/Grumbel/jstest-gtk) to verify that
 your virtual gamepad buttons and axes are working as expected.
@@ -328,8 +335,9 @@ your virtual gamepad buttons and axes are working as expected.
 
 ### Virtual Gamepads
 
-When you map an input to a gamepad action, Keymasq creates a virtual gamepad
-using Linux uinput. Games see it as a standard Xbox 360 controller.
+When you map an input to a gamepad action, Keymasq creates virtual gaming
+devices with Linux uinput. The existing virtual gamepads are instances of the
+built-in Xbox 360 template.
 
 Keymasq creates one virtual gamepad by default. You can configure 0–4 from
 the GUI hamburger menu under **Settings**. The setting is stored in
@@ -344,12 +352,183 @@ If the setting cannot be written to disk, the requested count remains active
 for the current session and Keymasq shows a warning that it may revert after a
 restart.
 
-Each virtual gamepad uses Xbox 360 hardware IDs:
+Each standard numbered virtual gamepad uses Xbox 360 hardware IDs:
 
 - **Name**: `keymasq-gamepad` (first), `keymasq-gamepad-2` through `-4`
 - **Vendor**: `0x045e` (Microsoft)
 - **Product**: `0x028e` (Xbox 360 controller)
 - **Capabilities**: 17 digital buttons, 8 analog axes
+
+### Template-backed virtual devices
+
+Open **Settings → Custom virtual devices** to create stable output instances
+from a template. Keymasq ships two built-in templates:
+
+- **Standard gamepad**, used by the existing 0–4 **Virtual gamepads** setting,
+  with two sticks, two triggers, and directional controls
+- **Flight stick**, with 12 joystick buttons and six
+  axes: X, Y, twist, throttle, and a two-axis hat
+
+The standard gamepad uses the Xbox 360 identity (`045e:028e`). The flight stick
+uses the Logitech Extreme 3D Pro identity (`046d:c215`) and Linux capability
+layout. These model references describe the emulated identities used for game
+detection; the GUI uses generic template names. Existing template IDs, Linux
+device names, and vendor/product IDs remain unchanged.
+
+An output instance keeps its configured
+`output_id` across restarts, so profiles do not depend on discovery order.
+
+The built-in flight stick has a dedicated mapping picker. Direction pads select
+stick and hat directions; twist selects left or right, and throttle shortcuts
+select Idle, Half, or Full. Grip buttons and base buttons surround a joystick
+illustration. Base buttons 7–12 correspond to the template's Base 1–6 controls.
+Tooltips show each control's Linux code.
+
+The axis editor accepts exact values or percentages of travel from rest. Stick
+and twist percentages range from -100 to 100; throttle ranges from 0 at idle to
+100 at full travel. The throttle's raw range is reversed: idle is 255 and full
+is 0. Select **Map axis** to use the chosen value. Custom templates retain their
+gamepad or flight stick layout, with shortcuts using the configured axis ranges.
+Only controls defined by the template are available to map. Other buttons appear
+in a numbered **Additional buttons** grid below the illustration and axis editor.
+The shortcut above the illustration jumps to this grid; search by label, number,
+control ID, or Linux code to find a button.
+
+Analog mappings to a virtual template resolve **Same**, **Left**, and **Right**
+using the destination's event codes, ranges, and rest values. A destination that
+does not contain the requested control receives no axis events. Choose a named
+destination control when the source and destination use different codes. Motion
+mappings also offer the template's named sticks instead of assuming two gamepad
+sticks.
+
+Use **Add output** on a template to create a controller from it. The output
+dialog selects that template and suggests an unused output ID. Identity overrides
+are optional and otherwise inherit the template's values.
+
+When applying changes, Keymasq prepares replacement outputs before removing the
+old ones. If creating or initializing a replacement fails, the existing outputs
+and their configuration remain available.
+
+Use **Customize** on a built-in template, or **Duplicate** on a custom template,
+to create an editable copy. Copies receive an unused ID that can be changed before
+saving. **New template** lets you start from the gamepad or flight stick. The
+**Layout** choice controls the mapping illustration independently of the template
+ID. Changing it preserves the configured buttons, axes, and device identity.
+
+The template editor has **Identity**, **Buttons**, and **Axes** tabs. Expand a
+control to edit its label and select a Linux code from a searchable list. Axis
+controls remain available in the mapping picker's axis selector. **Add numbered
+buttons** adds a batch of buttons using unused `BTN_TRIGGER_HAPPY*` codes, up to
+the template's 40-button total. Rename these buttons to describe their purpose.
+Axis rows include minimum, maximum, and rest fields. Control IDs, fuzz, flat, and
+resolution are under **Advanced**; the Linux device name, USB IDs, and bus type are under **Device
+identity**. Validation errors keep the editor open with your changes intact.
+Axis metadata must fit signed 32-bit integers. Linux aliases for the same button
+or axis count as one event code and cannot define separate controls.
+
+A template defines:
+
+- a template ID, display label, Linux device name, bus type, vendor ID,
+  product ID, and version
+- 1–40 named buttons, each bound to a Linux `BTN_*` code
+- 2–8 named axes, each bound to an `ABS_*` code with minimum, maximum, rest,
+  fuzz, flat, and resolution values
+
+Keymasq requires `ABS_X` and `ABS_Y` plus a joystick-classifying button or
+axis. This prevents custom devices that Linux exposes through uinput but SDL
+silently ignores. `BTN_TRIGGER_HAPPY*` controls are supported, but a template
+made only from TriggerHappy buttons still needs a classifying axis such as
+`ABS_RZ`.
+
+**Use changes** returns edits to the virtual devices dialog. Changes are drafts
+until **Apply** is pressed; closing with unapplied changes asks before discarding
+them. Applying reconnects affected
+uinput devices, so close games that currently have them open first.
+
+Named virtual outputs preserve raw axis values when mappings and superkeys are
+saved. At runtime, Keymasq limits those values to the target template's axis
+range and releases the axis to its declared rest value. The standard numbered
+virtual gamepads retain their existing axis limits.
+
+The advanced format is stored in
+`~/.config/keymasq/virtual_devices.toml`. Built-in templates are referenced by
+ID and are not copied into the file. This creates a flight stick output:
+
+```toml
+[[devices]]
+output_id = "flight-stick"
+template = "logitech-extreme-3d-pro"
+```
+
+Identity fields can be overridden per output:
+
+```toml
+[[devices]]
+output_id = "left-seat-stick"
+template = "logitech-extreme-3d-pro"
+name = "Left Seat Stick"
+vendor_id = "046d"
+product_id = "c215"
+version = "0110"
+bustype = "usb"
+```
+
+A custom template and output use arrays of button and axis tables:
+
+```toml
+[[templates]]
+id = "space-panel"
+label = "Space Panel"
+layout = "flight-stick"
+name = "Keymasq Space Panel"
+vendor_id = "4b4d"
+product_id = "2001"
+version = "0100"
+bustype = "usb"
+
+[[templates.buttons]]
+id = "fire"
+label = "Fire"
+evdev = "btn_trigger_happy1"
+
+[[templates.buttons]]
+id = "mode"
+label = "Mode"
+evdev = "btn_trigger_happy2"
+
+[[templates.axes]]
+id = "x"
+label = "Stick X"
+evdev = "abs_x"
+minimum = -32768
+maximum = 32767
+rest = 0
+
+[[templates.axes]]
+id = "y"
+label = "Stick Y"
+evdev = "abs_y"
+minimum = -32768
+maximum = 32767
+rest = 0
+
+[[templates.axes]]
+id = "twist"
+label = "Twist"
+evdev = "abs_rz"
+minimum = -32768
+maximum = 32767
+rest = 0
+
+[[devices]]
+output_id = "space-rig"
+template = "space-panel"
+```
+
+The mapper shows the selected template's control labels and axis endpoints.
+Profiles continue to store the corresponding evdev target, such as
+`btn_trigger_happy1` or `abs_rz`, together with the stable `output_id`. Axis
+actions return to the template's declared `rest` value when released.
 
 ### Output Routing
 
@@ -359,6 +538,7 @@ Valid values:
 | Value | Target |
 |-------|--------|
 | `virtual-gamepad-1` … `virtual-gamepad-4` | A configured virtual gamepad |
+| A configured template output ID (for example `flight-stick`) | A template-backed virtual device |
 | A hardware ID (e.g. `045e:028e@2`) | A grabbed physical controller |
 
 If `output_id` is omitted, output goes to `virtual-gamepad-1`. If the

--- a/docs/OUTPUT_AXES.md
+++ b/docs/OUTPUT_AXES.md
@@ -18,9 +18,11 @@ querying the physical device during output resolution. Axes with neither saved n
 runtime-resolved valid ranges are omitted.
 
 Output providers populate `GamepadOutputTarget.output_axes`. An empty tuple
-means no supported axes. A future virtual-device template provider can supply
-its own tuple of `OutputAxis` objects using the capabilities advertised when
-creating its uinput device. The editor should use the same descriptions.
+means no supported axes. Virtual-device templates supply their advertised axes
+through `template_output_axes()`. The editor and runtime use the same labels,
+ranges, and neutral values, including individual stick components and custom
+axes. A flight stick therefore offers twist and throttle without advertising
+unsupported standard-gamepad axes.
 
 Axis selection and range conversion must use the destination's metadata.
 An evdev code being valid does not mean every output supports it.

--- a/keymasq/common/gamepad_axes.py
+++ b/keymasq/common/gamepad_axes.py
@@ -4,6 +4,8 @@ from dataclasses import dataclass
 
 import evdev
 
+from keymasq.common.virtual_devices import is_virtual_gamepad_output_id
+
 
 @dataclass(frozen=True)
 class GamepadAxisRange:
@@ -74,12 +76,20 @@ def gamepad_axis_max_value(target: object) -> int:
     return axis_range.maximum if axis_range is not None else 0
 
 
-def clamp_gamepad_axis_value(target: object, value: object) -> int:
+def clamp_gamepad_axis_value(target: object, value: object, *, output_id: str | None = None) -> int:
     axis_range = gamepad_axis_range(target)
     try:
         raw_value = int(value)  # type: ignore[arg-type]
     except (TypeError, ValueError):
         raw_value = axis_range.maximum if axis_range is not None else 0
+    if output_id and not is_virtual_gamepad_output_id(output_id):
+        # Named outputs may use different ranges for standard ABS codes. Their
+        # capabilities are only available when the daemon resolves the output.
+        return (
+            max(-2147483648, min(2147483647, raw_value))
+            if normalize_gamepad_axis_target(target)
+            else 0
+        )
     if axis_range is None:
         # Custom axes have no known range; pass the value through unclamped.
         return raw_value if normalize_gamepad_axis_target(target) else 0

--- a/keymasq/common/model/actions.py
+++ b/keymasq/common/model/actions.py
@@ -449,7 +449,9 @@ def normalize_common_action_fields(action: _CommonActionFields) -> None:
     action.output_id = normalize_gamepad_output_id(action.action_type, action.output_id)
     if action.action_type == ActionType.GAMEPAD_AXIS:
         action.target = normalize_gamepad_axis_target(action.target)
-        action.axis_value = clamp_gamepad_axis_value(action.target, action.axis_value)
+        action.axis_value = clamp_gamepad_axis_value(
+            action.target, action.axis_value, output_id=action.output_id
+        )
     rapidfire_enabled, rapidfire_hold_ms, rapidfire_wait_ms = normalize_rapidfire_fields(
         action.action_type,
         rapidfire_enabled=bool(action.rapidfire_enabled),

--- a/keymasq/common/model/analog.py
+++ b/keymasq/common/model/analog.py
@@ -6,6 +6,7 @@ from typing import cast
 from keymasq.common.gamepad_axes import normalize_gamepad_axis_target
 from keymasq.common.model.actions import MappingAction, normalize_output_id
 from keymasq.common.model.core import ActionType
+from keymasq.common.virtual_devices import SAME_DEVICE_OUTPUT_ID as SAME_DEVICE_OUTPUT_ID
 
 ANALOG_THRESHOLD_ACTION_TYPES = frozenset(
     action_type
@@ -21,7 +22,6 @@ ANALOG_THRESHOLD_ACTION_TYPES = frozenset(
 
 ANALOG_MOUSE_DIRECTIONS = frozenset({"left", "right", "up", "down", "horizontal", "vertical"})
 ANALOG_MOUSE_MODES = frozenset({"velocity", "area"})
-SAME_DEVICE_OUTPUT_ID = "same-device"
 ANALOG_GAMEPAD_OUTPUT_TARGETS = frozenset({"same", "left", "right", "analog", "axis"})
 ANALOG_GAMEPAD_OUTPUT_DIRECTIONS = frozenset({"min", "max", "both"})
 MIN_ANALOG_GAMEPAD_OUTPUT_SENSITIVITY = 0.1

--- a/keymasq/common/virtual_device_templates.py
+++ b/keymasq/common/virtual_device_templates.py
@@ -1,0 +1,615 @@
+from __future__ import annotations
+
+import re
+from collections.abc import Collection, Sequence
+from dataclasses import dataclass
+from typing import cast
+
+import evdev
+
+from keymasq.common.output_axes import OutputAxis
+from keymasq.common.virtual_devices import MAX_VIRTUAL_GAMEPADS, virtual_gamepad_output_id
+
+MAX_USER_VIRTUAL_DEVICES = 4
+MAX_TEMPLATE_BUTTONS = 40
+MAX_TEMPLATE_AXES = 8
+XBOX_360_TEMPLATE_ID = "xbox-360"
+LOGITECH_EXTREME_3D_TEMPLATE_ID = "logitech-extreme-3d-pro"
+
+_ID_PATTERN = re.compile(r"^[a-z][a-z0-9_-]{0,63}$")
+_SDL_CLASSIFIER_AXES = {
+    "abs_rx",
+    "abs_ry",
+    "abs_rz",
+    "abs_throttle",
+    "abs_rudder",
+    "abs_wheel",
+    "abs_gas",
+    "abs_brake",
+}
+_BUS_TYPES = {
+    "pci": 0x01,
+    "usb": 0x03,
+    "bluetooth": 0x05,
+    "virtual": 0x06,
+}
+
+
+class VirtualDeviceConfigError(ValueError):
+    pass
+
+
+@dataclass(frozen=True, slots=True)
+class VirtualButton:
+    id: str
+    label: str
+    evdev: str
+
+
+@dataclass(frozen=True, slots=True)
+class VirtualAxis:
+    id: str
+    label: str
+    evdev: str
+    minimum: int
+    maximum: int
+    rest: int = 0
+    fuzz: int = 0
+    flat: int = 0
+    resolution: int = 0
+
+
+@dataclass(frozen=True, slots=True)
+class VirtualDeviceTemplate:
+    id: str
+    label: str
+    name: str
+    vendor_id: int
+    product_id: int
+    version: int
+    bustype: int
+    buttons: tuple[VirtualButton, ...]
+    axes: tuple[VirtualAxis, ...]
+    builtin: bool = False
+    layout: str = "gamepad"
+
+
+@dataclass(frozen=True, slots=True)
+class VirtualDeviceInstance:
+    output_id: str
+    template_id: str
+    name: str | None = None
+    vendor_id: int | None = None
+    product_id: int | None = None
+    version: int | None = None
+    bustype: int | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class VirtualDeviceConfig:
+    templates: tuple[VirtualDeviceTemplate, ...] = ()
+    devices: tuple[VirtualDeviceInstance, ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
+class ResolvedVirtualDevice:
+    output_id: str
+    template: VirtualDeviceTemplate
+    name: str
+    vendor_id: int
+    product_id: int
+    version: int
+    bustype: int
+
+
+def _button(id: str, label: str, evdev_name: str) -> VirtualButton:
+    return VirtualButton(id=id, label=label, evdev=evdev_name)
+
+
+def _axis(
+    id: str,
+    label: str,
+    evdev_name: str,
+    minimum: int,
+    maximum: int,
+    *,
+    rest: int = 0,
+    fuzz: int = 0,
+    flat: int = 0,
+) -> VirtualAxis:
+    return VirtualAxis(
+        id=id,
+        label=label,
+        evdev=evdev_name,
+        minimum=minimum,
+        maximum=maximum,
+        rest=rest,
+        fuzz=fuzz,
+        flat=flat,
+    )
+
+
+XBOX_360_TEMPLATE = VirtualDeviceTemplate(
+    id=XBOX_360_TEMPLATE_ID,
+    label="Standard gamepad",
+    name="keymasq-gamepad",
+    vendor_id=0x045E,
+    product_id=0x028E,
+    version=0x0110,
+    bustype=_BUS_TYPES["usb"],
+    buttons=(
+        _button("a", "A", "btn_south"),
+        _button("b", "B", "btn_east"),
+        _button("x", "X", "btn_west"),
+        _button("y", "Y", "btn_north"),
+        _button("left-shoulder", "LB", "btn_tl"),
+        _button("right-shoulder", "RB", "btn_tr"),
+        _button("left-trigger-button", "LT button", "btn_tl2"),
+        _button("right-trigger-button", "RT button", "btn_tr2"),
+        _button("select", "Select", "btn_select"),
+        _button("start", "Start", "btn_start"),
+        _button("guide", "Guide", "btn_mode"),
+        _button("left-stick", "LS", "btn_thumbl"),
+        _button("right-stick", "RS", "btn_thumbr"),
+        _button("dpad-up", "D-pad Up", "btn_dpad_up"),
+        _button("dpad-down", "D-pad Down", "btn_dpad_down"),
+        _button("dpad-left", "D-pad Left", "btn_dpad_left"),
+        _button("dpad-right", "D-pad Right", "btn_dpad_right"),
+    ),
+    axes=(
+        _axis("left-x", "Left Stick X", "abs_x", -32768, 32767, fuzz=16, flat=128),
+        _axis("left-y", "Left Stick Y", "abs_y", -32768, 32767, fuzz=16, flat=128),
+        _axis("right-x", "Right Stick X", "abs_rx", -32768, 32767, fuzz=16, flat=128),
+        _axis("right-y", "Right Stick Y", "abs_ry", -32768, 32767, fuzz=16, flat=128),
+        _axis("left-trigger", "Left Trigger", "abs_z", 0, 255),
+        _axis("right-trigger", "Right Trigger", "abs_rz", 0, 255),
+        _axis("dpad-x", "D-pad X", "abs_hat0x", -1, 1),
+        _axis("dpad-y", "D-pad Y", "abs_hat0y", -1, 1),
+    ),
+    builtin=True,
+)
+
+
+LOGITECH_EXTREME_3D_TEMPLATE = VirtualDeviceTemplate(
+    id=LOGITECH_EXTREME_3D_TEMPLATE_ID,
+    label="Flight stick",
+    name="Logitech Logitech Extreme 3D",
+    vendor_id=0x046D,
+    product_id=0xC215,
+    version=0x0110,
+    bustype=_BUS_TYPES["usb"],
+    buttons=(
+        _button("trigger", "Trigger", "btn_trigger"),
+        _button("thumb", "Thumb", "btn_thumb"),
+        _button("thumb-2", "Thumb 2", "btn_thumb2"),
+        _button("top", "Top", "btn_top"),
+        _button("top-2", "Top 2", "btn_top2"),
+        _button("pinkie", "Pinkie", "btn_pinkie"),
+        _button("base-1", "Base 1", "btn_base"),
+        _button("base-2", "Base 2", "btn_base2"),
+        _button("base-3", "Base 3", "btn_base3"),
+        _button("base-4", "Base 4", "btn_base4"),
+        _button("base-5", "Base 5", "btn_base5"),
+        _button("base-6", "Base 6", "btn_base6"),
+    ),
+    axes=(
+        _axis("stick-x", "Stick X", "abs_x", 0, 1023, rest=511, fuzz=3, flat=63),
+        _axis("stick-y", "Stick Y", "abs_y", 0, 1023, rest=511, fuzz=3, flat=63),
+        _axis("twist", "Twist", "abs_rz", 0, 255, rest=127, flat=15),
+        _axis("throttle", "Throttle", "abs_throttle", 0, 255, rest=255, flat=15),
+        _axis("hat-x", "Hat X", "abs_hat0x", -1, 1),
+        _axis("hat-y", "Hat Y", "abs_hat0y", -1, 1),
+    ),
+    builtin=True,
+    layout="flight-stick",
+)
+
+BUILTIN_VIRTUAL_DEVICE_TEMPLATES = (
+    XBOX_360_TEMPLATE,
+    LOGITECH_EXTREME_3D_TEMPLATE,
+)
+
+
+def _require_id(value: object, field: str) -> str:
+    normalized = str(value or "").strip().lower()
+    if not _ID_PATTERN.fullmatch(normalized):
+        raise VirtualDeviceConfigError(f"{field} must match {_ID_PATTERN.pattern}")
+    return normalized
+
+
+def _require_label(value: object, field: str) -> str:
+    normalized = str(value or "").strip()
+    if not normalized:
+        raise VirtualDeviceConfigError(f"{field} is required")
+    if len(normalized.encode("utf-8")) > 80:
+        raise VirtualDeviceConfigError(f"{field} must fit in 80 UTF-8 bytes")
+    return normalized
+
+
+def _hardware_int(value: object, field: str, *, default: int | None = None) -> int:
+    if value is None and default is not None:
+        return default
+    try:
+        parsed = int(str(value), 16) if isinstance(value, str) else int(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise VirtualDeviceConfigError(f"{field} must be a 16-bit integer or hex string") from exc
+    if not 0 <= parsed <= 0xFFFF:
+        raise VirtualDeviceConfigError(f"{field} must be between 0x0000 and 0xffff")
+    return parsed
+
+
+def _event_code(name: object, *, axis: bool) -> str:
+    normalized = str(name or "").strip().lower()
+    prefix = "abs_" if axis else "btn_"
+    if not normalized.startswith(prefix):
+        raise VirtualDeviceConfigError(f"event code must start with {prefix}")
+    code = getattr(evdev.ecodes, normalized.upper(), None)
+    code_table = evdev.ecodes.ABS if axis else evdev.ecodes.keys
+    if not isinstance(code, int) or code not in code_table:
+        raise VirtualDeviceConfigError(f"unknown evdev code {normalized!r}")
+    return normalized
+
+
+def _dict(value: object, field: str) -> dict[str, object]:
+    if not isinstance(value, dict):
+        raise VirtualDeviceConfigError(f"{field} must be a table")
+    return cast(dict[str, object], value)
+
+
+def _list(value: object, field: str) -> list[object]:
+    if value is None:
+        return []
+    if not isinstance(value, list):
+        raise VirtualDeviceConfigError(f"{field} must be an array")
+    return cast(list[object], value)
+
+
+def _button_from_data(value: object) -> VirtualButton:
+    data = _dict(value, "button")
+    return VirtualButton(
+        id=_require_id(data.get("id"), "button.id"),
+        label=_require_label(data.get("label"), "button.label"),
+        evdev=_event_code(data.get("evdev"), axis=False),
+    )
+
+
+def _axis_from_data(value: object) -> VirtualAxis:
+    data = _dict(value, "axis")
+    minimum = _integer(data.get("minimum"), "axis.minimum")
+    maximum = _integer(data.get("maximum"), "axis.maximum")
+    rest = _integer(data.get("rest", 0), "axis.rest")
+    if minimum >= maximum:
+        raise VirtualDeviceConfigError("axis.minimum must be less than axis.maximum")
+    if not minimum <= rest <= maximum:
+        raise VirtualDeviceConfigError("axis.rest must be inside the axis range")
+    return VirtualAxis(
+        id=_require_id(data.get("id"), "axis.id"),
+        label=_require_label(data.get("label"), "axis.label"),
+        evdev=_event_code(data.get("evdev"), axis=True),
+        minimum=minimum,
+        maximum=maximum,
+        rest=rest,
+        fuzz=max(0, _integer(data.get("fuzz", 0), "axis.fuzz")),
+        flat=max(0, _integer(data.get("flat", 0), "axis.flat")),
+        resolution=max(0, _integer(data.get("resolution", 0), "axis.resolution")),
+    )
+
+
+def _integer(value: object, field: str) -> int:
+    try:
+        parsed = int(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise VirtualDeviceConfigError(f"{field} must be an integer") from exc
+    if not -2147483648 <= parsed <= 2147483647:
+        raise VirtualDeviceConfigError(f"{field} must be a signed 32-bit integer")
+    return parsed
+
+
+def template_from_data(value: object) -> VirtualDeviceTemplate:
+    data = _dict(value, "template")
+    template_id = _require_id(data.get("id"), "template.id")
+    buttons = tuple(_button_from_data(item) for item in _list(data.get("buttons"), "buttons"))
+    axes = tuple(_axis_from_data(item) for item in _list(data.get("axes"), "axes"))
+    template = VirtualDeviceTemplate(
+        id=template_id,
+        label=_require_label(data.get("label"), "template.label"),
+        name=_require_label(data.get("name"), "template.name"),
+        vendor_id=_hardware_int(data.get("vendor_id"), "template.vendor_id"),
+        product_id=_hardware_int(data.get("product_id"), "template.product_id"),
+        version=_hardware_int(data.get("version"), "template.version", default=0x0100),
+        bustype=_parse_bustype(data.get("bustype", "usb")),
+        buttons=buttons,
+        axes=axes,
+        layout=str(data.get("layout", "gamepad")),
+    )
+    validate_template(template)
+    return template
+
+
+def _parse_bustype(value: object) -> int:
+    normalized = str(value or "usb").strip().lower()
+    if normalized in _BUS_TYPES:
+        return _BUS_TYPES[normalized]
+    return _hardware_int(value, "template.bustype")
+
+
+def validate_template(template: VirtualDeviceTemplate) -> None:
+    if template.layout not in {"gamepad", "flight-stick"}:
+        raise VirtualDeviceConfigError("template.layout must be gamepad or flight-stick")
+    if (
+        template.id in {item.id for item in BUILTIN_VIRTUAL_DEVICE_TEMPLATES}
+        and not template.builtin
+    ):
+        raise VirtualDeviceConfigError(f"template ID {template.id!r} is reserved")
+    if not 1 <= len(template.buttons) <= MAX_TEMPLATE_BUTTONS:
+        raise VirtualDeviceConfigError(f"template must define 1..{MAX_TEMPLATE_BUTTONS} buttons")
+    if not 2 <= len(template.axes) <= MAX_TEMPLATE_AXES:
+        raise VirtualDeviceConfigError(f"template must define 2..{MAX_TEMPLATE_AXES} axes")
+    control_ids = [item.id for item in (*template.buttons, *template.axes)]
+    if len(control_ids) != len(set(control_ids)):
+        raise VirtualDeviceConfigError("template control IDs must be unique")
+    event_codes = [
+        (isinstance(item, VirtualAxis), int(getattr(evdev.ecodes, item.evdev.upper())))
+        for item in (*template.buttons, *template.axes)
+    ]
+    if len(event_codes) != len(set(event_codes)):
+        raise VirtualDeviceConfigError("template evdev codes must be unique")
+    axis_codes = {axis.evdev for axis in template.axes}
+    if not {"abs_x", "abs_y"}.issubset(axis_codes):
+        raise VirtualDeviceConfigError("SDL-compatible templates must define abs_x and abs_y")
+    button_codes = {
+        cast(int, getattr(evdev.ecodes, button.evdev.upper())) for button in template.buttons
+    }
+    classifier_buttons = {
+        evdev.ecodes.BTN_TRIGGER,
+        evdev.ecodes.BTN_A,
+        evdev.ecodes.BTN_1,
+    }
+    if not button_codes.intersection(classifier_buttons) and not axis_codes.intersection(
+        _SDL_CLASSIFIER_AXES
+    ):
+        raise VirtualDeviceConfigError(
+            "SDL-compatible templates need a joystick button or an RX/RY/RZ-style axis"
+        )
+
+
+def instance_from_data(value: object) -> VirtualDeviceInstance:
+    data = _dict(value, "device")
+    return VirtualDeviceInstance(
+        output_id=_require_id(data.get("output_id"), "device.output_id"),
+        template_id=_require_id(data.get("template"), "device.template"),
+        name=_require_label(data.get("name"), "device.name") if data.get("name") else None,
+        vendor_id=(
+            _hardware_int(data.get("vendor_id"), "device.vendor_id")
+            if data.get("vendor_id") is not None
+            else None
+        ),
+        product_id=(
+            _hardware_int(data.get("product_id"), "device.product_id")
+            if data.get("product_id") is not None
+            else None
+        ),
+        version=(
+            _hardware_int(data.get("version"), "device.version")
+            if data.get("version") is not None
+            else None
+        ),
+        bustype=_parse_bustype(data.get("bustype")) if data.get("bustype") else None,
+    )
+
+
+def virtual_device_config_from_toml(data: dict[str, object]) -> VirtualDeviceConfig:
+    templates = tuple(
+        template_from_data(item) for item in _list(data.get("templates"), "templates")
+    )
+    if len({template.id for template in templates}) != len(templates):
+        raise VirtualDeviceConfigError("template IDs must be unique")
+    devices = tuple(instance_from_data(item) for item in _list(data.get("devices"), "devices"))
+    if len(devices) > MAX_USER_VIRTUAL_DEVICES:
+        raise VirtualDeviceConfigError(
+            f"at most {MAX_USER_VIRTUAL_DEVICES} user virtual devices may be configured"
+        )
+    if len({device.output_id for device in devices}) != len(devices):
+        raise VirtualDeviceConfigError("device output IDs must be unique")
+    reserved_outputs = {
+        virtual_gamepad_output_id(index) for index in range(1, MAX_VIRTUAL_GAMEPADS + 1)
+    }
+    if reserved_outputs.intersection(device.output_id for device in devices):
+        raise VirtualDeviceConfigError("virtual-gamepad-N output IDs are reserved")
+    template_ids = {template.id for template in (*BUILTIN_VIRTUAL_DEVICE_TEMPLATES, *templates)}
+    missing = {device.template_id for device in devices} - template_ids
+    if missing:
+        raise VirtualDeviceConfigError(f"unknown device template(s): {', '.join(sorted(missing))}")
+    return VirtualDeviceConfig(templates=templates, devices=devices)
+
+
+def _button_to_data(button: VirtualButton) -> dict[str, object]:
+    return {"id": button.id, "label": button.label, "evdev": button.evdev}
+
+
+def _axis_to_data(axis: VirtualAxis) -> dict[str, object]:
+    return {
+        "id": axis.id,
+        "label": axis.label,
+        "evdev": axis.evdev,
+        "minimum": axis.minimum,
+        "maximum": axis.maximum,
+        "rest": axis.rest,
+        "fuzz": axis.fuzz,
+        "flat": axis.flat,
+        "resolution": axis.resolution,
+    }
+
+
+def _hex(value: int) -> str:
+    return f"{value:04x}"
+
+
+def template_to_data(template: VirtualDeviceTemplate) -> dict[str, object]:
+    return {
+        "id": template.id,
+        "layout": template.layout,
+        "label": template.label,
+        "name": template.name,
+        "vendor_id": _hex(template.vendor_id),
+        "product_id": _hex(template.product_id),
+        "version": _hex(template.version),
+        "bustype": _hex(template.bustype),
+        "buttons": [_button_to_data(button) for button in template.buttons],
+        "axes": [_axis_to_data(axis) for axis in template.axes],
+    }
+
+
+def instance_to_data(instance: VirtualDeviceInstance) -> dict[str, object]:
+    data: dict[str, object] = {
+        "output_id": instance.output_id,
+        "template": instance.template_id,
+    }
+    for key, value in (
+        ("name", instance.name),
+        ("vendor_id", instance.vendor_id),
+        ("product_id", instance.product_id),
+        ("version", instance.version),
+        ("bustype", instance.bustype),
+    ):
+        if value is not None:
+            data[key] = _hex(value) if isinstance(value, int) else value
+    return data
+
+
+def virtual_device_config_to_toml(config: VirtualDeviceConfig) -> dict[str, object]:
+    return {
+        "templates": [template_to_data(template) for template in config.templates],
+        "devices": [instance_to_data(device) for device in config.devices],
+    }
+
+
+def template_catalog(config: VirtualDeviceConfig) -> dict[str, VirtualDeviceTemplate]:
+    return {
+        template.id: template for template in (*BUILTIN_VIRTUAL_DEVICE_TEMPLATES, *config.templates)
+    }
+
+
+def template_output_axes(template: VirtualDeviceTemplate) -> tuple[OutputAxis, ...]:
+    """Describe the exact axes advertised by a virtual output for routing and editing."""
+    return tuple(
+        OutputAxis(axis.evdev, axis.label, axis.minimum, axis.maximum, axis.rest)
+        for axis in template.axes
+    )
+
+
+def template_analog_inputs(template: VirtualDeviceTemplate) -> dict[str, object]:
+    inputs: dict[str, object] = {}
+    axes_by_evdev = {axis.evdev: axis for axis in template.axes}
+    paired_codes = (("abs_x", "abs_y"), ("abs_rx", "abs_ry"))
+    paired_axis_ids: set[str] = set()
+    for x_code, y_code in paired_codes:
+        x_axis = axes_by_evdev.get(x_code)
+        y_axis = axes_by_evdev.get(y_code)
+        if x_axis is None or y_axis is None:
+            continue
+        analog_id = f"{x_axis.id}__{y_axis.id}"
+        inputs[analog_id] = {
+            "label": f"{x_axis.label} / {y_axis.label}",
+            "type": "stick",
+            "axes": [
+                _axis_analog_data(x_axis, role="x"),
+                _axis_analog_data(y_axis, role="y"),
+            ],
+        }
+        paired_axis_ids.update((x_axis.id, y_axis.id))
+    for axis in template.axes:
+        if axis.id in paired_axis_ids:
+            continue
+        inputs[axis.id] = {
+            "label": axis.label,
+            "type": "axis",
+            "axes": [_axis_analog_data(axis, role="x")],
+        }
+    return inputs
+
+
+def _axis_analog_data(axis: VirtualAxis, *, role: str) -> dict[str, object]:
+    return {
+        "role": role,
+        "evdev": axis.evdev,
+        "minimum": axis.minimum,
+        "maximum": axis.maximum,
+        "center": axis.rest,
+        "rest": axis.rest,
+    }
+
+
+def resolve_virtual_devices(
+    xbox_count: int,
+    config: VirtualDeviceConfig,
+) -> tuple[ResolvedVirtualDevice, ...]:
+    catalog = template_catalog(config)
+    resolved: list[ResolvedVirtualDevice] = []
+    for index in range(1, xbox_count + 1):
+        name = XBOX_360_TEMPLATE.name if index == 1 else f"{XBOX_360_TEMPLATE.name}-{index}"
+        resolved.append(
+            ResolvedVirtualDevice(
+                output_id=virtual_gamepad_output_id(index),
+                template=XBOX_360_TEMPLATE,
+                name=name,
+                vendor_id=XBOX_360_TEMPLATE.vendor_id,
+                product_id=XBOX_360_TEMPLATE.product_id,
+                version=XBOX_360_TEMPLATE.version,
+                bustype=XBOX_360_TEMPLATE.bustype,
+            )
+        )
+    for instance in config.devices:
+        template = catalog[instance.template_id]
+        resolved.append(
+            ResolvedVirtualDevice(
+                output_id=instance.output_id,
+                template=template,
+                name=instance.name or template.name,
+                vendor_id=(
+                    instance.vendor_id if instance.vendor_id is not None else template.vendor_id
+                ),
+                product_id=(
+                    instance.product_id if instance.product_id is not None else template.product_id
+                ),
+                version=instance.version if instance.version is not None else template.version,
+                bustype=instance.bustype if instance.bustype is not None else template.bustype,
+            )
+        )
+    return tuple(resolved)
+
+
+def config_to_json(config: VirtualDeviceConfig) -> dict[str, object]:
+    return virtual_device_config_to_toml(config)
+
+
+def config_from_json(value: object) -> VirtualDeviceConfig:
+    return virtual_device_config_from_toml(_dict(value, "virtual device config"))
+
+
+def numbered_button_batch(
+    buttons: Sequence[VirtualButton], count: int, *, reserved_ids: Collection[str] = ()
+) -> tuple[VirtualButton, ...]:
+    """Allocate independent TriggerHappy buttons without reusing codes or IDs."""
+    if count < 1 or len(buttons) + count > MAX_TEMPLATE_BUTTONS:
+        raise VirtualDeviceConfigError(
+            f"A template can contain at most {MAX_TEMPLATE_BUTTONS} buttons"
+        )
+    codes = {int(getattr(evdev.ecodes, button.evdev.upper())) for button in buttons}
+    used_ids = {button.id for button in buttons} | set(reserved_ids)
+    added: list[VirtualButton] = []
+    for index in range(1, 41):
+        code = f"btn_trigger_happy{index}"
+        if int(getattr(evdev.ecodes, code.upper())) in codes:
+            continue
+        base = f"extra-button-{index}"
+        control_id = base
+        suffix = 2
+        while control_id in used_ids:
+            control_id = f"{base}-{suffix}"
+            suffix += 1
+        used_ids.add(control_id)
+        added.append(VirtualButton(control_id, f"Button {len(buttons) + len(added) + 1}", code))
+        if len(added) == count:
+            return tuple(added)
+    raise VirtualDeviceConfigError("Not enough unused TriggerHappy codes")

--- a/keymasq/common/virtual_device_templates.py
+++ b/keymasq/common/virtual_device_templates.py
@@ -8,7 +8,11 @@ from typing import cast
 import evdev
 
 from keymasq.common.output_axes import OutputAxis
-from keymasq.common.virtual_devices import MAX_VIRTUAL_GAMEPADS, virtual_gamepad_output_id
+from keymasq.common.virtual_devices import (
+    MAX_VIRTUAL_GAMEPADS,
+    SAME_DEVICE_OUTPUT_ID,
+    virtual_gamepad_output_id,
+)
 
 MAX_USER_VIRTUAL_DEVICES = 4
 MAX_TEMPLATE_BUTTONS = 40
@@ -373,6 +377,7 @@ def validate_template(template: VirtualDeviceTemplate) -> None:
         raise VirtualDeviceConfigError(
             "SDL-compatible templates need a joystick button or an RX/RY/RZ-style axis"
         )
+    template_analog_inputs(template)
 
 
 def instance_from_data(value: object) -> VirtualDeviceInstance:
@@ -414,10 +419,11 @@ def virtual_device_config_from_toml(data: dict[str, object]) -> VirtualDeviceCon
     if len({device.output_id for device in devices}) != len(devices):
         raise VirtualDeviceConfigError("device output IDs must be unique")
     reserved_outputs = {
-        virtual_gamepad_output_id(index) for index in range(1, MAX_VIRTUAL_GAMEPADS + 1)
+        SAME_DEVICE_OUTPUT_ID,
+        *(virtual_gamepad_output_id(index) for index in range(1, MAX_VIRTUAL_GAMEPADS + 1)),
     }
     if reserved_outputs.intersection(device.output_id for device in devices):
-        raise VirtualDeviceConfigError("virtual-gamepad-N output IDs are reserved")
+        raise VirtualDeviceConfigError("same-device and virtual-gamepad-N output IDs are reserved")
     template_ids = {template.id for template in (*BUILTIN_VIRTUAL_DEVICE_TEMPLATES, *templates)}
     missing = {device.template_id for device in devices} - template_ids
     if missing:
@@ -511,6 +517,8 @@ def template_analog_inputs(template: VirtualDeviceTemplate) -> dict[str, object]
         if x_axis is None or y_axis is None:
             continue
         analog_id = f"{x_axis.id}__{y_axis.id}"
+        if analog_id in inputs:
+            raise VirtualDeviceConfigError(f"derived analog ID {analog_id!r} is not unique")
         inputs[analog_id] = {
             "label": f"{x_axis.label} / {y_axis.label}",
             "type": "stick",
@@ -523,6 +531,8 @@ def template_analog_inputs(template: VirtualDeviceTemplate) -> dict[str, object]
     for axis in template.axes:
         if axis.id in paired_axis_ids:
             continue
+        if axis.id in inputs:
+            raise VirtualDeviceConfigError(f"derived analog ID {axis.id!r} is not unique")
         inputs[axis.id] = {
             "label": axis.label,
             "type": "axis",

--- a/keymasq/common/virtual_device_templates.py
+++ b/keymasq/common/virtual_device_templates.py
@@ -243,6 +243,8 @@ def _event_code(name: object, *, axis: bool) -> str:
     prefix = "abs_" if axis else "btn_"
     if not normalized.startswith(prefix):
         raise VirtualDeviceConfigError(f"event code must start with {prefix}")
+    if axis and normalized in {"abs_max", "abs_cnt"}:
+        raise VirtualDeviceConfigError(f"{normalized} is an axis sentinel, not an input axis")
     code = getattr(evdev.ecodes, normalized.upper(), None)
     code_table = evdev.ecodes.ABS if axis else evdev.ecodes.keys
     if not isinstance(code, int) or code not in code_table:

--- a/keymasq/common/virtual_devices.py
+++ b/keymasq/common/virtual_devices.py
@@ -1,6 +1,7 @@
 MIN_VIRTUAL_GAMEPADS = 0
 MAX_VIRTUAL_GAMEPADS = 4
 DEFAULT_VIRTUAL_GAMEPADS = 1
+SAME_DEVICE_OUTPUT_ID = "same-device"
 
 
 def clamp_virtual_gamepad_count(value: object) -> int:

--- a/keymasq/gui/widgets/analog_control/view.py
+++ b/keymasq/gui/widgets/analog_control/view.py
@@ -18,6 +18,12 @@ from keymasq.common.output_axes import (
     find_output_axis,
     learned_output_axes,
 )
+from keymasq.common.virtual_device_templates import (
+    XBOX_360_TEMPLATE_ID,
+    resolve_virtual_devices,
+    template_analog_inputs,
+    template_output_axes,
+)
 from keymasq.common.virtual_devices import is_virtual_gamepad_output_id
 from keymasq.gui.widgets.analog_control.draft import ControlDraft, GamepadDraft, MouseDraft
 from keymasq.gui.widgets.analog_control.gamepad import (
@@ -114,6 +120,8 @@ class AnalogControlEditorView(Gtk.Box):
         self._output_target_items: list[tuple[str, str | None]] = []
         self._output_target_buttons: dict[str, Gtk.ToggleButton] = {}
         self._hardware_output_configs: dict[str, object] = {}
+        self._virtual_output_axes: dict[str, tuple[OutputAxis, ...]] = {}
+        self._virtual_output_analog_inputs: dict[str, dict[str, object]] = {}
         self._refreshing_outputs = False
         self._tick_ms = 8
 
@@ -415,6 +423,9 @@ class AnalogControlEditorView(Gtk.Box):
         if selected == SAME_DEVICE_OUTPUT_ID:
             # Reusable controls have no source device until they are bound.
             return STANDARD_OUTPUT_AXES
+        virtual_axes = self._virtual_output_axes.get(selected or "")
+        if virtual_axes is not None:
+            return virtual_axes
         hardware = self._hardware_output_configs.get(selected or "")
         if hardware is not None:
             return learned_output_axes(getattr(hardware, "analog_inputs", []) or [])
@@ -501,6 +512,23 @@ class AnalogControlEditorView(Gtk.Box):
             )
             return axis_choices
         selected = self._selected_output_id
+        virtual_analogs = self._virtual_output_analog_inputs.get(selected or "")
+        if virtual_analogs is not None:
+            choices = [
+                (
+                    "same",
+                    None,
+                    gamepad_output_target_label_for_input_type(input_type, "same"),
+                )
+            ]
+            for analog_id, raw_analog in virtual_analogs.items():
+                if not isinstance(raw_analog, dict):
+                    continue
+                if str(raw_analog.get("type", "") or "") != input_type:
+                    continue
+                label = str(raw_analog.get("label", "") or analog_id)
+                choices.append(("analog", analog_id, label))
+            return choices
         hardware = (
             self._hardware_output_configs.get(selected or "")
             if selected and not is_virtual_gamepad_output_id(selected)
@@ -613,6 +641,17 @@ class AnalogControlEditorView(Gtk.Box):
         self._hardware_output_configs = {
             str(getattr(config, "hardware_id", "") or ""): config
             for config in choice_set.hardware_configs
+        }
+        virtual_devices = resolve_virtual_devices(
+            choice_set.count, choice_set.virtual_device_config
+        )
+        self._virtual_output_axes = {
+            device.output_id: template_output_axes(device.template) for device in virtual_devices
+        }
+        self._virtual_output_analog_inputs = {
+            device.output_id: template_analog_inputs(device.template)
+            for device in virtual_devices
+            if device.template.id != XBOX_360_TEMPLATE_ID
         }
         choices = [(SAME_DEVICE_OUTPUT_ID, "Default (same device)"), *choice_set.choices]
         self._output_ids = [output_id for output_id, _ in choices]

--- a/keymasq/gui/widgets/flight_stick_artwork.py
+++ b/keymasq/gui/widgets/flight_stick_artwork.py
@@ -1,0 +1,251 @@
+"""Unbranded flight stick artwork drawn as scalable, theme-aware paths."""
+
+import math
+from typing import Any
+
+import gi
+
+gi.require_version("Gtk", "4.0")
+from gi.repository import Gtk  # pyright: ignore[reportAttributeAccessIssue]
+
+
+class FlightStickDrawing(Gtk.DrawingArea):
+    def __init__(self) -> None:
+        super().__init__(content_width=220, content_height=240)
+        self.set_draw_func(self._draw, None)
+        self.set_tooltip_text("Flight stick with twist, throttle, and hat switch")
+
+    def _draw(self, area: Gtk.DrawingArea, cr: Any, width: int, height: int, _data: object) -> None:
+        foreground = area.get_color()
+        found, background = area.get_style_context().lookup_color("window_bg_color")
+        dark = foreground.red + foreground.green + foreground.blue > 1.5
+        bg = (
+            (background.red, background.green, background.blue)
+            if found
+            else ((0.13,) * 3 if dark else (0.98,) * 3)
+        )
+        fg = (foreground.red, foreground.green, foreground.blue)
+        shell, plate, edge = (0.045, 0.25, 0.48) if dark else (0.78, 0.20, 0.85)
+        cr.save()
+        scale = min(width / 300, height / 365)
+        cr.translate((width - 300 * scale) / 2, (height - 365 * scale) / 2)
+        cr.scale(scale, scale)
+        cr.set_line_join(1)
+        cr.set_line_cap(1)
+
+        def ink(tone: float) -> None:
+            cr.set_source_rgb(*(b + (f - b) * tone for b, f in zip(bg, fg, strict=True)))
+
+        def path(*segments: tuple[float, ...]) -> None:
+            cr.new_path()
+            for index, segment in enumerate(segments):
+                if not segment:
+                    cr.close_path()
+                elif len(segment) == 6:
+                    cr.curve_to(*segment)
+                elif index == 0:
+                    cr.move_to(*segment)
+                else:
+                    cr.line_to(*segment)
+
+        def finish(tone: float, outline: float = edge, line_width: float = 1.5) -> None:
+            ink(tone)
+            cr.fill_preserve()
+            ink(outline)
+            cr.set_line_width(line_width)
+            cr.stroke()
+
+        def ellipse(
+            x: float, y: float, rx: float, ry: float, tone: float, outline: float = edge
+        ) -> None:
+            cr.new_path()
+            cr.save()
+            cr.translate(x, y)
+            cr.scale(rx, ry)
+            cr.arc(0, 0, 1, 0, math.tau)
+            cr.restore()
+            finish(tone, outline)
+
+        # Four broad feet wrap around the raised top plate. Interior subpaths
+        # punch real holes through the frame rather than painting over it.
+        path(
+            (28, 204),
+            (53, 181, 85, 172, 111, 174),
+            (181, 168, 219, 180, 241, 201),
+            (253, 219),
+            (253, 251),
+            (269, 288),
+            (278, 322, 266, 340, 250, 345),
+            (204, 349),
+            (179, 337),
+            (110, 339),
+            (87, 353),
+            (43, 350, 18, 341, 15, 326),
+            (23, 278),
+            (20, 248),
+            (12, 225, 18, 214, 28, 204),
+            (),
+        )
+        # Front-left, front-right, and the two smaller rear openings.
+        for points in (
+            ((30, 292), (74, 316), (64, 336), (31, 329), (25, 317)),
+            ((235, 285), (256, 291), (266, 317), (250, 334), (217, 332), (211, 320)),
+            ((28, 212), (51, 193), (69, 191), (53, 210), (26, 231)),
+            ((218, 194), (236, 207), (245, 228), (244, 241), (229, 220)),
+        ):
+            cr.move_to(*points[0])
+            for point in points[1:]:
+                cr.line_to(*point)
+            cr.close_path()
+        cr.set_fill_rule(1)
+        finish(shell, edge, 2.2)
+        cr.set_fill_rule(0)
+        # A visible lower lip gives the base thickness.
+        path((19, 329), (38, 343, 68, 345, 85, 346), (109, 333), (179, 331), (204, 343), (252, 339))
+        ink(edge)
+        cr.set_line_width(1)
+        cr.stroke()
+
+        # Sculpted top plate, wider at the shoulders and tapered at the front.
+        path(
+            (49, 207),
+            (76, 188, 112, 178, 144, 180),
+            (180, 177, 210, 188, 226, 206),
+            (239, 235, 241, 263, 232, 281),
+            (215, 300, 205, 314, 190, 325),
+            (150, 333, 117, 332, 91, 324),
+            (71, 311, 48, 294, 39, 278),
+            (32, 253, 36, 222, 49, 207),
+            (),
+        )
+        finish(plate, edge, 1.8)
+        # Narrow highlights follow the bevel instead of outlining a flat slab.
+        path((48, 210), (80, 192, 106, 186, 130, 185))
+        ink(0.50 if dark else 0.08)
+        cr.set_line_width(2)
+        cr.stroke()
+        path((228, 224), (239, 256, 233, 276, 214, 298), (190, 322))
+        ink(0.14 if dark else 0.38)
+        cr.set_line_width(3)
+        cr.stroke()
+
+        # The six base switches form two concentric banks to the left of the
+        # stick, as in the reference, rather than being scattered across it.
+        for start in (153, 178, 203):
+            for inner, outer in ((0.72, 0.92), (0.98, 1.18)):
+                cr.new_path()
+                cr.save()
+                cr.translate(145, 242)
+                cr.scale(78, 59)
+                cr.arc(0, 0, outer, math.radians(start), math.radians(start + 20))
+                cr.arc_negative(0, 0, inner, math.radians(start + 20), math.radians(start))
+                cr.close_path()
+                cr.restore()
+                finish(shell, 0.48 if dark else 0.65, 1)
+        # Offset socket, stepped bearing, and rubber gaiter beneath the grip.
+        ellipse(153, 235, 57, 36, shell)
+        ellipse(153, 229, 51, 30, shell + (0.05 if dark else -0.08))
+        ellipse(154, 219, 38, 23, shell)
+        path((124, 219), (140, 228, 170, 227, 184, 217))
+        ink(edge)
+        cr.set_line_width(1)
+        cr.stroke()
+
+        # Front throttle sits in a recessed horizontal slot with a raised tab.
+        path(
+            (102, 297),
+            (118, 286, 163, 284, 180, 292),
+            (184, 300, 178, 305, 171, 307),
+            (107, 309),
+            (98, 307, 96, 302, 102, 297),
+            (),
+        )
+        finish(plate * 0.65, plate, 1)
+        path((110, 297), (169, 294), (171, 302), (108, 305), ())
+        finish(shell, edge, 1)
+        path((118, 291), (147, 288), (150, 309), (119, 312), (113, 307, 114, 296, 118, 291), ())
+        finish(shell, edge, 1.5)
+        for y in (298, 302, 306):
+            path((120, y), (143, y - 2))
+            ink(edge)
+            cr.set_line_width(0.8)
+            cr.stroke()
+
+        # Flared palm shelf with a lower rim; the grip rises from its left side.
+        path(
+            (139, 194),
+            (163, 190, 178, 202, 191, 218),
+            (199, 226, 206, 236, 201, 241),
+            (181, 250, 144, 241, 127, 230),
+            (120, 223, 128, 204, 139, 194),
+            (),
+        )
+        finish(shell, edge, 1.8)
+        path((128, 230), (145, 238, 181, 246, 200, 238))
+        ink(0.25 if dark else 0.6)
+        cr.set_line_width(2)
+        cr.stroke()
+
+        # Tapered ergonomic grip, leaning slightly forward. Its highlights and
+        # side seam describe the volume without the old horizontal finger lines.
+        path(
+            (134, 78),
+            (126, 66, 123, 41, 130, 27),
+            (138, 11, 173, 13, 187, 26),
+            (203, 42, 194, 71, 183, 91),
+            (174, 116, 168, 161, 172, 187),
+            (172, 198, 183, 211, 183, 218),
+            (176, 228, 149, 224, 140, 215),
+            (136, 200, 141, 179, 136, 156),
+            (132, 133, 122, 107, 126, 92),
+            (134, 78),
+            (),
+        )
+        finish(shell, edge, 1.9)
+        path(
+            (180, 89),
+            (169, 119, 163, 160, 166, 191),
+            (165, 203, 175, 215, 177, 216),
+            (170, 219, 164, 216, 161, 210),
+            (155, 179, 160, 119, 172, 91),
+            (),
+        )
+        finish(0.15 if dark else 0.61, 0.15 if dark else 0.61, 0.5)
+        path((136, 95), (133, 118, 146, 157, 145, 184), (144, 209))
+        ink(0.2 if dark else 0.9)
+        cr.set_line_width(1)
+        cr.stroke()
+        # Side trigger and top trigger tip.
+        path(
+            (127, 65),
+            (117, 68, 113, 81, 117, 96),
+            (119, 103, 126, 103, 130, 97),
+            (126, 85),
+            (127, 65),
+            (),
+        )
+        finish(shell + (0.08 if dark else -0.1), edge, 1.2)
+        path((150, 17), (151, 11), (166, 10), (169, 16), ())
+        finish(shell, edge, 1)
+
+        # Inset face: one hat and four shaped buttons, not generic circles.
+        path(
+            (137, 28),
+            (149, 21, 172, 23, 181, 33),
+            (190, 43, 185, 65, 175, 77),
+            (168, 88, 153, 90, 143, 79),
+            (133, 65, 128, 40, 137, 28),
+            (),
+        )
+        finish(shell + (0.03 if dark else -0.03), 0.28 if dark else 0.9, 1)
+        ellipse(158, 48, 12, 10, shell, edge)
+        ellipse(157, 45, 8, 7, shell + (0.14 if dark else -0.14), edge)
+        for segments in (
+            ((135, 47), (141, 45), (145, 57), (139, 61), (135, 56), ()),
+            ((176, 45), (182, 46), (180, 60), (174, 58), (173, 51), ()),
+            ((140, 65), (147, 60), (156, 72), (151, 80), (146, 77), ()),
+            ((171, 61), (178, 65), (174, 77), (167, 82), (161, 75), ()),
+        ):
+            path(*segments)
+            finish(0.62 if dark else 0.22, edge, 1)
+        cr.restore()

--- a/keymasq/gui/widgets/flight_stick_artwork.py
+++ b/keymasq/gui/widgets/flight_stick_artwork.py
@@ -215,16 +215,16 @@ class FlightStickDrawing(Gtk.DrawingArea):
         ink(0.2 if dark else 0.9)
         cr.set_line_width(1)
         cr.stroke()
-        # Side trigger and top trigger tip.
+        # Flush side button follows the grip contour below the head.
         path(
-            (127, 65),
-            (117, 68, 113, 81, 117, 96),
-            (119, 103, 126, 103, 130, 97),
-            (126, 85),
-            (127, 65),
+            (133, 83),
+            (129, 89, 127, 96, 128, 103),
+            (130, 108, 137, 107, 139, 101),
+            (140, 95, 136, 87, 133, 83),
             (),
         )
-        finish(shell + (0.08 if dark else -0.1), edge, 1.2)
+        finish(shell + (0.12 if dark else -0.18), shell, 0.6)
+        # Top trigger tip.
         path((150, 17), (151, 11), (166, 10), (169, 16), ())
         finish(shell, edge, 1)
 

--- a/keymasq/gui/widgets/gamepad_output_choices.py
+++ b/keymasq/gui/widgets/gamepad_output_choices.py
@@ -4,12 +4,17 @@ from dataclasses import dataclass
 from typing import Protocol
 
 from keymasq.common.devices import is_gamepad_button_name
+from keymasq.common.virtual_device_templates import (
+    VirtualDeviceConfig,
+    resolve_virtual_devices,
+)
 from keymasq.common.virtual_devices import (
     is_virtual_gamepad_output_id,
     virtual_gamepad_output_id,
 )
 from keymasq.session.hardware import HardwareManager
 from keymasq.session.settings import load_virtual_gamepad_count
+from keymasq.session.virtual_devices import load_virtual_device_config
 
 log = logging.getLogger("keymasq.gui.widgets.gamepad_output_choices")
 
@@ -19,6 +24,7 @@ class GamepadOutputChoiceSet:
     choices: list[tuple[str | None, str]]
     count: int
     hardware_configs: list[object]
+    virtual_device_config: VirtualDeviceConfig = VirtualDeviceConfig()
 
 
 class HardwareManagerLike(Protocol):
@@ -37,6 +43,14 @@ def virtual_gamepad_count() -> int:
     except Exception:
         log.exception("Unable to load virtual gamepad count; using default of 1")
         return 1
+
+
+def virtual_device_config() -> VirtualDeviceConfig:
+    try:
+        return load_virtual_device_config()
+    except Exception:
+        log.exception("Unable to load virtual device configuration; using built-ins only")
+        return VirtualDeviceConfig()
 
 
 def _virtual_gamepad_index(output_id: str | None) -> int | None:
@@ -100,12 +114,23 @@ def gamepad_output_choices_for(
     selected_id: str | None,
     count: int,
     hardware_configs: Sequence[object],
+    device_config: VirtualDeviceConfig | None = None,
 ) -> list[tuple[str | None, str]]:
+    if device_config is None:
+        device_config = VirtualDeviceConfig()
     default_label = "Virtual Gamepad 1" if count > 0 else "Default output unavailable"
     choices: list[tuple[str | None, str]] = [(None, default_label)]
     for index in range(2, count + 1):
         output_id = virtual_gamepad_output_id(index)
         choices.append((output_id, f"Virtual Gamepad {index}"))
+
+    for device in resolve_virtual_devices(count, device_config)[count:]:
+        choices.append(
+            (
+                device.output_id,
+                f"{device.template.label} ({device.output_id})",
+            )
+        )
 
     for config in hardware_configs:
         if _is_hardware_gamepad(config):
@@ -141,27 +166,38 @@ def gamepad_output_choices(
     *,
     count: int | None = None,
     hardware_configs: Sequence[object] | None = None,
+    device_config: VirtualDeviceConfig | None = None,
     hardware_manager_factory: Callable[[], HardwareManagerLike] = HardwareManager,
 ) -> list[tuple[str | None, str]]:
     if count is None:
         count = virtual_gamepad_count()
     if hardware_configs is None:
         hardware_configs = load_gamepad_output_hardware_configs(hardware_manager_factory)
-    return gamepad_output_choices_for(selected_id, count, hardware_configs)
+    if device_config is None:
+        device_config = virtual_device_config()
+    return gamepad_output_choices_for(selected_id, count, hardware_configs, device_config)
 
 
 def load_gamepad_output_choices(
     selected_id: str | None,
     *,
     count_loader: Callable[[], int] = virtual_gamepad_count,
+    config_loader: Callable[[], VirtualDeviceConfig] = virtual_device_config,
     hardware_manager_factory: Callable[[], HardwareManagerLike] = HardwareManager,
 ) -> GamepadOutputChoiceSet:
     count = count_loader()
     hardware_configs = load_gamepad_output_hardware_configs(hardware_manager_factory)
+    device_config = config_loader()
     return GamepadOutputChoiceSet(
-        choices=gamepad_output_choices_for(selected_id, count, hardware_configs),
+        choices=gamepad_output_choices_for(
+            selected_id,
+            count,
+            hardware_configs,
+            device_config,
+        ),
         count=count,
         hardware_configs=hardware_configs,
+        virtual_device_config=device_config,
     )
 
 

--- a/keymasq/gui/widgets/key_selector/tabs.py
+++ b/keymasq/gui/widgets/key_selector/tabs.py
@@ -14,11 +14,17 @@ from gi.repository import Gdk, Gtk  # pyright: ignore[reportAttributeAccessIssue
 from keymasq.common.model.actions import MappingAction
 from keymasq.common.model.core import ActionType
 from keymasq.common.model.superkeys import SuperkeyAction
+from keymasq.common.virtual_device_templates import (
+    XBOX_360_TEMPLATE_ID,
+    ResolvedVirtualDevice,
+    resolve_virtual_devices,
+)
 from keymasq.gui.widgets import input_picker_shared
 from keymasq.gui.widgets.gamepad_output_choices import (
     gamepad_output_choice_matches,
     gamepad_output_choices,
     gamepad_output_unavailable_message,
+    virtual_device_config,
     virtual_gamepad_count,
 )
 from keymasq.gui.widgets.mouse_move_units import (
@@ -538,7 +544,7 @@ class SharedInputTabsMixin:
             warning.add_css_class("warning")
             self._gamepad_output_warning_label = warning
             box.append(warning)
-            box.append(input_picker_shared.build_gamepad_tab(self))
+            self._append_gamepad_pickers(box)
             self._update_gamepad_output_warning()
             self._prefill_gamepad_inputs()
             return box
@@ -575,10 +581,71 @@ class SharedInputTabsMixin:
         warning.add_css_class("warning")
         self._gamepad_output_warning_label = warning
         outer.append(warning)
-        outer.append(input_picker_shared.build_gamepad_tab(self))
+        self._append_gamepad_pickers(outer)
         self._update_gamepad_output_warning()
         self._prefill_gamepad_inputs()
         return outer
+
+    def _append_gamepad_pickers(self, parent: Gtk.Box) -> None:
+        self._virtual_device_config = virtual_device_config()
+        self._virtual_gamepad_count = virtual_gamepad_count()
+        self._standard_gamepad_picker = input_picker_shared.build_gamepad_tab(self)
+        self._template_gamepad_picker = Gtk.Box(
+            orientation=Gtk.Orientation.VERTICAL,
+            spacing=12,
+        )
+        self._template_gamepad_picker.set_margin_top(12)
+        self._template_gamepad_picker.set_margin_bottom(12)
+        self._template_gamepad_picker.set_margin_start(12)
+        self._template_gamepad_picker.set_margin_end(12)
+        parent.append(self._standard_gamepad_picker)
+        self._template_gamepad_scroll = Gtk.ScrolledWindow(
+            vexpand=True, hscrollbar_policy=Gtk.PolicyType.NEVER
+        )
+        viewport = Gtk.Viewport(scroll_to_focus=True)
+        viewport.set_child(self._template_gamepad_picker)
+        self._template_gamepad_scroll.set_child(viewport)
+        parent.append(self._template_gamepad_scroll)
+        self._refresh_virtual_device_picker()
+
+    def _selected_virtual_device(self) -> ResolvedVirtualDevice | None:
+        output_id = self._selected_gamepad_output_id or "virtual-gamepad-1"
+        for device in resolve_virtual_devices(
+            self._virtual_gamepad_count,
+            self._virtual_device_config,
+        ):
+            if device.output_id == output_id:
+                return device
+        return None
+
+    def _refresh_virtual_device_picker(self) -> None:
+        standard = getattr(self, "_standard_gamepad_picker", None)
+        custom = getattr(self, "_template_gamepad_picker", None)
+        if standard is None or custom is None:
+            return
+        device = self._selected_virtual_device()
+        use_template = device is not None and device.template.id != XBOX_360_TEMPLATE_ID
+        standard.set_visible(not use_template)
+        custom.set_visible(use_template)
+        self._template_gamepad_scroll.set_visible(use_template)
+        if not use_template or device is None:
+            return
+
+        while child := custom.get_first_child():
+            custom.remove(child)
+
+        from keymasq.gui.widgets.virtual_device_picker import VirtualDevicePicker
+
+        action = getattr(self, "_current_action", None)
+        custom.append(
+            VirtualDevicePicker(
+                device.template,
+                self._on_gamepad_clicked,
+                self._on_gamepad_axis_clicked,
+                current_target=getattr(action, "target", None),
+                current_value=int(getattr(action, "axis_value", 0)),
+            )
+        )
 
     def _build_gamepad_output_header(self) -> Gtk.Widget | None:
         choices = self._gamepad_output_choices()
@@ -606,9 +673,16 @@ class SharedInputTabsMixin:
         return box
 
     def _gamepad_output_choices(self) -> list[tuple[str | None, str]]:
+        count = getattr(self, "_virtual_gamepad_count", None)
+        if count is None:
+            count = virtual_gamepad_count()
+        config = getattr(self, "_virtual_device_config", None)
+        if config is None:
+            config = virtual_device_config()
         return gamepad_output_choices(
             self._selected_gamepad_output_id,
-            count=virtual_gamepad_count(),
+            count=count,
+            device_config=config,
             hardware_manager_factory=HardwareManager,
         )
 
@@ -617,6 +691,7 @@ class SharedInputTabsMixin:
         if 0 <= selected < len(self._gamepad_output_ids):
             self._selected_gamepad_output_id = self._gamepad_output_ids[selected]
         self._update_gamepad_output_warning()
+        self._refresh_virtual_device_picker()
 
     def _update_gamepad_output_warning(self) -> None:
         label = self._gamepad_output_warning_label

--- a/keymasq/gui/widgets/motion_control/view.py
+++ b/keymasq/gui/widgets/motion_control/view.py
@@ -11,6 +11,11 @@ gi.require_version("Adw", "1")
 from gi.repository import Adw, Gtk  # pyright: ignore[reportAttributeAccessIssue]
 
 from keymasq.common.model.analog import SAME_DEVICE_OUTPUT_ID, AnalogControlConfig
+from keymasq.common.virtual_device_templates import (
+    XBOX_360_TEMPLATE_ID,
+    resolve_virtual_devices,
+    template_analog_inputs,
+)
 from keymasq.common.virtual_devices import (
     is_virtual_gamepad_output_id,
     virtual_gamepad_output_id,
@@ -92,6 +97,7 @@ class MotionControlEditorView(Gtk.Box):
         self._output_target_items: list[tuple[str, str | None]] = []
         self._output_target_buttons: dict[str, Gtk.ToggleButton] = {}
         self._hardware_output_configs: dict[str, object] = {}
+        self._virtual_output_analog_inputs: dict[str, dict[str, object]] = {}
         self._refreshing_outputs = False
         initial = MotionControlDraft.new()
         self._mouse_draft = initial.mouse
@@ -817,6 +823,13 @@ class MotionControlEditorView(Gtk.Box):
         selected = self._selected_output_id
         helper_selected = None if selected == SAME_DEVICE_OUTPUT_ID else selected
         choice_set = self._output_choices_loader(helper_selected)
+        self._virtual_output_analog_inputs = {
+            device.output_id: template_analog_inputs(device.template)
+            for device in resolve_virtual_devices(
+                choice_set.count, choice_set.virtual_device_config
+            )
+            if device.template.id != XBOX_360_TEMPLATE_ID
+        }
         self._hardware_output_configs = {
             str(getattr(config, "hardware_id", "") or ""): config
             for config in choice_set.hardware_configs
@@ -881,6 +894,13 @@ class MotionControlEditorView(Gtk.Box):
 
     def _output_target_choices(self) -> list[tuple[str, str | None, str]]:
         selected = self._selected_output_id
+        virtual_analogs = self._virtual_output_analog_inputs.get(selected or "")
+        if virtual_analogs is not None:
+            return [
+                ("analog", analog_id, str(analog.get("label", analog_id)))
+                for analog_id, analog in virtual_analogs.items()
+                if isinstance(analog, dict) and analog.get("type") == "stick"
+            ]
         hardware = (
             self._hardware_output_configs.get(selected or "")
             if selected and not is_virtual_gamepad_output_id(selected)

--- a/keymasq/gui/widgets/settings_dialog.py
+++ b/keymasq/gui/widgets/settings_dialog.py
@@ -27,7 +27,7 @@ def _count_value(value: object, default: int) -> int:
 
 class SettingsDialog(Adw.Dialog):
     def __init__(self, parent: Gtk.Window | None = None) -> None:
-        super().__init__(title="Settings", content_width=460, content_height=380)
+        super().__init__(title="Settings", content_width=460, content_height=480)
         self._parent = parent
         self._settings = load_global_settings()
         self._gamepad_count = self._settings.virtual_gamepad_count
@@ -44,11 +44,11 @@ class SettingsDialog(Adw.Dialog):
 
         page = Adw.PreferencesPage()
 
-        gamepad_group = Adw.PreferencesGroup(title="Virtual Devices")
+        gamepad_group = Adw.PreferencesGroup(title="Virtual devices")
         page.add(gamepad_group)
 
         gamepad_row = Adw.ActionRow(title="Virtual gamepads")
-        gamepad_row.set_subtitle("Set virtual controller outputs")
+        gamepad_row.set_subtitle("Number of standard virtual gamepads")
         count_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=6)
         count_box.set_valign(Gtk.Align.CENTER)
         self._minus_button = Gtk.Button(icon_name="list-remove-symbolic")
@@ -66,6 +66,16 @@ class SettingsDialog(Adw.Dialog):
         gamepad_row.add_suffix(count_box)
         gamepad_group.add(gamepad_row)
         self._sync_gamepad_count_controls()
+
+        virtual_devices_row = Adw.ActionRow(title="Custom virtual devices")
+        virtual_devices_row.set_subtitle("Configure templates and additional outputs")
+        virtual_devices_button = Gtk.Button(icon_name="go-next-symbolic")
+        virtual_devices_button.set_tooltip_text("Manage custom virtual devices")
+        virtual_devices_button.set_valign(Gtk.Align.CENTER)
+        virtual_devices_button.connect("clicked", self._on_virtual_devices_clicked)
+        virtual_devices_row.add_suffix(virtual_devices_button)
+        gamepad_group.add(virtual_devices_row)
+        self._virtual_devices_button = virtual_devices_button
 
         macro_group = Adw.PreferencesGroup(title="Macros")
         page.add(macro_group)
@@ -118,6 +128,11 @@ class SettingsDialog(Adw.Dialog):
 
         dialog = RecordMacroDialog(self._parent)
         dialog.present(self._parent)
+
+    def _on_virtual_devices_clicked(self, _button: Gtk.Button) -> None:
+        from keymasq.gui.widgets.virtual_devices_dialog import VirtualDevicesDialog
+
+        VirtualDevicesDialog(self).present(self)
 
     def _on_loaded(self, response: dict[str, object] | None) -> bool:
         if self._save_inflight or self._save_applied:

--- a/keymasq/gui/widgets/virtual_device_picker.py
+++ b/keymasq/gui/widgets/virtual_device_picker.py
@@ -1,0 +1,423 @@
+"""Illustrated mapping layouts driven by a virtual device template."""
+
+from collections.abc import Callable
+
+import evdev
+import gi
+
+gi.require_version("Gtk", "4.0")
+from gi.repository import Gtk  # pyright: ignore[reportAttributeAccessIssue]
+
+from keymasq.common.virtual_device_templates import (
+    LOGITECH_EXTREME_3D_TEMPLATE,
+    XBOX_360_TEMPLATE,
+    VirtualAxis,
+    VirtualDeviceTemplate,
+)
+from keymasq.gui.widgets.flight_stick_artwork import FlightStickDrawing
+from keymasq.gui.widgets.input_picker_shared import _get_gamepad_image_path
+
+
+def axis_percent_value(axis: VirtualAxis, percent: float) -> int:
+    if axis.rest == axis.maximum:
+        endpoint = axis.minimum
+    else:
+        endpoint = axis.maximum if percent >= 0 else axis.minimum
+    return round(axis.rest + abs(percent) / 100 * (endpoint - axis.rest))
+
+
+class VirtualDevicePicker(Gtk.Box):
+    def __init__(
+        self,
+        template: VirtualDeviceTemplate,
+        on_button: Callable[[Gtk.Button, str], None],
+        on_axis: Callable[[Gtk.Button, str, int], None],
+        *,
+        current_target: str | None = None,
+        current_value: int = 0,
+    ) -> None:
+        super().__init__(orientation=Gtk.Orientation.VERTICAL, spacing=16)
+        self.set_halign(Gtk.Align.CENTER)
+        self._on_button = on_button
+        self._on_axis = on_axis
+        self._axes = {axis.evdev: axis for axis in template.axes}
+        self._template = template
+        self._buttons = {
+            int(getattr(evdev.ecodes, item.evdev.upper())): item for item in template.buttons
+        }
+        self._shown_buttons: set[int] = set()
+        self._syncing = False
+        self._extras_jump = Gtk.Button(halign=Gtk.Align.END)
+        self._extras_jump.add_css_class("flat")
+        self._extras_jump.connect("clicked", self._jump_to_extras)
+        self.append(self._extras_jump)
+        layout = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=24)
+        layout.set_halign(Gtk.Align.CENTER)
+        self.append(layout)
+        left = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=16, valign=Gtk.Align.CENTER)
+        center = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=8, valign=Gtk.Align.CENTER)
+        right = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=16, valign=Gtk.Align.CENTER)
+        layout.append(left)
+        layout.append(center)
+        layout.append(right)
+
+        if template.layout == "flight-stick":
+            self._flight_layout(left, center, right)
+        else:
+            self._gamepad_layout(left, center, right)
+
+        editor = Gtk.Box(spacing=8, halign=Gtk.Align.CENTER)
+        editor.append(Gtk.Label(label="Axis"))
+        self.axis_names = list(self._axes)
+        self.axis_choice = Gtk.DropDown.new_from_strings(
+            [axis.label for axis in self._axes.values()]
+        )
+        editor.append(self.axis_choice)
+        self.value_spin = Gtk.SpinButton(numeric=True, width_chars=5)
+        self.value_spin.set_tooltip_text("Exact axis value")
+        editor.append(self.value_spin)
+        self.percent_spin = Gtk.SpinButton(numeric=True, width_chars=4)
+        self.percent_spin.set_tooltip_text("Deflection from rest; 100% is full travel")
+        editor.append(self.percent_spin)
+        editor.append(Gtk.Label(label="%"))
+        apply = Gtk.Button(label="Map axis")
+        apply.add_css_class("suggested-action")
+        apply.connect("clicked", self._map_axis)
+        editor.append(apply)
+        self.append(editor)
+        self.range_label = Gtk.Label()
+        self.range_label.add_css_class("dim-label")
+        self.append(self.range_label)
+        self.axis_choice.connect("notify::selected", self._axis_changed)
+        self.value_spin.connect("value-changed", self._value_changed)
+        self.percent_spin.connect("value-changed", self._percent_changed)
+        self._axis_changed()
+        if current_target in self.axis_names:
+            self.axis_choice.set_selected(self.axis_names.index(current_target))
+            self.value_spin.set_value(current_value)
+        self._build_extras()
+
+    def _flight_layout(self, left: Gtk.Box, center: Gtk.Box, right: Gtk.Box) -> None:
+        left.append(self._direction_pad("Stick", "abs_x", "abs_y"))
+        twist = self._section("Twist")
+        turns = Gtk.Box(spacing=6, halign=Gtk.Align.CENTER)
+        turns.append(self._axis_shortcut("↶ Left", "abs_rz", -100, "Twist left"))
+        turns.append(self._axis_shortcut("Right ↷", "abs_rz", 100, "Twist right"))
+        twist.append(turns)
+        twist.set_visible("abs_rz" in self._axes)
+        left.append(twist)
+        throttle = self._section("Throttle")
+        levels = Gtk.Box(spacing=6, halign=Gtk.Align.CENTER)
+        for caption, percent in (("Idle", 0), ("Half", 50), ("Full", 100)):
+            levels.append(
+                self._axis_shortcut(caption, "abs_throttle", percent, f"Throttle {percent}%")
+            )
+        throttle.append(levels)
+        throttle.set_visible("abs_throttle" in self._axes)
+        left.append(throttle)
+
+        center.append(FlightStickDrawing())
+        base = self._section("Base buttons")
+        base_buttons = Gtk.Grid(column_spacing=6, row_spacing=6, halign=Gtk.Align.CENTER)
+        for index, control in enumerate(LOGITECH_EXTREME_3D_TEMPLATE.buttons[6:]):
+            base_buttons.attach(
+                self._button(f"{index + 7}", control.evdev, control.label),
+                index % 3,
+                index // 3,
+                1,
+                1,
+            )
+        base.append(base_buttons)
+        base.set_visible(
+            any(
+                int(getattr(evdev.ecodes, item.evdev.upper())) in self._buttons
+                for item in LOGITECH_EXTREME_3D_TEMPLATE.buttons[6:]
+            )
+        )
+        center.append(base)
+        grip = self._section("Grip buttons")
+        grip_grid = Gtk.Grid(column_spacing=6, row_spacing=6, halign=Gtk.Align.CENTER)
+        for index, control in enumerate(LOGITECH_EXTREME_3D_TEMPLATE.buttons[:6]):
+            button = self._button(
+                control.label, control.evdev, f"Button {index + 1}: {control.label}"
+            )
+            if index == 0:
+                grip_grid.attach(button, 0, 0, 2, 1)
+            elif index == 5:
+                grip_grid.attach(button, 0, 3, 2, 1)
+            else:
+                grip_grid.attach(button, (index - 1) % 2, 1 + (index - 1) // 2, 1, 1)
+        grip.append(grip_grid)
+        grip.set_visible(
+            any(
+                int(getattr(evdev.ecodes, item.evdev.upper())) in self._buttons
+                for item in LOGITECH_EXTREME_3D_TEMPLATE.buttons[:6]
+            )
+        )
+        right.append(grip)
+        right.append(self._direction_pad("Hat switch", "abs_hat0x", "abs_hat0y"))
+
+    def _gamepad_layout(self, left: Gtk.Box, center: Gtk.Box, right: Gtk.Box) -> None:
+        left.set_spacing(8)
+        right.set_spacing(8)
+        for column, axis, shoulder in (
+            (left, "abs_z", "btn_tl"),
+            (right, "abs_rz", "btn_tr"),
+        ):
+            column.append(
+                self._axis_shortcut("LT" if column is left else "RT", axis, 100, "Trigger")
+            )
+            column.append(self._button("LB" if column is left else "RB", shoulder, "Shoulder"))
+        left.append(self._direction_pad("Left stick", "abs_x", "abs_y", stick_button="btn_thumbl"))
+        navigation = Gtk.Box(spacing=6, halign=Gtk.Align.CENTER)
+        for label, code in (
+            ("Select", "btn_select"),
+            ("Guide", "btn_mode"),
+            ("Start", "btn_start"),
+        ):
+            navigation.append(self._button(label, code, label))
+        center.append(navigation)
+        picture = Gtk.Picture.new_for_filename(_get_gamepad_image_path())
+        picture.set_can_shrink(True)
+        picture.set_size_request(220, 150)
+        center.append(picture)
+        face = Gtk.Grid(column_spacing=6, row_spacing=6, halign=Gtk.Align.CENTER)
+        for label, code, x, y in (
+            ("Y", "btn_north", 1, 0),
+            ("X", "btn_west", 0, 1),
+            ("B", "btn_east", 2, 1),
+            ("A", "btn_south", 1, 2),
+        ):
+            face.attach(self._button(label, code, label), x, y, 1, 1)
+        right.append(face)
+        right.append(
+            self._direction_pad("Right stick", "abs_rx", "abs_ry", stick_button="btn_thumbr")
+        )
+        left.append(self._direction_pad("D-pad axes", "abs_hat0x", "abs_hat0y"))
+        dpad = self._section("D-pad buttons")
+        grid = Gtk.Grid(column_spacing=6, row_spacing=6, halign=Gtk.Align.CENTER)
+        codes = (
+            ("↑", "btn_dpad_up", 1, 0),
+            ("←", "btn_dpad_left", 0, 1),
+            ("→", "btn_dpad_right", 2, 1),
+            ("↓", "btn_dpad_down", 1, 2),
+        )
+        for label, code, x, y in codes:
+            grid.attach(self._button(label, code, code), x, y, 1, 1)
+        dpad.append(grid)
+        dpad.set_visible(
+            any(
+                int(getattr(evdev.ecodes, code.upper())) in self._buttons for _, code, _, _ in codes
+            )
+        )
+        center.append(dpad)
+
+    def _axis_shortcut(self, label: str, code: str, percent: float, tooltip: str) -> Gtk.Widget:
+        axis = self._axes.get(code)
+        if axis is None:
+            return Gtk.Box(visible=False)
+        return self._axis_button(label, code, axis_percent_value(axis, percent), tooltip)
+
+    def _build_extras(self) -> None:
+        extra = [
+            (index + 1, button)
+            for index, button in enumerate(self._template.buttons)
+            if int(getattr(evdev.ecodes, button.evdev.upper())) not in self._shown_buttons
+        ]
+        self._extras_jump.set_visible(bool(extra))
+        self._extras_jump.set_label(f"Additional buttons ({len(extra)}) ↓")
+        if not extra:
+            return
+        self.append(Gtk.Separator())
+        header = Gtk.Box(spacing=12)
+        title = Gtk.Label(label=f"Additional buttons · {len(extra)}", hexpand=True, xalign=0)
+        title.add_css_class("heading")
+        header.append(title)
+        self.extra_search = Gtk.SearchEntry(placeholder_text="Search buttons", hexpand=True)
+        self.extra_search.connect("search-changed", self._filter_extras)
+        header.append(self.extra_search)
+        self.append(header)
+        self.extra_grid = Gtk.FlowBox(
+            selection_mode=Gtk.SelectionMode.NONE, homogeneous=True, column_spacing=6, row_spacing=6
+        )
+        self.extra_grid.set_min_children_per_line(2)
+        self.extra_grid.set_max_children_per_line(3)
+        self._extra_items: list[tuple[Gtk.FlowBoxChild, str]] = []
+        for number, control in extra:
+            label = (
+                control.label
+                if control.label == f"Button {number}"
+                else f"{number} · {control.label}"
+            )
+            button = Gtk.Button(label=label, tooltip_text=f"{control.id} · {control.evdev}")
+            button.set_size_request(-1, 40)
+            button.set_hexpand(True)
+            button.connect("clicked", self._on_button, control.evdev)
+            child = Gtk.FlowBoxChild()
+            child.set_child(button)
+            self.extra_grid.append(child)
+            self._extra_items.append(
+                (child, f"{number} {control.label} {control.id} {control.evdev}".casefold())
+            )
+        self.extra_grid.set_filter_func(self._extra_matches)
+        self.append(self.extra_grid)
+        self._no_results = Gtk.Label(label="No matching buttons", visible=False)
+        self._no_results.add_css_class("dim-label")
+        self.append(self._no_results)
+
+    def _extra_matches(self, child: Gtk.FlowBoxChild) -> bool:
+        query = self.extra_search.get_text().strip().casefold()
+        return any(
+            item is child and all(token in text for token in query.split())
+            for item, text in self._extra_items
+        )
+
+    def _filter_extras(self, *_args: object) -> None:
+        self.extra_grid.invalidate_filter()
+        self._no_results.set_visible(
+            not any(self._extra_matches(child) for child, _ in self._extra_items)
+        )
+
+    def _jump_to_extras(self, _button: Gtk.Button) -> None:
+        self.extra_search.grab_focus()
+        ancestor = self.get_ancestor(Gtk.ScrolledWindow)
+        if isinstance(ancestor, Gtk.ScrolledWindow):
+            adjustment = ancestor.get_vadjustment()
+            found, bounds = self.extra_search.compute_bounds(self)
+            if found:
+                adjustment.set_value(bounds.get_y())
+
+    @staticmethod
+    def _section(title: str) -> Gtk.Box:
+        box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=8)
+        label = Gtk.Label(label=title)
+        label.add_css_class("dim-label")
+        box.append(label)
+        return box
+
+    def _button(self, label: str, code: str, tooltip: str) -> Gtk.Widget:
+        numeric_code = int(getattr(evdev.ecodes, code.upper()))
+        control = self._buttons.get(numeric_code)
+        if control is None:
+            return Gtk.Box(visible=False)
+        self._shown_buttons.add(numeric_code)
+        original = next(
+            (
+                item
+                for item in (*XBOX_360_TEMPLATE.buttons, *LOGITECH_EXTREME_3D_TEMPLATE.buttons)
+                if int(getattr(evdev.ecodes, item.evdev.upper())) == numeric_code
+            ),
+            None,
+        )
+        if original is None or control.label != original.label:
+            label = control.label
+        code = control.evdev
+        button = Gtk.Button(label=label)
+        button.add_css_class("key-button")
+        button.set_size_request(36, 34)
+        button.set_tooltip_text(f"{control.label} · {tooltip} · {code}")
+        button.connect("clicked", self._on_button, code)
+        return button
+
+    def _axis_button(self, label: str, code: str, value: int, tooltip: str) -> Gtk.Button:
+        button = Gtk.Button(label=label)
+        button.add_css_class("key-button")
+        button.set_size_request(36, 34)
+        button.set_tooltip_text(f"{tooltip} · {code} = {value}")
+        button.connect("clicked", self._on_axis, code, value)
+        return button
+
+    def _direction_pad(
+        self, title: str, x_code: str, y_code: str, *, stick_button: str | None = None
+    ) -> Gtk.Box:
+        box = self._section(title)
+        grid = Gtk.Grid(column_spacing=6, row_spacing=6, halign=Gtk.Align.CENTER)
+        x_axis, y_axis = self._axes.get(x_code), self._axes.get(y_code)
+        if x_axis is None and y_axis is None:
+            box.set_visible(False)
+            return box
+        for label, code, value, col, row, direction in (
+            (
+                "↑",
+                y_code,
+                y_axis.minimum if y_axis else 0,
+                1,
+                0,
+                "forward" if title == "Stick" else "up",
+            ),
+            ("←", x_code, x_axis.minimum if x_axis else 0, 0, 1, "left"),
+            ("→", x_code, x_axis.maximum if x_axis else 0, 2, 1, "right"),
+            (
+                "↓",
+                y_code,
+                y_axis.maximum if y_axis else 0,
+                1,
+                2,
+                "back" if title == "Stick" else "down",
+            ),
+        ):
+            if code not in self._axes:
+                continue
+            button = self._axis_button(label, code, value, f"{title} {direction}")
+            grid.attach(button, col, row, 1, 1)
+        if stick_button is not None:
+            center = self._button(
+                "LS" if stick_button == "btn_thumbl" else "RS", stick_button, "Stick press"
+            )
+        else:
+            center = Gtk.Label(label="✛")
+            center.add_css_class("dim-label")
+        grid.attach(center, 1, 1, 1, 1)
+        box.append(grid)
+        return box
+
+    def _selected_axis(self) -> VirtualAxis:
+        return self._axes[self.axis_names[int(self.axis_choice.get_selected())]]
+
+    def _axis_changed(self, *_args: object) -> None:
+        axis = self._selected_axis()
+        self._syncing = True
+        self.value_spin.set_adjustment(
+            Gtk.Adjustment(
+                lower=axis.minimum, upper=axis.maximum, step_increment=1, page_increment=10
+            )
+        )
+        self.percent_spin.set_adjustment(
+            Gtk.Adjustment(
+                lower=-100 if axis.minimum < axis.rest < axis.maximum else 0,
+                upper=100,
+                step_increment=1,
+                page_increment=10,
+            )
+        )
+        self._syncing = False
+        self.value_spin.set_value(axis_percent_value(axis, 100))
+        self._value_changed()
+        self.range_label.set_text(f"Range {axis.minimum} to {axis.maximum} · Rest {axis.rest}")
+
+    def _value_changed(self, *_args: object) -> None:
+        if self._syncing:
+            return
+        axis = self._selected_axis()
+        value = self.value_spin.get_value()
+        endpoint = axis.maximum if value >= axis.rest else axis.minimum
+        distance = abs(endpoint - axis.rest)
+        percent = 0 if distance == 0 else (value - axis.rest) / distance * 100
+        if axis.rest == axis.maximum:
+            percent = -percent
+        self._syncing = True
+        self.percent_spin.set_value(percent)
+        self._syncing = False
+
+    def _percent_changed(self, *_args: object) -> None:
+        if self._syncing:
+            return
+        self._syncing = True
+        self.value_spin.set_value(
+            axis_percent_value(self._selected_axis(), self.percent_spin.get_value())
+        )
+        self._syncing = False
+
+    def _map_axis(self, button: Gtk.Button) -> None:
+        self.value_spin.update()
+        self._on_axis(button, self._selected_axis().evdev, int(self.value_spin.get_value()))

--- a/keymasq/gui/widgets/virtual_devices_dialog.py
+++ b/keymasq/gui/widgets/virtual_devices_dialog.py
@@ -1,0 +1,823 @@
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+
+import gi
+
+gi.require_version("Gtk", "4.0")
+gi.require_version("Adw", "1")
+
+from gi.repository import Adw, Gtk  # pyright: ignore[reportAttributeAccessIssue]
+
+from keymasq.common.virtual_device_templates import (
+    BUILTIN_VIRTUAL_DEVICE_TEMPLATES,
+    LOGITECH_EXTREME_3D_TEMPLATE_ID,
+    MAX_TEMPLATE_AXES,
+    MAX_TEMPLATE_BUTTONS,
+    MAX_USER_VIRTUAL_DEVICES,
+    XBOX_360_TEMPLATE_ID,
+    VirtualAxis,
+    VirtualButton,
+    VirtualDeviceConfig,
+    VirtualDeviceConfigError,
+    VirtualDeviceInstance,
+    VirtualDeviceTemplate,
+    config_from_json,
+    config_to_json,
+    instance_from_data,
+    instance_to_data,
+    numbered_button_batch,
+    template_from_data,
+    template_to_data,
+)
+from keymasq.gui.session_client import GuiTaskResult, run_gui_task, session_request_async
+from keymasq.gui.widgets.virtual_template_controls import TemplateControlRow, event_names
+from keymasq.session.virtual_devices import (
+    load_virtual_device_config,
+    save_virtual_device_config,
+)
+
+
+def unique_template_copy(
+    template: VirtualDeviceTemplate,
+    templates: Sequence[VirtualDeviceTemplate],
+) -> VirtualDeviceTemplate:
+    used = {item.id for item in templates}
+    base = f"{template.id[:54]}-copy"
+    candidate = base
+    index = 2
+    while candidate in used:
+        candidate = f"{base}-{index}"
+        index += 1
+    data = template_to_data(template)
+    data["id"] = candidate
+    label = template.label.encode("utf-8")[:75].decode("utf-8", errors="ignore")
+    data["label"] = f"{label} copy"
+    return template_from_data(data)
+
+
+def _entry_row(title: str, value: str = "") -> tuple[Adw.EntryRow, Gtk.Entry]:
+    row = Adw.EntryRow(title=title)
+    row.set_text(value)
+    return row, row
+
+
+class VirtualTemplateEditorDialog(Adw.Dialog):
+    def __init__(
+        self,
+        template: VirtualDeviceTemplate | None,
+        on_save: Callable[[VirtualDeviceTemplate], bool],
+        *,
+        creating: bool = False,
+    ) -> None:
+        super().__init__(
+            title="New template" if creating or template is None else "Edit template",
+            content_width=760,
+            content_height=680,
+        )
+        self._on_save = on_save
+
+        toolbar = Adw.ToolbarView()
+        toolbar.add_top_bar(Adw.HeaderBar())
+        pages = Gtk.Stack(vexpand=True)
+        page = Adw.PreferencesPage()
+        buttons_page = Adw.PreferencesPage()
+        axes_page = Adw.PreferencesPage()
+        pages.add_titled(page, "identity", "Identity")
+        pages.add_titled(buttons_page, "buttons", "Buttons")
+        pages.add_titled(axes_page, "axes", "Axes")
+        switcher = Gtk.StackSwitcher(stack=pages, halign=Gtk.Align.CENTER)
+        switcher.set_margin_top(8)
+        switcher.set_margin_bottom(8)
+        content = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
+        content.append(switcher)
+        content.append(pages)
+
+        identity = Adw.PreferencesGroup(
+            title="Template", description="Define the controls and identity a game will see."
+        )
+        page.add(identity)
+        values = template_to_data(template) if template else {}
+        self._id_row, _ = _entry_row("Template ID", str(values.get("id", "custom-controller")))
+        self._id_row.set_editable(creating or template is None)
+        self._label_row, _ = _entry_row(
+            "Display name", str(values.get("label", "Custom controller"))
+        )
+        self._name_row, _ = _entry_row(
+            "Linux device name", str(values.get("name", "Custom controller"))
+        )
+        self._vendor_row, _ = _entry_row("Vendor ID (hex)", str(values.get("vendor_id", "0000")))
+        self._product_row, _ = _entry_row("Product ID (hex)", str(values.get("product_id", "0000")))
+        self._version_row, _ = _entry_row("Version", str(values.get("version", "0100")))
+        self._bustype_row, _ = _entry_row("Bus type", str(values.get("bustype", "usb")))
+        identity.add(self._label_row)
+        self._layout_row = Adw.ComboRow(
+            title="Mapping layout",
+            subtitle="Changing the layout keeps your configured buttons and axes",
+        )
+        self._layout_row.set_model(Gtk.StringList.new(["Gamepad", "Flight stick"]))
+        self._layout_row.set_selected(1 if template and template.layout == "flight-stick" else 0)
+        identity.add(self._layout_row)
+        advanced = Adw.ExpanderRow(
+            title="Device identity", subtitle="Linux device name, template ID, USB IDs and bus type"
+        )
+        self._id_row.set_tooltip_text("Stable ID; cannot be changed after creating a template")
+        for row in (
+            self._name_row,
+            self._id_row,
+            self._vendor_row,
+            self._product_row,
+            self._version_row,
+            self._bustype_row,
+        ):
+            advanced.add_row(row)
+        identity.add(advanced)
+
+        self._button_rows: list[TemplateControlRow] = []
+        self._axis_rows: list[TemplateControlRow] = []
+        self._buttons_group = Adw.PreferencesGroup(title="Buttons")
+        self._axes_group = Adw.PreferencesGroup(
+            title="Axes",
+            description="X and Y are required. Expand an axis to edit its range and rest value.",
+        )
+        self._add_button = Gtk.Button(label="Add button", valign=Gtk.Align.CENTER)
+        self._add_button.connect("clicked", self._new_button)
+        button_actions = Gtk.Box(spacing=6)
+        self._batch_button = Gtk.Button(label="Add numbered buttons", valign=Gtk.Align.CENTER)
+        self._batch_button.connect("clicked", self._add_numbered_buttons)
+        button_actions.append(self._batch_button)
+        button_actions.append(self._add_button)
+        self._buttons_group.set_header_suffix(button_actions)
+        self._add_axis = Gtk.Button(label="Add axis", valign=Gtk.Align.CENTER)
+        self._add_axis.connect("clicked", self._new_axis)
+        self._axes_group.set_header_suffix(self._add_axis)
+        buttons_page.add(self._buttons_group)
+        axes_page.add(self._axes_group)
+        buttons = (
+            template.buttons if template else (VirtualButton("trigger", "Trigger", "btn_trigger"),)
+        )
+        axes = (
+            template.axes
+            if template
+            else (
+                VirtualAxis("x", "X", "abs_x", -32768, 32767),
+                VirtualAxis("y", "Y", "abs_y", -32768, 32767),
+            )
+        )
+        for control in (*buttons, *axes):
+            self._append_control(control)
+
+        footer = Gtk.ActionBar()
+        self._status = Gtk.Label(xalign=0, hexpand=True, wrap=True)
+        self._status.add_css_class("error")
+        footer.pack_start(self._status)
+        cancel = Gtk.Button(label="Cancel")
+        cancel.connect("clicked", self._close_clicked)
+        footer.pack_end(cancel)
+        save = Gtk.Button(label="Use changes")
+        save.add_css_class("suggested-action")
+        save.connect("clicked", self._save)
+        footer.pack_end(save)
+
+        toolbar.set_content(content)
+        toolbar.add_bottom_bar(footer)
+        self.set_child(toolbar)
+
+    def _append_control(self, control: VirtualButton | VirtualAxis) -> None:
+        row = TemplateControlRow(control, self._remove_control)
+        if isinstance(control, VirtualAxis):
+            self._axis_rows.append(row)
+            self._axes_group.add(row)
+        else:
+            self._button_rows.append(row)
+            self._buttons_group.add(row)
+        self._update_control_limits()
+
+    def _remove_control(self, row: TemplateControlRow) -> None:
+        rows = self._axis_rows if row.is_axis else self._button_rows
+        group = self._axes_group if row.is_axis else self._buttons_group
+        rows.remove(row)
+        group.remove(row)
+        self._update_control_limits()
+
+    def _update_control_limits(self) -> None:
+        self._add_button.set_sensitive(len(self._button_rows) < MAX_TEMPLATE_BUTTONS)
+        self._batch_button.set_sensitive(len(self._button_rows) < MAX_TEMPLATE_BUTTONS)
+        self._add_axis.set_sensitive(len(self._axis_rows) < MAX_TEMPLATE_AXES)
+        self._buttons_group.set_title(f"Buttons · {len(self._button_rows)}")
+        self._axes_group.set_title(f"Axes · {len(self._axis_rows)}")
+
+    def _new_button(self, _button: Gtk.Button) -> None:
+        self._new_control(axis=False)
+
+    def _add_numbered_buttons(self, _button: Gtk.Button) -> None:
+        remaining = MAX_TEMPLATE_BUTTONS - len(self._button_rows)
+        if remaining <= 0:
+            return
+        dialog = Adw.Dialog(title="Add numbered buttons", content_width=420)
+        toolbar = Adw.ToolbarView()
+        toolbar.add_top_bar(Adw.HeaderBar())
+        page = Adw.PreferencesPage()
+        group = Adw.PreferencesGroup(
+            description=(
+                f"Add up to {remaining} independent buttons. Each receives an unused "
+                "TriggerHappy code. You can rename them afterward."
+            )
+        )
+        count = Adw.SpinRow(
+            title="Number of buttons",
+            adjustment=Gtk.Adjustment(
+                value=min(8, remaining), lower=1, upper=remaining, step_increment=1
+            ),
+            digits=0,
+        )
+        group.add(count)
+        page.add(group)
+        toolbar.set_content(page)
+        footer = Gtk.ActionBar()
+        add = Gtk.Button(label="Add buttons")
+        add.add_css_class("suggested-action")
+
+        def add_clicked(_button: Gtk.Button) -> None:
+            count.update()
+            self._append_numbered_buttons(int(count.get_value()))
+            dialog.close()
+
+        add.connect("clicked", add_clicked)
+        footer.pack_end(add)
+        toolbar.add_bottom_bar(footer)
+        dialog.set_child(toolbar)
+        dialog.present(self)
+
+    def _append_numbered_buttons(self, count: int) -> None:
+        buttons = [
+            VirtualButton(
+                row.id_row.get_text(),
+                row.label_row.get_text(),
+                row.codes[int(row.code_row.get_selected())],
+            )
+            for row in self._button_rows
+        ]
+        try:
+            added = numbered_button_batch(
+                buttons, count, reserved_ids={row.id_row.get_text() for row in self._axis_rows}
+            )
+        except VirtualDeviceConfigError as exc:
+            self._status.set_text(str(exc))
+            return
+        for control in added:
+            self._append_control(control)
+        self._status.set_text("")
+
+    def _new_axis(self, _button: Gtk.Button) -> None:
+        self._new_control(axis=True)
+
+    def _new_control(self, *, axis: bool) -> None:
+        rows = self._axis_rows if axis else self._button_rows
+        used_codes = {row.to_data()["evdev"] for row in rows}
+        used_ids = {row.id_row.get_text() for row in (*self._button_rows, *self._axis_rows)}
+        preferred = (
+            ("abs_x", "abs_y", "abs_z", "abs_rx", "abs_ry", "abs_rz", "abs_hat0x", "abs_hat0y")
+            if axis
+            else ("btn_trigger", "btn_thumb", "btn_thumb2", "btn_top", "btn_top2", "btn_pinkie")
+        )
+        code = next(
+            code for code in (*preferred, *event_names(axis=axis)) if code not in used_codes
+        )
+        control_id = code.replace("_", "-")
+        index = 2
+        while control_id in used_ids:
+            control_id = f"{code.replace('_', '-')}-{index}"
+            index += 1
+        label = code.removeprefix("abs_").removeprefix("btn_").replace("_", " ").title()
+        control = (
+            VirtualAxis(control_id, label, code, -32768, 32767)
+            if axis
+            else VirtualButton(control_id, label, code)
+        )
+        self._append_control(control)
+        rows[-1].set_expanded(True)
+        rows[-1].label_row.grab_focus()
+
+    def _close_clicked(self, _button: Gtk.Button) -> None:
+        self.close()
+
+    def _save(self, _button: Gtk.Button) -> None:
+        try:
+            template = template_from_data(
+                {
+                    "id": self._id_row.get_text(),
+                    "layout": "flight-stick" if self._layout_row.get_selected() == 1 else "gamepad",
+                    "label": self._label_row.get_text(),
+                    "name": self._name_row.get_text(),
+                    "vendor_id": self._vendor_row.get_text(),
+                    "product_id": self._product_row.get_text(),
+                    "version": self._version_row.get_text(),
+                    "bustype": self._bustype_row.get_text(),
+                    "buttons": [row.to_data() for row in self._button_rows],
+                    "axes": [row.to_data() for row in self._axis_rows],
+                }
+            )
+        except VirtualDeviceConfigError as exc:
+            self._status.set_text(str(exc))
+            return
+        if self._on_save(template):
+            self.close()
+        else:
+            self._status.set_text(
+                "That template ID is already in use. Choose another ID under Device identity."
+            )
+
+
+class VirtualDeviceInstanceDialog(Adw.Dialog):
+    def __init__(
+        self,
+        instance: VirtualDeviceInstance | None,
+        templates: Sequence[VirtualDeviceTemplate],
+        on_save: Callable[[VirtualDeviceInstance], bool],
+        *,
+        creating: bool = False,
+    ) -> None:
+        super().__init__(
+            title="Edit output" if instance and not creating else "Add output",
+            content_width=520,
+            content_height=540,
+        )
+        self._on_save = on_save
+        self._template_ids = [template.id for template in templates]
+
+        toolbar = Adw.ToolbarView()
+        toolbar.add_top_bar(Adw.HeaderBar())
+        page = Adw.PreferencesPage()
+        group = Adw.PreferencesGroup(title="Device")
+        page.add(group)
+        values = instance_to_data(instance) if instance else {}
+        self._output_row, _ = _entry_row("Output ID", str(values.get("output_id", "")))
+        group.add(self._output_row)
+
+        template_row = Adw.ComboRow(title="Template")
+        template_row.set_model(Gtk.StringList.new([template.label for template in templates]))
+        selected_template = str(values.get("template", ""))
+        if selected_template in self._template_ids:
+            template_row.set_selected(self._template_ids.index(selected_template))
+        self._template_row = template_row
+        group.add(template_row)
+
+        self._name_row, _ = _entry_row("Device name override", str(values.get("name", "")))
+        self._vendor_row, _ = _entry_row("Vendor ID override", str(values.get("vendor_id", "")))
+        self._product_row, _ = _entry_row("Product ID override", str(values.get("product_id", "")))
+        self._version_row, _ = _entry_row("Version override", str(values.get("version", "")))
+        self._bustype_row, _ = _entry_row("Bus type override", str(values.get("bustype", "")))
+        overrides = Adw.ExpanderRow(
+            title="Identity overrides", subtitle="Leave empty to use the template's identity"
+        )
+        group.add(overrides)
+        for row in (
+            self._name_row,
+            self._vendor_row,
+            self._product_row,
+            self._version_row,
+            self._bustype_row,
+        ):
+            overrides.add_row(row)
+
+        footer = Gtk.ActionBar()
+        self._status = Gtk.Label(xalign=0, hexpand=True)
+        self._status.add_css_class("error")
+        footer.pack_start(self._status)
+        cancel = Gtk.Button(label="Cancel")
+        cancel.connect("clicked", self._close_clicked)
+        footer.pack_end(cancel)
+        save = Gtk.Button(label="Use changes")
+        save.add_css_class("suggested-action")
+        save.connect("clicked", self._save)
+        footer.pack_end(save)
+        toolbar.set_content(page)
+        toolbar.add_bottom_bar(footer)
+        self.set_child(toolbar)
+
+    def _close_clicked(self, _button: Gtk.Button) -> None:
+        self.close()
+
+    def _save(self, _button: Gtk.Button) -> None:
+        selected = int(self._template_row.get_selected())
+        if not 0 <= selected < len(self._template_ids):
+            self._status.set_text("Select a template")
+            return
+        data: dict[str, object] = {
+            "output_id": self._output_row.get_text(),
+            "template": self._template_ids[selected],
+        }
+        for key, row in (
+            ("name", self._name_row),
+            ("vendor_id", self._vendor_row),
+            ("product_id", self._product_row),
+            ("version", self._version_row),
+            ("bustype", self._bustype_row),
+        ):
+            if row.get_text().strip():
+                data[key] = row.get_text().strip()
+        try:
+            instance = instance_from_data(data)
+        except VirtualDeviceConfigError as exc:
+            self._status.set_text(str(exc))
+            return
+        if self._on_save(instance):
+            self.close()
+        else:
+            self._status.set_text("Output ID is already used or reserved. Choose a different ID.")
+
+
+class VirtualDevicesDialog(Adw.Dialog):
+    def __init__(self, parent: Gtk.Widget | None = None) -> None:
+        super().__init__(title="Custom virtual devices", content_width=760, content_height=660)
+        self._parent = parent
+        self._config = load_virtual_device_config()
+        self._dirty = False
+        self._applying = False
+        self.set_can_close(False)
+        self.connect("close-attempt", self._on_close_attempt)
+
+        toolbar = Adw.ToolbarView()
+        toolbar.add_top_bar(Adw.HeaderBar())
+        content = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=12)
+        self._content = content
+        content.set_margin_top(12)
+        content.set_margin_bottom(12)
+        content.set_margin_start(12)
+        content.set_margin_end(12)
+        scrolled = Gtk.ScrolledWindow(vexpand=True)
+        scrolled.set_child(content)
+
+        introduction = Gtk.Label(
+            label=(
+                "Templates describe a controller. Add an output to make it available "
+                "to games and mappings."
+            ),
+            xalign=0,
+            wrap=True,
+        )
+        content.append(introduction)
+
+        templates_header = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=6)
+        templates_header.append(Gtk.Label(label="Templates", xalign=0, hexpand=True))
+        add_template = Gtk.Button(label="New template")
+        add_template.connect("clicked", self._new_template)
+        templates_header.append(add_template)
+        content.append(templates_header)
+        self._templates_list = Gtk.ListBox(selection_mode=Gtk.SelectionMode.NONE)
+        self._templates_list.add_css_class("boxed-list")
+        content.append(self._templates_list)
+
+        devices_header = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=6)
+        devices_header.append(Gtk.Label(label="Configured outputs", xalign=0, hexpand=True))
+        self._add_device_button = Gtk.Button(label="Add output")
+        self._add_device_button.connect("clicked", self._new_device)
+        devices_header.append(self._add_device_button)
+        content.append(devices_header)
+        self._devices_list = Gtk.ListBox(selection_mode=Gtk.SelectionMode.NONE)
+        self._devices_list.add_css_class("boxed-list")
+        content.append(self._devices_list)
+        self._empty_outputs = Gtk.Label(
+            label=(
+                "No additional outputs. Choose Add output on a template to create one.\n"
+                "The standard virtual gamepad count is managed in Settings."
+            ),
+            xalign=0,
+            wrap=True,
+        )
+        self._empty_outputs.add_css_class("dim-label")
+        content.append(self._empty_outputs)
+
+        note = Gtk.Label(
+            label=(
+                "Applying changes reconnects affected virtual devices. Close games that are "
+                "currently reading them first."
+            ),
+            xalign=0,
+            wrap=True,
+        )
+        note.add_css_class("dim-label")
+        content.append(note)
+
+        footer = Gtk.ActionBar()
+        self._status = Gtk.Label(xalign=0, hexpand=True)
+        footer.pack_start(self._status)
+        close = Gtk.Button(label="Close")
+        close.connect("clicked", self._close_clicked)
+        footer.pack_end(close)
+        self._apply_button = Gtk.Button(label="Apply")
+        self._apply_button.add_css_class("suggested-action")
+        self._apply_button.connect("clicked", self._apply)
+        footer.pack_end(self._apply_button)
+        toolbar.set_content(scrolled)
+        toolbar.add_bottom_bar(footer)
+        self.set_child(toolbar)
+        self._rebuild()
+
+        session_request_async(
+            {"command": "get_virtual_devices"},
+            self._on_loaded,
+            timeout=1.0,
+        )
+
+    def _close_clicked(self, _button: Gtk.Button) -> None:
+        self.close()
+
+    def _on_close_attempt(self, _dialog: Adw.Dialog) -> None:
+        if self._applying:
+            return
+        if not self._dirty:
+            self.force_close()
+            return
+        confirmation = Adw.AlertDialog(
+            heading="Discard unapplied changes?",
+            body="Your template and output changes have not been applied.",
+        )
+        confirmation.add_response("cancel", "Keep editing")
+        confirmation.add_response("discard", "Discard")
+        confirmation.set_default_response("cancel")
+        confirmation.set_close_response("cancel")
+        confirmation.set_response_appearance("discard", Adw.ResponseAppearance.DESTRUCTIVE)
+        confirmation.connect("response", self._discard_response)
+        confirmation.present(self)
+
+    def _discard_response(self, _dialog: Adw.AlertDialog, response: str) -> None:
+        if response == "discard":
+            self.force_close()
+
+    def _catalog(self) -> tuple[VirtualDeviceTemplate, ...]:
+        return (*BUILTIN_VIRTUAL_DEVICE_TEMPLATES, *self._config.templates)
+
+    def _clear_list(self, list_box: Gtk.ListBox) -> None:
+        child = list_box.get_first_child()
+        while child is not None:
+            next_child = child.get_next_sibling()
+            list_box.remove(child)
+            child = next_child
+
+    def _rebuild(self) -> None:
+        self._clear_list(self._templates_list)
+        for template in BUILTIN_VIRTUAL_DEVICE_TEMPLATES:
+            self._templates_list.append(self._template_row(template, builtin=True))
+        for index, template in enumerate(self._config.templates):
+            self._templates_list.append(self._template_row(template, index=index))
+
+        self._empty_outputs.set_visible(not self._config.devices)
+        self._clear_list(self._devices_list)
+        catalog = {template.id: template for template in self._catalog()}
+        for index, device in enumerate(self._config.devices):
+            row = Gtk.ListBoxRow()
+            box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=8)
+            box.set_margin_top(8)
+            box.set_margin_bottom(8)
+            box.set_margin_start(12)
+            box.set_margin_end(8)
+            template = catalog.get(device.template_id)
+            label = Gtk.Label(
+                label=(f"{device.output_id}\n{template.label if template else device.template_id}"),
+                xalign=0,
+                hexpand=True,
+                tooltip_text=template.label if template else device.template_id,
+            )
+            box.append(label)
+            edit = Gtk.Button(icon_name="document-edit-symbolic")
+            edit.set_tooltip_text("Edit output")
+            edit.connect("clicked", self._edit_device, index)
+            box.append(edit)
+            remove = Gtk.Button(icon_name="user-trash-symbolic")
+            remove.set_tooltip_text("Remove output")
+            remove.connect("clicked", self._remove_device, index)
+            box.append(remove)
+            row.set_child(box)
+            self._devices_list.append(row)
+        self._add_device_button.set_sensitive(len(self._config.devices) < MAX_USER_VIRTUAL_DEVICES)
+        self._apply_button.set_sensitive(self._dirty and not self._applying)
+
+    def _template_row(
+        self,
+        template: VirtualDeviceTemplate,
+        *,
+        builtin: bool = False,
+        index: int = -1,
+    ) -> Gtk.ListBoxRow:
+        row = Gtk.ListBoxRow()
+        box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=8)
+        box.set_margin_top(8)
+        box.set_margin_bottom(8)
+        box.set_margin_start(12)
+        box.set_margin_end(8)
+        text = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=2, hexpand=True)
+        text.append(Gtk.Label(label=template.label, xalign=0, wrap=True, max_width_chars=30))
+        detail = Gtk.Label(
+            label=(
+                f"{'Built-in · ' if builtin else 'Custom · '}"
+                f"{len(template.buttons)} buttons, {len(template.axes)} axes"
+            ),
+            xalign=0,
+        )
+        detail.add_css_class("dim-label")
+        text.append(detail)
+        description = {
+            XBOX_360_TEMPLATE_ID: "Two sticks, two triggers, and directional controls",
+            LOGITECH_EXTREME_3D_TEMPLATE_ID: "Twist, throttle, hat switch, and 12 buttons",
+        }.get(template.id)
+        if description:
+            summary = Gtk.Label(label=description, xalign=0, wrap=True, max_width_chars=30)
+            summary.add_css_class("dim-label")
+            text.append(summary)
+        box.append(text)
+        use = Gtk.Button(label="Add output", valign=Gtk.Align.CENTER)
+        use.set_sensitive(len(self._config.devices) < MAX_USER_VIRTUAL_DEVICES)
+        use.connect("clicked", self._use_template, template)
+        box.append(use)
+        duplicate = Gtk.Button(
+            label="Customize" if builtin else "Duplicate", valign=Gtk.Align.CENTER
+        )
+        duplicate.connect("clicked", self._duplicate_template, template)
+        box.append(duplicate)
+        if not builtin:
+            edit = Gtk.Button(icon_name="document-edit-symbolic", valign=Gtk.Align.CENTER)
+            edit.set_tooltip_text("Edit template")
+            edit.connect("clicked", self._edit_template, index)
+            box.append(edit)
+            remove = Gtk.Button(icon_name="user-trash-symbolic", valign=Gtk.Align.CENTER)
+            used = any(device.template_id == template.id for device in self._config.devices)
+            remove.set_sensitive(not used)
+            remove.set_tooltip_text(
+                "Remove outputs using this template first" if used else "Remove template"
+            )
+            remove.connect("clicked", self._remove_template, index)
+            box.append(remove)
+        row.set_child(box)
+        return row
+
+    def _on_loaded(self, response: dict[str, object] | None) -> bool:
+        if self._dirty:
+            return False
+        if isinstance(response, dict) and response.get("status") == "ok":
+            try:
+                self._config = config_from_json(response.get("config", {}))
+            except VirtualDeviceConfigError as exc:
+                self._status.set_text(str(exc))
+                return False
+            self._rebuild()
+        return False
+
+    def _present_template_editor(
+        self, template: VirtualDeviceTemplate | None, *, creating: bool = False
+    ) -> None:
+        def save(updated: VirtualDeviceTemplate) -> bool:
+            templates = list(self._config.templates)
+            if not creating and template is not None and template in templates:
+                templates[templates.index(template)] = updated
+            else:
+                templates.append(updated)
+            return self._set_config(templates=templates)
+
+        VirtualTemplateEditorDialog(template, save, creating=creating).present(self)
+
+    def _new_template(self, _button: Gtk.Button) -> None:
+        dialog = Adw.AlertDialog(
+            heading="Choose a starting layout",
+            body="Start with a familiar controller, then rename, remove, or add controls.",
+        )
+        dialog.add_response("cancel", "Cancel")
+        dialog.add_response("gamepad", "Gamepad")
+        dialog.add_response("flight-stick", "Flight stick")
+        dialog.set_close_response("cancel")
+        dialog.connect("response", self._new_template_layout)
+        dialog.present(self)
+
+    def _new_template_layout(self, _dialog: Adw.AlertDialog, response: str) -> None:
+        if response not in {"gamepad", "flight-stick"}:
+            return
+        template = next(
+            item for item in BUILTIN_VIRTUAL_DEVICE_TEMPLATES if item.layout == response
+        )
+        copy = unique_template_copy(template, self._catalog())
+        self._present_template_editor(copy, creating=True)
+
+    def _duplicate_template(
+        self,
+        _button: Gtk.Button,
+        template: VirtualDeviceTemplate,
+    ) -> None:
+        copy = unique_template_copy(template, self._catalog())
+        self._present_template_editor(copy, creating=True)
+
+    def _edit_template(self, _button: Gtk.Button, index: int) -> None:
+        self._present_template_editor(self._config.templates[index])
+
+    def _remove_template(self, _button: Gtk.Button, index: int) -> None:
+        template = self._config.templates[index]
+        if any(device.template_id == template.id for device in self._config.devices):
+            self._status.set_text("Remove outputs using this template first")
+            return
+        templates = list(self._config.templates)
+        templates.pop(index)
+        self._set_config(templates=templates)
+
+    def _use_template(self, _button: Gtk.Button, template: VirtualDeviceTemplate) -> None:
+        used = {device.output_id for device in self._config.devices}
+        base = {
+            XBOX_360_TEMPLATE_ID: "standard-gamepad",
+            LOGITECH_EXTREME_3D_TEMPLATE_ID: "flight-stick",
+        }.get(template.id, template.id[:54])
+        output_id = base
+        index = 2
+        while output_id in used:
+            output_id = f"{base}-{index}"
+            index += 1
+        self._present_device_editor(VirtualDeviceInstance(output_id, template.id), creating=True)
+
+    def _present_device_editor(
+        self, instance: VirtualDeviceInstance | None, *, creating: bool = False
+    ) -> None:
+        def save(updated: VirtualDeviceInstance) -> bool:
+            devices = list(self._config.devices)
+            if not creating and instance is not None and instance in devices:
+                devices[devices.index(instance)] = updated
+            else:
+                devices.append(updated)
+            return self._set_config(devices=devices)
+
+        VirtualDeviceInstanceDialog(instance, self._catalog(), save, creating=creating).present(
+            self
+        )
+
+    def _new_device(self, _button: Gtk.Button) -> None:
+        self._present_device_editor(None)
+
+    def _edit_device(self, _button: Gtk.Button, index: int) -> None:
+        self._present_device_editor(self._config.devices[index])
+
+    def _remove_device(self, _button: Gtk.Button, index: int) -> None:
+        devices = list(self._config.devices)
+        devices.pop(index)
+        self._set_config(devices=devices)
+
+    def _set_config(
+        self,
+        *,
+        templates: Sequence[VirtualDeviceTemplate] | None = None,
+        devices: Sequence[VirtualDeviceInstance] | None = None,
+    ) -> bool:
+        candidate = VirtualDeviceConfig(
+            templates=tuple(templates if templates is not None else self._config.templates),
+            devices=tuple(devices if devices is not None else self._config.devices),
+        )
+        try:
+            candidate = config_from_json(config_to_json(candidate))
+        except VirtualDeviceConfigError as exc:
+            self._status.set_text(str(exc))
+            return False
+        self._config = candidate
+        self._dirty = True
+        self._status.set_text("Unapplied changes")
+        self._rebuild()
+        return True
+
+    def _apply(self, _button: Gtk.Button) -> None:
+        if self._applying:
+            return
+        config = self._config
+        payload = config_to_json(config)
+        self._applying = True
+        self._content.set_sensitive(False)
+        self._apply_button.set_sensitive(False)
+        self._status.set_text("Applying…")
+
+        def finish() -> None:
+            self._applying = False
+            self._content.set_sensitive(True)
+            self._rebuild()
+
+        def saved(result: GuiTaskResult[VirtualDeviceConfig]) -> bool:
+            if result.ok:
+                self._dirty = False
+                self._status.set_text("Saved. The session service is unavailable.")
+            else:
+                self._status.set_text(f"Could not save: {result.error}")
+            finish()
+            return False
+
+        def applied(response: dict[str, object] | None) -> bool:
+            if isinstance(response, dict) and response.get("status") == "ok":
+                self._config = config_from_json(response.get("config", payload))
+                self._dirty = False
+                self._status.set_text(str(response.get("warning") or "Applied"))
+                finish()
+                return False
+            if isinstance(response, dict):
+                self._status.set_text(str(response.get("message") or "Failed to apply"))
+                finish()
+                return False
+            run_gui_task(lambda: save_virtual_device_config(config), saved)
+            return False
+
+        session_request_async(
+            {"command": "set_virtual_devices", "config": payload},
+            applied,
+            timeout=2.0,
+        )

--- a/keymasq/gui/widgets/virtual_devices_dialog.py
+++ b/keymasq/gui/widgets/virtual_devices_dialog.py
@@ -30,12 +30,9 @@ from keymasq.common.virtual_device_templates import (
     template_from_data,
     template_to_data,
 )
-from keymasq.gui.session_client import GuiTaskResult, run_gui_task, session_request_async
+from keymasq.gui.session_client import session_request_async
 from keymasq.gui.widgets.virtual_template_controls import TemplateControlRow, event_names
-from keymasq.session.virtual_devices import (
-    load_virtual_device_config,
-    save_virtual_device_config,
-)
+from keymasq.session.virtual_devices import load_virtual_device_config
 
 
 def unique_template_copy(
@@ -793,12 +790,20 @@ class VirtualDevicesDialog(Adw.Dialog):
             self._content.set_sensitive(True)
             self._rebuild()
 
-        def saved(result: GuiTaskResult[VirtualDeviceConfig]) -> bool:
-            if result.ok:
-                self._dirty = False
-                self._status.set_text("Saved. The session service is unavailable.")
-            else:
-                self._status.set_text(f"Could not save: {result.error}")
+        def reconciled(response: dict[str, object] | None) -> bool:
+            confirmed = False
+            if isinstance(response, dict) and response.get("status") == "ok":
+                try:
+                    confirmed = config_from_json(response.get("config")) == config
+                except VirtualDeviceConfigError:
+                    pass
+            self._dirty = not confirmed
+            self._status.set_text(
+                "Applied. Confirmed with the session service."
+                if confirmed
+                else "Could not confirm changes. Your edits are kept; "
+                "retry when the service responds."
+            )
             finish()
             return False
 
@@ -813,7 +818,8 @@ class VirtualDevicesDialog(Adw.Dialog):
                 self._status.set_text(str(response.get("message") or "Failed to apply"))
                 finish()
                 return False
-            run_gui_task(lambda: save_virtual_device_config(config), saved)
+            self._status.set_text("No response to Apply. Checking the current configuration…")
+            session_request_async({"command": "get_virtual_devices"}, reconciled, timeout=2.0)
             return False
 
         session_request_async(

--- a/keymasq/gui/widgets/virtual_template_controls.py
+++ b/keymasq/gui/widgets/virtual_template_controls.py
@@ -1,0 +1,122 @@
+"""Editable controls for virtual gaming device templates."""
+
+from collections.abc import Callable
+
+import evdev
+import gi
+
+gi.require_version("Gtk", "4.0")
+gi.require_version("Adw", "1")
+from gi.repository import Adw, Gtk  # pyright: ignore[reportAttributeAccessIssue]
+
+from keymasq.common.virtual_device_templates import VirtualAxis, VirtualButton
+
+
+def entry_row(title: str, value: str) -> Adw.EntryRow:
+    row = Adw.EntryRow(title=title)
+    row.set_text(value)
+    return row
+
+
+def event_names(*, axis: bool) -> list[str]:
+    prefix = "ABS_" if axis else "BTN_"
+    table = evdev.ecodes.ABS if axis else evdev.ecodes.keys
+    return sorted(
+        name.lower()
+        for name, code in vars(evdev.ecodes).items()
+        if name.startswith(prefix) and isinstance(code, int) and code in table
+    )
+
+
+class TemplateControlRow(Adw.ExpanderRow):
+    def __init__(
+        self,
+        control: VirtualButton | VirtualAxis,
+        on_remove: Callable[["TemplateControlRow"], None],
+    ) -> None:
+        super().__init__(title=control.label, subtitle=control.evdev.upper())
+        self.is_axis = isinstance(control, VirtualAxis)
+        self.label_row = entry_row("Label", control.label)
+        self.id_row = entry_row("Control ID", control.id)
+        self.id_row.set_tooltip_text("Stable ID used to refer to this control in analog mappings")
+        self.add_row(self.label_row)
+        self.codes = event_names(axis=self.is_axis)
+        self.code_row = Adw.ComboRow(title="Linux axis" if self.is_axis else "Linux button")
+        self.code_row.set_model(Gtk.StringList.new([code.upper() for code in self.codes]))
+        self.code_row.set_enable_search(True)
+        self.code_row.set_selected(self.codes.index(control.evdev))
+        self.add_row(self.code_row)
+        self.range_rows: dict[str, Adw.SpinRow] = {}
+        if isinstance(control, VirtualAxis):
+            for key, title, value in (
+                ("minimum", "Minimum", control.minimum),
+                ("maximum", "Maximum", control.maximum),
+                ("rest", "Rest value", control.rest),
+            ):
+                row = self._number_row(title, value)
+                self.range_rows[key] = row
+                self.add_row(row)
+            self.range_rows["rest"].set_tooltip_text("Value sent when the control is released")
+        advanced = Adw.ExpanderRow(title="Advanced")
+        advanced.add_row(self.id_row)
+        if isinstance(control, VirtualAxis):
+            for key, title, value, hint in (
+                ("fuzz", "Fuzz", control.fuzz, "Noise tolerance reported to Linux"),
+                ("flat", "Flat", control.flat, "Dead zone reported to Linux"),
+                (
+                    "resolution",
+                    "Resolution",
+                    control.resolution,
+                    "Units per millimeter or radian; 0 means unspecified",
+                ),
+            ):
+                row = self._number_row(title, value, minimum=0)
+                row.set_tooltip_text(hint)
+                self.range_rows[key] = row
+                advanced.add_row(row)
+        self.add_row(advanced)
+        remove = Gtk.Button(icon_name="user-trash-symbolic", valign=Gtk.Align.CENTER)
+        remove.add_css_class("flat")
+        remove.set_tooltip_text(f"Remove {control.label}")
+        self._on_remove = on_remove
+        remove.connect("clicked", self._remove_clicked)
+        self.add_suffix(remove)
+        self.label_row.connect("changed", self._update_summary)
+        self.code_row.connect("notify::selected", self._update_summary)
+        for row in self.range_rows.values():
+            row.connect("notify::value", self._update_summary)
+        self._update_summary()
+
+    def _remove_clicked(self, _button: Gtk.Button) -> None:
+        self._on_remove(self)
+
+    @staticmethod
+    def _number_row(title: str, value: int, *, minimum: int = -2147483648) -> Adw.SpinRow:
+        return Adw.SpinRow(
+            title=title,
+            adjustment=Gtk.Adjustment(
+                value=value, lower=minimum, upper=2147483647, step_increment=1, page_increment=10
+            ),
+            digits=0,
+        )
+
+    def _update_summary(self, *_args: object) -> None:
+        self.set_title(self.label_row.get_text() or "Unnamed control")
+        code = self.codes[int(self.code_row.get_selected())].upper()
+        if self.is_axis:
+            minimum = int(self.range_rows["minimum"].get_value())
+            maximum = int(self.range_rows["maximum"].get_value())
+            rest = int(self.range_rows["rest"].get_value())
+            code = f"{code} · {minimum} to {maximum} · rest {rest}"
+        self.set_subtitle(code)
+
+    def to_data(self) -> dict[str, object]:
+        data: dict[str, object] = {
+            "id": self.id_row.get_text(),
+            "label": self.label_row.get_text(),
+            "evdev": self.codes[int(self.code_row.get_selected())],
+        }
+        for key, row in self.range_rows.items():
+            row.update()
+            data[key] = int(row.get_value())
+        return data

--- a/keymasq/gui/widgets/virtual_template_controls.py
+++ b/keymasq/gui/widgets/virtual_template_controls.py
@@ -24,7 +24,10 @@ def event_names(*, axis: bool) -> list[str]:
     return sorted(
         name.lower()
         for name, code in vars(evdev.ecodes).items()
-        if name.startswith(prefix) and isinstance(code, int) and code in table
+        if name.startswith(prefix)
+        and isinstance(code, int)
+        and code in table
+        and (not axis or name not in {"ABS_MAX", "ABS_CNT"})
     )
 
 

--- a/keymasq/keymasqd/daemon_device_commands.py
+++ b/keymasq/keymasqd/daemon_device_commands.py
@@ -44,7 +44,11 @@ class _DeviceCommandManager(Protocol):
         categories: Sequence[object] | None = None,
     ) -> JsonObject: ...
 
-    async def set_virtual_gamepads(self, count: object) -> JsonObject: ...
+    async def set_virtual_gamepads(
+        self,
+        count: object,
+        virtual_devices: object | None = None,
+    ) -> JsonObject: ...
 
     async def track_profile_activation(
         self,
@@ -148,7 +152,10 @@ async def handle_device_command(
         return await daemon.device_manager.set_diagnostics(enabled, interval, categories)
 
     if command_type == CommandType.SET_VIRTUAL_GAMEPADS:
-        return await daemon.device_manager.set_virtual_gamepads(data.get("count"))
+        return await daemon.device_manager.set_virtual_gamepads(
+            data.get("count"),
+            data.get("virtual_devices") if "virtual_devices" in data else None,
+        )
 
     if command_type == CommandType.TRACK_PROFILE_ACTIVATION:
         return await daemon.device_manager.track_profile_activation(

--- a/keymasq/keymasqd/device_manager.py
+++ b/keymasq/keymasqd/device_manager.py
@@ -22,6 +22,11 @@ from keymasq.common.ipc import CommandType
 from keymasq.common.model.actions import MappingAction, parse_profile_deactivation_policy
 from keymasq.common.model.core import DeviceType
 from keymasq.common.types import JsonObject
+from keymasq.common.virtual_device_templates import (
+    config_from_json,
+    config_to_json,
+    resolve_virtual_devices,
+)
 from keymasq.common.virtual_devices import (
     clamp_virtual_gamepad_count,
 )
@@ -196,8 +201,18 @@ class DeviceManager(CursorManagerMixin, MacroManagerMixin, ComboManagerMixin):
     def shutdown_output_devices(self) -> None:
         outputs.destroy_global_uinputs(cast(Any, self), log=log)
 
-    async def set_virtual_gamepads(self, count: object) -> JsonObject:
+    async def set_virtual_gamepads(
+        self,
+        count: object,
+        virtual_devices: object | None = None,
+    ) -> JsonObject:
         clamped_count = clamp_virtual_gamepad_count(count)
+        config = (
+            config_from_json(virtual_devices)
+            if virtual_devices is not None
+            else self.output_state.virtual_device_config
+        )
+        configuration_changed = config != self.output_state.virtual_device_config
         async with self._op_lock:
 
             async def clear_runtime() -> None:
@@ -213,9 +228,10 @@ class DeviceManager(CursorManagerMixin, MacroManagerMixin, ComboManagerMixin):
                     evdev_mod=evdev,  # pyright: ignore[reportArgumentType]
                     log=log,
                     uinput_writer=adapters.identity_uinput_writer,
+                    config=config,
                 )
 
-            return await virtual_gamepads.reconfigure_virtual_gamepads(
+            result = await virtual_gamepads.reconfigure_virtual_gamepads(
                 count=clamped_count,
                 current_count=self.output_state.virtual_gamepad_count,
                 output_devices_active=self.output_state.device_count > 0,
@@ -226,7 +242,17 @@ class DeviceManager(CursorManagerMixin, MacroManagerMixin, ComboManagerMixin):
                     self.output_state, "virtual_gamepad_count", value
                 ),
                 logger=log,
+                configuration_changed=configuration_changed,
             )
+            if self.output_state.device_count == 0 and configuration_changed:
+                self.output_state.virtual_device_config = config
+                self.output_state.virtual_device_specs = {
+                    device.output_id: device
+                    for device in resolve_virtual_devices(clamped_count, config)
+                }
+            if virtual_devices is not None:
+                result["virtual_devices"] = config_to_json(config)
+            return result
 
     def resolve_gamepad_output(
         self,

--- a/keymasq/keymasqd/runtime/action/outputs.py
+++ b/keymasq/keymasqd/runtime/action/outputs.py
@@ -11,6 +11,7 @@ from keymasq.keymasqd.runtime.action.state import (
 )
 from keymasq.keymasqd.runtime.grabbed_device.outputs import (
     bucket_for_uinput,
+    target_axis_release_value,
     write_abs_axis,
     write_key,
 )
@@ -62,6 +63,12 @@ async def execute_gamepad_axis_action(
     if axis_code is None:
         mark_action_started(execution_handle)
         return
+    target_bucket = str(getattr(target, "bucket", "gamepad"))
+    active_value = int(action.axis_value)
+    axis_ranges = getattr(target, "axis_ranges", {})
+    if axis_code in axis_ranges:
+        minimum, maximum = axis_ranges[axis_code]
+        active_value = max(minimum, min(maximum, active_value))
     await execute_abs_axis_output(
         device_runtime,
         action,
@@ -69,10 +76,10 @@ async def execute_gamepad_axis_action(
         event_name,
         deps=deps,
         axis_code=axis_code,
-        active_value=int(action.axis_value),
-        release_value=0,
+        active_value=active_value,
+        release_value=target_axis_release_value(target, axis_code),
         target_uinput=getattr(target, "uinput", None),
-        target_bucket=str(getattr(target, "bucket", "gamepad")),
+        target_bucket=target_bucket,
         rapidfire_kind="axis",
         tap_label=f"tap axis action {event_name}",
         shared_abs_output_tracker=shared_abs_output_tracker,
@@ -171,6 +178,7 @@ async def execute_abs_axis_output(
             evdev_mod=deps.evdev_mod,
             uinput_writer=deps.uinput_writer,
             bucket=target_bucket,
+            release_value=release_value,
         )
     mark_action_started(execution_handle)
 

--- a/keymasq/keymasqd/runtime/analog/gamepad.py
+++ b/keymasq/keymasqd/runtime/analog/gamepad.py
@@ -16,6 +16,7 @@ from keymasq.keymasqd.runtime.analog.metadata import (
     axis_min_max,
     resolve_gamepad_output_target,
     resolve_output_axis,
+    resolve_virtual_output_config,
     stick_axis_center,
     stick_output_axis_specs,
     stick_output_reset_axes,
@@ -42,8 +43,19 @@ def emit_gamepad_output(
 ) -> None:
     if not config.gamepad_output.enabled:
         return
+    target = resolve_gamepad_output_target(device_runtime, source_id, config)
+    if target is None:
+        return
+    resolved_config = resolve_virtual_output_config(
+        device_runtime, source_id, config, deps=deps, target=target
+    )
+    if resolved_config is None:
+        return
+    config = resolved_config
     if config.input_type == "axis":
-        _emit_axis_gamepad_output(device_runtime, state_key, source_id, config, deps=deps)
+        _emit_axis_gamepad_output(
+            device_runtime, state_key, source_id, config, deps=deps, target=target
+        )
         return
     _emit_stick_gamepad_output(
         device_runtime,
@@ -53,6 +65,7 @@ def emit_gamepad_output(
         gyro=gyro,
         minimum_output=minimum_output,
         deps=deps,
+        target=target,
     )
 
 
@@ -80,6 +93,7 @@ def _emit_stick_gamepad_output(
     gyro: bool = False,
     minimum_output: float = 0.0,
     deps: ActionExecutionDeps,
+    target: object,
 ) -> None:
     if config.gamepad_output.target == "analog":
         _emit_analog_stick_output(
@@ -90,10 +104,8 @@ def _emit_stick_gamepad_output(
             gyro=gyro,
             minimum_output=minimum_output,
             deps=deps,
+            target=target,
         )
-        return
-    target = resolve_gamepad_output_target(device_runtime, source_id, config)
-    if target is None:
         return
     axis_specs = stick_output_axis_specs(
         device_runtime,
@@ -154,10 +166,8 @@ def _emit_axis_gamepad_output(
     config: AnalogControlConfig,
     *,
     deps: ActionExecutionDeps,
+    target: object,
 ) -> None:
-    target = resolve_gamepad_output_target(device_runtime, source_id, config)
-    if target is None:
-        return
     axis = resolve_output_axis(device_runtime, source_id, config, target=target, deps=deps)
     if axis is None:
         return
@@ -223,23 +233,27 @@ def reset_gamepad_output(
     *,
     deps: ActionExecutionDeps,
 ) -> None:
-    if config.gamepad_output.target == "analog" and config.input_type != "axis":
-        _reset_analog_gamepad_output(device_runtime, state_key, source_id, config, deps=deps)
+    target = resolve_gamepad_output_target(device_runtime, source_id, config)
+    if target is None:
         return
-    target: object | None = None
+    resolved_config = resolve_virtual_output_config(
+        device_runtime, source_id, config, deps=deps, target=target
+    )
+    if resolved_config is None:
+        return
+    config = resolved_config
+    if config.gamepad_output.target == "analog" and config.input_type != "axis":
+        _reset_analog_gamepad_output(
+            device_runtime, state_key, source_id, config, deps=deps, target=target
+        )
+        return
     if config.input_type == "axis":
-        target = resolve_gamepad_output_target(device_runtime, source_id, config)
-        if target is None:
-            return
         axis = resolve_output_axis(device_runtime, source_id, config, target=target, deps=deps)
         if axis is None:
             return
         rest = config.gamepad_output.output_rest
         axes = ((axis.code, axis.clamp(rest if rest is not None else axis.neutral)),)
     else:
-        target = resolve_gamepad_output_target(device_runtime, source_id, config)
-        if target is None:
-            return
         axis_specs = stick_output_axis_specs(
             device_runtime,
             source_id,
@@ -272,10 +286,8 @@ def _emit_analog_stick_output(
     gyro: bool = False,
     minimum_output: float = 0.0,
     deps: ActionExecutionDeps,
+    target: object,
 ) -> None:
-    target = resolve_gamepad_output_target(device_runtime, source_id, config)
-    if target is None:
-        return
     analog = target_analog_input(target, config, expected_type="stick")
     if analog is None:
         return
@@ -342,10 +354,8 @@ def _reset_analog_gamepad_output(
     config: AnalogControlConfig,
     *,
     deps: ActionExecutionDeps,
+    target: object,
 ) -> None:
-    target = resolve_gamepad_output_target(device_runtime, source_id, config)
-    if target is None:
-        return
     analog = target_analog_input(target, config, expected_type=config.input_type)
     if analog is None:
         return

--- a/keymasq/keymasqd/runtime/analog/metadata.py
+++ b/keymasq/keymasqd/runtime/analog/metadata.py
@@ -1,5 +1,6 @@
 """Target-device and axis metadata resolution for analog output routing."""
 
+from dataclasses import replace
 from typing import cast
 
 from keymasq.common.devices import capability_name, resolve_evdev_code
@@ -129,6 +130,46 @@ def target_analog_input(
     raw_analog = typed_analog_inputs.get(target_analog_id)
     analog = _typed_analog_input(raw_analog, expected_type=expected_type)
     return analog
+
+
+def resolve_virtual_output_config(
+    device_runtime: GrabbedDeviceRuntime,
+    source_id: str,
+    config: AnalogControlConfig,
+    *,
+    deps: ActionExecutionDeps,
+    target: object,
+) -> AnalogControlConfig | None:
+    """Resolve implicit routing by event code before applying template ranges."""
+    # 1D routing resolves explicit and legacy targets through OutputAxis metadata.
+    if config.input_type == "axis" or config.gamepad_output.target == "analog":
+        return config
+    if not getattr(target, "axis_ranges", None):
+        return config
+    if config.input_type == "stick":
+        codes = _stick_outputaxis_codes(device_runtime, source_id, config, deps=deps)
+        roles = ("x", "y")
+    else:
+        code = trigger_outputaxis_code(device_runtime, source_id, config, deps=deps)
+        codes = (code,) if code is not None else None
+        roles = ("x",)
+    if codes is None:
+        return None
+    for analog_id, raw_analog in (target_analog_inputs(target) or {}).items():
+        analog = _typed_analog_input(raw_analog, expected_type=config.input_type)
+        if analog is None:
+            continue
+        if all(
+            (axis := target_axis(analog, role)) is not None and axis_evdev_code(axis) == code
+            for role, code in zip(roles, codes, strict=True)
+        ):
+            return replace(
+                config,
+                gamepad_output=replace(
+                    config.gamepad_output, target="analog", target_analog_id=analog_id
+                ),
+            )
+    return None
 
 
 def target_analog_inputs(target: object) -> dict[str, object] | None:
@@ -277,8 +318,6 @@ def _standard_stick_output_analog(
     config: AnalogControlConfig,
     target: object,
 ) -> dict[str, object] | None:
-    if bool(getattr(target, "is_virtual", False)):
-        return None
     analog_inputs = target_analog_inputs(target)
     if analog_inputs is None:
         return None

--- a/keymasq/keymasqd/runtime/analog/output_state.py
+++ b/keymasq/keymasqd/runtime/analog/output_state.py
@@ -72,7 +72,13 @@ def write_gamepad_axes(
         elif value == reset_values.get(axis_code, 0):
             _clear_tracked_abs_state(device_runtime, target_bucket, axis_code)
         else:
-            track_abs_state(device_runtime, axis_code, value, bucket=target_bucket)
+            track_abs_state(
+                device_runtime,
+                axis_code,
+                value,
+                bucket=target_bucket,
+                release_value=reset_values.get(axis_code, 0),
+            )
     syn_if_passthrough_frame_closed(
         target_uinput,
         writer,

--- a/keymasq/keymasqd/runtime/analog/thresholds.py
+++ b/keymasq/keymasqd/runtime/analog/thresholds.py
@@ -13,7 +13,10 @@ from keymasq.keymasqd.runtime.analog.threshold_state import (
     threshold_key,
 )
 from keymasq.keymasqd.runtime.grabbed_device import actions
-from keymasq.keymasqd.runtime.grabbed_device.outputs import track_refcounted_output_bucket
+from keymasq.keymasqd.runtime.grabbed_device.outputs import (
+    gamepad_axis_release_value,
+    track_refcounted_output_bucket,
+)
 from keymasq.keymasqd.runtime.grabbed_device.types import (
     ActionExecutionDeps,
     GrabbedDeviceRuntime,
@@ -232,6 +235,7 @@ def track_threshold_abs_output(
     axis_code: int,
     value: int,
 ) -> bool:
+    release_value = gamepad_axis_release_value(device_runtime, bucket, axis_code)
     return track_refcounted_output_bucket(
         device_runtime.state.analog_threshold_abs_refcounts,
         device_runtime.state.held_output_abs,
@@ -239,6 +243,7 @@ def track_threshold_abs_output(
         axis_code,
         value,
         pressed_value=None,
+        release_value=release_value,
     )
 
 

--- a/keymasq/keymasqd/runtime/grabbed_device/outputs.py
+++ b/keymasq/keymasqd/runtime/grabbed_device/outputs.py
@@ -113,14 +113,45 @@ def track_abs_state(
     value: int,
     *,
     bucket: str | None,
+    release_value: int = 0,
 ) -> None:
     if not bucket:
         return
     held = device_runtime.state.held_output_abs.setdefault(bucket, set())
-    if int(value) != 0:
+    if int(value) != int(release_value):
         held.add(int(axis_code))
     else:
         held.discard(int(axis_code))
+
+
+def gamepad_axis_release_value(
+    device_runtime: ActionRuntime,
+    bucket: str,
+    axis_code: int,
+) -> int:
+    if bucket == "gamepad":
+        output_id: str | None = None
+    elif bucket.startswith("gamepad:"):
+        output_id = bucket.removeprefix("gamepad:")
+    else:
+        return 0
+    resolver = getattr(device_runtime, "resolve_gamepad_output", None)
+    if not callable(resolver):
+        return 0
+    target = resolver(
+        output_id,
+        f"resolve rest value for axis {axis_code}",
+    )
+    return target_axis_release_value(target, axis_code)
+
+
+def target_axis_release_value(target: object | None, axis_code: int) -> int:
+    raw_values = getattr(target, "axis_rest_values", None)
+    if not isinstance(raw_values, dict):
+        return 0
+    values = cast(dict[int, int], raw_values)
+    value = values.get(int(axis_code), 0)
+    return int(value)
 
 
 def track_refcounted_held_output(
@@ -188,6 +219,7 @@ def write_abs_axis(
     evdev_mod: EvdevModule,
     uinput_writer: UInputWriter,
     bucket: str | None = None,
+    release_value: int = 0,
     defer_syn_to_passthrough_frame: bool = True,
 ) -> None:
     writer = uinput_writer(uinput_dev)
@@ -202,7 +234,13 @@ def write_abs_axis(
         )
     else:
         writer.syn()
-    track_abs_state(device_runtime, int(axis_code), int(value), bucket=bucket)
+    track_abs_state(
+        device_runtime,
+        int(axis_code),
+        int(value),
+        bucket=bucket,
+        release_value=release_value,
+    )
 
 
 def write_key(
@@ -251,8 +289,13 @@ def track_superkey_abs_output(
     axis_code: int,
     value: int,
     *,
-    release_value: int = 0,
+    release_value: int | None = None,
 ) -> bool:
+    resolved_release_value = (
+        gamepad_axis_release_value(device_runtime, bucket, axis_code)
+        if release_value is None
+        else int(release_value)
+    )
     return track_refcounted_output_bucket(
         device_runtime.state.superkey_abs_refcounts,
         device_runtime.state.held_output_abs,
@@ -260,7 +303,7 @@ def track_superkey_abs_output(
         axis_code,
         value,
         pressed_value=None,
-        release_value=release_value,
+        release_value=resolved_release_value,
     )
 
 
@@ -328,6 +371,7 @@ def ensure_abs_axis_released(
             evdev_mod=evdev_mod,
             uinput_writer=uinput_writer,
             bucket=bucket,
+            release_value=release_value,
         )
     except OSError as exc:
         log.debug(
@@ -435,15 +479,22 @@ def release_all_keys(
     for state in device_runtime.state.rapidfire_outputs.values():
         if state.kind == "axis" and state.bucket:
             devices.setdefault(state.bucket, state.uinput)
+    axis_rest_values: dict[str, dict[int, int]] = {}
     for bucket in set(device_runtime.state.held_output_keys) | set(
         device_runtime.state.held_output_abs
     ):
-        if bucket.startswith("gamepad:") and bucket not in devices:
+        if bucket.startswith("gamepad:"):
             target = device_runtime.resolve_gamepad_output(
                 bucket.removeprefix("gamepad:"),
                 f"release tracked {bucket}",
             )
-            devices[bucket] = getattr(target, "uinput", None) if target is not None else None
+            devices.setdefault(
+                bucket,
+                getattr(target, "uinput", None) if target is not None else None,
+            )
+            raw_rest_values = getattr(target, "axis_rest_values", None)
+            if isinstance(raw_rest_values, dict):
+                axis_rest_values[bucket] = cast(dict[int, int], raw_rest_values)
     for bucket, uinput_dev in devices.items():
         writer = uinput_writer(uinput_dev)
         if writer is None:
@@ -491,7 +542,11 @@ def release_all_keys(
         try:
             axes = held_abs or {evdev_mod.ecodes.ABS_Z, evdev_mod.ecodes.ABS_RZ}
             for axis_code in sorted(axes):
-                writer.write(evdev_mod.ecodes.EV_ABS, int(axis_code), 0)
+                writer.write(
+                    evdev_mod.ecodes.EV_ABS,
+                    int(axis_code),
+                    int(axis_rest_values.get(bucket, {}).get(int(axis_code), 0)),
+                )
             writer.syn()
         except OSError as exc:
             log.debug(

--- a/keymasq/keymasqd/runtime/grabbed_device/repeat.py
+++ b/keymasq/keymasqd/runtime/grabbed_device/repeat.py
@@ -247,6 +247,7 @@ async def rapidfire_abs_axis(
                     evdev_mod=evdev_mod,
                     uinput_writer=uinput_writer,
                     bucket=bucket,
+                    release_value=release_value,
                 )
             pressed = True
             if not started_set:
@@ -274,6 +275,7 @@ async def rapidfire_abs_axis(
                         evdev_mod=evdev_mod,
                         uinput_writer=uinput_writer,
                         bucket=bucket,
+                        release_value=release_value,
                     )
                 pressed = False
             if not device_runtime.state.rapidfire_active.get(event_name, False):
@@ -321,6 +323,7 @@ async def tap_abs_axis(
             evdev_mod=evdev_mod,
             uinput_writer=uinput_writer,
             bucket=bucket,
+            release_value=release_value,
         )
         pressed = True
         _mark_started(started)
@@ -334,6 +337,7 @@ async def tap_abs_axis(
             evdev_mod=evdev_mod,
             uinput_writer=uinput_writer,
             bucket=bucket,
+            release_value=release_value,
         )
         pressed = False
     finally:

--- a/keymasq/keymasqd/runtime/outputs.py
+++ b/keymasq/keymasqd/runtime/outputs.py
@@ -9,10 +9,15 @@ from typing import Any, Final, Protocol, cast
 
 from evdev.uinput import UInputError
 
+from keymasq.common.virtual_device_templates import (
+    ResolvedVirtualDevice,
+    VirtualDeviceConfig,
+    resolve_virtual_devices,
+)
 from keymasq.common.virtual_devices import (
     DEFAULT_VIRTUAL_GAMEPADS,
     clamp_virtual_gamepad_count,
-    virtual_gamepad_output_id,
+    is_virtual_gamepad_output_id,
 )
 from keymasq.keymasqd.permission_hints import (
     is_uinput_permission_error,
@@ -34,6 +39,8 @@ class OutputRuntimeState:
     mouse_uinput: ClosableUInput | None = None
     virtual_gamepad_uinputs: dict[str, ClosableUInput] = field(default_factory=dict)
     virtual_gamepad_count: int = DEFAULT_VIRTUAL_GAMEPADS
+    virtual_device_config: VirtualDeviceConfig = field(default_factory=VirtualDeviceConfig)
+    virtual_device_specs: dict[str, ResolvedVirtualDevice] = field(default_factory=dict)
 
     @property
     def gamepad_uinput(self) -> ClosableUInput | None:
@@ -66,6 +73,8 @@ class _OutputState(Protocol):
     gamepad_uinput: ClosableUInput | None
     virtual_gamepad_uinputs: dict[str, ClosableUInput]
     virtual_gamepad_count: int
+    virtual_device_config: VirtualDeviceConfig
+    virtual_device_specs: dict[str, ResolvedVirtualDevice]
 
 
 class _OutputManager(Protocol):
@@ -240,9 +249,7 @@ def keyboard_caps(
 ) -> dict[int, Sequence[object]]:
     ecodes = evdev_mod.ecodes
     key_codes = sorted(
-        int(code)
-        for code in ecodes.KEY
-        if ecodes.KEY_RESERVED < int(code) < ecodes.KEY_MAX
+        int(code) for code in ecodes.KEY if ecodes.KEY_RESERVED < int(code) < ecodes.KEY_MAX
     )
     return {
         ecodes.EV_KEY: key_codes,
@@ -250,58 +257,49 @@ def keyboard_caps(
     }
 
 
-def gamepad_caps(evdev_mod: _EvdevModule) -> dict[int, Sequence[object]]:
+def virtual_device_caps(
+    device: ResolvedVirtualDevice,
+    evdev_mod: _EvdevModule,
+) -> dict[int, Sequence[object]]:
     return {
         evdev_mod.ecodes.EV_KEY: [
-            evdev_mod.ecodes.BTN_SOUTH,
-            evdev_mod.ecodes.BTN_EAST,
-            evdev_mod.ecodes.BTN_NORTH,
-            evdev_mod.ecodes.BTN_WEST,
-            evdev_mod.ecodes.BTN_TL,
-            evdev_mod.ecodes.BTN_TR,
-            evdev_mod.ecodes.BTN_TL2,
-            evdev_mod.ecodes.BTN_TR2,
-            evdev_mod.ecodes.BTN_SELECT,
-            evdev_mod.ecodes.BTN_START,
-            evdev_mod.ecodes.BTN_MODE,
-            evdev_mod.ecodes.BTN_THUMBL,
-            evdev_mod.ecodes.BTN_THUMBR,
-            evdev_mod.ecodes.BTN_DPAD_UP,
-            evdev_mod.ecodes.BTN_DPAD_DOWN,
-            evdev_mod.ecodes.BTN_DPAD_LEFT,
-            evdev_mod.ecodes.BTN_DPAD_RIGHT,
+            cast(int, getattr(evdev_mod.ecodes, button.evdev.upper()))
+            for button in device.template.buttons
         ],
         evdev_mod.ecodes.EV_ABS: [
-            (evdev_mod.ecodes.ABS_X, evdev_mod.AbsInfo(0, -32768, 32767, 16, 128, 0)),
-            (evdev_mod.ecodes.ABS_Y, evdev_mod.AbsInfo(0, -32768, 32767, 16, 128, 0)),
-            (evdev_mod.ecodes.ABS_RX, evdev_mod.AbsInfo(0, -32768, 32767, 16, 128, 0)),
-            (evdev_mod.ecodes.ABS_RY, evdev_mod.AbsInfo(0, -32768, 32767, 16, 128, 0)),
-            (evdev_mod.ecodes.ABS_Z, evdev_mod.AbsInfo(0, 0, 255, 0, 0, 0)),
-            (evdev_mod.ecodes.ABS_RZ, evdev_mod.AbsInfo(0, 0, 255, 0, 0, 0)),
-            (evdev_mod.ecodes.ABS_HAT0X, evdev_mod.AbsInfo(0, -1, 1, 0, 0, 0)),
-            (evdev_mod.ecodes.ABS_HAT0Y, evdev_mod.AbsInfo(0, -1, 1, 0, 0, 0)),
+            (
+                cast(int, getattr(evdev_mod.ecodes, axis.evdev.upper())),
+                evdev_mod.AbsInfo(
+                    axis.rest,
+                    axis.minimum,
+                    axis.maximum,
+                    axis.fuzz,
+                    axis.flat,
+                    axis.resolution,
+                ),
+            )
+            for axis in device.template.axes
         ],
         evdev_mod.ecodes.EV_SYN: [],
     }
 
 
-def _initialize_gamepad_axes(
+def gamepad_caps(evdev_mod: _EvdevModule) -> dict[int, Sequence[object]]:
+    """Return the built-in Xbox template capabilities for compatibility."""
+    device = resolve_virtual_devices(1, VirtualDeviceConfig())[0]
+    return virtual_device_caps(device, evdev_mod)
+
+
+def _initialize_virtual_device_axes(
     uinput_dev: WritableUInput | None,
+    device: ResolvedVirtualDevice,
     evdev_mod: _EvdevModule,
 ) -> None:
     if uinput_dev is None:
         return
-    for axis in (
-        evdev_mod.ecodes.ABS_X,
-        evdev_mod.ecodes.ABS_Y,
-        evdev_mod.ecodes.ABS_RX,
-        evdev_mod.ecodes.ABS_RY,
-        evdev_mod.ecodes.ABS_Z,
-        evdev_mod.ecodes.ABS_RZ,
-        evdev_mod.ecodes.ABS_HAT0X,
-        evdev_mod.ecodes.ABS_HAT0Y,
-    ):
-        uinput_dev.write(evdev_mod.ecodes.EV_ABS, axis, 0)
+    for axis in device.template.axes:
+        code = cast(int, getattr(evdev_mod.ecodes, axis.evdev.upper()))
+        uinput_dev.write(evdev_mod.ecodes.EV_ABS, code, axis.rest)
     uinput_dev.syn()
 
 
@@ -343,29 +341,45 @@ def _create_synthetic_uinput(
     )
 
 
+def create_virtual_device(
+    device: ResolvedVirtualDevice,
+    evdev_mod: _EvdevModule,
+    uinput_writer: UInputWriter,
+) -> ClosableUInput:
+    test_name = device.output_id
+    if is_virtual_gamepad_output_id(device.output_id):
+        index = int(device.output_id.removeprefix("virtual-gamepad-"))
+        test_name = "gamepad" if index == 1 else f"gamepad-{index}"
+    gamepad_name, gamepad_vendor, gamepad_product = uinput_identity(
+        device.name,
+        "gamepad",
+        test_name=test_name,
+    )
+    uinput_dev = _create_synthetic_uinput(
+        f"virtual gaming device {device.output_id}",
+        evdev_mod,
+        events=virtual_device_caps(device, evdev_mod),
+        name=gamepad_name,
+        vendor=device.vendor_id if gamepad_vendor is None else gamepad_vendor,
+        product=device.product_id if gamepad_product is None else gamepad_product,
+        version=device.version,
+        bustype=device.bustype,
+    )
+    try:
+        _initialize_virtual_device_axes(uinput_writer(uinput_dev), device, evdev_mod)
+    except Exception:
+        uinput_dev.close()
+        raise
+    return uinput_dev
+
+
 def create_virtual_gamepad(
     index: int,
     evdev_mod: _EvdevModule,
     uinput_writer: UInputWriter,
 ) -> ClosableUInput:
-    normal_name = "keymasq-gamepad" if index == 1 else f"keymasq-gamepad-{index}"
-    gamepad_name, gamepad_vendor, gamepad_product = uinput_identity(
-        normal_name,
-        "gamepad",
-        test_name="gamepad" if index == 1 else f"gamepad-{index}",
-    )
-    uinput_dev = _create_synthetic_uinput(
-        "virtual gamepad",
-        evdev_mod,
-        events=gamepad_caps(evdev_mod),
-        name=gamepad_name,
-        vendor=0x045E if gamepad_vendor is None else gamepad_vendor,
-        product=0x028E if gamepad_product is None else gamepad_product,
-        version=0x0110,
-        bustype=0x0003,
-    )
-    _initialize_gamepad_axes(uinput_writer(uinput_dev), evdev_mod)
-    return uinput_dev
+    device = resolve_virtual_devices(index, VirtualDeviceConfig())[index - 1]
+    return create_virtual_device(device, evdev_mod, uinput_writer)
 
 
 def configure_virtual_gamepads(
@@ -375,15 +389,38 @@ def configure_virtual_gamepads(
     evdev_mod: _EvdevModule,
     log: logging.Logger,
     uinput_writer: UInputWriter,
+    config: VirtualDeviceConfig | None = None,
 ) -> int:
     count = clamp_virtual_gamepad_count(count)
     output_state = cast(Any, manager.output_state)
     if not hasattr(output_state, "virtual_gamepad_uinputs"):
         output_state.virtual_gamepad_uinputs = {}
+    if not hasattr(output_state, "virtual_device_config"):
+        output_state.virtual_device_config = VirtualDeviceConfig()
+    if not hasattr(output_state, "virtual_device_specs"):
+        output_state.virtual_device_specs = {}
+    if config is None:
+        config = cast(VirtualDeviceConfig, output_state.virtual_device_config)
     current = cast(dict[str, ClosableUInput], output_state.virtual_gamepad_uinputs)
-    desired_ids = {virtual_gamepad_output_id(index) for index in range(1, count + 1)}
+    current_specs = cast(dict[str, ResolvedVirtualDevice], output_state.virtual_device_specs)
+    desired = {device.output_id: device for device in resolve_virtual_devices(count, config)}
+    desired_ids = set(desired)
 
-    for output_id in sorted(set(current) - desired_ids):
+    prepared: dict[str, ClosableUInput] = {}
+    try:
+        for output_id, device in desired.items():
+            if output_id in current and current_specs.get(output_id) == device:
+                continue
+            prepared[output_id] = create_virtual_device(device, evdev_mod, uinput_writer)
+    except Exception:
+        for output_id, uinput_dev in prepared.items():
+            try:
+                uinput_dev.close()
+            except Exception:
+                log.exception("Failed to close prepared virtual gamepad %s", output_id)
+        raise
+
+    for output_id in sorted((set(current) - desired_ids) | (set(current) & set(prepared))):
         uinput_dev = current.pop(output_id)
         try:
             uinput_dev.close()
@@ -391,19 +428,16 @@ def configure_virtual_gamepads(
             log.warning("Failed to close virtual gamepad %s: %s", output_id, exc)
         except Exception:
             log.exception("Unexpected failure closing virtual gamepad %s", output_id)
+        current_specs.pop(output_id, None)
 
-    for index in range(1, count + 1):
-        output_id = virtual_gamepad_output_id(index)
-        if output_id in current:
-            continue
-        current[output_id] = create_virtual_gamepad(
-            index,
-            evdev_mod,
-            uinput_writer,
-        )
-        log.info("Created virtual gamepad %s", output_id)
+    for output_id, uinput_dev in prepared.items():
+        device = desired[output_id]
+        current[output_id] = uinput_dev
+        log.info("Created virtual gaming device %s from %s", output_id, device.template.id)
 
     output_state.virtual_gamepad_count = count
+    output_state.virtual_device_config = config
+    output_state.virtual_device_specs = desired
     return count
 
 
@@ -499,6 +533,9 @@ def _close_global_uinputs(manager: _OutputManager, *, log: logging.Logger) -> No
     manager.output_state.keyboard_uinput = None
     manager.output_state.mouse_uinput = None
     virtual_gamepad_uinputs.clear()
+    virtual_device_specs = getattr(manager.output_state, "virtual_device_specs", None)
+    if isinstance(virtual_device_specs, dict):
+        virtual_device_specs.clear()
 
 
 def create_global_uinputs(

--- a/keymasq/keymasqd/runtime/virtual_gamepads.py
+++ b/keymasq/keymasqd/runtime/virtual_gamepads.py
@@ -7,9 +7,16 @@ from collections.abc import Awaitable, Callable, Mapping, Sequence
 from dataclasses import dataclass, field
 from typing import cast
 
+import evdev
+
 from keymasq.common.model.core import DeviceType
 from keymasq.common.output_axes import STANDARD_OUTPUT_AXES, OutputAxis, learned_output_axes
 from keymasq.common.types import JsonObject
+from keymasq.common.virtual_device_templates import (
+    ResolvedVirtualDevice,
+    template_analog_inputs,
+    template_output_axes,
+)
 from keymasq.common.virtual_devices import is_virtual_gamepad_output_id
 from keymasq.keymasqd.runtime.stick_output import StickOutputState
 
@@ -23,6 +30,8 @@ class GamepadOutputTarget:
     analog_inputs: dict[str, object] = field(default_factory=dict)
     stick_output: StickOutputState = field(default_factory=StickOutputState)
     output_axes: tuple[OutputAxis, ...] | None = None
+    axis_rest_values: dict[int, int] = field(default_factory=dict)
+    axis_ranges: dict[int, tuple[int, int]] = field(default_factory=dict)
 
 
 type ClearComboRuntime = Callable[[], Awaitable[None]]
@@ -85,9 +94,10 @@ async def reconfigure_virtual_gamepads(
     configure_outputs: ConfigureVirtualGamepads,
     set_inactive_count: Callable[[int], None],
     logger: logging.Logger,
+    configuration_changed: bool = False,
 ) -> JsonObject:
     """Reset dependent output state before replacing virtual gamepads."""
-    if count == current_count:
+    if count == current_count and not configuration_changed:
         return {"status": "ok", "count": count}
 
     cancelled_tasks: list[asyncio.Task[None]] = []
@@ -147,9 +157,15 @@ class GamepadOutputRouter:
         explicit = output_id is not None
         resolved_id = str(output_id or "virtual-gamepad-1").strip() or "virtual-gamepad-1"
 
-        if is_virtual_gamepad_output_id(resolved_id):
-            raw_outputs = getattr(output_state, "virtual_gamepad_uinputs", {})
-            outputs = cast(dict[str, object], raw_outputs) if isinstance(raw_outputs, dict) else {}
+        raw_outputs = getattr(output_state, "virtual_gamepad_uinputs", {})
+        outputs = cast(dict[str, object], raw_outputs) if isinstance(raw_outputs, dict) else {}
+        raw_specs = getattr(output_state, "virtual_device_specs", {})
+        specs = cast(dict[str, object], raw_specs) if isinstance(raw_specs, dict) else {}
+        if (
+            resolved_id in outputs
+            or resolved_id in specs
+            or is_virtual_gamepad_output_id(resolved_id)
+        ):
             uinput = outputs.get(resolved_id)
             if uinput is None:
                 self._virtual_stick_outputs.pop(resolved_id, None)
@@ -159,13 +175,40 @@ class GamepadOutputRouter:
             if previous is None or previous[0] is not uinput:
                 previous = (uinput, StickOutputState())
                 self._virtual_stick_outputs[resolved_id] = previous
+            spec = specs.get(resolved_id)
+            axis_rest_values = (
+                {
+                    int(getattr(evdev.ecodes, axis.evdev.upper())): axis.rest
+                    for axis in spec.template.axes
+                }
+                if isinstance(spec, ResolvedVirtualDevice)
+                else {}
+            )
             return GamepadOutputTarget(
                 output_id=resolved_id,
                 uinput=uinput,
                 bucket=f"gamepad:{resolved_id}",
                 is_virtual=True,
                 stick_output=previous[1],
-                output_axes=STANDARD_OUTPUT_AXES,
+                output_axes=(
+                    template_output_axes(spec.template)
+                    if isinstance(spec, ResolvedVirtualDevice)
+                    else STANDARD_OUTPUT_AXES
+                ),
+                analog_inputs=(
+                    template_analog_inputs(spec.template)
+                    if isinstance(spec, ResolvedVirtualDevice)
+                    else {}
+                ),
+                axis_rest_values=axis_rest_values,
+                axis_ranges=(
+                    {
+                        int(getattr(evdev.ecodes, axis.evdev.upper())): (axis.minimum, axis.maximum)
+                        for axis in spec.template.axes
+                    }
+                    if isinstance(spec, ResolvedVirtualDevice)
+                    else {}
+                ),
             )
 
         devices = grabbed_devices.get(resolved_id)

--- a/keymasq/keymasqd/superkey_state.py
+++ b/keymasq/keymasqd/superkey_state.py
@@ -100,7 +100,9 @@ class SuperkeyActionData:
         ) or None
         if self.action_type == ActionType.GAMEPAD_AXIS.value:
             self.target = normalize_gamepad_axis_target(self.target)
-            self.axis_value = clamp_gamepad_axis_value(self.target, self.axis_value)
+            self.axis_value = clamp_gamepad_axis_value(
+                self.target, self.axis_value, output_id=self.output_id
+            )
         self.rapidfire_hold_ms = clamp_rapidfire_hold_ms(self.rapidfire_hold_ms)
         self.rapidfire_wait_ms = clamp_rapidfire_wait_ms(self.rapidfire_wait_ms)
         self.profile_deactivation = normalize_profile_deactivation_policy(

--- a/keymasq/session/manager/command/settings.py
+++ b/keymasq/session/manager/command/settings.py
@@ -5,12 +5,20 @@ from typing import TYPE_CHECKING, cast
 from keymasq.common.coercion import coerce_int
 from keymasq.common.ipc import Command, CommandType
 from keymasq.common.settings import GlobalSettings
+from keymasq.common.virtual_device_templates import (
+    BUILTIN_VIRTUAL_DEVICE_TEMPLATES,
+    VirtualDeviceConfigError,
+    config_from_json,
+    config_to_json,
+    template_to_data,
+)
 from keymasq.common.virtual_devices import (
     MAX_VIRTUAL_GAMEPADS,
     MIN_VIRTUAL_GAMEPADS,
     clamp_virtual_gamepad_count,
 )
 from keymasq.session.settings import save_global_settings, save_virtual_gamepad_count
+from keymasq.session.virtual_devices import save_virtual_device_config
 
 from ..common import JsonObject
 from .common import daemon_unavailable_response, send_daemon_request
@@ -20,13 +28,13 @@ if TYPE_CHECKING:
 
 log = logging.getLogger("keymasq-session")
 _PERSISTENCE_WARNING = (
-    "Virtual gamepad count was applied for this session but could not be saved. "
+    "Virtual device settings were applied for this session but could not be saved. "
     "It may revert after Keymasq restarts."
 )
 
 
 def _warn_persistence_failed(manager: "SessionManager") -> str:
-    log.exception("Failed to persist virtual gamepad count; keeping the runtime value")
+    log.exception("Failed to persist virtual device settings; keeping the runtime value")
     manager.send_notification("Keymasq Settings Warning", _PERSISTENCE_WARNING)
     return _PERSISTENCE_WARNING
 
@@ -36,6 +44,10 @@ async def handle_virtual_gamepad_commands(
     command: str,
     request: JsonObject,
 ) -> JsonObject | None:
+    if command == "get_virtual_devices":
+        return _virtual_devices_payload(manager)
+    if command == "set_virtual_devices":
+        return await _set_virtual_devices(manager, request)
     if command == "get_virtual_gamepads":
         return {
             "status": "ok",
@@ -51,7 +63,14 @@ async def handle_virtual_gamepad_commands(
     )
     if manager.connected:
         response = await send_daemon_request(
-            manager, Command(command=CommandType.SET_VIRTUAL_GAMEPADS, data={"count": count})
+            manager,
+            Command(
+                command=CommandType.SET_VIRTUAL_GAMEPADS,
+                data={
+                    "count": count,
+                    "virtual_devices": config_to_json(manager.virtual_device_config),
+                },
+            ),
         )
         if response is None:
             return daemon_unavailable_response()
@@ -103,7 +122,10 @@ async def handle_settings_commands(
             manager,
             Command(
                 command=CommandType.SET_VIRTUAL_GAMEPADS,
-                data={"count": count},
+                data={
+                    "count": count,
+                    "virtual_devices": config_to_json(manager.virtual_device_config),
+                },
             ),
         )
         if response is None:
@@ -152,3 +174,57 @@ def _settings_payload(manager: "SessionManager") -> JsonObject:
         "min_virtual_gamepad_count": MIN_VIRTUAL_GAMEPADS,
         "max_virtual_gamepad_count": MAX_VIRTUAL_GAMEPADS,
     }
+
+
+def _virtual_devices_payload(manager: "SessionManager") -> JsonObject:
+    return {
+        "status": "ok",
+        "config": config_to_json(manager.virtual_device_config),
+        "builtin_templates": [
+            template_to_data(template) for template in BUILTIN_VIRTUAL_DEVICE_TEMPLATES
+        ],
+    }
+
+
+async def _set_virtual_devices(
+    manager: "SessionManager",
+    request: JsonObject,
+) -> JsonObject:
+    try:
+        config = config_from_json(request.get("config", {}))
+    except VirtualDeviceConfigError as exc:
+        return {"status": "error", "message": str(exc)}
+
+    if manager.connected:
+        response = await send_daemon_request(
+            manager,
+            Command(
+                command=CommandType.SET_VIRTUAL_GAMEPADS,
+                data={
+                    "count": int(manager.virtual_gamepad_count),
+                    "virtual_devices": config_to_json(config),
+                },
+            ),
+        )
+        if response is None:
+            return daemon_unavailable_response()
+        if response.status != "ok":
+            return {
+                "status": "error",
+                "message": response.error or "daemon rejected virtual device configuration",
+            }
+
+    persistence_warning = ""
+    try:
+        config = await asyncio.to_thread(save_virtual_device_config, config)
+    except OSError:
+        persistence_warning = _warn_persistence_failed(manager)
+    manager.virtual_device_config = config
+    payload = _virtual_devices_payload(manager)
+    if persistence_warning:
+        payload["persisted"] = False
+        payload["warning"] = persistence_warning
+    manager.broadcast_to_session_clients(
+        {"event": "virtual_devices_changed", "config": config_to_json(config)}
+    )
+    return payload

--- a/keymasq/session/manager/core.py
+++ b/keymasq/session/manager/core.py
@@ -32,6 +32,7 @@ from keymasq.session.mpris import MprisController, MprisDBusError
 from keymasq.session.profile.manager import ProfileManager
 from keymasq.session.settings import load_global_settings
 from keymasq.session.superkeys import SuperkeyManager
+from keymasq.session.virtual_devices import load_virtual_device_config
 
 from . import compositor, events, recording_device_selection
 from .common import JsonObject
@@ -83,6 +84,7 @@ class SessionManager(SessionServerMixin, ConfigWatcherMixin, DaemonConnectionMix
         self.hardware = HardwareManager()
         settings = load_global_settings()
         self.virtual_gamepad_count = settings.virtual_gamepad_count
+        self.virtual_device_config = load_virtual_device_config()
         self.action_handler: ActionHandler | None = None
         self.running = False
         self._shutdown_event = asyncio.Event()

--- a/keymasq/session/manager/service/connection.py
+++ b/keymasq/session/manager/service/connection.py
@@ -4,6 +4,7 @@ from typing import Any, cast
 
 from keymasq.common.ipc import Command, CommandType
 from keymasq.common.paths import SOCKET_PATH
+from keymasq.common.virtual_device_templates import config_to_json
 
 from .. import events, recording_device_selection, recording_lifecycle
 from ..common import JsonObject
@@ -20,7 +21,10 @@ class DaemonConnectionMixin:
             response = await self.client.send_command(
                 Command(
                     command=CommandType.SET_VIRTUAL_GAMEPADS,
-                    data={"count": int(self.virtual_gamepad_count)},
+                    data={
+                        "count": int(self.virtual_gamepad_count),
+                        "virtual_devices": config_to_json(self.virtual_device_config),
+                    },
                 )
             )
             if response.status == "ok" and isinstance(response.data, dict):

--- a/keymasq/session/manager/service/watcher.py
+++ b/keymasq/session/manager/service/watcher.py
@@ -15,8 +15,10 @@ from keymasq.common.paths import (
     PROFILES_DIR,
     SETTINGS_PATH,
     SUPERKEYS_DIR,
+    VIRTUAL_DEVICES_PATH,
 )
 from keymasq.session.settings import load_global_settings
+from keymasq.session.virtual_devices import load_virtual_device_config
 
 log = logging.getLogger("keymasq-session")
 CONFIG_RELOAD_DEBOUNCE_S = 0.5
@@ -56,6 +58,7 @@ class ConfigWatcherMixin:
             profiles_snapshot = self.profiles.snapshot_profiles_for_reload()
             hardware_snapshot = self.hardware.snapshot_hardware()
             old_virtual_gamepad_count = self.virtual_gamepad_count
+            old_virtual_device_config = self.virtual_device_config
 
             try:
                 self.superkeys.reload()
@@ -65,6 +68,7 @@ class ConfigWatcherMixin:
                 self.hardware.reload()
                 settings = load_global_settings(strict=True)
                 self.virtual_gamepad_count = settings.virtual_gamepad_count
+                self.virtual_device_config = load_virtual_device_config(strict=True)
             except Exception:
                 self.superkeys.restore_superkeys(superkeys_snapshot)
                 self.analog_controls.restore_analog_controls(analog_controls_snapshot)
@@ -72,6 +76,7 @@ class ConfigWatcherMixin:
                 self.profiles.restore_profiles(profiles_snapshot)
                 self.hardware.restore_hardware(hardware_snapshot)
                 self.virtual_gamepad_count = old_virtual_gamepad_count
+                self.virtual_device_config = old_virtual_device_config
                 raise
 
     def _start_config_watcher(self: Any) -> None:
@@ -167,7 +172,7 @@ class ConfigWatcherMixin:
         self: Any, watched_path: Path, name: str, mask: int
     ) -> bool:
         if watched_path == CONFIG_DIR:
-            if name == SETTINGS_PATH.name:
+            if name in {SETTINGS_PATH.name, VIRTUAL_DEVICES_PATH.name}:
                 return True
             return bool(mask & IN_ISDIR) and name in {
                 PROFILES_DIR.name,

--- a/keymasq/session/virtual_devices.py
+++ b/keymasq/session/virtual_devices.py
@@ -1,0 +1,34 @@
+import logging
+import tomllib
+from typing import cast
+
+from keymasq.common import paths
+from keymasq.common.config_files import write_toml_atomically
+from keymasq.common.virtual_device_templates import (
+    VirtualDeviceConfig,
+    virtual_device_config_from_toml,
+    virtual_device_config_to_toml,
+)
+
+log = logging.getLogger("keymasq-session.virtual-devices")
+
+
+def load_virtual_device_config(*, strict: bool = False) -> VirtualDeviceConfig:
+    path = paths.VIRTUAL_DEVICES_PATH
+    if not path.exists():
+        return VirtualDeviceConfig()
+    try:
+        with path.open("rb") as config_file:
+            data = cast(dict[str, object], tomllib.load(config_file))
+        return virtual_device_config_from_toml(data)
+    except Exception as exc:
+        if strict:
+            raise
+        log.warning("Failed to load virtual devices from %s: %s; using none", path, exc)
+        return VirtualDeviceConfig()
+
+
+def save_virtual_device_config(config: VirtualDeviceConfig) -> VirtualDeviceConfig:
+    paths.ensure_config_dirs()
+    write_toml_atomically(paths.VIRTUAL_DEVICES_PATH, virtual_device_config_to_toml(config))
+    return config

--- a/tests/common/test_mapping_and_profile_state.py
+++ b/tests/common/test_mapping_and_profile_state.py
@@ -194,3 +194,23 @@ class TestProtectedButtons:
     def test_other_buttons_not_protected(self):
         assert is_protected_button("btn_back") is False
         assert is_protected_button("btn_forward") is False
+
+
+@pytest.mark.parametrize(("target", "value"), [("abs_x", 65535), ("abs_rz", -32768)])
+def test_named_output_axis_values_survive_action_conversions(target, value):
+    from keymasq.keymasqd.superkey_state import SuperkeyActionData
+
+    mapping = MappingAction(
+        action_type=ActionType.GAMEPAD_AXIS,
+        target=target,
+        axis_value=value,
+        output_id="custom-stick",
+    )
+    assert mapping.axis_value == value
+    superkey = mapping_action_to_superkey_action(mapping)
+    assert superkey.axis_value == value
+    assert superkey_action_to_mapping_action(superkey).axis_value == value
+    runtime = SuperkeyActionData(
+        action_type="gamepad_axis", target=target, axis_value=value, output_id="custom-stick"
+    )
+    assert runtime.axis_value == value

--- a/tests/common/test_virtual_device_templates.py
+++ b/tests/common/test_virtual_device_templates.py
@@ -210,3 +210,13 @@ def test_button_aliases_cannot_define_duplicate_controls():
     buttons.append({"id": "alias", "label": "Alias", "evdev": "btn_joystick"})
     with pytest.raises(VirtualDeviceConfigError, match="evdev codes must be unique"):
         virtual_device_config_from_toml(data)
+
+
+@pytest.mark.parametrize("sentinel", ["abs_max", "abs_cnt"])
+def test_axis_sentinels_are_not_template_controls(sentinel):
+    data = _custom_config_data()
+    templates = cast(list[dict[str, object]], data["templates"])
+    axes = cast(list[dict[str, object]], templates[0]["axes"])
+    axes[0]["evdev"] = sentinel
+    with pytest.raises(VirtualDeviceConfigError, match="axis sentinel"):
+        virtual_device_config_from_toml(data)

--- a/tests/common/test_virtual_device_templates.py
+++ b/tests/common/test_virtual_device_templates.py
@@ -1,0 +1,212 @@
+from typing import cast
+
+import pytest
+
+from keymasq.common.virtual_device_templates import (
+    BUILTIN_VIRTUAL_DEVICE_TEMPLATES,
+    LOGITECH_EXTREME_3D_TEMPLATE,
+    XBOX_360_TEMPLATE,
+    VirtualDeviceConfigError,
+    config_from_json,
+    config_to_json,
+    resolve_virtual_devices,
+    template_analog_inputs,
+    virtual_device_config_from_toml,
+)
+
+
+def _custom_config_data() -> dict[str, object]:
+    return {
+        "templates": [
+            {
+                "id": "space-panel",
+                "label": "Space Panel",
+                "name": "Keymasq Space Panel",
+                "vendor_id": "4b4d",
+                "product_id": "2001",
+                "version": "0100",
+                "bustype": "usb",
+                "buttons": [
+                    {"id": "fire", "label": "Fire", "evdev": "btn_trigger"},
+                    {"id": "mode", "label": "Mode", "evdev": "btn_thumb"},
+                ],
+                "axes": [
+                    {
+                        "id": "x",
+                        "label": "X",
+                        "evdev": "abs_x",
+                        "minimum": -32768,
+                        "maximum": 32767,
+                        "rest": 0,
+                    },
+                    {
+                        "id": "y",
+                        "label": "Y",
+                        "evdev": "abs_y",
+                        "minimum": -32768,
+                        "maximum": 32767,
+                        "rest": 0,
+                    },
+                ],
+            }
+        ],
+        "devices": [
+            {
+                "output_id": "space-rig",
+                "template": "space-panel",
+                "name": "My Space Rig",
+                "product_id": "2002",
+            }
+        ],
+    }
+
+
+def test_builtin_templates_use_the_generic_model() -> None:
+    assert BUILTIN_VIRTUAL_DEVICE_TEMPLATES == (
+        XBOX_360_TEMPLATE,
+        LOGITECH_EXTREME_3D_TEMPLATE,
+    )
+    assert XBOX_360_TEMPLATE.vendor_id == 0x045E
+    assert XBOX_360_TEMPLATE.product_id == 0x028E
+    assert len(XBOX_360_TEMPLATE.buttons) == 17
+    assert len(XBOX_360_TEMPLATE.axes) == 8
+    assert LOGITECH_EXTREME_3D_TEMPLATE.vendor_id == 0x046D
+    assert LOGITECH_EXTREME_3D_TEMPLATE.product_id == 0xC215
+    assert {button.evdev for button in LOGITECH_EXTREME_3D_TEMPLATE.buttons} >= {
+        "btn_trigger",
+        "btn_base6",
+    }
+    assert {axis.evdev for axis in LOGITECH_EXTREME_3D_TEMPLATE.axes} >= {
+        "abs_x",
+        "abs_y",
+        "abs_rz",
+        "abs_throttle",
+    }
+
+
+def test_user_templates_round_trip_and_resolve_with_builtin_instances() -> None:
+    config = virtual_device_config_from_toml(_custom_config_data())
+
+    assert config_from_json(config_to_json(config)) == config
+    devices = resolve_virtual_devices(2, config)
+    assert [device.output_id for device in devices] == [
+        "virtual-gamepad-1",
+        "virtual-gamepad-2",
+        "space-rig",
+    ]
+    assert devices[0].template is XBOX_360_TEMPLATE
+    assert devices[2].template.id == "space-panel"
+    assert devices[2].name == "My Space Rig"
+    assert devices[2].product_id == 0x2002
+
+
+def test_joystick_template_exposes_named_analog_targets() -> None:
+    analogs = template_analog_inputs(LOGITECH_EXTREME_3D_TEMPLATE)
+
+    stick = cast(dict[str, object], analogs["stick-x__stick-y"])
+    assert stick["type"] == "stick"
+    assert stick["label"] == "Stick X / Stick Y"
+    throttle = cast(dict[str, object], analogs["throttle"])
+    assert throttle["type"] == "axis"
+    axes = cast(list[dict[str, object]], throttle["axes"])
+    assert axes == [
+        {
+            "role": "x",
+            "evdev": "abs_throttle",
+            "minimum": 0,
+            "maximum": 255,
+            "center": 255,
+            "rest": 255,
+        }
+    ]
+
+
+@pytest.mark.parametrize(
+    ("mutate", "message"),
+    [
+        (
+            lambda data: data["templates"][0].update(id="xbox-360"),
+            "reserved",
+        ),
+        (
+            lambda data: data["templates"][0]["axes"].pop(),
+            "2..8 axes",
+        ),
+        (
+            lambda data: data["templates"][0]["buttons"].append(
+                {"id": "again", "label": "Again", "evdev": "btn_trigger"}
+            ),
+            "evdev codes must be unique",
+        ),
+        (
+            lambda data: data["devices"][0].update(template="missing"),
+            "unknown device template",
+        ),
+    ],
+)
+def test_invalid_template_configs_are_rejected(mutate, message: str) -> None:
+    data = _custom_config_data()
+    mutate(data)
+
+    with pytest.raises(VirtualDeviceConfigError, match=message):
+        virtual_device_config_from_toml(data)
+
+
+def test_templates_must_advertise_sdl_joystick_capabilities() -> None:
+    data = _custom_config_data()
+    templates = cast(list[dict[str, object]], data["templates"])
+    templates[0]["buttons"] = [{"id": "extra", "label": "Extra", "evdev": "btn_trigger_happy1"}]
+
+    with pytest.raises(VirtualDeviceConfigError, match="SDL-compatible"):
+        virtual_device_config_from_toml(data)
+
+
+def test_layout_survives_custom_template_round_trip():
+    from dataclasses import replace
+
+    from keymasq.common.virtual_device_templates import VirtualDeviceConfig
+
+    template = replace(LOGITECH_EXTREME_3D_TEMPLATE, id="custom-flight", builtin=False)
+    config = VirtualDeviceConfig(templates=(template,))
+    assert config_from_json(config_to_json(config)).templates[0].layout == "flight-stick"
+    data = config_to_json(config)
+    templates = cast(list[dict[str, object]], data["templates"])
+    templates[0]["layout"] = "unknown"
+    with pytest.raises(VirtualDeviceConfigError, match="layout"):
+        config_from_json(data)
+
+
+def test_numbered_batch_avoids_existing_codes_and_control_ids():
+    from keymasq.common.virtual_device_templates import VirtualButton, numbered_button_batch
+
+    existing = (VirtualButton("extra-button-2", "Existing", "btn_trigger_happy1"),)
+    added = numbered_button_batch(existing, 3, reserved_ids={"extra-button-3"})
+    assert [button.evdev for button in added] == [
+        "btn_trigger_happy2",
+        "btn_trigger_happy3",
+        "btn_trigger_happy4",
+    ]
+    assert len({button.id for button in (*existing, *added)}) == 4
+    assert "extra-button-3" not in {button.id for button in added}
+    with pytest.raises(VirtualDeviceConfigError, match="at most"):
+        numbered_button_batch(XBOX_360_TEMPLATE.buttons, 24)
+
+
+@pytest.mark.parametrize("field", ["minimum", "maximum", "rest", "fuzz", "flat", "resolution"])
+@pytest.mark.parametrize("value", [-2147483649, 2147483648])
+def test_axis_metadata_rejects_values_outside_kernel_integer_range(field, value):
+    data = _custom_config_data()
+    templates = cast(list[dict[str, object]], data["templates"])
+    axes = cast(list[dict[str, object]], templates[0]["axes"])
+    axes[0][field] = value
+    with pytest.raises(VirtualDeviceConfigError, match="signed 32-bit"):
+        virtual_device_config_from_toml(data)
+
+
+def test_button_aliases_cannot_define_duplicate_controls():
+    data = _custom_config_data()
+    templates = cast(list[dict[str, object]], data["templates"])
+    buttons = cast(list[dict[str, object]], templates[0]["buttons"])
+    buttons.append({"id": "alias", "label": "Alias", "evdev": "btn_joystick"})
+    with pytest.raises(VirtualDeviceConfigError, match="evdev codes must be unique"):
+        virtual_device_config_from_toml(data)

--- a/tests/common/test_virtual_device_templates.py
+++ b/tests/common/test_virtual_device_templates.py
@@ -220,3 +220,42 @@ def test_axis_sentinels_are_not_template_controls(sentinel):
     axes[0]["evdev"] = sentinel
     with pytest.raises(VirtualDeviceConfigError, match="axis sentinel"):
         virtual_device_config_from_toml(data)
+
+
+def test_same_device_routing_sentinel_cannot_name_virtual_output():
+    data = _custom_config_data()
+    devices = cast(list[dict[str, object]], data["devices"])
+    devices[0]["output_id"] = "same-device"
+    with pytest.raises(VirtualDeviceConfigError, match="same-device.*reserved"):
+        virtual_device_config_from_toml(data)
+
+
+@pytest.mark.parametrize(
+    "controls",
+    [
+        [("x", "abs_x"), ("y", "abs_y"), ("x__y", "abs_rz")],
+        [("a__b", "abs_x"), ("c", "abs_y"), ("a", "abs_rx"), ("b__c", "abs_ry")],
+    ],
+)
+def test_derived_analog_id_collisions_are_rejected(controls):
+    data = _custom_config_data()
+    templates = cast(list[dict[str, object]], data["templates"])
+    templates[0]["axes"] = [
+        {
+            "id": control_id,
+            "label": control_id,
+            "evdev": code,
+            "minimum": -100,
+            "maximum": 100,
+            "rest": 0,
+        }
+        for control_id, code in controls
+    ]
+    with pytest.raises(VirtualDeviceConfigError, match="derived analog ID.*not unique"):
+        virtual_device_config_from_toml(data)
+
+
+def test_existing_generated_analog_ids_remain_stable():
+    data = _custom_config_data()
+    config = virtual_device_config_from_toml(data)
+    assert set(template_analog_inputs(config.templates[0])) == {"x__y"}

--- a/tests/gui/test_analog_control_dialog.py
+++ b/tests/gui/test_analog_control_dialog.py
@@ -1902,3 +1902,67 @@ def test_analog_control_dialog_groups_saved_controls_by_input_type() -> None:
         ("1D Axes / Triggers", ["Axis Control"]),
         ("Sticks", ["Stick Control"]),
     ]
+
+
+@pytest.mark.parametrize(
+    "axis, neutral", [("ABS_X", 511), ("ABS_RZ", 127), ("ABS_THROTTLE", 255), ("ABS_BRAKE", 100)]
+)
+def test_custom_template_axis_picker_uses_advertised_axes_and_neutrals(
+    temp_config_dir, axis, neutral
+):
+    from dataclasses import replace
+
+    from gi.repository import Gtk
+
+    from keymasq.common.virtual_device_templates import (
+        LOGITECH_EXTREME_3D_TEMPLATE,
+        VirtualAxis,
+        VirtualDeviceConfig,
+        VirtualDeviceInstance,
+    )
+    from keymasq.gui.widgets.analog_control.dialog import AnalogControlDialog
+    from keymasq.session.virtual_devices import save_virtual_device_config
+
+    template = replace(
+        LOGITECH_EXTREME_3D_TEMPLATE,
+        id="custom-flight",
+        builtin=False,
+        axes=(
+            *LOGITECH_EXTREME_3D_TEMPLATE.axes,
+            VirtualAxis("brake", "Brake", "abs_brake", 10, 900, 100),
+        ),
+    )
+    save_virtual_device_config(
+        VirtualDeviceConfig(
+            templates=(template,), devices=(VirtualDeviceInstance("flight-test", template.id),)
+        )
+    )
+    dialog = AnalogControlDialog(Gtk.Window())
+    dialog.editor.name_entry.set_text("Flight Axis")
+    _select_input_type(dialog, "axis")
+    _select_mode(dialog, "gamepad")
+    output_index = dialog.editor._output_ids.index("flight-test")
+    dialog.editor.gamepad.gamepad_output_dropdown.set_selected(output_index)
+    _select_output_axis(dialog, axis)
+    assert dialog.editor.gamepad.gamepad_output_rest_row.get_value() == neutral
+    dropdown = dialog.editor.gamepad.gamepad_output_target_box.get_first_child()
+    model = dropdown.get_model()
+    labels = [model.get_string(index) for index in range(model.get_n_items())]
+    assert "Stick X · ABS_X" in labels
+    assert "Brake · ABS_BRAKE" in labels
+    assert not any(label.endswith("· ABS_Z") or label.endswith("· ABS_RX") for label in labels)
+    assert not dialog.editor.gamepad.gamepad_output_warning_row.get_visible()
+    assert dialog._save_current()
+    reloaded = AnalogControlDialog(Gtk.Window())
+    draft = reloaded.editor.draft()
+    assert draft.gamepad.output_id == "flight-test"
+    assert draft.gamepad.target_axis == axis.lower()
+    assert draft.gamepad.output_rest is None
+    assert reloaded.editor.gamepad.gamepad_output_rest_row.get_value() == neutral
+
+    # Switching destinations preserves the selected axis and warns if unsupported.
+    reloaded.editor.gamepad.gamepad_output_dropdown.set_selected(1)
+    assert reloaded.editor.draft().gamepad.target_axis == axis.lower()
+    assert reloaded.editor.gamepad.gamepad_output_warning_row.get_visible() == (
+        axis in {"ABS_THROTTLE", "ABS_BRAKE"}
+    )

--- a/tests/gui/test_flight_stick_picker.py
+++ b/tests/gui/test_flight_stick_picker.py
@@ -1,0 +1,154 @@
+import pytest
+
+gi = pytest.importorskip("gi")
+gi.require_version("Gtk", "4.0")
+from gi.repository import Gtk  # noqa: E402
+
+from keymasq.common.virtual_device_templates import LOGITECH_EXTREME_3D_TEMPLATE  # noqa: E402
+from keymasq.gui.widgets.virtual_device_picker import VirtualDevicePicker  # noqa: E402
+
+
+def buttons(widget):
+    if isinstance(widget, Gtk.Button):
+        yield widget
+    child = widget.get_first_child()
+    while child:
+        yield from buttons(child)
+        child = child.get_next_sibling()
+
+
+@pytest.fixture
+def picker():
+    selected = []
+    widget = VirtualDevicePicker(
+        LOGITECH_EXTREME_3D_TEMPLATE,
+        lambda button, code: selected.append((code,)),
+        lambda button, code, value: selected.append((code, value)),
+    )
+    return widget, selected
+
+
+@pytest.mark.parametrize(
+    ("label", "expected"),
+    [
+        ("Trigger", ("btn_trigger",)),
+        ("12", ("btn_base6",)),
+        ("↶ Left", ("abs_rz", 0)),
+        ("Right ↷", ("abs_rz", 255)),
+        ("Idle", ("abs_throttle", 255)),
+        ("Half", ("abs_throttle", 128)),
+        ("Full", ("abs_throttle", 0)),
+    ],
+)
+def test_flight_stick_shortcuts_emit_expected_controls(picker, label, expected):
+    widget, selected = picker
+    next(button for button in buttons(widget) if button.get_label() == label).emit("clicked")
+    assert selected == [expected]
+
+
+def test_direction_pads_keep_stick_and_hat_axes_distinct(picker):
+    widget, selected = picker
+    for button in buttons(widget):
+        if button.get_label() in {"↑", "↓", "←", "→"}:
+            button.emit("clicked")
+    assert set(selected) == {
+        ("abs_x", 0),
+        ("abs_x", 1023),
+        ("abs_y", 0),
+        ("abs_y", 1023),
+        ("abs_hat0x", -1),
+        ("abs_hat0x", 1),
+        ("abs_hat0y", -1),
+        ("abs_hat0y", 1),
+    }
+
+
+@pytest.mark.parametrize(
+    ("axis", "percent", "value"),
+    [
+        ("abs_x", -100, 0),
+        ("abs_x", 0, 511),
+        ("abs_x", 100, 1023),
+        ("abs_rz", 0, 127),
+        ("abs_throttle", 0, 255),
+        ("abs_throttle", 100, 0),
+    ],
+)
+def test_axis_editor_maps_percentage_using_target_rest(picker, axis, percent, value):
+    widget, selected = picker
+    widget.axis_choice.set_selected(widget.axis_names.index(axis))
+    widget.percent_spin.set_value(percent)
+    next(button for button in buttons(widget) if button.get_label() == "Map axis").emit("clicked")
+    assert selected == [(axis, value)]
+
+
+def test_reopening_exact_axis_value_does_not_round_it_to_a_percentage():
+    selected = []
+    widget = VirtualDevicePicker(
+        LOGITECH_EXTREME_3D_TEMPLATE,
+        lambda *args: None,
+        lambda button, code, value: selected.append((code, value)),
+        current_target="abs_x",
+        current_value=673,
+    )
+    next(button for button in buttons(widget) if button.get_label() == "Map axis").emit("clicked")
+    assert selected == [("abs_x", 673)]
+
+
+@pytest.mark.parametrize("layout", ["flight-stick", "gamepad"])
+def test_custom_template_layout_maps_only_configured_buttons(picker, layout):
+    from dataclasses import replace
+
+    from keymasq.common.virtual_device_templates import VirtualButton
+
+    template = replace(
+        LOGITECH_EXTREME_3D_TEMPLATE,
+        id="panel",
+        builtin=False,
+        layout=layout,
+        buttons=(VirtualButton("gear", "Landing gear", "btn_trigger_happy1"),),
+        axes=tuple(
+            axis
+            for axis in LOGITECH_EXTREME_3D_TEMPLATE.axes
+            if axis.evdev in {"abs_x", "abs_y", "abs_rz"}
+        ),
+    )
+    selected = []
+    widget = VirtualDevicePicker(
+        template, lambda button, code: selected.append(code), lambda *args: None
+    )
+    all_buttons = list(buttons(widget))
+    assert not any(
+        button.get_label() in {"Trigger", "Thumb", "A", "Start"} for button in all_buttons
+    )
+    next(button for button in all_buttons if button.get_label() == "1 · Landing gear").emit(
+        "clicked"
+    )
+    assert selected == ["btn_trigger_happy1"]
+    widget.extra_search.set_text("landing")
+    assert widget._extra_matches(widget._extra_items[0][0])
+    widget.extra_search.set_text("missing")
+    widget._filter_extras()
+    assert not widget._extra_matches(widget._extra_items[0][0])
+    assert widget._no_results.get_visible()
+
+
+def test_custom_flight_shortcuts_use_edited_ranges():
+    from dataclasses import replace
+
+    template = replace(
+        LOGITECH_EXTREME_3D_TEMPLATE,
+        id="custom-flight",
+        builtin=False,
+        axes=tuple(
+            replace(axis, minimum=-1000, maximum=1000, rest=0) if axis.evdev == "abs_rz" else axis
+            for axis in LOGITECH_EXTREME_3D_TEMPLATE.axes
+        ),
+    )
+    selected = []
+    widget = VirtualDevicePicker(
+        template, lambda *args: None, lambda button, code, value: selected.append((code, value))
+    )
+    next(button for button in buttons(widget) if button.get_label() == "↶ Left").emit("clicked")
+    next(button for button in buttons(widget) if button.get_label() == "Right ↷").emit("clicked")
+    assert selected == [("abs_rz", -1000), ("abs_rz", 1000)]

--- a/tests/gui/test_gui_device_tab_misc.py
+++ b/tests/gui/test_gui_device_tab_misc.py
@@ -2114,6 +2114,62 @@ def test_key_selector_dialog_gamepad_output_labels_hardware_by_name(monkeypatch)
     assert ("045e:028e@2", "Living Room Pad (045e:028e@2)") in dialog._gamepad_output_choices()
 
 
+def test_key_selector_dialog_uses_selected_virtual_device_template(monkeypatch):
+    from gi.repository import Gtk
+
+    from keymasq.common.model.actions import MappingAction
+    from keymasq.common.model.core import ActionType
+    from keymasq.common.virtual_device_templates import (
+        LOGITECH_EXTREME_3D_TEMPLATE_ID,
+        VirtualDeviceConfig,
+        VirtualDeviceInstance,
+    )
+    import keymasq.gui.widgets.key_selector.tabs as dialog_module
+    from keymasq.gui.widgets.key_selector.dialog import KeySelectorDialog
+
+    config = VirtualDeviceConfig(
+        devices=(
+            VirtualDeviceInstance(
+                output_id="flight-stick",
+                template_id=LOGITECH_EXTREME_3D_TEMPLATE_ID,
+            ),
+        )
+    )
+    monkeypatch.setattr(dialog_module, "virtual_gamepad_count", lambda: 1)
+    monkeypatch.setattr(dialog_module, "virtual_device_config", lambda: config)
+    monkeypatch.setattr(
+        dialog_module,
+        "HardwareManager",
+        lambda: SimpleNamespace(list_hardware=lambda: []),
+    )
+
+    dialog = KeySelectorDialog(
+        Gtk.Box(),
+        "Trigger",
+        MappingAction(
+            action_type=ActionType.GAMEPAD,
+            target="btn_trigger",
+            output_id="flight-stick",
+        ),
+    )
+
+    labels: set[str] = set()
+
+    def collect_labels(widget: Gtk.Widget) -> None:
+        if isinstance(widget, Gtk.Button) and widget.get_label():
+            labels.add(str(widget.get_label()))
+        child = widget.get_first_child()
+        while child is not None:
+            collect_labels(child)
+            child = child.get_next_sibling()
+
+    collect_labels(dialog._template_gamepad_picker)
+
+    assert dialog._standard_gamepad_picker.get_visible() is False
+    assert dialog._template_gamepad_picker.get_visible() is True
+    assert {"Trigger", "12", "Idle", "Half", "Full", "Map axis"} <= labels
+
+
 def test_key_selector_dialog_gamepad_default_warns_when_virtual_count_zero(monkeypatch):
     gi.require_version("Gtk", "4.0")
     from gi.repository import Gtk

--- a/tests/gui/test_gui_device_tab_misc.py
+++ b/tests/gui/test_gui_device_tab_misc.py
@@ -2115,6 +2115,7 @@ def test_key_selector_dialog_gamepad_output_labels_hardware_by_name(monkeypatch)
 
 
 def test_key_selector_dialog_uses_selected_virtual_device_template(monkeypatch):
+    gi.require_version("Gtk", "4.0")
     from gi.repository import Gtk
 
     from keymasq.common.model.actions import MappingAction

--- a/tests/gui/test_motion_control_dialog.py
+++ b/tests/gui/test_motion_control_dialog.py
@@ -25,6 +25,12 @@ from keymasq.common.model.motion import (
     MotionMouseConfig,
     MotionTiltConfig,
 )
+from keymasq.common.virtual_device_templates import (
+    LOGITECH_EXTREME_3D_TEMPLATE,
+    VirtualDeviceConfig,
+    VirtualDeviceInstance,
+    template_analog_inputs,
+)
 from keymasq.gui.widgets.gamepad_output_choices import GamepadOutputChoiceSet
 from keymasq.gui.widgets.key_selector.dialog import KeySelectorDialog
 from keymasq.gui.widgets.managed_editor.shell import ManagedEditorShell
@@ -324,6 +330,30 @@ def test_motion_controller_output_routes_to_a_learned_physical_stick() -> None:
     assert draft.gamepad.output_id == "1234:5678"
     assert draft.gamepad.target == "analog"
     assert draft.gamepad.target_analog_id == "right_stick"
+
+
+def test_motion_editor_routes_to_flight_stick_controls():
+    template = LOGITECH_EXTREME_3D_TEMPLATE
+    choices = GamepadOutputChoiceSet(
+        choices=[(None, "Virtual Gamepad 1"), ("flight-test", "Flight stick")],
+        count=1,
+        hardware_configs=[],
+        virtual_device_config=VirtualDeviceConfig(
+            devices=(VirtualDeviceInstance("flight-test", template.id),)
+        ),
+    )
+    view = MotionControlEditorView(
+        on_modified=lambda: None,
+        output_choices_loader=lambda _selected: choices,
+    )
+    view.load(MotionControlDraft.from_config(MotionControlConfig(name="Flight", mode="gamepad")))
+    view.gamepad_output.gamepad_output_dropdown.set_selected(2)
+    analog_id = next(iter(template_analog_inputs(template)))
+    assert list(view.output_target_buttons) == [f"analog:{analog_id}"]
+    draft = view.draft()
+    assert draft.gamepad.output_id == "flight-test"
+    assert draft.gamepad.target == "analog"
+    assert draft.gamepad.target_analog_id == analog_id
 
 
 def test_motion_selector_allows_multiple_controls(temp_config_dir) -> None:

--- a/tests/gui/test_settings_dialog.py
+++ b/tests/gui/test_settings_dialog.py
@@ -21,7 +21,7 @@ def test_settings_dialog_constructs(monkeypatch, temp_config_dir) -> None:
     assert isinstance(dialog, Adw.Dialog)
     assert dialog.get_child() is not None
     assert dialog.get_content_width() == 460
-    assert dialog.get_content_height() == 380
+    assert dialog.get_content_height() == 480
     assert dialog._macro_settings_btn.get_tooltip_text() == "Open macro recording settings"
 
 

--- a/tests/gui/test_virtual_devices_dialog.py
+++ b/tests/gui/test_virtual_devices_dialog.py
@@ -139,6 +139,144 @@ def test_apply_freezes_draft_and_restores_editor_on_failure(dialog_module, monke
     assert dialog._status.get_text() == "Could not create output"
 
 
+@pytest.mark.parametrize("outcome", ["unchanged", "applied", "unavailable", "invalid"])
+def test_unknown_apply_outcome_is_reconciled_without_local_save(
+    dialog_module, monkeypatch, temp_config_dir, outcome
+):
+    from keymasq.common.virtual_device_templates import (
+        LOGITECH_EXTREME_3D_TEMPLATE_ID,
+        VirtualDeviceConfig,
+        VirtualDeviceInstance,
+        config_to_json,
+    )
+    from keymasq.session.virtual_devices import save_virtual_device_config
+
+    old = VirtualDeviceConfig()
+    save_virtual_device_config(old)
+    config_path = temp_config_dir / "virtual_devices.toml"
+    previous_bytes = config_path.read_bytes()
+    requests = []
+    monkeypatch.setattr(
+        dialog_module,
+        "session_request_async",
+        lambda payload, callback, **kwargs: requests.append((payload, callback)),
+    )
+    dialog = dialog_module.VirtualDevicesDialog()
+    dialog._set_config(devices=[VirtualDeviceInstance("flight", LOGITECH_EXTREME_3D_TEMPLATE_ID)])
+    candidate = dialog._config
+    dialog._apply(None)
+    requests[-1][1](None)
+    assert requests[-1][0] == {"command": "get_virtual_devices"}
+    assert dialog._dirty
+    assert dialog._applying
+    assert config_path.read_bytes() == previous_bytes
+    confirmed = outcome == "applied"
+    response = {"status": "ok", "config": config_to_json(candidate if confirmed else old)}
+    if outcome == "invalid":
+        response["config"] = None
+    requests[-1][1](None if outcome == "unavailable" else response)
+    assert dialog._dirty is not confirmed
+    assert not dialog._applying
+    assert dialog._config == candidate
+    assert config_path.read_bytes() == previous_bytes
+    assert dialog._apply_button.get_sensitive() is not confirmed
+
+
+def test_apply_timeout_followed_by_rejection_preserves_disk(
+    dialog_module, monkeypatch, temp_config_dir, tmp_path
+):
+    import json
+    import socket
+    import threading
+
+    from keymasq.common.virtual_device_templates import (
+        LOGITECH_EXTREME_3D_TEMPLATE_ID,
+        VirtualDeviceConfig,
+        VirtualDeviceInstance,
+        config_to_json,
+    )
+    from keymasq.gui import session_client
+    from keymasq.session.virtual_devices import save_virtual_device_config
+
+    old = VirtualDeviceConfig()
+    save_virtual_device_config(old)
+    config_path = temp_config_dir / "virtual_devices.toml"
+    original = config_path.read_bytes()
+    dialog = dialog_module.VirtualDevicesDialog()
+    dialog._set_config(devices=[VirtualDeviceInstance("flight", LOGITECH_EXTREME_3D_TEMPLATE_ID)])
+    socket_path = tmp_path / "session.sock"
+    server = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    server.bind(str(socket_path))
+    server.listen(2)
+    server.settimeout(2)
+    timed_out = threading.Event()
+    requests = []
+    errors = []
+
+    def serve():
+        try:
+            connection, _ = server.accept()
+            with connection, connection.makefile("rb") as reader:
+                requests.append(json.loads(reader.readline()))
+                assert timed_out.wait(2)
+                try:
+                    connection.sendall(b'{"status":"error","message":"rejected"}\n')
+                except OSError:
+                    pass  # The client closes the first connection when its request times out.
+            connection, _ = server.accept()
+            with connection, connection.makefile("rb") as reader:
+                requests.append(json.loads(reader.readline()))
+                response = {"status": "ok", "config": config_to_json(old)}
+                connection.sendall((json.dumps(response) + "\n").encode())
+        except (OSError, ValueError, AssertionError) as exc:
+            errors.append(exc)
+
+    thread = threading.Thread(target=serve, daemon=True)
+    thread.start()
+    client = session_client._PersistentSessionConnection()
+    monkeypatch.setattr(session_client, "SESSION_SOCKET_PATH", socket_path)
+
+    def request(payload, callback, **kwargs):
+        timeout = 0.05 if payload["command"] == "set_virtual_devices" else 1.0
+        response = client.request(payload, timeout=timeout)
+        if payload["command"] == "set_virtual_devices":
+            assert response is None
+            timed_out.set()
+        callback(response)
+
+    monkeypatch.setattr(dialog_module, "session_request_async", request)
+    try:
+        dialog._apply(None)
+    finally:
+        timed_out.set()
+        client.shutdown()
+        thread.join(3)
+        server.close()
+    assert not thread.is_alive()
+    assert not errors
+    assert [item["command"] for item in requests] == ["set_virtual_devices", "get_virtual_devices"]
+    assert config_path.read_bytes() == original
+    assert dialog._dirty
+    assert dialog._apply_button.get_sensitive()
+    assert "Could not confirm" in dialog._status.get_text()
+
+
+def test_output_editor_rejects_same_device_id(dialog_module, monkeypatch):
+    editors = []
+    monkeypatch.setattr(
+        dialog_module.VirtualDeviceInstanceDialog,
+        "present",
+        lambda self, parent: editors.append(self),
+    )
+    dialog = dialog_module.VirtualDevicesDialog()
+    dialog._new_device(None)
+    editor = editors[-1]
+    editor._output_row.set_text("same-device")
+    editor._save(None)
+    assert not dialog._config.devices
+    assert "reserved" in editor._status.get_text()
+
+
 def test_custom_template_editor_preserves_layout_and_adds_batch(dialog_module):
     from keymasq.common.virtual_device_templates import LOGITECH_EXTREME_3D_TEMPLATE
 

--- a/tests/gui/test_virtual_devices_dialog.py
+++ b/tests/gui/test_virtual_devices_dialog.py
@@ -1,0 +1,147 @@
+import pytest
+
+gi = pytest.importorskip("gi")
+
+
+@pytest.fixture
+def dialog_module(monkeypatch, temp_config_dir):
+    from keymasq.gui.widgets import virtual_devices_dialog
+
+    monkeypatch.setattr(
+        virtual_devices_dialog, "session_request_async", lambda *args, **kwargs: None
+    )
+    return virtual_devices_dialog
+
+
+def test_template_form_edits_ranges_and_retains_invalid_draft(dialog_module) -> None:
+    from keymasq.common.virtual_device_templates import LOGITECH_EXTREME_3D_TEMPLATE
+
+    saved = []
+    dialog = dialog_module.VirtualTemplateEditorDialog(
+        dialog_module.unique_template_copy(LOGITECH_EXTREME_3D_TEMPLATE, ()),
+        lambda template: saved.append(template) or True,
+    )
+    axis = dialog._axis_rows[0]
+    axis.range_rows["maximum"].set_value(65535)
+    axis.range_rows["rest"].set_value(32767)
+    dialog._save(None)
+    assert saved[0].axes[0].maximum == 65535
+    assert saved[0].axes[0].rest == 32767
+    assert saved[0].buttons == LOGITECH_EXTREME_3D_TEMPLATE.buttons
+
+    axis.range_rows["rest"].set_value(70000)
+    dialog._save(None)
+    assert len(saved) == 1
+    assert "inside the axis range" in dialog._status.get_text()
+    assert axis.range_rows["rest"].get_value() == 70000
+
+
+def test_duplicate_twice_keeps_both_customizations(dialog_module, monkeypatch) -> None:
+    from keymasq.common.virtual_device_templates import XBOX_360_TEMPLATE
+
+    editors = []
+    monkeypatch.setattr(
+        dialog_module.VirtualTemplateEditorDialog,
+        "present",
+        lambda self, parent: editors.append(self),
+    )
+    dialog = dialog_module.VirtualDevicesDialog()
+    for label in ("First layout", "Second layout"):
+        dialog._duplicate_template(None, XBOX_360_TEMPLATE)
+        editor = editors[-1]
+        assert editor._id_row.get_editable()
+        editor._label_row.set_text(label)
+        editor._save(None)
+
+    assert [template.id for template in dialog._config.templates] == [
+        "xbox-360-copy",
+        "xbox-360-copy-2",
+    ]
+    assert [template.label for template in dialog._config.templates] == [
+        "First layout",
+        "Second layout",
+    ]
+
+
+def test_duplicate_id_error_stays_in_editor(dialog_module, monkeypatch) -> None:
+    from keymasq.common.virtual_device_templates import XBOX_360_TEMPLATE
+
+    editors = []
+    closed = []
+    monkeypatch.setattr(
+        dialog_module.VirtualTemplateEditorDialog,
+        "present",
+        lambda self, parent: editors.append(self),
+    )
+    monkeypatch.setattr(
+        dialog_module.VirtualTemplateEditorDialog, "close", lambda self: closed.append(self)
+    )
+    dialog = dialog_module.VirtualDevicesDialog()
+    dialog._duplicate_template(None, XBOX_360_TEMPLATE)
+    editors[-1]._save(None)
+    dialog._duplicate_template(None, XBOX_360_TEMPLATE)
+    editors[-1]._id_row.set_text("xbox-360-copy")
+    editors[-1]._save(None)
+    assert len(closed) == 1
+    assert len(dialog._config.templates) == 1
+    assert "already in use" in editors[-1]._status.get_text()
+
+
+def test_add_output_from_template_preselects_and_uses_unique_id(dialog_module, monkeypatch) -> None:
+    from keymasq.common.virtual_device_templates import LOGITECH_EXTREME_3D_TEMPLATE
+
+    editors = []
+    monkeypatch.setattr(
+        dialog_module.VirtualDeviceInstanceDialog,
+        "present",
+        lambda self, parent: editors.append(self),
+    )
+    dialog = dialog_module.VirtualDevicesDialog()
+    for _ in range(2):
+        dialog._use_template(None, LOGITECH_EXTREME_3D_TEMPLATE)
+        editors[-1]._save(None)
+    assert [device.template_id for device in dialog._config.devices] == [
+        LOGITECH_EXTREME_3D_TEMPLATE.id
+    ] * 2
+    assert len({device.output_id for device in dialog._config.devices}) == 2
+    assert dialog._dirty
+    assert dialog._apply_button.get_sensitive()
+    assert not dialog._empty_outputs.get_visible()
+
+
+def test_apply_freezes_draft_and_restores_editor_on_failure(dialog_module, monkeypatch) -> None:
+    requests = []
+    monkeypatch.setattr(
+        dialog_module,
+        "session_request_async",
+        lambda payload, callback, **kwargs: requests.append((payload, callback)),
+    )
+    dialog = dialog_module.VirtualDevicesDialog()
+    dialog._set_config(devices=[])
+    dialog._apply(None)
+    assert not dialog._content.get_sensitive()
+    assert not dialog._apply_button.get_sensitive()
+    requests[-1][1]({"status": "error", "message": "Could not create output"})
+    assert dialog._content.get_sensitive()
+    assert dialog._apply_button.get_sensitive()
+    assert dialog._dirty
+    assert dialog._status.get_text() == "Could not create output"
+
+
+def test_custom_template_editor_preserves_layout_and_adds_batch(dialog_module):
+    from keymasq.common.virtual_device_templates import LOGITECH_EXTREME_3D_TEMPLATE
+
+    template = dialog_module.unique_template_copy(LOGITECH_EXTREME_3D_TEMPLATE, ())
+    saved = []
+    dialog = dialog_module.VirtualTemplateEditorDialog(
+        template, lambda value: saved.append(value) or True, creating=True
+    )
+    assert dialog._layout_row.get_selected() == 1
+    dialog._append_numbered_buttons(20)
+    dialog._save(None)
+    assert saved[0].layout == "flight-stick"
+    assert len(saved[0].buttons) == 32
+    assert [button.evdev for button in saved[0].buttons[12:]] == [
+        f"btn_trigger_happy{i}" for i in range(1, 21)
+    ]
+    assert saved[0].buttons[:12] == LOGITECH_EXTREME_3D_TEMPLATE.buttons

--- a/tests/gui/test_virtual_devices_dialog.py
+++ b/tests/gui/test_virtual_devices_dialog.py
@@ -3,6 +3,17 @@ import pytest
 gi = pytest.importorskip("gi")
 
 
+def test_axis_choices_exclude_sentinels():
+    from keymasq.gui.widgets.virtual_template_controls import event_names
+
+    axes = event_names(axis=True)
+    assert "abs_x" in axes
+    assert "abs_throttle" in axes
+    assert "abs_max" not in axes
+    assert "abs_cnt" not in axes
+    assert "btn_trigger_happy1" in event_names(axis=False)
+
+
 @pytest.fixture
 def dialog_module(monkeypatch, temp_config_dir):
     from keymasq.gui.widgets import virtual_devices_dialog

--- a/tests/gui/test_virtual_devices_dialog.py
+++ b/tests/gui/test_virtual_devices_dialog.py
@@ -182,8 +182,18 @@ def test_unknown_apply_outcome_is_reconciled_without_local_save(
     assert dialog._apply_button.get_sensitive() is not confirmed
 
 
+@pytest.fixture
+def short_socket_path():
+    from pathlib import Path
+    from tempfile import TemporaryDirectory
+
+    # CI's pytest temporary paths can exceed the Unix socket address limit.
+    with TemporaryDirectory(prefix="km-", dir="/tmp") as directory:
+        yield Path(directory) / "session.sock"
+
+
 def test_apply_timeout_followed_by_rejection_preserves_disk(
-    dialog_module, monkeypatch, temp_config_dir, tmp_path
+    dialog_module, monkeypatch, temp_config_dir, short_socket_path
 ):
     import json
     import socket
@@ -204,7 +214,7 @@ def test_apply_timeout_followed_by_rejection_preserves_disk(
     original = config_path.read_bytes()
     dialog = dialog_module.VirtualDevicesDialog()
     dialog._set_config(devices=[VirtualDeviceInstance("flight", LOGITECH_EXTREME_3D_TEMPLATE_ID)])
-    socket_path = tmp_path / "session.sock"
+    socket_path = short_socket_path
     server = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
     server.bind(str(socket_path))
     server.listen(2)

--- a/tests/keymasqd/test_device_manager_runtime_recovery.py
+++ b/tests/keymasqd/test_device_manager_runtime_recovery.py
@@ -10,10 +10,11 @@ from evdev.uinput import UInputError
 
 from keymasq.common.model.actions import MappingAction
 from keymasq.common.model.core import ActionType, DeviceType, SuperkeyMode
+from keymasq.common.virtual_device_templates import virtual_device_config_from_toml
 from keymasq.keymasqd import device_manager
 from keymasq.keymasqd.device_manager import DeviceManager
 from keymasq.keymasqd.permission_hints import UINPUT_PERMISSION_HINT
-from keymasq.keymasqd.runtime import action_parser, adapters, outputs, topology
+from keymasq.keymasqd.runtime import action_parser, adapters, outputs, topology, virtual_gamepads
 from keymasq.keymasqd.runtime.combo import events, lifecycle
 from keymasq.keymasqd.runtime.grab import acquisition, planning, release
 from keymasq.keymasqd.runtime.grabbed_device import (
@@ -33,6 +34,69 @@ from tests.keymasqd.device_manager_support import (
     combo_runtime_deps,
     make_grabbed_device,
 )
+
+
+def test_configure_virtual_gamepads_instantiates_bundled_joystick_template(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv(outputs.TEST_UINPUT_ENV, raising=False)
+    created: list[FakeUInput] = []
+
+    def fake_uinput(**kwargs) -> FakeUInput:
+        device = FakeUInput(**kwargs)
+        created.append(device)
+        return device
+
+    manager = SimpleNamespace(output_state=outputs.OutputRuntimeState())
+    config = virtual_device_config_from_toml(
+        {
+            "devices": [
+                {
+                    "output_id": "flight-stick",
+                    "template": "logitech-extreme-3d-pro",
+                }
+            ]
+        }
+    )
+
+    outputs.configure_virtual_gamepads(
+        manager,
+        1,
+        evdev_mod=SimpleNamespace(
+            ecodes=evdev.ecodes,
+            UInput=fake_uinput,
+            AbsInfo=evdev.AbsInfo,
+        ),
+        log=logging.getLogger("test"),
+        uinput_writer=lambda device: device,
+        config=config,
+    )
+
+    assert list(manager.output_state.virtual_gamepad_uinputs) == [
+        "virtual-gamepad-1",
+        "flight-stick",
+    ]
+    joystick = created[1]
+    assert joystick.kwargs["name"] == "Logitech Logitech Extreme 3D"
+    assert joystick.kwargs["vendor"] == 0x046D
+    assert joystick.kwargs["product"] == 0xC215
+    assert evdev.ecodes.BTN_TRIGGER in joystick.kwargs["events"][evdev.ecodes.EV_KEY]
+    axis_codes = {
+        item[0]
+        for item in joystick.kwargs["events"][evdev.ecodes.EV_ABS]
+        if isinstance(item, tuple)
+    }
+    assert {evdev.ecodes.ABS_X, evdev.ecodes.ABS_Y, evdev.ecodes.ABS_THROTTLE} <= axis_codes
+
+    target = manager.output_state.virtual_gamepad_uinputs["flight-stick"]
+    resolved = virtual_gamepads.GamepadOutputRouter(logging.getLogger("test")).resolve(
+        manager.output_state,
+        {},
+        "flight-stick",
+    )
+    assert resolved is not None
+    assert resolved.uinput is target
+    assert resolved.bucket == "gamepad:flight-stick"
 
 
 class TestEventLoopRecovery:
@@ -435,8 +499,8 @@ class TestDeviceManagerHelpers:
                 return keyboard
             if context == "mouse":
                 return mouse
-            assert context == "virtual gamepad"
             gamepad_creations += 1
+            assert context == f"virtual gaming device virtual-gamepad-{gamepad_creations}"
             if gamepad_creations == 2:
                 raise RuntimeError("gamepad creation failed")
             return first_gamepad

--- a/tests/keymasqd/test_grabbed_device_runtime_helpers.py
+++ b/tests/keymasqd/test_grabbed_device_runtime_helpers.py
@@ -3022,6 +3022,132 @@ class TestGrabbedDeviceHelpers:
         ]
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize(("requested", "expected"), [(65535, 65535), (70000, 65535), (-10, 0)])
+    async def test_template_axis_action_uses_target_range(self, monkeypatch, requested, expected):
+        from keymasq.common.virtual_device_templates import (
+            XBOX_360_TEMPLATE,
+            config_from_json,
+            resolve_virtual_devices,
+            template_to_data,
+        )
+        from keymasq.keymasqd.runtime.virtual_gamepads import GamepadOutputRouter
+
+        template = template_to_data(XBOX_360_TEMPLATE)
+        template["id"] = "wide-stick"
+        template_axes = cast(list[dict[str, object]], template["axes"])
+        template_axes[0].update(minimum=0, maximum=65535, rest=32767)
+        config = config_from_json(
+            {
+                "templates": [template],
+                "devices": [{"output_id": "wide-output", "template": "wide-stick"}],
+            }
+        )
+        spec = resolve_virtual_devices(0, config)[0]
+        gamepad = FakeUInput()
+        state = SimpleNamespace(
+            virtual_gamepad_uinputs={"wide-output": gamepad},
+            virtual_device_specs={"wide-output": spec},
+        )
+        router = GamepadOutputRouter(logging.getLogger(__name__))
+        device = make_grabbed_device(monkeypatch, gamepad_uinput=gamepad)
+        device._gamepad_output_resolver = lambda output_id, context: router.resolve(
+            state, {}, output_id
+        )
+        action = MappingAction(
+            action_type=ActionType.GAMEPAD_AXIS,
+            target="abs_x",
+            axis_value=requested,
+            output_id="wide-output",
+        )
+        for value in (1, 0):
+            await actions.execute_action(
+                device,
+                action,
+                SimpleNamespace(value=value),
+                "axis_btn",
+                deps=pipeline.build_action_execution_deps(
+                    fire_and_observe_fn=pipeline.fire_and_observe
+                ),
+            )
+        assert gamepad.writes == [
+            (evdev.ecodes.EV_ABS, evdev.ecodes.ABS_X, expected),
+            (evdev.ecodes.EV_ABS, evdev.ecodes.ABS_X, 32767),
+        ]
+
+    @pytest.mark.asyncio
+    async def test_template_axis_action_uses_declared_rest_value(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        gamepad = FakeUInput()
+        device = make_grabbed_device(monkeypatch, gamepad_uinput=gamepad)
+        device._gamepad_output_resolver = lambda output_id, context: SimpleNamespace(  # type: ignore[method-assign, reportPrivateUsage]
+            output_id=output_id,
+            uinput=gamepad,
+            bucket="gamepad:flight-stick",
+            is_virtual=True,
+            axis_rest_values={evdev.ecodes.ABS_X: 511},
+        )
+        action = MappingAction(
+            action_type=ActionType.GAMEPAD_AXIS,
+            target="abs_x",
+            axis_value=1023,
+            output_id="flight-stick",
+        )
+
+        for value in (1, 0):
+            await actions.execute_action(
+                device,
+                action,
+                evdev.InputEvent(
+                    0,
+                    0,
+                    evdev.ecodes.EV_KEY,
+                    evdev.ecodes.BTN_SOUTH,
+                    value,
+                ),
+                "axis_btn",
+                deps=pipeline.build_action_execution_deps(
+                    fire_and_observe_fn=pipeline.fire_and_observe
+                ),
+            )
+
+        assert (evdev.ecodes.EV_ABS, evdev.ecodes.ABS_X, 1023) in gamepad.writes
+        assert gamepad.writes[-1] == (
+            evdev.ecodes.EV_ABS,
+            evdev.ecodes.ABS_X,
+            511,
+        )
+        assert device.state.held_output_abs["gamepad:flight-stick"] == set()
+
+        await actions.execute_action(
+            device,
+            action,
+            evdev.InputEvent(
+                0,
+                0,
+                evdev.ecodes.EV_KEY,
+                evdev.ecodes.BTN_SOUTH,
+                1,
+            ),
+            "axis_btn",
+            deps=pipeline.build_action_execution_deps(
+                fire_and_observe_fn=pipeline.fire_and_observe
+            ),
+        )
+        device_outputs.release_all_keys(
+            device,
+            evdev_mod=evdev,
+            uinput_writer=lambda output: cast(adapters.WritableUInput | None, output),
+        )
+
+        assert gamepad.writes[-1] == (
+            evdev.ecodes.EV_ABS,
+            evdev.ecodes.ABS_X,
+            511,
+        )
+
+    @pytest.mark.asyncio
     async def test_gamepad_axis_tap_uses_configured_value(
         self,
         monkeypatch: pytest.MonkeyPatch,

--- a/tests/keymasqd/test_virtual_device_analog_output.py
+++ b/tests/keymasqd/test_virtual_device_analog_output.py
@@ -1,3 +1,5 @@
+import logging
+from dataclasses import replace
 from types import SimpleNamespace
 from typing import Any
 from unittest.mock import Mock
@@ -8,31 +10,42 @@ import pytest
 from keymasq.common.model.analog import AnalogControlConfig, AnalogGamepadOutputConfig
 from keymasq.common.virtual_device_templates import (
     LOGITECH_EXTREME_3D_TEMPLATE,
-    template_analog_inputs,
+    VirtualAxis,
+    VirtualDeviceConfig,
+    VirtualDeviceInstance,
+    resolve_virtual_devices,
+    validate_template,
 )
 from keymasq.keymasqd.runtime.analog.gamepad import emit_gamepad_output, reset_gamepad_output
 from keymasq.keymasqd.runtime.analog.output_state import reset_recorded_gamepad_outputs
-from keymasq.keymasqd.runtime.virtual_gamepads import GamepadOutputTarget
+from keymasq.keymasqd.runtime.virtual_gamepads import GamepadOutputRouter
 
 
 @pytest.fixture
-def flight_output():
+def flight_output(request):
     template = LOGITECH_EXTREME_3D_TEMPLATE
+    if getattr(request, "param", "builtin") == "custom":
+        template = replace(
+            template,
+            id="custom-flight",
+            builtin=False,
+            axes=(*template.axes, VirtualAxis("brake", "Brake", "abs_brake", 10, 900, 100)),
+        )
+        validate_template(template)
     writer = Mock()
-    target = GamepadOutputTarget(
-        output_id="flight-test",
-        uinput=writer,
-        bucket="gamepad:flight-test",
-        is_virtual=True,
-        analog_inputs=template_analog_inputs(template),
-        axis_ranges={
-            getattr(evdev.ecodes, axis.evdev.upper()): (axis.minimum, axis.maximum)
-            for axis in template.axes
-        },
-        axis_rest_values={
-            getattr(evdev.ecodes, axis.evdev.upper()): axis.rest for axis in template.axes
+    router = GamepadOutputRouter(logging.getLogger(__name__))
+    config = VirtualDeviceConfig(
+        templates=() if template.builtin else (template,),
+        devices=(VirtualDeviceInstance("flight-test", template.id),),
+    )
+    outputs = SimpleNamespace(
+        virtual_gamepad_uinputs={"flight-test": writer},
+        virtual_device_specs={
+            device.output_id: device for device in resolve_virtual_devices(0, config)
         },
     )
+    target = router.resolve(outputs, {}, "flight-test")
+    assert target is not None
     runtime: Any = SimpleNamespace(
         hardware_id="source",
         analog_inputs={},
@@ -117,3 +130,86 @@ def test_missing_destination_axes_are_not_written(flight_output):
     emit_gamepad_output(runtime, "stick", "left_stick", config, deps=deps)
     reset_gamepad_output(runtime, "stick", "left_stick", config, deps=deps)
     writer.write.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "flight_output, axis, direction, value, expected, neutral",
+    [
+        ("builtin", "abs_x", "both", -1.0, 0, 511),
+        ("builtin", "abs_x", "both", 1.0, 1023, 511),
+        ("builtin", "abs_y", "both", 0.0, 511, 511),
+        ("builtin", "abs_rz", "both", -1.0, 0, 127),
+        ("builtin", "abs_throttle", "min", 1.0, 0, 255),
+        ("custom", "abs_brake", "max", 1.0, 900, 100),
+        ("custom", "abs_brake", "min", 1.0, 10, 100),
+    ],
+    indirect=["flight_output"],
+)
+@pytest.mark.parametrize("recorded_reset", [False, True])
+def test_individual_template_axis_emits_and_resets_only_selected_axis(
+    flight_output, axis, direction, value, expected, neutral, recorded_reset
+):
+    runtime, deps, writer = flight_output
+    config = AnalogControlConfig(
+        name="Single template axis",
+        input_type="axis",
+        gamepad_output=AnalogGamepadOutputConfig(
+            enabled=True,
+            output_id="flight-test",
+            target="axis",
+            target_axis=axis,
+            output_direction=direction,
+        ),
+    )
+    runtime.state.analog_axis_values["axis"] = {"x": value, "x_signed": value}
+    emit_gamepad_output(runtime, "axis", "left_trigger", config, deps=deps)
+    if recorded_reset:
+        reset_recorded_gamepad_outputs(runtime, deps=deps)
+    else:
+        reset_gamepad_output(runtime, "axis", "left_trigger", config, deps=deps)
+    code = getattr(evdev.ecodes, axis.upper())
+    assert [call.args for call in writer.write.call_args_list] == [
+        (evdev.ecodes.EV_ABS, code, expected),
+        (evdev.ecodes.EV_ABS, code, neutral),
+    ]
+
+
+@pytest.mark.parametrize("target", ["axis", "same", "left"])
+def test_flight_output_rejects_unadvertised_trigger_axis(flight_output, target):
+    runtime, deps, writer = flight_output
+    config = AnalogControlConfig(
+        name="Unsupported trigger",
+        input_type="axis",
+        gamepad_output=AnalogGamepadOutputConfig(
+            enabled=True,
+            output_id="flight-test",
+            target=target,
+            target_axis="abs_z" if target == "axis" else None,
+        ),
+    )
+    runtime.state.analog_axis_values["axis"] = {"x": 1.0}
+    emit_gamepad_output(runtime, "axis", "left_trigger", config, deps=deps)
+    reset_gamepad_output(runtime, "axis", "left_trigger", config, deps=deps)
+    writer.write.assert_not_called()
+
+
+def test_template_hat_preserves_hysteresis(flight_output):
+    runtime, deps, writer = flight_output
+    config = AnalogControlConfig(
+        name="Hat",
+        input_type="axis",
+        gamepad_output=AnalogGamepadOutputConfig(
+            enabled=True,
+            output_id="flight-test",
+            target="axis",
+            target_axis="abs_hat0x",
+            output_direction="both",
+        ),
+    )
+    for value in (0.5, 0.6, 0.5, 0.4, -0.6):
+        runtime.state.analog_axis_values["axis"] = {"x_signed": value}
+        emit_gamepad_output(runtime, "axis", "left_trigger", config, deps=deps)
+    reset_gamepad_output(runtime, "axis", "left_trigger", config, deps=deps)
+    assert [call.args for call in writer.write.call_args_list] == [
+        (evdev.ecodes.EV_ABS, evdev.ecodes.ABS_HAT0X, value) for value in (0, 1, 1, 0, -1, 0)
+    ]

--- a/tests/keymasqd/test_virtual_device_analog_output.py
+++ b/tests/keymasqd/test_virtual_device_analog_output.py
@@ -1,0 +1,119 @@
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import Mock
+
+import evdev
+import pytest
+
+from keymasq.common.model.analog import AnalogControlConfig, AnalogGamepadOutputConfig
+from keymasq.common.virtual_device_templates import (
+    LOGITECH_EXTREME_3D_TEMPLATE,
+    template_analog_inputs,
+)
+from keymasq.keymasqd.runtime.analog.gamepad import emit_gamepad_output, reset_gamepad_output
+from keymasq.keymasqd.runtime.analog.output_state import reset_recorded_gamepad_outputs
+from keymasq.keymasqd.runtime.virtual_gamepads import GamepadOutputTarget
+
+
+@pytest.fixture
+def flight_output():
+    template = LOGITECH_EXTREME_3D_TEMPLATE
+    writer = Mock()
+    target = GamepadOutputTarget(
+        output_id="flight-test",
+        uinput=writer,
+        bucket="gamepad:flight-test",
+        is_virtual=True,
+        analog_inputs=template_analog_inputs(template),
+        axis_ranges={
+            getattr(evdev.ecodes, axis.evdev.upper()): (axis.minimum, axis.maximum)
+            for axis in template.axes
+        },
+        axis_rest_values={
+            getattr(evdev.ecodes, axis.evdev.upper()): axis.rest for axis in template.axes
+        },
+    )
+    runtime: Any = SimpleNamespace(
+        hardware_id="source",
+        analog_inputs={},
+        analog_axis_output_codes={
+            ("left_stick", "x"): evdev.ecodes.ABS_X,
+            ("left_stick", "y"): evdev.ecodes.ABS_Y,
+            ("throttle", "x"): evdev.ecodes.ABS_THROTTLE,
+        },
+        resolve_gamepad_output=lambda *_args: target,
+        state=SimpleNamespace(
+            analog_axis_values={},
+            analog_gamepad_outputs={},
+            held_output_abs={},
+            passthrough_frame_output=None,
+        ),
+    )
+    deps: Any = SimpleNamespace(evdev_mod=evdev, uinput_writer=lambda output: output)
+    return runtime, deps, writer
+
+
+@pytest.mark.parametrize("gyro", [False, True])
+@pytest.mark.parametrize("value, expected", [(0.0, 511), (1.0, 1023), (-1.0, 0)])
+def test_implicit_flight_stick_uses_destination_range_and_rest(
+    flight_output, gyro, value, expected
+):
+    runtime, deps, writer = flight_output
+    config = AnalogControlConfig(
+        name="Stick",
+        gamepad_output=AnalogGamepadOutputConfig(enabled=True, output_id="flight-test"),
+    )
+    runtime.state.analog_axis_values["stick"] = {"x": value, "y": 0.0}
+    emit_gamepad_output(runtime, "stick", "left_stick", config, deps=deps, gyro=gyro)
+    assert [call.args for call in writer.write.call_args_list] == [
+        (evdev.ecodes.EV_ABS, evdev.ecodes.ABS_X, expected),
+        (evdev.ecodes.EV_ABS, evdev.ecodes.ABS_Y, 511),
+    ]
+    writer.reset_mock()
+    if gyro:
+        reset_recorded_gamepad_outputs(runtime, deps=deps)
+    else:
+        reset_gamepad_output(runtime, "stick", "left_stick", config, deps=deps)
+    assert [call.args for call in writer.write.call_args_list] == [
+        (evdev.ecodes.EV_ABS, evdev.ecodes.ABS_X, 511),
+        (evdev.ecodes.EV_ABS, evdev.ecodes.ABS_Y, 511),
+    ]
+
+
+@pytest.mark.parametrize(
+    "source, code, direction, expected, rest",
+    [
+        ("right_trigger", evdev.ecodes.ABS_RZ, "max", 255, 127),
+        ("throttle", evdev.ecodes.ABS_THROTTLE, "min", 0, 255),
+    ],
+)
+def test_implicit_flight_axis_uses_destination_rest(
+    flight_output, source, code, direction, expected, rest
+):
+    runtime, deps, writer = flight_output
+    config = AnalogControlConfig(
+        name="Axis",
+        input_type="axis",
+        gamepad_output=AnalogGamepadOutputConfig(
+            enabled=True, output_id="flight-test", output_direction=direction
+        ),
+    )
+    runtime.state.analog_axis_values["axis"] = {"x": 1.0}
+    emit_gamepad_output(runtime, "axis", source, config, deps=deps)
+    writer.write.assert_called_once_with(evdev.ecodes.EV_ABS, code, expected)
+    writer.reset_mock()
+    reset_gamepad_output(runtime, "axis", source, config, deps=deps)
+    writer.write.assert_called_once_with(evdev.ecodes.EV_ABS, code, rest)
+
+
+def test_missing_destination_axes_are_not_written(flight_output):
+    runtime, deps, writer = flight_output
+    config = AnalogControlConfig(
+        name="Stick",
+        gamepad_output=AnalogGamepadOutputConfig(
+            enabled=True, output_id="flight-test", target="right"
+        ),
+    )
+    emit_gamepad_output(runtime, "stick", "left_stick", config, deps=deps)
+    reset_gamepad_output(runtime, "stick", "left_stick", config, deps=deps)
+    writer.write.assert_not_called()

--- a/tests/keymasqd/test_virtual_device_reconfiguration.py
+++ b/tests/keymasqd/test_virtual_device_reconfiguration.py
@@ -1,0 +1,83 @@
+import logging
+from dataclasses import replace
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import Mock
+
+import evdev
+import pytest
+
+from keymasq.common.virtual_device_templates import (
+    LOGITECH_EXTREME_3D_TEMPLATE,
+    VirtualDeviceConfig,
+    VirtualDeviceInstance,
+    resolve_virtual_devices,
+)
+from keymasq.keymasqd.runtime import outputs
+
+
+def test_failed_replacement_preserves_all_existing_outputs(monkeypatch):
+    original_config = VirtualDeviceConfig(
+        devices=(
+            VirtualDeviceInstance("flight", LOGITECH_EXTREME_3D_TEMPLATE.id),
+            VirtualDeviceInstance("removed", LOGITECH_EXTREME_3D_TEMPLATE.id),
+        )
+    )
+    specs = {item.output_id: item for item in resolve_virtual_devices(0, original_config)}
+    old, removed, prepared = Mock(), Mock(), Mock()
+    state = outputs.OutputRuntimeState(
+        virtual_gamepad_count=0,
+        virtual_gamepad_uinputs={"flight": old, "removed": removed},
+        virtual_device_config=original_config,
+        virtual_device_specs=dict(specs),
+    )
+    changed = VirtualDeviceConfig(
+        devices=(
+            replace(original_config.devices[0], name="Changed"),
+            VirtualDeviceInstance("new", LOGITECH_EXTREME_3D_TEMPLATE.id),
+        )
+    )
+    create = Mock(side_effect=[prepared, OSError("device creation failed")])
+    monkeypatch.setattr(outputs, "create_virtual_device", create)
+    manager: Any = SimpleNamespace(output_state=state)
+    with pytest.raises(OSError, match="device creation failed"):
+        outputs.configure_virtual_gamepads(
+            manager,
+            0,
+            config=changed,
+            evdev_mod=Mock(),
+            log=logging.getLogger(__name__),
+            uinput_writer=lambda device: device,
+        )
+    old.close.assert_not_called()
+    removed.close.assert_not_called()
+    prepared.close.assert_called_once_with()
+    assert state.virtual_gamepad_uinputs == {"flight": old, "removed": removed}
+    assert state.virtual_device_specs == specs
+    assert state.virtual_device_config == original_config
+
+    replacement, added = Mock(), Mock()
+    create.side_effect = [replacement, added]
+    outputs.configure_virtual_gamepads(
+        manager,
+        0,
+        config=changed,
+        evdev_mod=Mock(),
+        log=logging.getLogger(__name__),
+        uinput_writer=lambda device: device,
+    )
+    old.close.assert_called_once_with()
+    removed.close.assert_called_once_with()
+    assert state.virtual_gamepad_uinputs == {"flight": replacement, "new": added}
+    assert state.virtual_device_config == changed
+
+
+def test_failed_axis_initialization_closes_new_device(monkeypatch):
+    device = Mock()
+    device.write.side_effect = OSError("initial write failed")
+    monkeypatch.setattr(outputs, "_create_synthetic_uinput", Mock(return_value=device))
+    spec = resolve_virtual_devices(1, VirtualDeviceConfig())[0]
+    evdev_mod: Any = SimpleNamespace(ecodes=evdev.ecodes, AbsInfo=evdev.AbsInfo)
+    with pytest.raises(OSError, match="initial write failed"):
+        outputs.create_virtual_device(spec, evdev_mod, lambda output: output)
+    device.close.assert_called_once_with()

--- a/tests/session/test_session_manager_command_runtime.py
+++ b/tests/session/test_session_manager_command_runtime.py
@@ -130,7 +130,10 @@ async def test_handle_session_request_set_virtual_gamepads_keeps_state_on_daemon
     assert result == {"status": "error", "message": "daemon rejected count"}
     sent = manager.client.send_command.await_args.args[0]
     assert sent.command == CommandType.SET_VIRTUAL_GAMEPADS
-    assert sent.data == {"count": 2}
+    assert sent.data == {
+        "count": 2,
+        "virtual_devices": {"templates": [], "devices": []},
+    }
     assert manager.virtual_gamepad_count == 3
     assert session_settings.load_global_settings().virtual_gamepad_count == 3
     manager.broadcast_to_session_clients.assert_not_called()  # type: ignore[attr-defined]

--- a/tests/session/test_virtual_device_config.py
+++ b/tests/session/test_virtual_device_config.py
@@ -1,0 +1,41 @@
+import logging
+
+from keymasq.common.virtual_device_templates import VirtualDeviceConfig
+
+
+def test_virtual_device_config_persists(temp_config_dir) -> None:
+    from keymasq.common.virtual_device_templates import virtual_device_config_from_toml
+    from keymasq.session.virtual_devices import (
+        load_virtual_device_config,
+        save_virtual_device_config,
+    )
+
+    config = virtual_device_config_from_toml(
+        {
+            "devices": [
+                {
+                    "output_id": "flight-stick",
+                    "template": "logitech-extreme-3d-pro",
+                }
+            ]
+        }
+    )
+
+    assert save_virtual_device_config(config) == config
+    assert load_virtual_device_config() == config
+    text = (temp_config_dir / "virtual_devices.toml").read_text(encoding="utf-8")
+    assert 'output_id = "flight-stick"' in text
+    assert 'template = "logitech-extreme-3d-pro"' in text
+
+
+def test_virtual_device_config_invalid_file_falls_back(
+    temp_config_dir,
+    caplog,
+) -> None:
+    from keymasq.session.virtual_devices import load_virtual_device_config
+
+    (temp_config_dir / "virtual_devices.toml").write_text("devices = nope", encoding="utf-8")
+
+    with caplog.at_level(logging.WARNING, logger="keymasq-session.virtual-devices"):
+        assert load_virtual_device_config() == VirtualDeviceConfig()
+    assert "Failed to load virtual devices" in caplog.text


### PR DESCRIPTION
## Summary

Controllers with more inputs than the standard virtual gamepad can now map to independently configured virtual outputs. Settings provides built-in gamepad and flight stick templates, editable copies, and up to four additional outputs with stable IDs.

- Define button codes, axis ranges and rest values, and optional device identity overrides in `virtual_devices.toml`. Add TriggerHappy buttons in batches and map extra controls through a searchable grid while retaining the selected controller illustration.
- Route button, analog, and motion mappings using the destination template's capabilities. Preserve existing numbered gamepads and their identity, restore nonzero rest values on release, and retain working outputs if a replacement fails to initialize.
- Integrate individual-axis routing from #259. The editor and runtime share template axis capabilities, including stick components, twist, throttle, hats, and custom axes, with automatic neutral values and preserved unavailable selections.
- Validate duplicate event-code aliases and axis integer bounds. Templates support up to 40 total buttons and 2–8 axes, including X/Y and joystick classification capabilities.

Addresses #240. Physical controller capability population and physical flight stick presentation are separate follow-ups.

## Testing

- [x] `./scripts/check.sh full`: Ruff, BasedPyright, Stylelint, and 3,167 tests passed; 28 skipped because `/dev/uinput` is unavailable in the test environment.
- [x] GUI changes: rendered and inspected the gamepad and flight stick template pickers, including additional-button navigation. Documentation screenshot regeneration was not run.
- [x] Regression coverage for template persistence, event-code aliases, integer bounds, destination ranges/rest values, gyro routing, unsupported axes, motion destination selection, failed output replacement, individual template axis emission/reset, template hat hysteresis, and custom-axis editor save/reload.

## Notes

- Packaging: no new dependencies.
- Services: uses the existing daemon/session IPC and uinput creation path; watches and persists the new virtual-device configuration.
- GUI: expands Settings and adds template/output editors plus illustrated mapping layouts with extra controls.


