### PR TITLE
Fix nightly release checksum filenames and verify uploaded assets

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -834,10 +834,22 @@ jobs:
           name: appimage-package
           path: dist/
 
+      - name: Normalize prerelease download filenames
+        run: |
+          set -euo pipefail
+          # GitHub replaces tildes in release asset names with periods.
+          # Keep package contents unchanged, including their native versions.
+          for artifact in dist/*~*; do
+            [[ -f "$artifact" ]] || continue
+            normalized="${artifact//\~/.}"
+            test ! -e "$normalized"
+            mv -- "$artifact" "$normalized"
+          done
+
       - name: Generate prerelease checksums
         run: |
           cd dist
-          sha256sum ./*.AppImage ./*.deb ./*.rpm ./*.tar.gz ./*.pkg.tar.* > SHA256SUMS
+          sha256sum ./*.AppImage ./*.deb ./*.rpm ./*.tar.gz ./*.pkg.tar.* ./*.changes ./*.buildinfo > SHA256SUMS
 
       - name: Generate prerelease artifact attestations
         if: ${{ github.event.repository.private == false }}
@@ -880,6 +892,19 @@ jobs:
             dist/*.tar.gz
             dist/*.pkg.tar.*
             dist/SHA256SUMS
+
+      - name: Verify uploaded nightly downloads
+        if: startsWith(needs.version-metadata.outputs.release_tag, 'nightly-')
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          RELEASE_TAG: ${{ needs.version-metadata.outputs.release_tag }}
+        run: |
+          set -euo pipefail
+          verification_dir="$(mktemp -d "$RUNNER_TEMP/nightly-downloads.XXXXXX")"
+          gh release download "$RELEASE_TAG" --dir "$verification_dir"
+          cd "$verification_dir"
+          sha256sum --check --strict SHA256SUMS
 
       - name: Publish complete nightly
         if: startsWith(needs.version-metadata.outputs.release_tag, 'nightly-')

--- a/docs/PACKAGING.md
+++ b/docs/PACKAGING.md
@@ -81,7 +81,8 @@ Nightlies appear only as GitHub prereleases with tags such as
 openSUSE, source archive, and checksums. RPMs are unsigned. GitHub records build
 attestations separately; see [Build attestations](SECURITY.md#build-attestations)
 for `gh attestation verify` instructions.
-The release stays a draft until all files have uploaded. Nightlies never update
+The release stays a draft until all files have uploaded and downloaded copies
+pass checksum verification. Nightlies never update
 AUR, COPR, the project package repositories, the stable AppImage update manifest,
 or GitHub's latest stable release.
 
@@ -90,7 +91,9 @@ UTC build timestamp. For stable `0.19.0`, a nightly uses
 `0.19.1.dev20260909100000` in Python and the AppImage,
 `0.19.1~dev20260909100000` in Debian/RPM, and
 `0.19.1dev20260909100000` in Arch. Each format sorts after `0.19.0` and before
-`0.19.1`. Version rewrites happen only in the build checkout.
+`0.19.1`. Version rewrites happen only in the build checkout. GitHub download
+filenames replace `~` with `.` before checksums are generated because GitHub
+normalizes asset names. The versions inside Debian and RPM packages retain `~`.
 
 Development versions link to <https://keymasq.tools/docs/master/> in the app
 and release notes. These docs follow current master, including when reading


### PR DESCRIPTION
GitHub replaces `~` with `.` in uploaded release filenames. The first live nightly exposed a mismatch between those download names and the names in `SHA256SUMS`, despite the package contents being correct.

Normalize prerelease filenames before generating checksums and attestations. Keep native Debian/RPM version metadata unchanged. Download and checksum-verify nightly assets while the release is still a draft, and publish only after that verification passes. Include Debian build metadata files in the checksum manifest as well.

Validation:
- Actionlint passes.
- Executed the workflow normalization and checksum commands against all nine artifacts from the first live nightly. All checksums pass with download-compatible names.
- A filename collision fails without overwriting either artifact.
- Confirmed the actual Debian and RPM package metadata retains `0.19.1~dev20260909190743`.
- The initial nightly has been returned to draft while this correction is verified.

Live verification completed:
- Corrected workflow run 34393830663 published nightly-20260909191414 after verifying downloaded assets.
- Independently downloaded all nine files and verified every SHA-256 checksum; Debian artifact attestation verification passed.
- Run 34394574772 completed with only preparation and skipped packaging for unchanged master.
- Stable latest remains v0.19.0. AUR, COPR, and repository publishers were skipped.
- All PR checks pass. CodeRabbit completed review with no actionable comments.
