### PR TITLE
Add client-owned macro requests and opt-in playback ordering

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -28,8 +28,9 @@ keymasq --json status
 
 ### type
 
-Queue text as a temporary keyboard macro. Text requests play in order across
-clients. Use `--wait` to wait for completion and cancel this request on interruption.
+Submit text as a temporary keyboard macro. Requests can run concurrently. Use
+`--ordered` to serialize with other requests that opt in, and `--wait` to wait
+for completion and cancel this request on interruption.
 
 ```bash
 keymasq type "hello"
@@ -52,6 +53,7 @@ keymasq type --print-json "hello"
 | `--pause-ms MS` | Pause between typed characters. Use `0` for no inter-key delay. Default: `10` |
 | `--speed SPEED` | Playback speed multiplier for event timestamps. Explicit wait controls keep their wall-clock duration |
 | `--no-unicode` | Fail on unsupported characters instead of using Linux Ctrl+Shift+U input |
+| `--ordered` | Serialize with other requests that opt into ordering |
 | `--wait` | Wait for completion; SIGINT or SIGTERM cancels this request |
 | `--print-json` | Print the compiled macro JSON instead of playing it |
 
@@ -118,7 +120,7 @@ Control macro playback.
 ```bash
 keymasq macros list
 keymasq macros create <name> [--force] [JSON]
-keymasq macros play <name> [--speed SPEED] [--wait]
+keymasq macros play <name> [--speed SPEED] [--wait] [--ordered]
 keymasq macros delete <name>
 keymasq macros cancel
 ```

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -138,6 +138,8 @@ keymasq macros cancel
 | Option | Description |
 |---|---|
 | `--speed SPEED` | Playback speed multiplier for event timestamps; explicit wait controls are not scaled |
+| `--wait` | Wait for the terminal playback result; interruption cancels this request |
+| `--ordered` | Opt into the shared FIFO with other ordered requests; concurrent playback is the default |
 
 **Options for `create`:**
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -28,7 +28,8 @@ keymasq --json status
 
 ### type
 
-Compile text into a temporary keyboard macro and play it immediately.
+Queue text as a temporary keyboard macro. Text requests play in order across
+clients. Use `--wait` to wait for completion and cancel this request on interruption.
 
 ```bash
 keymasq type "hello"
@@ -51,6 +52,7 @@ keymasq type --print-json "hello"
 | `--pause-ms MS` | Pause between typed characters. Use `0` for no inter-key delay. Default: `10` |
 | `--speed SPEED` | Playback speed multiplier for event timestamps. Explicit wait controls keep their wall-clock duration |
 | `--no-unicode` | Fail on unsupported characters instead of using Linux Ctrl+Shift+U input |
+| `--wait` | Wait for completion; SIGINT or SIGTERM cancels this request |
 | `--print-json` | Print the compiled macro JSON instead of playing it |
 
 When no text argument is given, `type` reads the full text from stdin. By
@@ -116,7 +118,7 @@ Control macro playback.
 ```bash
 keymasq macros list
 keymasq macros create <name> [--force] [JSON]
-keymasq macros play <name> [--speed SPEED]
+keymasq macros play <name> [--speed SPEED] [--wait]
 keymasq macros delete <name>
 keymasq macros cancel
 ```
@@ -181,3 +183,6 @@ The default category is `mainline`, which shows the normal passthrough and
 remap-action paths. Use `--include combo` for combo-specific timing and
 `--include macro` for stored-macro loading and playback timing, or
 `--include internal` for low-level daemon details.
+
+See [Playback requests](PLAYBACK_REQUESTS.md) for completion results, exit codes,
+and the session protocol for third-party clients.

--- a/docs/PLAYBACK_REQUESTS.md
+++ b/docs/PLAYBACK_REQUESTS.md
@@ -13,7 +13,7 @@ Send text with tracking enabled:
 {"command":"type_text","text":"hello<enter>","track":true}
 ```
 
-The session immediately acknowledges queue acceptance:
+The session immediately acknowledges request acceptance:
 
 ```json
 {"status":"ok","playback_id":"…","state":"queued"}
@@ -40,12 +40,16 @@ Named macros use the same protocol:
 {"command":"play_macro","name":"My macro","track":true}
 ```
 
-Text requests share one FIFO queue across session clients. Compilation and
-playback finish before the next text request starts, preventing interleaved text.
-Add `"ordered":true` to a tracked named macro to put it in the same queue.
-Other named macros and hardware-triggered macros can still run concurrently.
+Text and named macro requests run concurrently by default. Tracking and waiting
+for completion do not serialize requests.
 
-`track` defaults to false. Text still queues without tracking, and its acceptance
+Add `"ordered":true` to a text or named macro request to opt into a shared FIFO
+queue across session clients. Compilation and playback finish before the next
+ordered request starts. Only requests that opt in use this queue; ordinary
+requests and hardware-triggered macros can still run concurrently. Ordering
+follows acceptance order at the session socket, not shell process launch order.
+
+`track` defaults to false. Text still returns immediately without tracking, and its acceptance
 response includes a playback ID. Untracked named macros retain their immediate
 start acknowledgement. Use tracking when the result matters.
 
@@ -91,9 +95,11 @@ keymasq type --wait 'hello<enter>'
 keymasq type --wait 'first' && keymasq type --wait 'second'
 keymasq macros play --wait 'My macro'
 keymasq type --wait --json 'hello'
+keymasq type --ordered --wait 'hello'
 ```
 
-`--wait` keeps the CLI connected until a terminal result arrives. Successful
+`--ordered` opts into the shared FIFO. `--wait` alone permits concurrent playback
+and keeps the CLI connected until a terminal result arrives. Successful
 completion exits with status 0; cancellation or failure exits with status 1.
 SIGINT, including Ctrl+C, cancels this request and exits with status 130. SIGTERM
 cancels it and exits with status 143. The CLI waits up to three seconds for the

--- a/docs/PLAYBACK_REQUESTS.md
+++ b/docs/PLAYBACK_REQUESTS.md
@@ -65,7 +65,12 @@ Use the playback ID on the same connection:
 A query returns the current state and any result fields. Cancellation returns the
 current state after requesting the stop. If the request is still being submitted
 to the daemon, cancellation follows its start acknowledgement. The terminal event
-confirms the outcome. Completion can win a race with cancellation.
+confirms the outcome. Completion can win a race with cancellation. If the daemon
+has not acknowledged cancellation within two seconds, the command returns an
+error with an unknown outcome. The request remains tracked until a terminal event
+or daemon disconnect arrives. An acknowledgement timeout does not release the
+next ordered request. Disconnect and shutdown send cancellations concurrently so
+this timeout does not multiply by the number of requests.
 
 Cancelling queued work prevents it from starting. Cancelling running work stops
 that macro and its children and releases their held outputs. Requests belong to

--- a/docs/PLAYBACK_REQUESTS.md
+++ b/docs/PLAYBACK_REQUESTS.md
@@ -1,0 +1,104 @@
+# Playback requests
+
+Clients can submit text or named macros to `keymasq-session`, receive completion
+results, and cancel their own requests. The session socket is
+`$XDG_RUNTIME_DIR/keymasq/session.sock`. Messages are UTF-8 JSON objects, one per
+line. Keep the connection open to receive results or cancel a request.
+
+## Submit and wait
+
+Send text with tracking enabled:
+
+```json
+{"command":"type_text","text":"hello<enter>","track":true}
+```
+
+The session immediately acknowledges queue acceptance:
+
+```json
+{"status":"ok","playback_id":"…","state":"queued"}
+```
+
+Acceptance does not mean the text compiled successfully or played. After playback
+ends, the requesting connection receives one terminal event:
+
+```json
+{"event":"macro_playback_finished","status":"ok","playback_id":"…","state":"completed","char_count":12,"event_count":12}
+```
+
+Counts depend on the input and compilation settings. `char_count` counts the
+original input string, including inline controls. Terminal states are `completed`,
+`cancelled`, and `failed`. Cancellation and failure have `status: "error"` and a
+`message`. Compilation, macro lookup, and runtime errors produce failure results.
+Completion means Keymasq finished the macro and released its held outputs,
+including child macros. It does not confirm that an application consumed the
+input or updated its UI.
+
+Named macros use the same protocol:
+
+```json
+{"command":"play_macro","name":"My macro","track":true}
+```
+
+Text requests share one FIFO queue across session clients. Compilation and
+playback finish before the next text request starts, preventing interleaved text.
+Add `"ordered":true` to a tracked named macro to put it in the same queue.
+Other named macros and hardware-triggered macros can still run concurrently.
+
+`track` defaults to false. Text still queues without tracking, and its acceptance
+response includes a playback ID. Untracked named macros retain their immediate
+start acknowledgement. Use tracking when the result matters.
+
+## Query and cancel
+
+Use the playback ID on the same connection:
+
+```json
+{"command":"get_macro_playback","playback_id":"…"}
+{"command":"cancel_macro_request","playback_id":"…"}
+```
+
+A query returns the current state and any result fields. Cancellation returns the
+current state after requesting the stop. If the request is still being submitted
+to the daemon, cancellation follows its start acknowledgement. The terminal event
+confirms the outcome. Completion can win a race with cancellation.
+
+Cancelling queued work prevents it from starting. Cancelling running work stops
+that macro and its children and releases their held outputs. Requests belong to
+the socket connection that submitted them. Another connection cannot query or
+cancel them, even with a known playback ID. Caller-supplied IDs on submissions
+are ignored.
+
+Tracked requests default to `"cancel_on_disconnect":true`. Closing the connection
+cancels its queued and active requests. Set `"cancel_on_disconnect":false` to let
+playback continue after disconnect. Untracked requests default to continuing.
+Ownership cannot transfer to a new connection.
+
+The session accepts at most 128 active or queued requests and retains the last
+256 terminal results across connected clients. Older IDs return an unknown-ID
+error. Detached completed requests are discarded. A daemon disconnect reports
+failure with an unknown playback outcome and clears pending work. Requests are
+not replayed after reconnect.
+
+The existing `cancel_macro_playback` command and global stop bindings still stop
+all macros. They also cancel queued requests. `cancel_macro_request` is the
+command for stopping one client's individual playback.
+
+## CLI
+
+```sh
+keymasq type --wait 'hello<enter>'
+keymasq type --wait 'first' && keymasq type --wait 'second'
+keymasq macros play --wait 'My macro'
+keymasq type --wait --json 'hello'
+```
+
+`--wait` keeps the CLI connected until a terminal result arrives. Successful
+completion exits with status 0; cancellation or failure exits with status 1.
+SIGINT, including Ctrl+C, cancels this request and exits with status 130. SIGTERM
+cancels it and exits with status 143. The CLI waits up to three seconds for the
+cancellation event before closing its connection, which also requests cancellation.
+There is no playback duration timeout.
+
+Without `--wait`, the CLI returns after acceptance and playback continues after
+it disconnects. `--print-json` only compiles text and never submits playback.

--- a/keymasq/cli/__main__.py
+++ b/keymasq/cli/__main__.py
@@ -83,6 +83,9 @@ def main() -> None:
     type_parser.add_argument(
         "--wait", action="store_true", help="Wait for completion; interrupt to cancel this playback"
     )
