### PR TITLE
Add live motion sensor previews to the device inspector

### DIFF
--- a/docs/DEVICE_INSPECTOR.md
+++ b/docs/DEVICE_INSPECTOR.md
@@ -13,6 +13,7 @@ original hardware events.
 - the profiles that produced those final mappings
 - raw events from the inspected device, in an evtest-style stream
 - configured analog inputs, such as sticks and triggers, with live values
+- configured motion sensors, with a live controller preview and rotation speeds
 
 The mapping view is read-only. To change a mapping, close the inspector, edit
 the device tab, then open the inspector again.
@@ -25,6 +26,31 @@ The raw event stream shows buttons and keys by default. Axes, mouse movement,
 and `EV_SYN` reports can be enabled from the filter buttons in the inspector.
 The window keeps the most recent 100 events per filter category and displays
 the most recent 100 events that match the active filters.
+
+## Motion preview
+
+Configured motion sensors appear in both Resolved Mapping and Live Inputs.
+The live-input column scrolls to keep sticks, triggers, and motion sensors
+accessible in smaller windows.
+
+Each sensor has a shaded controller preview with a green mark at its front.
+The preview estimates orientation from calibrated gyro and accelerometer samples.
+Gyro-only sensors show relative rotation; accelerometer-only sensors show tilt.
+Heading is relative and can drift. **Recenter preview** uses the current pose as
+the visual reference without changing sensor calibration, mappings, or output.
+Profile changes preserve that reference when the sensor configuration is unchanged.
+
+Signed pitch, yaw, and roll bars show rotation speeds in degrees per second.
+The bars span −360 to +360 °/s; the numeric readings retain speeds beyond that
+range. **Sensor details** expands to show calibrated gyro values in rad/s,
+accelerometer values in m/s², and their original raw counts.
+
+The preview updates independently of the raw-event filters and continues while
+output is suppressed. It waits for sensor samples before showing a live state,
+dims after a second without frames, and resets when monitoring stops or the daemon
+disconnects. Dropped event frames discard the old estimate and incomplete samples.
+Accelerometer correction waits for all three axes and ignores readings far from
+normal gravity, such as free fall or a strong shake.
 
 ## Suppression Mode
 

--- a/keymasq/gui/widgets/device_inspector/analog.py
+++ b/keymasq/gui/widgets/device_inspector/analog.py
@@ -28,14 +28,14 @@ class AnalogMixin:
         self._clear_box(self._axes_box)
         self._analog_viewers.clear()
         analogs = list_of_dicts(snapshot.get("analog_inputs"))
-        self._axes_title.set_visible(bool(analogs))
-        self._axes_box.set_visible(bool(analogs))
-        if not analogs:
-            return
+        has_inputs = bool(analogs or list_of_dicts(snapshot.get("motion_sensors")))
+        self._axes_title.set_visible(has_inputs)
+        self._axes_box.set_visible(has_inputs)
 
         for analog in analogs:
             viewer = self._create_analog_viewer(analog)
             self._analog_viewers[viewer.analog_id] = viewer
+        self._render_motion(snapshot)
 
     def _create_analog_viewer(self: Any, analog: Payload) -> AnalogViewer:
         analog_id = text(analog.get("id"))

--- a/keymasq/gui/widgets/device_inspector/events.py
+++ b/keymasq/gui/widgets/device_inspector/events.py
@@ -17,6 +17,9 @@ class EventsMixin:
     def _on_inspector_event(self: Any, event: Payload) -> bool:
         if text(event.get("hardware_id")) != self._hardware_id:
             return False
+        if self._session.closing:
+            return False
+        self._update_motion_event(event)
         self._store_event(event)
 
         control_id = text(event.get("control_id"))

--- a/keymasq/gui/widgets/device_inspector/lifecycle.py
+++ b/keymasq/gui/widgets/device_inspector/lifecycle.py
@@ -46,6 +46,7 @@ class LifecycleMixin:
         return False
 
     def _on_runtime_reset(self: Any, _event: Payload) -> bool:
+        self._reset_motion()
         self._request_snapshot()
         return False
 
@@ -60,6 +61,7 @@ class LifecycleMixin:
         if self._session.finalized:
             return
         self._cancel_event_render()
+        self._cancel_motion_render()
         for source_id in list(self._flash_timeout_ids.values()):
             GLib.source_remove(source_id)
         self._flash_timeout_ids.clear()

--- a/keymasq/gui/widgets/device_inspector/mapping.py
+++ b/keymasq/gui/widgets/device_inspector/mapping.py
@@ -146,6 +146,10 @@ class MappingMixin:
                 self._control_widgets[text(analog.get("id"))] = widget
             self._mapping_box.append(grid)
 
+        motion_sensors = list_of_dicts(snapshot.get("motion_sensors"))
+        if motion_sensors:
+            self._append_flow_section("Motion Sensors", motion_sensors, is_keyboard=False)
+
     def _render_keyboard_buttons(self: Any, buttons: list[Payload]) -> None:
         buttons_by_id = {text(button.get("id")): button for button in buttons}
         used_ids: set[str] = set()
@@ -277,6 +281,8 @@ class MappingMixin:
         return describe_mapping_action_compact(mapping, include_state=True)
 
     def _passthrough_label(self: Any, control: Payload) -> str:
+        if text(control.get("kind")) == "motion":
+            return "Motion passthrough"
         if text(control.get("kind")) == "analog":
             if text(control.get("type")) == "axis":
                 return "Axis passthrough"

