### PR TITLE
Add GitHub-only nightly development builds at 12:17 Berlin time

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,60 @@
+name: Nightly
+
+on:
+  schedule:
+    - cron: "0 12 * * *"
+      timezone: Europe/Berlin
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - .github/workflows/nightly.yml
+      - .github/workflows/package.yml
+      - scripts/nightly-metadata.py
+      - tests/common/test_nightly_metadata.py
+
+concurrency:
+  group: nightly-${{ github.event_name == 'pull_request' && github.ref || 'publish' }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  prepare:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    outputs:
+      build: ${{ steps.meta.outputs.build }}
+      sha: ${{ steps.meta.outputs.sha }}
+      version: ${{ steps.meta.outputs.version }}
+      tag: ${{ steps.meta.outputs.tag }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Compare master with the last published nightly
+        id: meta
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          VALIDATE_ONLY: ${{ github.event_name == 'pull_request' }}
+        run: |
+          set -euo pipefail
+          sha="$(gh api "repos/$GH_REPO/commits/master" --jq .sha)"
+          gh api --paginate --slurp "repos/$GH_REPO/releases?per_page=100" > "$RUNNER_TEMP/releases.json"
+          python3 scripts/nightly-metadata.py "$sha" "$RUNNER_TEMP/releases.json" >> "$GITHUB_OUTPUT"
+
+  package:
+    needs: prepare
+    if: needs.prepare.outputs.build == 'true'
+    permissions:
+      contents: write
+      attestations: write
+      id-token: write
+      packages: read
+    uses: ./.github/workflows/package.yml
+    with:
+      ref: ${{ needs.prepare.outputs.sha }}
+      prerelease_version: ${{ needs.prepare.outputs.version }}
+      prerelease_tag: ${{ needs.prepare.outputs.tag }}
+      publish: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -2,7 +2,7 @@ name: Nightly
 
 on:
   schedule:
-    - cron: "0 12 * * *"
+    - cron: "17 12 * * *"
       timezone: Europe/Berlin
   workflow_dispatch:
   pull_request:

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -34,8 +34,27 @@ on:
       - "tests/**"
       - "tmpfiles.d/**"
       - "udev/**"
+  workflow_call:
+    inputs:
+      ref:
+        required: true
+        type: string
+      prerelease_tag:
+        required: true
+        type: string
+      prerelease_version:
+        required: true
+        type: string
+      publish:
+        description: Publish the tested artifacts to GitHub
+        type: boolean
+        default: true
   workflow_dispatch:
     inputs:
+      publish:
+        description: Publish the tested artifacts to GitHub
+        type: boolean
+        default: true
       ref:
         description: Git ref to build the prerelease from
         required: true
@@ -58,7 +77,7 @@ permissions:
   contents: read
 
 env:
-  KEYMASQ_CHECKOUT_REF: ${{ github.event_name == 'workflow_dispatch' && inputs.ref || github.ref }}
+  KEYMASQ_CHECKOUT_REF: ${{ inputs.ref || github.ref }}
 
 jobs:
   version-metadata:
@@ -107,13 +126,13 @@ jobs:
           release_tag=""
           release_name=""
 
-          if [[ "$GITHUB_EVENT_NAME" == "workflow_dispatch" ]]; then
+          if [[ -n "$PRERELEASE_VERSION" ]]; then
             if [[ -z "$PRERELEASE_TAG" || -z "$PRERELEASE_VERSION" ]]; then
               echo "workflow_dispatch requires prerelease_tag and prerelease_version" >&2
               exit 1
             fi
-            if [[ "$PRERELEASE_TAG" != v* ]]; then
-              echo "prerelease_tag must start with 'v'" >&2
+            if [[ "$PRERELEASE_TAG" != v* && "$PRERELEASE_TAG" != nightly-* ]]; then
+              echo "prerelease_tag must start with 'v' or 'nightly-'" >&2
               exit 1
             fi
 
@@ -135,8 +154,8 @@ jobs:
           PY
             )"
             rpm_version="$debian_version"
-            pkgver="$PRERELEASE_VERSION"
-            source_version="$PRERELEASE_VERSION"
+            pkgver="${PRERELEASE_VERSION/.dev/dev}"
+            source_version="$pkgver"
             release_tag="$PRERELEASE_TAG"
             release_name="Keymasq prerelease ${PRERELEASE_TAG#v}"
             is_manual_prerelease=true
@@ -179,7 +198,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ needs.version-metadata.outputs.checkout_ref }}
+          ref: ${{ needs.version-metadata.outputs.checkout_sha }}
           persist-credentials: false
 
       - name: Apply prerelease Python version