+    type_parser.add_argument(
+        "--ordered", action="store_true", help="Serialize with other requests that use --ordered"
+    )
     _add_json_output(type_parser)
     type_parser.add_argument("text", nargs="*", help="Text to type; stdin is used when omitted")
     type_parser.add_argument(
@@ -137,6 +140,9 @@ def main() -> None:
     macros_play_parser = macros_sub.add_parser("play", help="Play a macro by name")
     macros_play_parser.add_argument(
         "--wait", action="store_true", help="Wait for completion; interrupt to cancel this playback"
+    )
+    macros_play_parser.add_argument(
+        "--ordered", action="store_true", help="Serialize with other requests that use --ordered"
     )
     macros_play_parser.add_argument("name", help="Macro name")
     macros_play_parser.add_argument(
@@ -239,6 +245,7 @@ def main() -> None:
             use_unicode_input=not args.no_unicode,
             print_json=args.print_json,
             wait=args.wait,
+            ordered=args.ordered,
             json_output=json_output,
         )
     elif args.command == "macros":
@@ -257,6 +264,7 @@ def main() -> None:
                 args.speed,
                 json_output=json_output,
                 wait=args.wait,
+                ordered=args.ordered,
             )
         elif args.macros_command == "cancel":
             commands.cancel_macro_cli(json_output=json_output)

--- a/keymasq/cli/__main__.py
+++ b/keymasq/cli/__main__.py
@@ -80,6 +80,10 @@ def main() -> None:
             f"Full reference: {_docs_url()}"
         ),
     )
+    type_parser.add_argument(
+        "--wait", action="store_true", help="Wait for completion; interrupt to cancel this playback"
+    )
+    _add_json_output(type_parser)
     type_parser.add_argument("text", nargs="*", help="Text to type; stdin is used when omitted")
     type_parser.add_argument(
         "--down-ms",
@@ -131,6 +135,9 @@ def main() -> None:
     _add_json_output(macros_create_parser)
 
     macros_play_parser = macros_sub.add_parser("play", help="Play a macro by name")
+    macros_play_parser.add_argument(
+        "--wait", action="store_true", help="Wait for completion; interrupt to cancel this playback"
+    )
     macros_play_parser.add_argument("name", help="Macro name")
     macros_play_parser.add_argument(
         "--speed",
@@ -231,6 +238,7 @@ def main() -> None:
             speed=args.speed,
             use_unicode_input=not args.no_unicode,
             print_json=args.print_json,
+            wait=args.wait,
             json_output=json_output,
         )
     elif args.command == "macros":
@@ -244,7 +252,12 @@ def main() -> None:
                 json_output=json_output,
             )
         elif args.macros_command == "play":
-            commands.play_macro_cli(args.name, args.speed, json_output=json_output)
+            commands.play_macro_cli(
+                args.name,
+                args.speed,
+                json_output=json_output,
+                wait=args.wait,
+            )
         elif args.macros_command == "cancel":
             commands.cancel_macro_cli(json_output=json_output)
         elif args.macros_command == "delete":

--- a/keymasq/cli/commands.py
+++ b/keymasq/cli/commands.py
@@ -417,12 +417,26 @@ def _playback_request(payload: JsonObject, wait: bool) -> JsonObject:
 
 
 def play_macro_cli(
-    name: str, speed: float = 1.0, *, json_output: bool = False, wait: bool = False
+    name: str,
+    speed: float = 1.0,
+    *,
+    json_output: bool = False,
+    wait: bool = False,
+    ordered: bool = False,
 ) -> None:
-    result = _playback_request({"command": "play_macro", "name": name, "speed": float(speed)}, wait)
+    result = _playback_request(
+        {
+            "command": "play_macro",
+            "name": name,
+            "speed": float(speed),
+            **({"ordered": True} if ordered else {}),
+        },
+        wait,
+    )
     if _handled_json_or_error(result, json_output):
         return
-    print(f"Played macro: {name}")
+    action = "Completed" if wait else "Queued" if ordered else "Played"
+    print(f"{action} macro: {name}")
 
 
 def create_macro_cli(
@@ -466,6 +480,7 @@ def type_cli(
     use_unicode_input: bool = True,
     print_json: bool = False,
     wait: bool = False,
+    ordered: bool = False,
     json_output: bool = False,
 ) -> None:
     text = " ".join(text_parts) if text_parts else _read_stdin_or_exit("No text provided")
@@ -496,12 +511,13 @@ def type_cli(
             "pause_ms": max(0, int(pause_ms)),
             "use_unicode_input": bool(use_unicode_input),
             "speed": float(speed),
+            **({"ordered": True} if ordered else {}),
         },
         wait,
     )
     if _handled_json_or_error(result, json_output):
         return
-    action = "Completed" if wait else "Queued"
+    action = "Completed" if wait else "Submitted"
     print(f"{action} type macro: {len(text)} chars")
 
 

--- a/keymasq/cli/commands.py
+++ b/keymasq/cli/commands.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import socket
 import sys
@@ -407,8 +408,18 @@ def mpris_status_cli(*, json_output: bool = False) -> None:
     _print_mpris_status(_mpris_payload(result))
 
 
-def play_macro_cli(name: str, speed: float = 1.0, *, json_output: bool = False) -> None:
-    result = _request_or_error({"command": "play_macro", "name": name, "speed": float(speed)})
+def _playback_request(payload: JsonObject, wait: bool) -> JsonObject:
+    if wait:
+        from keymasq.cli.playback import wait_for_playback
+
+        return asyncio.run(wait_for_playback(payload))
+    return _request_or_error(payload)
+
+
+def play_macro_cli(
+    name: str, speed: float = 1.0, *, json_output: bool = False, wait: bool = False
+) -> None:
+    result = _playback_request({"command": "play_macro", "name": name, "speed": float(speed)}, wait)
     if _handled_json_or_error(result, json_output):
         return
     print(f"Played macro: {name}")
@@ -454,6 +465,7 @@ def type_cli(
     speed: float = 1.0,
     use_unicode_input: bool = True,
     print_json: bool = False,
+    wait: bool = False,
     json_output: bool = False,
 ) -> None:
     text = " ".join(text_parts) if text_parts else _read_stdin_or_exit("No text provided")