--- a/keymasq/gui/widgets/device_inspector/motion.py
+++ b/keymasq/gui/widgets/device_inspector/motion.py
@@ -1,0 +1,193 @@
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+from typing import Any
+
+import gi
+
+gi.require_version("Gtk", "4.0")
+
+from gi.repository import GLib, Gtk  # pyright: ignore[reportAttributeAccessIssue]
+
+from .model import Payload, list_of_dicts, text
+from .motion_drawing import draw_controller, draw_rate
+from .motion_model import MotionState
+
+
+@dataclass
+class MotionViewer:
+    state: MotionState
+    area: Gtk.DrawingArea
+    status: Gtk.Label
+    recenter: Gtk.Button
+    rates: dict[str, tuple[Gtk.Label, Gtk.DrawingArea]] = field(default_factory=dict)
+    details: dict[tuple[str, str], Gtk.Label] = field(default_factory=dict)
+    last_frame_us: int = 0
+
+    def draw(self, _area: Gtk.DrawingArea, cr: Any, width: int, height: int, _data: object) -> None:
+        draw_controller(cr, width, height, self.state.display_orientation, self.state.ready)
+
+    def draw_speed(
+        self, _area: Gtk.DrawingArea, cr: Any, width: int, height: int, role: str
+    ) -> None:
+        draw_rate(cr, width, height, math.degrees(self.state.values.get(("gyro", role), 0.0)))
+
+    def refresh(self) -> None:
+        live = self.state.ready and GLib.get_monotonic_time() - self.last_frame_us < 1_000_000
+        self.status.set_text(
+            "Estimated orientation"
+            if live
+            else "Motion data paused"
+            if self.state.ready
+            else "Waiting for motion data"
+        )
+        self.recenter.set_sensitive(live)
+        self.area.set_opacity(1.0 if live else 0.45)
+        self.area.queue_draw()
+        for role, (label, bar) in self.rates.items():
+            value = self.state.values.get(("gyro", role))
+            label.set_text(f"{math.degrees(value):+7.1f} °/s" if value is not None else "— °/s")
+            label.set_opacity(1.0 if live else 0.45)
+            bar.queue_draw()
+        for (kind, role), label in self.details.items():
+            value = self.state.values.get((kind, role))
+            raw = self.state.raw.get((kind, role))
+            unit = "rad/s" if kind == "gyro" else "m/s²"
+            label.set_text(
+                f"{role}: {value:+.3f} {unit} · raw {raw}"
+                if value is not None
+                else f"{role}: waiting"
+            )
+
+
+class MotionMixin:
+    def _render_motion(self: Any, snapshot: Payload) -> None:
+        self._cancel_motion_render()
+        previous = dict(self._motion_viewers)
+        self._motion_viewers.clear()
+        sensors = list_of_dicts(snapshot.get("motion_sensors"))
+        for sensor in sensors:
+            section = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=6)
+            section.add_css_class("inspector-axis-section")
+            title = Gtk.Label(label=text(sensor.get("label"), "Motion"))
+            title.add_css_class("heading")
+            title.set_wrap(True)
+            section.append(title)
+            area = Gtk.DrawingArea()
+            area.set_content_width(220)
+            area.set_content_height(175)
+            area.set_halign(Gtk.Align.CENTER)
+            section.append(area)
+            status = Gtk.Label()
+            status.add_css_class("caption")
+            status.add_css_class("dim-label")
+            section.append(status)
+            recenter = Gtk.Button(label="Recenter preview")
+            recenter.set_halign(Gtk.Align.CENTER)
+            recenter.add_css_class("flat")
+            recenter.set_tooltip_text(
+                "Use this pose as the preview's reference. "
+                "Does not change calibration or mappings. "
+                "Heading is relative and may drift."
+            )
+            viewer = MotionViewer(MotionState(sensor), area, status, recenter)
+            old = previous.get(text(sensor.get("id")))
+            if old is not None and all(
+                old.state.sensor.get(key) == sensor.get(key)
+                for key in ("source", "gyro_axes", "accelerometer_axes")
+            ):
+                viewer.state = old.state
+                viewer.last_frame_us = old.last_frame_us
+            area.set_draw_func(viewer.draw, None)
+            recenter.connect("clicked", self._recenter_motion, viewer)
+            section.append(recenter)
+            for role in ("pitch", "yaw", "roll"):
+                if not any(
+                    text(axis.get("role")) == role
+                    for axis in list_of_dicts(sensor.get("gyro_axes"))
+                ):
+                    continue
+                row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=8)
+                name = Gtk.Label(label=role.title())
+                name.set_xalign(0)
+                name.set_width_chars(5)
+                name.add_css_class("caption")
+                row.append(name)
+                bar = Gtk.DrawingArea()
+                bar.set_content_width(55)
+                bar.set_content_height(12)
+                bar.set_hexpand(True)
+                bar.set_valign(Gtk.Align.CENTER)
+                bar.set_tooltip_text("Rotation speed, −360 to +360 °/s")
+                bar.set_draw_func(viewer.draw_speed, role)
+                row.append(bar)
+                label = Gtk.Label()
+                label.set_width_chars(12)
+                label.set_xalign(1)
+                label.add_css_class("caption")
+                label.add_css_class("inspector-axis-value")
+                row.append(label)
+                viewer.rates[role] = label, bar
+                section.append(row)
+            details = Gtk.Expander(label="Sensor details")
+            detail_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=3)
+            for kind, heading in (("gyro", "Gyroscope"), ("accelerometer", "Accelerometer")):
+                axes = [axis for axis_kind, axis in viewer.state.axes if axis_kind == kind]
+                if not axes:
+                    continue
+                label = Gtk.Label(label=heading)
+                label.set_xalign(0)
+                label.add_css_class("caption")
+                label.add_css_class("heading")
+                detail_box.append(label)
+                for axis in axes:
+                    label = Gtk.Label()
+                    label.set_xalign(0)
+                    label.set_wrap(True)
+                    label.add_css_class("caption")
+                    label.add_css_class("inspector-axis-value")
+                    detail_box.append(label)
+                    viewer.details[kind, text(axis.get("role"))] = label
+            details.set_child(detail_box)
+            section.append(details)
+            self._axes_box.append(section)
+            self._motion_viewers[text(sensor.get("id"))] = viewer
+            viewer.refresh()
+        if any(viewer.state.ready for viewer in self._motion_viewers.values()):
+            self._motion_render_source_id = GLib.timeout_add(33, self._flush_motion_render)
+
+    def _recenter_motion(self: Any, _button: Gtk.Button, viewer: MotionViewer) -> None:
+        viewer.state.recenter()
+        viewer.refresh()
+
+    def _update_motion_event(self: Any, event: Payload) -> None:
+        for viewer in self._motion_viewers.values():
+            if viewer.state.accept(event):
+                viewer.last_frame_us = GLib.get_monotonic_time()
+                if not self._motion_render_source_id:
+                    self._motion_render_source_id = GLib.timeout_add(33, self._flush_motion_render)
+
+    def _flush_motion_render(self: Any) -> bool:
+        if self._session.closing:
+            self._motion_render_source_id = 0
+            return False
+        keep = False
+        for viewer in self._motion_viewers.values():
+            viewer.refresh()
+            keep = keep or GLib.get_monotonic_time() - viewer.last_frame_us < 1_000_000
+        if not keep:
+            self._motion_render_source_id = 0
+        return keep
+
+    def _cancel_motion_render(self: Any) -> None:
+        if self._motion_render_source_id:
+            GLib.source_remove(self._motion_render_source_id)
+            self._motion_render_source_id = 0
+
+    def _reset_motion(self: Any) -> None:
+        self._cancel_motion_render()
+        for viewer in self._motion_viewers.values():
+            viewer.state.reset()
+            viewer.last_frame_us = 0
+            viewer.refresh()

