### PR TITLE
Fix Unicode type macro activation and confirmation sequence

### DIFF
--- a/docs/MACROS.md
+++ b/docs/MACROS.md
@@ -190,9 +190,15 @@ keystrokes, and Keymasq builds the macro automatically.
 
 If the text contains Unicode or formatted characters, the dialog shows an
 optional Unicode input mode. When enabled, unsupported characters are emitted
-with the Linux `Ctrl+Shift+U`, hexadecimal codepoint, `Enter` sequence. This is
+by pressing `Ctrl+Shift+U`, releasing all three keys, typing the hexadecimal
+codepoint, then pressing `Space` to confirm. Space avoids sending Enter if the
+target does not recognize Unicode input. This is
 best-effort: it works in many text fields, but some apps, games, terminals,
 remote sessions, or input method setups may not accept it.
+
+Previously saved macros keep their compiled key events. Recreate a type macro
+to use this sequence, or edit its events to release the activation chord before
+the codepoint and use Space to confirm.
 
 **How to create one:**
 

--- a/keymasq/common/macro_compile.py
+++ b/keymasq/common/macro_compile.py
@@ -633,6 +633,11 @@ def _append_unicode_char_events(
     t_us += down_ms * 1000
     _append_key_event(events, "keyboard", evdev.ecodes.KEY_U, 0, t_us)
     t_us += modifier_settle_us
+    # Finish the activation chord before entering the codepoint as plain keys.
+    _append_key_event(events, "keyboard", evdev.ecodes.KEY_LEFTSHIFT, 0, t_us)
+    t_us += modifier_settle_us
+    _append_key_event(events, "keyboard", evdev.ecodes.KEY_LEFTCTRL, 0, t_us)
+    t_us += modifier_settle_us
 
     for hex_digit in f"{ord(ch):x}":
         code, needs_shift = char_to_key(hex_digit)
@@ -645,7 +650,8 @@ def _append_unicode_char_events(
             modifier_settle_us,
         )
 
-    code, needs_shift = char_to_key("\n")
+    # Space confirms Unicode input without sending Enter to an unsupported app.
+    code, needs_shift = char_to_key(" ")
     t_us = _append_direct_key_events(
         events,
         code,
@@ -654,10 +660,6 @@ def _append_unicode_char_events(
         down_ms,
         modifier_settle_us,
     )
-    t_us += modifier_settle_us
-    _append_key_event(events, "keyboard", evdev.ecodes.KEY_LEFTSHIFT, 0, t_us)
-    t_us += modifier_settle_us
-    _append_key_event(events, "keyboard", evdev.ecodes.KEY_LEFTCTRL, 0, t_us)
     return t_us
 
 

--- a/tests/common/test_macro_compile.py
+++ b/tests/common/test_macro_compile.py
@@ -352,7 +352,7 @@ def test_type_macro_builder_reports_unsupported_character_position() -> None:
         build_type_macro_events("aé", 10, 0)
 
 
-def test_type_macro_builder_unicode_input_holds_modifiers_until_confirmed() -> None:
+def test_type_macro_builder_unicode_input_releases_chord_before_codepoint() -> None:
     events = build_type_macro_events("é", 10, 0, use_unicode_input=True)
 
     assert [
@@ -362,14 +362,54 @@ def test_type_macro_builder_unicode_input_holds_modifiers_until_confirmed() -> N
         (evdev.ecodes.KEY_LEFTSHIFT, 1),
         (evdev.ecodes.KEY_U, 1),
         (evdev.ecodes.KEY_U, 0),
+        (evdev.ecodes.KEY_LEFTSHIFT, 0),
+        (evdev.ecodes.KEY_LEFTCTRL, 0),
         (evdev.ecodes.KEY_E, 1),
         (evdev.ecodes.KEY_E, 0),
         (evdev.ecodes.KEY_9, 1),
         (evdev.ecodes.KEY_9, 0),
-        (evdev.ecodes.KEY_ENTER, 1),
-        (evdev.ecodes.KEY_ENTER, 0),
-        (evdev.ecodes.KEY_LEFTSHIFT, 0),
-        (evdev.ecodes.KEY_LEFTCTRL, 0),
+        (evdev.ecodes.KEY_SPACE, 1),
+        (evdev.ecodes.KEY_SPACE, 0),
+    ]
+
+
+@pytest.mark.parametrize("down_ms,pause_ms", [(0, 0), (5, 10)])
+def test_unicode_codepoints_and_following_text_have_no_held_modifiers(
+    down_ms: int, pause_ms: int
+) -> None:
+    events = build_type_macro_events("é😀a", down_ms, pause_ms, use_unicode_input=True)
+    held: set[int] = set()
+    plain_presses: list[int] = []
+    last_release_us = -1
+    modifiers = {evdev.ecodes.KEY_LEFTCTRL, evdev.ecodes.KEY_LEFTSHIFT}
+
+    for event in events:
+        code = int(event["code"])
+        if event["value"] == 1:
+            if code == evdev.ecodes.KEY_U:
+                assert held == modifiers
+            elif code not in modifiers:
+                assert not held
+                assert event["t_us"] > last_release_us
+                plain_presses.append(code)
+            held.add(code)
+        else:
+            held.remove(code)
+            if code in modifiers:
+                last_release_us = event["t_us"]
+
+    assert not held
+    assert plain_presses == [
+        evdev.ecodes.KEY_E,
+        evdev.ecodes.KEY_9,
+        evdev.ecodes.KEY_SPACE,
+        evdev.ecodes.KEY_1,
+        evdev.ecodes.KEY_F,
+        evdev.ecodes.KEY_6,
+        evdev.ecodes.KEY_0,
+        evdev.ecodes.KEY_0,
+        evdev.ecodes.KEY_SPACE,
+        evdev.ecodes.KEY_A,
     ]
 
 

--- a/tests/common/test_macro_compile.py
+++ b/tests/common/test_macro_compile.py
@@ -381,9 +381,12 @@ def test_unicode_codepoints_and_following_text_have_no_held_modifiers(
     held: set[int] = set()
     plain_presses: list[int] = []
     last_release_us = -1
+    previous_event_us = -1
     modifiers = {evdev.ecodes.KEY_LEFTCTRL, evdev.ecodes.KEY_LEFTSHIFT}
 
     for event in events:
+        assert event["t_us"] >= previous_event_us
+        previous_event_us = event["t_us"]
         code = int(event["code"])
         if event["value"] == 1:
             if code == evdev.ecodes.KEY_U:

--- a/tests/gui/test_gui_demo_and_dialogs.py
+++ b/tests/gui/test_gui_demo_and_dialogs.py
@@ -2185,7 +2185,7 @@ class TestDialogConstruction:
             evdev.ecodes.KEY_U,
             evdev.ecodes.KEY_E,
             evdev.ecodes.KEY_9,
-            evdev.ecodes.KEY_ENTER,
+            evdev.ecodes.KEY_SPACE,
         ]
 
     def test_macro_manager_closes_when_recording_starts(self, monkeypatch):


### PR DESCRIPTION
## Summary

Unicode type macros held Ctrl and Shift while typing the hexadecimal codepoint, producing incorrect input. Release U, Shift, and Ctrl after the activation chord, then type the codepoint and confirm with Space. Space avoids sending Enter when the target does not recognize Unicode input.

Add regression coverage for modifier release order, consecutive Unicode characters, and following text at zero and default delays. Document the sequence and that previously saved macros need recreation or manual editing.

## Testing

- [x] `./scripts/check.sh`: all checks passed; 3,192 tests passed, 28 skipped.
- [x] User verified that the fix resolves the reported typing problem.
- VM suites: not run; `AGENTS.md` defines `./scripts/check.sh` as the full handoff gate and requires no additional checks.
- GUI screenshots: not applicable; no visual changes.

## Notes

- Packaging and service/security impact: none.
- GUI impact: newly compiled Unicode type macros use the corrected sequence.