@@ -476,7 +488,7 @@ def type_cli(
         _print_json(macro_definition_from_events(events))
         return
 
-    result = _request_or_error(
+    result = _playback_request(
         {
             "command": "type_text",
             "text": text,
@@ -484,11 +496,13 @@ def type_cli(
             "pause_ms": max(0, int(pause_ms)),
             "use_unicode_input": bool(use_unicode_input),
             "speed": float(speed),
-        }
+        },
+        wait,
     )
     if _handled_json_or_error(result, json_output):
         return
-    print(f"Played type macro: {len(text)} chars")
+    action = "Completed" if wait else "Queued"
+    print(f"{action} type macro: {len(text)} chars")
 
 
 def cancel_macro_cli(*, json_output: bool = False) -> None:

--- a/keymasq/cli/playback.py
+++ b/keymasq/cli/playback.py
@@ -1,0 +1,90 @@
+"""Wait for a connection-owned playback request without blocking the event loop."""
+
+import asyncio
+import json
+import signal
+from typing import cast
+
+from keymasq.common.paths import SESSION_SOCKET_PATH
+from keymasq.common.types import JsonObject
+
+
+async def wait_for_playback(payload: JsonObject) -> JsonObject:
+    loop = asyncio.get_running_loop()
+    task = asyncio.current_task()
+    interrupted = 0
+
+    def interrupt(signum: int) -> None:
+        nonlocal interrupted
+        interrupted = signum
+        if task is not None:
+            task.cancel()
+
+    for signum in (signal.SIGINT, signal.SIGTERM):
+        loop.add_signal_handler(signum, interrupt, signum)
+    reader: asyncio.StreamReader | None = None
+    writer: asyncio.StreamWriter | None = None
+    playback_id = ""
+    try:
+        reader, writer = await asyncio.open_unix_connection(str(SESSION_SOCKET_PATH))
+        writer.write(
+            (json.dumps({**payload, "track": True, "cancel_on_disconnect": True}) + "\n").encode()
+        )
+        await writer.drain()
+
+        while True:
+            result = await _receive(reader)
+            if result.get("event") == "macro_playback_finished":
+                if result.get("playback_id") == playback_id:
+                    return result
+            elif "event" not in result:
+                if result.get("status") != "ok":
+                    return result
+                playback_id = str(result.get("playback_id", ""))
+                if not playback_id:
+                    return {
+                        "status": "error",
+                        "message": "Session does not support tracked playback",
+                    }
+    except asyncio.CancelledError:
+        if writer is not None and reader is not None and playback_id:
+            try:
+                writer.write(
+                    (
+                        json.dumps({"command": "cancel_macro_request", "playback_id": playback_id})
+                        + "\n"
+                    ).encode()
+                )
+                await writer.drain()
+                async with asyncio.timeout(3):
+                    while True:
+                        result = await _receive(reader)
+                        if (
+                            result.get("event") == "macro_playback_finished"
+                            and result.get("playback_id") == playback_id
+                        ):
+                            break
+            except (OSError, TimeoutError, asyncio.CancelledError):
+                pass
+        raise SystemExit(128 + (interrupted or signal.SIGINT)) from None
+    except (OSError, ValueError) as exc:
+        return {"status": "error", "message": str(exc)}
+    finally:
+        if writer is not None:
+            writer.close()
+            try:
+                await writer.wait_closed()
+            except OSError:
+                pass
+        for signum in (signal.SIGINT, signal.SIGTERM):
+            loop.remove_signal_handler(signum)
+
+
+async def _receive(reader: asyncio.StreamReader) -> JsonObject:
+    while True:
+        line = await reader.readline()
+        if not line:
+            raise ConnectionError("Session disconnected before playback completed")
+        value = json.loads(line)
+        if isinstance(value, dict):
+            return cast(JsonObject, value)

--- a/keymasq/common/ipc.py
+++ b/keymasq/common/ipc.py
@@ -31,6 +31,7 @@ class CommandType(Enum):
     RECORDING_STARTED = "recording_started"
     RECORDING_STOPPED = "recording_stopped"
     RECORDING_PROGRESS = "recording_progress"
+    MACRO_PLAYBACK_FINISHED = "macro_playback_finished"
     MACRO_PLAYBACK_CANCELLED = "macro_playback_cancelled"
     RUNTIME_RESET = "runtime_reset"
     PLAY_MACRO = "play_macro"

--- a/keymasq/keymasqd/daemon_macro_commands.py
+++ b/keymasq/keymasqd/daemon_macro_commands.py
@@ -35,6 +35,8 @@ class _MacroCommandDeviceManager(Protocol):
         playback_options: MacroPlaybackOptions,
     ) -> JsonObject: ...
 
+    async def cancel_macro_request(self, playback_id: str) -> JsonObject: ...
+
     async def cancel_macro_playback(self) -> JsonObject: ...
 
     async def emergency_reset(self) -> JsonObject: ...
@@ -176,6 +178,11 @@ async def handle_macro_command(
         return await play_macro_by_name(daemon, data)
 
     if command_type == CommandType.CANCEL_MACRO_PLAYBACK:
+        if "playback_id" in data:
+            playback_id = coerce_str(data.get("playback_id"), "")
+            if not playback_id:
+                return {"status": "error", "message": "playback_id required"}
+            return await daemon.device_manager.cancel_macro_request(playback_id)
         return await daemon.device_manager.cancel_macro_playback()
 
     if command_type == CommandType.EMERGENCY_RESET:

--- a/keymasq/keymasqd/runtime/macro/options.py
+++ b/keymasq/keymasqd/runtime/macro/options.py
@@ -128,6 +128,7 @@ class MacroPlaybackOptions:
         default=1,
         metadata=_playback_metadata(_parse_playback_int),
     )
+    playback_id: str = field(default="", metadata=_playback_metadata(_parse_playback_text))
     load_stored_macro: bool = True
 
 

--- a/keymasq/keymasqd/runtime/macro/playback.py
+++ b/keymasq/keymasqd/runtime/macro/playback.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 from typing import Any
 
+from keymasq.common.ipc import CommandType
 from keymasq.common.model.actions import normalize_macro_loop_stop_behavior
 from keymasq.keymasqd.runtime.macro import cleanup, loops, scheduler
 from keymasq.keymasqd.runtime.macro.events import list_macro_event_source
@@ -53,7 +54,7 @@ async def play_macro(
     if int(playback_options.trigger_value) != 1:
         return {"status": "ok"}
 
-    if normalized_loop == "toggle":
+    if normalized_loop == "toggle" and not playback_options.playback_id:
         toggle_instances = loops.find_matching_macro_instances(
             manager.macro_state,
             loop_mode="toggle",
@@ -78,6 +79,14 @@ async def play_macro(
         int_value_fn=deps.int_value_fn,
     )
     if event_source.event_count <= 0:
+        if playback_options.playback_id:
+            manager._broadcast_runtime_event(
+                CommandType.MACRO_PLAYBACK_FINISHED,
+                {
+                    "playback_id": playback_options.playback_id,
+                    "state": "completed",
+                },
+            )
         return {"status": "ok"}
 
     _start_macro_instance(
@@ -157,6 +166,7 @@ def _start_macro_instance(
         loop_stop_behavior=normalized_loop_stop_behavior,
         parent_instance_id=parent_instance_id,
     )
+    manager.macro_state.instance_meta[instance_id]["playback_id"] = playback_options.playback_id
     task = deps.asyncio_mod.create_task(
         scheduler.play_macro_task(
             manager,
@@ -177,6 +187,19 @@ def _start_macro_instance(
         )
     )
     manager.macro_state.tasks[instance_id] = task
+    if playback_options.playback_id:
+
+        def finished(done: asyncio.Task[None]) -> None:
+            result: dict[str, object] = {"playback_id": playback_options.playback_id}
+            if done.cancelled():
+                result["state"] = "cancelled"
+            elif (error := done.exception()) is not None:
+                result.update(state="failed", message=str(error))
+            else:
+                result["state"] = "completed"
+            manager._broadcast_runtime_event(CommandType.MACRO_PLAYBACK_FINISHED, result)
+
+        task.add_done_callback(finished)
     return task
 
 

--- a/keymasq/keymasqd/runtime/macro/scheduler.py
+++ b/keymasq/keymasqd/runtime/macro/scheduler.py
@@ -209,11 +209,15 @@ async def play_macro_task(
     except asyncio_mod.CancelledError:
         raise
     except MacroCallError as exc:
-        if _is_child_instance(manager, instance_id):
+        if _is_child_instance(manager, instance_id) or manager.macro_state.instance_meta.get(
+            instance_id, {}
+        ).get("playback_id"):
             raise
         deps.log.error("Macro playback aborted: %s", exc)
     except MacroFileChangedError:
-        if _is_child_instance(manager, instance_id):
+        if _is_child_instance(manager, instance_id) or manager.macro_state.instance_meta.get(
+            instance_id, {}
+        ).get("playback_id"):
             raise MacroCallError(
                 f"{manager.macro_state.call_chain(instance_id)}: macro was modified or removed"
             ) from None
@@ -222,7 +226,9 @@ async def play_macro_task(
             macro_name or "<unnamed>",
         )
     except Exception as exc:
-        if _is_child_instance(manager, instance_id):
+        if _is_child_instance(manager, instance_id) or manager.macro_state.instance_meta.get(
+            instance_id, {}
+        ).get("playback_id"):
             if isinstance(exc, MacroChildPlaybackError):
                 raise
             raise MacroChildPlaybackError(

--- a/keymasq/keymasqd/runtime/manager_macros.py
+++ b/keymasq/keymasqd/runtime/manager_macros.py
@@ -192,16 +192,30 @@ class MacroManagerMixin:
             deps=deps,
         )
 
+    async def cancel_macro_request(self, playback_id: str) -> JsonObject:
+        ids = [
+            instance_id
+            for instance_id, meta in self.macro_state.instance_meta.items()
+            if meta.get("playback_id") == playback_id
+        ]
+        cancelled = await cleanup.cancel_macro_instances(
+            self,
+            ids,
+            deps=self._macro_runtime_deps_factory(),
+        )
+        return {"status": "ok", "cancelled": cancelled > 0}
+
     async def cancel_macro_playback(self) -> JsonObject:
         result = await cleanup.cancel_macro_playback(
             self,
             deps=self._macro_runtime_deps_factory(),
         )
-        if bool(result.get("cancelled", False)):
-            self._broadcast_runtime_event(
-                CommandType.MACRO_PLAYBACK_CANCELLED,
-                {"reason": "cancel_macro_playback", "cancelled": True},
-            )
+        # The session may still be compiling or queueing text even when no
+        # daemon instance is running yet.
+        self._broadcast_runtime_event(
+            CommandType.MACRO_PLAYBACK_CANCELLED,
+            {"reason": "cancel_macro_playback", "cancelled": bool(result.get("cancelled", False))},
+        )
         return result
 
     async def cancel_macro_playback_and_release_outputs(self) -> JsonObject:

--- a/keymasq/session/client.py
+++ b/keymasq/session/client.py
@@ -66,7 +66,7 @@ class KeymasqdClient:
         self.reader = None
         self.writer = None
 
-    async def send_command(self, command: Command, timeout: float = 10.0) -> Response:
+    async def send_command(self, command: Command, timeout: float | None = 10.0) -> Response:
         if not self.writer:
             raise ConnectionError("Not connected to keymasqd")
 

--- a/keymasq/session/manager/command/common.py
+++ b/keymasq/session/manager/command/common.py
@@ -37,6 +37,10 @@ async def send_daemon_request(
     command: Command,
 ) -> Response | None:
     try:
+        if command.data.get("playback_id"):
+            # A local timeout can lose acceptance while the daemon still starts
+            # the macro. Keep ownership until acceptance or transport failure.
+            return await manager.client.send_command(command, timeout=None)
         return await manager.client.send_command(command)
     except OSError as exc:
         log.debug("Daemon request %s failed: %s", command.command.value, exc, exc_info=True)

--- a/keymasq/session/manager/command/macro.py
+++ b/keymasq/session/manager/command/macro.py
@@ -21,7 +21,22 @@ async def handle_macro_commands(
     manager: "SessionManager",
     command: str,
     request: JsonObject,
+    writer: asyncio.StreamWriter | None = None,
 ) -> JsonObject | None:
+    if writer is not None:
+        request = dict(request)
+        if command in {"play_macro", "type_text"}:
+            request.pop("playback_id", None)
+        if command in {"get_macro_playback", "cancel_macro_request"}:
+            playback_id = coerce_str(request.get("playback_id"), "")
+            if command == "get_macro_playback":
+                return manager.playback_requests.status(playback_id, writer)
+            return await manager.playback_requests.cancel(playback_id, writer)
+        if command == "type_text" or (
+            command == "play_macro"
+            and (request.get("track") is True or request.get("ordered") is True)
+        ):
+            return manager.playback_requests.submit(request, writer)
     if command == "list_macros":
         result = await send_daemon_request(manager, Command(command=CommandType.MACRO_LIST_META))
         if result is None:
@@ -145,6 +160,11 @@ async def handle_macro_commands(
                 command=CommandType.MACRO_PLAY_BY_NAME,
                 data={
                     "name": name,
+                    **(
+                        {"playback_id": request["playback_id"]}
+                        if request.get("playback_id")
+                        else {}
+                    ),
                     "replay_mouse_movement": request.get("replay_mouse_movement", True),
                     "replay_mouse_clicks": request.get("replay_mouse_clicks", True),
                     "speed": coerce_float(request.get("speed"), 1.0),
@@ -172,13 +192,17 @@ async def handle_macro_commands(
         except (TypeError, ValueError) as exc:
             return {"status": "error", "message": str(exc)}
 
-        result = await _play_type_macro(manager, events, speed)
+        result = await _play_type_macro(
+            manager, events, speed, coerce_str(request.get("playback_id"), "")
+        )
         if result.get("status") == "ok":
             result.setdefault("char_count", len(text))
             result.setdefault("event_count", len(events))
         return result
 
     if command == "cancel_macro_playback":
+        if hasattr(manager, "playback_requests"):
+            manager.playback_requests.cancel_pending()
         result = await send_daemon_request(
             manager,
             Command(command=CommandType.CANCEL_MACRO_PLAYBACK),
@@ -213,7 +237,12 @@ async def _play_type_macro(
     manager: "SessionManager",
     events: list[JsonObject],
     speed: float,
+    playback_id: str = "",
 ) -> JsonObject:
+    if playback_id:
+        job = manager.playback_requests.requests.get(playback_id)
+        if job is not None and job.cancel_requested:
+            return {"status": "error", "message": "Playback cancelled"}
     if not events:
         return {"status": "error", "message": "type macro produced no events"}
 
@@ -226,6 +255,7 @@ async def _play_type_macro(
             command=CommandType.PLAY_MACRO,
             data={
                 "macro_events": sanitized_events,
+                **({"playback_id": playback_id} if playback_id else {}),
                 "speed": speed,
             },
         ),

--- a/keymasq/session/manager/commands.py
+++ b/keymasq/session/manager/commands.py
@@ -60,7 +60,7 @@ async def handle_session_request(
     if result is not None:
         return result
 
-    result = await handle_macro_commands(manager, command, request)
+    result = await handle_macro_commands(manager, command, request, writer)
     if result is not None:
         return result
 

--- a/keymasq/session/manager/core.py
+++ b/keymasq/session/manager/core.py
@@ -35,6 +35,7 @@ from keymasq.session.superkeys import SuperkeyManager
 
 from . import compositor, events, recording_device_selection
 from .common import JsonObject
+from .playback import PlaybackRequests
 from .profile import application, coordinator, runtime_state
 from .service.connection import DaemonConnectionMixin
 from .service.server import SessionServerMixin
@@ -112,6 +113,7 @@ class SessionManager(SessionServerMixin, ConfigWatcherMixin, DaemonConnectionMix
             asyncio.StreamWriter,
             asyncio.Task[None],
         ] = {}
+        self.playback_requests = PlaybackRequests(self)
         self.capture_state = CaptureRuntimeState()
 
         self.exec_state = ExecRuntimeState()
@@ -263,6 +265,7 @@ class SessionManager(SessionServerMixin, ConfigWatcherMixin, DaemonConnectionMix
                 log.exception("Unexpected failure ending daemon capture during session shutdown")
         self.capture_state.tokens.clear()
 
+        await self.playback_requests.shutdown()
         await self.client.disconnect()
         await events.cancel_event_tasks(self)
         if self.action_handler is not None:

--- a/keymasq/session/manager/events.py
+++ b/keymasq/session/manager/events.py
@@ -269,11 +269,19 @@ async def handle_event(
         handle_device_grab_status_event(manager, data)
         return
 
+    if event_type == CommandType.MACRO_PLAYBACK_FINISHED:
+        manager.playback_requests.finished(data)
+        return
+
     if event_type == CommandType.MACRO_PLAYBACK_CANCELLED:
+        if hasattr(manager, "playback_requests"):
+            manager.playback_requests.cancel_pending()
         handle_macro_playback_cancelled_event(manager, data)
         return
 
     if event_type == CommandType.RUNTIME_RESET:
+        if hasattr(manager, "playback_requests"):
+            manager.playback_requests.cancel_pending()
         create_event_task(
             manager,
             handle_runtime_reset_event(manager, data),
@@ -480,6 +488,8 @@ async def handle_stop_macro_trigger(
 
 
 async def handle_cancel_macro_trigger(manager: "SessionManager") -> None:
+    if hasattr(manager, "playback_requests"):
+        manager.playback_requests.cancel_pending()
     try:
         await manager.client.send_command(Command(command=CommandType.CANCEL_MACRO_PLAYBACK))
     except OSError:
@@ -489,6 +499,8 @@ async def handle_cancel_macro_trigger(manager: "SessionManager") -> None:
 
 
 async def handle_emergency_reset_trigger(manager: "SessionManager") -> None:
+    if hasattr(manager, "playback_requests"):
+        manager.playback_requests.cancel_pending()
     try:
         await manager.client.send_command(Command(command=CommandType.EMERGENCY_RESET))
     except OSError:
@@ -842,6 +854,8 @@ def handle_macro_playback_cancelled_event(
     data: JsonObject,
 ) -> None:
     manager.broadcast_to_session_clients({"event": "macro_playback_cancelled", **data})
+    if data.get("cancelled") is False:
+        return
     manager.send_notification(
         "Keymasq: Macro Playback Cancelled",
         "Stopped all running macro playback.",

--- a/keymasq/session/manager/playback.py
+++ b/keymasq/session/manager/playback.py
@@ -1,4 +1,4 @@
-"""Connection-owned playback requests and the FIFO text playback queue."""
+"""Connection-owned playback requests with optional FIFO ordering."""
 
 from __future__ import annotations
 
@@ -38,7 +38,7 @@ class PlaybackRequests:
     def __init__(self, manager: SessionManager) -> None:
         self.manager = manager
         self.requests: dict[str, PlaybackRequest] = {}
-        self.text_lock = asyncio.Lock()
+        self.ordered_lock = asyncio.Lock()
 
     def submit(self, request: JsonObject, writer: asyncio.StreamWriter) -> JsonObject:
         active = sum(job.result["state"] not in TERMINAL_STATES for job in self.requests.values())
@@ -93,8 +93,8 @@ class PlaybackRequests:
 
     async def _run(self, job: PlaybackRequest, request: JsonObject) -> None:
         try:
-            if request.get("command") == "type_text" or request.get("ordered") is True:
-                async with self.text_lock:
+            if request.get("ordered") is True:
+                async with self.ordered_lock:
                     await self._play(job, request)
             else:
                 await self._play(job, request)

--- a/keymasq/session/manager/playback.py
+++ b/keymasq/session/manager/playback.py
@@ -1,0 +1,203 @@
+"""Connection-owned playback requests and the FIFO text playback queue."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+from uuid import uuid4
+
+from keymasq.common.ipc import Command, CommandType
+from keymasq.common.types import JsonObject
+
+if TYPE_CHECKING:
+    from .core import SessionManager
+
+log = logging.getLogger("keymasq-session.playback")
+
+TERMINAL_STATES = {"completed", "cancelled", "failed"}
+MAX_ACTIVE_REQUESTS = 128
+MAX_FINISHED_REQUESTS = 256
+
+
+@dataclass
+class PlaybackRequest:
+    playback_id: str
+    owner: asyncio.StreamWriter | None
+    cancel_on_disconnect: bool
+    notify: bool
+    result: JsonObject
+    completion: asyncio.Future[JsonObject]
+    task: asyncio.Task[None] | None = None
+    submitted: bool = False
+    cancel_requested: bool = False
+
+
+class PlaybackRequests:
+    def __init__(self, manager: SessionManager) -> None:
+        self.manager = manager
+        self.requests: dict[str, PlaybackRequest] = {}
+        self.text_lock = asyncio.Lock()
+
+    def submit(self, request: JsonObject, writer: asyncio.StreamWriter) -> JsonObject:
+        active = sum(job.result["state"] not in TERMINAL_STATES for job in self.requests.values())
+        if active >= MAX_ACTIVE_REQUESTS:
+            return {"status": "error", "message": "Playback queue is full"}
+        playback_id = uuid4().hex
+        tracked = request.get("track") is True
+        job = PlaybackRequest(
+            playback_id,
+            writer,
+            request.get("cancel_on_disconnect", tracked) is True,
+            tracked,
+            {"status": "ok", "playback_id": playback_id, "state": "queued"},
+            asyncio.get_running_loop().create_future(),
+        )
+        self.requests[playback_id] = job
+        job.task = asyncio.create_task(self._run(job, dict(request)))
+        return dict(job.result)
+
+    def status(self, playback_id: str, writer: asyncio.StreamWriter) -> JsonObject:
+        job = self.requests.get(playback_id)
+        if job is None or job.owner is not writer:
+            return {"status": "error", "message": "Unknown playback_id for this connection"}
+        return dict(job.result)
+
+    async def cancel(self, playback_id: str, writer: asyncio.StreamWriter) -> JsonObject:
+        result = self.status(playback_id, writer)
+        if result.get("status") != "ok":
+            return result
+        job = self.requests[playback_id]
+        if job.result["state"] not in TERMINAL_STATES:
+            job.cancel_requested = True
+            if not job.submitted:
+                if job.task is not None:
+                    job.task.cancel()
+                self._finish(job, {"state": "cancelled"})
+            elif job.result["state"] == "running":
+                await self._cancel_daemon(job)
+            # A request being submitted is cancelled by _play once acceptance arrives.
+        return dict(job.result)
+
+    async def _cancel_daemon(self, job: PlaybackRequest) -> None:
+        response = await self.manager.client.send_command(
+            Command(
+                command=CommandType.CANCEL_MACRO_PLAYBACK,
+                data={"playback_id": job.playback_id},
+            ),
+            timeout=None,
+        )
+        if response.status != "ok":
+            raise RuntimeError(response.error or "Cancellation failed")
+
+    async def _run(self, job: PlaybackRequest, request: JsonObject) -> None:
+        try:
+            if request.get("command") == "type_text" or request.get("ordered") is True:
+                async with self.text_lock:
+                    await self._play(job, request)
+            else:
+                await self._play(job, request)
+        except asyncio.CancelledError:
+            self._finish(job, {"state": "cancelled"})
+            raise
+        except Exception as exc:
+            log.exception("Playback request failed")
+            self._finish(job, {"state": "failed", "message": str(exc)})
+
+    async def _play(self, job: PlaybackRequest, request: JsonObject) -> None:
+        from .command.macro import handle_macro_commands
+
+        request["playback_id"] = job.playback_id
+        # Mark submission before awaiting compilation/IPC so disconnect cannot lose
+        # a daemon request whose acknowledgement has not arrived yet.
+        job.submitted = True
+        result = await handle_macro_commands(self.manager, str(request["command"]), request)
+        if result is None or result.get("status") != "ok":
+            self._finish(
+                job,
+                {
+                    "state": "cancelled" if job.cancel_requested else "failed",
+                    "message": (result or {}).get("message", "Playback failed"),
+                },
+            )
+            return
+        if job.result["state"] in TERMINAL_STATES:
+            return
+        job.result.update(result)
+        job.result["state"] = "running"
+        if job.cancel_requested:
+            await self._cancel_daemon(job)
+        terminal = await job.completion
+        self._finish(job, terminal)
+
+    def finished(self, data: JsonObject) -> None:
+        job = self.requests.get(str(data.get("playback_id", "")))
+        if job is not None and not job.completion.done():
+            job.completion.set_result(data)
+
+    def _finish(self, job: PlaybackRequest, result: JsonObject) -> None:
+        if job.result["state"] in TERMINAL_STATES:
+            return
+        job.result.update(result)
+        job.result["status"] = "ok" if job.result["state"] == "completed" else "error"
+        if job.result["state"] == "cancelled":
+            job.result["message"] = "Playback cancelled"
+        if job.notify and job.owner is not None:
+            self.manager.broadcast_to_session_client_ids(
+                {**job.result, "event": "macro_playback_finished"},
+                {id(job.owner)},
+            )
+        if job.owner is None:
+            self.requests.pop(job.playback_id, None)
+        finished = [
+            key for key, value in self.requests.items() if value.result["state"] in TERMINAL_STATES
+        ]
+        for key in finished[:-MAX_FINISHED_REQUESTS]:
+            self.requests.pop(key, None)
+
+    async def disconnect(self, writer: asyncio.StreamWriter) -> None:
+        for job in list(self.requests.values()):
+            if job.owner is not writer:
+                continue
+            if job.cancel_on_disconnect:
+                try:
+                    await self.cancel(job.playback_id, writer)
+                except (OSError, RuntimeError):
+                    pass
+            job.owner = None
+            if job.result["state"] in TERMINAL_STATES:
+                self.requests.pop(job.playback_id, None)
+
+    async def daemon_disconnected(self) -> None:
+        tasks: list[asyncio.Task[None]] = []
+        for job in list(self.requests.values()):
+            self._finish(
+                job, {"state": "failed", "message": "Daemon disconnected; playback outcome unknown"}
+            )
+            if job.task is not None and not job.task.done():
+                job.task.cancel()
+                tasks.append(job.task)
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)
+
+    def cancel_pending(self) -> None:
+        """Stop queued work when the global macro stop or runtime reset fires."""
+        for job in list(self.requests.values()):
+            if job.result["state"] in TERMINAL_STATES:
+                continue
+            job.cancel_requested = True
+            if not job.submitted:
+                if job.task is not None:
+                    job.task.cancel()
+                self._finish(job, {"state": "cancelled"})
+
+    async def shutdown(self) -> None:
+        self.cancel_pending()
+        for job in list(self.requests.values()):
+            if job.submitted and job.result["state"] not in TERMINAL_STATES:
+                try:
+                    await self._cancel_daemon(job)
+                except (OSError, RuntimeError):
+                    pass
+        await self.daemon_disconnected()

--- a/keymasq/session/manager/playback.py
+++ b/keymasq/session/manager/playback.py
@@ -159,8 +159,11 @@ class PlaybackRequests:
                 {**job.result, "event": "macro_playback_finished"},
                 {id(job.owner)},
             )
-        if job.owner is None:
-            self.requests.pop(job.playback_id, None)
+        # Reinsert terminal requests so eviction follows completion order, even
+        # when an early request finishes after many later submissions.
+        self.requests.pop(job.playback_id, None)
+        if job.owner is not None:
+            self.requests[job.playback_id] = job
         finished = [
             key for key, value in self.requests.items() if value.result["state"] in TERMINAL_STATES
         ]

--- a/keymasq/session/manager/playback.py
+++ b/keymasq/session/manager/playback.py
@@ -19,6 +19,7 @@ log = logging.getLogger("keymasq-session.playback")
 TERMINAL_STATES = {"completed", "cancelled", "failed"}
 MAX_ACTIVE_REQUESTS = 128
 MAX_FINISHED_REQUESTS = 256
+CANCEL_ACK_TIMEOUT_S = 2.0
 
 
 @dataclass
@@ -76,20 +77,29 @@ class PlaybackRequests:
                     job.task.cancel()
                 self._finish(job, {"state": "cancelled"})
             elif job.result["state"] == "running":
-                await self._cancel_daemon(job)
+                error = await self._cancel_daemon(job)
+                if error is not None:
+                    return {**job.result, "status": "error", "message": error}
             # A request being submitted is cancelled by _play once acceptance arrives.
         return dict(job.result)
 
-    async def _cancel_daemon(self, job: PlaybackRequest) -> None:
-        response = await self.manager.client.send_command(
-            Command(
-                command=CommandType.CANCEL_MACRO_PLAYBACK,
-                data={"playback_id": job.playback_id},
-            ),
-            timeout=None,
-        )
+    async def _cancel_daemon(self, job: PlaybackRequest) -> str | None:
+        try:
+            response = await self.manager.client.send_command(
+                Command(
+                    command=CommandType.CANCEL_MACRO_PLAYBACK,
+                    data={"playback_id": job.playback_id},
+                ),
+                timeout=CANCEL_ACK_TIMEOUT_S,
+            )
+        except TimeoutError:
+            return "Cancellation acknowledgement timed out; playback outcome unknown"
+        except (OSError, RuntimeError) as exc:
+            log.warning("Playback cancellation request failed: %s", exc)
+            return "Cancellation unavailable; playback outcome unknown"
         if response.status != "ok":
-            raise RuntimeError(response.error or "Cancellation failed")
+            return response.error or "Cancellation failed"
+        return None
 
     async def _run(self, job: PlaybackRequest, request: JsonObject) -> None:
         try:
@@ -157,17 +167,15 @@ class PlaybackRequests:
             self.requests.pop(key, None)
 
     async def disconnect(self, writer: asyncio.StreamWriter) -> None:
-        for job in list(self.requests.values()):
-            if job.owner is not writer:
-                continue
-            if job.cancel_on_disconnect:
-                try:
-                    await self.cancel(job.playback_id, writer)
-                except (OSError, RuntimeError):
-                    pass
-            job.owner = None
-            if job.result["state"] in TERMINAL_STATES:
-                self.requests.pop(job.playback_id, None)
+        jobs = [job for job in self.requests.values() if job.owner is writer]
+        await asyncio.gather(*(self._disconnect_job(job, writer) for job in jobs))
+
+    async def _disconnect_job(self, job: PlaybackRequest, writer: asyncio.StreamWriter) -> None:
+        if job.cancel_on_disconnect:
+            await self.cancel(job.playback_id, writer)
+        job.owner = None
+        if job.result["state"] in TERMINAL_STATES:
+            self.requests.pop(job.playback_id, None)
 
     async def daemon_disconnected(self) -> None:
         tasks: list[asyncio.Task[None]] = []
@@ -194,10 +202,11 @@ class PlaybackRequests:
 
     async def shutdown(self) -> None:
         self.cancel_pending()
-        for job in list(self.requests.values()):
-            if job.submitted and job.result["state"] not in TERMINAL_STATES:
-                try:
-                    await self._cancel_daemon(job)
-                except (OSError, RuntimeError):
-                    pass
+        await asyncio.gather(
+            *(
+                self._cancel_daemon(job)
+                for job in list(self.requests.values())
+                if job.submitted and job.result["state"] not in TERMINAL_STATES
+            )
+        )
         await self.daemon_disconnected()

--- a/keymasq/session/manager/playback.py
+++ b/keymasq/session/manager/playback.py
@@ -85,13 +85,14 @@ class PlaybackRequests:
 
     async def _cancel_daemon(self, job: PlaybackRequest) -> str | None:
         try:
-            response = await self.manager.client.send_command(
-                Command(
-                    command=CommandType.CANCEL_MACRO_PLAYBACK,
-                    data={"playback_id": job.playback_id},
-                ),
-                timeout=CANCEL_ACK_TIMEOUT_S,
-            )
+            async with asyncio.timeout(CANCEL_ACK_TIMEOUT_S):
+                response = await self.manager.client.send_command(
+                    Command(
+                        command=CommandType.CANCEL_MACRO_PLAYBACK,
+                        data={"playback_id": job.playback_id},
+                    ),
+                    timeout=CANCEL_ACK_TIMEOUT_S,
+                )
         except TimeoutError:
             return "Cancellation acknowledgement timed out; playback outcome unknown"
         except (OSError, RuntimeError) as exc:

--- a/keymasq/session/manager/service/connection.py
+++ b/keymasq/session/manager/service/connection.py
@@ -83,6 +83,8 @@ class DaemonConnectionMixin:
 
     async def _handle_keymasqd_disconnect(self: Any) -> None:
         was_connected = self.connected
+        if hasattr(self, "playback_requests"):
+            await self.playback_requests.daemon_disconnected()
         await events.cancel_event_tasks(self)
         await runtime_state.cancel_all_grab_retries(self)
         self.connected = False

--- a/keymasq/session/manager/service/server.py
+++ b/keymasq/session/manager/service/server.py
@@ -131,6 +131,8 @@ class SessionServerMixin:
                 peer.uid,
             )
         finally:
+            if hasattr(self, "playback_requests"):
+                await self.playback_requests.disconnect(writer)
             try:
                 await device_inspector.clear_device_inspectors_for_writer(self, writer)
             except Exception:

--- a/tests/common/test_cli_commands_helpers.py
+++ b/tests/common/test_cli_commands_helpers.py
@@ -563,3 +563,19 @@ def test_type_cli_print_json_infers_mouse_device_type(
 
     payload = json.loads(capsys.readouterr().out)
     assert payload["device_types"] == ["mouse", "keyboard"]
+
+
+@pytest.mark.parametrize("ordered", [False, True])
+@pytest.mark.parametrize("wait", [False, True])
+def test_cli_playback_ordering_is_independent_of_wait(monkeypatch, ordered, wait) -> None:
+    sent = []
+
+    def request(payload, requested_wait):
+        sent.append((payload, requested_wait))
+        return {"status": "ok"}
+
+    monkeypatch.setattr(commands, "_playback_request", request)
+    commands.type_cli(["hello"], wait=wait, ordered=ordered)
+    commands.play_macro_cli("hello", wait=wait, ordered=ordered)
+    assert all(payload.get("ordered", False) == ordered for payload, _ in sent)
+    assert all(requested_wait == wait for _, requested_wait in sent)

--- a/tests/common/test_cli_playback.py
+++ b/tests/common/test_cli_playback.py
@@ -2,31 +2,39 @@ import asyncio
 import json
 import signal
 import sys
+import tempfile
+from collections.abc import Iterator
 from pathlib import Path
 
 import pytest
 
 
+@pytest.fixture
+def socket_path() -> Iterator[Path]:
+    # pytest's per-worker temporary paths can exceed Linux's AF_UNIX limit.
+    with tempfile.TemporaryDirectory(prefix="km-cli-", dir="/tmp") as directory:
+        yield Path(directory) / "session.sock"
+
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize("outcome,exit_code", [("completed", 0), ("failed", 1), ("cancelled", 1)])
 async def test_wait_cli_waits_for_its_terminal_event(
-    tmp_path: Path, outcome: str, exit_code: int
+    socket_path: Path, outcome: str, exit_code: int
 ) -> None:
-    await run_cli(tmp_path, outcome, exit_code)
+    await run_cli(socket_path, outcome, exit_code)
 
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("signum", [signal.SIGINT, signal.SIGTERM])
 async def test_interrupt_cancels_individual_playback(
-    tmp_path: Path, signum: signal.Signals
+    socket_path: Path, signum: signal.Signals
 ) -> None:
-    await run_cli(tmp_path, "cancelled", 128 + signum, signum)
+    await run_cli(socket_path, "cancelled", 128 + signum, signum)
 
 
 async def run_cli(
-    tmp_path: Path, outcome: str, exit_code: int, signum: signal.Signals | None = None
+    socket_path: Path, outcome: str, exit_code: int, signum: signal.Signals | None = None
 ) -> None:
-    socket_path = tmp_path / "session.sock"
     accepted = asyncio.Event()
     finish = asyncio.Event()
     disconnected = asyncio.Event()

--- a/tests/common/test_cli_playback.py
+++ b/tests/common/test_cli_playback.py
@@ -1,0 +1,119 @@
+import asyncio
+import json
+import signal
+import sys
+from pathlib import Path
+
+import pytest
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("outcome,exit_code", [("completed", 0), ("failed", 1), ("cancelled", 1)])
+async def test_wait_cli_waits_for_its_terminal_event(
+    tmp_path: Path, outcome: str, exit_code: int
+) -> None:
+    await run_cli(tmp_path, outcome, exit_code)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("signum", [signal.SIGINT, signal.SIGTERM])
+async def test_interrupt_cancels_individual_playback(
+    tmp_path: Path, signum: signal.Signals
+) -> None:
+    await run_cli(tmp_path, "cancelled", 128 + signum, signum)
+
+
+async def run_cli(
+    tmp_path: Path, outcome: str, exit_code: int, signum: signal.Signals | None = None
+) -> None:
+    socket_path = tmp_path / "session.sock"
+    accepted = asyncio.Event()
+    finish = asyncio.Event()
+    disconnected = asyncio.Event()
+    received: list[dict[str, object]] = []
+
+    async def handle(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        try:
+            received.append(json.loads(await reader.readline()))
+            writer.write(
+                b'{"event":"unrelated"}\n{"status":"ok","playback_id":"owned","state":"queued"}\n'
+            )
+            await writer.drain()
+            accepted.set()
+            if signum is not None:
+                received.append(json.loads(await reader.readline()))
+            else:
+                await finish.wait()
+            writer.write(
+                (
+                    json.dumps(
+                        {
+                            "event": "macro_playback_finished",
+                            "playback_id": "someone-else",
+                            "state": "completed",
+                            "status": "ok",
+                        }
+                    )
+                    + "\n"
+                ).encode()
+            )
+            writer.write(
+                (
+                    json.dumps(
+                        {
+                            "event": "macro_playback_finished",
+                            "playback_id": "owned",
+                            "state": outcome,
+                            "status": "ok" if outcome == "completed" else "error",
+                            "message": outcome,
+                        }
+                    )
+                    + "\n"
+                ).encode()
+            )
+            await writer.drain()
+            await reader.read()
+        finally:
+            writer.close()
+            await writer.wait_closed()
+            disconnected.set()
+
+    server = await asyncio.start_unix_server(handle, path=str(socket_path))
+    script = (
+        "import sys; from pathlib import Path; "
+        "from keymasq.cli import playback, commands; "
+        "playback.SESSION_SOCKET_PATH = Path(sys.argv[1]); "
+        "commands.type_cli(['hello'], wait=True, json_output=True)"
+    )
+    process = await asyncio.create_subprocess_exec(
+        sys.executable,
+        "-c",
+        script,
+        str(socket_path),
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    try:
+        await asyncio.wait_for(accepted.wait(), 5)
+        assert process.returncode is None
+        # Give the CLI time to consume acceptance before sending an OS signal.
+        if signum is not None:
+            await asyncio.sleep(0.05)
+            process.send_signal(signum)
+        else:
+            finish.set()
+        stdout, stderr = await asyncio.wait_for(process.communicate(), 5)
+        assert process.returncode == exit_code, stderr.decode()
+        assert received[0]["track"] is True
+        assert received[0]["cancel_on_disconnect"] is True
+        if signum is not None:
+            assert received[1] == {"command": "cancel_macro_request", "playback_id": "owned"}
+        else:
+            assert json.loads(stdout)["state"] == outcome
+        await asyncio.wait_for(disconnected.wait(), 1)
+    finally:
+        if process.returncode is None:
+            process.kill()
+            await process.wait()
+        server.close()
+        await server.wait_closed()

--- a/tests/common/test_entrypoints_and_cli.py
+++ b/tests/common/test_entrypoints_and_cli.py
@@ -319,6 +319,7 @@ def test_cli_main_type_routes_to_helper(monkeypatch: pytest.MonkeyPatch) -> None
             "speed": 1.25,
             "use_unicode_input": True,
             "print_json": False,
+            "wait": False,
             "json_output": False,
         }
     ]

--- a/tests/common/test_entrypoints_and_cli.py
+++ b/tests/common/test_entrypoints_and_cli.py
@@ -320,6 +320,7 @@ def test_cli_main_type_routes_to_helper(monkeypatch: pytest.MonkeyPatch) -> None
             "use_unicode_input": True,
             "print_json": False,
             "wait": False,
+            "ordered": False,
             "json_output": False,
         }
     ]

--- a/tests/keymasqd/test_device_manager_combo_state.py
+++ b/tests/keymasqd/test_device_manager_combo_state.py
@@ -292,24 +292,25 @@ class TestCombos:
         manager.emergency_reset.assert_awaited_once()
 
     @pytest.mark.asyncio
-    async def test_cancel_macro_playback_broadcasts_when_cancelled(self, monkeypatch):
+    @pytest.mark.parametrize("cancelled", [True, False])
+    async def test_cancel_macro_playback_broadcasts_when_cancelled(self, monkeypatch, cancelled):
         events: list[tuple[CommandType, dict[str, object]]] = []
 
         async def broadcast(event_type: CommandType, data: dict[str, object]) -> None:
             events.append((event_type, data))
 
         manager = DeviceManager(broadcast_callback=broadcast)
-        cancel_macro_playback = AsyncMock(return_value={"status": "ok", "cancelled": True})
+        cancel_macro_playback = AsyncMock(return_value={"status": "ok", "cancelled": cancelled})
         monkeypatch.setattr(cleanup, "cancel_macro_playback", cancel_macro_playback)
 
         result = await manager.cancel_macro_playback()
         await asyncio.sleep(0)
 
-        assert result == {"status": "ok", "cancelled": True}
+        assert result == {"status": "ok", "cancelled": cancelled}
         assert events == [
             (
                 CommandType.MACRO_PLAYBACK_CANCELLED,
-                {"reason": "cancel_macro_playback", "cancelled": True},
+                {"reason": "cancel_macro_playback", "cancelled": cancelled},
             )
         ]
 

--- a/tests/keymasqd/test_tracked_playback.py
+++ b/tests/keymasqd/test_tracked_playback.py
@@ -1,0 +1,120 @@
+import asyncio
+from unittest.mock import MagicMock
+
+import evdev
+import pytest
+
+from keymasq.common.ipc import CommandType
+from keymasq.keymasqd.device_manager import DeviceManager
+from keymasq.keymasqd.runtime.macro import controls
+
+
+def setup_manager():
+    manager = DeviceManager()
+    manager.output_state.keyboard_uinput = MagicMock()
+    events: asyncio.Queue[dict[str, object]] = asyncio.Queue()
+
+    async def broadcast(command, data):
+        if command == CommandType.MACRO_PLAYBACK_FINISHED:
+            events.put_nowait(data)
+
+    manager.broadcast_callback = broadcast
+    return manager, events
+
+
+def key_events(code: int, duration: int) -> list[dict[str, object]]:
+    return [
+        {
+            "type": evdev.ecodes.EV_KEY,
+            "code": code,
+            "value": 1,
+            "t_us": 0,
+            "device_type": "keyboard",
+        },
+        {
+            "type": evdev.ecodes.EV_KEY,
+            "code": code,
+            "value": 0,
+            "t_us": duration,
+            "device_type": "keyboard",
+        },
+    ]
+
+
+@pytest.mark.asyncio
+async def test_completion_follows_key_release_and_task_cleanup() -> None:
+    manager, events = setup_manager()
+    await manager.play_macro(macro_events=key_events(evdev.ecodes.KEY_A, 1000), playback_id="first")
+    result = await asyncio.wait_for(events.get(), 1)
+    assert result == {"playback_id": "first", "state": "completed"}
+    assert not manager.macro_state.tasks
+    assert not manager.macro_state.held_refcount
+    assert manager.output_state.keyboard_uinput.write.call_args_list[-1].args == (
+        evdev.ecodes.EV_KEY,
+        evdev.ecodes.KEY_A,
+        0,
+    )
+
+
+@pytest.mark.asyncio
+async def test_targeted_cancel_releases_only_target_and_acknowledges_once() -> None:
+    manager, events = setup_manager()
+    for playback_id, code in [("first", evdev.ecodes.KEY_A), ("second", evdev.ecodes.KEY_B)]:
+        await manager.play_macro(macro_events=key_events(code, 10_000_000), playback_id=playback_id)
+    async with asyncio.timeout(1):
+        while len(manager.macro_state.held_refcount) < 2:
+            await asyncio.sleep(0.001)
+    await manager.cancel_macro_request("first")
+    assert await asyncio.wait_for(events.get(), 1) == {"playback_id": "first", "state": "cancelled"}
+    assert len(manager.macro_state.tasks) == 1
+    assert ("keyboard", evdev.ecodes.KEY_B) in manager.macro_state.held_refcount
+    assert ("keyboard", evdev.ecodes.KEY_A) not in manager.macro_state.held_refcount
+    await manager.cancel_macro_request("second")
+    assert (await asyncio.wait_for(events.get(), 1))["playback_id"] == "second"
+    await manager.cancel_macro_request("first")
+    assert events.empty()
+
+
+@pytest.mark.asyncio
+async def test_cancel_before_scheduler_starts_still_acknowledges() -> None:
+    manager, events = setup_manager()
+    await manager.play_macro(
+        macro_events=key_events(evdev.ecodes.KEY_A, 10_000_000), playback_id="first"
+    )
+    await manager.cancel_macro_request("first")
+    assert await asyncio.wait_for(events.get(), 1) == {"playback_id": "first", "state": "cancelled"}
+    manager.output_state.keyboard_uinput.write.assert_not_called()
+    assert not manager.macro_state.instance_meta
+
+
+@pytest.mark.asyncio
+async def test_runtime_failure_is_reported_after_cleanup(monkeypatch) -> None:
+    manager, events = setup_manager()
+
+    async def fail(*args, **kwargs):
+        raise RuntimeError("control failed")
+
+    monkeypatch.setattr(controls, "run_macro_control_action", fail)
+    await manager.play_macro(
+        macro_events=[{"macro_action": "wait", "t_us": 0, "duration_ms": 1}], playback_id="first"
+    )
+    result = await asyncio.wait_for(events.get(), 1)
+    assert result["state"] == "failed"
+    assert "control failed" in str(result["message"])
+    assert not manager.macro_state.tasks
+
+
+@pytest.mark.asyncio
+async def test_tracked_toggle_requests_start_independent_instances() -> None:
+    manager, events = setup_manager()
+    for playback_id in ("first", "second"):
+        await manager.play_macro(
+            macro_events=key_events(evdev.ecodes.KEY_A, 10_000_000),
+            playback_id=playback_id,
+            loop_mode="toggle",
+        )
+    assert len(manager.macro_state.tasks) == 2
+    await manager.cancel_macro_playback()
+    results = [await asyncio.wait_for(events.get(), 1) for _ in range(2)]
+    assert {result["playback_id"] for result in results} == {"first", "second"}
+    assert all(result["state"] == "cancelled" for result in results)

--- a/tests/session/test_playback_requests.py
+++ b/tests/session/test_playback_requests.py
@@ -1,0 +1,221 @@
+import asyncio
+from types import SimpleNamespace
+from typing import cast
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from keymasq.common.ipc import Command, CommandType, Response
+from keymasq.common.types import JsonObject
+from keymasq.session.manager.command.macro import handle_macro_commands
+from keymasq.session.manager.core import SessionManager
+from keymasq.session.manager.playback import PlaybackRequests
+
+
+def setup_requests():
+    manager = cast(
+        SessionManager,
+        SimpleNamespace(
+            client=SimpleNamespace(send_command=AsyncMock()),
+            security_policy=SimpleNamespace(macro_exec_timeout_max_ms=1000),
+            broadcast_to_session_client_ids=Mock(),
+        ),
+    )
+    requests = PlaybackRequests(manager)
+    manager.playback_requests = requests
+    sent: asyncio.Queue[Command] = asyncio.Queue()
+
+    async def send(command: Command, timeout: float | None = None) -> Response:
+        assert timeout is None
+        sent.put_nowait(command)
+        if command.command == CommandType.CANCEL_MACRO_PLAYBACK:
+            requests.finished({"playback_id": command.data["playback_id"], "state": "cancelled"})
+        return Response(status="ok", data={"status": "ok"})
+
+    manager.client.send_command = AsyncMock(side_effect=send)
+    return manager, requests, sent
+
+
+def owner() -> asyncio.StreamWriter:
+    return cast(asyncio.StreamWriter, object())
+
+
+async def join(requests: PlaybackRequests, result: JsonObject) -> JsonObject:
+    job = requests.requests[str(result["playback_id"])]
+    assert job.task is not None
+    await asyncio.wait_for(asyncio.shield(job.task), 1)
+    return job.result
+
+
+@pytest.mark.asyncio
+async def test_text_fifo_across_clients_and_owner_only_completion() -> None:
+    manager, requests, sent = setup_requests()
+    first_owner, second_owner = owner(), owner()
+    first = requests.submit({"command": "type_text", "text": "a", "track": True}, first_owner)
+    second = requests.submit({"command": "type_text", "text": "b", "track": True}, second_owner)
+    command = await asyncio.wait_for(sent.get(), 1)
+    assert command.data["playback_id"] == first["playback_id"]
+    assert sent.empty()
+    requests.finished({"playback_id": first["playback_id"], "state": "completed"})
+    assert (await join(requests, first))["state"] == "completed"
+    command = await asyncio.wait_for(sent.get(), 1)
+    assert command.data["playback_id"] == second["playback_id"]
+    requests.finished({"playback_id": second["playback_id"], "state": "completed"})
+    await join(requests, second)
+    notifications = manager.broadcast_to_session_client_ids.call_args_list
+    assert [call.args[1] for call in notifications] == [{id(first_owner)}, {id(second_owner)}]
+
+
+@pytest.mark.asyncio
+async def test_cancel_is_scoped_and_queued_cancellation_never_starts() -> None:
+    _, requests, sent = setup_requests()
+    writer, stranger = owner(), owner()
+    first = requests.submit({"command": "type_text", "text": "a", "track": True}, writer)
+    second = requests.submit({"command": "type_text", "text": "b", "track": True}, writer)
+    await asyncio.wait_for(sent.get(), 1)
+    first_id, second_id = str(first["playback_id"]), str(second["playback_id"])
+    assert (await requests.cancel(first_id, stranger))["status"] == "error"
+    assert requests.status(first_id, stranger)["status"] == "error"
+    assert (await requests.cancel(second_id, writer))["state"] == "cancelled"
+    await requests.cancel(first_id, writer)
+    assert (await join(requests, first))["state"] == "cancelled"
+    command = sent.get_nowait()
+    assert command.command == CommandType.CANCEL_MACRO_PLAYBACK
+    assert command.data == {"playback_id": first_id}
+    assert sent.empty()
+
+
+@pytest.mark.asyncio
+async def test_disconnect_during_acceptance_cancels_after_ack() -> None:
+    manager, requests, sent = setup_requests()
+    accepted = asyncio.Event()
+    original_send = manager.client.send_command
+
+    async def send(command: Command, timeout: float | None = None) -> Response:
+        assert timeout is None
+        result = await original_send(command)
+        if command.command == CommandType.MACRO_PLAY_BY_NAME:
+            await accepted.wait()
+        return result
+
+    manager.client.send_command = AsyncMock(side_effect=send)
+    writer = owner()
+    result = requests.submit({"command": "play_macro", "name": "slow", "track": True}, writer)
+    job = requests.requests[str(result["playback_id"])]
+    await asyncio.wait_for(sent.get(), 1)
+    await requests.disconnect(writer)
+    assert sent.empty()
+    accepted.set()
+    assert job.task is not None
+    await asyncio.wait_for(job.task, 1)
+    assert sent.get_nowait().command == CommandType.CANCEL_MACRO_PLAYBACK
+    assert not requests.requests
+
+
+@pytest.mark.asyncio
+async def test_completion_before_acceptance_and_failure_release_queue() -> None:
+    manager, requests, _ = setup_requests()
+
+    async def send(command: Command, timeout: float | None = None) -> Response:
+        assert timeout is None
+        requests.finished(
+            {
+                "playback_id": command.data["playback_id"],
+                "state": "failed",
+                "message": "output failed",
+            }
+        )
+        return Response(status="ok", data={"status": "ok"})
+
+    manager.client.send_command = AsyncMock(side_effect=send)
+    writer = owner()
+    first = requests.submit({"command": "type_text", "text": "a", "track": True}, writer)
+    second = requests.submit({"command": "type_text", "text": "b", "track": True}, writer)
+    for result in (first, second):
+        terminal = await join(requests, result)
+        assert terminal["state"] == "failed"
+        assert terminal["message"] == "output failed"
+
+
+@pytest.mark.asyncio
+async def test_daemon_loss_finishes_active_and_queued_requests() -> None:
+    _, requests, sent = setup_requests()
+    writer = owner()
+    results = [
+        requests.submit({"command": "type_text", "text": "a", "track": True}, writer)
+        for _ in range(2)
+    ]
+    await asyncio.wait_for(sent.get(), 1)
+    await requests.daemon_disconnected()
+    for result in results:
+        assert requests.status(str(result["playback_id"]), writer)["state"] == "failed"
+    assert sent.empty()
+
+
+@pytest.mark.asyncio
+async def test_detached_text_survives_disconnect_and_caller_cannot_set_id() -> None:
+    manager, requests, sent = setup_requests()
+    writer = owner()
+    result = await handle_macro_commands(
+        manager, "type_text", {"command": "type_text", "text": "a", "playback_id": "forged"}, writer
+    )
+    assert result is not None
+    job = requests.requests[str(result["playback_id"])]
+    await requests.disconnect(writer)
+    command = await asyncio.wait_for(sent.get(), 1)
+    assert command.data["playback_id"] != "forged"
+    requests.finished({"playback_id": result["playback_id"], "state": "completed"})
+    assert job.task is not None
+    await asyncio.wait_for(job.task, 1)
+    assert not requests.requests
+
+
+@pytest.mark.asyncio
+async def test_cancel_during_compilation_prevents_submission(monkeypatch) -> None:
+    from keymasq.session.manager.command import macro
+
+    _, requests, sent = setup_requests()
+    compiling = asyncio.Event()
+    release = asyncio.Event()
+
+    async def compile_later(func, /, *args, **kwargs):
+        compiling.set()
+        await release.wait()
+        return func(*args, **kwargs)
+
+    monkeypatch.setattr(macro.asyncio, "to_thread", compile_later)
+    writer = owner()
+    result = requests.submit({"command": "type_text", "text": "a", "track": True}, writer)
+    await compiling.wait()
+    await requests.cancel(str(result["playback_id"]), writer)
+    release.set()
+    assert (await join(requests, result))["state"] == "cancelled"
+    assert sent.empty()
+
+
+@pytest.mark.asyncio
+async def test_global_stop_cancels_queue_and_submission_in_progress() -> None:
+    manager, requests, sent = setup_requests()
+    release = asyncio.Event()
+    original_send = manager.client.send_command
+
+    async def send(command: Command, timeout: float | None = None) -> Response:
+        assert timeout is None
+        result = await original_send(command)
+        if command.command == CommandType.MACRO_PLAY_BY_NAME:
+            await release.wait()
+        return result
+
+    manager.client.send_command = AsyncMock(side_effect=send)
+    writer = owner()
+    first = requests.submit(
+        {"command": "play_macro", "name": "a", "track": True, "ordered": True}, writer
+    )
+    second = requests.submit({"command": "type_text", "text": "b", "track": True}, writer)
+    await sent.get()
+    requests.cancel_pending()
+    release.set()
+    assert (await join(requests, first))["state"] == "cancelled"
+    assert requests.status(str(second["playback_id"]), writer)["state"] == "cancelled"
+    assert sent.get_nowait().command == CommandType.CANCEL_MACRO_PLAYBACK
+    assert sent.empty()

--- a/tests/session/test_playback_requests.py
+++ b/tests/session/test_playback_requests.py
@@ -342,3 +342,27 @@ async def test_teardown_returns_when_daemon_does_not_acknowledge_cancel(
         assert all(job.result["state"] == "failed" for job in requests.requests.values())
     assert cancellations == 8
     await requests.daemon_disconnected()
+
+
+@pytest.mark.asyncio
+async def test_terminal_retention_uses_completion_order_and_preserves_active_requests(
+    monkeypatch,
+) -> None:
+    _, requests, sent = setup_requests()
+    monkeypatch.setattr(playback_module, "MAX_FINISHED_REQUESTS", 2)
+    writer = owner()
+    results = [
+        requests.submit({"command": "play_macro", "name": "a", "track": True}, writer)
+        for _ in range(4)
+    ]
+    for _ in results:
+        await asyncio.wait_for(sent.get(), 1)
+    first, second, third, active = results
+    for result in (second, third, first):
+        requests.finished({"playback_id": result["playback_id"], "state": "completed"})
+        await join(requests, result)
+    assert requests.status(str(first["playback_id"]), writer)["state"] == "completed"
+    assert requests.status(str(third["playback_id"]), writer)["state"] == "completed"
+    assert requests.status(str(second["playback_id"]), writer)["status"] == "error"
+    assert requests.status(str(active["playback_id"]), writer)["state"] == "running"
+    await requests.daemon_disconnected()

--- a/tests/session/test_playback_requests.py
+++ b/tests/session/test_playback_requests.py
@@ -285,7 +285,8 @@ async def test_cancel_timeout_keeps_request_tracked_and_ordered_queue_blocked(mo
 
     async def send(command: Command, timeout: float | None = None) -> Response:
         if command.command == CommandType.CANCEL_MACRO_PLAYBACK:
-            await asyncio.wait_for(asyncio.Event().wait(), timeout)
+            # Also model a blocked write/drain before the client reply timeout.
+            await asyncio.Event().wait()
         return await original_send(command, timeout=timeout)
 
     manager.client.send_command = AsyncMock(side_effect=send)
@@ -323,7 +324,8 @@ async def test_teardown_returns_when_daemon_does_not_acknowledge_cancel(
         nonlocal cancellations
         if command.command == CommandType.CANCEL_MACRO_PLAYBACK:
             cancellations += 1
-            await asyncio.wait_for(asyncio.Event().wait(), timeout)
+            # Also model a blocked write/drain before the client reply timeout.
+            await asyncio.Event().wait()
         return await original_send(command, timeout=timeout)
 
     manager.client.send_command = AsyncMock(side_effect=send)

--- a/tests/session/test_playback_requests.py
+++ b/tests/session/test_playback_requests.py
@@ -7,6 +7,7 @@ import pytest
 
 from keymasq.common.ipc import Command, CommandType, Response
 from keymasq.common.types import JsonObject
+from keymasq.session.manager import playback as playback_module
 from keymasq.session.manager.command.macro import handle_macro_commands
 from keymasq.session.manager.core import SessionManager
 from keymasq.session.manager.playback import PlaybackRequests
@@ -26,7 +27,11 @@ def setup_requests():
     sent: asyncio.Queue[Command] = asyncio.Queue()
 
     async def send(command: Command, timeout: float | None = None) -> Response:
-        assert timeout is None
+        assert (
+            timeout is None
+            if command.command != CommandType.CANCEL_MACRO_PLAYBACK
+            else timeout is not None
+        )
         sent.put_nowait(command)
         if command.command == CommandType.CANCEL_MACRO_PLAYBACK:
             requests.finished({"playback_id": command.data["playback_id"], "state": "cancelled"})
@@ -100,8 +105,12 @@ async def test_disconnect_during_acceptance_cancels_after_ack() -> None:
     original_send = manager.client.send_command
 
     async def send(command: Command, timeout: float | None = None) -> Response:
-        assert timeout is None
-        result = await original_send(command)
+        assert (
+            timeout is None
+            if command.command != CommandType.CANCEL_MACRO_PLAYBACK
+            else timeout is not None
+        )
+        result = await original_send(command, timeout=timeout)
         if command.command == CommandType.MACRO_PLAY_BY_NAME:
             await accepted.wait()
         return result
@@ -125,7 +134,11 @@ async def test_completion_before_acceptance_and_failure_release_queue() -> None:
     manager, requests, _ = setup_requests()
 
     async def send(command: Command, timeout: float | None = None) -> Response:
-        assert timeout is None
+        assert (
+            timeout is None
+            if command.command != CommandType.CANCEL_MACRO_PLAYBACK
+            else timeout is not None
+        )
         requests.finished(
             {
                 "playback_id": command.data["playback_id"],
@@ -214,8 +227,12 @@ async def test_global_stop_cancels_queue_and_submission_in_progress() -> None:
     original_send = manager.client.send_command
 
     async def send(command: Command, timeout: float | None = None) -> Response:
-        assert timeout is None
-        result = await original_send(command)
+        assert (
+            timeout is None
+            if command.command != CommandType.CANCEL_MACRO_PLAYBACK
+            else timeout is not None
+        )
+        result = await original_send(command, timeout=timeout)
         if command.command == CommandType.MACRO_PLAY_BY_NAME:
             await release.wait()
         return result
@@ -258,3 +275,68 @@ async def test_default_requests_run_concurrently_even_with_an_ordered_request(co
         requests.finished({"playback_id": result["playback_id"], "state": "completed"})
     for result in results:
         assert (await join(requests, result))["state"] == "completed"
+
+
+@pytest.mark.asyncio
+async def test_cancel_timeout_keeps_request_tracked_and_ordered_queue_blocked(monkeypatch) -> None:
+    manager, requests, sent = setup_requests()
+    monkeypatch.setattr(playback_module, "CANCEL_ACK_TIMEOUT_S", 0.01)
+    original_send = manager.client.send_command
+
+    async def send(command: Command, timeout: float | None = None) -> Response:
+        if command.command == CommandType.CANCEL_MACRO_PLAYBACK:
+            await asyncio.wait_for(asyncio.Event().wait(), timeout)
+        return await original_send(command, timeout=timeout)
+
+    manager.client.send_command = AsyncMock(side_effect=send)
+    writer = owner()
+    first = requests.submit(
+        {"command": "play_macro", "name": "a", "track": True, "ordered": True}, writer
+    )
+    second = requests.submit(
+        {"command": "play_macro", "name": "b", "track": True, "ordered": True}, writer
+    )
+    await asyncio.wait_for(sent.get(), 1)
+    result = await asyncio.wait_for(requests.cancel(str(first["playback_id"]), writer), 0.5)
+    assert result["status"] == "error"
+    assert "outcome unknown" in str(result["message"])
+    assert requests.status(str(first["playback_id"]), writer)["state"] == "running"
+    assert sent.empty()
+    requests.finished({"playback_id": first["playback_id"], "state": "cancelled"})
+    assert (await join(requests, first))["state"] == "cancelled"
+    assert (await asyncio.wait_for(sent.get(), 1)).data["playback_id"] == second["playback_id"]
+    requests.finished({"playback_id": second["playback_id"], "state": "completed"})
+    await join(requests, second)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("operation", ["disconnect", "shutdown"])
+async def test_teardown_returns_when_daemon_does_not_acknowledge_cancel(
+    monkeypatch, operation
+) -> None:
+    manager, requests, sent = setup_requests()
+    monkeypatch.setattr(playback_module, "CANCEL_ACK_TIMEOUT_S", 0.1)
+    cancellations = 0
+    original_send = manager.client.send_command
+
+    async def send(command: Command, timeout: float | None = None) -> Response:
+        nonlocal cancellations
+        if command.command == CommandType.CANCEL_MACRO_PLAYBACK:
+            cancellations += 1
+            await asyncio.wait_for(asyncio.Event().wait(), timeout)
+        return await original_send(command, timeout=timeout)
+
+    manager.client.send_command = AsyncMock(side_effect=send)
+    writer = owner()
+    for _ in range(8):
+        requests.submit({"command": "play_macro", "name": "a", "track": True}, writer)
+    for _ in range(8):
+        await asyncio.wait_for(sent.get(), 1)
+    if operation == "disconnect":
+        await asyncio.wait_for(requests.disconnect(writer), 0.5)
+        assert all(job.owner is None for job in requests.requests.values())
+    else:
+        await asyncio.wait_for(requests.shutdown(), 0.5)
+        assert all(job.result["state"] == "failed" for job in requests.requests.values())
+    assert cancellations == 8
+    await requests.daemon_disconnected()

--- a/tests/session/test_playback_requests.py
+++ b/tests/session/test_playback_requests.py
@@ -51,8 +51,12 @@ async def join(requests: PlaybackRequests, result: JsonObject) -> JsonObject:
 async def test_text_fifo_across_clients_and_owner_only_completion() -> None:
     manager, requests, sent = setup_requests()
     first_owner, second_owner = owner(), owner()
-    first = requests.submit({"command": "type_text", "text": "a", "track": True}, first_owner)
-    second = requests.submit({"command": "type_text", "text": "b", "track": True}, second_owner)
+    first = requests.submit(
+        {"command": "type_text", "text": "a", "track": True, "ordered": True}, first_owner
+    )
+    second = requests.submit(
+        {"command": "type_text", "text": "b", "track": True, "ordered": True}, second_owner
+    )
     command = await asyncio.wait_for(sent.get(), 1)
     assert command.data["playback_id"] == first["playback_id"]
     assert sent.empty()
@@ -70,8 +74,12 @@ async def test_text_fifo_across_clients_and_owner_only_completion() -> None:
 async def test_cancel_is_scoped_and_queued_cancellation_never_starts() -> None:
     _, requests, sent = setup_requests()
     writer, stranger = owner(), owner()
-    first = requests.submit({"command": "type_text", "text": "a", "track": True}, writer)
-    second = requests.submit({"command": "type_text", "text": "b", "track": True}, writer)
+    first = requests.submit(
+        {"command": "type_text", "text": "a", "track": True, "ordered": True}, writer
+    )
+    second = requests.submit(
+        {"command": "type_text", "text": "b", "track": True, "ordered": True}, writer
+    )
     await asyncio.wait_for(sent.get(), 1)
     first_id, second_id = str(first["playback_id"]), str(second["playback_id"])
     assert (await requests.cancel(first_id, stranger))["status"] == "error"
@@ -129,8 +137,12 @@ async def test_completion_before_acceptance_and_failure_release_queue() -> None:
 
     manager.client.send_command = AsyncMock(side_effect=send)
     writer = owner()
-    first = requests.submit({"command": "type_text", "text": "a", "track": True}, writer)
-    second = requests.submit({"command": "type_text", "text": "b", "track": True}, writer)
+    first = requests.submit(
+        {"command": "type_text", "text": "a", "track": True, "ordered": True}, writer
+    )
+    second = requests.submit(
+        {"command": "type_text", "text": "b", "track": True, "ordered": True}, writer
+    )
     for result in (first, second):
         terminal = await join(requests, result)
         assert terminal["state"] == "failed"
@@ -142,7 +154,9 @@ async def test_daemon_loss_finishes_active_and_queued_requests() -> None:
     _, requests, sent = setup_requests()
     writer = owner()
     results = [
-        requests.submit({"command": "type_text", "text": "a", "track": True}, writer)
+        requests.submit(
+            {"command": "type_text", "text": "a", "track": True, "ordered": True}, writer
+        )
         for _ in range(2)
     ]
     await asyncio.wait_for(sent.get(), 1)
@@ -211,7 +225,9 @@ async def test_global_stop_cancels_queue_and_submission_in_progress() -> None:
     first = requests.submit(
         {"command": "play_macro", "name": "a", "track": True, "ordered": True}, writer
     )
-    second = requests.submit({"command": "type_text", "text": "b", "track": True}, writer)
+    second = requests.submit(
+        {"command": "type_text", "text": "b", "track": True, "ordered": True}, writer
+    )
     await sent.get()
     requests.cancel_pending()
     release.set()
@@ -219,3 +235,26 @@ async def test_global_stop_cancels_queue_and_submission_in_progress() -> None:
     assert requests.status(str(second["playback_id"]), writer)["state"] == "cancelled"
     assert sent.get_nowait().command == CommandType.CANCEL_MACRO_PLAYBACK
     assert sent.empty()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("command", ["type_text", "play_macro"])
+async def test_default_requests_run_concurrently_even_with_an_ordered_request(command: str) -> None:
+    _, requests, sent = setup_requests()
+    writer = owner()
+    results = [
+        requests.submit(
+            {"command": command, "text": "a", "name": "a", "track": True, "ordered": ordered},
+            writer,
+        )
+        for ordered in (True, False, False)
+    ]
+    submitted = [await asyncio.wait_for(sent.get(), 1) for _ in results]
+    assert {item.data["playback_id"] for item in submitted} == {
+        result["playback_id"] for result in results
+    }
+    # All three starts were accepted before any completion was delivered.
+    for result in results:
+        requests.finished({"playback_id": result["playback_id"], "state": "completed"})
+    for result in results:
+        assert (await join(requests, result))["state"] == "completed"

--- a/tests/session/test_session_manager_command_runtime.py
+++ b/tests/session/test_session_manager_command_runtime.py
@@ -888,7 +888,6 @@ async def test_type_text_compiles_in_thread_and_forwards_events(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     manager = SessionManager()
-    peer = PeerCredentials(pid=1, uid=1000, gid=1000)
     sent_commands = []
     to_thread_calls = []
 
@@ -903,7 +902,9 @@ async def test_type_text_compiles_in_thread_and_forwards_events(
     monkeypatch.setattr(macro_commands_module.asyncio, "to_thread", fake_to_thread)
     manager.client.send_command = send_command  # type: ignore[method-assign]
 
-    result = await manager._handle_session_request(
+    result = await macro_commands_module.handle_macro_commands(
+        manager,
+        "type_text",
         {
             "command": "type_text",
             "text": "Hi",
@@ -911,10 +912,9 @@ async def test_type_text_compiles_in_thread_and_forwards_events(
             "pause_ms": 0,
             "speed": 1.25,
         },
-        peer,
-        object(),
     )
 
+    assert result is not None
     assert result["status"] == "ok"
     assert result["char_count"] == 2
     assert result["event_count"] == len(sent_commands[0].data["macro_events"])
@@ -928,13 +928,12 @@ async def test_type_text_compiles_in_thread_and_forwards_events(
 @pytest.mark.asyncio
 async def test_type_text_reports_error_when_compilation_produces_no_events() -> None:
     manager = SessionManager()
-    peer = PeerCredentials(pid=1, uid=1000, gid=1000)
     manager.client.send_command = AsyncMock()
 
-    result = await manager._handle_session_request(
+    result = await macro_commands_module.handle_macro_commands(
+        manager,
+        "type_text",
         {"command": "type_text", "text": ""},
-        peer,
-        object(),
     )
 
     assert result == {"status": "error", "message": "type macro produced no events"}
@@ -3826,10 +3825,10 @@ async def test_macro_commands_validate_payloads_and_compile_errors(
         peer,
         object(),
     )
-    type_text_error = await manager._handle_session_request(
+    type_text_error = await macro_commands_module.handle_macro_commands(
+        manager,
+        "type_text",
         {"command": "type_text", "text": "Hi"},
-        peer,
-        object(),
     )
     assert create_missing == {"status": "error", "message": "macro payload required"}
     assert update_missing == {"status": "error", "message": "macro payload required"}
@@ -3839,16 +3838,15 @@ async def test_macro_commands_validate_payloads_and_compile_errors(
 @pytest.mark.asyncio
 async def test_type_text_reports_daemon_failures() -> None:
     manager = SessionManager()
-    peer = PeerCredentials(pid=1, uid=1000, gid=1000)
     payload = {"command": "type_text", "text": "a"}
 
     manager.client.send_command = AsyncMock(side_effect=OSError("daemon down"))
-    unavailable = await manager._handle_session_request(payload, peer, object())
+    unavailable = await macro_commands_module.handle_macro_commands(manager, "type_text", payload)
 
     manager.client.send_command = AsyncMock(
         return_value=Response(status="error", error="play failed")
     )
-    failed = await manager._handle_session_request(payload, peer, object())
+    failed = await macro_commands_module.handle_macro_commands(manager, "type_text", payload)
 
     assert unavailable == {"status": "error", "message": "Daemon unavailable"}
     assert failed == {"status": "error", "message": "play failed"}


### PR DESCRIPTION
## Summary

Macro requests previously acknowledged only that playback started, and cancellation stopped every macro. Add connection-owned playback IDs, status queries, terminal completion events, and individual cancellation.

`keymasq type --wait` and `keymasq macros play --wait` wait for the result; SIGINT and SIGTERM cancel only that request. Text and named macros run concurrently by default. `--ordered`, or `ordered: true` in the session protocol, opts into a shared FIFO used only by other ordered requests. Waiting alone does not serialize playback. Global stop also clears queued requests.

Document the third-party protocol in `docs/PLAYBACK_REQUESTS.md`.

## Testing

- [x] `./scripts/check.sh`: Ruff, BasedPyright, stylelint, and full pytest passed. 3,086 passed; 28 skipped because uinput access was unavailable.
- [x] Added tests for concurrent defaults, opt-in ordering, ownership, cancellation during compilation and acceptance, completion before acceptance, daemon loss, output cleanup, independent toggle requests, and CLI SIGINT/SIGTERM behavior over a Unix socket.
- VM suites not run. The repository's `AGENTS.md` specifies `./scripts/check.sh` as the full agent handoff gate, with nothing beyond it expected.
- GUI screenshot checks: not applicable.

## Notes

- Packaging: no changes.
- Services/protocol: adds tracked playback commands and daemon completion events; tracked requests default to cancellation on client disconnect. Existing untracked named-macro playback remains available.
- GUI: no visual changes.
