### PR TITLE
Add tmux workspace for Keymasq development

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -7,7 +7,7 @@ Use the Nix dev shell for normal Keymasq development.
 - use `nix develop` for all local work
 - run the source checkout directly from the repository
 - do not use a Python virtualenv for the standard dev flow
-- if Keymasq is already installed on the host, stop the installed services and run your local source changes manually
+- use `./scripts/dev.sh` to run and restart your local source checkout
 
 ## Enter The Dev Shell
 
@@ -21,7 +21,16 @@ and `basedpyright`.
 ## Recommended Runtime Flow
 
 If the machine already has the normal Keymasq install and permissions set up,
-use one terminal per process:
+open the tmux dev workspace in one terminal:
+
+```bash
+./scripts/dev.sh
+```
+
+The workspace shows daemon, session, and GUI logs with restart controls in
+the header. Run `./scripts/dev.sh --help` for command-line options.
+
+You can also run the individual launchers in separate terminals:
 
 **Terminal 1 - keymasqd from source as `keymasq`:**
 ```bash

--- a/flake.nix
+++ b/flake.nix
@@ -581,6 +581,8 @@
               pkgs.adwaita-icon-theme
               pkgs.hicolor-icon-theme
               pkgs.git
+              pkgs.tmux
+              pkgs.util-linux # flock for serializing dev workspace controls
               pkgs.openssh
               pkgs.gnupg
               pkgs.rpm

--- a/scripts/dev-keymasqd.sh
+++ b/scripts/dev-keymasqd.sh
@@ -16,29 +16,52 @@ fi
 source "${REPO_ROOT}/scripts/dev-shell-env.sh"
 normalize_dev_shell_for_pkexec
 
+host_command() {
+  # Match optional NixOS sudo rules even when the worktree's Nix shell uses
+  # another nixpkgs pin. Other hosts keep using their normal PATH commands.
+  local name="$1"
+  if [[ -x "/run/current-system/sw/bin/${name}" ]]; then
+    printf '/run/current-system/sw/bin/%s\n' "${name}"
+  else
+    command -v "${name}"
+  fi
+}
+
+if [[ -x /run/wrappers/bin/sudo ]]; then
+  SUDO_COMMAND=/run/wrappers/bin/sudo
+else
+  SUDO_COMMAND="$(command -v sudo)"
+fi
+SYSTEMCTL_COMMAND="$(host_command systemctl || true)"
+INSTALL_COMMAND="$(host_command install)"
+ENV_COMMAND="$(host_command env)"
+
+# Normal sudo uses a matching NOPASSWD rule automatically, and otherwise
+# authenticates as usual. Do not retry executed commands on failure: a daemon
+# exit is not an indication that passwordless authorization was unavailable.
 stop_installed_daemon_service() {
-  if ! command -v systemctl >/dev/null 2>&1; then
+  if [[ -z "${SYSTEMCTL_COMMAND}" ]]; then
     return
   fi
 
-  if ! systemctl is-active --quiet keymasqd.service; then
+  if ! "${SYSTEMCTL_COMMAND}" is-active --quiet keymasqd.service; then
     return
   fi
 
   if [[ "${EUID}" -eq 0 ]]; then
-    systemctl stop keymasqd.service
+    "${SYSTEMCTL_COMMAND}" stop keymasqd.service
   else
-    sudo systemctl stop keymasqd.service
+    "${SUDO_COMMAND}" "${SYSTEMCTL_COMMAND}" stop keymasqd.service
   fi
 }
 
 prepare_runtime_dirs() {
   if [[ "${EUID}" -eq 0 ]]; then
-    install -d -m 0755 -o keymasq -g keymasq /run/keymasq
-    install -d -m 0750 -o keymasq -g keymasq /var/lib/keymasq
+    "${INSTALL_COMMAND}" -d -m 0755 -o keymasq -g keymasq /run/keymasq
+    "${INSTALL_COMMAND}" -d -m 0750 -o keymasq -g keymasq /var/lib/keymasq
   else
-    sudo install -d -m 0755 -o keymasq -g keymasq /run/keymasq
-    sudo install -d -m 0750 -o keymasq -g keymasq /var/lib/keymasq
+    "${SUDO_COMMAND}" "${INSTALL_COMMAND}" -d -m 0755 -o keymasq -g keymasq /run/keymasq
+    "${SUDO_COMMAND}" "${INSTALL_COMMAND}" -d -m 0750 -o keymasq -g keymasq /var/lib/keymasq
   fi
 }
 
@@ -67,7 +90,7 @@ export PYTHONPATH="${STAGED_PYTHONPATH}${PYTHONPATH:+:${PYTHONPATH}}"
 stop_installed_daemon_service
 prepare_runtime_dirs
 
-exec sudo -u keymasq env \
+exec "${SUDO_COMMAND}" -u keymasq "${ENV_COMMAND}" \
   HOME=/var/lib/keymasq \
   PATH="${PATH}" \
   PYTHONPATH="${PYTHONPATH}" \

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -1,0 +1,223 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_PATH="${SCRIPT_DIR}/dev.sh"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+usage() {
+  cat <<'EOF'
+Usage: ./scripts/dev.sh [--detached]
+       ./scripts/dev.sh restart [both|daemon|session|gui|all]
+       ./scripts/dev.sh stop
+
+Open or reattach to the Keymasq tmux workspace. Daemon and session start
+immediately; F8 starts the GUI. --detached starts without attaching.
+
+F5 restart both    F6 restart daemon    F7 restart session
+F8 start/restart GUI    F9 detach    F10 stop everything
+
+The header buttons perform the same actions. Only one checkout can own the
+workspace at a time because the dev processes use the installed sockets.
+EOF
+}
+
+ACTION="${1:-open}"
+TARGET="${2:-both}"
+case "${ACTION}" in
+  -h|--help) usage; exit 0 ;;
+  open|--detached|stop)
+    if (( $# > 1 )); then usage >&2; exit 2; fi
+    ;;
+  restart)
+    if (( $# > 2 )); then usage >&2; exit 2; fi
+    case "${TARGET}" in
+      both|daemon|session|gui|all) ;;
+      *) usage >&2; exit 2 ;;
+    esac
+    ;;
+  *) usage >&2; exit 2 ;;
+esac
+
+if [[ -z "${IN_NIX_SHELL:-}" ]]; then
+  exec nix develop "${REPO_ROOT}" -c "${SCRIPT_PATH}" "$@"
+fi
+
+if [[ "${ACTION}" == open && ( ! -t 0 || ! -t 1 ) ]]; then
+  echo "Open dev.sh in a terminal, or use --detached." >&2
+  exit 1
+fi
+
+for tool in tmux flock timeout; do
+  if ! command -v "${tool}" >/dev/null 2>&1; then
+    echo "${tool} is missing. Re-enter the updated Nix dev shell." >&2
+    exit 1
+  fi
+done
+
+# A separate server keeps the layout and bindings local to Keymasq. Use one
+# server per user, since even different worktrees share the runtime sockets.
+TMUX_NAME="keymasq-dev"
+SESSION="keymasq"
+tmux_dev() {
+  tmux -L "${TMUX_NAME}" -f "${SCRIPT_DIR}/dev.tmux.conf" "$@" 9>&-
+}
+
+message() {
+  printf '%s\n' "$*"
+  tmux_dev set-option -t "${SESSION}" @dev_message "$*" 2>/dev/null || true
+}
+
+fail() {
+  message "$*" >&2
+  exit 1
+}
+
+# Ignore overlapping clicks instead of queuing a series of unwanted restarts.
+# The server and pane children must not inherit this lock.
+exec 9>"${XDG_RUNTIME_DIR:-${TMPDIR:-/tmp}}/keymasq-dev-${UID}.lock"
+flock -n 9 || fail "Another dev action is still running."
+
+pane_for() {
+  tmux_dev show-option -qv -t "${SESSION}" "@dev_$1"
+}
+
+pane_dead() {
+  [[ "$(tmux_dev display-message -p -t "$1" '#{pane_dead}')" == 1 ]]
+}
+
+shell_quote() {
+  local value="${1//\'/\'\\\'\'}"
+  printf "'%s'" "${value}"
+}
+
+stop_panes() {
+  local role pane channel
+  local -a waiting=()
+  for role in "$@"; do
+    pane="$(pane_for "${role}")"
+    [[ -n "${pane}" ]] || fail "Missing ${role} pane."
+    if pane_dead "${pane}"; then
+      continue
+    fi
+
+    # Install the hook before checking again, so a concurrent exit cannot be
+    # missed. Each operation gets its own channel, including after a timeout.
+    channel="keymasq-exit-$$-${role}"
+    tmux_dev set-hook -p -t "${pane}" pane-died "wait-for -S ${channel}"
+    waiting+=("${role}:${pane}:${channel}")
+    if pane_dead "${pane}"; then
+      tmux_dev wait-for -S "${channel}"
+      continue
+    fi
+    if [[ "$(tmux_dev display-message -p -t "${pane}" '#{pane_in_mode}')" == 1 ]]; then
+      tmux_dev send-keys -t "${pane}" -X cancel
+    fi
+    # Deliver Ctrl+C through the terminal, just like the manual dev flow.
+    # This also reaches the daemon behind sudo's terminal handling.
+    tmux_dev send-keys -t "${pane}" C-c
+  done
+
+  local entry
+  for entry in "${waiting[@]}"; do
+    IFS=: read -r role pane channel <<<"${entry}"
+    # Consume the notification even when the pane has already exited.
+    if ! timeout 15 tmux -L "${TMUX_NAME}" wait-for "${channel}" 9>&-; then
+      fail "${role} did not stop within 15s. Check its pane, then retry."
+    fi
+    pane_dead "${pane}" || fail "${role} is still running; restart cancelled."
+    tmux_dev set-hook -pu -t "${pane}" pane-died
+  done
+}
+
+start_pane() {
+  local role="$1"
+  local launcher
+  local -a args=()
+  case "${role}" in
+    daemon) launcher=dev-keymasqd.sh; args=(-v) ;;
+    session) launcher=dev-session.sh; args=(-v) ;;
+    gui) launcher=dev-gui.sh ;;
+  esac
+  # Respawn only exited panes. Reusing the launcher refreshes the daemon's
+  # staged source and preserves the established user and Nix environment.
+  tmux_dev respawn-pane -t "$(pane_for "${role}")" -c "${REPO_ROOT}" \
+    "${BASH}" "${SCRIPT_DIR}/${launcher}" "${args[@]}"
+}
+
+create_workspace() {
+  local daemon_pane session_pane gui_pane control
+  export REPO_ROOT
+  export PYTHONUNBUFFERED=1
+  export KEYMASQ_SESSION_RESTART_ON_DAEMON_DISCONNECT=0
+
+  daemon_pane="$(tmux_dev new-session -d -P -F '#{pane_id}' \
+    -s "${SESSION}" -n runtime -x 120 -y 36 -c "${REPO_ROOT}" \
+    "${BASH}" -c 'printf "Starting daemon...\n"')"
+  tmux_dev set-option -g default-shell "${BASH}"
+  tmux_dev set-option -t "${SESSION}" @dev_root "${REPO_ROOT}"
+  # run-shell uses /bin/sh. Quote each argument for that shell, including
+  # checkout paths containing spaces, quotes, or shell metacharacters.
+  control="$(shell_quote "${BASH}") $(shell_quote "${SCRIPT_PATH}")"
+  tmux_dev set-option -t "${SESSION}" @dev_control "${control}"
+
+  gui_pane="$(tmux_dev split-window -d -v -l 25% -P -F '#{pane_id}' \
+    -t "${daemon_pane}" -c "${REPO_ROOT}" \
+    "${BASH}" -c 'printf "Press F8 or click GUI to launch the GTK window.\n"')"
+  session_pane="$(tmux_dev split-window -d -h -l 50% -P -F '#{pane_id}' \
+    -t "${daemon_pane}" -c "${REPO_ROOT}" \
+    "${BASH}" -c 'printf "Starting session...\n"')"
+
+  tmux_dev set-option -t "${SESSION}" @dev_daemon "${daemon_pane}"
+  tmux_dev set-option -t "${SESSION}" @dev_session "${session_pane}"
+  tmux_dev set-option -t "${SESSION}" @dev_gui "${gui_pane}"
+  tmux_dev select-pane -t "${daemon_pane}" -T keymasqd
+  tmux_dev select-pane -t "${session_pane}" -T keymasq-session
+  tmux_dev select-pane -t "${gui_pane}" -T GUI
+  tmux_dev select-pane -t "${daemon_pane}"
+  stop_panes session daemon
+  start_pane daemon
+  start_pane session
+  message "Daemon and session launched. F8 starts the GUI."
+}
+
+if tmux_dev has-session -t "${SESSION}" 2>/dev/null; then
+  owner="$(tmux_dev show-option -qv -t "${SESSION}" @dev_root)"
+  if [[ "${owner}" != "${REPO_ROOT}" ]]; then
+    fail "Dev workspace belongs to ${owner:-another checkout}. Stop it from that checkout first."
+  fi
+elif [[ "${ACTION}" == open || "${ACTION}" == --detached ]]; then
+  create_workspace
+elif [[ "${ACTION}" == stop ]]; then
+  message "No dev workspace is running."
+  exit 0
+else
+  fail "No dev workspace is running. Start ./scripts/dev.sh first."
+fi
+
+case "${ACTION}" in
+  open)
+    flock -u 9
+    exec 9>&-
+    # Explicit socket targeting lets this also work from inside another tmux.
+    unset TMUX
+    exec tmux -L "${TMUX_NAME}" attach-session -t "${SESSION}"
+    ;;
+  --detached) ;;
+  restart)
+    message "Restarting ${TARGET}..."
+    case "${TARGET}" in
+      both) roles=(session daemon); starts=(daemon session) ;;
+      all) roles=(gui session daemon); starts=(daemon session gui) ;;
+      *) roles=("${TARGET}"); starts=("${TARGET}") ;;
+    esac
+    stop_panes "${roles[@]}"
+    for role in "${starts[@]}"; do start_pane "${role}"; done
+    message "Launched ${TARGET}. Check panes for startup errors."
+    ;;
+  stop)
+    message "Stopping GUI, session, and daemon..."
+    stop_panes gui session daemon
+    tmux_dev kill-session -t "${SESSION}"
+    ;;
+esac

--- a/scripts/dev.tmux.conf
+++ b/scripts/dev.tmux.conf
@@ -1,0 +1,47 @@
+# Loaded only by the dedicated keymasq-dev server.
+set -g mouse on
+set -g history-limit 50000
+set -g remain-on-exit on
+set -g remain-on-exit-format 'Exited (#{pane_dead_status}). Use the header or F5-F8 to start again.'
+set -g pane-border-status top
+set -g pane-border-format ' #{pane_title} '
+set -g pane-border-style 'fg=colour240'
+set -g pane-active-border-style 'fg=colour74'
+set -g allow-rename off
+set -g automatic-rename off
+set -g set-titles off
+set -g status-position top
+set -g status 2
+set -g status-style 'bg=colour235,fg=colour252'
+set -g status-format[0] '#[bold] Keymasq #[nobold] #[range=user|both,fg=colour81][F5 Restart both]#[norange,default] #[range=user|daemon][F6 Daemon]#[norange] #[range=user|session][F7 Session]#[norange] #[range=user|gui][F8 GUI]#[norange]'
+set -g status-format[1] ' #[range=user|detach][F9 Detach]#[norange] #[range=user|stop][F10 Stop]#[norange]  #{@dev_message}'
+
+bind-key -n F5 run-shell -b '#{@dev_control} restart both >/dev/null 2>&1 || :'
+bind-key -n F6 run-shell -b '#{@dev_control} restart daemon >/dev/null 2>&1 || :'
+bind-key -n F7 run-shell -b '#{@dev_control} restart session >/dev/null 2>&1 || :'
+bind-key -n F8 run-shell -b '#{@dev_control} restart gui >/dev/null 2>&1 || :'
+bind-key -n F9 detach-client
+bind-key -n F10 run-shell -b '#{@dev_control} stop >/dev/null 2>&1 || :'
+
+# Keep the controls available while scrolling in copy mode too.
+bind-key -T copy-mode F5 run-shell -b '#{@dev_control} restart both >/dev/null 2>&1 || :'
+bind-key -T copy-mode F6 run-shell -b '#{@dev_control} restart daemon >/dev/null 2>&1 || :'
+bind-key -T copy-mode F7 run-shell -b '#{@dev_control} restart session >/dev/null 2>&1 || :'
+bind-key -T copy-mode F8 run-shell -b '#{@dev_control} restart gui >/dev/null 2>&1 || :'
+bind-key -T copy-mode F9 detach-client
+bind-key -T copy-mode F10 run-shell -b '#{@dev_control} stop >/dev/null 2>&1 || :'
+bind-key -T copy-mode-vi F5 run-shell -b '#{@dev_control} restart both >/dev/null 2>&1 || :'
+bind-key -T copy-mode-vi F6 run-shell -b '#{@dev_control} restart daemon >/dev/null 2>&1 || :'
+bind-key -T copy-mode-vi F7 run-shell -b '#{@dev_control} restart session >/dev/null 2>&1 || :'
+bind-key -T copy-mode-vi F8 run-shell -b '#{@dev_control} restart gui >/dev/null 2>&1 || :'
+bind-key -T copy-mode-vi F9 detach-client
+bind-key -T copy-mode-vi F10 run-shell -b '#{@dev_control} stop >/dev/null 2>&1 || :'
+
+bind-key -n MouseDown1Status {
+  if-shell -F '#{==:#{mouse_status_range},both}' { run-shell -b '#{@dev_control} restart both >/dev/null 2>&1 || :' }
+  if-shell -F '#{==:#{mouse_status_range},daemon}' { run-shell -b '#{@dev_control} restart daemon >/dev/null 2>&1 || :' }
+  if-shell -F '#{==:#{mouse_status_range},session}' { run-shell -b '#{@dev_control} restart session >/dev/null 2>&1 || :' }
+  if-shell -F '#{==:#{mouse_status_range},gui}' { run-shell -b '#{@dev_control} restart gui >/dev/null 2>&1 || :' }
+  if-shell -F '#{==:#{mouse_status_range},detach}' { detach-client }
+  if-shell -F '#{==:#{mouse_status_range},stop}' { run-shell -b '#{@dev_control} stop >/dev/null 2>&1 || :' }
+}


### PR DESCRIPTION
Adds `./scripts/dev.sh` for side-by-side daemon and session logs, a GUI log pane, and clickable restart controls with function-key shortcuts. The workspace supports graceful restarts, reattaching, and starting or restarting the GUI.

Reuses the existing source launchers and prefers stable NixOS command paths so optional passwordless sudo rules work across worktrees. Includes the tmux dev-shell dependency and a brief usage note.
