### PR TITLE
Discover controller capabilities and edit analog input calibration

### DIFF
--- a/docs/GAMEPAD.md
+++ b/docs/GAMEPAD.md
@@ -35,11 +35,18 @@ releases the grab or stops.
 
 ## Button Mapping
 
-Keymasq uses an Xbox 360 controller as the template for game controllers.
-When you add a controller, buttons that the hardware reports are included
-automatically. Buttons the controller does not advertise are omitted — you
-can add extra buttons later from the device tab using the listen/capture
-flow.
+When you add a controller, Keymasq creates controls from its advertised
+capabilities, including joystick buttons, extra gamepad buttons, hats, and
+individual axes. Familiar gamepad controls keep their standard labels. Flight
+sticks use stick, twist, and throttle labels. Other controls use readable evdev
+names. Existing saved hardware configurations are not changed automatically.
+
+The device tab keeps the standard gamepad sections and lists remaining buttons
+under Additional Controls. In the key selector, physical controllers use their
+saved controls and axis ranges. Flight sticks use the flight-stick picker, with
+additional buttons available through its searchable list. Axes without known
+ranges use the previous standard ranges for conventional gamepad axes. Other
+axes without ranges are not offered; use Learn Analog to calibrate them.
 
 Remap any button from the device tab: click it in the grid and pick an
 action. Each button supports the same options as keyboard/mouse mappings,
@@ -70,13 +77,16 @@ the **Analog Controls** dialog (accessible from the main menu).
 
 ### Learning Analog Inputs
 
-The controller template already includes standard left and right stick
-inputs, so most controllers are ready for analog remapping out of the box.
-Use **Learn Analog** when your controller has additional or non-standard
-analog axes that the template does not cover. You can also delete a
-template stick and re-add its axes individually as 1D axes — useful when
-you want to remap a single stick direction to an analog trigger or other
-1D output.
+Setup pairs X/Y into a stick and, for gamepads, RX/RY into the right stick.
+Each complete hat X/Y pair becomes a two-axis control. Pairs must come from
+the same interface. Flight-stick rotation axes and all unmatched axes remain
+individual controls. Motion sensor axes are handled separately.
+
+Setup saves advertised minimum and maximum values. Centered sticks and
+flight-stick rotation axes use the range midpoint as an initial center.
+The current axis position is not saved as calibration. Use **Learn Analog**
+to adjust calibration or change grouping, for example by deleting a stick
+and re-adding its components as individual axes.
 
 1. Open the **Device** tab for your controller.
 2. Click **Learn Analog**.
@@ -574,3 +584,23 @@ Button positions are based on physical location, not labels.
   analog control configs
 - [Actions](ACTIONS.md)
 - [Super Keys](SUPERKEYS.md)
+
+### Editing an existing analog input
+
+Right-click an analog input's name in the device tab to open **Edit Analog Input**.
+You can rename it and edit each axis's minimum, maximum, and center for a stick
+or rest position for a single axis. Values are raw axis units; leaving a field
+blank removes that override and lets runtime calibration supply it. Minimum must
+be less than maximum, and an explicit center/rest must lie within the supplied
+bounds. Source interface and axis codes are shown for reference.
+
+Save preserves the input ID, axis assignments, and existing profile mappings.
+Cancel leaves the configuration unchanged. Delete remains available in the same
+dialog. To change stick grouping or source axes, use Learn Analog.
+
+Blank calibration fields display device-reported bounds when the connected
+interface can be identified. Automatic stick center shows the calculated
+midpoint of the effective bounds. Automatic single-axis rest shows the daemon's
+grab-time sample when available. The editor does not treat the current axis
+position as rest or estimate unavailable values. These hints are not saved as
+overrides unless you enter a value.

--- a/docs/GAMEPAD.md
+++ b/docs/GAMEPAD.md
@@ -102,6 +102,26 @@ and re-adding its components as individual axes.
 Right-click a learned analog input label on the device tab to rename or
 delete it.
 
+### Editing an existing analog input
+
+Right-click an analog input's name in the device tab to open **Edit Analog Input**.
+You can rename it and edit each axis's minimum, maximum, and center for a stick
+or rest position for a single axis. Values are raw axis units; leaving a field
+blank removes that override and lets runtime calibration supply it. Minimum must
+be less than maximum, and an explicit center/rest must lie within the supplied
+bounds. Source interface and axis codes are shown for reference.
+
+Save preserves the input ID, axis assignments, and existing profile mappings.
+Cancel leaves the configuration unchanged. Delete remains available in the same
+dialog. To change stick grouping or source axes, use Learn Analog.
+
+Blank calibration fields display device-reported bounds when the connected
+interface can be identified. Automatic stick center shows the calculated
+midpoint of the effective bounds. Automatic single-axis rest shows the daemon's
+grab-time sample when available. The editor does not treat the current axis
+position as rest or estimate unavailable values. These hints are not saved as
+overrides unless you enter a value.
+
 ### Assigning an Analog Control
 
 Open the **Device** tab and select the analog input. The mapping dialog opens
@@ -584,23 +604,3 @@ Button positions are based on physical location, not labels.
   analog control configs
 - [Actions](ACTIONS.md)
 - [Super Keys](SUPERKEYS.md)
-
-### Editing an existing analog input
-
-Right-click an analog input's name in the device tab to open **Edit Analog Input**.
-You can rename it and edit each axis's minimum, maximum, and center for a stick
-or rest position for a single axis. Values are raw axis units; leaving a field
-blank removes that override and lets runtime calibration supply it. Minimum must
-be less than maximum, and an explicit center/rest must lie within the supplied
-bounds. Source interface and axis codes are shown for reference.
-
-Save preserves the input ID, axis assignments, and existing profile mappings.
-Cancel leaves the configuration unchanged. Delete remains available in the same
-dialog. To change stick grouping or source axes, use Learn Analog.
-
-Blank calibration fields display device-reported bounds when the connected
-interface can be identified. Automatic stick center shows the calculated
-midpoint of the effective bounds. Automatic single-axis rest shows the daemon's
-grab-time sample when available. The editor does not treat the current axis
-position as rest or estimate unavailable values. These hints are not saved as
-overrides unless you enter a value.

--- a/docs/GAMEPAD.md
+++ b/docs/GAMEPAD.md
@@ -42,11 +42,13 @@ sticks use stick, twist, and throttle labels. Other controls use readable evdev
 names. Existing saved hardware configurations are not changed automatically.
 
 The device tab keeps the standard gamepad sections and lists remaining buttons
-under Additional Controls. In the key selector, physical controllers use their
-saved controls and axis ranges. Flight sticks use the flight-stick picker, with
-additional buttons available through its searchable list. Axes without known
-ranges use the previous standard ranges for conventional gamepad axes. Other
-axes without ranges are not offered; use Learn Analog to calibrate them.
+under Additional Controls. In the key selector, grab a physical controller to
+load its available output controls and resolved axis calibration. Flight sticks
+use the flight-stick picker, with additional buttons in its searchable list.
+For hardware with multiple gamepad interfaces, the picker offers only controls
+on the first grabbed interface with a passthrough output, matching the output
+router. Choosing a different destination interface is not currently supported.
+Axes without known ranges are not offered.
 
 Remap any button from the device tab: click it in the grid and pick an
 action. Each button supports the same options as keyboard/mouse mappings,
@@ -59,6 +61,10 @@ including rapidfire and tap (see [Actions](ACTIONS.md)).
 You can map any key or button to a gamepad axis value — useful for binding
 keyboard keys to stick or trigger output. The mapping sends a fixed axis
 value while the source is held and returns to neutral on release.
+Physical targets use their resolved center or rest value for release, tap,
+rapidfire, and cleanup. Percentage shortcuts use the same calibration, including
+the grab-time sample for an automatic rest. If rest is unavailable, percentage
+shortcuts are disabled and exact raw-value entry remains available.
 
 Triggers are analog axes, not buttons. Gamepad button mappings do not
 produce trigger output — use axis mappings instead.

--- a/keymasq/common/controller_capabilities.py
+++ b/keymasq/common/controller_capabilities.py
@@ -1,6 +1,7 @@
 """Controller naming and a shared capability-backed output picker description."""
 
 from collections.abc import Iterable
