### PR TITLE
Filter inspector motion sensor axes with Move

### DIFF
--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -52,6 +52,12 @@ resolved mapping and the raw events coming from that device. Enable suppression
 inside the inspector to test inputs without emitting remapped output. Press
 Escape on any grabbed keyboard to turn suppression off.
 
+The raw event **Move** filter includes mouse movement and absolute axes from
+motion interfaces, including gyro and accelerometer events. It is off by default.
+Use **Axes** for regular stick, trigger, and wheel events. Hidden motion events
+do not displace regular axes from their history, and copying events respects the
+selected filters. The live motion preview updates regardless of these filters.
+
 Unknown raw axis events appear in the event stream. Add the relevant event names
 and codes to the hardware setup, then reopen the inspector to see them in the
 configured axes viewer.

--- a/keymasq/gui/widgets/device_inspector/lifecycle.py
+++ b/keymasq/gui/widgets/device_inspector/lifecycle.py
@@ -38,7 +38,7 @@ class LifecycleMixin:
     def _apply_snapshot(self: Any, snapshot: Payload) -> None:
         self._snapshot = dict(snapshot)
         self._event_history.motion_sources = {
-            text(interface.get("id"))
+            text(interface.get("id")).strip().lower()
             for interface in list_of_dicts(snapshot.get("interfaces"))
             if interface.get("type") == "motion" and interface.get("id")
         }

--- a/keymasq/gui/widgets/device_inspector/lifecycle.py
+++ b/keymasq/gui/widgets/device_inspector/lifecycle.py
@@ -8,7 +8,7 @@ gi.require_version("Gtk", "4.0")
 
 from gi.repository import GLib  # pyright: ignore[reportAttributeAccessIssue]
 
-from .model import Payload, text
+from .model import Payload, list_of_dicts, text
 
 
 class LifecycleMixin:
@@ -37,6 +37,11 @@ class LifecycleMixin:
 
     def _apply_snapshot(self: Any, snapshot: Payload) -> None:
         self._snapshot = dict(snapshot)
+        self._event_history.motion_sources = {
+            text(interface.get("id"))
+            for interface in list_of_dicts(snapshot.get("interfaces"))
+            if interface.get("type") == "motion" and interface.get("id")
+        }
         self._sync_status(snapshot)
         self._render_mapping(snapshot)
         self._render_axes(snapshot)

--- a/keymasq/gui/widgets/device_inspector/model.py
+++ b/keymasq/gui/widgets/device_inspector/model.py
@@ -29,9 +29,12 @@ class EventHistory:
         default_factory=lambda: {filter_id: [] for filter_id, _label, _active in EVENT_FILTERS}
     )
     order: int = 0
+    motion_sources: set[str] = field(default_factory=set)
 
     def add(self, event: Payload) -> str:
-        category = event_category(event)
+        category = event_category(
+            event, is_motion_source=text(event.get("source")) in self.motion_sources
+        )
         self.order += 1
         stored = dict(event)
         stored["_inspector_order"] = self.order
@@ -88,7 +91,7 @@ def ellipsize_middle(value: str, max_chars: int) -> str:
     return f"{value[:head]}...{value[-tail:]}"
 
 
-def event_category(event: Payload) -> str:
+def event_category(event: Payload, *, is_motion_source: bool = False) -> str:
     event_type = text(event.get("type_name"), text(event.get("type"))).lower()
     code_name = text(event.get("code_name"), text(event.get("code"))).lower()
     if event_type in {"ev_key", "1"}:
@@ -98,7 +101,7 @@ def event_category(event: Payload) -> str:
     ):
         return "syn"
     if event_type in {"ev_abs", "3"}:
-        return "axis"
+        return "mousemove" if is_motion_source else "axis"
     if event_type in {"ev_rel", "2"}:
         if code_name in {"rel_x", "rel_y"}:
             return "mousemove"

