### PR TITLE
Add graceful worktree switching to the dev workspace

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -28,7 +28,9 @@ open the tmux dev workspace in one terminal:
 ```
 
 The workspace shows daemon, session, and GUI logs with restart controls in
-the header. Run `./scripts/dev.sh --help` for command-line options.
+the header. F4 opens a searchable worktree picker. Opening `dev.sh` from another
+worktree also switches over, gracefully stopping the old processes first.
+Run `./scripts/dev.sh --help` for command-line options.
 
 You can also run the individual launchers in separate terminals:
 

--- a/flake.nix
+++ b/flake.nix
@@ -582,6 +582,7 @@
               pkgs.hicolor-icon-theme
               pkgs.git
               pkgs.tmux
+              pkgs.fzf
               pkgs.util-linux # flock for serializing dev workspace controls
               pkgs.openssh
               pkgs.gnupg

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SCRIPT_PATH="${SCRIPT_DIR}/dev.sh"
-REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+REPO_ROOT="${KEYMASQ_DEV_ROOT:-$(cd "${SCRIPT_DIR}/.." && pwd)}"
 
 usage() {
   cat <<'EOF'
@@ -227,19 +227,36 @@ prepare_worktree() {
 }
 
 configure_workspace() {
-  local control branch
+  local controller control branch file
   tmux_dev source-file "${SCRIPT_DIR}/dev.tmux.conf"
   tmux_dev set-option -g default-shell "${BASH}"
   tmux_dev set-option -t "${SESSION}" @dev_root "${REPO_ROOT}"
   branch="$(git -C "${REPO_ROOT}" symbolic-ref --short -q HEAD \
     || git -C "${REPO_ROOT}" rev-parse --short HEAD)"
   tmux_dev set-option -t "${SESSION}" @dev_branch "${branch}"
-  # run-shell uses /bin/sh. Quote each argument for that shell, including
-  # checkout paths containing spaces, quotes, or shell metacharacters.
-  # An existing server may still carry another worktree's Nix environment.
-  control="env -u IN_NIX_SHELL $(shell_quote "${BASH}") $(shell_quote "${SCRIPT_PATH}")"
+  # Keep the controller outside Git worktrees: the previous checkout may be
+  # deleted, and an older selected checkout may not have a worktree picker.
+  controller="$(tmux_dev show-option -qv -t "${SESSION}" @dev_controller)"
+  if [[ -z "${controller}" ]]; then
+    controller="$(mktemp -d "${XDG_RUNTIME_DIR:-/tmp}/keymasq-dev-control.XXXXXXXX")"
+    tmux_dev set-option -t "${SESSION}" @dev_controller "${controller}"
+  fi
+  if [[ "${controller}" != "${SCRIPT_DIR}" ]]; then
+    for file in dev.sh dev.tmux.conf; do
+      cp -- "${SCRIPT_DIR}/${file}" "${controller}/${file}.new"
+      mv -- "${controller}/${file}.new" "${controller}/${file}"
+    done
+  fi
+  # Retain the controller's tools without depending on its checkout's flake.
+  # Replace files atomically so a running picker can finish during an update.
+  printf '#!/usr/bin/env bash\nexec env PATH=%s IN_NIX_SHELL=impure KEYMASQ_DEV_ROOT=%s %s %s "$@"\n' \
+    "$(shell_quote "${PATH}")" "$(shell_quote "${REPO_ROOT}")" \
+    "$(shell_quote "${BASH}")" "$(shell_quote "${controller}/dev.sh")" \
+    > "${controller}/control.sh.new"
+  mv -- "${controller}/control.sh.new" "${controller}/control.sh"
+  control="$(shell_quote "${BASH}") $(shell_quote "${controller}/control.sh")"
   tmux_dev set-option -t "${SESSION}" @dev_control "${control}"
-  tmux_dev set-option -t "${SESSION}" @dev_scripts "${SCRIPT_DIR}"
+  tmux_dev set-option -t "${SESSION}" @dev_scripts "${controller}"
 }
 
 create_workspace() {
@@ -320,6 +337,11 @@ case "${ACTION}" in
   stop)
     message "Stopping GUI, session, and daemon..."
     stop_panes gui session daemon
+    controller="$(tmux_dev show-option -qv -t "${SESSION}" @dev_controller)"
     tmux_dev kill-session -t "${SESSION}"
+    if [[ -n "${controller}" ]]; then
+      rm -f -- "${controller}/dev.sh" "${controller}/dev.tmux.conf" "${controller}/control.sh"
+      rmdir -- "${controller}"
+    fi
     ;;
 esac

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -88,6 +88,11 @@ message() {
   tmux_dev set-option -t "${SESSION}" @dev_message "$*" 2>/dev/null || true
 }
 
+success() {
+  printf '%s\n' "$*"
+  tmux_dev set-option -t "${SESSION}" @dev_message ''
+}
+
 fail() {
   message "$*" >&2
   exit 1
@@ -281,7 +286,7 @@ create_workspace() {
   stop_panes session daemon
   start_pane daemon
   start_pane session
-  message "Daemon and session launched. F8 starts the GUI."
+  success "Daemon and session launched. F8 starts the GUI."
 }
 
 if tmux_dev has-session -t "${SESSION}" 2>/dev/null; then
@@ -298,7 +303,7 @@ if tmux_dev has-session -t "${SESSION}" 2>/dev/null; then
     start_pane daemon
     start_pane session
     if (( restart_gui )); then start_pane gui; fi
-    message "Switched worktree. Check panes for startup errors."
+    success "Switched worktree. Check panes for startup errors."
   else
     configure_workspace
   fi
@@ -330,7 +335,7 @@ case "${ACTION}" in
     esac
     stop_panes "${roles[@]}"
     for role in "${starts[@]}"; do start_pane "${role}"; done
-    message "Launched ${TARGET}. Check panes for startup errors."
+    success "Launched ${TARGET}. Check panes for startup errors."
     ;;
   stop)
     message "Stopping GUI, session, and daemon..."

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -7,27 +7,41 @@ REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 
 usage() {
   cat <<'EOF'
-Usage: ./scripts/dev.sh [--detached]
+Usage: ./scripts/dev.sh [--detached] [switch [PATH]]
        ./scripts/dev.sh restart [both|daemon|session|gui|all]
        ./scripts/dev.sh stop
 
 Open or reattach to the Keymasq tmux workspace. Daemon and session start
 immediately; F8 starts the GUI. --detached starts without attaching.
+Opening from another worktree gracefully stops the old processes and switches
+to this checkout. A running GUI reopens from the new checkout too.
 
+F4 choose worktree (type to filter, Enter to switch, Esc to cancel)
 F5 restart both    F6 restart daemon    F7 restart session
 F8 start/restart GUI    F9 detach    F10 stop everything
 
-The header buttons perform the same actions. Only one checkout can own the
-workspace at a time because the dev processes use the installed sockets.
+switch opens the picker, or selects PATH directly. Worktrees are newest first,
+using filesystem creation time, or .git modification time if unavailable.
+Restart and stop operate on the active workspace, from any checkout.
+The header buttons perform the same actions. A switch waits for all old
+processes to exit; if one will not stop, the switch is cancelled.
 EOF
 }
 
+DETACHED=0
+if [[ "${1:-}" == --detached ]]; then
+  DETACHED=1
+  shift
+fi
 ACTION="${1:-open}"
 TARGET="${2:-both}"
 case "${ACTION}" in
   -h|--help) usage; exit 0 ;;
-  open|--detached|stop)
+  open|stop)
     if (( $# > 1 )); then usage >&2; exit 2; fi
+    ;;
+  switch)
+    if (( $# > 2 )); then usage >&2; exit 2; fi
     ;;
   restart)
     if (( $# > 2 )); then usage >&2; exit 2; fi
@@ -40,15 +54,19 @@ case "${ACTION}" in
 esac
 
 if [[ -z "${IN_NIX_SHELL:-}" ]]; then
-  exec nix develop "${REPO_ROOT}" -c "${SCRIPT_PATH}" "$@"
+  # Preserve --detached after parsing it above.
+  args=()
+  if (( DETACHED )); then args+=(--detached); fi
+  exec nix develop "${REPO_ROOT}" -c "${SCRIPT_PATH}" "${args[@]}" "$@"
 fi
 
-if [[ "${ACTION}" == open && ( ! -t 0 || ! -t 1 ) ]]; then
+if [[ "${ACTION}" == open || "${ACTION}" == switch ]] \
+  && (( ! DETACHED )) && [[ ! -t 0 || ! -t 1 ]]; then
   echo "Open dev.sh in a terminal, or use --detached." >&2
   exit 1
 fi
 
-for tool in tmux flock timeout; do
+for tool in tmux flock timeout fzf; do
   if ! command -v "${tool}" >/dev/null 2>&1; then
     echo "${tool} is missing. Re-enter the updated Nix dev shell." >&2
     exit 1
@@ -73,7 +91,57 @@ fail() {
   exit 1
 }
 
-# Ignore overlapping clicks instead of queuing a series of unwanted restarts.
+choose_worktree() {
+  local field path="" branch="" head="" active created modified row selection index
+  local -a paths=() rows=()
+  active="$(tmux_dev show-option -qv -t "${SESSION}" @dev_root 2>/dev/null || true)"
+  while IFS= read -r -d '' field; do
+    case "${field}" in
+      'worktree '*) path="${field#worktree }" ;;
+      'branch '*) branch="${field#branch refs/heads/}" ;;
+      'HEAD '*) head="${field#HEAD }" ;;
+      '')
+        if [[ -f "${path}/flake.nix" && -e "${path}/.git" ]]; then
+          read -r created modified < <(stat -c '%W %Y' -- "${path}/.git")
+          if (( created == 0 )); then created="${modified}"; fi
+          # Keep raw paths in an array, separate from escaped display text.
+          printf -v row '%s\t%s\t%s %s\t%q' "${created}" "${#paths[@]}" \
+            "$([[ "${path}" == "${active}" ]] && printf '*' || printf ' ')" \
+            "${branch:-detached @ ${head:0:8}}" "${path}"
+          rows+=("${row}")
+          paths+=("${path}")
+        fi
+        path=""; branch=""; head=""
+        ;;
+    esac
+  done < <(git -C "${REPO_ROOT}" worktree list --porcelain -z)
+
+  (( ${#paths[@]} )) || fail "No available worktrees found."
+  if ! selection="$(printf '%s\0' "${rows[@]}" | sort -z -t $'\t' -k1,1nr \
+    | FZF_DEFAULT_OPTS='' FZF_DEFAULT_OPTS_FILE='' fzf --read0 --no-sort \
+      --delimiter=$'\t' --with-nth=3.. --layout=reverse --border \
+      --prompt='Worktree > ' --header='Newest first | * active | Enter switch | Esc cancel')"; then
+    exit 0
+  fi
+  selection="${selection#*$'\t'}"
+  index="${selection%%$'\t'*}"
+  REPO_ROOT="${paths[index]}"
+}
+
+if [[ "${ACTION}" == switch ]]; then
+  if [[ -n "${2:-}" ]]; then
+    requested_root="$(cd -- "$2" && pwd)" || fail "Worktree not found: $2"
+    common="$(git -C "${REPO_ROOT}" rev-parse --path-format=absolute --git-common-dir)"
+    requested_common="$(git -C "${requested_root}" rev-parse --path-format=absolute --git-common-dir)" \
+      || fail "Not a Git worktree: ${requested_root}"
+    [[ "${common}" == "${requested_common}" ]] || fail "Choose a worktree of this repository."
+    REPO_ROOT="${requested_root}"
+  else
+    choose_worktree
+  fi
+fi
+
+# Choose first so leaving a picker open does not block restart/stop controls.
 # The server and pane children must not inherit this lock.
 exec 9>"${XDG_RUNTIME_DIR:-${TMPDIR:-/tmp}}/keymasq-dev-${UID}.lock"
 flock -n 9 || fail "Another dev action is still running."
@@ -139,27 +207,47 @@ start_pane() {
     session) launcher=dev-session.sh; args=(-v) ;;
     gui) launcher=dev-gui.sh ;;
   esac
-  # Respawn only exited panes. Reusing the launcher refreshes the daemon's
-  # staged source and preserves the established user and Nix environment.
+  # Enter the selected checkout's shell even when the tmux server was started
+  # from another worktree. In particular, never inherit its Python imports.
   tmux_dev respawn-pane -t "$(pane_for "${role}")" -c "${REPO_ROOT}" \
-    "${BASH}" "${SCRIPT_DIR}/${launcher}" "${args[@]}"
+    env -u IN_NIX_SHELL -u PYTHONPATH REPO_ROOT="${REPO_ROOT}" \
+    PYTHONUNBUFFERED=1 KEYMASQ_SESSION_RESTART_ON_DAEMON_DISCONNECT=0 \
+    nix develop "${REPO_ROOT}" -c bash "${REPO_ROOT}/scripts/${launcher}" "${args[@]}"
+}
+
+prepare_worktree() {
+  local file
+  for file in flake.nix scripts/dev-keymasqd.sh scripts/dev-session.sh scripts/dev-gui.sh; do
+    [[ -f "${REPO_ROOT}/${file}" ]] || fail "Missing ${file} in ${REPO_ROOT}."
+  done
+  message "Preparing ${REPO_ROOT}..."
+  # Resolve/build the target shell before interrupting the old processes.
+  env -u IN_NIX_SHELL -u PYTHONPATH nix develop "${REPO_ROOT}" -c true \
+    || fail "Could not prepare ${REPO_ROOT}; current processes left running."
+}
+
+configure_workspace() {
+  local control branch
+  tmux_dev source-file "${SCRIPT_DIR}/dev.tmux.conf"
+  tmux_dev set-option -g default-shell "${BASH}"
+  tmux_dev set-option -t "${SESSION}" @dev_root "${REPO_ROOT}"
+  branch="$(git -C "${REPO_ROOT}" symbolic-ref --short -q HEAD \
+    || git -C "${REPO_ROOT}" rev-parse --short HEAD)"
+  tmux_dev set-option -t "${SESSION}" @dev_branch "${branch}"
+  # run-shell uses /bin/sh. Quote each argument for that shell, including
+  # checkout paths containing spaces, quotes, or shell metacharacters.
+  # An existing server may still carry another worktree's Nix environment.
+  control="env -u IN_NIX_SHELL $(shell_quote "${BASH}") $(shell_quote "${SCRIPT_PATH}")"
+  tmux_dev set-option -t "${SESSION}" @dev_control "${control}"
+  tmux_dev set-option -t "${SESSION}" @dev_scripts "${SCRIPT_DIR}"
 }
 
 create_workspace() {
-  local daemon_pane session_pane gui_pane control
-  export REPO_ROOT
-  export PYTHONUNBUFFERED=1
-  export KEYMASQ_SESSION_RESTART_ON_DAEMON_DISCONNECT=0
-
+  local daemon_pane session_pane gui_pane
   daemon_pane="$(tmux_dev new-session -d -P -F '#{pane_id}' \
     -s "${SESSION}" -n runtime -x 120 -y 36 -c "${REPO_ROOT}" \
     "${BASH}" -c 'printf "Starting daemon...\n"')"
-  tmux_dev set-option -g default-shell "${BASH}"
-  tmux_dev set-option -t "${SESSION}" @dev_root "${REPO_ROOT}"
-  # run-shell uses /bin/sh. Quote each argument for that shell, including
-  # checkout paths containing spaces, quotes, or shell metacharacters.
-  control="$(shell_quote "${BASH}") $(shell_quote "${SCRIPT_PATH}")"
-  tmux_dev set-option -t "${SESSION}" @dev_control "${control}"
+  configure_workspace
 
   gui_pane="$(tmux_dev split-window -d -v -l 25% -P -F '#{pane_id}' \
     -t "${daemon_pane}" -c "${REPO_ROOT}" \
@@ -183,10 +271,24 @@ create_workspace() {
 
 if tmux_dev has-session -t "${SESSION}" 2>/dev/null; then
   owner="$(tmux_dev show-option -qv -t "${SESSION}" @dev_root)"
-  if [[ "${owner}" != "${REPO_ROOT}" ]]; then
-    fail "Dev workspace belongs to ${owner:-another checkout}. Stop it from that checkout first."
+  if [[ "${ACTION}" == restart || "${ACTION}" == stop ]]; then
+    REPO_ROOT="${owner}"
+  elif [[ "${owner}" != "${REPO_ROOT}" ]]; then
+    prepare_worktree
+    restart_gui=0
+    if ! pane_dead "$(pane_for gui)"; then restart_gui=1; fi
+    message "Stopping old processes before switching..."
+    stop_panes gui session daemon
+    configure_workspace
+    start_pane daemon
+    start_pane session
+    if (( restart_gui )); then start_pane gui; fi
+    message "Switched worktree. Check panes for startup errors."
+  else
+    configure_workspace
   fi
-elif [[ "${ACTION}" == open || "${ACTION}" == --detached ]]; then
+elif [[ "${ACTION}" == open || "${ACTION}" == switch ]]; then
+  prepare_worktree
   create_workspace
 elif [[ "${ACTION}" == stop ]]; then
   message "No dev workspace is running."
@@ -196,14 +298,14 @@ else
 fi
 
 case "${ACTION}" in
-  open)
+  open|switch)
+    if (( DETACHED )); then exit 0; fi
     flock -u 9
     exec 9>&-
     # Explicit socket targeting lets this also work from inside another tmux.
     unset TMUX
     exec tmux -L "${TMUX_NAME}" attach-session -t "${SESSION}"
     ;;
-  --detached) ;;
   restart)
     message "Restarting ${TARGET}..."
     case "${TARGET}" in

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -25,6 +25,8 @@ using filesystem creation time, or .git modification time if unavailable.
 Restart and stop operate on the active workspace, from any checkout.
 The header buttons perform the same actions. A switch waits for all old
 processes to exit; if one will not stop, the switch is cancelled.
+The workspace reuses its initial Nix dev shell across worktrees. Stop and
+reopen the workspace after changing Nix dependencies.
 EOF
 }
 
@@ -207,23 +209,19 @@ start_pane() {
     session) launcher=dev-session.sh; args=(-v) ;;
     gui) launcher=dev-gui.sh ;;
   esac
-  # Enter the selected checkout's shell even when the tmux server was started
-  # from another worktree. In particular, never inherit its Python imports.
+  # Reuse the tmux server's Nix dev shell. Only the source checkout changes;
+  # remove its old Python imports before the launcher sets the new path.
   tmux_dev respawn-pane -t "$(pane_for "${role}")" -c "${REPO_ROOT}" \
-    env -u IN_NIX_SHELL -u PYTHONPATH REPO_ROOT="${REPO_ROOT}" \
+    env -u PYTHONPATH REPO_ROOT="${REPO_ROOT}" \
     PYTHONUNBUFFERED=1 KEYMASQ_SESSION_RESTART_ON_DAEMON_DISCONNECT=0 \
-    nix develop "${REPO_ROOT}" -c bash "${REPO_ROOT}/scripts/${launcher}" "${args[@]}"
+    "${BASH}" "${REPO_ROOT}/scripts/${launcher}" "${args[@]}"
 }
 
-prepare_worktree() {
+validate_worktree() {
   local file
   for file in flake.nix scripts/dev-keymasqd.sh scripts/dev-session.sh scripts/dev-gui.sh; do
     [[ -f "${REPO_ROOT}/${file}" ]] || fail "Missing ${file} in ${REPO_ROOT}."
   done
-  message "Preparing ${REPO_ROOT}..."
-  # Resolve/build the target shell before interrupting the old processes.
-  env -u IN_NIX_SHELL -u PYTHONPATH nix develop "${REPO_ROOT}" -c true \
-    || fail "Could not prepare ${REPO_ROOT}; current processes left running."
 }
 
 configure_workspace() {
@@ -291,7 +289,7 @@ if tmux_dev has-session -t "${SESSION}" 2>/dev/null; then
   if [[ "${ACTION}" == restart || "${ACTION}" == stop ]]; then
     REPO_ROOT="${owner}"
   elif [[ "${owner}" != "${REPO_ROOT}" ]]; then
-    prepare_worktree
+    validate_worktree
     restart_gui=0
     if ! pane_dead "$(pane_for gui)"; then restart_gui=1; fi
     message "Stopping old processes before switching..."
@@ -305,7 +303,7 @@ if tmux_dev has-session -t "${SESSION}" 2>/dev/null; then
     configure_workspace
   fi
 elif [[ "${ACTION}" == open || "${ACTION}" == switch ]]; then
-  prepare_worktree
+  validate_worktree
   create_workspace
 elif [[ "${ACTION}" == stop ]]; then
   message "No dev workspace is running."

--- a/scripts/dev.tmux.conf
+++ b/scripts/dev.tmux.conf
@@ -16,7 +16,7 @@ set -g status-style 'bg=colour235,fg=colour252'
 set -g status-format[0] '#[bold] Keymasq #[nobold] #[range=user|worktree][F4 Worktree]#[norange] #[range=user|both,fg=colour81][F5 Restart both]#[norange,default] #[range=user|daemon][F6 Daemon]#[norange] #[range=user|session][F7 Session]#[norange] #[range=user|gui][F8 GUI]#[norange]'
 set -g status-format[1] ' #[range=user|detach][F9 Detach]#[norange] #[range=user|stop][F10 Stop]#[norange]  #{@dev_branch} | #{@dev_message}'
 
-bind-key -n F4 display-popup -E -d '#{@dev_scripts}' -w 90% -h 80% 'env -u IN_NIX_SHELL bash ./dev.sh --detached switch'
+bind-key -n F4 display-popup -E -d '#{@dev_scripts}' -w 90% -h 80% 'bash ./control.sh --detached switch'
 bind-key -n F5 run-shell -b '#{@dev_control} restart both >/dev/null 2>&1 || :'
 bind-key -n F6 run-shell -b '#{@dev_control} restart daemon >/dev/null 2>&1 || :'
 bind-key -n F7 run-shell -b '#{@dev_control} restart session >/dev/null 2>&1 || :'
@@ -25,14 +25,14 @@ bind-key -n F9 detach-client
 bind-key -n F10 run-shell -b '#{@dev_control} stop >/dev/null 2>&1 || :'
 
 # Keep the controls available while scrolling in copy mode too.
-bind-key -T copy-mode F4 display-popup -E -d '#{@dev_scripts}' -w 90% -h 80% 'env -u IN_NIX_SHELL bash ./dev.sh --detached switch'
+bind-key -T copy-mode F4 display-popup -E -d '#{@dev_scripts}' -w 90% -h 80% 'bash ./control.sh --detached switch'
 bind-key -T copy-mode F5 run-shell -b '#{@dev_control} restart both >/dev/null 2>&1 || :'
 bind-key -T copy-mode F6 run-shell -b '#{@dev_control} restart daemon >/dev/null 2>&1 || :'
 bind-key -T copy-mode F7 run-shell -b '#{@dev_control} restart session >/dev/null 2>&1 || :'
 bind-key -T copy-mode F8 run-shell -b '#{@dev_control} restart gui >/dev/null 2>&1 || :'
 bind-key -T copy-mode F9 detach-client
 bind-key -T copy-mode F10 run-shell -b '#{@dev_control} stop >/dev/null 2>&1 || :'
-bind-key -T copy-mode-vi F4 display-popup -E -d '#{@dev_scripts}' -w 90% -h 80% 'env -u IN_NIX_SHELL bash ./dev.sh --detached switch'
+bind-key -T copy-mode-vi F4 display-popup -E -d '#{@dev_scripts}' -w 90% -h 80% 'bash ./control.sh --detached switch'
 bind-key -T copy-mode-vi F5 run-shell -b '#{@dev_control} restart both >/dev/null 2>&1 || :'
 bind-key -T copy-mode-vi F6 run-shell -b '#{@dev_control} restart daemon >/dev/null 2>&1 || :'
 bind-key -T copy-mode-vi F7 run-shell -b '#{@dev_control} restart session >/dev/null 2>&1 || :'
@@ -41,7 +41,7 @@ bind-key -T copy-mode-vi F9 detach-client
 bind-key -T copy-mode-vi F10 run-shell -b '#{@dev_control} stop >/dev/null 2>&1 || :'
 
 bind-key -n MouseDown1Status {
-  if-shell -F '#{==:#{mouse_status_range},worktree}' { display-popup -E -d '#{@dev_scripts}' -w 90% -h 80% 'env -u IN_NIX_SHELL bash ./dev.sh --detached switch' }
+  if-shell -F '#{==:#{mouse_status_range},worktree}' { display-popup -E -d '#{@dev_scripts}' -w 90% -h 80% 'bash ./control.sh --detached switch' }
   if-shell -F '#{==:#{mouse_status_range},both}' { run-shell -b '#{@dev_control} restart both >/dev/null 2>&1 || :' }
   if-shell -F '#{==:#{mouse_status_range},daemon}' { run-shell -b '#{@dev_control} restart daemon >/dev/null 2>&1 || :' }
   if-shell -F '#{==:#{mouse_status_range},session}' { run-shell -b '#{@dev_control} restart session >/dev/null 2>&1 || :' }

--- a/scripts/dev.tmux.conf
+++ b/scripts/dev.tmux.conf
@@ -13,8 +13,9 @@ set -g set-titles off
 set -g status-position top
 set -g status 2
 set -g status-style 'bg=colour235,fg=colour252'
-set -g status-format[0] '#[bold] Keymasq #[nobold] #[range=user|worktree][F4 Worktree]#[norange] #[range=user|both,fg=colour81][F5 Restart both]#[norange,default] #[range=user|daemon][F6 Daemon]#[norange] #[range=user|session][F7 Session]#[norange] #[range=user|gui][F8 GUI]#[norange]'
-set -g status-format[1] ' #[range=user|detach][F9 Detach]#[norange] #[range=user|stop][F10 Stop]#[norange]  #{@dev_branch} | #{@dev_message}'
+# Context above, restart controls below. Leave room for the right-hand buttons.
+set -g status-format[0] '#[align=left,bg=colour235,fg=colour255,bold]  Keymasq  #[nobold]#{?@dev_message,#[fg=colour179]#{=/#{e|-:#{client_width},31}/...:@dev_message},#[fg=colour246]#{=/#{e|-:#{client_width},31}/...:@dev_branch}}#[align=right,bg=colour237,range=user|worktree,fg=colour245] F4 #[fg=colour252]Worktrees #[norange,bg=colour235] '
+set -g status-format[1] '#[align=left,bg=colour235] #[range=user|both,bg=colour24,fg=colour109] F5 #[fg=colour159,bold]Restart both #[nobold,norange,bg=colour235] #[range=user|daemon,bg=colour237,fg=colour245] F6 #[fg=colour252]Daemon #[norange,bg=colour235] #[range=user|session,bg=colour237,fg=colour245] F7 #[fg=colour252]Session #[norange,bg=colour235] #[range=user|gui,bg=colour237,fg=colour245] F8 #[fg=colour252]GUI #[norange,bg=colour235]#[align=right,range=user|detach,bg=colour237,fg=colour245] F9 #[fg=colour250]Detach #[norange,bg=colour235] #[range=user|stop,bg=colour237,fg=colour138] F10 #[fg=colour174]Stop #[norange,bg=colour235] '
 
 bind-key -n F4 display-popup -E -d '#{@dev_scripts}' -w 90% -h 80% 'bash ./control.sh --detached switch'
 bind-key -n F5 run-shell -b '#{@dev_control} restart both >/dev/null 2>&1 || :'

--- a/scripts/dev.tmux.conf
+++ b/scripts/dev.tmux.conf
@@ -13,9 +13,10 @@ set -g set-titles off
 set -g status-position top
 set -g status 2
 set -g status-style 'bg=colour235,fg=colour252'
-set -g status-format[0] '#[bold] Keymasq #[nobold] #[range=user|both,fg=colour81][F5 Restart both]#[norange,default] #[range=user|daemon][F6 Daemon]#[norange] #[range=user|session][F7 Session]#[norange] #[range=user|gui][F8 GUI]#[norange]'
-set -g status-format[1] ' #[range=user|detach][F9 Detach]#[norange] #[range=user|stop][F10 Stop]#[norange]  #{@dev_message}'
+set -g status-format[0] '#[bold] Keymasq #[nobold] #[range=user|worktree][F4 Worktree]#[norange] #[range=user|both,fg=colour81][F5 Restart both]#[norange,default] #[range=user|daemon][F6 Daemon]#[norange] #[range=user|session][F7 Session]#[norange] #[range=user|gui][F8 GUI]#[norange]'
+set -g status-format[1] ' #[range=user|detach][F9 Detach]#[norange] #[range=user|stop][F10 Stop]#[norange]  #{@dev_branch} | #{@dev_message}'
 
+bind-key -n F4 display-popup -E -d '#{@dev_scripts}' -w 90% -h 80% 'env -u IN_NIX_SHELL bash ./dev.sh --detached switch'
 bind-key -n F5 run-shell -b '#{@dev_control} restart both >/dev/null 2>&1 || :'
 bind-key -n F6 run-shell -b '#{@dev_control} restart daemon >/dev/null 2>&1 || :'
 bind-key -n F7 run-shell -b '#{@dev_control} restart session >/dev/null 2>&1 || :'
@@ -24,12 +25,14 @@ bind-key -n F9 detach-client
 bind-key -n F10 run-shell -b '#{@dev_control} stop >/dev/null 2>&1 || :'
 
 # Keep the controls available while scrolling in copy mode too.
+bind-key -T copy-mode F4 display-popup -E -d '#{@dev_scripts}' -w 90% -h 80% 'env -u IN_NIX_SHELL bash ./dev.sh --detached switch'
 bind-key -T copy-mode F5 run-shell -b '#{@dev_control} restart both >/dev/null 2>&1 || :'
 bind-key -T copy-mode F6 run-shell -b '#{@dev_control} restart daemon >/dev/null 2>&1 || :'
 bind-key -T copy-mode F7 run-shell -b '#{@dev_control} restart session >/dev/null 2>&1 || :'
 bind-key -T copy-mode F8 run-shell -b '#{@dev_control} restart gui >/dev/null 2>&1 || :'
 bind-key -T copy-mode F9 detach-client
 bind-key -T copy-mode F10 run-shell -b '#{@dev_control} stop >/dev/null 2>&1 || :'
+bind-key -T copy-mode-vi F4 display-popup -E -d '#{@dev_scripts}' -w 90% -h 80% 'env -u IN_NIX_SHELL bash ./dev.sh --detached switch'
 bind-key -T copy-mode-vi F5 run-shell -b '#{@dev_control} restart both >/dev/null 2>&1 || :'
 bind-key -T copy-mode-vi F6 run-shell -b '#{@dev_control} restart daemon >/dev/null 2>&1 || :'
 bind-key -T copy-mode-vi F7 run-shell -b '#{@dev_control} restart session >/dev/null 2>&1 || :'
@@ -38,6 +41,7 @@ bind-key -T copy-mode-vi F9 detach-client
 bind-key -T copy-mode-vi F10 run-shell -b '#{@dev_control} stop >/dev/null 2>&1 || :'
 
 bind-key -n MouseDown1Status {
+  if-shell -F '#{==:#{mouse_status_range},worktree}' { display-popup -E -d '#{@dev_scripts}' -w 90% -h 80% 'env -u IN_NIX_SHELL bash ./dev.sh --detached switch' }
   if-shell -F '#{==:#{mouse_status_range},both}' { run-shell -b '#{@dev_control} restart both >/dev/null 2>&1 || :' }
   if-shell -F '#{==:#{mouse_status_range},daemon}' { run-shell -b '#{@dev_control} restart daemon >/dev/null 2>&1 || :' }
   if-shell -F '#{==:#{mouse_status_range},session}' { run-shell -b '#{@dev_control} restart session >/dev/null 2>&1 || :' }


### PR DESCRIPTION
Running `dev.sh` in another worktree now gracefully stops the existing daemon, session, and GUI before switching in place. A running GUI reopens automatically.

F4 and the header open a searchable worktree picker showing branches and paths, newest first. The workspace reuses its initial Nix dev shell for switching and restarts. Invalid worktrees or failed shutdowns prevent takeover, and controls remain available after the previous worktree is deleted.

A two-row toolbar separates worktree context from restart controls, with padded buttons and Detach/Stop on the right. Routine success messages clear; errors remain visible.

Validated with real tmux and fzf using isolated stand-in processes, including keyboard and mouse selection, shutdown timeouts, and toolbar layouts down to 80 columns.