+from dataclasses import replace
 
 from keymasq.common.devices import (
     canonical_gamepad_button_name,
@@ -10,6 +11,7 @@ from keymasq.common.devices import (
 from keymasq.common.gamepad_axes import gamepad_axis_range
 from keymasq.common.model.hardware import HardwareConfig
 from keymasq.common.output_axes import OutputAxis, learned_output_axes
+from keymasq.common.types import JsonObject
 from keymasq.common.virtual_device_templates import (
     VirtualAxis,
     VirtualButton,
@@ -114,3 +116,53 @@ def hardware_controller_template(config: HardwareConfig) -> VirtualDeviceTemplat
         ),
         layout="flight-stick" if flight else "gamepad",
     )
+
+
+def routed_controller_template(
+    config: HardwareConfig, inventory: JsonObject
+) -> tuple[VirtualDeviceTemplate, frozenset[str]]:
+    """Describe only the live interface selected by the physical output router."""
+    source = str(inventory.get("source_interface_id", "") or "").lower()
+    capabilities = set(inventory.get("capabilities", []))
+
+    def advertised(name: str, event_type: str) -> bool:
+        return (
+            name.lower() in capabilities
+            or f"{event_type}_{resolve_evdev_code(name)}" in capabilities
+        )
+
+    config = replace(
+        config,
+        buttons=[
+            button
+            for button in config.buttons
+            if (not button.source or button.source.lower() == source)
+            and advertised(button.evdev, "EV_KEY")
+        ],
+        analog_inputs=[],
+    )
+    template = hardware_controller_template(config)
+    analogs = inventory["gamepad_output"].get("analog_inputs", {})
+    axes = learned_output_axes(analogs.values())
+    unknown_rest_codes = {
+        resolve_evdev_code(axis.get("evdev")) if axis.get("evdev") else axis.get("evdev_code")
+        for analog in analogs.values()
+        if analog.get("type") != "stick"
+        for axis in analog.get("axes", [])
+        if axis.get("rest") is None
+    }
+    return replace(
+        template,
+        axes=tuple(
+            VirtualAxis(
+                axis.evdev.lower(),
+                axis.label,
+                axis.evdev.lower(),
+                axis.minimum,
+                axis.maximum,
+                rest=axis.neutral,
+            )
+            for axis in axes
+            if advertised(axis.evdev, "EV_ABS")
+        ),
+    ), frozenset(axis.evdev.lower() for axis in axes if axis.code in unknown_rest_codes)

--- a/keymasq/common/controller_capabilities.py
+++ b/keymasq/common/controller_capabilities.py
@@ -1,0 +1,116 @@
+"""Controller naming and a shared capability-backed output picker description."""
+
+from collections.abc import Iterable
+
+from keymasq.common.devices import (
+    canonical_gamepad_button_name,
+    gamepad_button_label,
+    resolve_evdev_code,
+)
+from keymasq.common.gamepad_axes import gamepad_axis_range
+from keymasq.common.model.hardware import HardwareConfig
+from keymasq.common.output_axes import OutputAxis, learned_output_axes
+from keymasq.common.virtual_device_templates import (
+    VirtualAxis,
+    VirtualButton,
+    VirtualDeviceTemplate,
+)
+
+
+def is_flight_stick(names: Iterable[str]) -> bool:
+    capabilities = {name.lower() for name in names}
+    return bool(
+        capabilities & {"btn_trigger", "btn_joystick", "btn_thumb", "btn_top", "btn_pinkie"}
+    )
+
+
+def controller_button_name(name: str) -> str:
+    name = canonical_gamepad_button_name(name)
+    return {
+        "btn_joystick": "btn_trigger",
+        "btn_trigger_happy": "btn_trigger_happy1",
+        "btn_misc": "btn_0",
+        "btn_mouse": "btn_left",
+    }.get(name, name)
+
+
+def controller_control_label(name: str) -> str:
+    return gamepad_button_label(name) or {
+        "btn_tl2": "LT",
+        "btn_tr2": "RT",
+        "btn_thumb2": "Thumb 2",
+        "btn_top2": "Top 2",
+        "abs_rx": "Rotation X",
+        "abs_ry": "Rotation Y",
+        "abs_rz": "Rotation Z",
+    }.get(
+        name,
+        name.removeprefix("btn_")
+        .removeprefix("key_")
+        .removeprefix("abs_")
+        .replace("_", " ")
+        .title(),
+    )
+
+
+def _hardware_picker_axes(config: HardwareConfig) -> tuple[OutputAxis, ...]:
+    result: list[OutputAxis] = []
+    seen: set[int] = set()
+    for analog in config.analog_inputs:
+        known = {axis.code: axis for axis in learned_output_axes([analog])}
+        for axis in analog.axes:
+            code = resolve_evdev_code(axis.evdev)
+            if code is None or code in seen:
+                continue
+            spec = known.get(code)
+            if spec is None and (axis.minimum is None or axis.maximum is None):
+                # Older setup saved axis bindings without ranges. Preserve the
+                # previous picker's standard ranges without changing calibration.
+                fallback = gamepad_axis_range(axis.evdev)
+                if fallback is not None:
+                    label = (
+                        f"{analog.label} {axis.role.upper()}"
+                        if analog.type == "stick"
+                        else analog.label
+                    )
+                    spec = OutputAxis(
+                        axis.evdev, label, fallback.minimum, fallback.maximum, fallback.neutral
+                    )
+            if spec is not None:
+                seen.add(code)
+                result.append(spec)
+    return tuple(result)
+
+
+def hardware_controller_template(config: HardwareConfig) -> VirtualDeviceTemplate:
+    """Use saved physical controls, never a virtual device's assumed capabilities."""
+    names = [name for device in config.evdev_devices for name in device.capabilities]
+    names.extend(button.evdev for button in config.buttons)
+    flight = is_flight_stick(names)
+    buttons: dict[int, VirtualButton] = {}
+    for button in config.buttons:
+        code = resolve_evdev_code(button.evdev)
+        if code is not None and button.evdev_value is None:
+            buttons.setdefault(code, VirtualButton(button.id, button.label, button.evdev.lower()))
+    return VirtualDeviceTemplate(
+        id=config.hardware_id,
+        label="Flight stick" if flight else "Gamepad",
+        name=config.name,
+        vendor_id=int(config.vendor_id, 16),
+        product_id=int(config.product_id, 16),
+        version=0,
+        bustype=0,
+        buttons=tuple(buttons.values()),
+        axes=tuple(
+            VirtualAxis(
+                axis.evdev.lower(),
+                axis.label,
+                axis.evdev.lower(),
+                axis.minimum,
+                axis.maximum,
+                rest=axis.neutral,
+            )
+            for axis in _hardware_picker_axes(config)
+        ),
+        layout="flight-stick" if flight else "gamepad",
+    )

--- a/keymasq/gui/widgets/device_tab/analog_edit_dialog.py
+++ b/keymasq/gui/widgets/device_tab/analog_edit_dialog.py
@@ -1,0 +1,224 @@
+"""Edit saved analog calibration without replacing the source binding."""
+
+from collections.abc import Callable
+from dataclasses import replace
+
+import gi
+
+gi.require_version("Gtk", "4.0")
+gi.require_version("Adw", "1")
+from gi.repository import Adw, Gtk  # pyright: ignore[reportAttributeAccessIssue]
+
+from keymasq.common.devices import resolve_evdev_code
+from keymasq.common.model.hardware import (
+    AnalogAxisDefinition,
+    AnalogInputDefinition,
+    HardwareConfig,
+)
+
+
+class AnalogInputEditDialog(Adw.Dialog):
+    def __init__(
+        self,
+        analog: AnalogInputDefinition,
+        *,
+        on_save: Callable[[AnalogInputDefinition], bool],
+        on_delete_clicked: Callable[[Gtk.Button, Adw.Dialog, AnalogInputDefinition], None],
+        on_close_clicked: Callable[[Gtk.Button, Adw.Dialog], None],
+    ) -> None:
+        super().__init__(title="Edit Analog Input", content_width=520, content_height=-1)
+        self._analog = analog
+        self._on_save = on_save
+        self._detected: dict[str, object] = {}
+        self._runtime: dict[str, object] = {}
+        self.axis_entries: list[dict[str, Gtk.Entry]] = []
+        box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=12)
+        for side in ("top", "bottom", "start", "end"):
+            getattr(box, f"set_margin_{side}")(16)
+        box.append(Gtk.Label(label="Name", xalign=0))
+        self.name_entry = Gtk.Entry(text=analog.label)
+        box.append(self.name_entry)
+        source = Gtk.Label(label=f"Source interface: {analog.source or 'Default'}", xalign=0)
+        source.add_css_class("dim-label")
+        source.set_selectable(True)
+        box.append(source)
+        hint = Gtk.Label(
+            label="Blank fields show known automatic values. Unavailable values are not estimated.",
+            xalign=0,
+            wrap=True,
+        )
+        hint.add_css_class("dim-label")
+        box.append(hint)
+        neutral_field = "center" if analog.type == "stick" else "rest"
+        for axis in analog.axes:
+            label = Gtk.Label(label=f"{axis.role.upper()} · {axis.evdev}", xalign=0)
+            label.add_css_class("heading")
+            box.append(label)
+            grid = Gtk.Grid(column_spacing=12, row_spacing=6)
+            entries = {}
+            for col, (field, title) in enumerate(
+                (
+                    ("minimum", "Minimum"),
+                    ("maximum", "Maximum"),
+                    (neutral_field, "Center" if neutral_field == "center" else "Rest"),
+                )
+            ):
+                grid.attach(Gtk.Label(label=title, xalign=0), col, 0, 1, 1)
+                value = getattr(axis, field)
+                entry = Gtk.Entry(
+                    text="" if value is None else str(value),
+                    placeholder_text="Automatic",
+                    width_chars=10,
+                    hexpand=True,
+                )
+                entries[field] = entry
+                grid.attach(entry, col, 1, 1, 1)
+            self.axis_entries.append(entries)
+            box.append(grid)
+        self.error_label = Gtk.Label(xalign=0, wrap=True, visible=False)
+        self.error_label.add_css_class("error")
+        box.append(self.error_label)
+        footer = Gtk.Box(spacing=8)
+        delete = Gtk.Button(label="Delete")
+        delete.add_css_class("destructive-action")
+        delete.connect("clicked", on_delete_clicked, self, analog)
+        footer.append(delete)
+        footer.append(Gtk.Box(hexpand=True))
+        cancel = Gtk.Button(label="Cancel")
+        cancel.connect("clicked", on_close_clicked, self)
+        footer.append(cancel)
+        self.save_button = Gtk.Button(label="Save")
+        self.save_button.add_css_class("suggested-action")
+        self.save_button.connect("clicked", self._save)
+        footer.append(self.save_button)
+        box.append(footer)
+        self.set_child(box)
+        for entries in self.axis_entries:
+            for entry in entries.values():
+                entry.connect("changed", self._refresh_automatic_values)
+        self._refresh_automatic_values()
+
+    def update_device_inventory(self, response: object, hardware: HardwareConfig) -> bool:
+        if not isinstance(response, dict):
+            return False
+        paths = {
+            device.path
+            for device in hardware.evdev_devices
+            if self._analog.source is None or device.id == self._analog.source
+        }
+        matches = [
+            device
+            for device in response.get("devices", [])
+            if isinstance(device, dict)
+            and (
+                (
+                    device.get("source_hardware_id") == hardware.hardware_id
+                    and (
+                        self._analog.source is None
+                        or device.get("source_interface_id") == self._analog.source
+                    )
+                )
+                or (
+                    not device.get("source_hardware_id")
+                    and (device.get("path") in paths or device.get("stable_path") in paths)
+                )
+            )
+        ]
+        if matches:
+            # A hidden source may be represented by its passthrough device.
+            device = matches[0]
+            self._detected = device.get("abs_info") or {}
+            self._runtime = (device.get("analog_calibration") or {}).get(self._analog.id, {})
+        self._refresh_automatic_values()
+        return False
+
+    def _refresh_automatic_values(self, *_args: object) -> None:
+        for axis, entries in zip(self._analog.axes, self.axis_entries, strict=True):
+            code = (
+                axis.evdev_code if axis.evdev_code is not None else resolve_evdev_code(axis.evdev)
+            )
+            info = self._detected.get(str(code), {})
+            if not isinstance(info, dict):
+                info = {}
+            effective: dict[str, int | None] = {}
+            for field in ("minimum", "maximum"):
+                detected = info.get(field)
+                value = detected if isinstance(detected, int) else None
+                entries[field].set_placeholder_text(
+                    f"{value} (auto)" if value is not None else "Unavailable"
+                )
+                entries[field].set_tooltip_text(
+                    f"Device-reported {field}: {value}"
+                    if value is not None
+                    else "Device-reported value is unavailable"
+                )
+                try:
+                    effective[field] = int(entries[field].get_text())
+                except ValueError:
+                    effective[field] = value
+            if self._analog.type == "stick":
+                minimum, maximum = effective["minimum"], effective["maximum"]
+                placeholder = "Unavailable"
+                if minimum is not None and maximum is not None and minimum < maximum:
+                    placeholder = f"{(minimum + maximum) / 2:g} (auto)"
+                entries["center"].set_placeholder_text(placeholder)
+                entries["center"].set_tooltip_text("Calculated midpoint of the effective bounds")
+            else:
+                calibration = self._runtime.get(axis.role, {})
+                rest = calibration.get("rest") if isinstance(calibration, dict) else None
+                if axis.rest is None and isinstance(rest, int):
+                    entries["rest"].set_placeholder_text(f"{rest} (auto)")
+                    entries["rest"].set_tooltip_text(
+                        "Automatic rest sampled when the device was grabbed"
+                    )
+                else:
+                    entries["rest"].set_placeholder_text("On next grab")
+                    entries["rest"].set_tooltip_text(
+                        "Rest is sampled when the device is grabbed, not from its current position."
+                    )
+
+    def _edited_axis(
+        self,
+        axis: AnalogAxisDefinition,
+        entries: dict[str, Gtk.Entry],
+    ) -> AnalogAxisDefinition:
+        values: dict[str, int | None] = {}
+        for field, entry in entries.items():
+            text = entry.get_text().strip()
+            try:
+                value = int(text) if text else None
+            except ValueError as exc:
+                raise ValueError(f"{axis.evdev}: {field} must be a whole number or blank.") from exc
+            if value is not None and not -2147483648 <= value <= 2147483647:
+                raise ValueError(f"{axis.evdev}: {field} is outside the supported integer range.")
+            values[field] = value
+        minimum, maximum = values["minimum"], values["maximum"]
+        neutral = values.get("center", values.get("rest"))
+        if minimum is not None and maximum is not None and minimum >= maximum:
+            raise ValueError(f"{axis.evdev}: minimum must be less than maximum.")
+        if neutral is not None and (
+            (minimum is not None and neutral < minimum)
+            or (maximum is not None and neutral > maximum)
+        ):
+            raise ValueError(f"{axis.evdev}: center/rest must be within the axis range.")
+        return replace(axis, **values)
+
+    def _save(self, _button: Gtk.Button) -> None:
+        try:
+            label = self.name_entry.get_text().strip()
+            if not label:
+                raise ValueError("Enter a name for this analog input.")
+            axes = [
+                self._edited_axis(axis, entries)
+                for axis, entries in zip(self._analog.axes, self.axis_entries, strict=True)
+            ]
+            edited = replace(self._analog, label=label, axes=axes)
+            if not self._on_save(edited):
+                raise ValueError(
+                    "Could not save the analog input. Your changes have not been applied."
+                )
+        except (ValueError, OSError) as exc:
+            self.error_label.set_text(str(exc))
+            self.error_label.set_visible(True)
+            return
+        self.close()

--- a/keymasq/gui/widgets/device_tab/analog_edit_dialog.py
+++ b/keymasq/gui/widgets/device_tab/analog_edit_dialog.py
@@ -192,7 +192,15 @@ class AnalogInputEditDialog(Adw.Dialog):
             if value is not None and not -2147483648 <= value <= 2147483647:
                 raise ValueError(f"{axis.evdev}: {field} is outside the supported integer range.")
             values[field] = value
+        code = axis.evdev_code if axis.evdev_code is not None else resolve_evdev_code(axis.evdev)
+        detected = self._detected.get(str(code), {})
+        if not isinstance(detected, dict):
+            detected = {}
         minimum, maximum = values["minimum"], values["maximum"]
+        if minimum is None and isinstance(detected.get("minimum"), int):
+            minimum = detected["minimum"]
+        if maximum is None and isinstance(detected.get("maximum"), int):
+            maximum = detected["maximum"]
         neutral = values.get("center", values.get("rest"))
         if minimum is not None and maximum is not None and minimum >= maximum:
             raise ValueError(f"{axis.evdev}: minimum must be less than maximum.")