--- a/keymasq/gui/widgets/device_inspector_window.py
+++ b/keymasq/gui/widgets/device_inspector_window.py
@@ -60,7 +60,7 @@ class DeviceInspectorWindow(
         self._control_widgets: dict[str, Gtk.Widget] = {}
         self._event_history = EventHistory(
             motion_sources={
-                interface.id
+                interface.id.strip().lower()
                 for interface in device.evdev_devices
                 if interface.device_type == DeviceType.MOTION and interface.id
             }

--- a/keymasq/gui/widgets/device_inspector_window.py
+++ b/keymasq/gui/widgets/device_inspector_window.py
@@ -7,6 +7,7 @@ gi.require_version("Adw", "1")
 
 from gi.repository import Adw, GLib, Gtk, Pango  # pyright: ignore[reportAttributeAccessIssue]
 
+from keymasq.common.model.core import DeviceType
 from keymasq.common.model.hardware import HardwareConfig
 from keymasq.gui.icons import device_icon_names, image_from_icon_names
 from keymasq.gui.session_client import (
@@ -57,7 +58,13 @@ class DeviceInspectorWindow(
         self._device_kind = resolve_device_layout_kind(device)
         self._has_live_column = self._device_kind == "gamepad" or bool(device.motion_sensors)
         self._control_widgets: dict[str, Gtk.Widget] = {}
-        self._event_history = EventHistory()
+        self._event_history = EventHistory(
+            motion_sources={
+                interface.id
+                for interface in device.evdev_devices
+                if interface.device_type == DeviceType.MOTION and interface.id
+            }
+        )
         self._event_rows: list[Gtk.ListBoxRow] = []
         self._event_filter_buttons: dict[str, Gtk.ToggleButton] = {}
         self._event_render_source_id = 0

--- a/keymasq/gui/widgets/device_inspector_window.py
+++ b/keymasq/gui/widgets/device_inspector_window.py
@@ -215,6 +215,8 @@ class DeviceInspectorWindow(
         for filter_id, label, active in EVENT_FILTERS:
             button = Gtk.ToggleButton(label=label)
             button.add_css_class("inspector-event-filter-button")
+            if filter_id == "mousemove":
+                button.set_tooltip_text("Mouse movement and motion sensor axes")
             button.set_active(active)
             button.connect("toggled", self._on_event_filter_toggled)
             filter_box.append(button)

--- a/tests/gui/test_device_inspector_window.py
+++ b/tests/gui/test_device_inspector_window.py
@@ -341,6 +341,35 @@ def test_device_inspector_window_starts_and_renders_snapshot(inspector_harness) 
     assert trigger_viewer.value_labels["x"].get_text() == "x: raw      0 | norm +0.000"
 
 
+def test_motion_interface_axes_use_move_filter_without_evicting_regular_axes(
+    inspector_harness,
+) -> None:
+    window = inspector_harness.window
+    snapshot = _snapshot()
+    snapshot["interfaces"].append({"id": "imu", "type": "motion"})
+    window._apply_snapshot(snapshot)
+    assert not window._event_filter_buttons["mousemove"].get_active()
+    window._event_filter_buttons["axis"].set_active(True)
+
+    inspector_harness.emit_event(
+        {"type_name": "ev_abs", "code_name": "abs_x", "source": "pad", "value": 42}
+    )
+    for value in range(105):
+        inspector_harness.emit_event(
+            {"type": 3, "code_name": "abs_x", "source": "imu", "value": value}
+        )
+
+    assert [event["source"] for event in window._visible_event_history()] == ["pad"]
+    assert "source=pad" in window._visible_event_export_text()
+    assert "source=imu" not in window._visible_event_export_text()
+
+    window._event_filter_buttons["axis"].set_active(False)
+    window._event_filter_buttons["mousemove"].set_active(True)
+    assert len(window._visible_event_history()) == 100
+    assert all(event["source"] == "imu" for event in window._visible_event_history())
+    assert "source=imu" in window._visible_event_export_text()
+
+
 def test_device_inspector_axes_section_tracks_snapshot_analogs(inspector_harness) -> None:
     window = inspector_harness.window
 

--- a/tests/gui/test_device_inspector_window.py
+++ b/tests/gui/test_device_inspector_window.py
@@ -341,7 +341,10 @@ def test_device_inspector_window_starts_and_renders_snapshot(inspector_harness) 
     assert trigger_viewer.value_labels["x"].get_text() == "x: raw      0 | norm +0.000"
 
 
-def test_motion_events_before_start_response_use_move_filter(monkeypatch) -> None:
+@pytest.mark.parametrize("configured_source", ["imu", "IMU", " ImU "])
+def test_motion_events_before_start_response_use_move_filter(
+    monkeypatch, configured_source
+) -> None:
     from gi.repository import Gtk
 
     from keymasq.common.model.core import DeviceType
@@ -350,10 +353,10 @@ def test_motion_events_before_start_response_use_move_filter(monkeypatch) -> Non
 
     device = _device()
     device.evdev_devices.append(
-        EvdevDevice(path="/dev/input/event11", device_type=DeviceType.MOTION, id="imu")
+        EvdevDevice(path="/dev/input/event11", device_type=DeviceType.MOTION, id=configured_source)
     )
     snapshot = _snapshot()
-    snapshot["interfaces"].append({"id": "imu", "type": "motion"})
+    snapshot["interfaces"].append({"id": configured_source, "type": "motion"})
 
     def request_handler(payload, callback, _timeout):
         if payload.get("command") == "start_device_inspector":
@@ -386,12 +389,14 @@ def test_motion_events_before_start_response_use_move_filter(monkeypatch) -> Non
         window._on_destroy()
 
 
+@pytest.mark.parametrize("configured_source", ["imu", "IMU", " ImU "])
 def test_motion_interface_axes_use_move_filter_without_evicting_regular_axes(
     inspector_harness,
+    configured_source,
 ) -> None:
     window = inspector_harness.window
     snapshot = _snapshot()
-    snapshot["interfaces"].append({"id": "imu", "type": "motion"})
+    snapshot["interfaces"].append({"id": configured_source, "type": "motion"})
     window._apply_snapshot(snapshot)
     assert not window._event_filter_buttons["mousemove"].get_active()
     window._event_filter_buttons["axis"].set_active(True)

--- a/tests/gui/test_device_inspector_window.py
+++ b/tests/gui/test_device_inspector_window.py
@@ -341,6 +341,51 @@ def test_device_inspector_window_starts_and_renders_snapshot(inspector_harness) 
     assert trigger_viewer.value_labels["x"].get_text() == "x: raw      0 | norm +0.000"
 
 
+def test_motion_events_before_start_response_use_move_filter(monkeypatch) -> None:
+    from gi.repository import Gtk
+
+    from keymasq.common.model.core import DeviceType
+    from keymasq.common.model.hardware import EvdevDevice
+    from keymasq.gui.widgets import device_inspector_window as inspector_module
+
+    device = _device()
+    device.evdev_devices.append(
+        EvdevDevice(path="/dev/input/event11", device_type=DeviceType.MOTION, id="imu")
+    )
+    snapshot = _snapshot()
+    snapshot["interfaces"].append({"id": "imu", "type": "motion"})
+
+    def request_handler(payload, callback, _timeout):
+        if payload.get("command") == "start_device_inspector":
+            for source in ("pad", "imu"):
+                session.emit(
+                    "device_inspector_event",
+                    {
+                        "hardware_id": device.hardware_id,
+                        "type_name": "ev_abs",
+                        "code_name": "abs_x",
+                        "source": source,
+                        "value": 42,
+                    },
+                )
+            callback(snapshot)
+        else:
+            callback({"status": "ok"})
+
+    session = SessionIpcHarness(request_handler=request_handler).install(
+        monkeypatch, inspector_module
+    )
+    window = inspector_module.DeviceInspectorWindow(Gtk.Window(), device)
+    try:
+        window._event_filter_buttons["axis"].set_active(True)
+        assert [event["source"] for event in window._visible_event_history()] == ["pad"]
+        window._event_filter_buttons["axis"].set_active(False)
+        window._event_filter_buttons["mousemove"].set_active(True)
+        assert [event["source"] for event in window._visible_event_history()] == ["imu"]
+    finally:
+        window._on_destroy()
+
+
 def test_motion_interface_axes_use_move_filter_without_evicting_regular_axes(
     inspector_harness,
 ) -> None:


### PR DESCRIPTION
Motion sensor axes currently share the inspector's Axes filter and history with regular controller axes, so gyro traffic buries useful stick and trigger events. Route absolute-axis events from motion interfaces through the existing Move filter, which stays off by default. Regular axes retain their own history, and copying events follows the selected filters.

Initialize motion sources from the hardware config before subscribing to events, then refresh them from inspector snapshots. Normalize both source sets to match daemon IDs, including uppercase and whitespace-padded configured IDs. Add a Move tooltip, document the behavior, and test both motion traffic flooding and events arriving before the start response.

Validation: `./scripts/check.sh` passed, including lint, type checks, and all 895 GUI tests.
