### PR TITLE
Add modular hidraw drivers and Ultimate 2 motion support

### DIFF
--- a/debian/keymasq.postinst
+++ b/debian/keymasq.postinst
@@ -15,6 +15,7 @@ case "$1" in
             udevadm control --reload-rules >/dev/null 2>&1 || true
             udevadm trigger --subsystem-match=input --action=add >/dev/null 2>&1 || true
             udevadm trigger --subsystem-match=misc --action=add >/dev/null 2>&1 || true
+            udevadm trigger --subsystem-match=hidraw --action=change --settle >/dev/null 2>&1 || true
         fi
 
         if command -v systemctl >/dev/null 2>&1; then

--- a/docs/INPUT_DRIVER_DESIGN.md
+++ b/docs/INPUT_DRIVER_DESIGN.md
@@ -32,7 +32,10 @@ same resolved anchor. Other hardware configurations cannot claim its companion
 independently. Neither a serial number nor a permanent USB port assignment is
 required to select the driver. Native ownership and live-device preferences apply
 to the evdev companions before selection, even for button-only requests or when
-a motion-only profile adds buttons. Calibration retains the evdev selector's
+a motion-only profile adds buttons. Explicit event paths and their `by-id` or
+`by-path` aliases obey the same ownership checks. An explicitly selected
+controller that is already claimed stays unavailable; selection does not fall
+back to another controller. Calibration retains the evdev selector's
 physical-device preference.
 
 Association rules are declared by drivers. Shared helpers support the same HID

--- a/docs/INPUT_DRIVER_DESIGN.md
+++ b/docs/INPUT_DRIVER_DESIGN.md
@@ -1,0 +1,128 @@
+# Native input drivers
+
+Keymasq can supplement evdev with bundled hidraw drivers. The first driver adds
+motion from the 8BitDo Ultimate 2 Wireless in DInput dongle mode. Buttons, sticks,
+and the four extra buttons continue through evdev. Steam masking is maintained
+separately and is outside this driver layer.
+
+## Discovery and association
+
+The daemon discovers HID endpoints through sysfs. A registered driver matches
+VID/PID, transport, and its interface's report descriptor. The Ultimate 2 driver
+matches USB `2dc8:6012`, a Gamepad collection, report ID 1, and the vendor-defined
+report field. Its decoder accepts only the observed 34-byte report format.
+Older firmware and the receiver's idle `2dc8:6013` interface do not supply motion
+through this driver. Matching discovery metadata identifies a candidate; usable
+samples are confirmed when the source is opened.
+
+Saved hardware configurations contain native sources separately from evdev:
+
+```toml
+[[hardware.input_sources]]
+id = "imu"
+driver = "8bitdo-ultimate2"
+companion_of = "gamepad"
+```
+
+`gamepad` names an existing `hardware.evdev.devices` entry. Its existing path,
+VID/PID, and capability selectors choose the live controller. The native source
+then binds to that instance. A motion-only profile uses the evdev selector as an
+anchor without grabbing buttons. When both sources are active, they reuse the
+same resolved anchor. Other hardware configurations cannot claim its companion
+independently. Neither a serial number nor a permanent USB port assignment is
+required to select the driver.
+
+Association rules are declared by drivers. Shared helpers support the same HID
+ancestor or separate HID interfaces under the same USB device. The Ultimate 2
+uses the same HID ancestor. A shared hub or equal VID/PID alone is insufficient
+to pair two endpoints. Multiple matching endpoints or conflicting driver claims
+remain unresolved. The core also represents sources without an evdev companion;
+the first shipped GUI integration is supplemental controller motion.
+
+Live source addresses under `/dev/keymasq-sources/` identify a driver, HID
+connection, and hidraw node. They are internal addresses, not kernel device
+nodes. Hardware files save source IDs and selectors instead. Reconnection builds
+a new binding from sysfs. Opening validates the HID connection before and after
+opening the raw node, so a recycled hidraw number cannot select another device.
+
+## Driver and consumer boundaries
+
+The implementation lives in `keymasq/keymasqd/input_sources/`:
+
+| Module | Responsibility |
+| --- | --- |
+| `types.py` | Endpoint metadata, bindings, named channels, complete raw frames |
+| `registry.py` | Explicit registrations of bundled drivers |
+| `discovery.py` | Sysfs enumeration and common association rules |
+| `transports/hidraw.py` | Read-only, nonblocking reads with asyncio readiness |
+| `manager.py` | Shared connection ownership, subscribers, buffering, continuity |
+| `drivers/eightbitdo_ultimate2.py` | Device matching, report validation, channel decoding and conversion metadata |
+| `evdev_adapter.py` | Internal adaptation of motion frames to existing runtime and inspector consumers |
+
+Drivers describe named channels and decode reports without importing GUI,
+profile, or evdev runtime code. The source manager also accepts button and axis
+channel descriptions. The shipped consumer adapter handles motion; native button
+or ordinary-axis drivers will need the corresponding acquisition and event
+adapter behavior before they can be exposed to profiles. A synthetic button
+source tests that shared reader ownership does not depend on motion or on an
+evdev companion.
+
+The adapter assigns internal ABS channel numbers to motion samples. It creates
+no uinput device and emits no controller buttons. The existing runtime applies
+stored raw bias, scale, sign, noise threshold, smoothing, and output routing once.
+Inspector and calibration receive the same raw channels and conversion metadata.
+Gyro units are radians/second and acceleration units are metres/second squared.
+
+The Ultimate 2 follows SDL's raw layout and gyro scale, adapted to Keymasq's axis
+conventions. Its acceleration scale agrees with the captured Nintendo-mode
+comparison. Live user testing found motion behavior equivalent to Nintendo
+mode. Calibration remains specific to the source's raw units; it is not
+copied between DInput and Nintendo modes.
+
+## Lifetime and failure behavior
+
+One asyncio reader owns each active endpoint. Runtime and calibration subscribe
+to it; inspection uses the runtime's event stream. Acquisition starts when a
+profile, inspector, or calibration requires the source. The last subscriber
+closes it. The Ultimate 2 driver sends no device commands.
+
+Subscribers have bounded queues. Overflow discards stale backlog and marks the
+next complete frame as discontinuous. Disconnects discard queued samples and
+wake subscribers with an error. Long arrival gaps also mark discontinuities so
+the motion runtime resets its filters and outputs. Failed native motion does
+not release independent evdev button interfaces. Calibration reports missing
+sources, malformed streams, and reader failures through its existing errors.
+
+Native runtime addresses remain distinct from evdev paths, including when udev
+provides a `by-id` symlink to the underlying hidraw node. Passthrough virtual
+device creation and destruction run in workers so controller acquisition,
+rollback, and release do not block mouse event processing.
+
+Sample timestamps currently use monotonic report arrival time and are explicitly
+estimated. No hardware clock or sequence counter has been established for this
+report format. Equal sensor values are preserved; equality does not identify a
+duplicate sample. Kernel hidraw queue losses cannot all be detected. Keymasq's
+own queue overflows and observed timing gaps are detectable.
+
+A source has one active binding. A second native definition cannot acquire the
+same endpoint independently within the same hardware configuration. This change
+does not silently substitute kernel motion for calibrated native motion. Such a
+substitution requires verified channel equivalence and compatible calibration.
+When adding future kernel support, choose one provider for each physical sensor.
+
+## Adding another driver
+
+Implement the `InputDriver` contract, provide its supported endpoint match,
+association rule, named channels, and pure report decoder, then register it in
+`registry.py`. All packages grant the daemon generic read access to hidraw, so
+read-only drivers need no packaging changes. Add report fixtures and association
+tests. A driver using the existing supplemental motion arrangement needs no
+model-specific changes in
+profiles, calibration, or GUI setup. New input kinds or protocols requiring
+writes need their own consumer or transport support. Arbitrary Python imports
+from hardware files and an external plugin ABI are not supported.
+
+Tests cover captured reports, unsupported modes, identical devices and reversed
+selection order, missing companions, shared subscribers, overflow, disconnect,
+cancelled calibration, persistence, and adding motion to existing hardware.
+Python changes must pass `./scripts/check.sh`.

--- a/docs/INPUT_DRIVER_DESIGN.md
+++ b/docs/INPUT_DRIVER_DESIGN.md
@@ -30,7 +30,10 @@ then binds to that instance. A motion-only profile uses the evdev selector as an
 anchor without grabbing buttons. When both sources are active, they reuse the
 same resolved anchor. Other hardware configurations cannot claim its companion
 independently. Neither a serial number nor a permanent USB port assignment is
-required to select the driver.
+required to select the driver. Native ownership and live-device preferences apply
+to the evdev companions before selection, even for button-only requests or when
+a motion-only profile adds buttons. Calibration retains the evdev selector's
+physical-device preference.
 
 Association rules are declared by drivers. Shared helpers support the same HID
 ancestor or separate HID interfaces under the same USB device. The Ultimate 2
@@ -88,7 +91,9 @@ closes it. The Ultimate 2 driver sends no device commands.
 
 Subscribers have bounded queues. Overflow discards stale backlog and marks the
 next complete frame as discontinuous. Disconnects discard queued samples and
-wake subscribers with an error. Long arrival gaps also mark discontinuities so
+wake subscribers with an error. A source also fails if no valid sample arrives
+for one second, even if unrelated or malformed reports keep arriving. Valid
+samples reset this deadline. Long arrival gaps also mark discontinuities so
 the motion runtime resets its filters and outputs. Failed native motion does
 not release independent evdev button interfaces. Calibration reports missing
 sources, malformed streams, and reader failures through its existing errors.
@@ -96,7 +101,9 @@ sources, malformed streams, and reader failures through its existing errors.
 Native runtime addresses remain distinct from evdev paths, including when udev
 provides a `by-id` symlink to the underlying hidraw node. Passthrough virtual
 device creation and destruction run in workers so controller acquisition,
-rollback, and release do not block mouse event processing.
+rollback, and release do not block mouse event processing. Cancelled creation
+retains ownership of the worker result until it has been closed, including
+when cancellation repeats during cleanup.
 
 Sample timestamps currently use monotonic report arrival time and are explicitly
 estimated. No hardware clock or sequence counter has been established for this

--- a/docs/MOTION_CONTROLS.md
+++ b/docs/MOTION_CONTROLS.md
@@ -176,3 +176,26 @@ higher-priority mapping.
 Games and other apps can still read the controller's motion sensor while a Motion Control is
 active. Keymasq adds the configured mouse, gamepad, or digital-action output. It does not hide
 sensor input from other apps.
+
+## Ultimate 2 Wireless motion through hidraw
+
+The Ultimate 2 Wireless can provide motion in DInput dongle mode through the
+bundled `8bitdo-ultimate2` driver. Its active USB identity is `2dc8:6012`, and it
+must send the extended 34-byte input reports. The idle receiver identity
+`2dc8:6013` is not a motion source. Bluetooth and other Ultimate models are not
+covered by this driver.
+
+New hardware setup attaches the discovered motion source to the controller.
+For an existing hardware configuration, use its hardware settings to add the
+motion interface from device discovery. Native sources appear in hardware
+settings with an enable switch. Map the resulting motion sensor to a Motion
+Control and calibrate its gyro as usual. Buttons and sticks continue through
+evdev, including the four extra buttons.
+
+Native motion uses the existing bias calibration, noise threshold, smoothing,
+and mouse/stick/analog output processing. DInput calibration is separate from
+Nintendo-mode calibration. Report times are estimated from monotonic arrival
+time; repeated sensor values are retained.
+
+See [Native input drivers](INPUT_DRIVER_DESIGN.md) for configuration and extension
+points.

--- a/docs/PACKAGING.md
+++ b/docs/PACKAGING.md
@@ -34,6 +34,23 @@ The repository currently maintains these package outputs:
 | openSUSE RPM | openSUSE systems | `packaging/rpm/` | `.opensuse.x86_64.rpm` |
 | AnyLinux AppImage | SteamOS and other systemd distros without a native package | `packaging/appimage/` | `Keymasq-<version>-x86_64.AppImage` |
 
+## Native driver permissions
+
+All maintained packages ship `udev/91-keymasq-acl.rules`. It grants the
+`keymasq` daemon user read access to hidraw devices, preserving existing
+ownership and desktop-user access. The driver registry decides which devices
+to open. Device IDs and protocol matching stay in the drivers.
+
+Debian, RPM, Arch/AUR, source, and AppImage install/upgrade hooks retrigger
+hidraw devices and wait for udev to apply the ACLs. Systemd units and the NixOS
+module do this before daemon startup too, covering already-connected devices.
+AppImage's non-systemd instructions include the same step, and its uninstall
+removes the daemon's hidraw ACLs. Installing the Nix package alone does not
+activate system services or udev rules; NixOS users must enable the module.
+
+Adding another read-only native driver requires no packaging changes.
+Drivers that send device commands need an explicit write-access policy.
+
 ## Release channels
 
 The repository uses two packaging channels:

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -193,6 +193,13 @@ distinct per mechanism, so a missing input ACL, missing uinput access, and a
 missing capability are directly distinguishable in the logs (see
 [TROUBLESHOOTING.md](TROUBLESHOOTING.md)).
 
+Native motion drivers also use explicit ACLs in `91-keymasq-acl.rules`.
+The daemon user gets read access to hidraw nodes, including devices with no
+registered driver. The registry controls which endpoints Keymasq actually
+opens; it is not a permission boundary. The rule does not grant write access
+or change device ownership. The Ultimate 2 driver opens its node read-only
+and sends no commands. Future drivers that write need an explicit access policy.
+
 The containment around the capability is retained deliberately: dedicated
 service user, `NoNewPrivileges`, bounding set limited to this single
 capability, protected system and home paths, and writable directories

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -208,6 +208,16 @@ What to verify:
 - no other input remapping tool has already grabbed the device — only one program can exclusively
   hold a device at a time
 
+### Native gyro reports permission denied
+
+Native motion reads `/dev/hidrawN` as the daemon user `keymasq`. Access granted
+only to your desktop user is insufficient. Check the node named in the daemon
+log with `getfacl /dev/hidrawN`; hidraw devices should have a `user:keymasq:r--`
+entry. Install the updated package rules, or rebuild the NixOS configuration
+with the updated Keymasq module/package, then restart the daemon. The startup
+hook reapplies native ACLs to connected controllers. Reconnecting also applies
+the rule. A manual ACL is temporary and disappears when the device is recreated.
+
 ### Missing CAP_DAC_OVERRIDE capability
 
 `keymasqd` needs the `CAP_DAC_OVERRIDE` capability for gamepad source

--- a/flake.nix
+++ b/flake.nix
@@ -429,6 +429,7 @@
                 SupplementaryGroups = [ "input" ];
                 Nice = -5;
                 ExecStartPre = [
+                  "+${pkgs.systemd}/bin/udevadm trigger --subsystem-match=hidraw --action=change --settle"
                   "+${pkgs.acl}/bin/setfacl -m u:keymasq:rw /dev/uinput"
                   "+${pkgs.bash}/bin/sh -c 'for p in /dev/input/event*; do [ -e \"$p\" ] && ${pkgs.acl}/bin/setfacl -m u:keymasq:rw \"$p\"; done'"
                 ];

