### PR TITLE
Support arbitrary destination axes for 1D analog controls

### DIFF
--- a/docs/ANALOG_CONTROLS.md
+++ b/docs/ANALOG_CONTROLS.md
@@ -81,9 +81,10 @@ Returning to rest brings the pointer back to the origin. When
 enabled = true
 output_id = "same-device"    # same-device, hardware ID, or virtual-gamepad-N
 deadzone = 0.0               # 0.0–0.95; values below are sent as centered
-target = "same"              # same|left|right|analog
+target = "same"              # same|left|right|analog|axis
 target_analog_id = ""        # required when target = "analog"
-output_rest = 0              # raw value at rest (1D axis only)
+# target_axis = "abs_x"      # required when target = "axis" (1D axis only)
+# output_rest = 0            # optional raw rest override; omitted uses destination neutral
 output_direction = "both"    # min|max|both (1D axis only)
 output_invert = false        # 1D axis only; inverts direction when output_direction = "both"
 output_invert_x = false      # stick output only
@@ -94,6 +95,11 @@ response_curve = 1.0         # 0.25–4.0
 
 ### Output targets
 
+- `axis` selects one supported destination axis by `target_axis`, independently
+  of the source axis. The built-in virtual gamepad supports `abs_x`, `abs_y`,
+  `abs_rx`, `abs_ry`, `abs_z`, `abs_rz`, `abs_hat0x`, and `abs_hat0y`.
+  Hardware outputs expose learned axes with valid ranges, including individual
+  components of a stick and custom axes such as `abs_throttle`.
 - `same` — preserves the source side: `left_stick` writes `ABS_X`/`ABS_Y`,
   `right_stick` writes `ABS_RX`/`ABS_RY`, `left_trigger` writes `ABS_Z`,
   `right_trigger` writes `ABS_RZ`.
@@ -125,8 +131,49 @@ output axis independently after deadzone/sensitivity/curve shaping. Learned
 hardware target-axis inversion is still honored and combines with these
 per-control flags.
 
-Virtual Xbox gamepads use fixed semantic targets (left/right stick and
-trigger) and ignore `target_analog_id`.
+Virtual Xbox gamepads also accept the legacy left/right stick and trigger
+targets. Their individual axes can be selected with `target = "axis"`.
+
+### Individual axis routing
+
+The editor's **Output Axis** dropdown lists axes on the selected destination.
+**Use Axis Neutral** keeps the rest value automatic. Turn it off to enter a
+raw rest override. Saved unavailable selections remain visible and are not
+silently replaced. With the default same-device output, the editor offers
+standard axes; availability and neutral are resolved against the bound device
+at runtime. Select a specific hardware output to choose its custom axes.
+
+For example, a trigger can drive the negative half of a stick:
+
+```toml
+name = "Trigger to Stick X"
+input_type = "axis"
+
+[gamepad_output]
+enabled = true
+output_id = "virtual-gamepad-1"
+target = "axis"
+target_axis = "abs_x"
+output_direction = "min"
+```
+
+Released input writes zero and full input writes -32768. With `max`, full
+input writes 32767. `both` uses signed input on either side of neutral, with
+optional inversion. Deadzone, sensitivity, and response curve apply before
+conversion to the destination range. Rest overrides and emitted values are
+clamped to that range. Only the selected axis is written and reset, including
+when a profile is removed or replaced. Single stick-axis output also preserves
+the existing gyro-offset behavior.
+
+Three-state hat axes use -1, 0, and 1. After output shaping, a direction engages
+at 55% displacement from zero and releases at 45%. This hysteresis prevents
+chatter near the threshold. Release/reset clears the previous hat state.
+
+Existing `same`, `left`, `right`, and `analog` configurations remain readable.
+Standard targets now use destination axis metadata too. Unsupported axes emit
+no output, rather than falling back to a different axis. Selecting an axis does
+not add capabilities to an output device; additional virtual-device axes must
+be advertised by its provider. See [Output axis metadata](OUTPUT_AXES.md).
 
 ## Thresholds (Digital Actions)
 

--- a/docs/ANALOG_CONTROLS.md
+++ b/docs/ANALOG_CONTROLS.md
@@ -100,6 +100,9 @@ response_curve = 1.0         # 0.25–4.0
   `abs_rx`, `abs_ry`, `abs_z`, `abs_rz`, `abs_hat0x`, and `abs_hat0y`.
   Hardware outputs expose learned axes with valid ranges, including individual
   components of a stick and custom axes such as `abs_throttle`.
+  At runtime, missing saved ranges and rest values are filled from the
+  destination's grab-time calibration. Valid numeric-only `evdev_code` identities
+  are also supported by the daemon's output capability resolver.
 - `same` — preserves the source side: `left_stick` writes `ABS_X`/`ABS_Y`,
   `right_stick` writes `ABS_RX`/`ABS_RY`, `left_trigger` writes `ABS_Z`,
   `right_trigger` writes `ABS_RZ`.

--- a/docs/GAMEPAD.md
+++ b/docs/GAMEPAD.md
@@ -207,21 +207,27 @@ after applying.
 
 #### Analog Output
 