--- a/keymasq/gui/widgets/device_inspector/motion_drawing.py
+++ b/keymasq/gui/widgets/device_inspector/motion_drawing.py
@@ -1,0 +1,283 @@
+"""Small projected controller and signed rate bars, drawn with GTK's Cairo context."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Any
+
+import cairo
+
+from .motion_model import Quaternion, Vector, rotate
+
+Point = tuple[float, float]
+_FACE_Z = 0.14
+_VIEW_SIN = math.sin(math.radians(52))
+_VIEW_COS = math.cos(math.radians(52))
+
+
+def _shell_outline() -> tuple[Point, ...]:
+    """Sample a curved right grip and reflect it to make a continuous shell."""
+    curves = (
+        ((0.26, 0.58), (0.54, 0.64), (0.73, 0.55)),
+        ((0.87, 0.49), (0.94, 0.32), (0.98, 0.10)),
+        ((1.02, -0.10), (1.13, -0.48), (1.04, -0.68)),
+        ((0.99, -0.85), (0.82, -0.91), (0.71, -0.76)),
+        ((0.62, -0.64), (0.52, -0.35), (0.40, -0.30)),
+        ((0.24, -0.25), (0.15, -0.29), (0.0, -0.29)),
+    )
+    start = (0.0, 0.58)
+    right = [start]
+    for control_a, control_b, end in curves:
+        for step in range(1, 9):
+            t = step / 8
+            u = 1 - t
+            right.append(
+                (
+                    u**3 * start[0]
+                    + 3 * u * u * t * control_a[0]
+                    + 3 * u * t * t * control_b[0]
+                    + t**3 * end[0],
+                    u**3 * start[1]
+                    + 3 * u * u * t * control_a[1]
+                    + 3 * u * t * t * control_b[1]
+                    + t**3 * end[1],
+                )
+            )
+        start = end
+    return tuple(right + [(-x, y) for x, y in reversed(right[1:-1])])
+
+
+_OUTLINE = _shell_outline()
+# Rounded bevels join the face to the underside without exposed polygon edges.
+_RINGS = tuple(
+    tuple((x * inset, y * inset, z) for x, y in _OUTLINE)
+    for inset, z in ((0.94, _FACE_Z), (0.987, 0.10), (1.0, 0.0), (0.977, -0.11), (0.92, -0.16))
+)
+
+
+@dataclass(frozen=True)
+class _Face:
+    points: tuple[Vector, ...]
+    normal: Vector
+    surface: str = "side"
+
+
+def _shell_faces() -> tuple[_Face, ...]:
+    faces = [
+        _Face(_RINGS[0], (0.0, 0.0, 1.0), "top"),
+        _Face(_RINGS[-1], (0.0, 0.0, -1.0), "bottom"),
+    ]
+    for upper, lower in zip(_RINGS, _RINGS[1:], strict=False):
+        for index in range(len(_OUTLINE)):
+            following = (index + 1) % len(_OUTLINE)
+            points = upper[index], upper[following], lower[following], lower[index]
+            ax, ay, az = (points[1][i] - points[0][i] for i in range(3))
+            bx, by, bz = (points[3][i] - points[0][i] for i in range(3))
+            nx, ny, nz = ay * bz - az * by, az * bx - ax * bz, ax * by - ay * bx
+            length = math.sqrt(nx * nx + ny * ny + nz * nz)
+            faces.append(_Face(points, (nx / length, ny / length, nz / length)))
+    return tuple(faces)
+
+
+_SHELL = _shell_faces()
+
+
+class _ControllerDrawing:
+    def __init__(self, cr: Any, width: int, height: int, q: Quaternion):
+        self.cr = cr
+        self.scale = min(width / 2.55, height / 2.5)
+        self.cx, self.cy = width / 2.0, height / 2.0
+        self.q = q
+
+    def project(self, point: Vector, *, fixed: bool = False) -> Vector:
+        x, y, z = point if fixed else rotate(self.q, point)
+        return (
+            self.cx + self.scale * x,
+            self.cy - self.scale * (_VIEW_SIN * y + _VIEW_COS * z),
+            _VIEW_COS * y - _VIEW_SIN * z,
+        )
+
+    def path(self, points: tuple[Vector, ...], *, fixed: bool = False) -> None:
+        for index, point in enumerate(points):
+            x, y, _depth = self.project(point, fixed=fixed)
+            if index:
+                self.cr.line_to(x, y)
+            else:
+                self.cr.move_to(x, y)
+        self.cr.close_path()
+
+    def gradient(self, light: float, dark: float) -> None:
+        gradient = cairo.LinearGradient(
+            self.cx - self.scale,
+            self.cy - self.scale,
+            self.cx + self.scale * 0.6,
+            self.cy + self.scale,
+        )
+        gradient.add_color_stop_rgb(0, light, light + 0.006, light + 0.014)
+        gradient.add_color_stop_rgb(1, dark, dark + 0.006, dark + 0.014)
+        self.cr.set_source(gradient)
+
+    def shell(self) -> None:
+        cr = self.cr
+        # A stationary ellipse gives the pose a reference without a grid behind it.
+        self.path(
+            tuple(
+                (1.15 * math.cos(i * math.tau / 96), 0.75 * math.sin(i * math.tau / 96), -0.29)
+                for i in range(96)
+            ),
+            fixed=True,
+        )
+        cr.set_source_rgba(0.60, 0.62, 0.65, 0.10)
+        cr.set_line_width(0.8)
+        cr.stroke()
+
+        projected = {point: self.project(point) for ring in _RINGS for point in ring}
+        visible: list[tuple[float, _Face, Vector]] = []
+        for face in _SHELL:
+            normal = rotate(self.q, face.normal)
+            if _VIEW_COS * normal[1] - _VIEW_SIN * normal[2] < -0.001:
+                depth = sum(projected[p][2] for p in face.points) / len(face.points)
+                visible.append((depth, face, normal))
+        visible.sort(key=lambda item: item[0], reverse=True)
+        for _depth, face, normal in visible:
+            for index, point in enumerate(face.points):
+                x, y, _ = projected[point]
+                if index:
+                    cr.line_to(x, y)
+                else:
+                    cr.move_to(x, y)
+            cr.close_path()
+            light = max(0.0, -0.35 * normal[0] - 0.25 * normal[1] + 0.90 * normal[2])
+            if face.surface == "top":
+                self.gradient(0.25 + 0.065 * light, 0.19 + 0.045 * light)
+            else:
+                shade = 0.15 + 0.13 * light
+                cr.set_source_rgb(shade, shade + 0.006, shade + 0.014)
+            cr.fill_preserve()
+            # Overlap adjacent fills to avoid antialiasing cracks. No wireframe strokes.
+            cr.set_line_width(0.65)
+            cr.set_line_join(cairo.LINE_JOIN_ROUND)
+            cr.stroke()
+            if face.surface == "top":
+                cr.save()
+                self.path(face.points)
+                cr.clip()
+                self.controls()
+                cr.restore()
+
+    def disc(self, x: float, y: float, radius: float, z: float, light: float, dark: float) -> None:
+        self.path(
+            tuple(
+                (
+                    x + radius * math.cos(i * math.tau / 32),
+                    y + radius * math.sin(i * math.tau / 32),
+                    z,
+                )
+                for i in range(32)
+            )
+        )
+        self.gradient(light, dark)
+        self.cr.fill_preserve()
+        self.cr.set_source_rgba(0.62, 0.64, 0.67, 0.16)
+        self.cr.set_line_width(0.65)
+        self.cr.stroke()
+
+    def dpad(self) -> None:
+        # Positioned inward and below the left stick, fully inside the face bridge.
+        cx, cy = -0.34, -0.045
+        arm, half_width = 0.145, 0.052
+        outline = (
+            (-half_width, arm),
+            (half_width, arm),
+            (half_width, half_width),
+            (arm, half_width),
+            (arm, -half_width),
+            (half_width, -half_width),
+            (half_width, -arm),
+            (-half_width, -arm),
+            (-half_width, -half_width),
+            (-arm, -half_width),
+            (-arm, half_width),
+            (-half_width, half_width),
+        )
+        cr = self.cr
+        # Round the cross in controller coordinates so its corners follow the pose.
+        for index, (x, y) in enumerate(outline):
+            previous, following = outline[index - 1], outline[(index + 1) % len(outline)]
+            incoming = math.hypot(previous[0] - x, previous[1] - y)
+            outgoing = math.hypot(following[0] - x, following[1] - y)
+            entry = (
+                x + (previous[0] - x) * 0.014 / incoming,
+                y + (previous[1] - y) * 0.014 / incoming,
+            )
+            leave = (
+                x + (following[0] - x) * 0.014 / outgoing,
+                y + (following[1] - y) * 0.014 / outgoing,
+            )
+            start = self.project((cx + entry[0], cy + entry[1], _FACE_Z + 0.008))
+            corner = self.project((cx + x, cy + y, _FACE_Z + 0.008))
+            end = self.project((cx + leave[0], cy + leave[1], _FACE_Z + 0.008))
+            if index:
+                cr.line_to(*start[:2])
+            else:
+                cr.move_to(*start[:2])
+            cr.curve_to(
+                start[0] + (corner[0] - start[0]) * 2 / 3,
+                start[1] + (corner[1] - start[1]) * 2 / 3,
+                end[0] + (corner[0] - end[0]) * 2 / 3,
+                end[1] + (corner[1] - end[1]) * 2 / 3,
+                *end[:2],
+            )
+        cr.close_path()
+        self.gradient(0.15, 0.075)
+        cr.fill_preserve()
+        cr.set_source_rgba(0.62, 0.64, 0.67, 0.21)
+        cr.set_line_width(0.7)
+        cr.stroke()
+
+    def controls(self) -> None:
+        for x, y in ((-0.57, 0.28), (0.34, -0.045)):
+            self.disc(x, y, 0.169, _FACE_Z + 0.002, 0.11, 0.065)
+            self.disc(x, y, 0.124, _FACE_Z + 0.035, 0.24, 0.12)
+        self.dpad()
+        for x, y in ((0.59, 0.42), (0.73, 0.28), (0.59, 0.14), (0.45, 0.28)):
+            self.disc(x, y, 0.054, _FACE_Z + 0.01, 0.18, 0.085)
+        for x in (-0.14, 0.14):
+            self.disc(x, 0.30, 0.025, _FACE_Z + 0.005, 0.20, 0.11)
+        cr = self.cr
+        cr.set_line_width(2)
+        cr.set_line_cap(cairo.LINE_CAP_ROUND)
+        cr.move_to(*self.project((-0.10, 0.515, _FACE_Z + 0.005))[:2])
+        cr.line_to(*self.project((0.10, 0.515, _FACE_Z + 0.005))[:2])
+        cr.set_source_rgb(0.39, 0.78, 0.63)
+        cr.stroke()
+
+
+def draw_controller(cr: Any, width: int, height: int, q: Quaternion, ready: bool) -> None:
+    cr.save()
+    if not ready:
+        cr.push_group()
+    _ControllerDrawing(cr, width, height, q).shell()
+    if not ready:
+        cr.pop_group_to_source()
+        cr.paint_with_alpha(0.45)
+    cr.restore()
+
+
+def draw_rate(cr: Any, width: int, height: int, value: float) -> None:
+    center = width / 2.0
+    cr.set_line_width(4)
+    cr.set_source_rgba(0.5, 0.5, 0.5, 0.25)
+    cr.move_to(0, height / 2)
+    cr.line_to(width, height / 2)
+    cr.stroke()
+    cr.set_source_rgba(0.39, 0.83, 0.66, 0.85)
+    cr.move_to(center, height / 2)
+    cr.line_to(center + max(-1.0, min(1.0, value / 360.0)) * center, height / 2)
+    cr.stroke()
+    cr.set_line_width(1)
+    cr.set_source_rgba(0.6, 0.6, 0.6, 0.7)
+    cr.move_to(center, 1)
+    cr.line_to(center, height - 1)
+    cr.stroke()

--- a/keymasq/gui/widgets/device_inspector/motion_model.py
+++ b/keymasq/gui/widgets/device_inspector/motion_model.py
@@ -1,0 +1,167 @@
+"""Inspector-only motion estimation from calibrated, timestamped sensor frames."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+
+from keymasq.common.coercion import coerce_float
+
+from .model import Payload, int_or_none, list_of_dicts, text
+
+Vector = tuple[float, float, float]
+Quaternion = tuple[float, float, float, float]
+IDENTITY: Quaternion = (1.0, 0.0, 0.0, 0.0)
+GRAVITY = 9.80665
+
+
+def multiply(a: Quaternion, b: Quaternion) -> Quaternion:
+    w, x, y, z = a
+    v, i, j, k = b
+    return (
+        w * v - x * i - y * j - z * k,
+        w * i + x * v + y * k - z * j,
+        w * j - x * k + y * v + z * i,
+        w * k + x * j - y * i + z * v,
+    )
+
+
+def conjugate(q: Quaternion) -> Quaternion:
+    return q[0], -q[1], -q[2], -q[3]
+
+
+def rotate(q: Quaternion, point: Vector) -> Vector:
+    result = multiply(multiply(q, (0.0, *point)), conjugate(q))
+    return result[1], result[2], result[3]
+
+
+def unit(q: Quaternion) -> Quaternion:
+    length = math.sqrt(sum(value * value for value in q))
+    return (q[0] / length, q[1] / length, q[2] / length, q[3] / length)
+
+
+@dataclass
+class MotionState:
+    sensor: Payload
+    raw: dict[tuple[str, str], int] = field(default_factory=dict)
+    values: dict[tuple[str, str], float] = field(default_factory=dict)
+    orientation: Quaternion = IDENTITY
+    reference: Quaternion = IDENTITY
+    timestamp_us: int = 0
+    ready: bool = False
+    gravity_initialized: bool = False
+    resyncing: bool = False
+    bound_source: str | None = None
+
+    @property
+    def axes(self) -> list[tuple[str, Payload]]:
+        return [
+            (kind, axis)
+            for kind, key in (("gyro", "gyro_axes"), ("accelerometer", "accelerometer_axes"))
+            for axis in list_of_dicts(self.sensor.get(key))
+        ]
+
+    @property
+    def display_orientation(self) -> Quaternion:
+        return multiply(conjugate(self.reference), self.orientation)
+
+    def recenter(self) -> None:
+        self.reference = self.orientation
+
+    def reset(self) -> None:
+        self.raw.clear()
+        self.values.clear()
+        self.orientation = IDENTITY
+        self.reference = IDENTITY
+        self.timestamp_us = 0
+        self.ready = False
+        self.gravity_initialized = False
+        self.resyncing = False
+        self.bound_source = None
+
+    def accept(self, event: Payload) -> bool:
+        """Consume matching ABS samples and integrate once per SYN_REPORT."""
+        source = text(event.get("source")).strip().lower()
+        configured_source = text(self.sensor.get("source")).strip().lower()
+        if configured_source and source != configured_source:
+            return False
+        # Unscoped definitions must never combine samples from different interfaces.
+        if self.bound_source is not None and source != self.bound_source:
+            return False
+        event_type = text(event.get("type_name"), text(event.get("type"))).lower()
+        code = int_or_none(event.get("code"))
+        name = text(event.get("code_name")).lower()
+        if event_type in {"ev_syn", "0"}:
+            if code == 3 or name == "syn_dropped":
+                self.reset()
+                self.bound_source = source
+                self.resyncing = True
+                return True
+            if code != 0 and name != "syn_report":
+                return False
+            if self.resyncing:
+                self.resyncing = False
+                return False
+            if not self.values:
+                return False
+            self._finish_frame(int_or_none(event.get("time_us")) or 0)
+            return True
+        if self.resyncing or event_type not in {"ev_abs", "3"}:
+            return False
+        for kind, axis in self.axes:
+            axis_code = int_or_none(axis.get("evdev_code"))
+            if not ((code is not None and code == axis_code) or name == text(axis.get("evdev"))):
+                continue
+            raw = int_or_none(event.get("value"))
+            if raw is None:
+                return False
+            value = (raw - coerce_float(axis.get("offset"), 0.0)) * coerce_float(
+                axis.get("scale"), 1.0
+            )
+            if axis.get("invert"):
+                value = -value
+            if not math.isfinite(value):
+                return False
+            if abs(value) < coerce_float(axis.get("noise"), 0.0):
+                value = 0.0
+            key = kind, text(axis.get("role"))
+            self.raw[key] = raw
+            self.values[key] = value
+            self.bound_source = source
+        return False
+
+    def _finish_frame(self, timestamp_us: int) -> None:
+        dt = (timestamp_us - self.timestamp_us) / 1_000_000 if self.timestamp_us else 0.0
+        self.timestamp_us = timestamp_us
+        self.ready = True
+        gravity: Vector | None = None
+        if all(("accelerometer", role) in self.values for role in ("x", "y", "z")):
+            ax, ay, az = (self.values["accelerometer", role] for role in ("x", "y", "z"))
+            magnitude = math.sqrt(ax * ax + ay * ay + az * az)
+            # Shakes and free fall are not a reliable gravity reference.
+            if 0.8 * GRAVITY <= magnitude <= 1.2 * GRAVITY:
+                gravity = ax / magnitude, ay / magnitude, az / magnitude
+        if gravity is not None and not self.gravity_initialized:
+            ax, ay, az = gravity
+            self.orientation = (
+                unit((1.0 + az, ay, -ax, 0.0)) if az > -0.999999 else (0.0, 1.0, 0.0, 0.0)
+            )
+            self.gravity_initialized = True
+        if not 0.0 < dt <= 0.1:
+            return
+        # Canonical pitch tips the front up, roll tips the right side down.
+        wx = self.values.get(("gyro", "pitch"), 0.0)
+        wy = -self.values.get(("gyro", "roll"), 0.0)
+        wz = self.values.get(("gyro", "yaw"), 0.0)
+        if gravity is not None:
+            px, py, pz = rotate(conjugate(self.orientation), (0.0, 0.0, 1.0))
+            ax, ay, az = gravity
+            wx += 2.5 * (ay * pz - az * py)
+            wy += 2.5 * (az * px - ax * pz)
+            wz += 2.5 * (ax * py - ay * px)
+        speed = math.sqrt(wx * wx + wy * wy + wz * wz)
+        if speed > 0.0:
+            half_angle = speed * dt / 2.0
+            factor = math.sin(half_angle) / speed
+            delta = (math.cos(half_angle), wx * factor, wy * factor, wz * factor)
+            self.orientation = unit(multiply(self.orientation, delta))