--- a/keymasq.install
+++ b/keymasq.install
@@ -36,6 +36,7 @@ post_install() {
     udevadm control --reload-rules
     udevadm trigger --subsystem-match=input --action=add
     udevadm trigger --subsystem-match=misc --action=add
+    udevadm trigger --subsystem-match=hidraw --action=change --settle
 
     if [ -f /etc/systemd/system/keymasqd.service ]; then
         echo ""
@@ -73,6 +74,7 @@ post_upgrade() {
     udevadm control --reload-rules
     udevadm trigger --subsystem-match=input --action=add
     udevadm trigger --subsystem-match=misc --action=add
+    udevadm trigger --subsystem-match=hidraw --action=change --settle
 
     if [ -f /etc/systemd/system/keymasqd.service ]; then
         echo ""

--- a/keymasq/common/devices.py
+++ b/keymasq/common/devices.py
@@ -598,22 +598,23 @@ def _resolve_stable_path_cached(event_path: str) -> str:
         or the original path if no by-id symlink exists
     """
     path = Path(event_path)
-    if path.name.startswith("event"):
-        full_path = Path("/dev/input") / path.name
-    else:
-        full_path = path
+    # Only evdev node addresses participate in this lookup. Native source
+    # addresses may end in hidrawN, but must never become raw-device symlinks.
+    if path.parent not in {Path("."), Path("/dev/input")} or not re.fullmatch(
+        r"event\d+", path.name
+    ):
+        return event_path
+    full_path = Path("/dev/input") / path.name
 
     by_id_dir = Path("/dev/input/by-id")
     if not by_id_dir.exists():
         return event_path
 
-    target_name = full_path.name
-
     for symlink in by_id_dir.iterdir():
         try:
             if symlink.is_symlink():
                 link_target = os.readlink(symlink)
-                if link_target.endswith(target_name) or link_target == f"../{target_name}":
+                if os.path.normpath(by_id_dir / link_target) == str(full_path):
                     return str(symlink)
         except OSError:
             continue

--- a/keymasq/common/model/hardware.py
+++ b/keymasq/common/model/hardware.py
@@ -16,6 +16,21 @@ class EvdevDevice:
 
 
 @dataclass
+class NativeInputSource:
+    """A bundled driver's logical source, optionally paired with an evdev interface."""
+
+    id: str
+    driver: str
+    companion_of: str | None = None
+    phys: str | None = None
+    enabled: bool = True
+
+    @property
+    def path(self) -> str:
+        return f"keymasq-source:{self.id}"
+
+
+@dataclass
 class ButtonDefinition:
     id: str
     label: str
@@ -61,6 +76,7 @@ class HardwareConfig:
     motion_sensors: list[MotionSensorDefinition] = field(default_factory=list)
     image: str | None = None
     id: str | None = None
+    input_sources: list[NativeInputSource] = field(default_factory=list)
 
     @property
     def hardware_id(self) -> str:

--- a/keymasq/gui/widgets/device_tab/hardware.py
+++ b/keymasq/gui/widgets/device_tab/hardware.py
@@ -369,6 +369,11 @@ class HardwareSettingsMixin:
         if not source:
             return []
 
+        companions = {item.id for item in self.device.input_sources if item.companion_of == source}
+        self.device.input_sources = [
+            item for item in self.device.input_sources if item.id not in companions
+        ]
+
         removed_button_ids = [
             button.id for button in self.device.buttons if button.source == source
         ]
@@ -376,7 +381,9 @@ class HardwareSettingsMixin:
             analog.id for analog in self.device.analog_inputs if analog.source == source
         ]
         removed_motion_ids = [
-            sensor.id for sensor in self.device.motion_sensors if sensor.source == source
+            sensor.id
+            for sensor in self.device.motion_sensors
+            if sensor.source in {source, *companions}
         ]
         if removed_button_ids:
             self.device.buttons = [
@@ -388,7 +395,9 @@ class HardwareSettingsMixin:
             ]
         if removed_motion_ids:
             self.device.motion_sensors = [
-                sensor for sensor in self.device.motion_sensors if sensor.source != source
+                sensor
+                for sensor in self.device.motion_sensors
+                if sensor.source not in {source, *companions}
             ]
         return [*removed_button_ids, *removed_analog_ids, *removed_motion_ids]
 

--- a/keymasq/gui/widgets/device_tab/hardware_settings_dialog.py
+++ b/keymasq/gui/widgets/device_tab/hardware_settings_dialog.py
@@ -14,8 +14,9 @@ from gi.repository import Adw, Gtk  # pyright: ignore[reportAttributeAccessIssue
 from keymasq import __version__
 from keymasq.common.devices import is_keymasq_device_path
 from keymasq.common.model.core import DeviceType
-from keymasq.common.model.hardware import EvdevDevice, HardwareConfig
+from keymasq.common.model.hardware import EvdevDevice, HardwareConfig, NativeInputSource
 from keymasq.common.model.motion import MotionSensorDefinition
+from keymasq.gui.session_client import session_request_async
 from keymasq.gui.widgets.device_tab.motion_calibration_dialog import (
     MotionCalibrationDialog,
 )
@@ -93,10 +94,42 @@ def append_evdev_device_selection(
             source_ids[original_source] = source_id
         added += 1
 
+    if isinstance(evdev_devices, EvdevDeviceSelection):
+        used_ids.update(source.id for source in hardware_config.input_sources)
+        for source in evdev_devices.input_sources:
+            companion = source_ids.get(source.companion_of or "", source.companion_of)
+            if companion is None:
+                candidates = [
+                    device
+                    for device in hardware_config.evdev_devices
+                    if device.id and source.phys and device.phys == source.phys
+                ]
+                if not candidates and len(hardware_config.evdev_devices) == 1:
+                    candidates = hardware_config.evdev_devices
+                if len(candidates) == 1:
+                    companion = candidates[0].id
+            existing = next(
+                (
+                    item
+                    for item in hardware_config.input_sources
+                    if item.driver == source.driver
+                    and item.companion_of == companion
+                    and item.phys == source.phys
+                ),
+                None,
+            )
+            if existing is not None:
+                source_ids[source.id] = existing.id
+                continue
+            appended_source = deepcopy(source)
+            appended_source.id = _dedupe_interface_id(source.id, used_ids)
+            appended_source.companion_of = companion
+            hardware_config.input_sources.append(appended_source)
+            source_ids[source.id] = appended_source.id
+            added += 1
+
     selected_motion_sensors = (
-        evdev_devices.motion_sensors
-        if isinstance(evdev_devices, EvdevDeviceSelection)
-        else []
+        evdev_devices.motion_sensors if isinstance(evdev_devices, EvdevDeviceSelection) else []
     )
     used_motion_ids = {
         _normalize_interface_id(sensor.id) for sensor in hardware_config.motion_sensors
@@ -261,7 +294,7 @@ class HardwareSettingsDialog(Adw.Dialog):
             self._interfaces_group.remove(row)
         self._interface_rows = []
 
-        if not self._hardware_config.evdev_devices:
+        if not self._hardware_config.evdev_devices and not self._hardware_config.input_sources:
             row = Adw.ActionRow(
                 title="No event devices attached",
                 subtitle="Add an event device to make this hardware ID match live input.",
@@ -292,6 +325,25 @@ class HardwareSettingsDialog(Adw.Dialog):
             row.add_suffix(delete_btn)
             self._interfaces_group.add(row)
             self._interface_rows.append(row)
+
+        for source in self._hardware_config.input_sources:
+            native_row = Adw.SwitchRow(
+                title=f"{source.id}: {source.driver}",
+                subtitle=f"Native input source, paired with {source.companion_of}"
+                if source.companion_of
+                else "Native input source",
+                active=source.enabled,
+            )
+            native_row.connect("notify::active", self._on_native_source_toggled, source)
+            self._interfaces_group.add(native_row)
+            self._interface_rows.append(native_row)
+
+    def _on_native_source_toggled(
+        self, row: Adw.SwitchRow, _param: object, source: NativeInputSource
+    ) -> None:
+        source.enabled = row.get_active()
+        self._hardware_manager.save_hardware(self._hardware_config)
+        session_request_async({"command": "reload"}, lambda _result: False)
 
     def _refresh_motion_rows(self) -> None:
         if self._motion_group is None:
@@ -414,7 +466,9 @@ class HardwareSettingsDialog(Adw.Dialog):
         ]
         selection: list[EvdevDevice] | EvdevDeviceSelection = devices
         if isinstance(raw_devices, EvdevDeviceSelection):
-            selection = EvdevDeviceSelection(devices, raw_devices.motion_sensors)
+            selection = EvdevDeviceSelection(
+                devices, raw_devices.motion_sensors, raw_devices.input_sources
+            )
         _added, message, error = self._on_add_devices(selection)
         self._refresh_interface_rows()
         self._refresh_motion_rows()

--- a/keymasq/gui/wizards/hardware_setup/dialog.py
+++ b/keymasq/gui/wizards/hardware_setup/dialog.py
@@ -13,6 +13,7 @@ from gi.repository import Adw, Gdk, GObject, Gtk  # pyright: ignore[reportAttrib
 from keymasq.common.devices import find_all_interfaces, resolve_stable_path
 from keymasq.gui.session_client import GuiTaskResult, run_gui_task
 from keymasq.gui.widgets.fuzzy_search import fuzzy_query_matches, install_listbox_fuzzy_filter
+from keymasq.gui.wizards.hardware_setup import templates
 from keymasq.gui.wizards.hardware_setup.flow import DiscoveryMixin
 from keymasq.gui.wizards.hardware_setup.persistence import PersistenceMixin
 from keymasq.gui.wizards.hardware_setup.selection import SelectionMixin
@@ -307,13 +308,15 @@ class HardwareSetupDialog(
     def _emit_selected_evdev_devices(self) -> None:
         interfaces = list(self._discovery_state.discovered_interfaces.values())
         evdev_devices = self._build_evdev_devices(interfaces)
-        if not evdev_devices:
+        input_sources = templates.build_input_sources(interfaces)
+        if not evdev_devices and not input_sources:
             return
         self.emit(
             "evdev-devices-selected",
             EvdevDeviceSelection(
                 evdev_devices,
                 self._build_motion_sensors(interfaces),
+                input_sources,
             ),
         )
         self.close()

--- a/keymasq/gui/wizards/hardware_setup/discovery.py
+++ b/keymasq/gui/wizards/hardware_setup/discovery.py
@@ -79,9 +79,7 @@ def _session_device_sort_key(
     dtype_raw = str(dev.get("device_type", "other") or "other")
     device_types = normalize_input_classes(dev.get("device_types"), dtype_raw)
     motion_only = (
-        motion_siblings_last
-        and "motion" in device_types
-        and "gamepad" not in device_types
+        motion_siblings_last and "motion" in device_types and "gamepad" not in device_types
     )
     return (
         str(dev.get("vendor_id", "") or "").lower(),
@@ -299,6 +297,12 @@ def _attach_motion_siblings(detected_devices: dict[str, DetectedDevice]) -> None
             for iface in motion_interfaces
             if iface.get("phys")
         }
+        native_companions = {
+            str(path)
+            for iface in motion_interfaces
+            if iface.get("backend") == "hidraw"
+            for path in iface.get("companion_paths", [])
+        }
         candidates: list[DetectedDevice] = []
         for key, candidate in detected_devices.items():
             if key == motion_key or candidate.get("model_id") != motion_device.get("model_id"):
@@ -314,7 +318,12 @@ def _attach_motion_siblings(detected_devices: dict[str, DetectedDevice]) -> None
                 for iface in candidate_interfaces
                 if iface.get("phys")
             }
-            if motion_phys and motion_phys.intersection(candidate_phys):
+            candidate_paths = {str(iface.get("path", "")) for iface in candidate_interfaces}
+            if (
+                native_companions.intersection(candidate_paths)
+                if native_companions
+                else motion_phys and motion_phys.intersection(candidate_phys)
+            ):
                 candidates.append(candidate)
         if len(candidates) != 1:
             continue

--- a/keymasq/gui/wizards/hardware_setup/flow.py
+++ b/keymasq/gui/wizards/hardware_setup/flow.py
@@ -171,7 +171,10 @@ class DiscoveryMixin:
                 stable_path,
             )
             config_path = str(iface.get("config_path") or default_config_path)
-            capability_names, raw_capabilities = self._read_interface_capabilities(raw_path)
+            if iface.get("backend") == "hidraw":
+                capability_names, raw_capabilities = [], {}
+            else:
+                capability_names, raw_capabilities = self._read_interface_capabilities(raw_path)
             raw_capabilities = merge_inventory_abs_info(
                 raw_capabilities,
                 iface.get("abs_info"),

--- a/keymasq/gui/wizards/hardware_setup/identity.py
+++ b/keymasq/gui/wizards/hardware_setup/identity.py
@@ -111,6 +111,9 @@ def config_path_for_detected_interface(
 
 def interface_source_fields(dev: Mapping[str, Any]) -> dict[str, object]:
     fields: dict[str, object] = {}
+    for key in ("backend", "native_motion_axes", "companion_paths"):
+        if key in dev:
+            fields[key] = dev[key]
     if bool(dev.get("grabbed_by_keymasq", False)):
         fields["grabbed_by_keymasq"] = True
     for key in (

--- a/keymasq/gui/wizards/hardware_setup/persistence.py
+++ b/keymasq/gui/wizards/hardware_setup/persistence.py
@@ -144,6 +144,7 @@ class PersistenceMixin:
                 buttons=self._build_gamepad_buttons(gamepad_interfaces),
                 analog_inputs=self._build_gamepad_analog_inputs(gamepad_interfaces),
                 motion_sensors=self._build_motion_sensors(motion_interfaces),
+                input_sources=templates.build_input_sources(interfaces),
                 id=self._selected_config_id(selected_device),
             )
         )

--- a/keymasq/gui/wizards/hardware_setup/templates.py
+++ b/keymasq/gui/wizards/hardware_setup/templates.py
@@ -28,6 +28,7 @@ from keymasq.common.model.hardware import (
     AnalogInputDefinition,
     ButtonDefinition,
     EvdevDevice,
+    NativeInputSource,
 )
 from keymasq.common.model.motion import (
     MOTION_NORMALIZATION_VERSION,
@@ -96,6 +97,8 @@ def interfaces_have_capability(
 def build_evdev_devices(interfaces: Sequence[InterfaceInfo]) -> list[EvdevDevice]:
     evdev_devices = []
     for iface in interfaces:
+        if iface.get("backend") == "hidraw":
+            continue
         stable_path = str(iface.get("stable_path", "") or "")
         config_path = str(iface.get("config_path", "") or "")
         event_path = str(iface.get("path", "") or "")
@@ -115,6 +118,23 @@ def build_evdev_devices(interfaces: Sequence[InterfaceInfo]) -> list[EvdevDevice
             )
         )
     return evdev_devices
+
+
+def build_input_sources(interfaces: Sequence[InterfaceInfo]) -> list[NativeInputSource]:
+    by_path = {str(iface.get("path", "")): str(iface.get("id", "")) for iface in interfaces}
+    return [
+        NativeInputSource(
+            id=str(iface["id"]),
+            driver=str(iface["driver"]),
+            companion_of=next(
+                (by_path[path] for path in iface.get("companion_paths", []) if path in by_path),
+                None,
+            ),
+            phys=str(iface.get("phys", "")) or None,
+        )
+        for iface in interfaces
+        if iface.get("backend") == "hidraw" and iface.get("id")
+    ]
 
 
 def build_standard_mouse_buttons(
@@ -381,6 +401,24 @@ def build_motion_sensors(interfaces: Sequence[InterfaceInfo]) -> list[MotionSens
             continue
         source_id = str(iface.get("id", "") or "")
         if not source_id:
+            continue
+        native_axes = iface.get("native_motion_axes")
+        if iface.get("backend") == "hidraw" and isinstance(native_axes, dict):
+            sensors.append(
+                MotionSensorDefinition(
+                    id=f"motion_{len(sensors) + 1}",
+                    label=str(iface.get("name") or "Motion Sensor"),
+                    source=source_id,
+                    driver=str(iface.get("driver", "")),
+                    gyro_axes=[
+                        MotionAxisDefinition(**axis) for axis in native_axes.get("gyro_axes", [])
+                    ],
+                    accelerometer_axes=[
+                        MotionAxisDefinition(**axis)
+                        for axis in native_axes.get("accelerometer_axes", [])
+                    ],
+                )
+            )
             continue
         raw_capabilities = iface.get("raw_capabilities") or {}
         if not isinstance(raw_capabilities, dict):

--- a/keymasq/gui/wizards/hardware_setup/types.py
+++ b/keymasq/gui/wizards/hardware_setup/types.py
@@ -1,7 +1,7 @@
 from collections.abc import Sequence
 from typing import Any, TypedDict
 
-from keymasq.common.model.hardware import EvdevDevice
+from keymasq.common.model.hardware import EvdevDevice, NativeInputSource
 from keymasq.common.model.motion import MotionSensorDefinition
 
 
@@ -12,12 +12,17 @@ class EvdevDeviceSelection(list[EvdevDevice]):
         self,
         devices: Sequence[EvdevDevice],
         motion_sensors: Sequence[MotionSensorDefinition] = (),
+        input_sources: Sequence[NativeInputSource] = (),
     ) -> None:
         super().__init__(devices)
         self.motion_sensors = list(motion_sensors)
+        self.input_sources = list(input_sources)
 
 
 class DetectedInterface(TypedDict, total=False):
+    backend: str
+    companion_paths: list[str]
+    native_motion_axes: dict[str, object]
     id: str
     path: str
     stable_path: str

--- a/keymasq/keymasqd/capture_manager.py
+++ b/keymasq/keymasqd/capture_manager.py
@@ -1,4 +1,5 @@
 import asyncio
+import contextlib
 import errno
 import logging
 import os
@@ -89,6 +90,7 @@ class CaptureSession:
     motion_dropped_frames: int = 0
     motion_discontinuities: int = 0
     motion_reader_error: str = ""
+    native_task: asyncio.Task[None] | None = None
     motion_stats_lock: threading.Lock = field(default_factory=threading.Lock)
     mode: str = "button"
 
@@ -102,6 +104,89 @@ class CaptureManager:
     def __init__(self) -> None:
         self._sessions: dict[str, CaptureSession] = {}
         self._combo_capture_authorizations: set[str] = set()
+
+    async def begin_native(
+        self,
+        hardware_id: str,
+        interfaces: list[JsonObject],
+        axis_codes: list[int],
+    ) -> JsonObject:
+        from keymasq.keymasqd.input_sources.discovery import SOURCE_PREFIX, binding_for_path
+        from keymasq.keymasqd.input_sources.evdev_adapter import channel_codes
+        from keymasq.keymasqd.input_sources.manager import source_manager
+
+        if not axis_codes:
+            raise ValueError("Motion capture requires axis codes")
+        resolved = await asyncio.to_thread(
+            device_path_resolver.resolve_evdev_interfaces,
+            interfaces,
+            deps=_device_path_resolver_deps(),
+            hardware_id=hardware_id,
+        )
+        if len(resolved) != 1 or not resolved[0].path.startswith(SOURCE_PREFIX):
+            raise ValueError("Native motion source is unavailable or ambiguous")
+        interface = resolved[0]
+        binding = await asyncio.to_thread(binding_for_path, interface.path)
+        codes = channel_codes(binding)
+        if not set(axis_codes).issubset(codes.values()):
+            raise ValueError("Requested axes are not supplied by this input driver")
+        token = str(uuid.uuid4())
+        session = CaptureSession(
+            token=token,
+            hardware_id=hardware_id,
+            devices=[],
+            started_at=time.time(),
+            mode="motion",
+            motion_axis_codes=tuple(axis_codes),
+            motion_frame_queue=queue.Queue(maxsize=_MOTION_FRAME_QUEUE_SIZE),
+        )
+        ready = asyncio.get_running_loop().create_future()
+
+        async def consume() -> None:
+            try:
+                async with source_manager().subscribe(binding) as subscriber:
+                    while True:
+                        frame = await subscriber.read()
+                        if frame.discontinuity:
+                            with session.motion_stats_lock:
+                                session.motion_discontinuities += 1
+                        self._queue_motion_frame(
+                            session,
+                            {
+                                "timestamp_ns": frame.sample_ns,
+                                "path": interface.path,
+                                "source": interface.interface_id,
+                                "values": {
+                                    str(codes[name]): value
+                                    for name, value in frame.values.items()
+                                    if codes[name] in axis_codes
+                                },
+                                "estimated_time": frame.estimated_time,
+                            },
+                        )
+                        if not ready.done():
+                            ready.set_result(None)
+            except OSError as exc:
+                self._set_motion_reader_error(session, str(exc))
+                if not ready.done():
+                    ready.set_exception(exc)
+
+        self._sessions[token] = session
+        session.native_task = asyncio.create_task(consume())
+        try:
+            await asyncio.wait_for(ready, 2.0)
+        except BaseException:
+            await self.stop_native(token)
+            self.end(token)
+            raise
+        return {"token": token, "hardware_id": hardware_id, "warnings": []}
+
+    async def stop_native(self, token: str) -> None:
+        session = self._sessions.get(token)
+        if session is not None and session.native_task is not None:
+            session.native_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await session.native_task
 
     def begin(
         self,
@@ -373,6 +458,9 @@ class CaptureManager:
         session = self._sessions.pop(token, None)
         if session is None:
             return {"status": "ok", "ended": False}
+
+        if session.native_task is not None and not session.native_task.done():
+            session.native_task.get_loop().call_soon_threadsafe(session.native_task.cancel)
 
         if session.stop_event is not None:
             session.stop_event.set()

--- a/keymasq/keymasqd/capture_manager.py
+++ b/keymasq/keymasqd/capture_manager.py
@@ -123,9 +123,10 @@ class CaptureManager:
             deps=_device_path_resolver_deps(),
             hardware_id=hardware_id,
         )
-        if len(resolved) != 1 or not resolved[0].path.startswith(SOURCE_PREFIX):
+        native = [item for item in resolved if item.path.startswith(SOURCE_PREFIX)]
+        if len(native) != 1:
             raise ValueError("Native motion source is unavailable or ambiguous")
-        interface = resolved[0]
+        interface = native[0]
         binding = await asyncio.to_thread(binding_for_path, interface.path)
         codes = channel_codes(binding)
         if not set(axis_codes).issubset(codes.values()):

--- a/keymasq/keymasqd/daemon_capture_commands.py
+++ b/keymasq/keymasqd/daemon_capture_commands.py
@@ -113,9 +113,10 @@ async def handle_capture_command(
             for code in cast(list[object], data.get("motion_axis_codes", []))
             if isinstance(code, int) and not isinstance(code, bool) and code >= 0
         ]
-        if mode == "motion" and any(item.get("backend") == "hidraw" for item in evdev_interfaces):
+        native_interfaces = [item for item in evdev_interfaces if item.get("backend") == "hidraw"]
+        if mode == "motion" and native_interfaces:
             return await daemon.capture_manager.begin_native(
-                hardware_id, evdev_interfaces, motion_axis_codes
+                hardware_id, native_interfaces, motion_axis_codes
             )
         return await asyncio.to_thread(
             daemon.capture_manager.begin,

--- a/keymasq/keymasqd/daemon_capture_commands.py
+++ b/keymasq/keymasqd/daemon_capture_commands.py
@@ -1,6 +1,7 @@
 import asyncio
 import logging
 import uuid
+from collections.abc import Awaitable, Callable
 from typing import Protocol, cast
 
 from keymasq.common.coercion import coerce_bool, coerce_float, coerce_int
@@ -45,6 +46,12 @@ class _CaptureCommandRecordingManager(Protocol):
 
 
 class _CaptureCommandCaptureManager(Protocol):
+    async def begin_native(
+        self, hardware_id: str, interfaces: JsonObjectList, axis_codes: list[int]
+    ) -> JsonObject: ...
+
+    async def stop_native(self, token: str) -> None: ...
+
     def begin(
         self,
         hardware_id: str,
@@ -106,17 +113,17 @@ async def handle_capture_command(
             for code in cast(list[object], data.get("motion_axis_codes", []))
             if isinstance(code, int) and not isinstance(code, bool) and code >= 0
         ]
+        if mode == "motion" and any(item.get("backend") == "hidraw" for item in evdev_interfaces):
+            return await daemon.capture_manager.begin_native(
+                hardware_id, evdev_interfaces, motion_axis_codes
+            )
         return await asyncio.to_thread(
             daemon.capture_manager.begin,
             hardware_id=hardware_id,
             evdev_paths=evdev_paths or None,
             evdev_interfaces=evdev_interfaces or None,
             mode=mode,
-            **(
-                {"motion_axis_codes": motion_axis_codes}
-                if motion_axis_codes
-                else {}
-            ),
+            **({"motion_axis_codes": motion_axis_codes} if motion_axis_codes else {}),
         )
 
     if command_type == CommandType.CAPTURE_READ:
@@ -125,6 +132,9 @@ async def handle_capture_command(
 
     if command_type == CommandType.CAPTURE_END:
         token = str(data.get("token", ""))
+        stop_native = getattr(daemon.capture_manager, "stop_native", None)
+        if callable(stop_native):
+            await cast(Callable[[str], Awaitable[None]], stop_native)(token)
         return await asyncio.to_thread(daemon.capture_manager.end, token)
 
     if command_type == CommandType.CAPTURE_COMBO:

--- a/keymasq/keymasqd/daemon_capture_commands.py
+++ b/keymasq/keymasqd/daemon_capture_commands.py
@@ -107,7 +107,7 @@ async def handle_capture_command(
         hardware_id = str(data.get("hardware_id", ""))
         evdev_paths = cast(list[str], data.get("evdev_paths", []))
         evdev_interfaces = cast(JsonObjectList, data.get("evdev_interfaces", []))
-        mode = str(data.get("mode", "button") or "button")
+        mode = str(data.get("mode", "button") or "button").strip().lower()
         motion_axis_codes = [
             int(code)
             for code in cast(list[object], data.get("motion_axis_codes", []))

--- a/keymasq/keymasqd/device_inventory.py
+++ b/keymasq/keymasqd/device_inventory.py
@@ -220,6 +220,17 @@ def scan_devices(
                     **(grabbed_source or {}),
                 }
             )
+            from keymasq.keymasqd.input_sources.evdev_adapter import NativeInputDevice, motion_axes
+
+            if isinstance(device, NativeInputDevice):
+                devices[-1].update(
+                    {
+                        "backend": "hidraw",
+                        "driver": device.binding.driver.id,
+                        "native_motion_axes": motion_axes(device.binding),
+                        "companion_paths": list(device.binding.companions),
+                    }
+                )
         except OSError as exc:
             if deps.is_permission_error(exc):
                 deps.logger.warning(

--- a/keymasq/keymasqd/device_manager.py
+++ b/keymasq/keymasqd/device_manager.py
@@ -31,6 +31,9 @@ from keymasq.common.virtual_devices import (
     clamp_virtual_gamepad_count,
 )
 from keymasq.keymasqd import device_inventory
+from keymasq.keymasqd.input_sources import discovery as native_discovery
+from keymasq.keymasqd.input_sources.evdev_adapter import NativeInputDevice
+from keymasq.keymasqd.input_sources.types import Binding
 from keymasq.keymasqd.permission_hints import (
     input_device_permission_message,
     is_permission_error,
@@ -106,28 +109,41 @@ class _ManagedInputDevice(Protocol):
 
 
 def _device_input(path: str) -> _ManagedInputDevice:
-    from keymasq.keymasqd.input_sources.discovery import SOURCE_PREFIX
-    from keymasq.keymasqd.input_sources.evdev_adapter import NativeInputDevice
-
-    if path.startswith(SOURCE_PREFIX):
+    if path.startswith(native_discovery.SOURCE_PREFIX):
         return cast(_ManagedInputDevice, cast(object, NativeInputDevice(path)))
     return cast(_ManagedInputDevice, evdev.InputDevice(path))
 
 
 def _device_paths() -> list[str]:
-    from keymasq.keymasqd.input_sources.discovery import discover_bindings
+    return cast(Callable[[], list[str]], evdev.list_devices)()
 
-    return cast(Callable[[], list[str]], evdev.list_devices)() + [
-        binding.path for binding in discover_bindings()
-    ]
+
+class _InputDeviceScan:
+    """Reuse one HID discovery snapshot while probing a scan's device paths."""
+
+    def __init__(self) -> None:
+        self.bindings: dict[str, Binding] = {}
+
+    def paths(self) -> list[str]:
+        self.bindings = {item.path: item for item in native_discovery.discover_bindings()}
+        return _device_paths() + list(self.bindings)
+
+    def open(self, path: str) -> _ManagedInputDevice:
+        if path.startswith(native_discovery.SOURCE_PREFIX):
+            binding = self.bindings.get(path)
+            if binding is None:
+                raise FileNotFoundError(errno.ENODEV, "Native source is absent from scan", path)
+            return cast(_ManagedInputDevice, cast(object, NativeInputDevice(path, binding=binding)))
+        return _device_input(path)
 
 
 def _topology_runtime_deps() -> topology.TopologyRuntimeDeps:
+    scan = _InputDeviceScan()
     return topology.TopologyRuntimeDeps(
         asyncio_mod=adapters.ASYNCIO_RUNTIME,
         clear_device_path_cache_fn=clear_device_path_cache,
-        device_paths_fn=_device_paths,
-        device_input_fn=_device_input,
+        device_paths_fn=scan.paths,
+        device_input_fn=scan.open,
         detect_input_classes_fn=detect_input_classes,
         primary_input_class_fn=primary_input_class,
         resolve_stable_path_fn=resolve_stable_path,
@@ -685,10 +701,11 @@ class DeviceManager(CursorManagerMixin, MacroManagerMixin, ComboManagerMixin):
             )
 
     def _list_devices_sync(self) -> JsonObject:
+        scan = _InputDeviceScan()
         deps = device_inventory.InventoryScanDeps(
             clear_path_cache=clear_device_path_cache,
-            device_paths=_device_paths,
-            open_device=cast(Any, _device_input),
+            device_paths=scan.paths,
+            open_device=cast(Any, scan.open),
             resolve_stable_path=resolve_stable_path,
             get_interface_id=get_interface_id,
             detect_device_types=cast(Any, self._detect_device_types),

--- a/keymasq/keymasqd/device_manager.py
+++ b/keymasq/keymasqd/device_manager.py
@@ -106,11 +106,20 @@ class _ManagedInputDevice(Protocol):
 
 
 def _device_input(path: str) -> _ManagedInputDevice:
+    from keymasq.keymasqd.input_sources.discovery import SOURCE_PREFIX
+    from keymasq.keymasqd.input_sources.evdev_adapter import NativeInputDevice
+
+    if path.startswith(SOURCE_PREFIX):
+        return cast(_ManagedInputDevice, cast(object, NativeInputDevice(path)))
     return cast(_ManagedInputDevice, evdev.InputDevice(path))
 
 
 def _device_paths() -> list[str]:
-    return cast(Callable[[], list[str]], evdev.list_devices)()
+    from keymasq.keymasqd.input_sources.discovery import discover_bindings
+
+    return cast(Callable[[], list[str]], evdev.list_devices)() + [
+        binding.path for binding in discover_bindings()
+    ]
 
 
 def _topology_runtime_deps() -> topology.TopologyRuntimeDeps:

--- a/keymasq/keymasqd/input_sources/__init__.py
+++ b/keymasq/keymasqd/input_sources/__init__.py
@@ -1,0 +1,1 @@
+"""Bundled input drivers and shared native source lifetimes."""

--- a/keymasq/keymasqd/input_sources/discovery.py
+++ b/keymasq/keymasqd/input_sources/discovery.py
@@ -1,0 +1,107 @@
+"""Read-only sysfs discovery and instance association for native inputs."""
+
+import errno
+from collections.abc import Iterable
+from pathlib import Path
+
+from .registry import DRIVERS
+from .types import Binding, Endpoint, InputDriver
+
+SOURCE_PREFIX = "/dev/keymasq-sources/"
+
+
+def subsystem_parent(path: Path, subsystem: str) -> Path | None:
+    current = path.resolve()
+    for candidate in (current, *current.parents):
+        if (candidate / "subsystem").resolve().name == subsystem:
+            return candidate
+    return None
+
+
+def hid_parent(event_path: str, sysfs: Path = Path("/sys")) -> str:
+    node = Path(event_path).resolve().name
+    parent = subsystem_parent(sysfs / "class/input" / node / "device", "hid")
+    return str(parent) if parent else ""
+
+
+def usb_device_parent(path: Path) -> Path | None:
+    for candidate in (path, *path.parents):
+        if (candidate / "subsystem").resolve().name == "usb" and (candidate / "idVendor").exists():
+            return candidate
+    return None
+
+
+def discover_bindings(
+    *,
+    sysfs: Path = Path("/sys"),
+    drivers: Iterable[InputDriver] = DRIVERS,
+) -> list[Binding]:
+    bindings: list[Binding] = []
+    drivers = tuple(drivers)
+    for node in sorted((sysfs / "class/hidraw").glob("hidraw*")):
+        try:
+            parent = subsystem_parent(node / "device", "hid")
+            if parent is None:
+                continue
+            fields = dict(
+                line.split("=", 1)
+                for line in (parent / "uevent").read_text().splitlines()
+                if "=" in line
+            )
+            bus, vendor, product = (int(value, 16) for value in fields["HID_ID"].split(":"))
+            usb = usb_device_parent(parent)
+            endpoint = Endpoint(
+                path=f"/dev/{node.name}",
+                hid_parent=str(parent),
+                usb_parent=str(usb) if usb else "",
+                bus=bus,
+                vendor=vendor,
+                product=product,
+                descriptor=(parent / "report_descriptor").read_bytes(),
+                name=fields.get("HID_NAME", ""),
+                phys=fields.get("HID_PHYS", ""),
+            )
+            companions = tuple(
+                sorted(f"/dev/input/{event.name}" for event in parent.glob("input/input*/event*"))
+            )
+            matches = [driver for driver in drivers if driver.matches(endpoint)]
+            if len(matches) == 1:
+                if matches[0].association == "same_usb" and usb is not None:
+                    companions = tuple(
+                        sorted(
+                            f"/dev/input/{event.name}"
+                            for event in usb.glob("**/input/input*/event*")
+                        )
+                    )
+                bindings.append(Binding(matches[0], endpoint, companions))
+        except (OSError, ValueError, KeyError):
+            continue
+    return bindings
+
+
+def binding_for_path(path: str) -> Binding:
+    for binding in discover_bindings():
+        if binding.path == path:
+            return binding
+    raise FileNotFoundError(errno.ENODEV, "Native input source disconnected or unsupported", path)
+
+
+def companion_binding(
+    bindings: Iterable[Binding], driver_id: str, event_path: str
+) -> Binding | None:
+    parent = hid_parent(event_path)
+    usb = usb_device_parent(Path(parent)) if parent else None
+    matches = [
+        binding
+        for binding in bindings
+        if binding.driver.id == driver_id
+        and (
+            (binding.driver.association == "same_hid" and binding.endpoint.hid_parent == parent)
+            or (
+                binding.driver.association == "same_usb"
+                and usb is not None
+                and binding.endpoint.usb_parent == str(usb)
+            )
+        )
+    ]
+    return matches[0] if len(matches) == 1 else None

--- a/keymasq/keymasqd/input_sources/drivers/__init__.py
+++ b/keymasq/keymasqd/input_sources/drivers/__init__.py
@@ -1,0 +1,1 @@
+"""Device protocol implementations. Registration lives in registry.py."""

--- a/keymasq/keymasqd/input_sources/drivers/eightbitdo_ultimate2.py
+++ b/keymasq/keymasqd/input_sources/drivers/eightbitdo_ultimate2.py
@@ -1,0 +1,47 @@
+"""Ultimate 2 Wireless DInput reports, following SDL's 8BitDo protocol layout.
+
+Reference: SDL commit 6083940ef432b0c7b077083e5459da0f6a386f40,
+src/joystick/hidapi/SDL_hidapi_8bitdo.c. No device initialization writes are needed.
+"""
+
+import math
+import struct
+from typing import Literal
+
+from ..types import Channel, Endpoint
+
+
+class Ultimate2Driver:
+    id = "8bitdo-ultimate2"
+    label = "Ultimate 2 motion"
+    association: Literal["same_hid", "same_usb"] = "same_hid"
+    channels = (
+        Channel("accel_x", "accelerometer", "y", 9.80665 / 4096),
+        Channel("accel_y", "accelerometer", "x", 9.80665 / 4096, True),
+        Channel("accel_z", "accelerometer", "z", 9.80665 / 4096),
+        Channel("gyro_x", "gyro", "roll", math.radians(2000) / 32767, True),
+        Channel("gyro_y", "gyro", "pitch", math.radians(2000) / 32767, True),
+        Channel("gyro_z", "gyro", "yaw", math.radians(2000) / 32767),
+    )
+
+    def matches(self, endpoint: Endpoint) -> bool:
+        # The tested interface is a Generic Desktop / Gamepad application
+        # collection, with report 1 and a vendor-defined tail. Report decoding
+        # below verifies the firmware's extended format before exposing samples.
+        return (
+            (endpoint.bus, endpoint.vendor, endpoint.product) == (3, 0x2DC8, 0x6012)
+            and endpoint.descriptor.startswith(bytes.fromhex("05010905a101"))
+            and bytes.fromhex("8501") in endpoint.descriptor
+            and bytes.fromhex("0600ff") in endpoint.descriptor
+        )
+
+    def decode(self, report: bytes) -> dict[str, int] | None:
+        if len(report) != 34 or report[0] != 0x01:
+            return None
+        return dict(
+            zip(
+                (channel.name for channel in self.channels),
+                struct.unpack_from("<6h", report, 15),
+                strict=True,
+            )
+        )

--- a/keymasq/keymasqd/input_sources/evdev_adapter.py
+++ b/keymasq/keymasqd/input_sources/evdev_adapter.py
@@ -61,8 +61,10 @@ def frame_events(binding: Binding, frame: InputFrame) -> list[evdev.InputEvent]:
 
 
 class NativeInputDevice:
-    def __init__(self, path: str) -> None:
-        self.binding = binding_for_path(path)
+    def __init__(self, path: str, *, binding: Binding | None = None) -> None:
+        self.binding = binding if binding is not None else binding_for_path(path)
+        if self.binding.path != path:
+            raise ValueError("Native input binding does not match its source address")
         self.path = path
         self.name = self.binding.driver.label
         self.phys = self.binding.endpoint.phys

--- a/keymasq/keymasqd/input_sources/evdev_adapter.py
+++ b/keymasq/keymasqd/input_sources/evdev_adapter.py
@@ -1,0 +1,112 @@
+"""Adapt native motion frames to existing runtime/inspection event consumers.
+
+These events stay inside the daemon. No synthetic kernel input device is created.
+Driver protocols and shared subscriptions use named channels, not evdev codes.
+"""
+
+from collections.abc import AsyncGenerator
+
+import evdev
+
+from keymasq.common.types import JsonObject
+
+from .discovery import binding_for_path
+from .manager import source_manager
+from .types import Binding, InputFrame
+
+
+def channel_codes(binding: Binding) -> dict[str, int]:
+    codes = {"accelerometer": iter((0, 1, 2)), "gyro": iter((3, 4, 5))}
+    return {
+        channel.name: next(codes[channel.kind])
+        for channel in binding.driver.channels
+        if channel.kind in codes
+    }
+
+
+def motion_axes(binding: Binding) -> JsonObject:
+    codes = channel_codes(binding)
+    result: JsonObject = {"gyro_axes": [], "accelerometer_axes": []}
+    for channel in binding.driver.channels:
+        if channel.kind not in {"gyro", "accelerometer"}:
+            continue
+        code = codes[channel.name]
+        result[f"{channel.kind}_axes"].append(
+            {
+                "role": channel.role,
+                "evdev": str(evdev.ecodes.ABS[code]).lower(),
+                "evdev_code": code,
+                "scale": channel.scale,
+                "invert": channel.invert,
+            }
+        )
+    return result
+
+
+def frame_events(binding: Binding, frame: InputFrame) -> list[evdev.InputEvent]:
+    sec, ns = divmod(frame.sample_ns, 1_000_000_000)
+    codes = channel_codes(binding)
+    events: list[evdev.InputEvent] = []
+    if frame.discontinuity:
+        events.extend(
+            (evdev.InputEvent(sec, ns // 1000, 0, 3, 0), evdev.InputEvent(sec, ns // 1000, 0, 0, 0))
+        )
+    events.extend(
+        evdev.InputEvent(sec, ns // 1000, 3, codes[name], value)
+        for name, value in frame.values.items()
+        if name in codes
+    )
+    events.append(evdev.InputEvent(sec, ns // 1000, 0, 0, 0))
+    return events
+
+
+class NativeInputDevice:
+    def __init__(self, path: str) -> None:
+        self.binding = binding_for_path(path)
+        self.path = path
+        self.name = self.binding.driver.label
+        self.phys = self.binding.endpoint.phys
+        self.uniq = ""
+        self.info = evdev.DeviceInfo(
+            self.binding.endpoint.bus,
+            self.binding.endpoint.vendor,
+            self.binding.endpoint.product,
+            0,
+        )
+        self._values: dict[int, int] = {}
+        self._codes = channel_codes(self.binding)
+        self._stream: AsyncGenerator[evdev.InputEvent] | None = None
+
+    def capabilities(self, *, absinfo: bool = False) -> dict[int, list[object]]:
+        codes = channel_codes(self.binding).values()
+        return {3: [(code, self.absinfo(code)) for code in codes] if absinfo else list(codes)}
+
+    def input_props(self) -> list[int]:
+        return [evdev.ecodes.INPUT_PROP_ACCELEROMETER]
+
+    def absinfo(self, code: int) -> evdev.AbsInfo:
+        return evdev.AbsInfo(self._values.get(code, 0), -32768, 32767, 0, 0, 0)
+
+    def active_keys(self) -> list[int]:
+        return []
+
+    def close(self) -> None:
+        # The async reader's finally block owns the shared subscription.
+        pass
+
+    def async_read_loop(self) -> AsyncGenerator[evdev.InputEvent]:
+        self._stream = self._events()
+        return self._stream
+
+    async def aclose(self) -> None:
+        if self._stream is not None:
+            await self._stream.aclose()
+            self._stream = None
+
+    async def _events(self) -> AsyncGenerator[evdev.InputEvent]:
+        async with source_manager().subscribe(self.binding) as subscriber:
+            while True:
+                frame = await subscriber.read()
+                self._values = {self._codes[name]: value for name, value in frame.values.items()}
+                for event in frame_events(self.binding, frame):
+                    yield event

--- a/keymasq/keymasqd/input_sources/manager.py
+++ b/keymasq/keymasqd/input_sources/manager.py
@@ -1,0 +1,133 @@
+"""One native reader per connection, shared by independent bounded subscribers."""
+
+import asyncio
+import contextlib
+import errno
+import logging
+import time
+import weakref
+from collections.abc import AsyncGenerator, Callable
+from dataclasses import dataclass, field, replace
+
+from .transports.hidraw import reports
+from .types import Binding, InputFrame
+
+log = logging.getLogger("keymasqd.input_sources")
+
+
+@dataclass(eq=False)
+class Subscription:
+    queue: asyncio.Queue[InputFrame | OSError] = field(default_factory=lambda: asyncio.Queue(256))
+    dropped_frames: int = 0
+
+    async def read(self) -> InputFrame:
+        item = await self.queue.get()
+        if isinstance(item, OSError):
+            raise item
+        return item
+
+    def offer(self, item: InputFrame | OSError) -> None:
+        if self.queue.full() or isinstance(item, OSError):
+            # Discard stale backlog and mark the first retained complete frame.
+            while not self.queue.empty():
+                self.queue.get_nowait()
+                self.dropped_frames += 1
+            if isinstance(item, InputFrame):
+                item = replace(item, discontinuity=True)
+        self.queue.put_nowait(item)
+
+
+@dataclass
+class _Session:
+    binding: Binding
+    subscribers: set[Subscription] = field(default_factory=set)
+    latest: InputFrame | None = None
+    task: asyncio.Task[None] | None = None
+    error: OSError | None = None
+
+
+class SourceManager:
+    def __init__(self, reader: Callable[[str], AsyncGenerator[bytes]] | None = None) -> None:
+        self._reader = reader
+        self._sessions: dict[str, _Session] = {}
+        self._lifecycle_lock = asyncio.Lock()
+
+    @contextlib.asynccontextmanager
+    async def subscribe(self, binding: Binding) -> AsyncGenerator[Subscription]:
+        async with self._lifecycle_lock:
+            session = self._sessions.get(binding.path)
+            if session is None:
+                session = _Session(binding)
+                self._sessions[binding.path] = session
+            subscriber = Subscription()
+            session.subscribers.add(subscriber)
+            if session.error is not None:
+                subscriber.offer(session.error)
+            elif session.latest is not None:
+                subscriber.offer(session.latest)
+            if session.task is None:
+                session.task = asyncio.create_task(self._run(session))
+        try:
+            yield subscriber
+        finally:
+            async with self._lifecycle_lock:
+                session.subscribers.discard(subscriber)
+                if not session.subscribers:
+                    self._sessions.pop(binding.path, None)
+                    session.task.cancel()
+                    with contextlib.suppress(asyncio.CancelledError):
+                        await session.task
+
+    async def _run(self, session: _Session) -> None:
+        endpoint = session.binding.endpoint
+        stream = (
+            self._reader(endpoint.path)
+            if self._reader is not None
+            else reports(endpoint.path, hid_parent=endpoint.hid_parent)
+        )
+        started_ns = time.monotonic_ns()
+        try:
+            async with contextlib.aclosing(stream):
+                while True:
+                    report = await asyncio.wait_for(anext(stream), 1.0)
+                    now = time.monotonic_ns()
+                    values = session.binding.driver.decode(report)
+                    if values is None:
+                        if session.latest is None and now - started_ns > 1_000_000_000:
+                            raise OSError(
+                                errno.ENOTSUP, "Input reports do not support this driver's channels"
+                            )
+                        continue
+                    gap = (
+                        session.latest is not None and now - session.latest.arrival_ns > 100_000_000
+                    )
+                    frame = InputFrame(values, now, now, discontinuity=gap)
+                    session.latest = frame
+                    for subscriber in session.subscribers:
+                        subscriber.offer(frame)
+        except asyncio.CancelledError:
+            raise
+        except (OSError, TimeoutError, StopAsyncIteration) as exc:
+            self._fail(session, OSError(errno.ENODEV, f"Native input unavailable: {exc}"))
+        except Exception as exc:
+            log.exception("Input driver failed for %s", session.binding.path)
+            self._fail(session, OSError(errno.EIO, f"Input driver failed: {exc}"))
+
+    @staticmethod
+    def _fail(session: _Session, error: OSError) -> None:
+        session.error = error
+        session.latest = None
+        for subscriber in session.subscribers:
+            subscriber.offer(error)
+
+
+_managers: weakref.WeakKeyDictionary[asyncio.AbstractEventLoop, SourceManager] = (
+    weakref.WeakKeyDictionary()
+)
+
+
+def source_manager() -> SourceManager:
+    loop = asyncio.get_running_loop()
+    if loop not in _managers:
+        _managers[loop] = SourceManager()
+    return _managers[loop]

--- a/keymasq/keymasqd/input_sources/manager.py
+++ b/keymasq/keymasqd/input_sources/manager.py
@@ -85,19 +85,21 @@ class SourceManager:
             if self._reader is not None
             else reports(endpoint.path, hid_parent=endpoint.hid_parent)
         )
-        started_ns = time.monotonic_ns()
+        last_valid_ns = time.monotonic_ns()
         try:
             async with contextlib.aclosing(stream):
                 while True:
-                    report = await asyncio.wait_for(anext(stream), 1.0)
+                    remaining = 1.0 - (time.monotonic_ns() - last_valid_ns) / 1_000_000_000
+                    report = await asyncio.wait_for(anext(stream), max(0.0, remaining))
                     now = time.monotonic_ns()
                     values = session.binding.driver.decode(report)
                     if values is None:
-                        if session.latest is None and now - started_ns > 1_000_000_000:
+                        if now - last_valid_ns > 1_000_000_000:
                             raise OSError(
                                 errno.ENOTSUP, "Input reports do not support this driver's channels"
                             )
                         continue
+                    last_valid_ns = now
                     gap = (
                         session.latest is not None and now - session.latest.arrival_ns > 100_000_000
                     )

--- a/keymasq/keymasqd/input_sources/registry.py
+++ b/keymasq/keymasqd/input_sources/registry.py
@@ -1,0 +1,13 @@
+"""Only bundled drivers can be selected by configuration."""
+
+from .drivers.eightbitdo_ultimate2 import Ultimate2Driver
+from .types import InputDriver
+
+DRIVERS: tuple[InputDriver, ...] = (Ultimate2Driver(),)
+
+
+def get_driver(driver_id: str) -> InputDriver:
+    for driver in DRIVERS:
+        if driver.id == driver_id:
+            return driver
+    raise ValueError(f"Unknown input driver: {driver_id}")

--- a/keymasq/keymasqd/input_sources/transports/__init__.py
+++ b/keymasq/keymasqd/input_sources/transports/__init__.py
@@ -1,0 +1,1 @@
+"""Native endpoint I/O."""

--- a/keymasq/keymasqd/input_sources/transports/hidraw.py
+++ b/keymasq/keymasqd/input_sources/transports/hidraw.py
@@ -1,0 +1,60 @@
+"""Read-only nonblocking hidraw transport using asyncio readiness."""
+
+import asyncio
+import errno
+import os
+from collections.abc import AsyncGenerator
+from pathlib import Path
+
+
+async def reports(path: str, *, hid_parent: str | None = None) -> AsyncGenerator[bytes]:
+    opening = asyncio.create_task(asyncio.to_thread(_open, path, hid_parent))
+    try:
+        fd = await asyncio.shield(opening)
+    except asyncio.CancelledError:
+        opening.add_done_callback(_close_cancelled_open)
+        raise
+    loop = asyncio.get_running_loop()
+    ready = asyncio.Event()
+    try:
+        loop.add_reader(fd, ready.set)
+        while True:
+            await ready.wait()
+            ready.clear()
+            # Bound each drain so a fast endpoint cannot monopolize the loop.
+            for _ in range(64):
+                try:
+                    report = os.read(fd, 4096)
+                except BlockingIOError:
+                    break
+                if not report:
+                    raise OSError("hidraw endpoint closed")
+                yield report
+            else:
+                await asyncio.sleep(0)
+    finally:
+        loop.remove_reader(fd)
+        os.close(fd)
+
+
+def _close_cancelled_open(task: asyncio.Task[int]) -> None:
+    if not task.cancelled() and task.exception() is None:
+        os.close(task.result())
+
+
+def _open(path: str, expected_parent: str | None) -> int:
+    def validate_connection() -> None:
+        if expected_parent is None:
+            return
+        current = (Path("/sys/class/hidraw") / Path(path).name / "device").resolve()
+        if str(current) != expected_parent:
+            raise OSError(errno.ENODEV, "HID connection changed while opening", path)
+
+    validate_connection()
+    fd = os.open(path, os.O_RDONLY | os.O_NONBLOCK | os.O_CLOEXEC)
+    try:
+        validate_connection()
+    except OSError:
+        os.close(fd)
+        raise
+    return fd

--- a/keymasq/keymasqd/input_sources/types.py
+++ b/keymasq/keymasqd/input_sources/types.py
@@ -1,0 +1,62 @@
+"""Transport-independent driver descriptions and complete input frames."""
+
+from dataclasses import dataclass, field
+from typing import Literal, Protocol
+
+
+@dataclass(frozen=True)
+class Endpoint:
+    path: str
+    hid_parent: str
+    usb_parent: str
+    bus: int
+    vendor: int
+    product: int
+    descriptor: bytes
+    name: str = ""
+    phys: str = ""
+
+
+@dataclass(frozen=True)
+class Channel:
+    name: str
+    kind: Literal["gyro", "accelerometer", "button", "axis"]
+    role: str
+    scale: float = 1.0
+    invert: bool = False
+
+
+@dataclass(frozen=True)
+class InputFrame:
+    """Raw channel snapshot. Timestamps are monotonic; sample time may be estimated."""
+
+    values: dict[str, int]
+    arrival_ns: int
+    sample_ns: int
+    estimated_time: bool = True
+    discontinuity: bool = False
+
+
+class InputDriver(Protocol):
+    id: str
+    label: str
+    channels: tuple[Channel, ...]
+    association: Literal["same_hid", "same_usb"]
+
+    def matches(self, endpoint: Endpoint) -> bool: ...
+
+    def decode(self, report: bytes) -> dict[str, int] | None: ...
+
+
+@dataclass(frozen=True)
+class Binding:
+    driver: InputDriver
+    endpoint: Endpoint
+    companions: tuple[str, ...] = field(default_factory=tuple)
+
+    @property
+    def path(self) -> str:
+        # A connection-local source address, never a node opened by the kernel.
+        hid_name = self.endpoint.hid_parent.rsplit("/", 1)[-1]
+        node = self.endpoint.path.rsplit("/", 1)[-1]
+        return f"/dev/keymasq-sources/{self.driver.id}/{hid_name}/{node}"

--- a/keymasq/keymasqd/runtime/device_path_resolver.py
+++ b/keymasq/keymasqd/runtime/device_path_resolver.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import threading
 from collections.abc import Callable, Iterable, Mapping, Sequence
 from dataclasses import dataclass, field
@@ -249,6 +250,11 @@ def resolve_evdev_interfaces(
         if binding.path in normalized_preferred_paths:
             normalized_preferred_paths.update(binding.companions)
 
+    # Compare event-node identities as well as the supplied aliases. Keep the
+    # original paths for stable selectors and internal native source addresses.
+    normalized_excluded_paths |= {os.path.realpath(path) for path in normalized_excluded_paths}
+    normalized_preferred_paths |= {os.path.realpath(path) for path in normalized_preferred_paths}
+
     for descriptor in interfaces:
         if descriptor.get("backend") == "hidraw":
             continue
@@ -270,6 +276,12 @@ def resolve_evdev_interfaces(
         if model_path is not None and _same_keymasq_model_path(configured_path, model_path):
             resolution_phys = ""
         if not is_keymasq_device_path(configured_path):
+            if normalized_excluded_paths and _path_matches_resolved(
+                configured_path,
+                _candidate_order_path(configured_path, deps),
+                normalized_excluded_paths,
+            ):
+                continue
             resolved.append(
                 ResolvedInterface(
                     path=configured_path,
@@ -534,7 +546,12 @@ def _path_matches_resolved(
 ) -> bool:
     if not paths:
         return False
-    return path in paths or resolved_path in paths
+    return (
+        path in paths
+        or resolved_path in paths
+        or os.path.realpath(path) in paths
+        or os.path.realpath(resolved_path) in paths
+    )
 
 
 def _candidate_order_path(path: str, deps: DevicePathResolverDeps) -> str:

--- a/keymasq/keymasqd/runtime/device_path_resolver.py
+++ b/keymasq/keymasqd/runtime/device_path_resolver.py
@@ -230,6 +230,8 @@ def resolve_evdev_interfaces(
     }
 
     for descriptor in interfaces:
+        if descriptor.get("backend") == "hidraw":
+            continue
         configured_path = str(descriptor.get("path", "") or "").strip()
         if not configured_path:
             continue
@@ -284,7 +286,91 @@ def resolve_evdev_interfaces(
                 capabilities=sorted(configured_caps),
             )
         )
-    return resolved
+    return resolved + _resolve_native_interfaces(
+        interfaces,
+        resolved,
+        deps=deps,
+        hardware_id=hardware_id,
+        excluded_paths=normalized_excluded_paths,
+        preferred_paths=normalized_preferred_paths,
+    )
+
+
+def _resolve_native_interfaces(
+    interfaces: list[JsonObject],
+    resolved: list[ResolvedInterface],
+    *,
+    deps: DevicePathResolverDeps,
+    hardware_id: str | None,
+    excluded_paths: set[str],
+    preferred_paths: set[str],
+) -> list[ResolvedInterface]:
+    from keymasq.keymasqd.input_sources.discovery import companion_binding, discover_bindings
+
+    native = [item for item in interfaces if item.get("backend") == "hidraw"]
+    if not native:
+        return []
+    bindings = discover_bindings()
+    excluded_anchors = excluded_paths | {
+        path
+        for binding in bindings
+        if binding.path in excluded_paths
+        for path in binding.companions
+    }
+    preferred_anchors = preferred_paths | {
+        path
+        for binding in bindings
+        if binding.path in preferred_paths
+        for path in binding.companions
+    }
+    result: list[ResolvedInterface] = []
+    for descriptor in native:
+        driver_id = str(descriptor.get("driver", ""))
+        raw_anchor = descriptor.get("anchor")
+        anchor = cast(JsonObject, raw_anchor) if isinstance(raw_anchor, dict) else None
+        binding = None
+        if anchor is not None and anchor.get("backend") != "hidraw":
+            anchor_id = str(anchor.get("id", ""))
+            matches = [item for item in resolved if item.interface_id == anchor_id]
+            if not matches:
+                matches = resolve_evdev_interfaces(
+                    [anchor],
+                    deps=deps,
+                    hardware_id=hardware_id,
+                    excluded_paths=excluded_anchors,
+                    preferred_paths=preferred_anchors,
+                    match_model_gamepads=True,
+                )
+            if len(matches) == 1:
+                binding = companion_binding(bindings, driver_id, matches[0].path)
+        elif not descriptor.get("companion_of"):
+            model = parse_hardware_model_id(hardware_id)
+            candidates = [
+                item
+                for item in bindings
+                if item.driver.id == driver_id
+                and model == (f"{item.endpoint.vendor:04x}", f"{item.endpoint.product:04x}")
+                and (not descriptor.get("phys") or item.endpoint.phys == descriptor["phys"])
+                and item.path not in excluded_paths
+            ]
+            if len(candidates) == 1:
+                binding = candidates[0]
+        if (
+            binding is None
+            or binding.path in excluded_paths
+            or any(item.path == binding.path for item in result)
+        ):
+            continue
+        result.append(
+            ResolvedInterface(
+                path=binding.path,
+                configured_path=str(descriptor.get("path", "")),
+                interface_id=str(descriptor.get("id", "")),
+                device_type=DeviceType.MOTION,
+                capabilities=[],
+            )
+        )
+    return result
 
 
 def _resolve_keymasq_paths(

--- a/keymasq/keymasqd/runtime/device_path_resolver.py
+++ b/keymasq/keymasqd/runtime/device_path_resolver.py
@@ -20,6 +20,9 @@ from keymasq.common.devices import (
 )
 from keymasq.common.model.core import DeviceType
 from keymasq.common.types import JsonObject
+from keymasq.keymasqd.input_sources import discovery as native_discovery
+from keymasq.keymasqd.input_sources.discovery import SOURCE_PREFIX
+from keymasq.keymasqd.input_sources.types import Binding
 from keymasq.keymasqd.permission_hints import (
     input_device_permission_message,
     is_permission_error,
@@ -229,6 +232,23 @@ def resolve_evdev_interfaces(
         path for value in preferred_paths or [] if (path := str(value or "").strip())
     }
 
+    # A native-only owner still owns its controller's evdev companions. Expand
+    # claims before resolving any interface, including evdev-only requests.
+    bindings = (
+        native_discovery.discover_bindings()
+        if any(item.get("backend") == "hidraw" for item in interfaces)
+        or any(
+            path.startswith(SOURCE_PREFIX)
+            for path in normalized_excluded_paths | normalized_preferred_paths
+        )
+        else []
+    )
+    for binding in bindings:
+        if binding.path in normalized_excluded_paths:
+            normalized_excluded_paths.update(binding.companions)
+        if binding.path in normalized_preferred_paths:
+            normalized_preferred_paths.update(binding.companions)
+
     for descriptor in interfaces:
         if descriptor.get("backend") == "hidraw":
             continue
@@ -289,6 +309,8 @@ def resolve_evdev_interfaces(
     return resolved + _resolve_native_interfaces(
         interfaces,
         resolved,
+        bindings=bindings,
+        match_model_gamepads=match_model_gamepads,
         deps=deps,
         hardware_id=hardware_id,
         excluded_paths=normalized_excluded_paths,
@@ -300,29 +322,18 @@ def _resolve_native_interfaces(
     interfaces: list[JsonObject],
     resolved: list[ResolvedInterface],
     *,
+    bindings: list[Binding],
+    match_model_gamepads: bool,
     deps: DevicePathResolverDeps,
     hardware_id: str | None,
     excluded_paths: set[str],
     preferred_paths: set[str],
 ) -> list[ResolvedInterface]:
-    from keymasq.keymasqd.input_sources.discovery import companion_binding, discover_bindings
+    from keymasq.keymasqd.input_sources.discovery import companion_binding
 
     native = [item for item in interfaces if item.get("backend") == "hidraw"]
     if not native:
         return []
-    bindings = discover_bindings()
-    excluded_anchors = excluded_paths | {
-        path
-        for binding in bindings
-        if binding.path in excluded_paths
-        for path in binding.companions
-    }
-    preferred_anchors = preferred_paths | {
-        path
-        for binding in bindings
-        if binding.path in preferred_paths
-        for path in binding.companions
-    }
     result: list[ResolvedInterface] = []
     for descriptor in native:
         driver_id = str(descriptor.get("driver", ""))
@@ -337,9 +348,13 @@ def _resolve_native_interfaces(
                     [anchor],
                     deps=deps,
                     hardware_id=hardware_id,
-                    excluded_paths=excluded_anchors,
-                    preferred_paths=preferred_anchors,
-                    match_model_gamepads=True,
+                    excluded_paths={
+                        path for path in excluded_paths if not path.startswith(SOURCE_PREFIX)
+                    },
+                    preferred_paths={
+                        path for path in preferred_paths if not path.startswith(SOURCE_PREFIX)
+                    },
+                    match_model_gamepads=match_model_gamepads,
                 )
             if len(matches) == 1:
                 binding = companion_binding(bindings, driver_id, matches[0].path)

--- a/keymasq/keymasqd/runtime/grab/acquisition.py
+++ b/keymasq/keymasqd/runtime/grab/acquisition.py
@@ -11,6 +11,7 @@ import evdev
 from keymasq.common.model.actions import MappingAction
 from keymasq.common.model.core import DeviceType
 from keymasq.keymasqd.combo_engine import ComboDecision
+from keymasq.keymasqd.input_sources.discovery import SOURCE_PREFIX
 from keymasq.keymasqd.runtime import adapters, device_path_resolver
 from keymasq.keymasqd.runtime.combo import events, lifecycle
 from keymasq.keymasqd.runtime.combo.state import ComboRuntimeDeps
@@ -73,7 +74,7 @@ async def grab_device_unlocked(
     device_path_resolver.clear_cached_devices()
     cancel_pending_hardware_release(manager, request.hardware_id)
 
-    plan = build_grab_plan(manager, request, deps)
+    plan = await adapters.ASYNCIO_RUNTIME.to_thread(build_grab_plan, manager, request, deps)
     if request.update_desired:
         persist_desired_grab(manager, request, plan, deps)
     log_grab_request(plan)
@@ -116,6 +117,7 @@ def reconcile_existing_interface_releases(
             device.path,
             asyncio_mod=adapters.ASYNCIO_RUNTIME,
             log=log,
+            **({"grace_s": 0.0} if device.path.startswith(SOURCE_PREFIX) else {}),
         )
 
 

--- a/keymasq/keymasqd/runtime/grab/release.py
+++ b/keymasq/keymasqd/runtime/grab/release.py
@@ -214,9 +214,10 @@ def schedule_interface_release(
     *,
     asyncio_mod: adapters.AsyncioRuntimeAdapter,
     log: logging.Logger,
+    grace_s: float | None = None,
 ) -> None:
     cancel_pending_interface_release(manager, hardware_id, path)
-    delay = manager.grab_state.release_grace_s
+    delay = manager.grab_state.release_grace_s if grace_s is None else max(0.0, grace_s)
     manager.grab_state.pending_interface_release[(hardware_id, path)] = asyncio_mod.create_task(
         delayed_interface_release(
             manager,

--- a/keymasq/keymasqd/runtime/grabbed_device/device.py
+++ b/keymasq/keymasqd/runtime/grabbed_device/device.py
@@ -21,6 +21,8 @@ from keymasq.common.devices import (
 from keymasq.common.model.actions import MappingAction
 from keymasq.common.model.core import ActionType, DeviceType
 from keymasq.keymasqd.evdev_clock import set_evdev_clock_monotonic
+from keymasq.keymasqd.input_sources.discovery import SOURCE_PREFIX
+from keymasq.keymasqd.input_sources.evdev_adapter import NativeInputDevice
 from keymasq.keymasqd.output_helpers import resolve_output_code
 from keymasq.keymasqd.recording import RecordingManager
 from keymasq.keymasqd.runtime import adapters, force_feedback, source_hiding
@@ -75,6 +77,8 @@ class _PassthroughUInputKwargs(TypedDict):
 
 
 def _device_input(path: str) -> ManagedInputDevice:
+    if path.startswith(SOURCE_PREFIX):
+        return cast(ManagedInputDevice, cast(object, NativeInputDevice(path)))
     device = cast(object, evdev.InputDevice(path))
     set_evdev_clock_monotonic(device, device_path=path, logger=log)
     return cast(ManagedInputDevice, device)
@@ -211,6 +215,24 @@ def _passthrough_uinput_kwargs(
     if supports_max_effects:
         kwargs["max_effects"] = ff_max_effects
     return kwargs
+
+
+async def _create_passthrough_uinput(create: Callable[[], evdev.UInput]) -> evdev.UInput:
+    # UI_DEV_CREATE and discovery of the resulting event node can wait on the
+    # kernel. Keep other grabbed devices running during creation and rollback.
+    task = asyncio.create_task(asyncio.to_thread(create))
+    try:
+        return await asyncio.shield(task)
+    except asyncio.CancelledError:
+        # Cancelling to_thread cannot stop creation. Retain ownership until the
+        # worker finishes so an interrupted profile switch cannot leak a device.
+        try:
+            uinput = await task
+        except Exception:  # noqa: BLE001 - preserve cancellation if the worker also failed.
+            log.debug("Passthrough creation failed after cancellation", exc_info=True)
+        else:
+            await asyncio.to_thread(_close_passthrough_uinput, uinput, context="cancelled grab")
+        raise
 
 
 def _close_passthrough_uinput(
@@ -511,7 +533,7 @@ class GrabbedDevice:
         await self._stop_output_feedback_proxy()
         uinput = self.uinput
         if uinput is not None:
-            _close_passthrough_uinput(uinput, context="failed grab")
+            await asyncio.to_thread(_close_passthrough_uinput, uinput, context="failed grab")
         self.uinput = None
 
         device = self.device
@@ -535,7 +557,11 @@ class GrabbedDevice:
     async def grab(self) -> None:
         self.resolved_event_path = os.path.realpath(self.path)
         self.source_hidden_kernel_names = []
-        self.device = _device_input(self.path)
+        self.device = (
+            await asyncio.to_thread(_device_input, self.path)
+            if self.path.startswith(SOURCE_PREFIX)
+            else _device_input(self.path)
+        )
         initialize_motion_state(self, self.mapping_getter())
 
         if self.access_mode is InputAccessMode.OBSERVE:
@@ -615,7 +641,9 @@ class GrabbedDevice:
                     ),
                 )
 
-            self.uinput = make_passthrough_uinput(ff_max_effects)
+            self.uinput = await _create_passthrough_uinput(
+                lambda: make_passthrough_uinput(ff_max_effects)
+            )
             if force_feedback.has_passthrough_output_feedback(caps):
                 try:
                     self._start_output_feedback_proxy()
@@ -625,11 +653,15 @@ class GrabbedDevice:
                         self.path,
                         exc_info=True,
                     )
-                    _close_passthrough_uinput(self.uinput, context="output-feedback retry")
+                    await asyncio.to_thread(
+                        _close_passthrough_uinput, self.uinput, context="output-feedback retry"
+                    )
                     self.uinput = None
                     force_feedback.disable_passthrough_output_feedback(caps)
                     ff_max_effects = 0
-                    self.uinput = make_passthrough_uinput(ff_max_effects)
+                    self.uinput = await _create_passthrough_uinput(
+                        lambda: make_passthrough_uinput(ff_max_effects)
+                    )
 
             await grab.wait_for_active_keys_to_clear(
                 self,
@@ -704,6 +736,8 @@ class GrabbedDevice:
         await self._stop_output_feedback_proxy()
 
         if self.device:
+            if isinstance(self.device, NativeInputDevice):
+                await self.device.aclose()
             if self.access_mode is InputAccessMode.EXCLUSIVE:
                 try:
                     self.device.ungrab()
@@ -719,7 +753,8 @@ class GrabbedDevice:
                 log.exception("Unexpected failure closing input device %s", self.path)
 
         if self.uinput:
-            _close_passthrough_uinput(
+            await asyncio.to_thread(
+                _close_passthrough_uinput,
                 self.uinput,
                 context=f"release {self.path}",
                 close_error_log_level=logging.WARNING,

--- a/keymasq/keymasqd/runtime/grabbed_device/device.py
+++ b/keymasq/keymasqd/runtime/grabbed_device/device.py
@@ -226,12 +226,23 @@ async def _create_passthrough_uinput(create: Callable[[], evdev.UInput]) -> evde
     except asyncio.CancelledError:
         # Cancelling to_thread cannot stop creation. Retain ownership until the
         # worker finishes so an interrupted profile switch cannot leak a device.
-        try:
-            uinput = await task
-        except Exception:  # noqa: BLE001 - preserve cancellation if the worker also failed.
-            log.debug("Passthrough creation failed after cancellation", exc_info=True)
-        else:
-            await asyncio.to_thread(_close_passthrough_uinput, uinput, context="cancelled grab")
+        async def settle() -> None:
+            try:
+                uinput = await task
+            except Exception:  # noqa: BLE001 - preserve cancellation if creation failed.
+                log.debug("Passthrough creation failed after cancellation", exc_info=True)
+            else:
+                await asyncio.to_thread(_close_passthrough_uinput, uinput, context="cancelled grab")
+
+        cleanup = asyncio.create_task(settle())
+        while not cleanup.done():
+            try:
+                await asyncio.shield(cleanup)
+            except asyncio.CancelledError:
+                # Profile cancellation may be followed by shutdown cancellation.
+                # Neither may cancel the worker or discard its eventual result.
+                continue
+        cleanup.result()
         raise
 
 

--- a/keymasq/session/hardware.py
+++ b/keymasq/session/hardware.py
@@ -18,6 +18,7 @@ from keymasq.common.model.hardware import (
     ButtonDefinition,
     EvdevDevice,
     HardwareConfig,
+    NativeInputSource,
 )
 from keymasq.common.model.motion import (
     MOTION_NORMALIZATION_VERSION,
@@ -226,6 +227,7 @@ class HardwareManager:
             motion_sensors=motion_sensors,
             image=hw.get("image"),
             id=hardware_id or None,
+            input_sources=[NativeInputSource(**source) for source in hw.get("input_sources", [])],
         )
 
     @staticmethod
@@ -559,6 +561,18 @@ class HardwareManager:
 
         if config.id:
             data["hardware"]["hardware_id"] = config.hardware_id
+
+        if config.input_sources:
+            data["hardware"]["input_sources"] = [
+                {
+                    "id": source.id,
+                    "driver": source.driver,
+                    **({"enabled": False} if not source.enabled else {}),
+                    **({"companion_of": source.companion_of} if source.companion_of else {}),
+                    **({"phys": source.phys} if source.phys else {}),
+                }
+                for source in config.input_sources
+            ]
 
         if config.image:
             data["hardware"]["image"] = config.image

--- a/keymasq/session/manager/profile/application.py
+++ b/keymasq/session/manager/profile/application.py
@@ -581,6 +581,13 @@ async def apply_resolved_device_profile(
     )
     grab_signature = grab_device_payload_signature(grab_payload)
     if not new_interfaces and not inspector_active:
+        if hardware_id in manager.profile_state.grabbed_devices:
+            await operations.deactivate_profile(
+                manager,
+                hardware_id,
+                immediate=True,
+                generation=generation,
+            )
         if manager.profile_state.last_sent_grab_signatures.get(hardware_id) != grab_signature:
             log.warning(
                 (

--- a/keymasq/session/manager/profile/grab_plan.py
+++ b/keymasq/session/manager/profile/grab_plan.py
@@ -84,7 +84,12 @@ def _motion_requires_gamepad_output(
     hardware: HardwareConfig,
     resolved: ResolvedDeviceProfile,
 ) -> bool:
+    disabled_sources = {
+        source.id for source in getattr(hardware, "input_sources", []) if not source.enabled
+    }
     for sensor in getattr(hardware, "motion_sensors", ()):
+        if sensor.source in disabled_sources:
+            continue
         action = resolved.mappings.get(sensor.id)
         if action is None or action.action_type != ActionType.MOTION_CONTROL:
             continue
@@ -123,6 +128,10 @@ def all_configured_interfaces(hardware_config: HardwareConfig) -> dict[str, str]
         device.id: device.path
         for device in hardware_config.evdev_devices
         if device.id and str(device.path or "").strip()
+    } | {
+        source.id: source.path
+        for source in getattr(hardware_config, "input_sources", [])
+        if source.enabled
     }
 
 
@@ -146,6 +155,32 @@ def configured_interface_descriptors(
                 "type": getattr(getattr(device, "device_type", None), "value", "other"),
                 "phys": str(getattr(device, "phys", "") or ""),
                 "capabilities": list(getattr(device, "capabilities", []) or []),
+            }
+        )
+    anchors = {str(item["id"]): item for item in descriptors}
+    # A motion-only profile still needs the evdev selector to identify its
+    # physical companion, without acquiring that companion's ordinary inputs.
+    if selected_sources is not None:
+        anchors = {
+            str(item["id"]): item
+            for item in configured_interface_descriptors(hardware_config, None)
+            if item.get("backend") != "hidraw"
+        }
+    for source in getattr(hardware_config, "input_sources", []):
+        if not source.enabled:
+            continue
+        if selected_sources is not None and source.id not in selected_sources:
+            continue
+        descriptors.append(
+            {
+                "id": source.id,
+                "path": source.path,
+                "type": "motion",
+                "backend": "hidraw",
+                "driver": source.driver,
+                "phys": source.phys or "",
+                "anchor": anchors.get(source.companion_of or ""),
+                "companion_of": source.companion_of or "",
             }
         )
     return descriptors

--- a/keymasq/session/manager/recording_capture.py
+++ b/keymasq/session/manager/recording_capture.py
@@ -503,6 +503,10 @@ def _hardware_evdev_interfaces(manager: "SessionManager", hardware_id: str) -> l
     hardware = manager.hardware.get_hardware(hardware_id)
     if hardware is None:
         return []
+    if getattr(hardware, "input_sources", []):
+        from .profile.grab_plan import configured_interface_descriptors
+
+        return configured_interface_descriptors(hardware, None)
     interfaces: list[JsonObject] = []
     for device in getattr(hardware, "evdev_devices", []):
         device_id = coerce_str(getattr(device, "id", ""), "")

--- a/keymasq/session/manager/recording_device_selection.py
+++ b/keymasq/session/manager/recording_device_selection.py
@@ -293,6 +293,15 @@ async def get_devices_for_recording(
                 "analog_calibration": json_object(d.get("analog_calibration")) or {},
                 "gamepad_output": json_object(d.get("gamepad_output")),
                 "driver": coerce_str(d.get("driver"), ""),
+                **(
+                    {
+                        "backend": "hidraw",
+                        "native_motion_axes": json_object(d.get("native_motion_axes")) or {},
+                        "companion_paths": json_list(d.get("companion_paths")),
+                    }
+                    if d.get("backend") == "hidraw"
+                    else {}
+                ),
                 "recording_id": coerce_str(d.get("recording_id"), f"physical:{stable_path}"),
                 "recording_kind": coerce_str(d.get("recording_kind"), "physical"),
                 "grabbed_by_keymasq": is_grabbed,

--- a/packaging/appimage/assets/keymasqd.service
+++ b/packaging/appimage/assets/keymasqd.service
@@ -13,6 +13,8 @@ SupplementaryGroups=input
 Nice=-5
 ExecStartPre=+/usr/bin/setfacl -m u:keymasq:rw /dev/uinput
 ExecStartPre=+/usr/bin/sh -c 'for p in /dev/input/event*; do [ -e "$p" ] && /usr/bin/setfacl -m u:keymasq:rw "$p"; done'
+# Apply native-driver ACLs to controllers already connected at startup.
+ExecStartPre=+/usr/bin/udevadm trigger --subsystem-match=hidraw --action=change --settle
 ExecStart=/opt/keymasq/bin/keymasqd
 Restart=on-failure
 RestartSec=5

--- a/packaging/appimage/runtime/keymasq-appimage-runtime.sh
+++ b/packaging/appimage/runtime/keymasq-appimage-runtime.sh
@@ -675,6 +675,7 @@ reload_udev_rules() {
 	fi
 	udevadm trigger --subsystem-match=input --action=add || true
 	udevadm trigger --subsystem-match=misc --action=add || true
+	udevadm trigger --subsystem-match=hidraw --action=change --settle || true
 }
 
 clear_keymasq_udev_state() {
@@ -711,7 +712,8 @@ clear_keymasq_udev_state() {
 		for keymasq_device in \
 			"$(root_path /dev/uinput)" \
 			"$(root_path /dev/input)"/event* \
-			"$(root_path /dev/input)"/js*; do
+			"$(root_path /dev/input)"/js* \
+			"$(root_path /dev)"/hidraw*; do
 			[ -e "$keymasq_device" ] || continue
 			if ! setfacl -x u:keymasq "$keymasq_device" 2>/dev/null; then
 				warn "could not remove the Keymasq ACL from $keymasq_device"
@@ -807,6 +809,7 @@ Before starting the daemon, grant device ACLs:
   install -d -o keymasq -g keymasq -m 0755 /run/keymasq
   install -d -o keymasq -g keymasq -m 0750 /var/lib/keymasq
   setfacl -m u:keymasq:rw /dev/uinput
+  udevadm trigger --subsystem-match=hidraw --action=change --settle
   for p in /dev/input/event*; do [ -e "\$p" ] && setfacl -m u:keymasq:rw "\$p"; done
 
 The per-user session manager was installed as an XDG autostart entry for:

--- a/packaging/aur/keymasq.install
+++ b/packaging/aur/keymasq.install
@@ -38,6 +38,7 @@ post_install() {
     udevadm control --reload-rules
     udevadm trigger --subsystem-match=input --action=add
     udevadm trigger --subsystem-match=misc --action=add
+    udevadm trigger --subsystem-match=hidraw --action=change --settle
 
     if [ -f /etc/systemd/system/keymasqd.service ]; then
         echo ""
@@ -75,6 +76,7 @@ post_upgrade() {
     udevadm control --reload-rules
     udevadm trigger --subsystem-match=input --action=add
     udevadm trigger --subsystem-match=misc --action=add
+    udevadm trigger --subsystem-match=hidraw --action=change --settle
 
     if [ -f /etc/systemd/system/keymasqd.service ]; then
         echo ""

--- a/packaging/pacman/templates/keymasq.install.in
+++ b/packaging/pacman/templates/keymasq.install.in
@@ -37,6 +37,7 @@ post_install() {
     udevadm control --reload-rules
     udevadm trigger --subsystem-match=input --action=add
     udevadm trigger --subsystem-match=misc --action=add
+    udevadm trigger --subsystem-match=hidraw --action=change --settle
 
     if [ -f /etc/systemd/system/keymasqd.service ]; then
         echo ""
@@ -74,6 +75,7 @@ post_upgrade() {
     udevadm control --reload-rules
     udevadm trigger --subsystem-match=input --action=add
     udevadm trigger --subsystem-match=misc --action=add
+    udevadm trigger --subsystem-match=hidraw --action=change --settle
 
     if [ -f /etc/systemd/system/keymasqd.service ]; then
         echo ""

--- a/scripts/install-systemd.sh
+++ b/scripts/install-systemd.sh
@@ -70,6 +70,7 @@ install -Dm644 "${REPO_ROOT}/udev/99-keymasq-hide-grabbed.rules" /etc/udev/rules
 udevadm control --reload-rules
 udevadm trigger --subsystem-match=input --action=add
 udevadm trigger --subsystem-match=misc --action=add
+udevadm trigger --subsystem-match=hidraw --action=change --settle
 
 install -d -m 0750 -o keymasq -g keymasq /var/lib/keymasq
 
@@ -97,6 +98,8 @@ User=keymasq
 Group=keymasq
 SupplementaryGroups=input
 Nice=-5
+# Apply native-driver ACLs to controllers already connected at startup.
+ExecStartPre=+/usr/bin/udevadm trigger --subsystem-match=hidraw --action=change --settle
 ExecStart=/usr/local/bin/keymasqd-wrapper
 Restart=on-failure
 RestartSec=5

--- a/scripts/rpm-postinstall.sh
+++ b/scripts/rpm-postinstall.sh
@@ -9,6 +9,7 @@ systemd-tmpfiles --create /usr/lib/tmpfiles.d/keymasq.conf >/dev/null 2>&1 || tr
 udevadm control --reload-rules 2>/dev/null || true
 udevadm trigger --subsystem-match=input --action=add 2>/dev/null || true
 udevadm trigger --subsystem-match=misc --action=add 2>/dev/null || true
+udevadm trigger --subsystem-match=hidraw --action=change --settle 2>/dev/null || true
 
 # Reload systemd
 systemctl daemon-reload 2>/dev/null || true

--- a/systemd/keymasqd.service
+++ b/systemd/keymasqd.service
@@ -14,6 +14,8 @@ SupplementaryGroups=input
 Nice=-5
 ExecStartPre=+/usr/bin/setfacl -m u:keymasq:rw /dev/uinput
 ExecStartPre=+/usr/bin/sh -c 'for p in /dev/input/event*; do [ -e "$p" ] && /usr/bin/setfacl -m u:keymasq:rw "$p"; done'
+# Apply native-driver ACLs to controllers already connected at startup.
+ExecStartPre=+/usr/bin/udevadm trigger --subsystem-match=hidraw --action=change --settle
 ExecStart=/usr/bin/keymasqd
 Restart=on-failure
 RestartSec=5

--- a/tests/common/test_appimage_packaging.py
+++ b/tests/common/test_appimage_packaging.py
@@ -1100,12 +1100,14 @@ def test_appimage_install_generic_fallback_writes_manual_service_instructions(
     assert "install -d -o keymasq -g keymasq -m 0755 /run/keymasq" in instructions
     assert "install -d -o keymasq -g keymasq -m 0750 /var/lib/keymasq" in instructions
     assert "setfacl -m u:keymasq:rw /dev/uinput" in instructions
+    assert "udevadm trigger --subsystem-match=hidraw --action=change --settle" in instructions
     assert current_user in instructions
     assert "systemd was not detected" in result.stderr
     assert "could not reload udev rules" in result.stderr
     command_log = Path(env["KEYMASQ_COMMAND_LOG"]).read_text(encoding="utf-8")
     assert "udevadm control --reload-rules" in command_log
     assert "systemctl" not in command_log
+    assert "udevadm trigger --subsystem-match=hidraw --action=change --settle" in command_log
     assert "systemd-sysusers" not in command_log
     assert "systemd-tmpfiles" not in command_log
 
@@ -1210,10 +1212,12 @@ def test_appimage_uninstall_removes_integration_but_keeps_config_and_state(
     uinput = fake_root / "dev/uinput"
     event = fake_root / "dev/input/event0"
     joystick = fake_root / "dev/input/js0"
+    hidraw = fake_root / "dev/hidraw7"
     event.parent.mkdir(parents=True)
     uinput.touch()
     event.touch()
     joystick.touch()
+    hidraw.touch()
 
     subprocess.run(
         ["sh", str(RUNTIME_SCRIPT), "--uninstall", "--user", "root"],
@@ -1244,6 +1248,7 @@ def test_appimage_uninstall_removes_integration_but_keeps_config_and_state(
     assert f"setfacl -x u:keymasq {uinput}" in command_log
     assert f"setfacl -x u:keymasq {event}" in command_log
     assert f"setfacl -x u:keymasq {joystick}" in command_log
+    assert f"setfacl -x u:keymasq {hidraw}" in command_log
 
 
 def test_appimage_runtime_exports_gtk_introspection_environment(tmp_path: Path) -> None:

--- a/tests/common/test_devices.py
+++ b/tests/common/test_devices.py
@@ -100,6 +100,26 @@ def test_resolve_stable_path_returns_original_when_by_id_dir_missing(
     clear_device_path_cache()
 
 
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/dev/keymasq-sources/8bitdo-ultimate2/0003:2DC8:6012.0052/hidraw7",
+        "/dev/keymasq-sources/future-driver/instance/event7",
+        "keymasq-source:imu",
+    ],
+)
+def test_stable_path_preserves_native_addresses(monkeypatch, path):
+    symlink = Path("/dev/input/by-id/usb-8BitDo-hidraw")
+    clear_device_path_cache()
+    monkeypatch.setattr(Path, "exists", lambda self: True)
+    monkeypatch.setattr(Path, "iterdir", lambda self: iter([symlink]))
+    monkeypatch.setattr(Path, "is_symlink", lambda self: True)
+    monkeypatch.setattr(os, "readlink", lambda _path: f"../../{Path(path).name}")
+
+    assert resolve_stable_path(path) == path
+    clear_device_path_cache()
+
+
 def test_resolve_stable_path_skips_symlink_read_errors(monkeypatch: pytest.MonkeyPatch) -> None:
     by_id_dir = Path("/dev/input/by-id")
     symlink = by_id_dir / "usb-Example-event-kbd"

--- a/tests/common/test_udev_rules.py
+++ b/tests/common/test_udev_rules.py
@@ -1,5 +1,43 @@
 from pathlib import Path
 
+import pytest
+
+ROOT = Path(__file__).parents[2]
+
+
+def test_native_hidraw_acl_is_read_only_and_independent_of_driver_models() -> None:
+    lines = (ROOT / "udev/91-keymasq-acl.rules").read_text().splitlines()
+    hidraw_rules = [line for line in lines if 'SUBSYSTEM=="hidraw"' in line]
+    assert len(hidraw_rules) == 1
+    rule = hidraw_rules[0]
+    assert 'ACTION=="add|change"' in rule
+    assert "ATTRS{" not in rule
+    assert 'KERNEL=="hidraw*"' in rule
+    assert 'RUN+="/usr/bin/setfacl -m u:keymasq:r /dev/%k"' in rule
+    assert "MODE=" not in rule
+    assert "GROUP=" not in rule
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "systemd/keymasqd.service",
+        "packaging/appimage/assets/keymasqd.service",
+        "packaging/appimage/runtime/keymasq-appimage-runtime.sh",
+        "flake.nix",
+        "scripts/install-systemd.sh",
+        "debian/keymasq.postinst",
+        "scripts/rpm-postinstall.sh",
+        "keymasq.install",
+        "packaging/aur/keymasq.install",
+        "packaging/pacman/templates/keymasq.install.in",
+    ],
+)
+def test_install_and_startup_apply_native_acls_to_connected_devices(path: str) -> None:
+    assert "udevadm trigger --subsystem-match=hidraw --action=change --settle" in (
+        ROOT / path
+    ).read_text()
+
 
 def test_hardware_hotplug_udev_rule_only_hides_joystick_event_nodes() -> None:
     rule_path = Path(__file__).parents[2] / "udev" / "99-keymasq-hide-grabbed.rules"

--- a/tests/gui/test_native_input_setup.py
+++ b/tests/gui/test_native_input_setup.py
@@ -1,0 +1,105 @@
+import math
+
+import pytest
+
+from keymasq.common.model.core import DeviceType
+from keymasq.common.model.hardware import EvdevDevice, HardwareConfig
+from keymasq.gui.widgets.device_tab.hardware_settings_dialog import append_evdev_device_selection
+from keymasq.gui.wizards.hardware_setup import templates
+from keymasq.gui.wizards.hardware_setup.types import EvdevDeviceSelection
+from keymasq.session.hardware import HardwareManager
+from keymasq.session.manager.profile.grab_plan import (
+    all_configured_interfaces,
+    configured_interface_descriptors,
+)
+
+
+def interfaces():
+    return [
+        {
+            "id": "gamepad",
+            "path": "/dev/input/event26",
+            "config_path": "keymasq:2dc8:6012",
+            "device_types": ["gamepad"],
+            "phys": "usb-test/input0",
+        },
+        {
+            "id": "imu",
+            "path": "/dev/keymasq-sources/8bitdo-ultimate2/instance/hidraw7",
+            "backend": "hidraw",
+            "driver": "8bitdo-ultimate2",
+            "device_types": ["motion"],
+            "name": "Ultimate 2 motion",
+            "phys": "usb-test/input0",
+            "companion_paths": ["/dev/input/event26"],
+            "native_motion_axes": {
+                "gyro_axes": [
+                    {
+                        "role": "yaw",
+                        "evdev": "abs_rz",
+                        "evdev_code": 5,
+                        "scale": math.radians(2000) / 32767,
+                    }
+                ],
+                "accelerometer_axes": [
+                    {"role": "z", "evdev": "abs_z", "evdev_code": 2, "scale": 9.80665 / 4096}
+                ],
+            },
+        },
+    ]
+
+
+def test_setup_persists_native_source_and_precise_calibration(temp_config_dir):
+    detected = interfaces()
+    hardware = HardwareConfig(
+        "2dc8",
+        "6012",
+        "Ultimate 2",
+        templates.build_evdev_devices(detected),
+        [],
+        motion_sensors=templates.build_motion_sensors(detected),
+        input_sources=templates.build_input_sources(detected),
+    )
+    assert len(hardware.evdev_devices) == 1
+    assert hardware.input_sources[0].companion_of == "gamepad"
+    hardware.motion_sensors[0].gyro_axes[0].offset = 23.5
+    manager = HardwareManager()
+    manager.save_hardware(hardware)
+    reloaded = HardwareManager().get_hardware(hardware.hardware_id)
+    assert reloaded is not None
+    assert reloaded.input_sources == hardware.input_sources
+    assert reloaded.motion_sensors == hardware.motion_sensors
+    assert reloaded.motion_sensors[0].gyro_axes[0].scale == pytest.approx(
+        math.radians(2000) / 32767
+    )
+    payload = configured_interface_descriptors(reloaded, {"imu"})
+    assert len(payload) == 1
+    assert payload[0]["anchor"]["id"] == "gamepad"
+    assert payload[0]["anchor"]["path"] == "keymasq:2dc8:6012"
+    assert payload[0]["path"] == "keymasq-source:imu"
+    reloaded.input_sources[0].enabled = False
+    manager.save_hardware(reloaded)
+    assert configured_interface_descriptors(reloaded, {"imu"}) == []
+    assert "imu" not in all_configured_interfaces(reloaded)
+    assert not HardwareManager().get_hardware(hardware.hardware_id).input_sources[0].enabled
+
+
+def test_add_motion_to_existing_controller_without_duplicating_evdev():
+    hardware = HardwareConfig(
+        "2dc8",
+        "6012",
+        "Ultimate 2",
+        [
+            EvdevDevice("keymasq:2dc8:6012", DeviceType.GAMEPAD, "controls", "usb-test/input0"),
+        ],
+        [],
+    )
+    detected = interfaces()[1:]
+    selection = EvdevDeviceSelection(
+        [], templates.build_motion_sensors(detected), templates.build_input_sources(detected)
+    )
+    assert append_evdev_device_selection(hardware, selection) == (1, 1)
+    assert len(hardware.evdev_devices) == 1
+    assert hardware.input_sources[0].companion_of == "controls"
+    assert hardware.motion_sensors[0].source == hardware.input_sources[0].id
+    assert append_evdev_device_selection(hardware, selection) == (0, 0)

--- a/tests/keymasqd/test_daemon_capture_commands.py
+++ b/tests/keymasqd/test_daemon_capture_commands.py
@@ -598,7 +598,8 @@ async def test_capture_begin_forwards_evdev_interfaces(daemon_testbed):
 
 
 @pytest.mark.asyncio
-async def test_native_capture_filters_evdev_siblings(daemon_testbed):
+@pytest.mark.parametrize("mode", ["motion", "MOTION", " motion "])
+async def test_native_capture_filters_evdev_siblings(daemon_testbed, mode):
     daemon, _device_manager, _recording_manager, _macro_store, capture_manager = daemon_testbed
     capture_manager.begin_native = AsyncMock(return_value={"token": "native-token"})
     gamepad = {"id": "gamepad", "path": "keymasq:2dc8:6012", "type": "gamepad"}
@@ -608,7 +609,7 @@ async def test_native_capture_filters_evdev_siblings(daemon_testbed):
         {
             "hardware_id": "2dc8:6012",
             "evdev_interfaces": [gamepad, native],
-            "mode": "motion",
+            "mode": mode,
             "motion_axis_codes": [3, 4, 5],
         },
     )

--- a/tests/keymasqd/test_daemon_capture_commands.py
+++ b/tests/keymasqd/test_daemon_capture_commands.py
@@ -598,6 +598,26 @@ async def test_capture_begin_forwards_evdev_interfaces(daemon_testbed):
 
 
 @pytest.mark.asyncio
+async def test_native_capture_filters_evdev_siblings(daemon_testbed):
+    daemon, _device_manager, _recording_manager, _macro_store, capture_manager = daemon_testbed
+    capture_manager.begin_native = AsyncMock(return_value={"token": "native-token"})
+    gamepad = {"id": "gamepad", "path": "keymasq:2dc8:6012", "type": "gamepad"}
+    native = {"id": "imu", "path": "keymasq-source:imu", "backend": "hidraw", "anchor": gamepad}
+    result = await daemon._handle_command(
+        CommandType.CAPTURE_BEGIN,
+        {
+            "hardware_id": "2dc8:6012",
+            "evdev_interfaces": [gamepad, native],
+            "mode": "motion",
+            "motion_axis_codes": [3, 4, 5],
+        },
+    )
+    assert result == {"token": "native-token"}
+    capture_manager.begin_native.assert_awaited_once_with("2dc8:6012", [native], [3, 4, 5])
+    capture_manager.begin.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_capture_begin_forwards_motion_axis_codes(daemon_testbed):
     daemon, _device_manager, _recording_manager, _macro_store, capture_manager = daemon_testbed
 

--- a/tests/keymasqd/test_device_manager_core.py
+++ b/tests/keymasqd/test_device_manager_core.py
@@ -2739,6 +2739,7 @@ class TestListDevices:
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         manager = DeviceManager(topology_poll_s=0.01)
+        deps = device_manager._topology_runtime_deps()
         snapshot = {
             "/dev/input/by-id/test-mouse": topology.LiveInterfaceInfo(
                 hardware_id="1234:5678",
@@ -2769,14 +2770,14 @@ class TestListDevices:
 
         with pytest.raises(asyncio.CancelledError):
             await topology.topology_watch_loop(
-                manager, log=device_manager.log, deps=device_manager._topology_runtime_deps()
+                manager, log=device_manager.log, deps=deps
             )
 
         schedule_topology_reconcile.assert_called_once_with(
             manager,
             snapshot,
             log=device_manager.log,
-            deps=device_manager._topology_runtime_deps(),
+            deps=deps,
         )
 
     @pytest.mark.asyncio
@@ -2786,6 +2787,7 @@ class TestListDevices:
         caplog: pytest.LogCaptureFixture,
     ) -> None:
         manager = DeviceManager(topology_poll_s=0.01)
+        deps = device_manager._topology_runtime_deps()
         snapshot = {
             "/dev/input/by-id/test-mouse": topology.LiveInterfaceInfo(
                 hardware_id="1234:5678",
@@ -2820,7 +2822,7 @@ class TestListDevices:
         with caplog.at_level(logging.WARNING, logger="keymasqd.devices"):
             with pytest.raises(asyncio.CancelledError):
                 await topology.topology_watch_loop(
-                    manager, log=device_manager.log, deps=device_manager._topology_runtime_deps()
+                    manager, log=device_manager.log, deps=deps
                 )
 
         assert "Topology scan failed: scan boom" in caplog.text
@@ -2828,7 +2830,7 @@ class TestListDevices:
             manager,
             snapshot,
             log=device_manager.log,
-            deps=device_manager._topology_runtime_deps(),
+            deps=deps,
         )
 
     def test_scan_live_interfaces_logs_snapshot_device_failures(

--- a/tests/keymasqd/test_device_manager_rapidfire.py
+++ b/tests/keymasqd/test_device_manager_rapidfire.py
@@ -167,6 +167,8 @@ class TestRapidfireRelease:
             return True
 
         def fake_create_task(coro):
+            if coro.cr_code is not grabbed_device.pipeline.event_loop.__code__:
+                return original_create_task(coro)
             coro.close()
             task = original_create_task(original_sleep(0))
             created_tasks.append(task)
@@ -200,7 +202,7 @@ class TestRapidfireRelease:
         await original_sleep(0)
 
         assert wait_timeouts == [pytest.approx(grabbed_device.ACTIVE_KEY_IDLE_LOG_INTERVAL_S)]
-        assert [call[0] for call in to_thread_calls] == [
+        assert [call[0] for call in to_thread_calls[1:]] == [
             fake_input.active_keys,
             fake_input.active_keys,
         ]
@@ -237,6 +239,8 @@ class TestRapidfireRelease:
         original_sleep = asyncio.sleep
 
         def fake_create_task(coro):
+            if coro.cr_code is not grabbed_device.pipeline.event_loop.__code__:
+                return original_create_task(coro)
             coro.close()
             return original_create_task(original_sleep(0))
 
@@ -318,7 +322,7 @@ class TestRapidfireRelease:
             return monotonic_last["value"]
 
         monkeypatch.setattr(grabbed_device.asyncio, "to_thread", fake_to_thread)
-        monkeypatch.setattr(grabbed_device.time, "monotonic", fake_monotonic)
+        monkeypatch.setattr(grabbed_device, "time", SimpleNamespace(monotonic=fake_monotonic))
         monkeypatch.setattr(
             grab,
             "wait_for_active_key_activity",
@@ -479,7 +483,7 @@ class TestRapidfireRelease:
             return monotonic_last["value"]
 
         monkeypatch.setattr(grabbed_device.asyncio, "to_thread", fake_to_thread)
-        monkeypatch.setattr(grabbed_device.time, "monotonic", fake_monotonic)
+        monkeypatch.setattr(grabbed_device, "time", SimpleNamespace(monotonic=fake_monotonic))
         monkeypatch.setattr(
             grab,
             "wait_for_active_key_activity",
@@ -560,7 +564,7 @@ class TestRapidfireRelease:
         monkeypatch.setattr(grabbed_device.evdev, "InputDevice", lambda _path: _FakeInputDevice())
         monkeypatch.setattr(grabbed_device.evdev, "UInput", fake_uinput)
         monkeypatch.setattr(grabbed_device.asyncio, "to_thread", fake_to_thread)
-        monkeypatch.setattr(grabbed_device.time, "monotonic", fake_monotonic)
+        monkeypatch.setattr(grabbed_device, "time", SimpleNamespace(monotonic=fake_monotonic))
 
         device = GrabbedDevice(
             path="/dev/input/event-test",
@@ -608,6 +612,8 @@ class TestRapidfireRelease:
             return func(*args, **kwargs)
 
         def fake_create_task(coro):
+            if coro.cr_code is not grabbed_device.pipeline.event_loop.__code__:
+                return original_create_task(coro)
             coro.close()
             task = original_create_task(asyncio.sleep(0))
             created_tasks.append(task)
@@ -687,6 +693,8 @@ class TestRapidfireRelease:
             return func(*args, **kwargs)
 
         def fake_create_task(coro):
+            if coro.cr_code is not grabbed_device.pipeline.event_loop.__code__:
+                return original_create_task(coro)
             coro.close()
             task = original_create_task(asyncio.sleep(0))
             created_tasks.append(task)
@@ -757,6 +765,8 @@ class TestRapidfireRelease:
             return func(*args, **kwargs)
 
         def fake_create_task(coro):
+            if coro.cr_code is not grabbed_device.pipeline.event_loop.__code__:
+                return original_create_task(coro)
             coro.close()
             task = original_create_task(asyncio.sleep(0))
             created_tasks.append(task)
@@ -844,6 +854,8 @@ class TestRapidfireRelease:
             return func(*args, **kwargs)
 
         def fake_create_task(coro):
+            if coro.cr_code is not grabbed_device.pipeline.event_loop.__code__:
+                return original_create_task(coro)
             coro.close()
             task = original_create_task(asyncio.sleep(0))
             created_tasks.append(task)
@@ -936,6 +948,8 @@ class TestRapidfireRelease:
             return func(*args, **kwargs)
 
         def fake_create_task(coro):
+            if coro.cr_code is not grabbed_device.pipeline.event_loop.__code__:
+                return original_create_task(coro)
             coro.close()
             task = original_create_task(asyncio.sleep(60))
             created_tasks.append(task)
@@ -1114,6 +1128,8 @@ class TestRapidfireRelease:
             return func(*args, **kwargs)
 
         def fake_create_task(coro):
+            if coro.cr_code is not grabbed_device.pipeline.event_loop.__code__:
+                return original_create_task(coro)
             coro.close()
             task = original_create_task(asyncio.sleep(60))
             created_tasks.append(task)

--- a/tests/keymasqd/test_force_feedback.py
+++ b/tests/keymasqd/test_force_feedback.py
@@ -917,6 +917,8 @@ async def test_grab_starts_passthrough_output_feedback_proxy(
     original_sleep = grabbed_device.asyncio.sleep
 
     def fake_create_task(coro):
+        if coro.cr_code is not grabbed_device.pipeline.event_loop.__code__:
+            return original_create_task(coro)
         coro.close()
         return original_create_task(original_sleep(0))
 
@@ -1020,6 +1022,8 @@ async def test_grab_retries_without_output_feedback_when_proxy_start_fails(
     original_sleep = grabbed_device.asyncio.sleep
 
     def fake_create_task(coro):
+        if coro.cr_code is not grabbed_device.pipeline.event_loop.__code__:
+            return original_create_task(coro)
         coro.close()
         return original_create_task(original_sleep(0))
 

--- a/tests/keymasqd/test_grab_lifecycle_planning.py
+++ b/tests/keymasqd/test_grab_lifecycle_planning.py
@@ -21,6 +21,17 @@ from keymasq.keymasqd.runtime.grab.state import (
 )
 
 
+def test_native_source_removal_does_not_wait_for_evdev_release_grace(monkeypatch):
+    native = SimpleNamespace(path="/dev/keymasq-sources/test/instance/hidraw7")
+    existing = SimpleNamespace(path="/dev/input/event26")
+    plan = SimpleNamespace(existing_devices=[native, existing], requested_claim_paths=set())
+    schedule = Mock()
+    monkeypatch.setattr(acquisition, "schedule_interface_release", schedule)
+    acquisition.reconcile_existing_interface_releases(_manager(), "2dc8:6012", plan, _deps())
+    assert schedule.call_args_list[0].kwargs["grace_s"] == 0
+    assert "grace_s" not in schedule.call_args_list[1].kwargs
+
+
 def _manager(
     *,
     grabbed_devices: dict[str, list[object]] | None = None,
@@ -389,9 +400,7 @@ async def test_failed_multi_interface_grab_does_not_update_existing_device_metad
     monkeypatch.setattr(acquisition, "update_existing_devices", update_existing_devices)
     monkeypatch.setattr(acquisition, "reconcile_existing_interface_releases", Mock())
     monkeypatch.setattr(acquisition, "build_runtime_callbacks", Mock(return_value=object()))
-    grab_one_interface = AsyncMock(
-        side_effect=[None, RuntimeError("second interface failed")]
-    )
+    grab_one_interface = AsyncMock(side_effect=[None, RuntimeError("second interface failed")])
     monkeypatch.setattr(
         acquisition,
         "grab_one_interface",

--- a/tests/keymasqd/test_grabbed_device.py
+++ b/tests/keymasqd/test_grabbed_device.py
@@ -352,7 +352,8 @@ async def test_mouse_events_continue_during_controller_uinput_io(monkeypatch, ph
 
 
 @pytest.mark.asyncio
-async def test_cancelled_passthrough_creation_closes_worker_result(monkeypatch):
+@pytest.mark.parametrize("cancellations", [1, 2, 3])
+async def test_cancelled_passthrough_creation_closes_worker_result(monkeypatch, cancellations):
     started = asyncio.Event()
     finish = threading.Event()
     loop = asyncio.get_running_loop()
@@ -366,8 +367,9 @@ async def test_cancelled_passthrough_creation_closes_worker_result(monkeypatch):
     task = asyncio.create_task(grabbed_device._create_passthrough_uinput(create))
     try:
         await asyncio.wait_for(started.wait(), 1)
-        task.cancel()
-        await asyncio.sleep(0)
+        for _ in range(cancellations):
+            task.cancel()
+            await asyncio.sleep(0)
     finally:
         finish.set()
     with pytest.raises(asyncio.CancelledError):

--- a/tests/keymasqd/test_grabbed_device.py
+++ b/tests/keymasqd/test_grabbed_device.py
@@ -1,5 +1,6 @@
 import asyncio
 import os
+import threading
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
@@ -15,6 +16,12 @@ from keymasq.keymasqd.runtime import adapters
 from keymasq.keymasqd.runtime.grabbed_device import device as grabbed_device
 from keymasq.keymasqd.runtime.grabbed_device import outputs, repeat
 from keymasq.keymasqd.runtime.grabbed_device.device import GrabbedDevice
+from keymasq.keymasqd.runtime.grabbed_device.event import pipeline
+from tests.keymasqd.device_manager_support import (
+    FakeUInput,
+    grabbed_event_processing_deps,
+    make_grabbed_device,
+)
 
 
 async def _wait_for_uinput_events(
@@ -267,6 +274,105 @@ async def test_grab_failure_closes_opened_input_device(monkeypatch):
     passthrough_uinput.close.assert_called_once_with()
     assert grabbed.device is None
     assert grabbed.uinput is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("phase", ["create", "rollback", "release"])
+async def test_mouse_events_continue_during_controller_uinput_io(monkeypatch, phase):
+    loop = asyncio.get_running_loop()
+    started = asyncio.Event()
+    finish = threading.Event()
+    stalled = []
+
+    def slow_kernel_operation():
+        loop.call_soon_threadsafe(started.set)
+        if not finish.wait(2):
+            stalled.append(True)
+
+    output = MagicMock()
+    if phase != "create":
+        output.close.side_effect = slow_kernel_operation
+
+    def create_output(**kwargs):
+        if phase == "create":
+            slow_kernel_operation()
+        return output
+
+    source = SimpleNamespace(
+        name="controller",
+        info=SimpleNamespace(vendor=None, product=None, version=None, bustype=None),
+        capabilities=lambda: {evdev.ecodes.EV_KEY: [evdev.ecodes.BTN_SOUTH]},
+        close=MagicMock(),
+        grab=MagicMock(),
+        ungrab=MagicMock(),
+    )
+    monkeypatch.setattr(grabbed_device, "_device_input", lambda path: source)
+    monkeypatch.setattr(grabbed_device.evdev, "UInput", create_output)
+    preflight = AsyncMock()
+    if phase == "rollback":
+        preflight.side_effect = PermissionError("controller unavailable")
+    monkeypatch.setattr(grabbed_device.grab, "wait_for_active_keys_to_clear", preflight)
+
+    async def idle_event_loop(*args, **kwargs):
+        await asyncio.Event().wait()
+
+    monkeypatch.setattr(pipeline, "event_loop", idle_event_loop)
+    controller = make_grabbed_device(monkeypatch, hardware_id="2dc8:6012")
+    mouse_output = FakeUInput()
+    mouse = make_grabbed_device(
+        monkeypatch,
+        hardware_id="test:mouse",
+        device_type=DeviceType.MOUSE,
+        passthrough_uinput=mouse_output,
+        running=True,
+    )
+    if phase == "release":
+        await controller.grab()
+    operation = asyncio.create_task(
+        controller.release() if phase == "release" else controller.grab()
+    )
+    try:
+        await asyncio.wait_for(started.wait(), 3)
+        await pipeline.process_event(
+            mouse,
+            evdev.InputEvent(0, 0, evdev.ecodes.EV_REL, evdev.ecodes.REL_X, 7),
+            deps=grabbed_event_processing_deps(),
+        )
+        assert mouse_output.writes == [(evdev.ecodes.EV_REL, evdev.ecodes.REL_X, 7)]
+        assert not stalled, "controller I/O blocked mouse processing"
+        assert not operation.done()
+    finally:
+        finish.set()
+        if phase == "rollback":
+            with pytest.raises(PermissionError, match="controller unavailable"):
+                await operation
+        else:
+            await operation
+        await controller.release()
+
+
+@pytest.mark.asyncio
+async def test_cancelled_passthrough_creation_closes_worker_result(monkeypatch):
+    started = asyncio.Event()
+    finish = threading.Event()
+    loop = asyncio.get_running_loop()
+    output = MagicMock()
+
+    def create():
+        loop.call_soon_threadsafe(started.set)
+        assert finish.wait(2)
+        return output
+
+    task = asyncio.create_task(grabbed_device._create_passthrough_uinput(create))
+    try:
+        await asyncio.wait_for(started.wait(), 1)
+        task.cancel()
+        await asyncio.sleep(0)
+    finally:
+        finish.set()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    output.close.assert_called_once_with()
 
 
 @pytest.mark.asyncio

--- a/tests/keymasqd/test_input_sources.py
+++ b/tests/keymasqd/test_input_sources.py
@@ -5,6 +5,7 @@ import struct
 from collections.abc import AsyncGenerator
 from dataclasses import replace
 from pathlib import Path
+from unittest.mock import Mock
 
 import evdev
 import pytest
@@ -309,7 +310,10 @@ def test_native_adapter_does_not_open_or_grab_evdev(monkeypatch):
     device.close()
 
 
-async def test_calibration_shares_runtime_reader_and_closes_its_subscription(monkeypatch):
+@pytest.mark.parametrize("include_gamepad", [False, True])
+async def test_calibration_shares_runtime_reader_and_closes_its_subscription(
+    monkeypatch, include_gamepad
+):
     from keymasq.keymasqd.capture_manager import CaptureManager
 
     packets: asyncio.Queue[bytes] = asyncio.Queue()
@@ -332,17 +336,31 @@ async def test_calibration_shares_runtime_reader_and_closes_its_subscription(mon
     monkeypatch.setattr(
         resolver,
         "resolve_evdev_interfaces",
-        lambda *_args, **_kwargs: [
-            resolver.ResolvedInterface(
-                source.path, "keymasq-source:imu", "imu", DeviceType.MOTION, []
+        lambda *_args, **_kwargs: (
+            (
+                [
+                    resolver.ResolvedInterface(
+                        "/dev/input/event7", "keymasq:2dc8:6012", "gamepad", DeviceType.GAMEPAD, []
+                    )
+                ]
+                if include_gamepad
+                else []
             )
-        ],
+            + [
+                resolver.ResolvedInterface(
+                    source.path, "keymasq-source:imu", "imu", DeviceType.MOTION, []
+                )
+            ]
+        ),
     )
     captures = CaptureManager()
     async with shared.subscribe(source) as runtime:
         await packets.put(CAPTURED_REPORT)
         await runtime.read()
-        result = await captures.begin_native("2dc8:6012", [], [3, 4, 5])
+        gamepad = {"id": "gamepad", "path": "keymasq:2dc8:6012", "type": "gamepad"}
+        native = {"id": "imu", "path": "keymasq-source:imu", "backend": "hidraw", "anchor": gamepad}
+        interfaces = [gamepad, native] if include_gamepad else [native]
+        result = await captures.begin_native("2dc8:6012", interfaces, [3, 4, 5])
         token = result["token"]
         frames = captures.read(token)["frames"]
         assert frames[0]["values"] == {"3": 3, "4": 23, "5": 2}
@@ -355,6 +373,31 @@ async def test_calibration_shares_runtime_reader_and_closes_its_subscription(mon
         await runtime.read()
     assert closed == 1
     assert not captures._sessions
+
+
+def test_inventory_scan_reuses_bindings_and_refreshes_each_scan(monkeypatch):
+    from keymasq.keymasqd import device_manager
+
+    first, second, reconnected = binding(7), binding(8), binding(9)
+    discover = Mock(side_effect=[[first, second], [reconnected], [reconnected]])
+    monkeypatch.setattr(discovery, "discover_bindings", discover)
+    monkeypatch.setattr(device_manager, "_device_paths", lambda: [])
+    scan = device_manager._InputDeviceScan()
+    assert scan.paths() == [first.path, second.path]
+    assert scan.open(first.path).info.vendor == 0x2DC8
+    assert scan.open(second.path).info.product == 0x6012
+    assert discover.call_count == 1
+
+    other_scan = device_manager._InputDeviceScan()
+    assert other_scan.paths() == [reconnected.path]
+    assert scan.open(first.path).path == first.path
+    assert discover.call_count == 2
+
+    assert scan.paths() == [reconnected.path]
+    with pytest.raises(FileNotFoundError):
+        scan.open(first.path)
+    assert scan.open(reconnected.path).path == reconnected.path
+    assert discover.call_count == 3
 
 
 async def test_cancelled_calibration_start_releases_native_reader(monkeypatch):

--- a/tests/keymasqd/test_input_sources.py
+++ b/tests/keymasqd/test_input_sources.py
@@ -519,3 +519,79 @@ async def test_valid_sample_timeout_wakes_existing_and_new_subscribers():
         async with manager.subscribe(binding()) as late:
             with pytest.raises(OSError, match="Native input unavailable"):
                 await asyncio.wait_for(late.read(), 0.1)
+
+
+@pytest.mark.parametrize("selection", ["event", "by-id", "by-path"])
+@pytest.mark.parametrize("owner", ["native", "event", "by-id", "by-path"])
+@pytest.mark.parametrize("requested_kind", ["evdev", "mixed", "native"])
+def test_explicit_companion_claims_respect_aliases(
+    tmp_path, monkeypatch, selection, owner, requested_kind
+):
+    event = tmp_path / "event7"
+    event.touch()
+    aliases = {"event": str(event)}
+    for kind in ("by-id", "by-path"):
+        alias = tmp_path / kind / "controller"
+        alias.parent.mkdir()
+        alias.symlink_to("../event7")
+        aliases[kind] = str(alias)
+    claimed = replace(binding(7), companions=(str(event),))
+    free = replace(binding(8), companions=(str(tmp_path / "event8"),))
+    devices = [claimed, free]
+    monkeypatch.setattr(discovery, "discover_bindings", lambda: devices)
+    monkeypatch.setattr(
+        discovery,
+        "hid_parent",
+        lambda path: next(
+            item.endpoint.hid_parent
+            for item in devices
+            if str(Path(path).resolve()) in item.companions
+        ),
+    )
+    cache = resolver.DeviceCache()
+    cache._devices = {
+        item.companions[0]: resolver.CachedDeviceInfo(
+            item.companions[0],
+            "2dc8",
+            "6012",
+            "",
+            DeviceType.GAMEPAD,
+            {"ev_key_304"},
+            False,
+        )
+        for item in devices
+    }
+    deps = resolver.DevicePathResolverDeps(
+        device_paths_fn=lambda: list(cache._devices),
+        device_input_fn=lambda _path: None,
+        detect_input_classes_fn=lambda _dev: [],
+        primary_input_class_fn=lambda _types: DeviceType.GAMEPAD,
+        cache=cache,
+    )
+    anchor = {"id": "gamepad", "path": aliases[selection], "type": "gamepad"}
+    native = {
+        "id": "imu",
+        "path": "keymasq-source:imu",
+        "backend": "hidraw",
+        "driver": "8bitdo-ultimate2",
+        "anchor": anchor,
+        "companion_of": "gamepad",
+    }
+    interfaces = {"evdev": [anchor], "mixed": [anchor, native], "native": [native]}[requested_kind]
+    excluded = claimed.path if owner == "native" else aliases[owner]
+    assert (
+        resolver.resolve_evdev_interfaces(
+            interfaces,
+            deps=deps,
+            hardware_id="2dc8:6012@2",
+            excluded_paths=[excluded],
+            match_model_gamepads=True,
+        )
+        == []
+    )
+    # Removing the claim restores precisely the selected device, never the free sibling.
+    resolved = resolver.resolve_evdev_interfaces(interfaces, deps=deps, hardware_id="2dc8:6012")
+    expected = [] if requested_kind == "native" else [aliases[selection]]
+    if requested_kind != "evdev":
+        expected.append(claimed.path)
+    assert [item.path for item in resolved] == expected

--- a/tests/keymasqd/test_input_sources.py
+++ b/tests/keymasqd/test_input_sources.py
@@ -1,0 +1,425 @@
+import asyncio
+import math
+import os
+import struct
+from collections.abc import AsyncGenerator
+from dataclasses import replace
+from pathlib import Path
+
+import evdev
+import pytest
+
+from keymasq.common.model.core import DeviceType
+from keymasq.keymasqd.input_sources import discovery
+from keymasq.keymasqd.input_sources.drivers.eightbitdo_ultimate2 import Ultimate2Driver
+from keymasq.keymasqd.input_sources.evdev_adapter import (
+    NativeInputDevice,
+    frame_events,
+    motion_axes,
+)
+from keymasq.keymasqd.input_sources.manager import SourceManager, Subscription
+from keymasq.keymasqd.input_sources.types import Binding, Channel, Endpoint, InputFrame
+from keymasq.keymasqd.runtime import device_path_resolver as resolver
+
+DESCRIPTOR = bytes.fromhex(
+    "05010905a1018501050115002507463b0195017504651409398142750195048101150026ff00"
+    "09300931093209359504750881020502150026ff0009c409c5950275088102050919012918"
+    "150025017501951881020600ff0920750895178102050f0970850515002564750895049102c0"
+)
+CAPTURED_REPORT = bytes.fromhex(
+    "010f7f807f7f00000000000000006443fe04000f1003001700020000000000000000"
+)
+
+
+def binding(node: int = 7) -> Binding:
+    return Binding(
+        Ultimate2Driver(),
+        Endpoint(
+            f"/dev/hidraw{node}",
+            f"/sys/devices/usb/0003:2DC8:6012.00{node}",
+            "/sys/devices/usb",
+            3,
+            0x2DC8,
+            0x6012,
+            DESCRIPTOR,
+        ),
+        (f"/dev/input/event{node}",),
+    )
+
+
+def test_ultimate2_captured_report_and_normalization():
+    device = binding()
+    assert device.driver.matches(device.endpoint)
+    values = device.driver.decode(CAPTURED_REPORT)
+    assert values == {
+        "accel_x": -445,
+        "accel_y": 4,
+        "accel_z": 4111,
+        "gyro_x": 3,
+        "gyro_y": 23,
+        "gyro_z": 2,
+    }
+    axes = motion_axes(device)
+    assert axes["gyro_axes"][0]["role"] == "roll"
+    assert axes["gyro_axes"][0]["invert"] is True
+    assert axes["gyro_axes"][0]["scale"] == pytest.approx(math.radians(2000) / 32767)
+    assert axes["accelerometer_axes"][2]["scale"] == pytest.approx(9.80665 / 4096)
+    assert values is not None
+    events = frame_events(device, InputFrame(values, 2_000_000_000, 2_000_000_000))
+    assert len(events) == 7
+    assert {event.type for event in events} == {evdev.ecodes.EV_ABS, evdev.ecodes.EV_SYN}
+    assert events[-1].code == evdev.ecodes.SYN_REPORT
+
+
+@pytest.mark.parametrize(
+    "report",
+    [
+        b"",
+        CAPTURED_REPORT[:12],
+        CAPTURED_REPORT[:-1],
+        b"\x02" + CAPTURED_REPORT[1:],
+        CAPTURED_REPORT + b"\x00",
+    ],
+)
+def test_ultimate2_rejects_unvalidated_formats(report):
+    assert Ultimate2Driver().decode(report) is None
+
+
+def test_ultimate2_does_not_claim_other_modes_or_interfaces():
+    endpoint = binding().endpoint
+    for altered in (
+        replace(endpoint, product=0x6013),
+        replace(endpoint, bus=5),
+        replace(endpoint, vendor=0x057E, product=0x2009),
+        replace(endpoint, descriptor=b"\x06\xa0\xff"),
+    ):
+        assert not Ultimate2Driver().matches(altered)
+    report = bytearray(CAPTURED_REPORT)
+    struct.pack_into("<6h", report, 15, -32768, 32767, 0, -1, -200, 300)
+    assert list(Ultimate2Driver().decode(bytes(report)).values()) == [
+        -32768,
+        32767,
+        0,
+        -1,
+        -200,
+        300,
+    ]
+
+
+def make_sysfs(root: Path, node: int) -> Path:
+    parent = root / f"devices/usb/0003:2DC8:6012.00{node}"
+    parent.mkdir(parents=True)
+    (parent / "subsystem").symlink_to(root / "bus/hid")
+    (parent / "uevent").write_text(
+        "HID_ID=0003:00002DC8:00006012\nHID_NAME=8BitDo\nHID_PHYS=usb-test/input0\n"
+    )
+    (parent / "report_descriptor").write_bytes(DESCRIPTOR)
+    input_parent = parent / f"input/input{node}"
+    (input_parent / f"event{node}").mkdir(parents=True)
+    event = root / f"class/input/event{node}"
+    event.mkdir(parents=True)
+    (event / "device").symlink_to(input_parent)
+    raw = root / f"class/hidraw/hidraw{node}"
+    raw.mkdir(parents=True)
+    (raw / "device").symlink_to(parent)
+    return parent
+
+
+def test_discovery_pairs_hid_ancestors_not_model_or_hub(tmp_path, monkeypatch):
+    first = make_sysfs(tmp_path, 7)
+    second = make_sysfs(tmp_path, 8)
+    discovered = discovery.discover_bindings(sysfs=tmp_path)
+    assert len(discovered) == 2
+    assert {item.endpoint.hid_parent for item in discovered} == {str(first), str(second)}
+    original = discovery.hid_parent
+    monkeypatch.setattr(discovery, "hid_parent", lambda path: original(path, tmp_path))
+    assert (
+        discovery.companion_binding(
+            discovered, "8bitdo-ultimate2", "/dev/input/event8"
+        ).endpoint.path
+        == "/dev/hidraw8"
+    )
+    assert discovery.companion_binding(discovered, "8bitdo-ultimate2", "/dev/input/event9") is None
+
+
+def test_driver_can_associate_different_hid_interfaces_on_one_usb_device(tmp_path, monkeypatch):
+    raw_parent = make_sysfs(tmp_path, 7)
+    keyboard_parent = make_sysfs(tmp_path, 8)
+    (raw_parent / "input/input7/event7").rmdir()
+    (keyboard_parent / "report_descriptor").write_bytes(b"keyboard descriptor")
+    usb = raw_parent.parent
+    (usb / "subsystem").symlink_to(tmp_path / "bus/usb")
+    (usb / "idVendor").write_text("2dc8")
+    driver = Ultimate2Driver()
+    driver.association = "same_usb"
+    discovered = discovery.discover_bindings(sysfs=tmp_path, drivers=iter([driver]))
+    assert len(discovered) == 1
+    assert discovered[0].companions == ("/dev/input/event8",)
+    original = discovery.hid_parent
+    monkeypatch.setattr(discovery, "hid_parent", lambda path: original(path, tmp_path))
+    assert discovery.companion_binding(discovered, driver.id, "/dev/input/event8") is discovered[0]
+
+
+def test_resolver_keeps_two_identical_controllers_together(monkeypatch):
+    devices = [binding(8), binding(7)]
+    monkeypatch.setattr(discovery, "discover_bindings", lambda: devices)
+    monkeypatch.setattr(
+        discovery,
+        "hid_parent",
+        lambda path: next(item.endpoint.hid_parent for item in devices if path in item.companions),
+    )
+    cache = resolver.DeviceCache()
+    cache._devices = {
+        item.companions[0]: resolver.CachedDeviceInfo(
+            item.companions[0],
+            "2dc8",
+            "6012",
+            "",
+            DeviceType.GAMEPAD,
+            {"ev_key_304"},
+            False,
+        )
+        for item in devices
+    }
+    deps = resolver.DevicePathResolverDeps(
+        device_paths_fn=lambda: list(cache._devices),
+        device_input_fn=lambda _path: None,
+        detect_input_classes_fn=lambda _dev: [],
+        primary_input_class_fn=lambda _types: DeviceType.GAMEPAD,
+        cache=cache,
+    )
+    anchor = {"id": "gamepad", "path": "keymasq:2dc8:6012", "type": "gamepad"}
+    native = {
+        "id": "imu",
+        "path": "keymasq-source:imu",
+        "backend": "hidraw",
+        "driver": "8bitdo-ultimate2",
+        "anchor": anchor,
+        "companion_of": "gamepad",
+    }
+    first = resolver.resolve_evdev_interfaces(
+        [native, anchor], deps=deps, hardware_id="2dc8:6012", preferred_paths=["/dev/input/event8"]
+    )
+    assert [item.path for item in first] == ["/dev/input/event8", devices[0].path]
+    # Even when only motion is active, another hardware config cannot borrow
+    # the first controller's evdev anchor for its own native source.
+    second = resolver.resolve_evdev_interfaces(
+        [native], deps=deps, hardware_id="2dc8:6012@2", excluded_paths=[devices[0].path]
+    )
+    assert [item.path for item in second] == [devices[1].path]
+    devices.reverse()
+    again = resolver.resolve_evdev_interfaces(
+        [native], deps=deps, hardware_id="2dc8:6012", preferred_paths=[first[-1].path]
+    )
+    assert again[0].path == first[-1].path
+    native["anchor"] = {"id": "missing", "path": "keymasq:ffff:ffff"}
+    assert not resolver.resolve_evdev_interfaces([native], deps=deps, hardware_id="2dc8:6012")
+
+
+async def test_source_manager_shares_reader_and_preserves_equal_reports():
+    packets: asyncio.Queue[bytes] = asyncio.Queue()
+    opened = 0
+    closed = 0
+
+    async def reader(_path: str) -> AsyncGenerator[bytes]:
+        nonlocal opened, closed
+        opened += 1
+        try:
+            while True:
+                yield await packets.get()
+        finally:
+            closed += 1
+
+    manager = SourceManager(reader)
+    async with manager.subscribe(binding()) as runtime:
+        async with manager.subscribe(binding()) as inspector:
+            await packets.put(CAPTURED_REPORT)
+            first = await asyncio.wait_for(runtime.read(), 1)
+            assert (await inspector.read()).values == first.values
+            assert opened == 1
+        await packets.put(CAPTURED_REPORT)
+        assert (await asyncio.wait_for(runtime.read(), 1)).values == first.values
+        assert closed == 0
+    assert closed == 1
+    assert not manager._sessions
+
+
+def test_slow_subscriber_has_bounded_queue_and_discontinuity():
+    subscriber = Subscription(queue=asyncio.Queue(2))
+    for timestamp in range(3):
+        subscriber.offer(InputFrame({"gyro_x": 1}, timestamp, timestamp))
+    frame = subscriber.queue.get_nowait()
+    assert isinstance(frame, InputFrame)
+    assert frame.discontinuity and frame.sample_ns == 2
+    assert subscriber.dropped_frames == 2
+
+
+async def test_reader_failure_wakes_all_subscribers_and_reconnect_opens_fresh():
+    unplugged = asyncio.Event()
+
+    async def reader(_path: str) -> AsyncGenerator[bytes]:
+        yield CAPTURED_REPORT
+        await unplugged.wait()
+        raise OSError("unplugged")
+
+    manager = SourceManager(reader)
+    for _ in range(2):
+        unplugged.clear()
+        async with manager.subscribe(binding()) as first, manager.subscribe(binding()) as second:
+            await first.read()
+            await second.read()
+            unplugged.set()
+            with pytest.raises(OSError, match="unplugged"):
+                await first.read()
+            with pytest.raises(OSError, match="unplugged"):
+                await second.read()
+
+
+async def test_raw_only_non_motion_driver_uses_shared_manager():
+    class ExtraButtonDriver:
+        id = "test-extra-buttons"
+        label = "Extra buttons"
+        association = "same_usb"
+        channels = (Channel("rear", "button", "rear"),)
+
+        def matches(self, endpoint):
+            return endpoint.vendor == 0x1234
+
+        def decode(self, report):
+            return {"rear": report[0]} if len(report) == 1 else None
+
+    async def reader(_path: str) -> AsyncGenerator[bytes]:
+        yield b"\x01"
+        await asyncio.Event().wait()
+
+    native = Binding(ExtraButtonDriver(), replace(binding().endpoint, vendor=0x1234))
+    async with SourceManager(reader).subscribe(native) as subscriber:
+        assert (await subscriber.read()).values == {"rear": 1}
+    assert native.companions == ()
+
+
+def test_native_adapter_does_not_open_or_grab_evdev(monkeypatch):
+    monkeypatch.setattr(
+        "keymasq.keymasqd.input_sources.evdev_adapter.binding_for_path", lambda _path: binding()
+    )
+    device = NativeInputDevice(binding().path)
+    assert device.input_props() == [evdev.ecodes.INPUT_PROP_ACCELEROMETER]
+    assert evdev.ecodes.EV_KEY not in device.capabilities()
+    assert evdev.ecodes.EV_ABS in device.capabilities(absinfo=True)
+    device.close()
+
+
+async def test_calibration_shares_runtime_reader_and_closes_its_subscription(monkeypatch):
+    from keymasq.keymasqd.capture_manager import CaptureManager
+
+    packets: asyncio.Queue[bytes] = asyncio.Queue()
+    opens = 0
+    closed = 0
+
+    async def reader(_path: str) -> AsyncGenerator[bytes]:
+        nonlocal opens, closed
+        opens += 1
+        try:
+            while True:
+                yield await packets.get()
+        finally:
+            closed += 1
+
+    shared = SourceManager(reader)
+    source = binding()
+    monkeypatch.setattr(discovery, "binding_for_path", lambda _path: source)
+    monkeypatch.setattr("keymasq.keymasqd.input_sources.manager.source_manager", lambda: shared)
+    monkeypatch.setattr(
+        resolver,
+        "resolve_evdev_interfaces",
+        lambda *_args, **_kwargs: [
+            resolver.ResolvedInterface(
+                source.path, "keymasq-source:imu", "imu", DeviceType.MOTION, []
+            )
+        ],
+    )
+    captures = CaptureManager()
+    async with shared.subscribe(source) as runtime:
+        await packets.put(CAPTURED_REPORT)
+        await runtime.read()
+        result = await captures.begin_native("2dc8:6012", [], [3, 4, 5])
+        token = result["token"]
+        frames = captures.read(token)["frames"]
+        assert frames[0]["values"] == {"3": 3, "4": 23, "5": 2}
+        assert frames[0]["source"] == "imu"
+        assert opens == 1
+        await captures.stop_native(token)
+        captures.end(token)
+        assert closed == 0
+        await packets.put(CAPTURED_REPORT)
+        await runtime.read()
+    assert closed == 1
+    assert not captures._sessions
+
+
+async def test_cancelled_calibration_start_releases_native_reader(monkeypatch):
+    from keymasq.keymasqd.capture_manager import CaptureManager
+
+    opened = asyncio.Event()
+    closed = asyncio.Event()
+
+    async def reader(_path: str) -> AsyncGenerator[bytes]:
+        opened.set()
+        try:
+            await asyncio.Event().wait()
+            yield CAPTURED_REPORT
+        finally:
+            closed.set()
+
+    shared = SourceManager(reader)
+    source = binding()
+    monkeypatch.setattr(discovery, "binding_for_path", lambda _path: source)
+    monkeypatch.setattr("keymasq.keymasqd.input_sources.manager.source_manager", lambda: shared)
+    monkeypatch.setattr(
+        resolver,
+        "resolve_evdev_interfaces",
+        lambda *_args, **_kwargs: [
+            resolver.ResolvedInterface(
+                source.path, "keymasq-source:imu", "imu", DeviceType.MOTION, []
+            )
+        ],
+    )
+    captures = CaptureManager()
+    starting = asyncio.create_task(captures.begin_native("2dc8:6012", [], [3]))
+    await asyncio.wait_for(opened.wait(), 1)
+    starting.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await starting
+    assert closed.is_set()
+    assert not captures._sessions
+    assert not shared._sessions
+
+
+async def test_hidraw_transport_uses_readiness_and_closes_fd(monkeypatch):
+    from keymasq.keymasqd.input_sources.transports import hidraw
+
+    read_fd, write_fd = os.pipe2(os.O_NONBLOCK | os.O_CLOEXEC)
+    monkeypatch.setattr(hidraw, "_open", lambda _path, _parent: read_fd)
+    stream = hidraw.reports("test")
+    try:
+        pending = asyncio.create_task(anext(stream))
+        await asyncio.sleep(0.01)
+        assert not pending.done()
+        os.write(write_fd, CAPTURED_REPORT)
+        assert await asyncio.wait_for(pending, 1) == CAPTURED_REPORT
+        await stream.aclose()
+        with pytest.raises(OSError):
+            os.fstat(read_fd)
+    finally:
+        os.close(write_fd)
+
+
+def test_transport_rejects_recycled_hidraw_number_before_open(monkeypatch):
+    from keymasq.keymasqd.input_sources.transports import hidraw
+
+    def unexpected_open(*_args):
+        pytest.fail("Stale connection must not be opened")
+
+    monkeypatch.setattr(hidraw.os, "open", unexpected_open)
+    with pytest.raises(OSError, match="connection changed"):
+        hidraw._open("/dev/hidraw999999", "/sys/devices/old-connection")

--- a/tests/keymasqd/test_input_sources.py
+++ b/tests/keymasqd/test_input_sources.py
@@ -175,7 +175,7 @@ def test_resolver_keeps_two_identical_controllers_together(monkeypatch):
             item.companions[0],
             "2dc8",
             "6012",
-            "",
+            item.companions[0],
             DeviceType.GAMEPAD,
             {"ev_key_304"},
             False,
@@ -208,11 +208,39 @@ def test_resolver_keeps_two_identical_controllers_together(monkeypatch):
         [native], deps=deps, hardware_id="2dc8:6012@2", excluded_paths=[devices[0].path]
     )
     assert [item.path for item in second] == [devices[1].path]
+    for requested in ([anchor], [anchor, native]):
+        second = resolver.resolve_evdev_interfaces(
+            requested,
+            deps=deps,
+            hardware_id="2dc8:6012@2",
+            excluded_paths=[devices[1].path],
+            match_model_gamepads=True,
+        )
+        expected = ["/dev/input/event8"]
+        if native in requested:
+            expected.append(devices[0].path)
+        assert [item.path for item in second] == expected
+    mixed = resolver.resolve_evdev_interfaces(
+        [anchor, native],
+        deps=deps,
+        hardware_id="2dc8:6012",
+        preferred_paths=[devices[0].path],
+        match_model_gamepads=True,
+    )
+    assert [item.path for item in mixed] == ["/dev/input/event8", devices[0].path]
     devices.reverse()
     again = resolver.resolve_evdev_interfaces(
         [native], deps=deps, hardware_id="2dc8:6012", preferred_paths=[first[-1].path]
     )
     assert again[0].path == first[-1].path
+    # Calibration respects the same physical selector as ordinary evdev capture.
+    anchor["phys"] = "/dev/input/event8"
+    capture = resolver.resolve_evdev_interfaces(
+        [native],
+        deps=deps,
+        hardware_id="2dc8:6012",
+    )
+    assert [item.path for item in capture] == [first[-1].path]
     native["anchor"] = {"id": "missing", "path": "keymasq:ffff:ffff"}
     assert not resolver.resolve_evdev_interfaces([native], deps=deps, hardware_id="2dc8:6012")
 
@@ -466,3 +494,28 @@ def test_transport_rejects_recycled_hidraw_number_before_open(monkeypatch):
     monkeypatch.setattr(hidraw.os, "open", unexpected_open)
     with pytest.raises(OSError, match="connection changed"):
         hidraw._open("/dev/hidraw999999", "/sys/devices/old-connection")
+
+
+async def test_valid_sample_timeout_wakes_existing_and_new_subscribers():
+    closed = asyncio.Event()
+
+    async def reader(_path: str) -> AsyncGenerator[bytes]:
+        try:
+            yield CAPTURED_REPORT
+            while True:
+                await asyncio.sleep(0.005)
+                yield CAPTURED_REPORT[:12]
+        finally:
+            closed.set()
+
+    manager = SourceManager(reader)
+    async with manager.subscribe(binding()) as first, manager.subscribe(binding()) as second:
+        await first.read()
+        await second.read()
+        for subscriber in (first, second):
+            with pytest.raises(OSError, match="Native input unavailable"):
+                await asyncio.wait_for(subscriber.read(), 1.5)
+        assert closed.is_set()
+        async with manager.subscribe(binding()) as late:
+            with pytest.raises(OSError, match="Native input unavailable"):
+                await asyncio.wait_for(late.read(), 0.1)

--- a/tests/keymasqd/test_motion_controls.py
+++ b/tests/keymasqd/test_motion_controls.py
@@ -1,5 +1,6 @@
 import logging
 import math
+import struct
 import tomllib
 from types import SimpleNamespace
 
@@ -38,6 +39,53 @@ from keymasq.session.manager.profile import grab_plan
 from keymasq.session.motion_controls import MotionControlManager
 from keymasq.session.profile.codec import ProfileCodec
 from keymasq.session.profile.types import ResolvedDeviceProfile
+
+
+@pytest.mark.asyncio
+async def test_native_reports_use_existing_bias_and_smoothing_pipeline():
+    from keymasq.keymasqd.input_sources.drivers.eightbitdo_ultimate2 import Ultimate2Driver
+    from keymasq.keymasqd.input_sources.evdev_adapter import frame_events, motion_axes
+    from keymasq.keymasqd.input_sources.types import Binding, Endpoint, InputFrame
+    from keymasq.keymasqd.runtime.grabbed_device.device import GrabbedDevice
+
+    binding = Binding(Ultimate2Driver(), Endpoint("raw", "hid", "usb", 3, 0x2DC8, 0x6012, b""))
+    displacements = []
+    for smoothing, bias in ((0.0, 0.0), (0.8, 0.0), (0.0, 16384.0)):
+        runtime = _Runtime()
+        runtime.interface_id = "imu"
+        axes = motion_axes(binding)
+        axes["gyro_axes"][2]["offset"] = bias
+        GrabbedDevice.update_motion_sensors(runtime, {"motion_1": {"source": "imu", **axes}})
+        mapping = {
+            "motion_1": MappingAction(
+                action_type=ActionType.MOTION_CONTROL,
+                motion_control_config=MotionControlConfig(
+                    name="Native aim", mouse=MotionMouseConfig(smoothing=smoothing, deadzone_dps=0)
+                ),
+            )
+        }
+        for index in range(11):
+            packet = bytearray(34)
+            packet[0] = 1
+            yaw = 0 if index == 0 and bias == 0 else 16384
+            struct.pack_into("<6h", packet, 15, 0, 0, 4096, 0, 0, yaw)
+            values = binding.driver.decode(bytes(packet))
+            assert values is not None
+            timestamp = 1_000_000_000 + index * 10_000_000
+            for event in frame_events(binding, InputFrame(values, timestamp, timestamp)):
+                await dispatch_motion_event(
+                    runtime, event, mapping, deps=build_action_execution_deps()
+                )
+        displacements.append(
+            sum(
+                value
+                for kind, code, value in runtime.mouse_uinput.events
+                if kind == evdev.ecodes.EV_REL and code == evdev.ecodes.REL_X
+            )
+        )
+    assert abs(displacements[0]) >= 799
+    assert 0 < abs(displacements[1]) < abs(displacements[0])
+    assert displacements[2] == 0
 
 
 class _Writer:

--- a/tests/session/test_session_manager_profile_apply.py
+++ b/tests/session/test_session_manager_profile_apply.py
@@ -30,6 +30,43 @@ from keymasq.session.profile.types import (
 
 
 @pytest.mark.asyncio
+async def test_disabling_last_native_source_releases_active_motion_immediately(monkeypatch):
+    from keymasq.common.model.core import DeviceType
+    from keymasq.common.model.hardware import EvdevDevice, HardwareConfig, NativeInputSource
+    from keymasq.common.model.motion import MotionControlConfig, MotionSensorDefinition
+
+    hardware = HardwareConfig(
+        "2dc8",
+        "6012",
+        "Ultimate 2",
+        [EvdevDevice("keymasq:2dc8:6012", DeviceType.GAMEPAD, "gamepad")],
+        [],
+        motion_sensors=[MotionSensorDefinition("motion_1", "Motion", "imu")],
+        input_sources=[NativeInputSource("imu", "8bitdo-ultimate2", "gamepad", enabled=False)],
+    )
+    manager = SessionManager()
+    monkeypatch.setattr(manager.hardware, "get_hardware", lambda _id: hardware)
+    manager.profile_state.grabbed_devices.add(hardware.hardware_id)
+    manager.profile_state.grabbed_interfaces[hardware.hardware_id] = {"imu": "keymasq-source:imu"}
+    manager.client.send_command = AsyncMock(return_value=Response(status="ok", data={}))
+    resolved = ResolvedDeviceProfile(
+        hardware_id=hardware.hardware_id,
+        active_profile_names=["Aim"],
+        mappings={
+            "motion_1": MappingAction(
+                action_type=ActionType.MOTION_CONTROL,
+                motion_control_config=MotionControlConfig(name="Aim", mode="gamepad"),
+            )
+        },
+    )
+    await coordinator.apply_resolved_device_profile(manager, hardware.hardware_id, resolved)
+    command = manager.client.send_command.await_args.args[0]
+    assert command.command == CommandType.RELEASE_DEVICE
+    assert command.data["immediate"] is True
+    assert hardware.hardware_id not in manager.profile_state.grabbed_devices
+
+
+@pytest.mark.asyncio
 async def test_reevaluate_profiles_skips_unchanged_mapping_and_combos() -> None:
     manager = SessionManager()
     hardware_id = "1234:5678"

--- a/udev/91-keymasq-acl.rules
+++ b/udev/91-keymasq-acl.rules
@@ -6,3 +6,7 @@ ACTION=="add|change", KERNEL=="uinput", GROUP="input", MODE="0660", RUN+="/usr/b
 
 # input event devices across all drivers (including vendor-managed groups)
 ACTION=="add|change", SUBSYSTEM=="input", KERNEL=="event*", RUN+="/usr/bin/setfacl -m u:keymasq:rw /dev/input/%k"
+
+# Native input drivers: transport access is generic; the driver registry
+# decides which endpoints to open. Preserve existing ownership and user ACLs.
+ACTION=="add|change", SUBSYSTEM=="hidraw", KERNEL=="hidraw*", RUN+="/usr/bin/setfacl -m u:keymasq:r /dev/%k"


### PR DESCRIPTION
## Summary

Add a modular native input-source layer so bundled hidraw drivers can supplement evdev. The first driver supplies gyro and acceleration from the 8BitDo Ultimate 2 Wireless in DInput mode while its buttons, sticks, and extra buttons continue through evdev.

Drivers own device matching and report decoding. Shared discovery associates the source with its physical controller, and a shared asynchronous reader feeds runtime and calibration through the existing motion processing. Hardware setup can discover, attach, and enable native sources. Controller ownership and preferences carry across motion-only and mixed profiles. A one-second timeout without valid samples wakes consumers with an error.

Keep native source addresses distinct from evdev paths and move passthrough device creation and cleanup off the input event loop so failed controller acquisition does not stall mouse movement. All packaging surfaces grant the daemon generic read-only hidraw ACLs and apply them to already-connected devices.

## Validation

- `./scripts/check.sh full` passed: Ruff, BasedPyright, stylesheet checks, and 3,381 tests.
- `./scripts/check.sh` passed after the review fixes: Ruff, BasedPyright, and 1,283 daemon tests.
- Tests cover report parsing, controller association, reader sharing and cancellation, motion routing, configuration persistence, packaging permissions, and mouse processing during delayed controller setup and rollback.
- Live Ultimate 2 testing confirmed gyro operation with no perceptible difference from Nintendo mode.
- Udev rule validation, shell syntax checks, and Nix expression parsing passed.
