### PR TITLE
fix: bound daemon command response drains

### DIFF
--- a/keymasq/keymasqd/socket_server.py
+++ b/keymasq/keymasqd/socket_server.py
@@ -54,6 +54,7 @@ class SocketServer:
         broadcast_drain_timeout_s: float = 0.25,
         close_timeout_s: float = 0.25,
         handler_drain_timeout_s: float = 2.0,
+        response_drain_timeout_s: float = 0.25,
     ) -> None:
         self.socket_path = socket_path
         self.command_handler = command_handler
@@ -64,6 +65,7 @@ class SocketServer:
         self.broadcast_drain_timeout_s = max(0.01, float(broadcast_drain_timeout_s))
         self.close_timeout_s = max(0.01, float(close_timeout_s))
         self.handler_drain_timeout_s = max(0.01, float(handler_drain_timeout_s))
+        self.response_drain_timeout_s = max(0.01, float(response_drain_timeout_s))
         self.server: asyncio.Server | None = None
         self.clients: set[asyncio.StreamWriter] = set()
         self._buffer: dict[asyncio.StreamWriter, bytes] = {}
@@ -415,7 +417,7 @@ class SocketServer:
     ) -> None:
         response = await self._process_command(cmd, context)
         writer.write(encode_response(response))
-        await writer.drain()
+        await asyncio.wait_for(writer.drain(), timeout=self.response_drain_timeout_s)
 
     async def _process_command(self, cmd: Command, context: ClientContext) -> Response:
         if self._quiescing:

--- a/tests/keymasqd/test_socket_server.py
+++ b/tests/keymasqd/test_socket_server.py
@@ -14,6 +14,7 @@ from keymasq.common.ipc import (
     decode_response,
     encode_command,
 )
+from keymasq.common.security import PeerCredentials
 from keymasq.keymasqd.socket_server import ClientContext, SocketServer
 from tests.async_fakes import (
     FakeStreamWriter as _BroadcastWriter,
@@ -552,6 +553,44 @@ class TestSocketServer:
         writer.close()
         await writer.wait_closed()
         await server.stop()
+
+    async def test_response_timeout_disconnects_owner_and_stops_buffered_commands(
+        self, temp_socket_dir, monkeypatch
+    ):
+        handler = MockCommandHandler()
+        disconnect = MockDisconnectHandler()
+        server = SocketServer(
+            str(paths.SOCKET_PATH),
+            handler.handle,
+            disconnect.handle,
+            single_owner=True,
+            response_drain_timeout_s=0.01,
+        )
+        monkeypatch.setattr(
+            server, "_extract_peer", lambda _writer: PeerCredentials(pid=100, uid=1000, gid=1000)
+        )
+        reader = asyncio.StreamReader()
+        command = encode_command(Command(command=CommandType.PING, data={}))
+        reader.feed_data(command + command)
+        writer = _BroadcastWriter(drain_waiter=asyncio.Event())
+        task = asyncio.create_task(server._serve_client(reader, writer))  # type: ignore[arg-type]
+        try:
+            done, _pending = await asyncio.wait({task}, timeout=1.0)
+            assert task in done, "Stalled response did not disconnect the client"
+            await task
+            assert len(handler.commands_received) == 1
+            assert len(writer.writes) == 1
+            assert writer.closed
+            assert writer.wait_closed_calls == 1
+            assert disconnect.disconnect_called
+            assert server.owner_context is None
+            assert not server.clients
+            assert not server._buffer
+            assert not server._client_context
+            assert not server._active_command_tasks
+        finally:
+            task.cancel()
+            await asyncio.gather(task, return_exceptions=True)
 
     async def test_broadcast_event_does_not_block_on_slow_client(
         self,


### PR DESCRIPTION
## Summary

A client that stops reading command responses can leave the daemon waiting indefinitely in `writer.drain()` while retaining ownership. Bound response drains to 0.25 seconds by default so a stalled response triggers the existing disconnect and ownership cleanup.

Add a regression test verifying that a stalled owner disconnects, releases its state, and cannot execute the next buffered command.

## Testing

- [x] `./scripts/check.sh`: static checks passed; 1,326 tests passed, 28 skipped.
- [x] Required VM suite: `./scripts/integration.sh daemon-session` passed.
- Listener and AppImage suites skipped because this change only touches daemon socket handling.
- GUI screenshots: not applicable.

## Notes

- Service impact: response drain timeout starts after command execution; command execution time is unchanged.
- No packaging or GUI changes.