@@ -215,7 +234,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ needs.version-metadata.outputs.checkout_ref }}
+          ref: ${{ needs.version-metadata.outputs.checkout_sha }}
           persist-credentials: false
 
       - name: Download source tarball
@@ -264,7 +283,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ needs.version-metadata.outputs.checkout_ref }}
+          ref: ${{ needs.version-metadata.outputs.checkout_sha }}
           persist-credentials: false
 
       - name: Download Arch package
@@ -298,7 +317,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ needs.version-metadata.outputs.checkout_ref }}
+          ref: ${{ needs.version-metadata.outputs.checkout_sha }}
           persist-credentials: false
 
       - name: Apply prerelease Python version
@@ -340,7 +359,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ needs.version-metadata.outputs.checkout_ref }}
+          ref: ${{ needs.version-metadata.outputs.checkout_sha }}
           persist-credentials: false
 
       - name: Apply prerelease Debian build metadata
@@ -396,7 +415,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ needs.version-metadata.outputs.checkout_ref }}
+          ref: ${{ needs.version-metadata.outputs.checkout_sha }}
           persist-credentials: false
 
       - name: Download Debian artifacts
@@ -431,7 +450,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ needs.version-metadata.outputs.checkout_ref }}
+          ref: ${{ needs.version-metadata.outputs.checkout_sha }}
           persist-credentials: false
 
       - name: Apply prerelease RPM build metadata
@@ -491,7 +510,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ needs.version-metadata.outputs.checkout_ref }}
+          ref: ${{ needs.version-metadata.outputs.checkout_sha }}
           persist-credentials: false
 
       - name: Apply prerelease RPM build metadata
@@ -562,7 +581,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ needs.version-metadata.outputs.checkout_ref }}
+          ref: ${{ needs.version-metadata.outputs.checkout_sha }}
           persist-credentials: false
 
       - name: Install RPM signing tools
@@ -655,7 +674,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ needs.version-metadata.outputs.checkout_ref }}
+          ref: ${{ needs.version-metadata.outputs.checkout_sha }}
           persist-credentials: false
 
       - name: Test RPM
@@ -759,6 +778,7 @@ jobs:
         always() &&
         !cancelled() &&
         github.actor != 'nektos/act' &&
+        inputs.publish != false &&
         needs.version-metadata.outputs.is_manual_prerelease == 'true' &&
         needs.build-source-tarball.result == 'success' &&
         needs.build-pacman-arch.result == 'success' &&
@@ -781,6 +801,12 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: source-tarball
+          path: dist/
+
+      - name: Download Arch package
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: pacman-arch-package
           path: dist/
 
       - name: Download Debian artifacts
@@ -811,7 +837,7 @@ jobs:
       - name: Generate prerelease checksums
         run: |
           cd dist