--- a/keymasq/gui/widgets/device_tab/inputs.py
+++ b/keymasq/gui/widgets/device_tab/inputs.py
@@ -77,34 +77,40 @@ class InputInventoryMixin:
     def _show_analog_relabel_dialog(self: Any, analog: AnalogInputDefinition) -> None:
         if self.hardware_manager is None:
             return
-        rename_dialogs.present_analog_relabel_dialog(
+        dialog = rename_dialogs.present_analog_relabel_dialog(
             parent=self.get_root(),
             analog=analog,
             on_delete_clicked=self._on_delete_analog_clicked,
-            on_save=self._rename_analog_label,
+            on_save=self._save_analog_properties,
             on_close_clicked=self._on_close_dialog_clicked,
         )
 
-    def _rename_analog_label(
-        self: Any,
-        analog: AnalogInputDefinition,
-        new_label: str,
-    ) -> bool:
-        new_label = new_label.strip()
-        if not new_label:
-            return False
+        def received(response: object) -> bool:
+            return dialog.update_device_inventory(response, self.device)
+
+        self._request_session_async(
+            {"command": "list_devices_for_recording", "include_other": True},
+            received,
+        )
+
+    def _save_analog_properties(self: Any, edited: AnalogInputDefinition) -> bool:
         if self.hardware_manager is None:
-            log.warning("Cannot rename analog input %s without a hardware manager", analog.id)
             return False
-        for item in self.device.analog_inputs:
-            if item.id == analog.id:
-                item.label = new_label
-                break
-        self.hardware_manager.save_hardware(self.device)
+        item = next((item for item in self.device.analog_inputs if item.id == edited.id), None)
+        if item is None:
+            return False
+        old_label, old_axes = item.label, item.axes
+        item.label, item.axes = edited.label, edited.axes
+        try:
+            self.hardware_manager.save_hardware(self.device)
+        except (OSError, ValueError):
+            item.label, item.axes = old_label, old_axes
+            log.exception("Cannot save analog input %s", edited.id)
+            return False
         self._request_session_async({"command": "reload"}, self._ignore_session_response)
-        widget = self._button_widgets.get(analog.id)
+        widget = self._button_widgets.get(edited.id)
         if widget:
-            widget._name_label.set_text(new_label)
+            widget._name_label.set_text(edited.label)
         return True
 
     def _on_delete_button_clicked(

--- a/keymasq/gui/widgets/device_tab/rename_dialogs.py
+++ b/keymasq/gui/widgets/device_tab/rename_dialogs.py
@@ -89,19 +89,19 @@ def present_analog_relabel_dialog(
     parent,
     analog: AnalogInputDefinition,
     on_delete_clicked: Callable[[Gtk.Button, Adw.Dialog, AnalogInputDefinition], None],
-    on_save: Callable[[AnalogInputDefinition, str], bool],
+    on_save: Callable[[AnalogInputDefinition], bool],
     on_close_clicked: Callable[[Gtk.Button, Adw.Dialog], None],
-) -> None:
-    _present_input_relabel_dialog(
-        parent=parent,
-        title="Rename Analog Input",
-        label=f"Rename '{analog.label}'",
-        current_label=analog.label,
-        subject=analog,
-        on_delete_clicked=on_delete_clicked,
+):
+    from keymasq.gui.widgets.device_tab.analog_edit_dialog import AnalogInputEditDialog
+
+    dialog = AnalogInputEditDialog(
+        analog,
         on_save=on_save,
+        on_delete_clicked=on_delete_clicked,
         on_close_clicked=on_close_clicked,
     )
+    dialog.present(parent)
+    return dialog
 
 
 def present_delete_device_dialog(

--- a/keymasq/gui/widgets/gamepad_output_choices.py
+++ b/keymasq/gui/widgets/gamepad_output_choices.py
@@ -3,6 +3,7 @@ from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from typing import Protocol
 
+from keymasq.common.controller_capabilities import is_flight_stick
 from keymasq.common.devices import is_gamepad_button_name
 from keymasq.common.virtual_device_templates import (
     VirtualDeviceConfig,
@@ -99,6 +100,14 @@ def _is_hardware_gamepad(config: object) -> bool:
 def _hardware_gamepad_output_label(config: object) -> str:
     hardware_id = str(getattr(config, "hardware_id", "") or "")
     name = str(getattr(config, "name", "") or "").strip()
+    names = [str(getattr(button, "evdev", "")) for button in getattr(config, "buttons", [])]
+    names.extend(
+        str(capability)
+        for device in getattr(config, "evdev_devices", [])
+        for capability in getattr(device, "capabilities", [])
+    )
+    if is_flight_stick(names):
+        name = f"{name or hardware_id} · Flight stick"
     if name and hardware_id:
         return f"{name} ({hardware_id})"
     return name or hardware_id

--- a/keymasq/gui/widgets/key_selector/tabs.py
+++ b/keymasq/gui/widgets/key_selector/tabs.py
@@ -11,16 +11,21 @@ gi.require_version("Gtk", "4.0")
 
 from gi.repository import Gdk, Gtk  # pyright: ignore[reportAttributeAccessIssue]
 
-from keymasq.common.controller_capabilities import hardware_controller_template
+from keymasq.common.controller_capabilities import (
+    hardware_controller_template,
+    routed_controller_template,
+)
 from keymasq.common.model.actions import MappingAction
 from keymasq.common.model.core import ActionType
 from keymasq.common.model.hardware import HardwareConfig
 from keymasq.common.model.superkeys import SuperkeyAction
+from keymasq.common.types import JsonObject
 from keymasq.common.virtual_device_templates import (
     XBOX_360_TEMPLATE_ID,
     ResolvedVirtualDevice,
     resolve_virtual_devices,
 )
+from keymasq.gui.session_client import session_request_async
 from keymasq.gui.widgets import input_picker_shared
 from keymasq.gui.widgets.gamepad_output_choices import (
     gamepad_output_choice_matches,
@@ -630,12 +635,38 @@ class SharedInputTabsMixin:
             self._physical_gamepad_configs = load_gamepad_output_hardware_configs(HardwareManager)
         device = self._selected_virtual_device()
         template = device.template if device is not None else None
+        unknown_rest_axes = frozenset()
+        physical_message = None
         for hardware in getattr(self, "_physical_gamepad_configs", []):
             if (
                 isinstance(hardware, HardwareConfig)
                 and hardware.hardware_id == self._selected_gamepad_output_id
             ):
                 template = hardware_controller_template(hardware)
+                if not hasattr(self, "_physical_output_inventory"):
+                    self._physical_output_inventory = []
+                    self._physical_output_loading = True
+                    session_request_async(
+                        {"command": "list_devices_for_recording", "include_other": True},
+                        self._received_physical_output_inventory,
+                    )
+                routed = next(
+                    (
+                        item
+                        for item in self._physical_output_inventory
+                        if item.get("source_hardware_id") == hardware.hardware_id
+                        and isinstance(item.get("gamepad_output"), dict)
+                    ),
+                    None,
+                )
+                if routed is not None:
+                    template, unknown_rest_axes = routed_controller_template(hardware, routed)
+                else:
+                    physical_message = (
+                        "Loading physical output controls…"
+                        if self._physical_output_loading
+                        else "Grab this controller to select its available output controls."
+                    )
                 break
         use_template = template is not None and (
             device is None or template.id != XBOX_360_TEMPLATE_ID
@@ -649,6 +680,10 @@ class SharedInputTabsMixin:
         while child := custom.get_first_child():
             custom.remove(child)
 
+        if physical_message:
+            custom.append(Gtk.Label(label=physical_message, wrap=True))
+            return
+
         from keymasq.gui.widgets.virtual_device_picker import VirtualDevicePicker
 
         action = getattr(self, "_current_action", None)
@@ -659,8 +694,15 @@ class SharedInputTabsMixin:
                 self._on_gamepad_axis_clicked,
                 current_target=getattr(action, "target", None),
                 current_value=int(getattr(action, "axis_value", 0)),
+                unknown_rest_axes=unknown_rest_axes,
             )
         )
+
+    def _received_physical_output_inventory(self, response: JsonObject | None) -> bool:
+        self._physical_output_loading = False
+        self._physical_output_inventory = (response or {}).get("devices", [])
+        self._refresh_virtual_device_picker()
+        return False
 
     def _build_gamepad_output_header(self) -> Gtk.Widget | None:
         choices = self._gamepad_output_choices()

--- a/keymasq/gui/widgets/key_selector/tabs.py
+++ b/keymasq/gui/widgets/key_selector/tabs.py
@@ -11,8 +11,10 @@ gi.require_version("Gtk", "4.0")
 
 from gi.repository import Gdk, Gtk  # pyright: ignore[reportAttributeAccessIssue]
 
+from keymasq.common.controller_capabilities import hardware_controller_template
 from keymasq.common.model.actions import MappingAction
 from keymasq.common.model.core import ActionType
+from keymasq.common.model.hardware import HardwareConfig
 from keymasq.common.model.superkeys import SuperkeyAction
 from keymasq.common.virtual_device_templates import (
     XBOX_360_TEMPLATE_ID,
@@ -24,6 +26,7 @@ from keymasq.gui.widgets.gamepad_output_choices import (
     gamepad_output_choice_matches,
     gamepad_output_choices,
     gamepad_output_unavailable_message,
+    load_gamepad_output_hardware_configs,
     virtual_device_config,
     virtual_gamepad_count,
 )
@@ -623,12 +626,24 @@ class SharedInputTabsMixin:
         custom = getattr(self, "_template_gamepad_picker", None)
         if standard is None or custom is None:
             return
+        if not hasattr(self, "_physical_gamepad_configs"):
+            self._physical_gamepad_configs = load_gamepad_output_hardware_configs(HardwareManager)
         device = self._selected_virtual_device()
-        use_template = device is not None and device.template.id != XBOX_360_TEMPLATE_ID
+        template = device.template if device is not None else None
+        for hardware in getattr(self, "_physical_gamepad_configs", []):
+            if (
+                isinstance(hardware, HardwareConfig)
+                and hardware.hardware_id == self._selected_gamepad_output_id
+            ):
+                template = hardware_controller_template(hardware)
+                break
+        use_template = template is not None and (
+            device is None or template.id != XBOX_360_TEMPLATE_ID
+        )
         standard.set_visible(not use_template)
         custom.set_visible(use_template)
         self._template_gamepad_scroll.set_visible(use_template)
-        if not use_template or device is None:
+        if not use_template or template is None:
             return
 
         while child := custom.get_first_child():
@@ -639,7 +654,7 @@ class SharedInputTabsMixin:
         action = getattr(self, "_current_action", None)
         custom.append(
             VirtualDevicePicker(
-                device.template,
+                template,
                 self._on_gamepad_clicked,
                 self._on_gamepad_axis_clicked,
                 current_target=getattr(action, "target", None),
@@ -679,11 +694,13 @@ class SharedInputTabsMixin:
         config = getattr(self, "_virtual_device_config", None)
         if config is None:
             config = virtual_device_config()
+        if not hasattr(self, "_physical_gamepad_configs"):
+            self._physical_gamepad_configs = load_gamepad_output_hardware_configs(HardwareManager)
         return gamepad_output_choices(
             self._selected_gamepad_output_id,
             count=count,
             device_config=config,
-            hardware_manager_factory=HardwareManager,
+            hardware_configs=self._physical_gamepad_configs,
         )
 
     def _on_gamepad_output_selected(self, dropdown: Gtk.DropDown, _param) -> None:

--- a/keymasq/gui/widgets/virtual_device_picker.py
+++ b/keymasq/gui/widgets/virtual_device_picker.py
@@ -35,6 +35,7 @@ class VirtualDevicePicker(Gtk.Box):
         *,
         current_target: str | None = None,
         current_value: int = 0,
+        unknown_rest_axes: frozenset[str] = frozenset(),
     ) -> None:
         super().__init__(orientation=Gtk.Orientation.VERTICAL, spacing=16)
         self.set_halign(Gtk.Align.CENTER)
@@ -42,6 +43,7 @@ class VirtualDevicePicker(Gtk.Box):
         self._on_axis = on_axis
         self._axes = {axis.evdev: axis for axis in template.axes}
         self._template = template
+        self._unknown_rest_axes = unknown_rest_axes
         self._buttons = {
             int(getattr(evdev.ecodes, item.evdev.upper())): item for item in template.buttons
         }
@@ -79,7 +81,8 @@ class VirtualDevicePicker(Gtk.Box):
         self.percent_spin = Gtk.SpinButton(numeric=True, width_chars=4)
         self.percent_spin.set_tooltip_text("Deflection from rest; 100% is full travel")
         editor.append(self.percent_spin)
-        editor.append(Gtk.Label(label="%"))
+        self._percent_label = Gtk.Label(label="%")
+        editor.append(self._percent_label)
         apply = Gtk.Button(label="Map axis")
         apply.add_css_class("suggested-action")
         apply.connect("clicked", self._map_axis)
@@ -217,7 +220,7 @@ class VirtualDevicePicker(Gtk.Box):
 
     def _axis_shortcut(self, label: str, code: str, percent: float, tooltip: str) -> Gtk.Widget:
         axis = self._axes.get(code)
-        if axis is None:
+        if axis is None or code in self._unknown_rest_axes:
             return Gtk.Box(visible=False)
         return self._axis_button(label, code, axis_percent_value(axis, percent), tooltip)
 
@@ -379,6 +382,10 @@ class VirtualDevicePicker(Gtk.Box):
 
     def _axis_changed(self, *_args: object) -> None:
         axis = self._selected_axis()
+        rest_known = axis.evdev not in self._unknown_rest_axes
+        self.percent_spin.set_sensitive(rest_known)
+        self.percent_spin.set_visible(rest_known)
+        self._percent_label.set_visible(rest_known)
         self._syncing = True
         self.value_spin.set_adjustment(
             Gtk.Adjustment(
@@ -394,14 +401,17 @@ class VirtualDevicePicker(Gtk.Box):
             )
         )
         self._syncing = False
-        self.value_spin.set_value(axis_percent_value(axis, 100))
+        self.value_spin.set_value(axis_percent_value(axis, 100) if rest_known else axis.minimum)
         self._value_changed()
-        self.range_label.set_text(f"Range {axis.minimum} to {axis.maximum} · Rest {axis.rest}")
+        rest = str(axis.rest) if rest_known else "unavailable"
+        self.range_label.set_text(f"Range {axis.minimum} to {axis.maximum} · Rest {rest}")
 
     def _value_changed(self, *_args: object) -> None:
         if self._syncing:
             return
         axis = self._selected_axis()
+        if axis.evdev in self._unknown_rest_axes:
+            return
         value = self.value_spin.get_value()
         endpoint = axis.maximum if value >= axis.rest else axis.minimum
         distance = abs(endpoint - axis.rest)
@@ -413,7 +423,7 @@ class VirtualDevicePicker(Gtk.Box):
         self._syncing = False
 
     def _percent_changed(self, *_args: object) -> None:
-        if self._syncing:
+        if self._syncing or self._selected_axis().evdev in self._unknown_rest_axes:
             return
         self._syncing = True
         self.value_spin.set_value(

--- a/keymasq/gui/widgets/virtual_device_picker.py
+++ b/keymasq/gui/widgets/virtual_device_picker.py
@@ -91,7 +91,10 @@ class VirtualDevicePicker(Gtk.Box):
         self.axis_choice.connect("notify::selected", self._axis_changed)
         self.value_spin.connect("value-changed", self._value_changed)
         self.percent_spin.connect("value-changed", self._percent_changed)
-        self._axis_changed()
+        editor.set_visible(bool(self.axis_names))
+        self.range_label.set_visible(bool(self.axis_names))
+        if self.axis_names:
+            self._axis_changed()
         if current_target in self.axis_names:
             self.axis_choice.set_selected(self.axis_names.index(current_target))
             self.value_spin.set_value(current_value)

--- a/keymasq/gui/wizards/hardware_setup/dialog.py
+++ b/keymasq/gui/wizards/hardware_setup/dialog.py
@@ -251,9 +251,8 @@ class HardwareSetupDialog(
             "standard mouse with scroll wheel directions."
         )
         self.gamepad_mode_info = add_mode_info_label(
-            "Gamepad template includes detected digital buttons and standard stick "
-            "inputs. Use Learn Analog from the device tab to add triggers or other "
-            "analog axes."
+            "Controller setup includes detected buttons, sticks, hats, and individual "
+            "axes. Use Learn Analog from the device tab to customize axis grouping."
         )
         self.custom_mode_info = add_mode_info_label(
             "Custom profile saves the selected raw evdev interface without preset "

--- a/keymasq/gui/wizards/hardware_setup/templates.py
+++ b/keymasq/gui/wizards/hardware_setup/templates.py
@@ -4,16 +4,22 @@ from typing import Any
 
 import evdev
 
+from keymasq.common.controller_capabilities import (
+    controller_button_name,
+    controller_control_label,
+    is_flight_stick,
+)
 from keymasq.common.devices import (
     canonical_gamepad_button_name,
     capability_name,
     evdev_code_value,
-    gamepad_button_label,
     is_by_id_path,
     is_low_res_wheel_evdev,
     normalize_input_classes,
     ordered_gamepad_button_names,
     primary_input_class,
+    resolve_evdev_code,
+    resolve_evdev_event_type,
     wheel_button_id,
     wheel_label,
 )
@@ -192,119 +198,168 @@ def standard_wheel_buttons(
     return buttons
 
 
+def _controller_entries(iface: InterfaceInfo, event_type: int) -> dict[int, object]:
+    raw = iface.get("raw_capabilities") or {}
+    entries = {
+        code: entry
+        for entry in raw.get(event_type, [])
+        if (code := evdev_code_value(entry)) is not None
+    }
+    for name in iface.get("capabilities", []):
+        code = resolve_evdev_code(name)
+        if code is not None and resolve_evdev_event_type(name) == event_type:
+            entries.setdefault(code, code)
+    return entries
+
+
+def _controller_names(iface: InterfaceInfo) -> list[str]:
+    return [
+        controller_button_name(name)
+        for code in _controller_entries(iface, evdev.ecodes.EV_KEY)
+        if (name := capability_name(evdev.ecodes.EV_KEY, code)) is not None
+    ]
+
+
+def _unique_control_id(base: str, source: str | None, used: set[str]) -> str:
+    candidate = base
+    suffix = 2
+    if candidate in used and source:
+        candidate = f"{base}_{source}"
+    while candidate in used:
+        candidate = f"{base}_{suffix}"
+        suffix += 1
+    used.add(candidate)
+    return candidate
+
+
 def build_gamepad_buttons(interfaces: Sequence[InterfaceInfo]) -> list[ButtonDefinition]:
-    button_specs: dict[str, tuple[int, str | None]] = {}
-
-    for iface in interfaces:
-        raw_capabilities = iface.get("raw_capabilities") or {}
-        if not isinstance(raw_capabilities, dict):
-            continue
-
-        source_id = str(iface.get("id", "") or "")
-        for code in raw_capabilities.get(evdev.ecodes.EV_KEY, []):
-            code_int = evdev_code_value(code)
-            if code_int is None:
-                continue
-            evdev_name = capability_name(evdev.ecodes.EV_KEY, code_int)
-            if not evdev_name:
-                continue
-            label = gamepad_button_label(evdev_name)
-            canonical = canonical_gamepad_button_name(evdev_name)
-            if canonical in button_specs or label is None:
-                continue
-            button_specs[canonical] = (code_int, source_id or None)
-
     buttons: list[ButtonDefinition] = []
-    for canonical in ordered_gamepad_button_names(button_specs):
-        code_int, source_id = button_specs[canonical]
-        label = gamepad_button_label(canonical)
-        if label is None:
+    used: set[str] = set()
+    for iface in interfaces:
+        if interface_has_role(iface, "motion"):
             continue
-        buttons.append(
-            ButtonDefinition(
-                id=canonical,
-                label=label,
-                evdev=canonical,
-                evdev_code=code_int,
-                source=source_id,
-                type="gamepad",
+        source = str(iface.get("id", "") or "") or None
+        names = ordered_gamepad_button_names(_controller_names(iface))
+        for name in names:
+            canonical = canonical_gamepad_button_name(name)
+            buttons.append(
+                ButtonDefinition(
+                    id=_unique_control_id(canonical, source, used),
+                    label=controller_control_label(canonical),
+                    evdev=canonical,
+                    evdev_code=resolve_evdev_code(canonical),
+                    source=source,
+                    type="gamepad",
+                )
             )
-        )
-
     return buttons
 
 
 def build_gamepad_analog_inputs(
     interfaces: Sequence[InterfaceInfo],
 ) -> list[AnalogInputDefinition]:
-    axis_specs = {
-        "left_stick": (
-            "Left Stick",
-            "stick",
-            ((evdev.ecodes.ABS_X, "x"), (evdev.ecodes.ABS_Y, "y")),
-        ),
-        "right_stick": (
-            "Right Stick",
-            "stick",
-            ((evdev.ecodes.ABS_RX, "x"), (evdev.ecodes.ABS_RY, "y")),
-        ),
-        "left_trigger": (
-            "Left Trigger",
-            "axis",
-            ((evdev.ecodes.ABS_Z, "x"),),
-        ),
-        "right_trigger": (
-            "Right Trigger",
-            "axis",
-            ((evdev.ecodes.ABS_RZ, "x"),),
-        ),
-    }
-    discovered: dict[str, dict[int, tuple[str, str]]] = {}
-
+    analogs: list[AnalogInputDefinition] = []
+    used: set[str] = set()
+    flight = any(
+        is_flight_stick(_controller_names(iface))
+        for iface in interfaces
+        if not interface_has_role(iface, "motion")
+    )
     for iface in interfaces:
         if interface_has_role(iface, "motion"):
             continue
-        raw_capabilities = iface.get("raw_capabilities") or {}
-        if not isinstance(raw_capabilities, dict):
-            continue
-        source_id = str(iface.get("id", "") or "")
-        abs_codes = {
-            code_int
-            for code in raw_capabilities.get(evdev.ecodes.EV_ABS, [])
-            if (code_int := evdev_code_value(code)) is not None
+        source = str(iface.get("id", "") or "") or None
+        entries = _controller_entries(iface, evdev.ecodes.EV_ABS)
+        # Touch and sensor axes do not describe controller controls.
+        entries = {
+            code: entry
+            for code, entry in entries.items()
+            if code < evdev.ecodes.ABS_MT_SLOT and code != evdev.ecodes.ABS_RESERVED
         }
-        for analog_id, (_label, _input_type, axes) in axis_specs.items():
-            codes = tuple(code for code, _role in axes)
-            if all(code in abs_codes for code in codes):
-                discovered[analog_id] = {code: (role, source_id) for code, role in axes}
-
-    analog_inputs: list[AnalogInputDefinition] = []
-    for analog_id, (label, input_type, axes) in axis_specs.items():
-        axis_data = discovered.get(analog_id)
-        if axis_data is None:
-            continue
-        codes = tuple(code for code, _role in axes)
-        source_id = next(
-            (axis_data[code][1] for code in codes if axis_data[code][1]),
-            None,
-        )
-        analog_inputs.append(
-            AnalogInputDefinition(
-                id=analog_id,
-                label=label,
-                type=input_type,
-                source=source_id,
-                axes=[
-                    AnalogAxisDefinition(
-                        role=axis_data[code][0],
-                        evdev=capability_name(evdev.ecodes.EV_ABS, code) or str(code),
-                        evdev_code=code,
-                    )
-                    for code in codes
-                ],
+        groups = [
+            (
+                "stick" if flight else "left_stick",
+                "Stick" if flight else "Left Stick",
+                (evdev.ecodes.ABS_X, evdev.ecodes.ABS_Y),
             )
-        )
-    return analog_inputs
+        ]
+        if not flight:
+            groups.append(
+                ("right_stick", "Right Stick", (evdev.ecodes.ABS_RX, evdev.ecodes.ABS_RY))
+            )
+        for index in range(4):
+            groups.append(
+                (
+                    f"hat_{index}",
+                    f"Hat {index + 1}",
+                    (evdev.ecodes.ABS_HAT0X + index * 2, evdev.ecodes.ABS_HAT0Y + index * 2),
+                )
+            )
+
+        def add(
+            analog_id: str,
+            label: str,
+            codes: tuple[int, ...],
+            *,
+            entries: dict[int, object] = entries,
+            flight: bool = flight,
+            source: str | None = source,
+        ) -> None:
+            axes = []
+            paired = len(codes) == 2
+            for role, code in zip(("x", "y"), codes, strict=False):
+                entry = entries.pop(code)
+                info = entry[1] if isinstance(entry, (tuple, list)) and len(entry) > 1 else None
+                minimum, maximum = getattr(info, "min", None), getattr(info, "max", None)
+                valid = isinstance(minimum, int) and isinstance(maximum, int) and minimum < maximum
+                name = capability_name(evdev.ecodes.EV_ABS, code) or str(code)
+                # Current position is not calibration. Only conventional centered
+                # controls get a midpoint; other single axes retain runtime learning.
+                centered = paired or (
+                    flight and name in {"abs_rx", "abs_ry", "abs_rz", "abs_rudder"}
+                )
+                midpoint = (
+                    (minimum + maximum) // 2
+                    if isinstance(minimum, int) and isinstance(maximum, int) and valid and centered
+                    else None
+                )
+                axes.append(
+                    AnalogAxisDefinition(
+                        role=role,
+                        evdev=name,
+                        evdev_code=code,
+                        minimum=minimum if valid else None,
+                        maximum=maximum if valid else None,
+                        center=midpoint if paired else None,
+                        rest=midpoint if not paired else None,
+                    )
+                )
+            analogs.append(
+                AnalogInputDefinition(
+                    id=_unique_control_id(analog_id, source, used),
+                    label=label,
+                    type="stick" if paired else "axis",
+                    source=source,
+                    axes=axes,
+                )
+            )
+
+        for analog_id, label, codes in groups:
+            if all(code in entries for code in codes):
+                add(analog_id, label, codes)
+        for code in sorted(entries):
+            name = capability_name(evdev.ecodes.EV_ABS, code) or str(code)
+            analog_id, label = name, controller_control_label(name)
+            if not flight and code in {evdev.ecodes.ABS_Z, evdev.ecodes.ABS_RZ}:
+                analog_id, label = (
+                    ("left_trigger", "Left Trigger")
+                    if code == evdev.ecodes.ABS_Z
+                    else ("right_trigger", "Right Trigger")
+                )
+            elif flight and code == evdev.ecodes.ABS_RZ:
+                label = "Twist"
+            add(analog_id, label, (code,))
+    return analogs
 
 
 MOTION_DRIVER_LABELS = {

--- a/keymasq/keymasqd/device_inventory.py
+++ b/keymasq/keymasqd/device_inventory.py
@@ -11,6 +11,10 @@ from typing import Any, Protocol, cast
 from keymasq.common.coercion import coerce_str
 from keymasq.common.model.core import DeviceType
 from keymasq.common.types import JsonObject
+from keymasq.keymasqd.runtime.virtual_gamepads import (
+    physical_gamepad_output_device,
+    resolved_hardware_analog_inputs,
+)
 
 
 class InventoryDeviceInfo(Protocol):
@@ -119,6 +123,7 @@ def recording_virtual_device_metadata(
         }
 
     for devices in grabbed_devices.values():
+        output_device = physical_gamepad_output_device(devices)
         for grabbed in devices:
             path = uinput_device_path(getattr(grabbed, "uinput", None))
             if not path:
@@ -133,6 +138,11 @@ def recording_virtual_device_metadata(
                 **_analog_calibration_metadata(grabbed),
                 "source_stable_path": str(getattr(grabbed, "stable_path", "") or ""),
                 "source_path": str(getattr(grabbed, "path", "") or ""),
+                **(
+                    {"gamepad_output": {"analog_inputs": resolved_hardware_analog_inputs(grabbed)}}
+                    if grabbed is output_device
+                    else {}
+                ),
             }
     return metadata
 

--- a/keymasq/keymasqd/device_inventory.py
+++ b/keymasq/keymasqd/device_inventory.py
@@ -67,6 +67,21 @@ def is_virtual_input(device: object) -> bool:
     return phys == "py-evdev-uinput" or name.startswith("keymasq-")
 
 
+def _analog_calibration_metadata(device: object) -> JsonObject:
+    result: JsonObject = {}
+    raw = getattr(device, "analog_axis_calibrations", {})
+    if not isinstance(raw, dict):
+        return result
+    calibrations = cast(dict[tuple[str, str], dict[str, object]], raw)
+    for (analog_id, role), values in calibrations.items():
+        result.setdefault(analog_id, {})[role] = {
+            field: value
+            for field, value in values.items()
+            if field in {"minimum", "maximum", "center", "rest"} and isinstance(value, int)
+        }
+    return {"analog_calibration": result} if result else {}
+
+
 def recording_virtual_device_metadata(
     output_state: object,
     grabbed_devices: Mapping[str, Sequence[object]],
@@ -115,6 +130,7 @@ def recording_virtual_device_metadata(
                 "recording_kind": "keymasq_passthrough",
                 "source_hardware_id": hardware_id,
                 "source_interface_id": interface_id,
+                **_analog_calibration_metadata(grabbed),
                 "source_stable_path": str(getattr(grabbed, "stable_path", "") or ""),
                 "source_path": str(getattr(grabbed, "path", "") or ""),
             }
@@ -132,6 +148,7 @@ def recording_grabbed_source_metadata(
                 metadata[stable_path] = {
                     "source_hardware_id": str(getattr(grabbed, "hardware_id", "") or ""),
                     "source_interface_id": str(getattr(grabbed, "interface_id", "") or ""),
+                    **_analog_calibration_metadata(grabbed),
                 }
     return metadata
 

--- a/keymasq/keymasqd/runtime/virtual_gamepads.py
+++ b/keymasq/keymasqd/runtime/virtual_gamepads.py
@@ -97,7 +97,7 @@ def physical_gamepad_output_device(devices: Sequence[object]) -> object | None:
         )
         if (
             getattr(device, "device_type", None) == DeviceType.GAMEPAD
-            or DeviceType.GAMEPAD in device_types
+            or DeviceType.GAMEPAD.value in device_types
         ) and getattr(device, "uinput", None) is not None:
             return device
     return None

--- a/keymasq/keymasqd/runtime/virtual_gamepads.py
+++ b/keymasq/keymasqd/runtime/virtual_gamepads.py
@@ -38,7 +38,7 @@ type ClearComboRuntime = Callable[[], Awaitable[None]]
 type ConfigureVirtualGamepads = Callable[[int], None]
 
 
-def _resolved_hardware_analog_inputs(device: object) -> dict[str, object]:
+def resolved_hardware_analog_inputs(device: object) -> dict[str, object]:
     """Combine saved metadata with cached grab-time calibration without mutating either."""
     raw_inputs = getattr(device, "analog_inputs", None)
     if not isinstance(raw_inputs, dict):
@@ -56,10 +56,14 @@ def _resolved_hardware_analog_inputs(device: object) -> dict[str, object]:
         if isinstance(raw_ranges, dict)
         else {}
     )
-    for analog_id, raw_input in inputs.items():
+    for analog_id, raw_input in list(inputs.items()):
         if not isinstance(raw_input, dict):
             continue
         analog = cast(dict[str, object], raw_input)
+        source = str(analog.get("source", "") or "").strip().lower()
+        if source and source != getattr(device, "interface_id", ""):
+            inputs.pop(analog_id, None)
+            continue
         raw_axes = analog.get("axes")
         if not isinstance(raw_axes, list):
             continue
@@ -82,6 +86,21 @@ def _resolved_hardware_analog_inputs(device: object) -> dict[str, object]:
             axes.append(axis)
         inputs[analog_id] = {**analog, "axes": axes}
     return inputs
+
+
+def physical_gamepad_output_device(devices: Sequence[object]) -> object | None:
+    """Select the same passthrough interface for routing and inventory."""
+    for device in devices:
+        raw_types = getattr(device, "device_types", None)
+        device_types: set[object] = (
+            set(cast(Sequence[object], raw_types)) if isinstance(raw_types, Sequence) else set()
+        )
+        if (
+            getattr(device, "device_type", None) == DeviceType.GAMEPAD
+            or DeviceType.GAMEPAD in device_types
+        ) and getattr(device, "uinput", None) is not None:
+            return device
+    return None
 
 
 async def reconfigure_virtual_gamepads(
@@ -216,31 +235,24 @@ class GamepadOutputRouter:
             self._warn(resolved_id, "target hardware is not grabbed", context, explicit)
             return None
 
-        for device in devices:
-            device_type = getattr(device, "device_type", None)
-            raw_types = getattr(device, "device_types", None)
-            device_types: set[object] = (
-                set(cast(Sequence[object], raw_types)) if isinstance(raw_types, Sequence) else set()
+        device = physical_gamepad_output_device(devices)
+        if device is not None:
+            stick_output = getattr(getattr(device, "state", None), "passthrough_stick_output", None)
+            analog_inputs = resolved_hardware_analog_inputs(device)
+            axes = learned_output_axes(analog_inputs.values())
+            return GamepadOutputTarget(
+                output_id=resolved_id,
+                uinput=getattr(device, "uinput", None),
+                bucket=f"gamepad:{resolved_id}",
+                is_virtual=False,
+                analog_inputs=analog_inputs,
+                output_axes=axes,
+                axis_rest_values={axis.code: axis.neutral for axis in axes},
+                axis_ranges={axis.code: (axis.minimum, axis.maximum) for axis in axes},
+                stick_output=stick_output
+                if isinstance(stick_output, StickOutputState)
+                else StickOutputState(),
             )
-            if device_type != DeviceType.GAMEPAD and DeviceType.GAMEPAD not in device_types:
-                continue
-            uinput = getattr(device, "uinput", None)
-            if uinput is not None:
-                stick_output = getattr(
-                    getattr(device, "state", None), "passthrough_stick_output", None
-                )
-                analog_inputs = _resolved_hardware_analog_inputs(device)
-                return GamepadOutputTarget(
-                    output_id=resolved_id,
-                    uinput=uinput,
-                    bucket=f"gamepad:{resolved_id}",
-                    is_virtual=False,
-                    analog_inputs=analog_inputs,
-                    output_axes=learned_output_axes(analog_inputs.values()),
-                    stick_output=stick_output
-                    if isinstance(stick_output, StickOutputState)
-                    else StickOutputState(),
-                )
         self._warn(
             resolved_id,
             "target hardware has no grabbed gamepad passthrough output",

--- a/keymasq/session/hardware.py
+++ b/keymasq/session/hardware.py
@@ -101,6 +101,9 @@ class HardwareManager:
         hw = cast(dict[str, Any], data["hardware"])
         vendor_id = str(hw["vendor_id"])
         product_id = str(hw["product_id"])
+        for field, value in (("vendor_id", vendor_id), ("product_id", product_id)):
+            if re.fullmatch(r"[0-9a-fA-F]{1,4}", value) is None:
+                raise ValueError(f"{field} must contain one to four hexadecimal digits")
         model_id = f"{vendor_id}:{product_id}"
         hardware_id = str(hw.get("hardware_id", "") or "")
         if hardware_id and not _valid_hardware_id_for_model(hardware_id, model_id):

--- a/keymasq/session/manager/recording_device_selection.py
+++ b/keymasq/session/manager/recording_device_selection.py
@@ -291,6 +291,7 @@ async def get_devices_for_recording(
                 "capabilities": [str(value) for value in json_list(d.get("capabilities"))],
                 "abs_info": json_object(d.get("abs_info")) or {},
                 "analog_calibration": json_object(d.get("analog_calibration")) or {},
+                "gamepad_output": json_object(d.get("gamepad_output")),
                 "driver": coerce_str(d.get("driver"), ""),
                 "recording_id": coerce_str(d.get("recording_id"), f"physical:{stable_path}"),
                 "recording_kind": coerce_str(d.get("recording_kind"), "physical"),

--- a/keymasq/session/manager/recording_device_selection.py
+++ b/keymasq/session/manager/recording_device_selection.py
@@ -290,6 +290,7 @@ async def get_devices_for_recording(
                 "device_types": resolved_types,
                 "capabilities": [str(value) for value in json_list(d.get("capabilities"))],
                 "abs_info": json_object(d.get("abs_info")) or {},
+                "analog_calibration": json_object(d.get("analog_calibration")) or {},
                 "driver": coerce_str(d.get("driver"), ""),
                 "recording_id": coerce_str(d.get("recording_id"), f"physical:{stable_path}"),
                 "recording_kind": coerce_str(d.get("recording_kind"), "physical"),

--- a/tests/gui/test_analog_input_edit_dialog.py
+++ b/tests/gui/test_analog_input_edit_dialog.py
@@ -198,3 +198,24 @@ def test_automatic_rest_uses_grab_sample_not_current_position():
     new_dialog = make_dialog(analog, [])
     new_dialog.update_device_inventory({"devices": [other]}, hardware)
     assert new_dialog.axis_entries[0]["rest"].get_placeholder_text() == "On next grab"
+
+
+@pytest.mark.parametrize("kind,neutral", [("stick", "center"), ("axis", "rest")])
+def test_editor_validates_against_detected_bounds_without_saving_them(kind, neutral):
+    analog = make_analog(kind)
+    for axis in analog.axes:
+        axis.minimum = axis.maximum = axis.center = axis.rest = None
+    saved = []
+    dialog = make_dialog(analog, saved)
+    dialog._detected = {"0": {"minimum": 0, "maximum": 255}}
+    row = dialog.axis_entries[0]
+    row[neutral].set_text("1000")
+    dialog.save_button.emit("clicked")
+    assert not saved
+    assert dialog.error_label.get_visible()
+    row[neutral].set_text("100")
+    dialog.save_button.emit("clicked")
+    assert len(saved) == 1
+    assert saved[0].axes[0].minimum is None
+    assert saved[0].axes[0].maximum is None
+    assert getattr(saved[0].axes[0], neutral) == 100

--- a/tests/gui/test_analog_input_edit_dialog.py
+++ b/tests/gui/test_analog_input_edit_dialog.py
@@ -1,0 +1,200 @@
+from copy import deepcopy
+from dataclasses import replace
+from types import SimpleNamespace
+
+import pytest
+
+from keymasq.common.model.hardware import AnalogAxisDefinition, AnalogInputDefinition
+from keymasq.gui.widgets.device_tab.analog_edit_dialog import AnalogInputEditDialog
+from keymasq.gui.widgets.device_tab.inputs import InputInventoryMixin
+
+
+def make_analog(kind="stick"):
+    return AnalogInputDefinition(
+        id="existing-control",
+        label="Stick",
+        type=kind,
+        source="joystick",
+        axes=[
+            AnalogAxisDefinition(
+                role=role,
+                evdev=code,
+                evdev_code=index,
+                minimum=0,
+                maximum=1023,
+                center=511 if kind == "stick" else None,
+                rest=255 if kind == "axis" else None,
+                invert=True,
+            )
+            for index, (role, code) in enumerate(
+                [("x", "abs_x"), ("y", "abs_y")] if kind == "stick" else [("x", "abs_throttle")]
+            )
+        ],
+    )
+
+
+def make_dialog(analog, saved):
+    return AnalogInputEditDialog(
+        analog,
+        on_save=lambda edited: saved.append(edited) or True,
+        on_delete_clicked=lambda *args: None,
+        on_close_clicked=lambda button, dialog: dialog.close(),
+    )
+
+
+@pytest.mark.parametrize("kind,neutral_field", [("stick", "center"), ("axis", "rest")])
+def test_edit_calibration_preserves_source_and_identity(kind, neutral_field):
+    analog = make_analog(kind)
+    original = deepcopy(analog)
+    saved = []
+    dialog = make_dialog(analog, saved)
+    dialog.name_entry.set_text("Adjusted control")
+    row = dialog.axis_entries[0]
+    row["minimum"].set_text("-100")
+    row["maximum"].set_text("900")
+    row[neutral_field].set_text("300")
+    assert analog == original
+    dialog.save_button.emit("clicked")
+    assert len(saved) == 1
+    edited = saved[0]
+    assert (edited.id, edited.source, edited.type) == (analog.id, analog.source, kind)
+    assert edited.label == "Adjusted control"
+    assert (edited.axes[0].minimum, edited.axes[0].maximum) == (-100, 900)
+    assert getattr(edited.axes[0], neutral_field) == 300
+    assert edited.axes[0].evdev == analog.axes[0].evdev
+    assert edited.axes[0].invert is True
+    if kind == "stick":
+        assert edited.axes[1] == original.axes[1]
+    assert analog == original
+
+
+def test_blank_calibration_removes_overrides():
+    saved = []
+    dialog = make_dialog(make_analog(), saved)
+    for row in dialog.axis_entries:
+        for entry in row.values():
+            entry.set_text("")
+    dialog.save_button.emit("clicked")
+    assert all(a.minimum is None and a.maximum is None and a.center is None for a in saved[0].axes)
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("minimum", "1023"),
+        ("maximum", "-1"),
+        ("center", "1024"),
+        ("minimum", "1.5"),
+        ("maximum", "2147483648"),
+    ],
+)
+def test_invalid_values_do_not_save(field, value):
+    analog = make_analog()
+    original = deepcopy(analog)
+    saved = []
+    dialog = make_dialog(analog, saved)
+    dialog.axis_entries[0][field].set_text(value)
+    dialog.save_button.emit("clicked")
+    assert not saved
+    assert analog == original
+    assert dialog.error_label.get_visible()
+
+
+def test_cancel_and_failed_save_leave_original_unchanged():
+    analog = make_analog()
+    original = deepcopy(analog)
+    dialog = make_dialog(analog, [])
+    dialog.name_entry.set_text("Unsaved")
+    dialog.close()
+    assert analog == original
+    dialog = make_dialog(analog, [])
+    dialog._on_save = lambda edited: False
+    dialog.save_button.emit("clicked")
+    assert dialog.error_label.get_visible()
+    assert analog == original
+
+
+@pytest.mark.parametrize("fail", [False, True])
+def test_commit_preserves_mapping_identity_and_rolls_back_failed_writes(fail):
+    analog = make_analog()
+    original = deepcopy(analog)
+    writes, requests = [], []
+
+    def save_hardware(device):
+        if fail:
+            raise OSError("Cannot write hardware config")
+        writes.append(deepcopy(device))
+
+    host = SimpleNamespace(
+        hardware_manager=SimpleNamespace(save_hardware=save_hardware),
+        device=SimpleNamespace(analog_inputs=[analog]),
+        _request_session_async=lambda request, callback: requests.append(request),
+        _ignore_session_response=lambda *args: None,
+        _button_widgets={},
+    )
+    edited = replace(analog, label="Adjusted", axes=[replace(a, center=400) for a in analog.axes])
+    assert InputInventoryMixin._save_analog_properties(host, edited) is (not fail)
+    if fail:
+        assert analog == original
+        assert requests == []
+    else:
+        assert writes[0].analog_inputs[0] == edited
+        assert analog.id == original.id
+        assert requests == [{"command": "reload"}]
+
+
+def test_automatic_values_use_reported_bounds_and_do_not_save_hints():
+    from keymasq.common.model.hardware import HardwareConfig
+
+    analog = make_analog()
+    for axis in analog.axes:
+        axis.minimum = axis.maximum = axis.center = None
+    saved = []
+    dialog = make_dialog(analog, saved)
+    hardware = HardwareConfig("1234", "5678", "Test", [], [], [analog])
+    assert dialog.axis_entries[0]["minimum"].get_placeholder_text() == "Unavailable"
+    dialog.update_device_inventory(
+        {
+            "devices": [
+                {
+                    "source_hardware_id": hardware.hardware_id,
+                    "source_interface_id": analog.source,
+                    "abs_info": {"0": {"minimum": 10, "maximum": 810, "value": 750}},
+                }
+            ]
+        },
+        hardware,
+    )
+    row = dialog.axis_entries[0]
+    assert row["minimum"].get_placeholder_text() == "10 (auto)"
+    assert row["maximum"].get_placeholder_text() == "810 (auto)"
+    assert row["center"].get_placeholder_text() == "410 (auto)"
+    row["maximum"].set_text("1010")
+    assert row["center"].get_placeholder_text() == "510 (auto)"
+    row["maximum"].set_text("")
+    dialog.save_button.emit("clicked")
+    assert saved[0].axes[0].minimum is None
+    assert saved[0].axes[0].center is None
+
+
+def test_automatic_rest_uses_grab_sample_not_current_position():
+    from keymasq.common.model.hardware import HardwareConfig
+
+    analog = make_analog("axis")
+    analog.axes[0].rest = None
+    dialog = make_dialog(analog, [])
+    hardware = HardwareConfig("1234", "5678", "Test", [], [], [analog])
+    data = {
+        "source_hardware_id": hardware.hardware_id,
+        "source_interface_id": analog.source,
+        "abs_info": {"0": {"minimum": 0, "maximum": 255, "value": 200}},
+    }
+    dialog.update_device_inventory({"devices": [data]}, hardware)
+    assert dialog.axis_entries[0]["rest"].get_placeholder_text() == "On next grab"
+    data["analog_calibration"] = {analog.id: {"x": {"rest": 25}}}
+    dialog.update_device_inventory({"devices": [data]}, hardware)
+    assert dialog.axis_entries[0]["rest"].get_placeholder_text() == "25 (auto)"
+    other = dict(data, source_interface_id="another-interface")
+    new_dialog = make_dialog(analog, [])
+    new_dialog.update_device_inventory({"devices": [other]}, hardware)
+    assert new_dialog.axis_entries[0]["rest"].get_placeholder_text() == "On next grab"

--- a/tests/gui/test_controller_capability_setup.py
+++ b/tests/gui/test_controller_capability_setup.py
@@ -1,0 +1,213 @@
+"""Capability-to-hardware regression tests for controller setup and targeting."""
+
+import evdev
+
+from keymasq.common.controller_capabilities import hardware_controller_template
+from keymasq.common.model.core import DeviceType
+from keymasq.common.model.hardware import EvdevDevice, HardwareConfig
+from keymasq.common.virtual_device_templates import LOGITECH_EXTREME_3D_TEMPLATE, XBOX_360_TEMPLATE
+from keymasq.gui.wizards.hardware_setup.flow import merge_inventory_abs_info
+from keymasq.gui.wizards.hardware_setup.templates import (
+    build_gamepad_analog_inputs,
+    build_gamepad_buttons,
+)
+
+
+def controller_interface(template):
+    return {
+        "id": "controller",
+        "device_types": ["gamepad"],
+        "capabilities": [button.evdev for button in template.buttons],
+        "raw_capabilities": {
+            evdev.ecodes.EV_KEY: [getattr(evdev.ecodes, b.evdev.upper()) for b in template.buttons],
+            evdev.ecodes.EV_ABS: [
+                (
+                    getattr(evdev.ecodes, a.evdev.upper()),
+                    evdev.AbsInfo(a.maximum, a.minimum, a.maximum, 0, 0, 0),
+                )
+                for a in template.axes
+            ],
+        },
+    }
+
+
+def hardware_from_interfaces(interfaces):
+    return HardwareConfig(
+        vendor_id="046d",
+        product_id="c215",
+        name="Test controller",
+        evdev_devices=[EvdevDevice("/dev/test", DeviceType.GAMEPAD)],
+        buttons=build_gamepad_buttons(interfaces),
+        analog_inputs=build_gamepad_analog_inputs(interfaces),
+    )
+
+
+def test_flight_stick_preserves_every_control_and_range():
+    config = hardware_from_interfaces([controller_interface(LOGITECH_EXTREME_3D_TEMPLATE)])
+    assert {b.evdev for b in config.buttons} == {
+        b.evdev for b in LOGITECH_EXTREME_3D_TEMPLATE.buttons
+    }
+    analogs = {a.id: a for a in config.analog_inputs}
+    assert set(analogs) == {"stick", "hat_0", "abs_rz", "abs_throttle"}
+    assert analogs["abs_rz"].label == "Twist"
+    assert analogs["abs_rz"].axes[0].rest == 127
+    assert analogs["abs_throttle"].axes[0].rest is None
+    assert analogs["stick"].axes[0].center == 511
+    output = hardware_controller_template(config)
+    assert output.layout == "flight-stick"
+    assert {a.evdev: (a.minimum, a.maximum) for a in output.axes} == {
+        a.evdev: (a.minimum, a.maximum) for a in LOGITECH_EXTREME_3D_TEMPLATE.axes
+    }
+
+
+def test_gamepad_keeps_digital_triggers_and_hats():
+    config = hardware_from_interfaces([controller_interface(XBOX_360_TEMPLATE)])
+    assert len(config.buttons) == len(XBOX_360_TEMPLATE.buttons)
+    assert {a.id for a in config.analog_inputs} == {
+        "left_stick",
+        "right_stick",
+        "left_trigger",
+        "right_trigger",
+        "hat_0",
+    }
+    assert hardware_controller_template(config).layout == "gamepad"
+
+
+def test_inventory_fallback_preserves_buttons_and_axis_metadata():
+    iface = {
+        "id": "controller",
+        "device_types": ["gamepad"],
+        "capabilities": ["btn_trigger", "btn_trigger_happy1", "abs_throttle"],
+        "raw_capabilities": merge_inventory_abs_info(
+            {},
+            {
+                str(evdev.ecodes.ABS_THROTTLE): {"minimum": 10, "maximum": 900, "value": 500},
+            },
+        ),
+    }
+    config = hardware_from_interfaces([iface])
+    assert {b.evdev for b in config.buttons} == {"btn_trigger", "btn_trigger_happy1"}
+    axis = config.analog_inputs[0].axes[0]
+    assert (axis.minimum, axis.maximum, axis.rest) == (10, 900, None)
+
+
+def test_pairing_does_not_cross_interfaces_or_drop_duplicate_controls():
+    interfaces = [
+        {"id": "one", "capabilities": ["btn_trigger", "abs_x", "abs_rx", "abs_ry"]},
+        {"id": "two", "capabilities": ["btn_trigger", "abs_y", "abs_rx"]},
+    ]
+    config = hardware_from_interfaces(interfaces)
+    assert len(config.buttons) == 2
+    assert len({b.id for b in config.buttons}) == 2
+    assert len(config.analog_inputs) == 5
+    assert all(a.type == "axis" for a in config.analog_inputs)
+    assert len({a.id for a in config.analog_inputs}) == 5
+
+
+def test_motion_interfaces_are_excluded():
+    iface = controller_interface(LOGITECH_EXTREME_3D_TEMPLATE)
+    iface["device_types"] = ["motion"]
+    config = hardware_from_interfaces([iface])
+    assert not config.buttons
+    assert not config.analog_inputs
+
+
+def test_physical_selector_uses_saved_flight_controls_and_ranges(monkeypatch):
+    from types import SimpleNamespace
+
+    import gi
+
+    gi.require_version("Gtk", "4.0")
+    from gi.repository import Gtk
+
+    import keymasq.gui.widgets.key_selector.tabs as tabs
+    from keymasq.common.model.actions import MappingAction
+    from keymasq.common.model.core import ActionType
+    from keymasq.common.virtual_device_templates import VirtualDeviceConfig
+    from keymasq.gui.widgets.key_selector.dialog import KeySelectorDialog
+
+    iface = controller_interface(LOGITECH_EXTREME_3D_TEMPLATE)
+    iface["capabilities"].append("btn_trigger_happy1")
+    config = hardware_from_interfaces([iface])
+    monkeypatch.setattr(tabs, "virtual_gamepad_count", lambda: 1)
+    monkeypatch.setattr(tabs, "virtual_device_config", VirtualDeviceConfig)
+    monkeypatch.setattr(
+        tabs, "HardwareManager", lambda: SimpleNamespace(list_hardware=lambda: [config])
+    )
+    dialog = KeySelectorDialog(
+        Gtk.Box(),
+        "Source",
+        MappingAction(
+            action_type=ActionType.GAMEPAD,
+            target="btn_trigger",
+            output_id=config.hardware_id,
+        ),
+    )
+    assert not dialog._standard_gamepad_picker.get_visible()
+    picker = dialog._template_gamepad_picker.get_first_child()
+    assert picker._template.layout == "flight-stick"
+    assert picker._axes["abs_x"].maximum == 1023
+    assert len(picker._template.buttons) == 13
+    assert "Flight stick" in dict(dialog._gamepad_output_choices())[config.hardware_id]
+    actions = []
+    dialog._emit_selected_action = actions.append
+    dialog._close_after_selection_emit = lambda: None
+    picker._on_axis(Gtk.Button(), "abs_x", 1023)
+    assert actions[0].output_id == config.hardware_id
+    assert actions[0].axis_value == 1023
+    assert actions[0].target == "abs_x"
+    assert all(axis.evdev != "abs_z" for axis in picker._template.axes)
+
+
+def test_button_only_physical_picker_does_not_invent_axes():
+    import gi
+
+    gi.require_version("Gtk", "4.0")
+    from gi.repository import Gtk
+
+    from keymasq.gui.widgets.virtual_device_picker import VirtualDevicePicker
+
+    config = hardware_from_interfaces([{"id": "buttons", "capabilities": ["btn_trigger"]}])
+    selected = []
+    picker = VirtualDevicePicker(
+        hardware_controller_template(config),
+        lambda _, code: selected.append(code),
+        lambda *args: None,
+    )
+    assert picker.axis_names == []
+    assert not picker.range_label.get_visible()
+    picker._on_button(Gtk.Button(), "btn_trigger")
+    assert selected == ["btn_trigger"]
+
+
+def test_legacy_controller_keeps_axis_targets_without_mutating_calibration():
+    from copy import deepcopy
+
+    config = hardware_from_interfaces([controller_interface(XBOX_360_TEMPLATE)])
+    for analog in config.analog_inputs:
+        for axis in analog.axes:
+            if analog.id != "hat_0":
+                axis.minimum = axis.maximum = axis.center = axis.rest = None
+    original = deepcopy(config)
+    output = hardware_controller_template(config)
+    axes = {axis.evdev: axis for axis in output.axes}
+    assert len(axes) == 8
+    assert (axes["abs_x"].minimum, axes["abs_x"].maximum, axes["abs_x"].rest) == (
+        -32768,
+        32767,
+        0,
+    )
+    assert (axes["abs_z"].minimum, axes["abs_z"].maximum) == (0, 255)
+    assert config == original
+
+
+def test_picker_prefers_saved_ranges_over_legacy_defaults():
+    config = hardware_from_interfaces([controller_interface(XBOX_360_TEMPLATE)])
+    stick = next(a for a in config.analog_inputs if a.id == "left_stick")
+    stick.axes[0].minimum = 10
+    stick.axes[0].maximum = 1000
+    stick.axes[0].center = 400
+    stick.axes[1].minimum = stick.axes[1].maximum = stick.axes[1].center = None
+    axes = {a.evdev: a for a in hardware_controller_template(config).axes}
+    assert (axes["abs_x"].minimum, axes["abs_x"].maximum, axes["abs_x"].rest) == (10, 1000, 400)
+    assert (axes["abs_y"].minimum, axes["abs_y"].maximum) == (-32768, 32767)

--- a/tests/gui/test_controller_capability_setup.py
+++ b/tests/gui/test_controller_capability_setup.py
@@ -1,10 +1,12 @@
 """Capability-to-hardware regression tests for controller setup and targeting."""
 
 import evdev
+import pytest
 
 from keymasq.common.controller_capabilities import hardware_controller_template
 from keymasq.common.model.core import DeviceType
 from keymasq.common.model.hardware import EvdevDevice, HardwareConfig
+from keymasq.common.types import JsonObject
 from keymasq.common.virtual_device_templates import LOGITECH_EXTREME_3D_TEMPLATE, XBOX_360_TEMPLATE
 from keymasq.gui.wizards.hardware_setup.flow import merge_inventory_abs_info
 from keymasq.gui.wizards.hardware_setup.templates import (
@@ -40,6 +42,74 @@ def hardware_from_interfaces(interfaces):
         buttons=build_gamepad_buttons(interfaces),
         analog_inputs=build_gamepad_analog_inputs(interfaces),
     )
+
+
+def output_inventory(config, *, source="controller") -> JsonObject:
+    from dataclasses import asdict
+
+    return {
+        "source_hardware_id": config.hardware_id,
+        "source_interface_id": source,
+        "capabilities": [b.evdev for b in config.buttons]
+        + [axis.evdev for analog in config.analog_inputs for axis in analog.axes],
+        "gamepad_output": {
+            "analog_inputs": {analog.id: asdict(analog) for analog in config.analog_inputs}
+        },
+    }
+
+
+def test_routed_picker_excludes_secondary_interface_buttons_and_duplicates():
+    from keymasq.common.controller_capabilities import routed_controller_template
+
+    config = hardware_from_interfaces(
+        [
+            {"id": "one", "capabilities": ["btn_trigger"]},
+            {"id": "two", "capabilities": ["btn_trigger", "btn_trigger_happy1"]},
+        ]
+    )
+    inventory = output_inventory(config, source="one")
+    inventory["capabilities"] = [f"EV_KEY_{evdev.ecodes.BTN_TRIGGER}"]
+    template, _ = routed_controller_template(config, inventory)
+    assert [(b.id, b.evdev) for b in template.buttons] == [
+        (config.buttons[0].id, "btn_trigger"),
+    ]
+
+
+@pytest.mark.parametrize("rest", [None, 255])
+def test_routed_picker_uses_resolved_rest_or_disables_percentages(rest):
+    import gi
+
+    gi.require_version("Gtk", "4.0")
+    from gi.repository import Gtk
+
+    from keymasq.common.controller_capabilities import routed_controller_template
+    from keymasq.gui.widgets.virtual_device_picker import VirtualDevicePicker
+
+    config = hardware_from_interfaces([controller_interface(LOGITECH_EXTREME_3D_TEMPLATE)])
+    inventory = output_inventory(config)
+    inventory["gamepad_output"]["analog_inputs"]["abs_throttle"]["axes"][0]["rest"] = rest
+    template, unknown = routed_controller_template(config, inventory)
+    events = []
+    picker = VirtualDevicePicker(
+        template,
+        lambda *_: None,
+        lambda _b, code, value: events.append((code, value)),
+        unknown_rest_axes=unknown,
+    )
+    picker.axis_choice.set_selected(picker.axis_names.index("abs_throttle"))
+    assert picker.percent_spin.get_sensitive() == (rest is not None)
+    if rest is None:
+        shortcut = picker._axis_shortcut("Idle", "abs_throttle", 0, "Idle")
+        assert not shortcut.get_visible()
+        assert "unavailable" in picker.range_label.get_text()
+        picker.value_spin.set_value(42)
+        picker._map_axis(Gtk.Button())
+        assert events == [("abs_throttle", 42)]
+    else:
+        picker.percent_spin.set_value(0)
+        assert picker.value_spin.get_value_as_int() == 255
+        picker.percent_spin.set_value(100)
+        assert picker.value_spin.get_value_as_int() == 0
 
 
 def test_flight_stick_preserves_every_control_and_range():
@@ -134,6 +204,11 @@ def test_physical_selector_uses_saved_flight_controls_and_ranges(monkeypatch):
     monkeypatch.setattr(
         tabs, "HardwareManager", lambda: SimpleNamespace(list_hardware=lambda: [config])
     )
+    monkeypatch.setattr(
+        tabs,
+        "session_request_async",
+        lambda _request, callback: callback({"devices": [output_inventory(config)]}),
+    )
     dialog = KeySelectorDialog(
         Gtk.Box(),
         "Source",
@@ -157,6 +232,55 @@ def test_physical_selector_uses_saved_flight_controls_and_ranges(monkeypatch):
     assert actions[0].axis_value == 1023
     assert actions[0].target == "abs_x"
     assert all(axis.evdev != "abs_z" for axis in picker._template.axes)
+
+    # Execute the action emitted by the picker through the physical router.
+    import asyncio
+    import logging
+    from dataclasses import asdict
+    from unittest.mock import AsyncMock
+
+    from keymasq.keymasqd.runtime.action.outputs import execute_gamepad_axis_action
+    from keymasq.keymasqd.runtime.adapters import identity_uinput_writer
+    from keymasq.keymasqd.runtime.grabbed_device.device import GrabbedDevice
+    from keymasq.keymasqd.runtime.grabbed_device.types import ActionExecutionDeps
+    from keymasq.keymasqd.runtime.virtual_gamepads import GamepadOutputRouter
+
+    runtime = GrabbedDevice(
+        path="/dev/test",
+        hardware_id=config.hardware_id,
+        button_map={},
+        mapping_getter=lambda: {},
+        event_callback=AsyncMock(),
+        device_type=DeviceType.GAMEPAD,
+    )
+    runtime.interface_id = "controller"
+    runtime.update_analog_inputs({analog.id: asdict(analog) for analog in config.analog_inputs})
+    emitted = []
+    runtime.uinput = SimpleNamespace(write=lambda *event: emitted.append(event), syn=lambda: None)
+    router = GamepadOutputRouter(logging.getLogger(__name__))
+    runtime._gamepad_output_resolver = lambda output_id, _context: router.resolve(
+        SimpleNamespace(),
+        {config.hardware_id: [runtime]},
+        output_id,
+    )
+    deps = ActionExecutionDeps(
+        asyncio_mod=asyncio,
+        evdev_mod=evdev,
+        uinput_writer=identity_uinput_writer,
+        fire_and_observe_fn=lambda coro, _label: asyncio.create_task(coro),
+    )
+
+    async def press_release():
+        for value in (1, 0):
+            await execute_gamepad_axis_action(
+                runtime, actions[0], SimpleNamespace(value=value), "key_a", deps=deps
+            )
+
+    asyncio.run(press_release())
+    assert emitted == [
+        (evdev.ecodes.EV_ABS, evdev.ecodes.ABS_X, 1023),
+        (evdev.ecodes.EV_ABS, evdev.ecodes.ABS_X, 511),
+    ]
 
 
 def test_button_only_physical_picker_does_not_invent_axes():

--- a/tests/keymasqd/test_analog_calibration_inventory.py
+++ b/tests/keymasqd/test_analog_calibration_inventory.py
@@ -1,0 +1,25 @@
+from types import SimpleNamespace
+
+from keymasq.keymasqd.device_inventory import (
+    recording_grabbed_source_metadata,
+    recording_virtual_device_metadata,
+)
+
+
+def test_inventory_exposes_grab_calibration_for_source_and_passthrough():
+    device = SimpleNamespace(
+        hardware_id="1234:5678",
+        interface_id="stick",
+        stable_path="/dev/input/event1",
+        path="/dev/input/event1",
+        uinput=SimpleNamespace(device=SimpleNamespace(path="/dev/input/event2")),
+        analog_axis_calibrations={
+            ("throttle", "x"): {"minimum": 0, "maximum": 255, "rest": 37},
+        },
+    )
+    grabbed = {device.hardware_id: [device]}
+    source = recording_grabbed_source_metadata(grabbed)[device.stable_path]
+    passthrough = recording_virtual_device_metadata(SimpleNamespace(), grabbed)["/dev/input/event2"]
+    expected = {"throttle": {"x": {"minimum": 0, "maximum": 255, "rest": 37}}}
+    assert source["analog_calibration"] == expected
+    assert passthrough["analog_calibration"] == expected

--- a/tests/keymasqd/test_output_axis_routing.py
+++ b/tests/keymasqd/test_output_axis_routing.py
@@ -117,3 +117,112 @@ def test_hardware_axis_can_use_cached_range_without_calibration() -> None:
     assert target is not None and target.output_axes
     axis = target.output_axes[0]
     assert (axis.minimum, axis.maximum, axis.neutral) == (100, 900, 100)
+
+
+@pytest.mark.parametrize("mode", ["release", "tap", "rapidfire", "cleanup"])
+def test_physical_axis_action_returns_to_calibrated_neutral(mode):
+    from keymasq.common.model.actions import MappingAction
+    from keymasq.common.model.core import ActionType
+    from keymasq.keymasqd.runtime.action.outputs import execute_gamepad_axis_action
+
+    device = _hardware(
+        {"role": "x", "evdev": "ABS_RZ", "minimum": 0, "maximum": 255, "rest": 127},
+        absinfo=evdev.AbsInfo(127, 0, 255, 0, 0, 0),
+    )
+    target = _router_target(device)
+    device._gamepad_output_resolver = lambda *_args: target
+    device.running = True
+    action = MappingAction(
+        action_type=ActionType.GAMEPAD_AXIS,
+        target="abs_rz",
+        axis_value=255,
+        output_id="hardware",
+        tap_enabled=mode == "tap",
+        rapidfire_enabled=mode == "rapidfire",
+        tap_hold_ms=1,
+        rapidfire_hold_ms=1,
+        rapidfire_wait_ms=1,
+    )
+    tasks = []
+
+    def start(coro, _label):
+        task = asyncio.create_task(coro)
+        tasks.append(task)
+        return task
+
+    deps = ActionExecutionDeps(
+        asyncio_mod=asyncio,
+        evdev_mod=evdev,
+        uinput_writer=identity_uinput_writer,
+        fire_and_observe_fn=start,
+    )
+
+    async def run():
+        await execute_gamepad_axis_action(
+            device,
+            action,
+            SimpleNamespace(value=1),
+            "key_a",
+            deps=deps,
+        )
+        if mode == "tap":
+            await asyncio.gather(*tasks)
+        elif mode == "rapidfire":
+            # Wait for an actual pulse before releasing, without relying on sleep timing.
+            async with asyncio.timeout(1):
+                while len(device.uinput.events) < 2:
+                    await asyncio.sleep(0)
+            await execute_gamepad_axis_action(
+                device,
+                action,
+                SimpleNamespace(value=0),
+                "key_a",
+                deps=deps,
+            )
+        elif mode == "cleanup":
+            device.release_tracked_outputs()
+        else:
+            await execute_gamepad_axis_action(
+                device,
+                action,
+                SimpleNamespace(value=0),
+                "key_a",
+                deps=deps,
+            )
+
+    asyncio.run(run())
+    values = [value for _type, code, value in device.uinput.events if code == evdev.ecodes.ABS_RZ]
+    assert values[0] == 255
+    assert values[-1] == 127
+    assert set(values) == {127, 255}
+
+
+def test_physical_output_inventory_matches_router_interface_and_calibration():
+    from keymasq.keymasqd.device_inventory import recording_virtual_device_metadata
+
+    first = _hardware(
+        {"role": "x", "evdev": "ABS_THROTTLE", "minimum": 0, "maximum": 255},
+        absinfo=evdev.AbsInfo(255, 0, 255, 0, 0, 0),
+    )
+    second = _hardware(
+        {"role": "x", "evdev": "ABS_RZ"}, absinfo=evdev.AbsInfo(127, 0, 255, 0, 0, 0)
+    )
+    first.interface_id, second.interface_id = "one", "two"
+    first.uinput.device = SimpleNamespace(path="/dev/input/first-output")
+    second.uinput.device = SimpleNamespace(path="/dev/input/second-output")
+    first.analog_inputs["other"] = {
+        "source": "two",
+        "type": "axis",
+        "axes": [{"role": "x", "evdev": "ABS_RZ", "minimum": 0, "maximum": 255, "rest": 127}],
+    }
+    grabbed = {"hardware": [first, second]}
+    target = GamepadOutputRouter(logging.getLogger(__name__)).resolve(
+        SimpleNamespace(), grabbed, "hardware"
+    )
+    metadata = recording_virtual_device_metadata(SimpleNamespace(), grabbed)
+    assert target.uinput is first.uinput
+    assert "gamepad_output" not in metadata["/dev/input/second-output"]
+    analogs = metadata["/dev/input/first-output"]["gamepad_output"]["analog_inputs"]
+    assert "other" not in analogs
+    assert analogs["left_trigger"]["axes"][0]["rest"] == 255
+    assert target.axis_rest_values[evdev.ecodes.ABS_THROTTLE] == 255

--- a/tests/keymasqd/test_output_axis_routing.py
+++ b/tests/keymasqd/test_output_axis_routing.py
@@ -197,7 +197,8 @@ def test_physical_axis_action_returns_to_calibrated_neutral(mode):
     assert set(values) == {127, 255}
 
 
-def test_physical_output_inventory_matches_router_interface_and_calibration():
+@pytest.mark.parametrize("primary_type", [DeviceType.GAMEPAD, DeviceType.KEYBOARD])
+def test_physical_output_inventory_matches_router_interface_and_calibration(primary_type):
     from keymasq.keymasqd.device_inventory import recording_virtual_device_metadata
 
     first = _hardware(
@@ -207,6 +208,8 @@ def test_physical_output_inventory_matches_router_interface_and_calibration():
     second = _hardware(
         {"role": "x", "evdev": "ABS_RZ"}, absinfo=evdev.AbsInfo(127, 0, 255, 0, 0, 0)
     )
+    first.device_type = primary_type
+    first.device_types = [primary_type.value, "gamepad"]
     first.interface_id, second.interface_id = "one", "two"
     first.uinput.device = SimpleNamespace(path="/dev/input/first-output")
     second.uinput.device = SimpleNamespace(path="/dev/input/second-output")

--- a/tests/session/test_session_hardware.py
+++ b/tests/session/test_session_hardware.py
@@ -763,3 +763,15 @@ def test_hardware_manager_saves_gamepad_layout_type(temp_config_dir) -> None:
     assert 'type = "gamepad"' in text
     assert "evdev_code = 304" in text
     assert HardwareManager().get_hardware("9999:0001") == config
+
+
+@pytest.mark.parametrize("field", ["vendor_id", "product_id"])
+@pytest.mark.parametrize("value", ["", "not-hex", "-1", "10000"])
+def test_invalid_hardware_identifiers_are_not_cached(temp_config_dir, field, value):
+    config_path = temp_config_dir / "hardware" / "invalid-id.toml"
+    identifiers = {"vendor_id": "1234", "product_id": "5678", field: value}
+    _write_minimal_hardware_config(config_path, name="Invalid", **identifiers)
+    manager = HardwareManager()
+    assert manager.list_hardware() == []
+    with pytest.raises(ValueError, match=f"{field} must contain"):
+        manager._load_config(config_path)

--- a/tests/session/test_session_manager_recording_settings.py
+++ b/tests/session/test_session_manager_recording_settings.py
@@ -450,6 +450,42 @@ async def test_get_devices_for_recording_preserves_motion_axis_metadata() -> Non
 
 
 @pytest.mark.asyncio
+async def test_recording_inventory_preserves_physical_output_calibration() -> None:
+    manager = SessionManager()
+    output = {
+        "analog_inputs": {
+            "throttle": {
+                "type": "axis",
+                "axes": [{"evdev": "ABS_THROTTLE", "minimum": 0, "maximum": 255, "rest": 255}],
+            }
+        }
+    }
+    manager.client.send_command = AsyncMock(
+        return_value=Response(
+            status="ok",
+            data={
+                "devices": [
+                    {
+                        "path": "/dev/input/output",
+                        "device_type": "gamepad",
+                        "recording_kind": "keymasq_passthrough",
+                        "source_hardware_id": "046d:c215",
+                        "source_interface_id": "stick",
+                        "capabilities": ["EV_KEY_288", "EV_ABS_6"],
+                        "gamepad_output": output,
+                    }
+                ]
+            },
+        )
+    )
+    devices = await recording_device_selection_module.get_devices_for_recording(
+        manager, ["gamepad"]
+    )
+    assert devices[0]["gamepad_output"] == output
+    assert devices[0]["source_interface_id"] == "stick"
+
+
+@pytest.mark.asyncio
 async def test_get_devices_for_recording_logs_unexpected_failure(
     caplog: pytest.LogCaptureFixture,
 ) -> None:


### PR DESCRIPTION
## Summary

Controller setup previously discarded buttons and axes outside its fixed Xbox-style layout. Adding any controller now creates controls from its advertised capabilities, with device-reported ranges and distinct bindings across interfaces. Gamepads retain familiar button and stick labels while gaining extra buttons, hats, and unmatched axes. Flight sticks receive stick, twist, and throttle labels with appropriate axis grouping.

Physical output targets reuse the template picker, including additional buttons and a flight-stick layout. The picker loads controls and resolved calibration from the grabbed interface that the output router selects. Physical axis actions return to their calibrated neutral on release, tap, rapid fire, and cleanup. Percentage shortcuts use the same neutral; when rest is unavailable, only exact raw-value entry is offered.

The analog rename dialog now edits bounds and center/rest without replacing controls or their mappings. Automatic hints use device metadata, calculated midpoints, or daemon grab-time samples; unavailable values are not estimated.

## Testing

- NixOS daemon/session integration passed on this branch and the pre-PR baseline. The extended-keyboard-outputs scenario also passed 10 consecutive repetitions on this branch. An earlier intermittent KEY_PLAY release failure was not reproduced; its cause is not established.
- [x] `./scripts/check.sh`: the full pytest suite, ruff, basedpyright, and stylelint passed. The subsequent composite-interface regression also passed in the focused daemon suite.
- Regression tests execute a picker-generated action through the physical router and check emitted press/release values. Additional cases cover tap, rapid fire, cleanup, multiple interfaces, composite interfaces with a non-gamepad primary type, duplicate button codes, automatic throttle rest, unavailable rest, and metadata propagation through the session broker.
- Earlier manual testing: a flight stick created by an independent uinput emulator was added, grabbed, and used for button remapping. The physical flight-stick target picker was inspected. A legacy Nintendo controller's missing axis targets were reproduced and covered by regression tests. The subsequent routing fixes were tested automatically, without restarting the running services.
- Other regression coverage includes capability fallback, joystick aliases, ranges, legacy axes, editing validation, canceled/failed saves, and automatic calibration data.
- Existing GUI screenshots were not regenerated.

## Notes

- Physical output selection requires the controller to be grabbed. For hardware with multiple gamepad interfaces, the picker offers controls only on the first grabbed interface with a passthrough output. Selecting another output interface remains unsupported.
- Device inventory adds optional calibration and routed-interface metadata; access policy is unchanged.
- Existing hardware files are not migrated automatically. Editing calibration preserves input IDs and profile mappings.
- No packaging changes.