--- a/keymasq/gui/widgets/device_inspector/suppression.py
+++ b/keymasq/gui/widgets/device_inspector/suppression.py
@@ -30,6 +30,8 @@ class SuppressionMixin:
             self._syncing_suppression = False
         self._suppression_switch.set_sensitive(active and not self._session.closing)
         self._suppression_hint_label.set_visible(active and suppressed)
+        if not active:
+            self._reset_motion()
 
     def _set_status_title(self: Any, value: str, state: str) -> None:
         self._status_label.set_text(value)
@@ -55,6 +57,7 @@ class SuppressionMixin:
 
     def _on_keymasqd_status(self: Any, event: Payload) -> bool:
         if not bool(event.get("connected", False)):
+            self._reset_motion()
             self._set_status_title(f"{self.device.name} - Daemon disconnected", "stopped")
             self._suppression_switch.set_sensitive(False)
         return False

--- a/keymasq/gui/widgets/device_inspector_window.py
+++ b/keymasq/gui/widgets/device_inspector_window.py
@@ -24,6 +24,7 @@ from keymasq.gui.widgets.device_inspector.model import (
     EventHistory,
     Payload,
 )
+from keymasq.gui.widgets.device_inspector.motion import MotionMixin, MotionViewer
 from keymasq.gui.widgets.device_inspector.session import InspectorSession
 from keymasq.gui.widgets.device_inspector.suppression import SuppressionMixin
 