+For a 1D control, choose an **Output Axis** on the destination: a trigger,
+an individual stick axis, a Hat 0 axis, or a learned hardware axis. Output uses
+that axis's range and neutral value. **Use Axis Neutral** supplies the default
+release value; disable it for a manual override. Hat output uses three states
+with hysteresis. See [Individual axis routing](ANALOG_CONTROLS.md#individual-axis-routing)
+for direction, scaling, and compatibility details.
+
 Routes the analog source to a gamepad axis on a selected output device.
 Use this to remap one stick to another, route a trigger to a different
 controller, or pass through with adjusted tuning.
 
 - **Output** — target device: a virtual gamepad, the same physical device
   (`same-device`), or another grabbed controller by hardware ID
-- **Output Control** — which axis to write:
-  - `Same Axis` — preserves the source side (left stick stays left stick)
-  - `Left Trigger` / `Right Trigger` or `Left` / `Right` — forces the
-    output side
-  - Learned analog outputs on physical hardware are also available
+- **Output Axis** — for 1D controls, choose `Same Axis` or an individual
+  supported destination axis, including components of a stick
+- **Output Control** — for sticks, preserve the source side, force `Left` or
+  `Right`, or select a learned stick on physical hardware
 - Physical stick outputs use the target stick's hardware range and center
   when available; virtual gamepad sticks use the standard Xbox stick range
 - **Output Deadzone** — values below this are sent as centered/released
-- **Output Rest** — raw value written when the axis is at rest (1D axes)
+- **Output Rest** — manual release value when **Use Axis Neutral** is disabled
 - **Output Direction** — `Min`, `Max`, or `Both` (1D axes):
   - `Min` maps from rest toward the minimum endpoint
   - `Max` maps from rest toward the maximum endpoint

--- a/docs/OUTPUT_AXES.md
+++ b/docs/OUTPUT_AXES.md
@@ -7,7 +7,15 @@ increase and contain the neutral value.
 `STANDARD_OUTPUT_AXES` describes the built-in virtual gamepad, including its
 two Hat 0 axes. `learned_output_axes()` flattens hardware controls into axes,
 including each component of a stick, using learned ranges and rest/center
-values. Axes without valid ranges are omitted.
+values. Numeric-only identities use the canonical ABS name for `evdev_code`;
+unknown codes and explicitly invalid names are omitted.
+
+The hardware router fills missing metadata from the destination's cached
+grab-time calibration and axis ranges before constructing output capabilities.
+Saved calibration takes precedence. It supplies the resolved metadata to legacy
+learned-control routing too, without modifying the saved hardware description or
+querying the physical device during output resolution. Axes with neither saved nor
+runtime-resolved valid ranges are omitted.
 
 Output providers populate `GamepadOutputTarget.output_axes`. An empty tuple
 means no supported axes. A future virtual-device template provider can supply

--- a/docs/OUTPUT_AXES.md
+++ b/docs/OUTPUT_AXES.md
@@ -1,0 +1,18 @@
+# Output axis metadata
+
+`keymasq.common.output_axes.OutputAxis` describes one advertised output axis:
+its evdev name/code, label, minimum, maximum, and neutral value. Ranges must
+increase and contain the neutral value.
+
+`STANDARD_OUTPUT_AXES` describes the built-in virtual gamepad, including its
+two Hat 0 axes. `learned_output_axes()` flattens hardware controls into axes,
+including each component of a stick, using learned ranges and rest/center
+values. Axes without valid ranges are omitted.
+
+Output providers populate `GamepadOutputTarget.output_axes`. An empty tuple
+means no supported axes. A future virtual-device template provider can supply
+its own tuple of `OutputAxis` objects using the capabilities advertised when
+creating its uinput device. The editor should use the same descriptions.
+
+Axis selection and range conversion must use the destination's metadata.
+An evdev code being valid does not mean every output supports it.

--- a/keymasq/common/model/analog.py
+++ b/keymasq/common/model/analog.py
@@ -3,6 +3,7 @@
 from dataclasses import dataclass, field, replace
 from typing import cast
 
+from keymasq.common.gamepad_axes import normalize_gamepad_axis_target
 from keymasq.common.model.actions import MappingAction, normalize_output_id
 from keymasq.common.model.core import ActionType
 
@@ -21,7 +22,7 @@ ANALOG_THRESHOLD_ACTION_TYPES = frozenset(
 ANALOG_MOUSE_DIRECTIONS = frozenset({"left", "right", "up", "down", "horizontal", "vertical"})
 ANALOG_MOUSE_MODES = frozenset({"velocity", "area"})
 SAME_DEVICE_OUTPUT_ID = "same-device"
-ANALOG_GAMEPAD_OUTPUT_TARGETS = frozenset({"same", "left", "right", "analog"})
+ANALOG_GAMEPAD_OUTPUT_TARGETS = frozenset({"same", "left", "right", "analog", "axis"})
 ANALOG_GAMEPAD_OUTPUT_DIRECTIONS = frozenset({"min", "max", "both"})
 MIN_ANALOG_GAMEPAD_OUTPUT_SENSITIVITY = 0.1
 MAX_ANALOG_GAMEPAD_OUTPUT_SENSITIVITY = 2.0
@@ -110,6 +111,7 @@ class AnalogGamepadOutputConfig:
     deadzone: float = 0.0
     target: str = "same"
     target_analog_id: str | None = None
+    target_axis: str | None = None
     output_rest: int | None = None
     output_direction: str = ""
     output_invert: bool = False
@@ -127,6 +129,13 @@ class AnalogGamepadOutputConfig:
         self.target_analog_id = normalize_output_id(self.target_analog_id)
         if self.target != "analog":
             self.target_analog_id = None
+        if self.target == "axis":
+            normalized_axis = normalize_gamepad_axis_target(self.target_axis)
+            if normalized_axis is None:
+                raise ValueError("analog output target_axis must be a valid ABS axis")
+            self.target_axis = normalized_axis
+        else:
+            self.target_axis = None
         if self.output_rest is not None:
             self.output_rest = int(self.output_rest)
         output_invert = bool(self.output_invert)
@@ -213,6 +222,8 @@ def validate_analog_control_config(config: AnalogControlConfig) -> None:
         raise ValueError("analog control input_type must be 'stick' or 'axis'")
     if config.input_type == "axis" and config.mouse_motion.mode == "area":
         raise ValueError("analog mouse area mode requires a stick control")
+    if config.gamepad_output.target == "axis" and config.input_type != "axis":
+        raise ValueError("an individual output axis requires a 1D axis control")
     for index, threshold in enumerate(config.thresholds, start=1):
         allowed_axes = {"x", "y"} if config.input_type == "stick" else {"x"}
         if threshold.axis not in allowed_axes:

--- a/keymasq/common/output_axes.py
+++ b/keymasq/common/output_axes.py
@@ -6,6 +6,7 @@ from typing import cast
 
 import evdev
 
+from keymasq.common.devices import capability_name
 from keymasq.common.gamepad_axes import GAMEPAD_AXIS_RANGES, normalize_gamepad_axis_target
 
 
@@ -85,9 +86,13 @@ def learned_output_axes(analog_inputs: Iterable[object]) -> tuple[OutputAxis, ..
             if neutral is None:
                 neutral = round((minimum + maximum) / 2) if stick else max(minimum, min(0, maximum))
             role = str(_field(axis, "role") or "").upper()
+            name = str(_field(axis, "evdev") or "")
+            if not name:
+                code = _integer(_field(axis, "evdev_code"))
+                name = capability_name(evdev.ecodes.EV_ABS, code) or ""
             try:
                 spec = OutputAxis(
-                    str(_field(axis, "evdev") or ""),
+                    name,
                     f"{label} {role}" if stick else label,
                     minimum,
                     maximum,

--- a/keymasq/common/output_axes.py
+++ b/keymasq/common/output_axes.py
@@ -1,0 +1,104 @@
+"""Axis capabilities shared by output providers, editors, and analog routing."""
+
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+from typing import cast
+
+import evdev
+
+from keymasq.common.gamepad_axes import GAMEPAD_AXIS_RANGES, normalize_gamepad_axis_target
+
+
+@dataclass(frozen=True, slots=True)
+class OutputAxis:
+    evdev: str
+    label: str
+    minimum: int
+    maximum: int
+    neutral: int = 0
+
+    def __post_init__(self) -> None:
+        name = normalize_gamepad_axis_target(self.evdev)
+        if name is None or self.minimum >= self.maximum:
+            raise ValueError("Output axis requires a valid ABS code and increasing range")
+        if not self.minimum <= self.neutral <= self.maximum:
+            raise ValueError("Output axis neutral must be within its range")
+        object.__setattr__(self, "evdev", name.upper())
+
+    @property
+    def code(self) -> int:
+        return int(getattr(evdev.ecodes, self.evdev))
+
+    @property
+    def discrete(self) -> bool:
+        return self.evdev.startswith("ABS_HAT") and (self.minimum, self.maximum) == (-1, 1)
+
+    def clamp(self, value: int) -> int:
+        return max(self.minimum, min(self.maximum, value))
+
+
+STANDARD_OUTPUT_AXES = tuple(
+    OutputAxis(axis.evdev_name, axis.label, axis.minimum, axis.maximum, axis.neutral)
+    for axis in GAMEPAD_AXIS_RANGES.values()
+) + (
+    OutputAxis("ABS_HAT0X", "Hat 0 X", -1, 1),
+    OutputAxis("ABS_HAT0Y", "Hat 0 Y", -1, 1),
+)
+
+
+def _field(value: object, name: str) -> object:
+    if isinstance(value, Mapping):
+        return cast(Mapping[str, object], value).get(name)
+    return getattr(value, name, None)
+
+
+def _integer(value: object) -> int | None:
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str):
+        try:
+            return int(value, 0)
+        except ValueError:
+            pass
+    return None
+
+
+def learned_output_axes(analog_inputs: Iterable[object]) -> tuple[OutputAxis, ...]:
+    """Flatten learned controls, including stick components, without guessing ranges.
+
+    Accept hardware model objects or their IPC dictionaries. Providers such as
+    virtual-device templates can also construct OutputAxis directly.
+    """
+    result: dict[int, OutputAxis] = {}
+    for analog in analog_inputs:
+        axes = _field(analog, "axes")
+        if not isinstance(axes, (list, tuple)):
+            continue
+        stick = _field(analog, "type") == "stick"
+        label = str(_field(analog, "label") or _field(analog, "id") or "Axis")
+        for axis in cast(Iterable[object], axes):
+            minimum = _integer(_field(axis, "minimum"))
+            maximum = _integer(_field(axis, "maximum"))
+            if minimum is None or maximum is None or minimum >= maximum:
+                continue
+            neutral = _integer(_field(axis, "center" if stick else "rest"))
+            if neutral is None:
+                neutral = round((minimum + maximum) / 2) if stick else max(minimum, min(0, maximum))
+            role = str(_field(axis, "role") or "").upper()
+            try:
+                spec = OutputAxis(
+                    str(_field(axis, "evdev") or ""),
+                    f"{label} {role}" if stick else label,
+                    minimum,
+                    maximum,
+                    neutral,
+                )
+            except ValueError:
+                continue
+            result.setdefault(spec.code, spec)
+    return tuple(result.values())
+
+
+def find_output_axis(axes: Iterable[OutputAxis], name: str) -> OutputAxis | None:
+    normalized = normalize_gamepad_axis_target(name)
+    return next((axis for axis in axes if axis.evdev.lower() == normalized), None)

--- a/keymasq/gui/widgets/analog_control/draft.py
+++ b/keymasq/gui/widgets/analog_control/draft.py
@@ -98,12 +98,13 @@ class GamepadDraft:
     deadzone: float
     target: str
     target_analog_id: str | None
-    output_rest: int
+    output_rest: int | None
     output_direction: str
     invert_x: bool
     invert_y: bool
     sensitivity: float
     response_curve: float
+    target_axis: str | None = None
 
     @classmethod
     def from_config(cls, config: AnalogGamepadOutputConfig) -> "GamepadDraft":
@@ -115,7 +116,8 @@ class GamepadDraft:
             deadzone=config.deadzone,
             target=config.target,
             target_analog_id=config.target_analog_id,
-            output_rest=config.output_rest or 0,
+            output_rest=config.output_rest,
+            target_axis=config.target_axis,
             output_direction=config.output_direction,
             invert_x=invert_x,
             invert_y=config.output_invert_y,
@@ -132,6 +134,7 @@ class GamepadDraft:
             deadzone=self.deadzone,
             target=self.target,
             target_analog_id=self.target_analog_id,
+            target_axis=self.target_axis,
             output_rest=self.output_rest if is_axis else None,
             output_direction=direction,
             output_invert=is_axis

--- a/keymasq/gui/widgets/analog_control/gamepad.py
+++ b/keymasq/gui/widgets/analog_control/gamepad.py
@@ -40,6 +40,7 @@ class GamepadOutputGroupHandle(GamepadOutputRoutingHandle):
     group: Adw.PreferencesGroup
     gamepad_output_deadzone_row: Adw.SpinRow
     gamepad_output_rest_row: Adw.SpinRow
+    gamepad_output_auto_rest_row: Adw.SwitchRow
     gamepad_output_direction_row: Adw.ActionRow
     gamepad_output_direction_min_btn: Gtk.ToggleButton
     gamepad_output_direction_max_btn: Gtk.ToggleButton
@@ -200,6 +201,10 @@ def build_gamepad_output_group(
         reset_value=0,
     )
     gamepad_output_rest_row.set_subtitle("Raw value written when the output axis is released")
+    auto_rest = Adw.SwitchRow(title="Use Axis Neutral", active=True)
+    auto_rest.set_subtitle("Use the destination axis neutral value when released")
+    auto_rest.connect("notify::active", modified)
+    group.add(auto_rest)
     group.add(gamepad_output_rest_row)
 
     gamepad_output_direction_row = Adw.ActionRow(title="Output Direction")
@@ -254,7 +259,7 @@ def build_gamepad_output_group(
         gamepad_output_sensitivity_row,
         page_step=ANALOG_CURVE_SENSITIVITY.page_step,
     )
-    gamepad_output_sensitivity_row.set_subtitle("How quickly stick output reaches full range")
+    gamepad_output_sensitivity_row.set_subtitle("How quickly output reaches full range")
     gamepad_output_sensitivity_row.connect(
         "notify::value",
         curve_changed,
@@ -305,6 +310,7 @@ def build_gamepad_output_group(
         gamepad_output_target_box=routing.gamepad_output_target_box,
         gamepad_output_deadzone_row=gamepad_output_deadzone_row,
         gamepad_output_rest_row=gamepad_output_rest_row,
+        gamepad_output_auto_rest_row=auto_rest,
         gamepad_output_direction_row=gamepad_output_direction_row,
         gamepad_output_direction_min_btn=gamepad_output_direction_min_btn,
         gamepad_output_direction_max_btn=gamepad_output_direction_max_btn,

--- a/keymasq/gui/widgets/analog_control/view.py
+++ b/keymasq/gui/widgets/analog_control/view.py
@@ -12,6 +12,12 @@ gi.require_version("Adw", "1")
 from gi.repository import Adw, Gtk  # pyright: ignore[reportAttributeAccessIssue]
 
 from keymasq.common.model.analog import SAME_DEVICE_OUTPUT_ID
+from keymasq.common.output_axes import (
+    STANDARD_OUTPUT_AXES,
+    OutputAxis,
+    find_output_axis,
+    learned_output_axes,
+)
 from keymasq.common.virtual_devices import is_virtual_gamepad_output_id
 from keymasq.gui.widgets.analog_control.draft import ControlDraft, GamepadDraft, MouseDraft
 from keymasq.gui.widgets.analog_control.gamepad import (
@@ -104,6 +110,7 @@ class AnalogControlEditorView(Gtk.Box):
         self._mode_items = mode_items_for_input_type("stick")
         self._selected_output_id: str | None = SAME_DEVICE_OUTPUT_ID
         self._output_ids: list[str | None] = []
+        self._axis_target_dropdown: Gtk.DropDown | None = None
         self._output_target_items: list[tuple[str, str | None]] = []
         self._output_target_buttons: dict[str, Gtk.ToggleButton] = {}
         self._hardware_output_configs: dict[str, object] = {}
@@ -163,6 +170,9 @@ class AnalogControlEditorView(Gtk.Box):
 
         self.input_type_dropdown.connect("notify::selected", self._on_input_type_changed)
         self.mode_dropdown.connect("notify::selected", self._on_mode_changed)
+        self.gamepad.gamepad_output_auto_rest_row.connect(
+            "notify::active", self._on_auto_rest_changed
+        )
         self._loading = False
         self.load(ControlDraft.new())
 
@@ -179,12 +189,10 @@ class AnalogControlEditorView(Gtk.Box):
         self.name_entry.connect("changed", self._on_modified)
         self.description_entry.connect("changed", self._on_modified)
         for label, widget in (
-            (
-                ("Name:", self.name_entry),
-                ("Description:", self.description_entry),
-                ("Input Type:", self.input_type_dropdown),
-                ("Mode:", self.mode_dropdown),
-            )
+            ("Name:", self.name_entry),
+            ("Description:", self.description_entry),
+            ("Input Type:", self.input_type_dropdown),
+            ("Mode:", self.mode_dropdown),
         ):
             form.append(label, widget)
         self.append(form.grid)
@@ -234,7 +242,12 @@ class AnalogControlEditorView(Gtk.Box):
                 deadzone=self.gamepad.gamepad_output_deadzone_row.get_value() / 100.0,
                 target=self.current_output_target(),
                 target_analog_id=self.current_output_target_analog_id(),
-                output_rest=int(self.gamepad.gamepad_output_rest_row.get_value()),
+                target_axis=self.current_output_axis(),
+                output_rest=(
+                    None
+                    if self.gamepad.gamepad_output_auto_rest_row.get_active()
+                    else int(self.gamepad.gamepad_output_rest_row.get_value())
+                ),
                 output_direction=self.current_output_direction(),
                 invert_x=self.gamepad.gamepad_output_invert_x_btn.get_active(),
                 invert_y=self.gamepad.gamepad_output_invert_y_btn.get_active(),
@@ -267,9 +280,7 @@ class AnalogControlEditorView(Gtk.Box):
 
     def capture_active(self) -> bool:
         return bool(
-            self.capture.pending
-            or self.capture.timeout_id
-            or self.capture.apply is not None
+            self.capture.pending or self.capture.timeout_id or self.capture.apply is not None
         )
 
     def set_modifier_key(self, keyval: int, pressed: bool) -> None:
@@ -338,9 +349,12 @@ class AnalogControlEditorView(Gtk.Box):
     def _load_gamepad(self, draft: GamepadDraft, input_type: str) -> None:
         self._selected_output_id = draft.output_id
         self._refresh_output_choices()
-        self._set_output_target_options(input_type, draft.target, draft.target_analog_id)
+        self._set_output_target_options(
+            input_type, draft.target, draft.target_analog_id, draft.target_axis
+        )
         self.gamepad.gamepad_output_deadzone_row.set_value(round(draft.deadzone * 100.0))
-        self.gamepad.gamepad_output_rest_row.set_value(draft.output_rest)
+        self.gamepad.gamepad_output_rest_row.set_value(draft.output_rest or 0)
+        self.gamepad.gamepad_output_auto_rest_row.set_active(draft.output_rest is None)
         direction = {
             "both": self.gamepad.gamepad_output_direction_both_btn,
             "min": self.gamepad.gamepad_output_direction_min_btn,
@@ -365,8 +379,9 @@ class AnalogControlEditorView(Gtk.Box):
         input_type: str,
         selected_target: str | None = None,
         selected_analog_id: str | None = None,
+        selected_axis: str | None = None,
     ) -> None:
-        choices = self._output_target_choices(input_type)
+        choices: list[tuple[str, str | None, str]] = self._output_target_choices(input_type)
         if not choices:
             choices = [
                 (
@@ -375,6 +390,17 @@ class AnalogControlEditorView(Gtk.Box):
                     gamepad_output_target_label_for_input_type(input_type, "same"),
                 )
             ]
+        self.gamepad.gamepad_output_target_side_row.set_title(
+            "Output Axis" if input_type == "axis" else "Output Control"
+        )
+        if input_type == "axis":
+            self._set_axis_target_choices(
+                choices,
+                selected_target or "same",
+                selected_axis if selected_target == "axis" else selected_analog_id,
+            )
+            return
+        self._axis_target_dropdown = None
         self._output_target_items = [(target, analog_id) for target, analog_id, _ in choices]
         self._output_target_buttons = populate_gamepad_output_target_buttons(
             self.gamepad.gamepad_output_target_box,
@@ -384,7 +410,96 @@ class AnalogControlEditorView(Gtk.Box):
             on_toggled=self._on_output_target_toggled,
         )
 
+    def _available_output_axes(self) -> tuple[OutputAxis, ...]:
+        selected = self._selected_output_id
+        if selected == SAME_DEVICE_OUTPUT_ID:
+            # Reusable controls have no source device until they are bound.
+            return STANDARD_OUTPUT_AXES
+        hardware = self._hardware_output_configs.get(selected or "")
+        if hardware is not None:
+            return learned_output_axes(getattr(hardware, "analog_inputs", []) or [])
+        if selected is None or is_virtual_gamepad_output_id(selected):
+            return STANDARD_OUTPUT_AXES
+        return ()
+
+    def _set_axis_target_choices(
+        self,
+        choices: list[tuple[str, str | None, str]],
+        target: str,
+        detail: str | None,
+    ) -> None:
+        selected = (target, detail)
+        if selected not in [(kind, value) for kind, value, _ in choices]:
+            saved_label = detail or gamepad_output_target_label_for_input_type("axis", target)
+            label = (
+                f"{saved_label} (unavailable)"
+                if target == "axis"
+                else f"{saved_label} (saved target)"
+            )
+            choices.append((target, detail, label))
+        box = self.gamepad.gamepad_output_target_box
+        while child := box.get_first_child():
+            box.remove(child)
+        self._output_target_buttons.clear()
+        self._output_target_items = [(kind, value) for kind, value, _ in choices]
+        dropdown = Gtk.DropDown.new_from_strings([label for _, _, label in choices])
+        dropdown.set_enable_search(True)
+        dropdown.set_selected(self._output_target_items.index(selected))
+        dropdown.connect("notify::selected", self._on_axis_target_selected)
+        self._axis_target_dropdown = dropdown
+        box.append(dropdown)
+        self._sync_axis_rest()
+
+    def _selected_axis_target(self) -> tuple[str, str | None]:
+        dropdown = self._axis_target_dropdown
+        if dropdown is not None and 0 <= dropdown.get_selected() < len(self._output_target_items):
+            return self._output_target_items[dropdown.get_selected()]
+        return "same", None
+
+    def current_output_axis(self) -> str | None:
+        target, detail = self._selected_axis_target()
+        return detail if target == "axis" else None
+
+    def _on_axis_target_selected(self, _dropdown: Gtk.DropDown, _param: object) -> None:
+        self._sync_axis_rest()
+        self._update_output_warning()
+        self._on_modified()
+
+    def _sync_axis_rest(self) -> None:
+        automatic = self.gamepad.gamepad_output_auto_rest_row.get_active()
+        row = self.gamepad.gamepad_output_rest_row
+        row.set_sensitive(not automatic)
+        axis = find_output_axis(self._available_output_axes(), self.current_output_axis() or "")
+        if self._selected_output_id == SAME_DEVICE_OUTPUT_ID:
+            axis = None
+        if automatic and axis is not None:
+            row.set_value(axis.neutral)
+        elif automatic:
+            row.set_value(0)
+        row.set_visible(
+            self.current_mode() == "gamepad"
+            and self.current_input_type() == "axis"
+            and (not automatic or axis is not None)
+        )
+        self.gamepad.gamepad_output_auto_rest_row.set_subtitle(
+            f"Neutral: {axis.neutral}. Range: {axis.minimum} to {axis.maximum}."
+            if axis is not None
+            else "Use the destination axis neutral value when released"
+        )
+
+    def _on_auto_rest_changed(self, _row: Adw.SwitchRow, _param: object) -> None:
+        self._sync_axis_rest()
+
     def _output_target_choices(self, input_type: str) -> list[tuple[str, str | None, str]]:
+        if input_type == "axis":
+            axis_choices: list[tuple[str, str | None, str]] = [("same", None, "Same Axis")]
+            axis_choices.extend(
+                [
+                    ("axis", axis.evdev.lower(), f"{axis.label} · {axis.evdev}")
+                    for axis in self._available_output_axes()
+                ]
+            )
+            return axis_choices
         selected = self._selected_output_id
         hardware = (
             self._hardware_output_configs.get(selected or "")
@@ -417,6 +532,8 @@ class AnalogControlEditorView(Gtk.Box):
         return gamepad_output_target_key(target, analog_id)
 
     def current_output_target(self) -> str:
+        if self._axis_target_dropdown is not None:
+            return self._selected_axis_target()[0]
         for target, analog_id in self._output_target_items:
             button = self._output_target_buttons.get(self._output_target_key(target, analog_id))
             if button is not None and button.get_active():
@@ -424,6 +541,9 @@ class AnalogControlEditorView(Gtk.Box):
         return "same"
 
     def current_output_target_analog_id(self) -> str | None:
+        if self._axis_target_dropdown is not None:
+            target, detail = self._selected_axis_target()
+            return detail if target == "analog" else None
         for target, analog_id in self._output_target_items:
             button = self._output_target_buttons.get(self._output_target_key(target, analog_id))
             if button is not None and button.get_active() and target == "analog":
@@ -470,6 +590,8 @@ class AnalogControlEditorView(Gtk.Box):
         gamepad_visible = mode == "gamepad"
         self.gamepad.group.set_visible(gamepad_visible)
         self.gamepad.gamepad_output_rest_row.set_visible(gamepad_visible and is_axis)
+        self.gamepad.gamepad_output_auto_rest_row.set_visible(gamepad_visible and is_axis)
+        self._sync_axis_rest()
         self.gamepad.gamepad_output_direction_row.set_visible(gamepad_visible and is_axis)
         show_invert = gamepad_visible and (not is_axis or self.current_output_direction() == "both")
         self.gamepad.gamepad_output_invert_row.set_title(
@@ -518,12 +640,13 @@ class AnalogControlEditorView(Gtk.Box):
             return
         target = self.current_output_target()
         analog_id = self.current_output_target_analog_id()
+        selected_axis = self.current_output_axis()
         self._selected_output_id = selected_gamepad_output_id(
             int(dropdown.get_selected()),
             self._output_ids,
             self._selected_output_id,
         )
-        self._set_output_target_options(self.current_input_type(), target, analog_id)
+        self._set_output_target_options(self.current_input_type(), target, analog_id, selected_axis)
         self._update_output_warning()
         self._on_modified()
 
@@ -537,6 +660,16 @@ class AnalogControlEditorView(Gtk.Box):
             self._selected_output_id,
             count_loader=self._output_count_loader,
         )
+        axis_name = self.current_output_axis()
+        if (
+            axis_name
+            and self._selected_output_id != SAME_DEVICE_OUTPUT_ID
+            and find_output_axis(self._available_output_axes(), axis_name) is None
+        ):
+            message = (
+                f"{axis_name.upper()} is unavailable on this output. No axis output will be sent."
+            )
+            self.gamepad.gamepad_output_warning_label.set_label(message)
         self.gamepad.gamepad_output_warning_row.set_visible(bool(message))
 
     def _on_input_type_changed(self, _dropdown: Gtk.DropDown, _param: object) -> None:
@@ -548,6 +681,7 @@ class AnalogControlEditorView(Gtk.Box):
             input_type,
             self.current_output_target(),
             self.current_output_target_analog_id(),
+            self.current_output_axis(),
         )
         expanded = self.thresholds.expanded_indices()
         self.thresholds.sync_for_input_type(axis_control=input_type == "axis")

--- a/keymasq/keymasqd/runtime/action_parser.py
+++ b/keymasq/keymasqd/runtime/action_parser.py
@@ -420,6 +420,7 @@ def parse_analog_control_config(
         deadzone=coerce_float((gamepad_config or {}).get("deadzone"), 0.0),
         target=coerce_str((gamepad_config or {}).get("target"), "same") or "same",
         target_analog_id=coerce_str((gamepad_config or {}).get("target_analog_id"), None),
+        target_axis=coerce_str((gamepad_config or {}).get("target_axis"), None),
         output_rest=coerce_int(
             (gamepad_config or {}).get("output_rest"),
             None,

--- a/keymasq/keymasqd/runtime/analog/gamepad.py
+++ b/keymasq/keymasqd/runtime/analog/gamepad.py
@@ -4,26 +4,24 @@ from keymasq.common.model.analog import AnalogControlConfig
 from keymasq.keymasqd.runtime.analog.curves import (
     DEFAULT_STICK_MAX,
     DEFAULT_STICK_MIN,
-    DEFAULT_TRIGGER_MAX,
-    DEFAULT_TRIGGER_MIN,
     apply_control_axis_output_curve,
     apply_signed_axis_output_curve,
     apply_stick_output_curve,
     denormalize_axis_value,
     denormalize_control_axis_value,
 )
+from keymasq.keymasqd.runtime.analog.hat import quantize_hat
 from keymasq.keymasqd.runtime.analog.metadata import (
     axis_evdev_code,
-    axis_int,
     axis_min_max,
     resolve_gamepad_output_target,
+    resolve_output_axis,
     stick_axis_center,
     stick_output_axis_specs,
     stick_output_reset_axes,
     target_analog_input,
     target_axes,
     target_axis,
-    trigger_outputaxis_code,
 )
 from keymasq.keymasqd.runtime.analog.output_state import write_gamepad_axes
 from keymasq.keymasqd.runtime.grabbed_device.types import (
@@ -45,7 +43,7 @@ def emit_gamepad_output(
     if not config.gamepad_output.enabled:
         return
     if config.input_type == "axis":
-        _emit_trigger_gamepad_output(device_runtime, state_key, source_id, config, deps=deps)
+        _emit_axis_gamepad_output(device_runtime, state_key, source_id, config, deps=deps)
         return
     _emit_stick_gamepad_output(
         device_runtime,
@@ -149,7 +147,7 @@ def _emit_stick_gamepad_output(
     )
 
 
-def _emit_trigger_gamepad_output(
+def _emit_axis_gamepad_output(
     device_runtime: GrabbedDeviceRuntime,
     state_key: str,
     source_id: str,
@@ -157,62 +155,63 @@ def _emit_trigger_gamepad_output(
     *,
     deps: ActionExecutionDeps,
 ) -> None:
-    if config.gamepad_output.target == "analog":
-        _emit_analog_axis_output(device_runtime, state_key, source_id, config, deps=deps)
+    target = resolve_gamepad_output_target(device_runtime, source_id, config)
+    if target is None:
         return
-    axis_code = trigger_outputaxis_code(device_runtime, source_id, config, deps=deps)
-    if axis_code is None:
+    axis = resolve_output_axis(device_runtime, source_id, config, target=target, deps=deps)
+    if axis is None:
         return
+    output = config.gamepad_output
+    rest = axis.clamp(output.output_rest if output.output_rest is not None else axis.neutral)
     axis_values = device_runtime.state.analog_axis_values.get(state_key, {})
     if _gamepad_output_direction(config) == "both":
-        value = float(axis_values.get("x_signed", 0.0))
         value = apply_signed_axis_output_curve(
-            value,
-            deadzone=float(config.gamepad_output.deadzone),
-            sensitivity=float(config.gamepad_output.sensitivity),
-            response_curve=float(config.gamepad_output.response_curve),
+            float(axis_values.get("x_signed", 0.0)),
+            deadzone=output.deadzone,
+            sensitivity=output.sensitivity,
+            response_curve=output.response_curve,
         )
         raw_value = denormalize_axis_value(
             value,
-            DEFAULT_TRIGGER_MIN,
-            DEFAULT_TRIGGER_MAX,
-            center=(
-                config.gamepad_output.output_rest
-                if config.gamepad_output.output_rest is not None
-                else DEFAULT_TRIGGER_MIN
-            ),
-            invert=config.gamepad_output.output_invert,
+            axis.minimum,
+            axis.maximum,
+            center=rest,
+            invert=output.output_invert,
         )
     else:
-        value = float(axis_values.get("x", 0.0))
         value = apply_control_axis_output_curve(
-            value,
-            deadzone=float(config.gamepad_output.deadzone),
-            sensitivity=float(config.gamepad_output.sensitivity),
-            response_curve=float(config.gamepad_output.response_curve),
+            float(axis_values.get("x", 0.0)),
+            deadzone=output.deadzone,
+            sensitivity=output.sensitivity,
+            response_curve=output.response_curve,
         )
         raw_value = denormalize_control_axis_value(
             value,
-            DEFAULT_TRIGGER_MIN,
-            DEFAULT_TRIGGER_MAX,
-            rest=config.gamepad_output.output_rest,
+            axis.minimum,
+            axis.maximum,
+            rest=rest,
             invert=_gamepad_output_direction(config) == "min",
         )
+    if axis.discrete:
+        if _gamepad_output_direction(config) == "both":
+            signed = -value if output.output_invert else value
+            endpoint = axis.maximum if signed >= 0 else axis.minimum
+            position = rest + abs(signed) * (endpoint - rest)
+        else:
+            endpoint = axis.minimum if _gamepad_output_direction(config) == "min" else axis.maximum
+            position = rest + value * (endpoint - rest)
+        previous = device_runtime.state.analog_gamepad_outputs.get(state_key)
+        last = dict(previous.last_axes).get(axis.code, rest) if previous is not None else rest
+        raw_value = quantize_hat(position, last)
     write_gamepad_axes(
         device_runtime,
         state_key,
         source_id,
         config,
-        ((axis_code, raw_value),),
-        reset_axes=(
-            (
-                axis_code,
-                config.gamepad_output.output_rest
-                if config.gamepad_output.output_rest is not None
-                else DEFAULT_TRIGGER_MIN,
-            ),
-        ),
+        ((axis.code, axis.clamp(raw_value)),),
+        reset_axes=((axis.code, rest),),
         deps=deps,
+        target=target,
     )
 
 
@@ -224,22 +223,19 @@ def reset_gamepad_output(
     *,
     deps: ActionExecutionDeps,
 ) -> None:
-    if config.gamepad_output.target == "analog":
+    if config.gamepad_output.target == "analog" and config.input_type != "axis":
         _reset_analog_gamepad_output(device_runtime, state_key, source_id, config, deps=deps)
         return
     target: object | None = None
     if config.input_type == "axis":
-        axis_code = trigger_outputaxis_code(device_runtime, source_id, config, deps=deps)
-        if axis_code is None:
+        target = resolve_gamepad_output_target(device_runtime, source_id, config)
+        if target is None:
             return
-        axes = (
-            (
-                axis_code,
-                config.gamepad_output.output_rest
-                if config.gamepad_output.output_rest is not None
-                else 0,
-            ),
-        )
+        axis = resolve_output_axis(device_runtime, source_id, config, target=target, deps=deps)
+        if axis is None:
+            return
+        rest = config.gamepad_output.output_rest
+        axes = ((axis.code, axis.clamp(rest if rest is not None else axis.neutral)),)
     else:
         target = resolve_gamepad_output_target(device_runtime, source_id, config)
         if target is None:
@@ -262,74 +258,6 @@ def reset_gamepad_output(
         axes,
         reset_axes=axes,
         releasing=True,
-        deps=deps,
-        target=target,
-    )
-
-
-def _emit_analog_axis_output(
-    device_runtime: GrabbedDeviceRuntime,
-    state_key: str,
-    source_id: str,
-    config: AnalogControlConfig,
-    *,
-    deps: ActionExecutionDeps,
-) -> None:
-    target = resolve_gamepad_output_target(device_runtime, source_id, config)
-    if target is None:
-        return
-    analog = target_analog_input(target, config, expected_type="axis")
-    axis = target_axis(analog, "x") if analog is not None else None
-    if axis is None:
-        return
-    axis_values = device_runtime.state.analog_axis_values.get(state_key, {})
-    axis_code = axis_evdev_code(axis)
-    if axis_code is None:
-        return
-    minimum, maximum = axis_min_max(axis, DEFAULT_TRIGGER_MIN, DEFAULT_TRIGGER_MAX)
-    output_rest = (
-        config.gamepad_output.output_rest
-        if config.gamepad_output.output_rest is not None
-        else axis_int(axis, "rest")
-    )
-    reset_value = output_rest if output_rest is not None else (minimum if minimum >= 0 else 0)
-    if _gamepad_output_direction(config) == "both":
-        value = float(axis_values.get("x_signed", 0.0))
-        value = apply_signed_axis_output_curve(
-            value,
-            deadzone=float(config.gamepad_output.deadzone),
-            sensitivity=float(config.gamepad_output.sensitivity),
-            response_curve=float(config.gamepad_output.response_curve),
-        )
-        raw_value = denormalize_axis_value(
-            value,
-            minimum,
-            maximum,
-            center=reset_value,
-            invert=config.gamepad_output.output_invert,
-        )
-    else:
-        value = float(axis_values.get("x", 0.0))
-        value = apply_control_axis_output_curve(
-            value,
-            deadzone=float(config.gamepad_output.deadzone),
-            sensitivity=float(config.gamepad_output.sensitivity),
-            response_curve=float(config.gamepad_output.response_curve),
-        )
-        raw_value = denormalize_control_axis_value(
-            value,
-            minimum,
-            maximum,
-            rest=output_rest,
-            invert=_gamepad_output_direction(config) == "min",
-        )
-    write_gamepad_axes(
-        device_runtime,
-        state_key,
-        source_id,
-        config,
-        ((axis_code, raw_value),),
-        reset_axes=((axis_code, reset_value),),
         deps=deps,
         target=target,
     )
@@ -426,18 +354,8 @@ def _reset_analog_gamepad_output(
         axis_code = axis_evdev_code(axis)
         if axis_code is None:
             continue
-        if config.input_type == "axis":
-            axes.append(
-                (
-                    axis_code,
-                    config.gamepad_output.output_rest
-                    if config.gamepad_output.output_rest is not None
-                    else axis_int(axis, "rest") or DEFAULT_TRIGGER_MIN,
-                )
-            )
-        else:
-            minimum, maximum = axis_min_max(axis, DEFAULT_STICK_MIN, DEFAULT_STICK_MAX)
-            axes.append((axis_code, stick_axis_center(axis, minimum, maximum)))
+        minimum, maximum = axis_min_max(axis, DEFAULT_STICK_MIN, DEFAULT_STICK_MAX)
+        axes.append((axis_code, stick_axis_center(axis, minimum, maximum)))
     write_gamepad_axes(
         device_runtime,
         state_key,

--- a/keymasq/keymasqd/runtime/analog/hat.py
+++ b/keymasq/keymasqd/runtime/analog/hat.py
@@ -1,0 +1,13 @@
+"""Convert a shaped hat position to a stable three-state output."""
+
+
+def quantize_hat(value: float, previous: int) -> int:
+    if value >= 0.55:
+        return 1
+    if value <= -0.55:
+        return -1
+    if previous == 1 and value > 0.45:
+        return 1
+    if previous == -1 and value < -0.45:
+        return -1
+    return 0

--- a/keymasq/keymasqd/runtime/analog/metadata.py
+++ b/keymasq/keymasqd/runtime/analog/metadata.py
@@ -2,8 +2,14 @@
 
 from typing import cast
 
-from keymasq.common.devices import resolve_evdev_code
+from keymasq.common.devices import capability_name, resolve_evdev_code
 from keymasq.common.model.analog import SAME_DEVICE_OUTPUT_ID, AnalogControlConfig
+from keymasq.common.output_axes import (
+    STANDARD_OUTPUT_AXES,
+    OutputAxis,
+    find_output_axis,
+    learned_output_axes,
+)
 from keymasq.keymasqd.runtime.analog.curves import (
     DEFAULT_STICK_MAX,
     DEFAULT_STICK_MIN,
@@ -21,6 +27,54 @@ TRIGGER_OUTPUT_AXES = {
     "left_trigger": "ABS_Z",
     "right_trigger": "ABS_RZ",
 }
+
+
+def output_axis_specs(target: object) -> tuple[OutputAxis, ...]:
+    supplied = getattr(target, "output_axes", None)
+    if supplied is not None:
+        return cast(tuple[OutputAxis, ...], supplied)
+    analog_inputs = target_analog_inputs(target)
+    if analog_inputs:
+        return learned_output_axes(analog_inputs.values())
+    return STANDARD_OUTPUT_AXES if bool(getattr(target, "is_virtual", True)) else ()
+
+
+def resolve_output_axis(
+    device_runtime: GrabbedDeviceRuntime,
+    source_id: str,
+    config: AnalogControlConfig,
+    *,
+    target: object,
+    deps: ActionExecutionDeps,
+) -> OutputAxis | None:
+    output = config.gamepad_output
+    if output.target == "axis":
+        return find_output_axis(output_axis_specs(target), output.target_axis or "")
+    if output.target == "analog":
+        analog = target_analog_input(target, config, expected_type="axis")
+        if analog is None:
+            return None
+        axis = target_axis(analog, "x")
+        if axis is None:
+            return None
+        code = axis_evdev_code(axis)
+        if code is None:
+            return None
+        minimum, maximum = axis_min_max(axis, 0, 255)
+        neutral = axis_int(axis, "rest")
+        if neutral is None:
+            neutral = max(minimum, min(0, maximum))
+        return OutputAxis(
+            str(axis.get("evdev") or capability_name(deps.evdev_mod.ecodes.EV_ABS, code)),
+            str(analog.get("label", "Axis")),
+            minimum,
+            maximum,
+            max(minimum, min(maximum, neutral)),
+        )
+    code = trigger_outputaxis_code(device_runtime, source_id, config, deps=deps)
+    if code is None:
+        return None
+    return next((axis for axis in output_axis_specs(target) if axis.code == code), None)
 
 
 def _gamepad_output_stick_axis_inverted(

--- a/keymasq/keymasqd/runtime/analog/metadata.py
+++ b/keymasq/keymasqd/runtime/analog/metadata.py
@@ -64,13 +64,19 @@ def resolve_output_axis(
         neutral = axis_int(axis, "rest")
         if neutral is None:
             neutral = max(minimum, min(0, maximum))
-        return OutputAxis(
-            str(axis.get("evdev") or capability_name(deps.evdev_mod.ecodes.EV_ABS, code)),
-            str(analog.get("label", "Axis")),
-            minimum,
-            maximum,
-            max(minimum, min(maximum, neutral)),
-        )
+        name = str(axis.get("evdev") or "") or capability_name(deps.evdev_mod.ecodes.EV_ABS, code)
+        if not name:
+            return None
+        try:
+            return OutputAxis(
+                name,
+                str(analog.get("label", "Axis")),
+                minimum,
+                maximum,
+                max(minimum, min(maximum, neutral)),
+            )
+        except ValueError:
+            return None
     code = trigger_outputaxis_code(device_runtime, source_id, config, deps=deps)
     if code is None:
         return None

--- a/keymasq/keymasqd/runtime/analog/output_state.py
+++ b/keymasq/keymasqd/runtime/analog/output_state.py
@@ -51,7 +51,7 @@ def write_gamepad_axes(
         axis_code = int(axis_code)
         value = int(value)
         emitted = value
-        if isinstance(stick_output, StickOutputState) and config.input_type == "stick":
+        if isinstance(stick_output, StickOutputState):
             if gyro_axes is not None:
                 emitted = stick_output.write_gyro(
                     device_runtime.hardware_id,
@@ -81,6 +81,7 @@ def write_gamepad_axes(
     device_runtime.state.analog_gamepad_outputs[state_key] = AnalogGamepadOutputState(
         output_id=resolved_gamepad_output_id(device_runtime, config),
         gyro=gyro_axes is not None,
+        last_axes=axes,
         reset_axes=(
             tuple((int(axis_code), int(value)) for axis_code, value in reset_axes)
             if reset_axes is not None

--- a/keymasq/keymasqd/runtime/grabbed_device/types.py
+++ b/keymasq/keymasqd/runtime/grabbed_device/types.py
@@ -182,6 +182,7 @@ class AnalogGamepadOutputState:
     output_id: str | None
     reset_axes: tuple[tuple[int, int], ...]
     gyro: bool = False
+    last_axes: tuple[tuple[int, int], ...] = ()
 
 
 @dataclass

--- a/keymasq/keymasqd/runtime/virtual_gamepads.py
+++ b/keymasq/keymasqd/runtime/virtual_gamepads.py
@@ -29,6 +29,52 @@ type ClearComboRuntime = Callable[[], Awaitable[None]]
 type ConfigureVirtualGamepads = Callable[[int], None]
 
 
+def _resolved_hardware_analog_inputs(device: object) -> dict[str, object]:
+    """Combine saved metadata with cached grab-time calibration without mutating either."""
+    raw_inputs = getattr(device, "analog_inputs", None)
+    if not isinstance(raw_inputs, dict):
+        return {}
+    inputs = dict(cast(dict[str, object], raw_inputs))
+    raw_calibrations = getattr(device, "analog_axis_calibrations", None)
+    calibrations = (
+        cast(dict[tuple[str, str], dict[str, object]], raw_calibrations)
+        if isinstance(raw_calibrations, dict)
+        else {}
+    )
+    raw_ranges = getattr(device, "analog_axis_ranges", None)
+    ranges = (
+        cast(dict[tuple[str, str], tuple[int, int]], raw_ranges)
+        if isinstance(raw_ranges, dict)
+        else {}
+    )
+    for analog_id, raw_input in inputs.items():
+        if not isinstance(raw_input, dict):
+            continue
+        analog = cast(dict[str, object], raw_input)
+        raw_axes = analog.get("axes")
+        if not isinstance(raw_axes, list):
+            continue
+        axes: list[object] = []
+        for raw_axis in cast(list[object], raw_axes):
+            if not isinstance(raw_axis, dict):
+                axes.append(raw_axis)
+                continue
+            axis = dict(cast(dict[str, object], raw_axis))
+            key = (analog_id, str(axis.get("role", "") or "").strip().lower())
+            calibration = calibrations.get(key, {})
+            for field_name in ("minimum", "maximum", "center", "rest"):
+                if axis.get(field_name) is None and calibration.get(field_name) is not None:
+                    axis[field_name] = calibration[field_name]
+            axis_range = ranges.get(key)
+            if axis_range is not None:
+                for field_name, value in zip(("minimum", "maximum"), axis_range, strict=True):
+                    if axis.get(field_name) is None:
+                        axis[field_name] = value
+            axes.append(axis)
+        inputs[analog_id] = {**analog, "axes": axes}
+    return inputs
+
+
 async def reconfigure_virtual_gamepads(
     *,
     count: int,
@@ -140,12 +186,7 @@ class GamepadOutputRouter:
                 stick_output = getattr(
                     getattr(device, "state", None), "passthrough_stick_output", None
                 )
-                raw_analog_inputs = getattr(device, "analog_inputs", {}) or {}
-                analog_inputs = (
-                    dict(cast(dict[str, object], raw_analog_inputs))
-                    if isinstance(raw_analog_inputs, dict)
-                    else {}
-                )
+                analog_inputs = _resolved_hardware_analog_inputs(device)
                 return GamepadOutputTarget(
                     output_id=resolved_id,
                     uinput=uinput,

--- a/keymasq/keymasqd/runtime/virtual_gamepads.py
+++ b/keymasq/keymasqd/runtime/virtual_gamepads.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass, field
 from typing import cast
 
 from keymasq.common.model.core import DeviceType
+from keymasq.common.output_axes import STANDARD_OUTPUT_AXES, OutputAxis, learned_output_axes
 from keymasq.common.types import JsonObject
 from keymasq.common.virtual_devices import is_virtual_gamepad_output_id
 from keymasq.keymasqd.runtime.stick_output import StickOutputState
@@ -21,6 +22,7 @@ class GamepadOutputTarget:
     is_virtual: bool
     analog_inputs: dict[str, object] = field(default_factory=dict)
     stick_output: StickOutputState = field(default_factory=StickOutputState)
+    output_axes: tuple[OutputAxis, ...] | None = None
 
 
 type ClearComboRuntime = Callable[[], Awaitable[None]]
@@ -117,6 +119,7 @@ class GamepadOutputRouter:
                 bucket=f"gamepad:{resolved_id}",
                 is_virtual=True,
                 stick_output=previous[1],
+                output_axes=STANDARD_OUTPUT_AXES,
             )
 
         devices = grabbed_devices.get(resolved_id)
@@ -149,6 +152,7 @@ class GamepadOutputRouter:
                     bucket=f"gamepad:{resolved_id}",
                     is_virtual=False,
                     analog_inputs=analog_inputs,
+                    output_axes=learned_output_axes(analog_inputs.values()),
                     stick_output=stick_output
                     if isinstance(stick_output, StickOutputState)
                     else StickOutputState(),

--- a/keymasq/session/analog_controls.py
+++ b/keymasq/session/analog_controls.py
@@ -168,6 +168,7 @@ class AnalogControlManager:
                 deadzone=coerce_float(gamepad_data.get("deadzone"), 0.0),
                 target=_toml_str(gamepad_data, "target", "same") or "same",
                 target_analog_id=_toml_str(gamepad_data, "target_analog_id"),
+                target_axis=_toml_str(gamepad_data, "target_axis"),
                 output_rest=(
                     coerce_int(gamepad_data.get("output_rest"), 0)
                     if gamepad_data.get("output_rest") is not None
@@ -324,6 +325,9 @@ class AnalogControlManager:
         if config.gamepad_output.target_analog_id:
             gamepad_output = cast(dict[str, object], data["gamepad_output"])
             gamepad_output["target_analog_id"] = config.gamepad_output.target_analog_id
+        if config.gamepad_output.target_axis:
+            gamepad_output = cast(dict[str, object], data["gamepad_output"])
+            gamepad_output["target_axis"] = config.gamepad_output.target_axis
         if config.gamepad_output.output_rest is not None:
             gamepad_output = cast(dict[str, object], data["gamepad_output"])
             gamepad_output["output_rest"] = int(config.gamepad_output.output_rest)

--- a/keymasq/session/manager/payload/analog.py
+++ b/keymasq/session/manager/payload/analog.py
@@ -102,6 +102,7 @@ def _serialize_control(
             "deadzone": float(config.gamepad_output.deadzone),
             "target": config.gamepad_output.target,
             "target_analog_id": config.gamepad_output.target_analog_id,
+            "target_axis": config.gamepad_output.target_axis,
             "output_rest": config.gamepad_output.output_rest,
             "output_direction": config.gamepad_output.output_direction,
             "output_invert": bool(config.gamepad_output.output_invert),

--- a/tests/common/test_output_axes.py
+++ b/tests/common/test_output_axes.py
@@ -54,3 +54,44 @@ def test_provider_axes_require_valid_range_and_neutral() -> None:
         OutputAxis("ABS_X", "X", 0, 10, 20)
     with pytest.raises(ValueError):
         OutputAxis("KEY_A", "X", 0, 10)
+
+
+@pytest.mark.parametrize("code", [2, "0x2"])
+def test_learned_output_axes_accept_numeric_only_identity(code) -> None:
+    assert learned_output_axes(
+        [
+            {
+                "type": "axis",
+                "label": "Trigger",
+                "axes": [
+                    {"role": "x", "evdev_code": code, "minimum": 0, "maximum": 255},
+                ],
+            }
+        ]
+    ) == (OutputAxis("ABS_Z", "Trigger", 0, 255),)
+
+
+@pytest.mark.parametrize(
+    "identity",
+    [
+        {"evdev_code": 99999},
+        {"evdev_code": -1},
+        {"evdev_code": "unknown"},
+        {"evdev": "ABS_UNKNOWN", "evdev_code": 2},
+        {"evdev": "KEY_A", "evdev_code": 2},
+    ],
+)
+def test_learned_output_axes_reject_invalid_identities(identity) -> None:
+    assert (
+        learned_output_axes(
+            [
+                {
+                    "type": "axis",
+                    "axes": [
+                        {"role": "x", "minimum": 0, "maximum": 255, **identity},
+                    ],
+                }
+            ]
+        )
+        == ()
+    )

--- a/tests/common/test_output_axes.py
+++ b/tests/common/test_output_axes.py
@@ -1,0 +1,56 @@
+import pytest
+
+from keymasq.common.model.hardware import AnalogAxisDefinition, AnalogInputDefinition
+from keymasq.common.output_axes import (
+    STANDARD_OUTPUT_AXES,
+    OutputAxis,
+    find_output_axis,
+    learned_output_axes,
+)
+
+
+def test_standard_output_axes_include_sticks_triggers_and_hats() -> None:
+    assert len(STANDARD_OUTPUT_AXES) == 8
+    assert find_output_axis(STANDARD_OUTPUT_AXES, "x") == OutputAxis(
+        "ABS_X", "Left Stick X", -32768, 32767
+    )
+    hat = find_output_axis(STANDARD_OUTPUT_AXES, "abs_hat0y")
+    assert hat is not None and hat.discrete
+    assert find_output_axis(STANDARD_OUTPUT_AXES, "ABS_THROTTLE") is None
+
+
+def test_learned_axes_include_stick_components_and_custom_ranges() -> None:
+    controls = [
+        AnalogInputDefinition(
+            "stick",
+            "Stick",
+            "stick",
+            axes=[
+                AnalogAxisDefinition("x", "ABS_X", minimum=0, maximum=1023, center=512),
+                AnalogAxisDefinition("y", "ABS_Y", minimum=-100, maximum=100, center=5),
+            ],
+        )
+    ]
+    assert learned_output_axes(controls) == (
+        OutputAxis("ABS_X", "Stick X", 0, 1023, 512),
+        OutputAxis("ABS_Y", "Stick Y", -100, 100, 5),
+    )
+    assert learned_output_axes(
+        [
+            {
+                "type": "axis",
+                "label": "Throttle",
+                "axes": [
+                    {"evdev": "ABS_THROTTLE", "minimum": 10, "maximum": 500, "rest": 500},
+                    {"evdev": "ABS_RUDDER"},
+                ],
+            }
+        ]
+    ) == (OutputAxis("ABS_THROTTLE", "Throttle", 10, 500, 500),)
+
+
+def test_provider_axes_require_valid_range_and_neutral() -> None:
+    with pytest.raises(ValueError):
+        OutputAxis("ABS_X", "X", 0, 10, 20)
+    with pytest.raises(ValueError):
+        OutputAxis("KEY_A", "X", 0, 10)

--- a/tests/gui/test_analog_control_dialog.py
+++ b/tests/gui/test_analog_control_dialog.py
@@ -35,6 +35,77 @@ def _select_mode(dialog, mode: str) -> None:
     )
 
 
+def _select_output_axis(dialog, axis: str) -> None:
+    dropdown = dialog.editor.gamepad.gamepad_output_target_box.get_first_child()
+    model = dropdown.get_model()
+    for index in range(model.get_n_items()):
+        if model.get_string(index).endswith(f"· {axis}"):
+            dropdown.set_selected(index)
+            return
+    pytest.fail(f"Missing output axis {axis}")
+
+
+def test_axis_dropdown_saves_virtual_stick_component_and_automatic_neutral(temp_config_dir):
+    from gi.repository import Gtk
+
+    from keymasq.gui.widgets.analog_control.dialog import AnalogControlDialog
+
+    dialog = AnalogControlDialog(Gtk.Window())
+    dialog.editor.name_entry.set_text("Stick Component")
+    _select_input_type(dialog, "axis")
+    _select_mode(dialog, "gamepad")
+    dialog.editor.gamepad.gamepad_output_dropdown.set_selected(1)
+    _select_output_axis(dialog, "ABS_Y")
+    assert dialog.editor.gamepad.gamepad_output_target_side_row.get_title() == "Output Axis"
+    assert dialog.editor.gamepad.gamepad_output_auto_rest_row.get_active()
+    assert not dialog.editor.gamepad.gamepad_output_rest_row.get_sensitive()
+    assert dialog._save_current()
+    saved = dialog.manager.get_analog_control("Stick Component")
+    assert saved.gamepad_output.target_axis == "abs_y"
+    assert saved.gamepad_output.output_rest is None
+    reloaded = AnalogControlDialog(Gtk.Window())
+    assert reloaded.editor.draft().gamepad.target_axis == "abs_y"
+    assert reloaded.editor.draft().gamepad.output_rest is None
+    _select_output_axis(reloaded, "ABS_HAT0X")
+    assert reloaded.editor.draft().gamepad.target_axis == "abs_hat0x"
+
+
+@pytest.mark.parametrize(
+    "target, detail", [("left", None), ("analog", "brake"), ("axis", "abs_throttle")]
+)
+def test_axis_editor_preserves_saved_unavailable_and_legacy_targets(
+    temp_config_dir, target, detail
+):
+    from dataclasses import replace
+
+    from gi.repository import Gtk
+
+    from keymasq.common.model.analog import AnalogControlConfig, AnalogGamepadOutputConfig
+    from keymasq.gui.widgets.analog_control.dialog import AnalogControlDialog
+    from keymasq.session.analog_controls import AnalogControlManager
+
+    config = AnalogControlConfig(
+        name="Saved Axis",
+        input_type="axis",
+        gamepad_output=AnalogGamepadOutputConfig(
+            enabled=True,
+            output_id="virtual-gamepad-1",
+            target=target,
+            target_axis=detail if target == "axis" else None,
+            target_analog_id=detail if target == "analog" else None,
+            output_rest=123,
+        ),
+    )
+    AnalogControlManager().save_analog_control(config)
+    dialog = AnalogControlDialog(Gtk.Window())
+    # The editor canonicalizes virtual-gamepad-1 to the default output.
+    assert dialog.editor.draft().to_config().gamepad_output == replace(
+        config.gamepad_output, output_id=None
+    )
+    if target == "axis":
+        assert dialog.editor.gamepad.gamepad_output_warning_row.get_visible()
+
+
 def test_new_analog_control_keeps_draft_when_add_row_reselected(temp_config_dir) -> None:
     gi.require_version("Gtk", "4.0")
     from gi.repository import Gtk
@@ -1311,16 +1382,33 @@ def test_analog_output_controls_use_learned_hardware_targets(temp_config_dir, mo
         buttons=[],
         analog_inputs=[
             AnalogInputDefinition(
+                id="stick",
+                label="Stick",
+                type="stick",
+                axes=[
+                    AnalogAxisDefinition("x", "ABS_X", minimum=-100, maximum=100, center=5),
+                    AnalogAxisDefinition("y", "ABS_Y", minimum=0, maximum=1023, center=512),
+                ],
+            ),
+            AnalogInputDefinition(
                 id="gas",
                 label="Gas",
                 type="axis",
-                axes=[AnalogAxisDefinition(role="x", evdev="abs_gas", evdev_code=9)],
+                axes=[
+                    AnalogAxisDefinition(
+                        role="x", evdev="abs_gas", evdev_code=9, minimum=0, maximum=1023
+                    )
+                ],
             ),
             AnalogInputDefinition(
                 id="brake",
                 label="Brake",
                 type="axis",
-                axes=[AnalogAxisDefinition(role="x", evdev="abs_brake", evdev_code=10)],
+                axes=[
+                    AnalogAxisDefinition(
+                        role="x", evdev="abs_brake", evdev_code=10, minimum=0, maximum=1023
+                    )
+                ],
             ),
         ],
     )
@@ -1339,8 +1427,11 @@ def test_analog_output_controls_use_learned_hardware_targets(temp_config_dir, mo
     assert dialog.editor.gamepad.gamepad_output_dropdown is not None
     dialog.editor.gamepad.gamepad_output_dropdown.set_selected(2)
 
-    assert "analog:brake" in dialog.editor.output_target_buttons
-    dialog.editor.output_target_buttons["analog:brake"].set_active(True)
+    _select_output_axis(dialog, "ABS_Y")
+    assert dialog.editor.gamepad.gamepad_output_rest_row.get_value() == 512
+    assert dialog.editor.draft().gamepad.output_rest is None
+    _select_output_axis(dialog, "ABS_BRAKE")
+    dialog.editor.gamepad.gamepad_output_auto_rest_row.set_active(False)
     dialog.editor.gamepad.gamepad_output_rest_row.set_value(100)
     dialog.editor.gamepad.gamepad_output_direction_both_btn.set_active(True)
 
@@ -1348,8 +1439,8 @@ def test_analog_output_controls_use_learned_hardware_targets(temp_config_dir, mo
     saved = dialog.manager.get_analog_control("Route Pedal")
     assert saved is not None
     assert saved.gamepad_output.output_id == "1234:5678"
-    assert saved.gamepad_output.target == "analog"
-    assert saved.gamepad_output.target_analog_id == "brake"
+    assert saved.gamepad_output.target == "axis"
+    assert saved.gamepad_output.target_axis == "abs_brake"
     assert saved.gamepad_output.output_rest == 100
     assert saved.gamepad_output.output_direction == "both"
     assert saved.gamepad_output.output_invert is False

--- a/tests/keymasqd/test_analog_controls_runtime.py
+++ b/tests/keymasqd/test_analog_controls_runtime.py
@@ -14,6 +14,7 @@ from keymasq.common.model.analog import (
     AnalogMouseMotionConfig,
 )
 from keymasq.common.model.core import ActionType
+from keymasq.common.output_axes import STANDARD_OUTPUT_AXES, OutputAxis
 from keymasq.keymasqd.device_manager import DeviceManager
 from keymasq.keymasqd.runtime.adapters import identity_uinput_writer
 from keymasq.keymasqd.runtime.analog.binding_state import preserved_analog_state_keys
@@ -21,6 +22,7 @@ from keymasq.keymasqd.runtime.analog.curves import (
     normalize_axis_value,
     normalize_control_axis_value,
 )
+from keymasq.keymasqd.runtime.analog.gamepad import emit_gamepad_output, reset_gamepad_output
 from keymasq.keymasqd.runtime.analog.mouse import axis_motion_delta, motion_delta
 from keymasq.keymasqd.runtime.analog.reset import reset_analog_controls
 from keymasq.keymasqd.runtime.analog_controls import (
@@ -33,6 +35,7 @@ from keymasq.keymasqd.runtime.grabbed_device.types import (
     AnalogGamepadOutputState,
     GrabbedDeviceState,
 )
+from keymasq.keymasqd.runtime.virtual_gamepads import GamepadOutputTarget
 
 
 class FakeUInput:
@@ -87,6 +90,189 @@ def _runtime(mapping: dict[str, MappingAction], keyboard: FakeUInput) -> SimpleN
         analog_axis_calibrations={},
         resolve_gamepad_output=lambda _output_id, _context: None,
     )
+
+
+def _axis_output_runtime(config: AnalogControlConfig, axes=STANDARD_OUTPUT_AXES):
+    gamepad = FakeUInput()
+    runtime = _runtime({}, FakeUInput())
+    target = GamepadOutputTarget("virtual-gamepad-1", gamepad, "gamepad", True, output_axes=axes)
+    runtime.resolve_gamepad_output = lambda _id, _context: target
+
+    def emit(value: float) -> None:
+        runtime.state.analog_axis_values["source"] = {"x": abs(value), "x_signed": value}
+        emit_gamepad_output(runtime, "source", "source", config, deps=_deps())
+
+    return runtime, gamepad, target, emit
+
+
+@pytest.mark.parametrize("axis", STANDARD_OUTPUT_AXES)
+def test_explicit_axis_uses_destination_endpoints_and_resets_only_that_axis(axis) -> None:
+    config = AnalogControlConfig(
+        name="Axis",
+        input_type="axis",
+        gamepad_output=AnalogGamepadOutputConfig(
+            enabled=True,
+            target="axis",
+            target_axis=axis.evdev,
+            output_direction="both",
+        ),
+    )
+    runtime, gamepad, _, emit = _axis_output_runtime(config)
+    for value, expected in [(1.0, axis.maximum), (-1.0, axis.minimum), (0.0, axis.neutral)]:
+        emit(value)
+        assert gamepad.events[-1] == (evdev.ecodes.EV_ABS, axis.code, expected)
+    reset_gamepad_output(runtime, "source", "source", config, deps=_deps())
+    assert gamepad.events[-1] == (evdev.ecodes.EV_ABS, axis.code, axis.neutral)
+    assert {code for _, code, _ in gamepad.events} == {axis.code}
+
+
+@pytest.mark.parametrize("direction, expected", [("max", 32767), ("min", -32768)])
+def test_trigger_can_drive_either_half_of_stick(direction, expected) -> None:
+    config = AnalogControlConfig(
+        name="Axis",
+        input_type="axis",
+        gamepad_output=AnalogGamepadOutputConfig(
+            enabled=True,
+            target="axis",
+            target_axis="ABS_X",
+            output_direction=direction,
+        ),
+    )
+    _, gamepad, _, emit = _axis_output_runtime(config)
+    emit(1)
+    emit(0)
+    assert gamepad.events == [
+        (evdev.ecodes.EV_ABS, evdev.ecodes.ABS_X, expected),
+        (evdev.ecodes.EV_ABS, evdev.ecodes.ABS_X, 0),
+    ]
+
+
+@pytest.mark.parametrize("rest", [None, 400, 5000])
+@pytest.mark.asyncio
+async def test_custom_axis_neutral_override_and_recorded_reset_after_profile_change(rest) -> None:
+    config = AnalogControlConfig(
+        name="Axis",
+        input_type="axis",
+        gamepad_output=AnalogGamepadOutputConfig(
+            enabled=True,
+            target="axis",
+            target_axis="ABS_THROTTLE",
+            output_direction="both",
+            output_rest=rest,
+            output_invert=True,
+        ),
+    )
+    axis = OutputAxis("ABS_THROTTLE", "Throttle", 100, 900, 500)
+    runtime, gamepad, _, emit = _axis_output_runtime(config, (axis,))
+    emit(1)
+    assert gamepad.events[-1] == (evdev.ecodes.EV_ABS, axis.code, 100)
+    emit(-1)
+    assert gamepad.events[-1] == (evdev.ecodes.EV_ABS, axis.code, 900)
+    await reset_analog_controls(runtime, deps=_deps())
+    assert gamepad.events[-1] == (
+        evdev.ecodes.EV_ABS,
+        axis.code,
+        axis.clamp(rest if rest is not None else 500),
+    )
+    assert runtime.state.analog_gamepad_outputs == {}
+    assert runtime.state.held_output_abs.get("gamepad", set()) == set()
+
+
+@pytest.mark.parametrize("axes", [(), STANDARD_OUTPUT_AXES])
+def test_unsupported_axis_does_not_write_or_fall_back(axes) -> None:
+    config = AnalogControlConfig(
+        name="Axis",
+        input_type="axis",
+        gamepad_output=AnalogGamepadOutputConfig(
+            enabled=True,
+            target="axis",
+            target_axis="ABS_THROTTLE",
+        ),
+    )
+    runtime, gamepad, _, emit = _axis_output_runtime(config, axes)
+    emit(1)
+    reset_gamepad_output(runtime, "source", "source", config, deps=_deps())
+    assert gamepad.events == []
+    assert runtime.state.analog_gamepad_outputs == {}
+
+
+def test_hat_hysteresis_and_reset() -> None:
+    config = AnalogControlConfig(
+        name="Hat",
+        input_type="axis",
+        gamepad_output=AnalogGamepadOutputConfig(
+            enabled=True,
+            target="axis",
+            target_axis="ABS_HAT0X",
+            output_direction="both",
+        ),
+    )
+    runtime, gamepad, _, emit = _axis_output_runtime(config)
+    for value in [0.54, 0.55, 0.50, 0.45, -0.55, -0.50, -0.45]:
+        emit(value)
+    assert [value for _, _, value in gamepad.events] == [0, 1, 1, 0, -1, -1, 0]
+    emit(1)
+    reset_gamepad_output(runtime, "source", "source", config, deps=_deps())
+    emit(0.50)
+    assert gamepad.events[-1][2] == 0
+
+
+def test_explicit_axis_resolves_component_of_learned_hardware_stick() -> None:
+    config = AnalogControlConfig(
+        name="Hardware Axis",
+        input_type="axis",
+        gamepad_output=AnalogGamepadOutputConfig(
+            enabled=True,
+            target="axis",
+            target_axis="ABS_Y",
+            output_direction="both",
+        ),
+    )
+    runtime, gamepad, _, emit = _axis_output_runtime(config)
+    target = GamepadOutputTarget(
+        "hardware",
+        gamepad,
+        "gamepad:hardware",
+        False,
+        analog_inputs={
+            "stick": {
+                "type": "stick",
+                "axes": [
+                    {"role": "x", "evdev": "ABS_X", "minimum": -100, "maximum": 100, "center": 0},
+                    {"role": "y", "evdev": "ABS_Y", "minimum": 0, "maximum": 1023, "center": 512},
+                ],
+            }
+        },
+    )
+    runtime.resolve_gamepad_output = lambda _id, _context: target
+    emit(0.5)
+    reset_gamepad_output(runtime, "source", "source", config, deps=_deps())
+    assert gamepad.events == [
+        (evdev.ecodes.EV_ABS, evdev.ecodes.ABS_Y, 768),
+        (evdev.ecodes.EV_ABS, evdev.ecodes.ABS_Y, 512),
+    ]
+
+
+def test_single_stick_axis_preserves_gyro_offset_and_other_axis() -> None:
+    config = AnalogControlConfig(
+        name="Axis",
+        input_type="axis",
+        gamepad_output=AnalogGamepadOutputConfig(
+            enabled=True,
+            target="axis",
+            target_axis="ABS_X",
+        ),
+    )
+    runtime, gamepad, target, emit = _axis_output_runtime(config)
+    target.stick_output.write_base(runtime.hardware_id, evdev.ecodes.ABS_Y, 1234)
+    target.stick_output.write_gyro(
+        runtime.hardware_id, (1, "gyro"), evdev.ecodes.ABS_X, -32768, 32767, 0, 0.1
+    )
+    emit(0.5)
+    assert gamepad.events[-1][2] == round(round(32767 * 0.5) + 32767 * 0.1)
+    reset_gamepad_output(runtime, "source", "source", config, deps=_deps())
+    assert gamepad.events[-1][2] == round(32767 * 0.1)
+    assert target.stick_output.bases[evdev.ecodes.ABS_Y][1] == 1234
 
 
 def test_normalize_axis_value_maps_sides_independently() -> None:
@@ -1354,6 +1540,7 @@ async def test_generic_axis_gamepad_output_same_uses_learned_axis_code() -> None
     runtime.resolve_gamepad_output = lambda _output_id, _context: SimpleNamespace(  # noqa: E731
         uinput=gamepad,
         bucket="gamepad",
+        output_axes=(OutputAxis("ABS_GAS", "Gas", 0, 255),),
     )
     event = FakeEvent(255)
     event.code = evdev.ecodes.ABS_GAS
@@ -1741,9 +1928,7 @@ async def test_scoped_analog_reset_only_resets_tracked_matching_outputs() -> Non
         (evdev.ecodes.EV_ABS, evdev.ecodes.ABS_RX, 0),
         (evdev.ecodes.EV_ABS, evdev.ecodes.ABS_RY, 0),
     ]
-    assert runtime.state.analog_axis_values == {
-        "left_stick": {"x": 1.0, "y": 0.0}
-    }
+    assert runtime.state.analog_axis_values == {"left_stick": {"x": 1.0, "y": 0.0}}
     assert set(runtime.state.analog_gamepad_outputs) == {"left_stick"}
 
 

--- a/tests/keymasqd/test_analog_controls_runtime.py
+++ b/tests/keymasqd/test_analog_controls_runtime.py
@@ -253,6 +253,53 @@ def test_explicit_axis_resolves_component_of_learned_hardware_stick() -> None:
     ]
 
 
+@pytest.mark.parametrize(
+    "axis_identity, expected",
+    [
+        ({"evdev_code": 99999}, []),
+        ({"evdev_code": evdev.ecodes.ABS_BRAKE, "evdev": "abs_unknown"}, []),
+        (
+            {"evdev_code": evdev.ecodes.ABS_BRAKE},
+            [
+                (evdev.ecodes.EV_ABS, evdev.ecodes.ABS_BRAKE, 1023),
+                (evdev.ecodes.EV_ABS, evdev.ecodes.ABS_BRAKE, 0),
+            ],
+        ),
+    ],
+)
+def test_learned_axis_name_resolution_handles_invalid_metadata(axis_identity, expected) -> None:
+    config = AnalogControlConfig(
+        name="Learned Axis",
+        input_type="axis",
+        gamepad_output=AnalogGamepadOutputConfig(
+            enabled=True,
+            target="analog",
+            target_analog_id="pedal",
+        ),
+    )
+    runtime, gamepad, _, emit = _axis_output_runtime(config)
+    target = GamepadOutputTarget(
+        "hardware",
+        gamepad,
+        "gamepad:hardware",
+        False,
+        analog_inputs={
+            "pedal": {
+                "type": "axis",
+                "axes": [
+                    {"role": "x", "minimum": 0, "maximum": 1023, "rest": 0, **axis_identity},
+                ],
+            }
+        },
+    )
+    runtime.resolve_gamepad_output = lambda _id, _context: target
+    emit(1)
+    reset_gamepad_output(runtime, "source", "source", config, deps=_deps())
+    assert gamepad.events == expected
+    if not expected:
+        assert runtime.state.analog_gamepad_outputs == {}
+
+
 def test_single_stick_axis_preserves_gyro_offset_and_other_axis() -> None:
     config = AnalogControlConfig(
         name="Axis",

--- a/tests/keymasqd/test_output_axis_routing.py
+++ b/tests/keymasqd/test_output_axis_routing.py
@@ -1,0 +1,119 @@
+"""Hardware capability discovery through calibration, routing, emission, and reset."""
+
+import asyncio
+import copy
+import logging
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import evdev
+import pytest
+
+from keymasq.common.model.analog import AnalogControlConfig, AnalogGamepadOutputConfig
+from keymasq.common.model.core import DeviceType
+from keymasq.keymasqd.runtime.adapters import identity_uinput_writer
+from keymasq.keymasqd.runtime.analog.gamepad import emit_gamepad_output, reset_gamepad_output
+from keymasq.keymasqd.runtime.grabbed_device.device import GrabbedDevice
+from keymasq.keymasqd.runtime.grabbed_device.types import ActionExecutionDeps
+from keymasq.keymasqd.runtime.virtual_gamepads import GamepadOutputRouter
+
+
+class OutputWriter:
+    def __init__(self) -> None:
+        self.events: list[tuple[int, int, int]] = []
+
+    def write(self, event_type: int, code: int, value: int) -> None:
+        self.events.append((event_type, code, value))
+
+    def syn(self) -> None:
+        pass
+
+
+def _hardware(axis, *, absinfo):
+    device = GrabbedDevice(
+        path="/dev/input/test-output-axis",
+        hardware_id="hardware",
+        button_map={},
+        mapping_getter=lambda: {},
+        event_callback=AsyncMock(),
+        device_type=DeviceType.GAMEPAD,
+    )
+    device.device = SimpleNamespace(absinfo=lambda _code: absinfo)
+    device.uinput = OutputWriter()
+    device.update_analog_inputs({"left_trigger": {"type": "axis", "axes": [axis]}})
+    return device
+
+
+def _router_target(device):
+    router = GamepadOutputRouter(logging.getLogger(__name__))
+    return router.resolve(SimpleNamespace(), {"hardware": [device]}, "hardware")
+
+
+@pytest.mark.parametrize("identity", [{"evdev": "ABS_Z"}, {"evdev_code": 2}])
+@pytest.mark.parametrize("saved_range", [False, True])
+@pytest.mark.parametrize("target_kind", ["same", "left", "axis", "analog"])
+def test_hardware_axis_routes_with_saved_or_discovered_metadata(identity, saved_range, target_kind):
+    axis = {"role": "x", **identity}
+    if saved_range:
+        axis.update(minimum=100, maximum=900, rest=200)
+    original = copy.deepcopy(axis)
+    device = _hardware(axis, absinfo=evdev.AbsInfo(200, 100, 900, 0, 0, 0))
+    original_inputs = copy.deepcopy(device.analog_inputs)
+    target = _router_target(device)
+    assert target is not None and target.output_axes
+    spec = target.output_axes[0]
+    assert (spec.evdev, spec.minimum, spec.maximum, spec.neutral) == ("ABS_Z", 100, 900, 200)
+    assert device.analog_inputs == original_inputs
+    assert axis == original
+    device._gamepad_output_resolver = lambda _id, _context: target
+    device.state.analog_axis_values["left_trigger"] = {"x": 1.0, "x_signed": 1.0}
+    config = AnalogControlConfig(
+        name="Route",
+        input_type="axis",
+        gamepad_output=AnalogGamepadOutputConfig(
+            enabled=True,
+            output_id="hardware",
+            target=target_kind,
+            target_axis="abs_z" if target_kind == "axis" else None,
+            target_analog_id="left_trigger" if target_kind == "analog" else None,
+        ),
+    )
+    deps = ActionExecutionDeps(
+        asyncio_mod=asyncio,
+        evdev_mod=evdev,
+        uinput_writer=identity_uinput_writer,
+        fire_and_observe_fn=lambda coro, _label: asyncio.create_task(coro),
+    )
+    emit_gamepad_output(device, "left_trigger", "left_trigger", config, deps=deps)
+    reset_gamepad_output(device, "left_trigger", "left_trigger", config, deps=deps)
+    assert device.uinput.events == [
+        (evdev.ecodes.EV_ABS, evdev.ecodes.ABS_Z, 900),
+        (evdev.ecodes.EV_ABS, evdev.ecodes.ABS_Z, 200),
+    ]
+
+
+def test_hardware_axis_preserves_saved_calibration_over_absinfo() -> None:
+    device = _hardware(
+        {"role": "x", "evdev": "ABS_Z", "minimum": 10, "maximum": 500, "rest": 50},
+        absinfo=evdev.AbsInfo(0, 0, 1023, 0, 0, 0),
+    )
+    target = _router_target(device)
+    assert target is not None and target.output_axes
+    axis = target.output_axes[0]
+    assert (axis.minimum, axis.maximum, axis.neutral) == (10, 500, 50)
+
+
+def test_hardware_axis_without_saved_or_runtime_range_is_not_advertised() -> None:
+    device = _hardware({"role": "x", "evdev": "ABS_Z"}, absinfo=None)
+    target = _router_target(device)
+    assert target is not None
+    assert target.output_axes == ()
+
+
+def test_hardware_axis_can_use_cached_range_without_calibration() -> None:
+    device = _hardware({"role": "x", "evdev": "ABS_Z"}, absinfo=None)
+    device.analog_axis_ranges[("left_trigger", "x")] = (100, 900)
+    target = _router_target(device)
+    assert target is not None and target.output_axes
+    axis = target.output_axes[0]
+    assert (axis.minimum, axis.maximum, axis.neutral) == (100, 900, 100)

--- a/tests/session/test_analog_controls.py
+++ b/tests/session/test_analog_controls.py
@@ -30,6 +30,67 @@ def test_gamepad_output_deadzone_defaults_to_zero() -> None:
     assert AnalogGamepadOutputConfig().deadzone == 0.0
 
 
+@pytest.mark.parametrize("axis", ["ABS_X", "ABS_HAT0X", "ABS_THROTTLE"])
+@pytest.mark.parametrize("rest", [None, 100])
+def test_explicit_output_axis_round_trips_toml_and_runtime_payload(temp_config_dir, axis, rest):
+    from types import SimpleNamespace
+
+    from keymasq.keymasqd.runtime.action_parser import parse_analog_control_config
+    from keymasq.session.manager.payload.analog import serialize, serialize_signature
+
+    config = AnalogControlConfig(
+        name="Axis Output",
+        input_type="axis",
+        gamepad_output=AnalogGamepadOutputConfig(
+            enabled=True,
+            target="axis",
+            target_axis=axis,
+            output_direction="both",
+            output_rest=rest,
+            output_invert=True,
+        ),
+    )
+    AnalogControlManager().save_analog_control(config)
+    loaded = AnalogControlManager().get_analog_control(config.name)
+    assert loaded == config
+    payload = serialize(SimpleNamespace(), config, "hardware")
+    assert parse_analog_control_config(SimpleNamespace(), payload, json_object=None) == config
+    assert (
+        serialize_signature(SimpleNamespace(), config, "hardware")["gamepad_output"]["target_axis"]
+        == axis.lower()
+    )
+
+
+def test_explicit_output_axis_validation() -> None:
+    with pytest.raises(ValueError, match="valid ABS"):
+        AnalogGamepadOutputConfig(target="axis", target_axis="KEY_A")
+    with pytest.raises(ValueError, match="valid ABS"):
+        AnalogGamepadOutputConfig(target="axis")
+    with pytest.raises(ValueError, match="1D"):
+        validate_analog_control_config(
+            AnalogControlConfig(
+                name="Stick",
+                input_type="stick",
+                gamepad_output=AnalogGamepadOutputConfig(target="axis", target_axis="ABS_X"),
+            )
+        )
+
+
+@pytest.mark.parametrize("target", ["same", "left", "right", "analog"])
+def test_legacy_output_targets_preserve_automatic_rest(temp_config_dir, target) -> None:
+    config = AnalogControlConfig(
+        name="Legacy",
+        input_type="axis",
+        gamepad_output=AnalogGamepadOutputConfig(
+            enabled=True,
+            target=target,
+            target_analog_id="brake" if target == "analog" else None,
+        ),
+    )
+    AnalogControlManager().save_analog_control(config)
+    assert AnalogControlManager().get_analog_control("Legacy") == config
+
+
 def test_analog_control_non_finite_mouse_values_use_defaults(temp_config_dir) -> None:
     config_path = temp_config_dir / "analog_controls" / "non_finite.toml"
     config_path.write_text(


### PR DESCRIPTION
## Summary

1D analog controls can now select any supported destination axis, including individual stick axes, triggers, hats, and learned hardware axes. For example, a trigger can drive either half of a stick using the destination's range and neutral value.

- Add shared `OutputAxis` metadata for the editor, runtime, and future virtual-device templates.
- Preserve existing target configurations and unavailable saved selections; add automatic neutral values, per-axis resets, and hat hysteresis.
- Resolve hardware capabilities using saved metadata plus cached grab-time calibration. Support valid numeric-only axis identities, and skip invalid identities safely.
- Keep single-axis output compatible with gyro offsets. Update behavior docs and regression coverage.

## Testing

- [x] `./scripts/check.sh`: Ruff, BasedPyright, Stylelint, and 3,063 tests passed; 28 tests skipped because uinput access is unavailable.
- VM suites skipped: `AGENTS.md` defines `./scripts/check.sh` as the full agent handoff gate, with no additional checks expected.
- GUI screenshots: no screenshot assets regenerated. GTK tests cover the axis picker, saved selections, and neutral-value controls.
- Regression tests cover supported and unsupported axes, custom ranges, signed routing, hat hysteresis, configuration/IPC round trips, profile-change resets, and gyro coexistence.
- Hardware router regressions exercise real calibration and routing code with mocked hardware I/O. They verify named/numeric-only identities, saved/discovered ranges, saved calibration precedence, missing-range rejection, and emission/reset across legacy and explicit-axis targets.

## Notes

- No packaging changes.
- Daemon output uses destination axis capabilities and only writes/resets the selected axis. Hardware resolution uses cached metadata without querying the physical device during event handling.
- GUI adds an Output Axis dropdown and Use Axis Neutral switch for 1D controls.
- Shared metadata is isolated in commit `c086cd45` for the templates branch to consume; subsequent fixes are included in the full branch.