-          sha256sum ./*.AppImage ./*.deb ./*.rpm ./*.tar.gz > SHA256SUMS
+          sha256sum ./*.AppImage ./*.deb ./*.rpm ./*.tar.gz ./*.pkg.tar.* > SHA256SUMS
 
       - name: Generate prerelease artifact attestations
         if: ${{ github.event.repository.private == false }}
@@ -822,6 +848,7 @@ jobs:
             dist/*.deb
             dist/*.rpm
             dist/*.tar.gz
+            dist/*.pkg.tar.*
             dist/SHA256SUMS
 
       - name: Create GitHub prerelease
@@ -831,10 +858,16 @@ jobs:
           target_commitish: ${{ needs.version-metadata.outputs.checkout_sha }}
           name: ${{ needs.version-metadata.outputs.release_name }}
           prerelease: true
+          draft: ${{ startsWith(needs.version-metadata.outputs.release_tag, 'nightly-') }}
           make_latest: false
           generate_release_notes: false
           body: |
-            Manual prerelease build from `${{ needs.version-metadata.outputs.checkout_ref }}`.
+            Development prerelease build from `${{ needs.version-metadata.outputs.checkout_ref }}`.
+
+            Install these files manually. This build is not published to AUR, COPR,
+            package repositories, or the stable AppImage updater.
+
+            Documentation: https://keymasq.tools/docs/${{ contains(needs.version-metadata.outputs.python_version, 'dev') && 'master' || format('v{0}', needs.version-metadata.outputs.python_version) }}/
 
             Commit: https://github.com/${{ github.repository }}/commit/${{ needs.version-metadata.outputs.checkout_sha }}
             Workflow run: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
@@ -845,7 +878,16 @@ jobs:
             dist/*.buildinfo
             dist/*.rpm
             dist/*.tar.gz
+            dist/*.pkg.tar.*
             dist/SHA256SUMS
+
+      - name: Publish complete nightly
+        if: startsWith(needs.version-metadata.outputs.release_tag, 'nightly-')
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          RELEASE_TAG: ${{ needs.version-metadata.outputs.release_tag }}
+        run: gh release edit "$RELEASE_TAG" --draft=false --latest=false
 
   publish-repos:
     needs:
@@ -865,7 +907,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ needs.version-metadata.outputs.checkout_ref }}
+          ref: ${{ needs.version-metadata.outputs.checkout_sha }}
           persist-credentials: false
 
       - name: Install repo tools
@@ -919,7 +961,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ needs.version-metadata.outputs.checkout_ref }}
+          ref: ${{ needs.version-metadata.outputs.checkout_sha }}
           persist-credentials: false
 
       - name: Download source tarball
@@ -974,7 +1016,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ needs.version-metadata.outputs.checkout_ref }}
+          ref: ${{ needs.version-metadata.outputs.checkout_sha }}
           persist-credentials: false
 
       - name: Download source tarball

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -867,7 +867,7 @@ jobs:
             Install these files manually. This build is not published to AUR, COPR,
             package repositories, or the stable AppImage updater.
 
-            Documentation: https://keymasq.tools/docs/${{ contains(needs.version-metadata.outputs.python_version, 'dev') && 'master' || format('v{0}', needs.version-metadata.outputs.python_version) }}/
+            Documentation: https://keymasq.tools/docs/master/
 
             Commit: https://github.com/${{ github.repository }}/commit/${{ needs.version-metadata.outputs.checkout_sha }}
             Workflow run: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/docs/DEPENDENCIES.md
+++ b/docs/DEPENDENCIES.md
@@ -200,10 +200,12 @@ Defined in `pyproject.toml` under `[project.optional-dependencies]`:
 - `speedups`
   - `uvloop`
 - `test`
+  - `packaging>=24.0`
   - `pytest>=8.0.0`
   - `pytest-asyncio>=0.23.0`
   - `pytest-cov>=5.0.0`
 - `dev`
+  - `packaging>=24.0`
   - `basedpyright>=1.38.2`
   - `pytest>=8.0.0`
   - `pytest-asyncio>=0.23.0`

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -470,7 +470,7 @@ grep 'keymasq_.*_all.deb' SHA256SUMS
 
 For manual testing, download a `nightly-*` prerelease from
 [GitHub Releases](https://github.com/nyrda/keymasq/releases). Builds are scheduled
-for noon Europe/Berlin when master has changed since the last published nightly.
+for 12:17 Europe/Berlin when master has changed since the last published nightly.
 Use the manual installation instructions above for your package format.
 
 Nightlies may contain unfinished changes. They are not distributed through AUR,

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -473,8 +473,12 @@ For manual testing, download a `nightly-*` prerelease from
 for noon Europe/Berlin when master has changed since the last published nightly.
 Use the manual installation instructions above for your package format.
 
-Nightlies replace your installed Keymasq and may contain unfinished changes.
-They are not distributed through AUR, COPR, package repositories, or the stable
-AppImage updater. Returning to an older stable release requires an explicit
-package downgrade. Nightly documentation follows
-[master](https://keymasq.tools/docs/master/).
+Nightlies may contain unfinished changes. They are not distributed through AUR,
+COPR, package repositories, or the stable AppImage updater. Nightly documentation
+follows [master](https://keymasq.tools/docs/master/).
+
+Native packages replace your installed package. To return to an older stable
+release, explicitly downgrade with your package manager. Installing a nightly
+AppImage replaces the installed AppImage; return to the stable updater's release
+with `keymasq --self-update --allow-downgrade`. If you installed from a source
+archive, rebuild or reinstall from the desired stable source archive.

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -465,3 +465,16 @@ Or verify a single artifact:
 sha256sum keymasq_*_all.deb
 grep 'keymasq_.*_all.deb' SHA256SUMS
 ```
+
+## Nightly development builds
+
+For manual testing, download a `nightly-*` prerelease from
+[GitHub Releases](https://github.com/nyrda/keymasq/releases). Builds are scheduled
+for noon Europe/Berlin when master has changed since the last published nightly.
+Use the manual installation instructions above for your package format.
+
+Nightlies replace your installed Keymasq and may contain unfinished changes.
+They are not distributed through AUR, COPR, package repositories, or the stable
+AppImage updater. Returning to an older stable release requires an explicit
+package downgrade. Nightly documentation follows
+[master](https://keymasq.tools/docs/master/).

--- a/docs/PACKAGING.md
+++ b/docs/PACKAGING.md
@@ -63,7 +63,7 @@ The repository uses three packaging channels:
   artifacts to a GitHub prerelease, and do not publish to AUR or external
   repositories.
 
-- Nightlies run through the `Nightly` workflow at 12:00 Europe/Berlin daily,
+- Nightlies run through the `Nightly` workflow at 12:17 Europe/Berlin daily,
   including daylight-saving changes. GitHub may delay scheduled runs. A manual
   dispatch uses the same change detection. A build runs only when master's SHA
   differs from the last successfully published nightly. Failed builds and draft

--- a/docs/PACKAGING.md
+++ b/docs/PACKAGING.md
@@ -53,7 +53,7 @@ Drivers that send device commands need an explicit write-access policy.
 
 ## Release channels
 
-The repository uses two packaging channels:
+The repository uses three packaging channels:
 
 - Stable releases are created from stable `v*` tags. These are the only runs
   that sign RPMs, publish GitHub release artifacts as the official release, and
@@ -63,7 +63,40 @@ The repository uses two packaging channels:
   artifacts to a GitHub prerelease, and do not publish to AUR or external
   repositories.
 
+- Nightlies run through the `Nightly` workflow at 12:00 Europe/Berlin daily,
+  including daylight-saving changes. GitHub may delay scheduled runs. A manual
+  dispatch uses the same change detection. A build runs only when master's SHA
+  differs from the last successfully published nightly. Failed builds and draft
+  releases do not advance that marker, so a later run retries pending changes.
+
+### Nightly builds
+
+The nightly workflow snapshots master's full commit SHA and calls the shared
+`Package` workflow. All package builds and installation checks use that same
+commit. Pull requests affecting the nightly setup run the same builds against
+master without publishing, so workflow changes can be verified before merging.
+
+Nightlies appear only as GitHub prereleases with tags such as
+`nightly-20260909100000`. Downloads include the AppImage, Debian, Arch, Fedora,
+openSUSE, source archive, checksums, and artifact attestations. RPMs are unsigned.
+The release stays a draft until all files have uploaded. Nightlies never update
+AUR, COPR, the project package repositories, the stable AppImage update manifest,
+or GitHub's latest stable release.
+
+Versions use the next patch after the highest published stable version, with a
+UTC build timestamp. For stable `0.19.0`, a nightly uses
+`0.19.1.dev20260909100000` in Python and the AppImage,
+`0.19.1~dev20260909100000` in Debian/RPM, and
+`0.19.1dev20260909100000` in Arch. Each format sorts after `0.19.0` and before
+`0.19.1`. Version rewrites happen only in the build checkout.
+
+Development versions link to <https://keymasq.tools/docs/master/> in the app
+and release notes. These docs follow current master, including when reading
+from an older nightly. Installing a nightly replaces the installed Keymasq;
+returning to the previous stable version requires an explicit downgrade.
+
 ## Release checklist
+
 
 Before tagging a stable `v*` release, run the manual VM gates from
 [VM_TESTING.md](VM_TESTING.md) in full, regardless of what changed since the

--- a/docs/PACKAGING.md
+++ b/docs/PACKAGING.md
@@ -78,7 +78,9 @@ master without publishing, so workflow changes can be verified before merging.
 
 Nightlies appear only as GitHub prereleases with tags such as
 `nightly-20260909100000`. Downloads include the AppImage, Debian, Arch, Fedora,
-openSUSE, source archive, checksums, and artifact attestations. RPMs are unsigned.
+openSUSE, source archive, and checksums. RPMs are unsigned. GitHub records build
+attestations separately; see [Build attestations](SECURITY.md#build-attestations)
+for `gh attestation verify` instructions.
 The release stays a draft until all files have uploaded. Nightlies never update
 AUR, COPR, the project package repositories, the stable AppImage update manifest,
 or GitHub's latest stable release.
@@ -92,11 +94,13 @@ UTC build timestamp. For stable `0.19.0`, a nightly uses
 
 Development versions link to <https://keymasq.tools/docs/master/> in the app
 and release notes. These docs follow current master, including when reading
-from an older nightly. Installing a nightly replaces the installed Keymasq;
-returning to the previous stable version requires an explicit downgrade.
+from an older nightly. Native packages replace the installed package; returning
+to an older stable release requires a package-manager downgrade. Installing the
+nightly AppImage replaces the installed AppImage; use
+`keymasq --self-update --allow-downgrade` to return to the stable updater's
+release. Source-archive users must rebuild or reinstall the desired stable source.
 
 ## Release checklist
-
 
 Before tagging a stable `v*` release, run the manual VM gates from
 [VM_TESTING.md](VM_TESTING.md) in full, regardless of what changed since the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,11 +52,13 @@ speedups = [
     "uvloop",
 ]
 test = [
+    "packaging>=24.0",
     "pytest>=8.0.0",
     "pytest-asyncio>=0.23.0",
     "pytest-cov>=5.0.0",
 ]
 dev = [
+    "packaging>=24.0",
     "basedpyright>=1.38.2",
     "pytest>=8.0.0",
     "pytest-asyncio>=0.23.0",

--- a/scripts/nightly-metadata.py
+++ b/scripts/nightly-metadata.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Select an immutable master snapshot and a version for GitHub nightlies."""
+
+import json
+import os
+import re
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+
+
+def nightly_metadata(
+    sha: str,
+    releases: list[dict[str, object]],
+    now: datetime,
+    *,
+    validate_only: bool = False,
+) -> dict[str, str]:
+    if re.fullmatch(r"[0-9a-f]{40}", sha) is None:
+        raise ValueError("master must resolve to a full commit SHA")
+    published = [release for release in releases if not release.get("draft")]
+    nightlies = [
+        release
+        for release in published
+        if release.get("prerelease") and str(release["tag_name"]).startswith("nightly-")
+    ]
+    latest = max(nightlies, key=lambda r: str(r["published_at"]), default=None)
+    if not validate_only and latest and latest["target_commitish"] == sha:
+        return {"build": "false", "sha": sha}
+
+    stable_versions = []
+    for release in published:
+        if release.get("prerelease"):
+            continue
+        match = re.fullmatch(r"v(\d+)\.(\d+)\.(\d+)", str(release["tag_name"]))
+        if match:
+            stable_versions.append(tuple(int(part) for part in match.groups()))
+    if not stable_versions:
+        raise ValueError("a published stable vMAJOR.MINOR.PATCH release is required")
+    major, minor, patch = max(stable_versions)
+    stamp = now.astimezone(UTC).strftime("%Y%m%d%H%M%S")
+    return {
+        "build": "true",
+        "sha": sha,
+        "version": f"{major}.{minor}.{patch + 1}.dev{stamp}",
+        "tag": f"nightly-{stamp}",
+    }
+
+
+def main() -> None:
+    sha, releases_path = sys.argv[1:]
+    pages = json.loads(Path(releases_path).read_text(encoding="utf-8"))
+    metadata = nightly_metadata(
+        sha,
+        [release for page in pages for release in page],
+        datetime.now(UTC),
+        validate_only=os.environ.get("VALIDATE_ONLY") == "true",
+    )
+    for key, value in metadata.items():
+        print(f"{key}={value}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/common/test_nightly_metadata.py
+++ b/tests/common/test_nightly_metadata.py
@@ -1,0 +1,82 @@
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+from packaging.version import Version
+
+from tests.script_loader import load_script
+
+SCRIPT = Path(__file__).resolve().parents[2] / "scripts/nightly-metadata.py"
+SHA = "a" * 40
+NOW = datetime(2026, 9, 9, 10, tzinfo=UTC)
+
+
+def release(tag: str, **overrides: object) -> dict[str, object]:
+    return {
+        "tag_name": tag,
+        "draft": False,
+        "prerelease": tag.startswith("nightly-"),
+        "published_at": "2026-09-08T10:00:00Z",
+        "target_commitish": "b" * 40,
+        **overrides,
+    }
+
+
+def metadata(releases: list[dict[str, object]], **kwargs: object):
+    script = load_script(SCRIPT, "nightly_metadata_test")
+    return script.nightly_metadata(SHA, releases, NOW, **kwargs)
+
+
+def test_first_nightly_sorts_between_stable_releases() -> None:
+    result = metadata([release("v0.19.0")])
+    assert result == {
+        "build": "true",
+        "sha": SHA,
+        "version": "0.19.1.dev20260909100000",
+        "tag": "nightly-20260909100000",
+    }
+    assert Version("0.19.0") < Version(result["version"]) < Version("0.19.1")
+
+
+def test_unchanged_master_skips_only_after_successful_publication() -> None:
+    releases = [release("v0.19.0"), release("nightly-old", target_commitish=SHA)]
+    assert metadata(releases) == {"build": "false", "sha": SHA}
+    assert metadata(releases, validate_only=True)["build"] == "true"
+    releases[-1]["draft"] = True
+    assert metadata(releases)["build"] == "true"
+
+
+def test_changed_master_builds_after_missed_days_and_ignores_drafts() -> None:
+    releases = [
+        release("v0.19.0"),
+        release("nightly-old"),
+        release("nightly-draft", target_commitish=SHA, draft=True),
+        release("v99.0.0", draft=True),
+        release("v50.0.0", prerelease=True),
+    ]
+    assert metadata(releases)["version"] == "0.19.1.dev20260909100000"
+
+
+def test_latest_publication_controls_comparison_not_api_order() -> None:
+    releases = [
+        release("v0.19.0"),
+        release("nightly-old", target_commitish=SHA),
+        release("nightly-new", published_at="2026-09-09T09:00:00Z"),
+    ]
+    assert metadata(releases)["build"] == "true"
+
+
+def test_stable_version_selection_is_numeric() -> None:
+    releases = [release("v0.9.9"), release("v0.19.1"), release("v0.19.1rc1")]
+    assert metadata(releases)["version"].startswith("0.19.2.dev")
+
+
+def test_requires_a_published_stable_version() -> None:
+    with pytest.raises(ValueError, match="published stable"):
+        metadata([])
+
+
+def test_rejects_mutable_source_ref() -> None:
+    script = load_script(SCRIPT, "nightly_metadata_test")
+    with pytest.raises(ValueError, match="full commit SHA"):
+        script.nightly_metadata("master", [release("v0.19.0")], NOW)


### PR DESCRIPTION
Build master at 12:17 Europe/Berlin when its commit differs from the last published nightly. Reuse the package workflow to create GitHub-only development prereleases with AppImage, Debian, Arch, Fedora, openSUSE, source, checksums, and attestations. Package repositories, AUR, COPR, and the stable updater remain gated on stable releases.

All jobs build the captured SHA. Development versions sort between the current stable and next patch release, with format-specific prerelease syntax and links to master documentation. Publish nightlies only after uploading all assets to a draft release; failed builds do not advance change detection.

Validation:
- Nightly metadata tests cover version ordering, unchanged master, failed/draft builds, numeric stable selection, and immutable refs.
- Actionlint passes for both workflows.
- The PR runs every nightly package build and installation check without publishing.
- `./scripts/check.sh` passes: Ruff, basedpyright, stylelint, and 3,444 tests passed with 28 skipped. All package builds and installation checks passed on the final commit. CodeRabbit review passed with all feedback addressed and no unresolved threads.