@@ -41,6 +42,7 @@ class DeviceInspectorWindow(
     LifecycleMixin,
     EventsMixin,
     AnalogMixin,
+    MotionMixin,
     MappingMixin,
     SuppressionMixin,
     Adw.Window,
@@ -53,12 +55,15 @@ class DeviceInspectorWindow(
         self._syncing_suppression = False
         self._snapshot: Payload = {}
         self._device_kind = resolve_device_layout_kind(device)
+        self._has_live_column = self._device_kind == "gamepad" or bool(device.motion_sensors)
         self._control_widgets: dict[str, Gtk.Widget] = {}
         self._event_history = EventHistory()
         self._event_rows: list[Gtk.ListBoxRow] = []
         self._event_filter_buttons: dict[str, Gtk.ToggleButton] = {}
         self._event_render_source_id = 0
         self._analog_viewers: dict[str, AnalogViewer] = {}
+        self._motion_viewers: dict[str, MotionViewer] = {}
+        self._motion_render_source_id = 0
         self._flash_timeout_ids: dict[str, int] = {}
         self._session = InspectorSession(
             hardware_id=self._hardware_id,
@@ -68,7 +73,9 @@ class DeviceInspectorWindow(
         )
 
         self.set_title(f"Inspect {device.name}")
-        window_width, window_height = _inspector_default_size(self._device_kind)
+        window_width, window_height = _inspector_default_size(
+            "gamepad" if self._has_live_column else self._device_kind
+        )
         self.set_default_size(window_width, window_height)
         self.set_transient_for(parent)
         self.set_modal(False)
@@ -130,10 +137,12 @@ class DeviceInspectorWindow(
         key_controller.connect("key-pressed", self._on_key_pressed)
         self.add_controller(key_controller)
 
-        window_width, _window_height = _inspector_default_size(self._device_kind)
+        window_width, _window_height = _inspector_default_size(
+            "gamepad" if self._has_live_column else self._device_kind
+        )
         live_panel_width = (
             AXES_PANEL_WIDTH + RAW_EVENTS_PANEL_WIDTH
-            if self._device_kind == "gamepad"
+            if self._has_live_column
             else RAW_EVENTS_PANEL_WIDTH
         )
         self._paned = Gtk.Paned(orientation=Gtk.Orientation.HORIZONTAL)
@@ -154,13 +163,17 @@ class DeviceInspectorWindow(
         mapping_scrolled.set_child(self._mapping_box)
         self._paned.set_start_child(mapping_scrolled)
 
-        if self._device_kind == "gamepad":
+        if self._has_live_column:
             live_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=0)
             live_box.set_size_request(live_panel_width, -1)
             live_box.set_hexpand(False)
             axes_parent = self._build_live_panel_column(AXES_PANEL_WIDTH)
             events_parent = self._build_live_panel_column(RAW_EVENTS_PANEL_WIDTH)
-            live_box.append(axes_parent)
+            axes_scrolled = Gtk.ScrolledWindow()
+            axes_scrolled.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
+            axes_scrolled.set_vexpand(True)
+            axes_scrolled.set_child(axes_parent)
+            live_box.append(axes_scrolled)
             live_box.append(Gtk.Separator(orientation=Gtk.Orientation.VERTICAL))
             live_box.append(events_parent)
         else:
@@ -168,7 +181,7 @@ class DeviceInspectorWindow(
             axes_parent = live_box
             events_parent = live_box
 
-        self._axes_title = Gtk.Label(label="Configured Axes")
+        self._axes_title = Gtk.Label(label="Live Inputs")
         self._axes_title.add_css_class("button-section-title")
         self._axes_title.set_halign(Gtk.Align.START)
         self._axes_title.set_visible(False)

--- a/tests/gui/test_device_inspector_motion.py
+++ b/tests/gui/test_device_inspector_motion.py
@@ -1,0 +1,115 @@
+"""Motion preview follows sensor frames without changing remap state."""
+
+import math
+
+import pytest
+
+from keymasq.gui.widgets.device_inspector.motion_model import GRAVITY, MotionState, rotate
+
+
+def motion_sensor():
+    return {
+        "id": "motion",
+        "label": "Nintendo Motion Sensor",
+        "kind": "motion",
+        "source": "imu",
+        "profile_name": "Desktop",
+        "action": {"action": "suppress"},
+        "gyro_axes": [
+            {"role": role, "evdev": f"abs_r{axis}", "evdev_code": code, "scale": 0.001}
+            for role, axis, code in (("pitch", "x", 3), ("yaw", "y", 4), ("roll", "z", 5))
+        ],
+        "accelerometer_axes": [
+            {"role": role, "evdev": f"abs_{role}", "evdev_code": code, "scale": GRAVITY / 1000}
+            for code, role in enumerate(("x", "y", "z"))
+        ],
+    }
+
+
+def sample(code, value, source="imu"):
+    return {"type_name": "ev_abs", "code": code, "value": value, "source": source}
+
+
+def frame(time_us):
+    return {"type_name": "ev_syn", "code": 0, "time_us": time_us, "source": "imu"}
+
+
+def test_motion_uses_calibration_and_ignores_the_gamepad_interface():
+    sensor = motion_sensor()
+    sensor["gyro_axes"][0].update(offset=10, scale=0.01, invert=True, noise=0.02)
+    state = MotionState(sensor)
+    state.accept(sample(3, 60, source="pad"))
+    assert not state.raw
+    state.accept(sample(3, 60))
+    assert state.values["gyro", "pitch"] == pytest.approx(-0.5)
+    state.accept(sample(3, 11))
+    assert state.raw["gyro", "pitch"] == 11
+    assert state.values["gyro", "pitch"] == 0.0
+
+
+def test_motion_integrates_once_per_frame_and_recenter_only_changes_reference():
+    sensor = motion_sensor()
+    sensor["accelerometer_axes"] = []
+    state = MotionState(sensor)
+    state.accept(sample(4, 1000))
+    assert not state.ready
+    state.accept(frame(1_000_000))
+    for index in range(1, 101):
+        state.accept(frame(1_000_000 + 10_000 * index))
+    assert rotate(state.orientation, (1.0, 0.0, 0.0)) == pytest.approx(
+        (math.cos(1.0), math.sin(1.0), 0.0)
+    )
+    pose = state.orientation
+    state.recenter()
+    assert rotate(state.display_orientation, (1.0, 0.0, 0.0)) == pytest.approx((1, 0, 0))
+    assert state.orientation == pose
+    assert state.values["gyro", "yaw"] == 1.0
+    # Never integrate seconds of stale velocity after a pause or clock jump.
+    state.accept(frame(10_000_000))
+    state.accept(frame(9_000_000))
+    assert state.orientation == pose
+
+
+@pytest.mark.parametrize("gravity", [(0, 0, 1000), (0, 600, 800), (600, 0, 800), (0, 0, -1000)])
+def test_motion_gravity_orients_the_controller_including_upside_down(gravity):
+    state = MotionState(motion_sensor())
+    for code, value in enumerate(gravity):
+        state.accept(sample(code, value))
+    state.accept(frame(1_000_000))
+    assert rotate(state.orientation, tuple(value / 1000 for value in gravity)) == pytest.approx(
+        (0, 0, 1)
+    )
+    assert all(math.isfinite(value) for value in state.orientation)
+
+
+def test_motion_drop_discards_partial_frames_and_waits_for_new_samples():
+    state = MotionState(motion_sensor())
+    state.accept(sample(4, 1000))
+    state.accept(frame(1_000_000))
+    state.accept({"type_name": "ev_syn", "code": 3, "source": "imu"})
+    state.accept(sample(4, 2000))
+    state.accept(frame(1_010_000))
+    assert not state.ready
+    assert not state.values
+    state.accept(sample(4, 3000))
+    state.accept(frame(1_020_000))
+    assert state.ready
+    assert state.values["gyro", "yaw"] == 3.0
+
+
+def test_motion_shake_does_not_become_a_tilt_reference():
+    state = MotionState(motion_sensor())
+    for code, value in enumerate((3000, 0, 1000)):
+        state.accept(sample(code, value))
+    state.accept(frame(1_000_000))
+    assert not state.gravity_initialized
+    assert rotate(state.orientation, (0.0, 0.0, 1.0)) == pytest.approx((0, 0, 1))
+
+
+def test_motion_unscoped_sensor_never_mixes_interfaces():
+    sensor = motion_sensor()
+    sensor["source"] = ""
+    state = MotionState(sensor)
+    state.accept(sample(4, 1000))
+    state.accept(sample(4, 2000, source="pad"))
+    assert state.values["gyro", "yaw"] == 1.0

--- a/tests/gui/test_device_inspector_window.py
+++ b/tests/gui/test_device_inspector_window.py
@@ -1,6 +1,6 @@
 import pytest
 
-from tests.gui.support import SessionIpcHarness, collect_child_widgets
+from tests.gui.support import SessionIpcHarness, collect_child_widgets, collect_widgets
 
 gi = pytest.importorskip("gi")
 gi.require_version("Gtk", "4.0")
@@ -584,3 +584,58 @@ def test_device_inspector_close_stops_inspector_and_unregisters_events(
     assert callbacks["runtime_reset"] == []
     assert callbacks["keymasqd_status"] == []
     window._on_destroy()
+
+
+def test_motion_preview_mapping_frames_recenter_and_cleanup(inspector_harness):
+    from gi.repository import GLib, Gtk
+
+    from tests.gui.test_device_inspector_motion import frame, motion_sensor, sample
+
+    window = inspector_harness.window
+    snapshot = {**_snapshot(), "motion_sensors": [motion_sensor()]}
+    window._apply_snapshot(snapshot)
+    viewer = window._motion_viewers["motion"]
+    assert "motion" in window._control_widgets
+    assert window._axes_title.get_text() == "Live Inputs"
+    assert viewer.status.get_text() == "Waiting for motion data"
+    assert not viewer.recenter.get_sensitive()
+    inspector_harness.emit_event(sample(4, 1000, source="pad"))
+    assert not viewer.state.values
+    inspector_harness.emit_event(sample(4, 1000))
+    inspector_harness.emit_event(frame(1_000_000))
+    inspector_harness.emit_event(frame(1_010_000))
+    # The Axes/Syn raw-event filters are off; the preview still receives frames.
+    assert not window._event_filter_buttons["axis"].get_active()
+    assert window._motion_render_source_id
+    viewer.refresh()
+    assert viewer.status.get_text() == "Estimated orientation"
+    assert "+57.3" in viewer.rates["yaw"][0].get_text()
+    assert viewer.recenter.get_sensitive()
+    requests_before = list(inspector_harness.requests)
+    viewer.recenter.emit("clicked")
+    assert viewer.state.display_orientation == pytest.approx((1, 0, 0, 0))
+    assert inspector_harness.requests == requests_before
+    # A mapping refresh preserves the visual reference and samples.
+    window._apply_snapshot(snapshot)
+    viewer = window._motion_viewers["motion"]
+    assert viewer.state.ready
+    assert viewer.state.display_orientation == pytest.approx((1, 0, 0, 0))
+    assert any(
+        widget.get_label() == "Sensor details"
+        for widget in collect_widgets(window._axes_box, Gtk.Expander)
+    )
+    viewer.last_frame_us = GLib.get_monotonic_time() - 2_000_000
+    viewer.refresh()
+    assert viewer.status.get_text() == "Motion data paused"
+    assert not viewer.recenter.get_sensitive()
+    inspector_harness.emit_status({"active": False})
+    assert not viewer.state.ready
+    assert not window._motion_render_source_id
+    window._apply_snapshot({**snapshot, "analog_inputs": []})
+    assert window._axes_box.get_visible()
+    assert "motion" in window._motion_viewers
+    inspector_harness.emit_event(sample(4, 1000))
+    inspector_harness.emit_event(frame(2_000_000))
+    assert window._motion_render_source_id
+    window._on_close_request()
+    assert not window._motion_render_source_id


### PR DESCRIPTION
## Summary

Controllers with configured motion sensors now show a live orientation preview in the Device Inspector, along with signed rotation speeds, expandable calibrated/raw readings, and the resolved motion mapping. The preview uses the existing sensor metadata and raw event stream.

The rounded controller drawing includes correctly positioned controls and a stationary reference ellipse. Recenter changes only the preview reference. The Live Inputs column scrolls, and previews handle paused streams, dropped frames, runtime resets, and disconnects.

## Testing

- [x] `./scripts/check.sh`: Ruff, basedpyright, stylelint, and all 851 GUI tests passed.
- Documentation screenshots: not applicable to existing published screenshots. Rendered the inspector locally with simulated motion and inspected twelve orientations, including inverted and edge-on poses.
- Added coverage for calibration, interface isolation, timestamp gaps, gravity estimation, dropped frames, recentering, mapping refreshes, and cleanup.

## Notes

- Packaging impact: uses the existing GTK/Cairo environment.
- Service or security impact: application changes are GUI-only; daemon, session IPC, calibration storage, and remapping behavior are unchanged.
- GUI impact: adds motion sensors to Resolved Mapping and Live Inputs; the controller preview has no hover tooltip.


## Preview
https://github.com/user-attachments/assets/fd69beb2-0e13-4e8b-aa2c-837d5a000554

