### PR TITLE
Add rapidfire blocks to the macro editor

### DIFF
--- a/docs/ACTIONS.md
+++ b/docs/ACTIONS.md
@@ -605,6 +605,11 @@ in a continuous cycle: press → hold → release → wait → press → hold �
 
 This continues for as long as the key is physically held down.
 
+The macro editor also uses this selector's Rapidfire option for keys and buttons.
+Inside a macro, the block's duration controls the pulse lifetime, and Keymasq
+adjusts the gaps to place the final release at the block's end. See
+[macro rapidfire](MACRO_EDITOR.md#rapidfire-keys-and-buttons).
+
 | Setting | What it controls | Default | Range |
 |---|---|---|---|
 | **Hold (ms)** | How long each pulse is held. | 20 ms | 0–1000 ms |

--- a/docs/MACRO_EDITOR.md
+++ b/docs/MACRO_EDITOR.md
@@ -92,6 +92,19 @@ button, edit **Press**, **Duration**, and **Release** in milliseconds. Use
 and configuration fields. Properties edit the selected action immediately;
 [saving](#save-and-undo-changes) writes the changes to the macro library.
 
+### Rapidfire keys and buttons
+
+Enable **Rapidfire** in the key selector when adding a keyboard key, mouse
+button, or gamepad button, or use **Change Key…** on an existing action.
+The pulses stay in one editable timeline block. **Edit Rapidfire…** reopens
+the selector; disabling Rapidfire restores a continuous hold.
+
+**Hold** sets each press's duration and **Wait** sets the preferred gap.
+Keymasq spaces the pulses evenly, adjusting the gaps so the final release
+lands at the block's end. Resizing the block recalculates the pulses.
+If two pulses cannot fit, one hold spans the block. The properties panel
+shows the pulse count and fitted gap.
+
 ### Mouse movement
 
 **Add Mouse Move** opens the mouse-action picker. Choose a natural move to a

--- a/docs/agents/macros.txt
+++ b/docs/agents/macros.txt
@@ -110,6 +110,7 @@ Raw key/button event fields:
 Semantic macro control events:
 
 ```json
+{"device_type":"keyboard","type":1,"code":30,"value":0,"t_us":0,"macro_action":"macro_rapidfire","duration_us":100000,"rapidfire_hold_ms":10,"rapidfire_wait_ms":10}
 {"device_type":"macro","type":0,"code":0,"value":0,"t_us":0,"macro_action":"wait","duration_us":10000}
 {"device_type":"macro","type":0,"code":0,"value":0,"t_us":0,"macro_action":"wait_random","min_us":10000,"max_us":50000}
 {"device_type":"macro","type":0,"code":0,"value":0,"t_us":0,"macro_action":"mouse_move_abs","x":100,"y":200}
@@ -121,6 +122,11 @@ Semantic macro control events:
 {"device_type":"macro","type":0,"code":0,"value":0,"t_us":0,"macro_action":"macro_sync","macro_name":"child","loop_mode":"none","loop_count":1,"loop_stop_behavior":"finish_run","speed":1.0,"replay_mouse_movement":true,"replay_mouse_clicks":true}
 {"device_type":"macro","type":0,"code":0,"value":0,"t_us":0,"macro_action":"macro_parallel","macro_name":"child","loop_mode":"hold","loop_count":1,"loop_stop_behavior":"cancel_run","speed":1.0,"replay_mouse_movement":true,"replay_mouse_clicks":true}
 ```
+
+macro_rapidfire pulses a keyboard, mouse, or gamepad button for duration_us.
+Use type=1 and the target code; gamepads can specify output_id. Set
+rapidfire_hold_ms and rapidfire_wait_ms. Gaps adjust so
+the final release lands at the block's end.
 
 loop_stop_behavior also accepts "pause_run" for none/count/hold playback and
 child calls. Release cleans up this instance's held outputs and freezes its

--- a/keymasq/common/macro_rapidfire.py
+++ b/keymasq/common/macro_rapidfire.py
@@ -1,0 +1,83 @@
+"""Fixed-duration rapidfire blocks shared by macro playback and the editor."""
+
+from collections.abc import Iterator, Mapping
+from dataclasses import dataclass
+from fractions import Fraction
+
+from keymasq.common.coercion import coerce_int
+from keymasq.common.model.actions import (
+    DEFAULT_RAPIDFIRE_HOLD_MS,
+    DEFAULT_RAPIDFIRE_WAIT_MS,
+    MIN_RAPIDFIRE_WAIT_MS,
+    clamp_rapidfire_hold_ms,
+    clamp_rapidfire_wait_ms,
+)
+
+
+@dataclass(frozen=True)
+class MacroRapidfirePlan:
+    duration_us: int
+    hold_us: int
+    count: int
+
+    @property
+    def wait_us(self) -> float:
+        if self.count == 1:
+            return 0.0
+        return (self.duration_us - self.count * self.hold_us) / (self.count - 1)
+
+    def pulse(self, index: int) -> tuple[int, int]:
+        """Round absolute offsets, avoiding accumulated interval rounding error."""
+        if self.count == 1:
+            return 0, self.duration_us
+        gaps = self.count - 1
+        press = ((self.duration_us - self.hold_us) * index + gaps // 2) // gaps
+        return press, press + self.hold_us
+
+
+def plan_macro_rapidfire(duration_us: int, hold_ms: int, wait_ms: int) -> MacroRapidfirePlan:
+    duration = max(0, int(duration_us))
+    hold = clamp_rapidfire_hold_ms(hold_ms) * 1000
+    wait = clamp_rapidfire_wait_ms(wait_ms) * 1000
+    min_wait = MIN_RAPIDFIRE_WAIT_MS * 1000
+    max_count = (duration + min_wait) // (hold + min_wait)
+    if max_count < 2:
+        return MacroRapidfirePlan(duration, duration, 1)
+
+    # D = N*H + (N-1)*W. The closest adjusted wait is on either side
+    # of this ideal count; ties prefer fewer presses.
+    below = (duration + wait) // (hold + wait)
+    candidates = {max(2, min(max_count, n)) for n in (below, below + 1)}
+    count = min(
+        candidates,
+        key=lambda n: (abs(Fraction(duration - n * hold, n - 1) - wait), n),
+    )
+    return MacroRapidfirePlan(duration, hold, count)
+
+
+def macro_event_end_us(event: Mapping[str, object]) -> int:
+    start = coerce_int(event.get("t_us"), 0)
+    if event.get("macro_action") == "macro_rapidfire":
+        return start + max(0, coerce_int(event.get("duration_us"), 0))
+    return start
+
+
+def macro_rapidfire_events(event: Mapping[str, object]) -> Iterator[dict[str, object]]:
+    """Expand one stored block lazily; the caller merges it into the timeline."""
+    if event.get("device_type") not in {"keyboard", "mouse", "gamepad"}:
+        raise ValueError("Macro rapidfire requires a keyboard, mouse, or gamepad button")
+    if coerce_int(event.get("type"), 0) != 1:
+        raise ValueError("Macro rapidfire requires an EV_KEY target")
+    plan = plan_macro_rapidfire(
+        coerce_int(event.get("duration_us"), 0),
+        coerce_int(event.get("rapidfire_hold_ms"), DEFAULT_RAPIDFIRE_HOLD_MS),
+        coerce_int(event.get("rapidfire_wait_ms"), DEFAULT_RAPIDFIRE_WAIT_MS),
+    )
+    start = coerce_int(event.get("t_us"), 0)
+    target = {key: event[key] for key in ("device_type", "type", "code")}
+    if event.get("output_id"):
+        target["output_id"] = event["output_id"]
+    for index in range(plan.count):
+        press, release = plan.pulse(index)
+        yield {**target, "value": 1, "t_us": start + press}
+        yield {**target, "value": 0, "t_us": start + release}

--- a/keymasq/gui/widgets/key_selector/dialog.py
+++ b/keymasq/gui/widgets/key_selector/dialog.py
@@ -77,6 +77,21 @@ class KeySelectorDialog(
         return MappingAction(action_type=action_type, **kwargs)
 
     def _emit_selected_action(self, action: MappingAction | None) -> None:
+        if (
+            action is not None
+            and action.action_type == ActionType.GAMEPAD_AXIS
+            and action.rapidfire_enabled
+            and not self._allow_gamepad_axis_rapidfire
+        ):
+            dialog = Adw.AlertDialog(
+                heading="Rapidfire is unavailable for axes",
+                body="Turn off Rapidfire to select an axis, or choose a gamepad button.",
+            )
+            dialog.add_response("ok", "OK")
+            dialog.set_default_response("ok")
+            dialog.set_close_response("ok")
+            dialog.present(self)
+            return
         self.emit("key-selected", action)
         self.close()
 
@@ -93,6 +108,7 @@ class KeySelectorDialog(
         allow_superkey: bool = True,
         allow_repeat: bool = True,
         allow_rapidfire: bool = True,
+        allow_gamepad_axis_rapidfire: bool = True,
         allow_tap: bool = True,
         allow_macro_options: bool = True,
         macro_library_only: bool = False,
@@ -120,6 +136,7 @@ class KeySelectorDialog(
         self._allow_superkey = allow_superkey
         self._allow_repeat = allow_repeat
         self._allow_rapidfire = allow_rapidfire
+        self._allow_gamepad_axis_rapidfire = allow_gamepad_axis_rapidfire
         self._allow_tap = allow_tap
         self._allow_macro_options = allow_macro_options
         self._macro_library_only = bool(macro_library_only)

--- a/keymasq/gui/widgets/macro_editor/add_popovers.py
+++ b/keymasq/gui/widgets/macro_editor/add_popovers.py
@@ -486,6 +486,7 @@ class MacroEditorAddPopoversMixin:
             allow_superkey=False,
             allow_repeat=False,
             allow_rapidfire=True,
+            allow_gamepad_axis_rapidfire=False,
             allow_tap=False,
             allowed_tabs=allowed_tabs,
             initial_tab=device_type if device_type in {"mouse", "gamepad"} else "keyboard",

--- a/keymasq/gui/widgets/macro_editor/add_popovers.py
+++ b/keymasq/gui/widgets/macro_editor/add_popovers.py
@@ -485,13 +485,20 @@ class MacroEditorAddPopoversMixin:
             allow_suppress=False,
             allow_superkey=False,
             allow_repeat=False,
-            allow_rapidfire=False,
+            allow_rapidfire=True,
             allow_tap=False,
             allowed_tabs=allowed_tabs,
             initial_tab=device_type if device_type in {"mouse", "gamepad"} else "keyboard",
             include_mpris_controls=False,
             include_mouse_move_controls=False,
             include_mouse_scroll_controls=False if device_type == "mouse" else True,
+        )
+        dialog.rapidfire_check.set_tooltip_text(
+            "Pulse this input within its macro duration. The gaps adjust so the last release "
+            "lands at the configured end."
+        )
+        dialog.wait_spin.set_tooltip_text(
+            "Preferred gap between pulses; adjusted to fit the duration."
         )
         dialog.connect(
             "key-selected",
@@ -554,6 +561,7 @@ class MacroEditorAddPopoversMixin:
                 if action.action_type == ActionType.GAMEPAD
                 else None,
             )
+        ev.apply_rapidfire(action)
         self._events.append(ev)
         self._events.sort(key=lambda item: item.press_t_us)
         self._timeline._selected = ev

--- a/keymasq/gui/widgets/macro_editor/model.py
+++ b/keymasq/gui/widgets/macro_editor/model.py
@@ -312,6 +312,7 @@ def parse_events(
                     release_t_us=start + max(0, coerce_int(ev.get("duration_us"), 0)),
                     output_id=str(ev.get("output_id", "") or "").strip() or None,
                     original_press_order=original_order,
+                    original_release_order=original_order,
                     rapidfire_enabled=True,
                     rapidfire_hold_ms=clamp_rapidfire_hold_ms(
                         coerce_int(ev.get("rapidfire_hold_ms"), DEFAULT_RAPIDFIRE_HOLD_MS)

--- a/keymasq/gui/widgets/macro_editor/model.py
+++ b/keymasq/gui/widgets/macro_editor/model.py
@@ -13,7 +13,11 @@ from keymasq.common.model.actions import (
     DEFAULT_NATURAL_MOUSE_MOVE_MAX_DURATION_MS,
     DEFAULT_NATURAL_MOUSE_MOVE_SPEED,
     DEFAULT_NATURAL_MOUSE_MOVE_TOLERANCE,
+    DEFAULT_RAPIDFIRE_HOLD_MS,
+    DEFAULT_RAPIDFIRE_WAIT_MS,
     MappingAction,
+    clamp_rapidfire_hold_ms,
+    clamp_rapidfire_wait_ms,
     normalize_natural_mouse_move_curve,
 )
 from keymasq.common.model.core import ActionType
@@ -134,6 +138,14 @@ class EditableEvent:
     output_id: str | None = None
     original_press_order: int | None = None
     original_release_order: int | None = None
+    rapidfire_enabled: bool = False
+    rapidfire_hold_ms: int = DEFAULT_RAPIDFIRE_HOLD_MS
+    rapidfire_wait_ms: int = DEFAULT_RAPIDFIRE_WAIT_MS
+
+    def apply_rapidfire(self, action: MappingAction) -> None:
+        self.rapidfire_enabled = self.ev_type == evdev.ecodes.EV_KEY and action.rapidfire_enabled
+        self.rapidfire_hold_ms = clamp_rapidfire_hold_ms(action.rapidfire_hold_ms)
+        self.rapidfire_wait_ms = clamp_rapidfire_wait_ms(action.rapidfire_wait_ms)
 
 
 @dataclass
@@ -285,6 +297,31 @@ def parse_events(
 
     for original_order, ev in enumerate(raw_events):
         macro_action = str(ev.get("macro_action", "") or "")
+        if (
+            macro_action == "macro_rapidfire"
+            and ev.get("type") == ev_key
+            and ev.get("device_type") in {"keyboard", "mouse", "gamepad"}
+        ):
+            start = coerce_int(ev.get("t_us"), 0)
+            editable.append(
+                EditableEvent(
+                    device_type=str(ev["device_type"]),
+                    ev_type=ev_key,
+                    code=int(ev["code"]),
+                    press_t_us=start,
+                    release_t_us=start + max(0, coerce_int(ev.get("duration_us"), 0)),
+                    output_id=str(ev.get("output_id", "") or "").strip() or None,
+                    original_press_order=original_order,
+                    rapidfire_enabled=True,
+                    rapidfire_hold_ms=clamp_rapidfire_hold_ms(
+                        coerce_int(ev.get("rapidfire_hold_ms"), DEFAULT_RAPIDFIRE_HOLD_MS)
+                    ),
+                    rapidfire_wait_ms=clamp_rapidfire_wait_ms(
+                        coerce_int(ev.get("rapidfire_wait_ms"), DEFAULT_RAPIDFIRE_WAIT_MS)
+                    ),
+                )
+            )
+            continue
         if macro_action in {"mouse_move_abs", "mouse_move_rel", "mouse_move_natural_abs"}:
             editable_moves.append(
                 EditableMove(
@@ -424,6 +461,24 @@ def reconstruct_events(
     raw: list[MacroEvent] = []
 
     for ev in editable:
+        if ev.rapidfire_enabled and ev.ev_type == evdev.ecodes.EV_KEY:
+            rapidfire_event: MacroEvent = {
+                "macro_action": "macro_rapidfire",
+                "device_type": ev.device_type,
+                "type": ev.ev_type,
+                "code": ev.code,
+                "value": 0,
+                "t_us": ev.press_t_us,
+                "duration_us": max(0, ev.release_t_us - ev.press_t_us),
+                "rapidfire_hold_ms": ev.rapidfire_hold_ms,
+                "rapidfire_wait_ms": ev.rapidfire_wait_ms,
+            }
+            if ev.device_type == "gamepad" and ev.output_id:
+                rapidfire_event["output_id"] = ev.output_id
+            if ev.original_press_order is not None:
+                rapidfire_event = _with_editor_order(rapidfire_event, ev.original_press_order)
+            raw.append(rapidfire_event)
+            continue
         if ev.ev_type == evdev.ecodes.EV_KEY:
             press_event: MacroEvent = {
                 "device_type": ev.device_type,

--- a/keymasq/gui/widgets/macro_editor/panel/properties.py
+++ b/keymasq/gui/widgets/macro_editor/panel/properties.py
@@ -606,6 +606,7 @@ class EventPropertiesMixin:
             allow_superkey=False,
             allow_repeat=False,
             allow_rapidfire=True,
+            allow_gamepad_axis_rapidfire=False,
             allow_tap=False,
             allowed_tabs={
                 "gamepad"

--- a/keymasq/gui/widgets/macro_editor/panel/properties.py
+++ b/keymasq/gui/widgets/macro_editor/panel/properties.py
@@ -13,6 +13,7 @@ from keymasq.common.gamepad_axes import (
     clamp_gamepad_axis_value,
     gamepad_axis_range,
 )
+from keymasq.common.macro_rapidfire import plan_macro_rapidfire
 from keymasq.gui.widgets.macro_editor.model import (
     EditableControl,
     EditableEvent,
@@ -390,9 +391,20 @@ class EventPropertiesMixin:
             return
 
         name = _get_key_name(ev.code)
-        self._prop_title.set_label(name)
+        self._prop_title.set_label(f"{name} Rapidfire" if ev.rapidfire_enabled else name)
         output_suffix = f" @ {ev.output_id}" if ev.device_type == "gamepad" and ev.output_id else ""
-        self._key_info_label.set_label(f"{name} (code {ev.code}){output_suffix}")
+        detail = f"{name} (code {ev.code}){output_suffix}"
+        if ev.rapidfire_enabled:
+            plan = plan_macro_rapidfire(
+                ev.release_t_us - ev.press_t_us, ev.rapidfire_hold_ms, ev.rapidfire_wait_ms
+            )
+            detail += (
+                f" · {plan.count} pulses · Hold {plan.hold_us / 1000:g} ms"
+                f" · Fitted wait {plan.wait_us / 1000:.3f} ms"
+                if plan.count > 1
+                else " · One hold spanning the duration"
+            )
+        self._key_info_label.set_label(detail)
         self._press_label.set_label("Press:")
         self._duration_text_label.set_visible(True)
         self._duration_spin.set_visible(True)
@@ -401,7 +413,9 @@ class EventPropertiesMixin:
         self._release_spin.set_visible(True)
         self._release_unit_label.set_visible(True)
         self._change_key_btn.set_visible(True)
-        self._change_key_btn.set_label("Change Key...")
+        self._change_key_btn.set_label(
+            "Edit Rapidfire..." if ev.rapidfire_enabled else "Change Key..."
+        )
         self._move_row.set_visible(False)
 
         self._updating_props = True
@@ -578,6 +592,10 @@ class EventPropertiesMixin:
                     output_id=ev.output_id,
                 )
 
+        current_action.rapidfire_enabled = ev.rapidfire_enabled
+        current_action.rapidfire_hold_ms = ev.rapidfire_hold_ms
+        current_action.rapidfire_wait_ms = ev.rapidfire_wait_ms
+
         dialog = KeySelectorDialog(
             self._parent,
             dialog_label,
@@ -587,7 +605,7 @@ class EventPropertiesMixin:
             allow_suppress=False,
             allow_superkey=False,
             allow_repeat=False,
-            allow_rapidfire=False,
+            allow_rapidfire=True,
             allow_tap=False,
             allowed_tabs={
                 "gamepad"
@@ -607,6 +625,13 @@ class EventPropertiesMixin:
             include_mpris_controls=False,
             include_mouse_move_controls=False,
             include_mouse_scroll_controls=(False if ev.device_type == "mouse" else True),
+        )
+        dialog.rapidfire_check.set_tooltip_text(
+            "Pulse this input within its macro duration. The gaps adjust so the last release "
+            "lands at the configured end."
+        )
+        dialog.wait_spin.set_tooltip_text(
+            "Preferred gap between pulses; adjusted to fit the duration."
         )
         dialog.connect("key-selected", self._on_key_selected_for_edit)
         dialog.present(self._parent)
@@ -665,6 +690,7 @@ class EventPropertiesMixin:
 
         if ev.ev_type == evdev.ecodes.EV_KEY and ev.release_t_us <= ev.press_t_us + 1:
             ev.release_t_us = ev.press_t_us + 50000
+        ev.apply_rapidfire(action)
         self._on_selection_changed(ev)
         self._timeline.queue_draw()
         self._sync_close_guard()

--- a/keymasq/gui/widgets/macro_editor/timeline_render.py
+++ b/keymasq/gui/widgets/macro_editor/timeline_render.py
@@ -1,9 +1,11 @@
 """Cairo rendering helpers for the macro editor timeline."""
 
 from dataclasses import dataclass
+from math import ceil
 
 import evdev
 
+from keymasq.common.macro_rapidfire import plan_macro_rapidfire
 from keymasq.gui.widgets.macro_editor.gaps import TimelineGap
 from keymasq.gui.widgets.macro_editor.model import (
     EditableControl,
@@ -327,6 +329,27 @@ def _draw_event_rect(
     cr.rectangle(x1 + 0.5, rect_y + 0.5, max(w - 1, 0), max(rect_h - 1, 0))
     cr.stroke()
 
+    if ev.rapidfire_enabled:
+        plan = plan_macro_rapidfire(
+            ev.release_t_us - ev.press_t_us, ev.rapidfire_hold_ms, ev.rapidfire_wait_ms
+        )
+        # Limit drawing to visible pulses and at most one mark per three pixels.
+        span = max(x2 - x1, 1)
+        step = max(1, ceil(plan.count * 3 / span))
+        first = max(0, int((state.LABEL_WIDTH - x1) / span * (plan.count - 1)) - 1)
+        last = min(plan.count, int((width - x1) / span * (plan.count - 1)) + 2)
+        cr.save()
+        cr.rectangle(max(x1 + 1, state.LABEL_WIDTH), rect_y + 1, min(w - 2, width), rect_h - 2)
+        cr.clip()
+        cr.set_source_rgba(*border[:3], 0.7)
+        for index in range(first, last, step):
+            press, release = plan.pulse(index)
+            left = state._time_to_x(ev.press_t_us + press)
+            right = state._time_to_x(ev.press_t_us + release)
+            cr.rectangle(left, rect_y + rect_h * 0.6, max(1, right - left), rect_h * 0.4)
+        cr.fill()
+        cr.restore()
+
     # Label (only if wide and tall enough)
     if w > 28 and rect_h > 10:
         name = (
@@ -334,6 +357,8 @@ def _draw_event_rect(
             if ev.ev_type == evdev.ecodes.EV_KEY
             else _get_event_name(ev.ev_type, ev.code)
         )
+        if ev.rapidfire_enabled:
+            name += " RF"
         cr.select_font_face("sans", 0, 0)
         cr.set_font_size(min(9.0, rect_h * 0.65))
         extents = cr.text_extents(name)

--- a/keymasq/keymasqd/macro_file.py
+++ b/keymasq/keymasqd/macro_file.py
@@ -13,6 +13,7 @@ from typing import BinaryIO, cast
 
 from keymasq.common.coercion import coerce_float, require_json_object
 from keymasq.common.config_files import write_config_atomically
+from keymasq.common.macro_rapidfire import macro_event_end_us
 from keymasq.common.model.actions import DEFAULT_MACRO_LOOP_STOP_BEHAVIOR
 from keymasq.common.types import JsonObject
 
@@ -305,13 +306,8 @@ def _event_count(payload: JsonObject) -> int:
     return len(cast(list[object], events)) if isinstance(events, list) else 0
 
 
-def _event_t_us(event: MacroEvent) -> int:
-    value = event.get("t_us", 0)
-    return value if isinstance(value, int) else 0
-
-
 def _duration_us(events: list[MacroEvent]) -> int:
-    return max((_event_t_us(event) for event in events), default=0)
+    return max((macro_event_end_us(event) for event in events), default=0)
 
 
 def _device_types(events: list[MacroEvent]) -> list[str]:

--- a/keymasq/keymasqd/runtime/macro/events.py
+++ b/keymasq/keymasqd/runtime/macro/events.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
+import heapq
 import time
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Callable, Iterator
 from typing import Any
 
+from keymasq.common.coercion import coerce_int
+from keymasq.common.macro_rapidfire import macro_event_end_us, macro_rapidfire_events
 from keymasq.keymasqd.runtime.macro.state import (
-    IntValueFn,
     MacroEventSource,
     MacroRuntimeDeps,
 )
@@ -13,12 +15,10 @@ from keymasq.keymasqd.runtime.macro.state import (
 
 def list_macro_event_source(
     macro_events: list[dict[str, object]],
-    *,
-    int_value_fn: IntValueFn,
 ) -> MacroEventSource:
     return MacroEventSource(
         event_count=len(macro_events),
-        duration_us=max((int_value_fn(event.get("t_us"), 0) for event in macro_events), default=0),
+        duration_us=max((macro_event_end_us(event) for event in macro_events), default=0),
         iter_events=lambda: iter(macro_events),
     )
 
@@ -38,6 +38,43 @@ class MacroBatchReader:
             except StopIteration:
                 break
         return batch
+
+
+async def expand_macro_rapidfire(
+    source: AsyncIterator[dict[str, object]],
+    *,
+    observe: Callable[[dict[str, object]], None] | None = None,
+) -> AsyncIterator[dict[str, object]]:
+    """Merge active pulse streams with source events, preserving equal-time source order.
+
+    Keep only the next edge of each active block. Cache the original source,
+    never its generated pulses, so cache size stays proportional to stored data.
+    """
+    pending: list[tuple[int, int, dict[str, object], Iterator[dict[str, object]]]] = []
+
+    def advance(order: int, pulses: Iterator[dict[str, object]]) -> None:
+        event = next(pulses, None)
+        if event is not None:
+            heapq.heappush(pending, (coerce_int(event.get("t_us"), 0), order, event, pulses))
+
+    order = 0
+    async for event in source:
+        if observe is not None:
+            observe(event)
+        timestamp = coerce_int(event.get("t_us"), 0)
+        while pending and pending[0][:2] <= (timestamp, order):
+            _, pulse_order, pulse, pulses = heapq.heappop(pending)
+            yield pulse
+            advance(pulse_order, pulses)
+        if event.get("macro_action") == "macro_rapidfire":
+            advance(order, macro_rapidfire_events(event))
+        else:
+            yield event
+        order += 1
+    while pending:
+        _, pulse_order, pulse, pulses = heapq.heappop(pending)
+        yield pulse
+        advance(pulse_order, pulses)
 
 
 async def iter_macro_source_events(

--- a/keymasq/keymasqd/runtime/macro/playback.py
+++ b/keymasq/keymasqd/runtime/macro/playback.py
@@ -128,7 +128,6 @@ async def play_macro(
 
     event_source = macro_event_source or list_macro_event_source(
         playback_options.macro_events,
-        int_value_fn=deps.int_value_fn,
     )
     if event_source.event_count <= 0:
         if playback_options.playback_id:

--- a/keymasq/keymasqd/runtime/macro/scheduler.py
+++ b/keymasq/keymasqd/runtime/macro/scheduler.py
@@ -78,7 +78,6 @@ async def play_macro_task(
     if macro_event_source is None:
         macro_event_source = events.list_macro_event_source(
             macro_events,
-            int_value_fn=deps.int_value_fn,
         )
 
     if manager.verbosity >= 1:
@@ -306,18 +305,19 @@ async def _play_iteration(
         return await _await_with_parallel_errors(awaitable, parallel_tasks)
 
     index = 0
-    async for event in events.iter_macro_source_events(
+    source = events.iter_macro_source_events(
         macro_event_source,
         deps=deps,
         diagnostic_initial_load_us=diagnostic_initial_load_us,
         cached_events=cached_events,
         verify_cached_revision=verify_cached_revision,
+    )
+    async for event in events.expand_macro_rapidfire(
+        source, observe=cache_candidate.observe if cache_candidate is not None else None
     ):
         _raise_finished_parallel_errors(parallel_tasks)
         if instance_id in manager.macro_state.cancel_instance_ids:
             break
-        if cache_candidate is not None:
-            cache_candidate.observe(event)
         if (index & 127) == 127:
             await asyncio_mod.sleep(0)
         index += 1

--- a/tests/common/test_macro_rapidfire.py
+++ b/tests/common/test_macro_rapidfire.py
@@ -1,0 +1,58 @@
+from fractions import Fraction
+
+import pytest
+
+from keymasq.common.macro_rapidfire import plan_macro_rapidfire
+
+
+def test_fits_equal_gaps_and_preserves_every_hold() -> None:
+    plan = plan_macro_rapidfire(100_000, 10, 10)
+    assert plan.count == 6
+    assert plan.wait_us == 8_000
+    assert [plan.pulse(i) for i in range(plan.count)] == [
+        (0, 10_000),
+        (18_000, 28_000),
+        (36_000, 46_000),
+        (54_000, 64_000),
+        (72_000, 82_000),
+        (90_000, 100_000),
+    ]
+
+
+@pytest.mark.parametrize("duration", [0, 1, 10_000, 20_000])
+def test_short_block_is_one_hold_covering_the_whole_duration(duration: int) -> None:
+    plan = plan_macro_rapidfire(duration, 10, 10)
+    assert plan.count == 1
+    assert plan.pulse(0) == (0, duration)
+
+
+def test_fractional_intervals_round_without_drift() -> None:
+    plan = plan_macro_rapidfire(100_001, 10, 10)
+    pulses = [plan.pulse(i) for i in range(plan.count)]
+    assert pulses[0][0] == 0
+    assert pulses[-1][1] == 100_001
+    assert all(release - press == 10_000 for press, release in pulses)
+    gaps = [right[0] - left[1] for left, right in zip(pulses, pulses[1:], strict=False)]
+    assert max(gaps) - min(gaps) == 1
+
+
+@pytest.mark.parametrize("hold", [0, 1, 5, 20])
+@pytest.mark.parametrize("wait", [1, 3, 10, 1000])
+def test_count_minimizes_wait_error_with_positive_gaps(hold: int, wait: int) -> None:
+    for duration in [2_000, 23_456, 100_001, 250_000]:
+        plan = plan_macro_rapidfire(duration, hold, wait)
+        maximum = (duration + 1000) // (hold * 1000 + 1000)
+        if maximum < 2:
+            assert plan.count == 1
+            continue
+        best = min(
+            range(2, maximum + 1),
+            key=lambda n: (abs(Fraction(duration - n * hold * 1000, n - 1) - wait * 1000), n),
+        )
+        assert plan.count == best
+        assert plan.wait_us >= 1000
+
+
+def test_zero_hold_keeps_press_release_pairs_at_both_endpoints() -> None:
+    plan = plan_macro_rapidfire(10_000, 0, 5)
+    assert [plan.pulse(i) for i in range(plan.count)] == [(0, 0), (5000, 5000), (10000, 10000)]

--- a/tests/gui/test_macro_editor_dialog_widget.py
+++ b/tests/gui/test_macro_editor_dialog_widget.py
@@ -964,7 +964,7 @@ def test_macro_editor_insert_delete_and_save_payload(monkeypatch) -> None:
 
     dialog._on_key_selected_for_insert(
         None,
-        type("Action", (), {"action_type": ActionType.KEYBOARD, "target": "key_b"})(),
+        MappingAction(action_type=ActionType.KEYBOARD, target="key_b"),
         12000,
     )
 
@@ -974,7 +974,7 @@ def test_macro_editor_insert_delete_and_save_payload(monkeypatch) -> None:
 
     dialog._on_key_selected_for_insert(
         None,
-        type("Action", (), {"action_type": ActionType.KEYBOARD, "target": "key_b"})(),
+        MappingAction(action_type=ActionType.KEYBOARD, target="key_b"),
         12000,
     )
     dialog._control_events = [EditableControl(mode="wait", t_us=5000, duration_us=80_000)]
@@ -1924,6 +1924,9 @@ def test_macro_editor_add_key_dialog_starts_on_requested_device_type(monkeypatch
     class DummyDialog:
         def __init__(self, _parent, _label, current_action=None, **_kwargs):
             captured_actions.append(current_action)
+            assert _kwargs["allow_rapidfire"] is True
+            self.rapidfire_check = Gtk.CheckButton()
+            self.wait_spin = Gtk.SpinButton()
 
         def connect(self, _signal_name, _callback, default_t_us):
             captured_times.append(default_t_us)

--- a/tests/gui/test_macro_editor_rapidfire.py
+++ b/tests/gui/test_macro_editor_rapidfire.py
@@ -82,6 +82,7 @@ def test_edit_reopens_shared_selector_with_saved_rapidfire_settings(monkeypatch)
     assert action.rapidfire_enabled
     assert action.rapidfire_hold_ms == action.rapidfire_wait_ms == 10
     assert factory.call_args.kwargs["allow_rapidfire"] is True
+    assert factory.call_args.kwargs["allow_gamepad_axis_rapidfire"] is False
     assert factory.call_args.kwargs["allow_tap"] is False
     factory.return_value.connect.assert_called_once_with(
         "key-selected", dialog._on_key_selected_for_edit
@@ -132,3 +133,123 @@ def test_selector_result_creates_edits_and_disables_rapidfire(
     assert not event.rapidfire_enabled
     raw = reconstruct_events(dialog._events, [], [], [], [])
     assert [(e["t_us"], e["value"]) for e in raw] == [(50_000, 1), (150_000, 0)]
+
+
+@pytest.mark.parametrize(
+    ("device_type", "code", "action_type", "output_id"),
+    [
+        ("keyboard", evdev.ecodes.KEY_A, ActionType.KEYBOARD, None),
+        ("mouse", evdev.ecodes.BTN_LEFT, ActionType.MOUSE, None),
+        ("gamepad", evdev.ecodes.BTN_SOUTH, ActionType.GAMEPAD, "virtual-gamepad-3"),
+    ],
+)
+def test_disable_saved_rapidfire_releases_before_adjacent_same_target_hold(
+    device_type: str,
+    code: int,
+    action_type: ActionType,
+    output_id: str | None,
+) -> None:
+    target = {"device_type": device_type, "type": evdev.ecodes.EV_KEY, "code": code}
+    if output_id is not None:
+        target["output_id"] = output_id
+    raw = [
+        {
+            **target,
+            "value": 0,
+            "t_us": 0,
+            "macro_action": "macro_rapidfire",
+            "duration_us": 100_000,
+            "rapidfire_hold_ms": 10,
+            "rapidfire_wait_ms": 10,
+        },
+        {**target, "value": 1, "t_us": 100_000},
+        {**target, "value": 0, "t_us": 200_000},
+    ]
+    reopened = parse_events(json.loads(json.dumps(raw)))
+    reopened[0][0].apply_rapidfire(MappingAction(action_type=action_type, rapidfire_enabled=False))
+    expected = [
+        {**target, "value": 1, "t_us": 0},
+        {**target, "value": 0, "t_us": 100_000},
+        {**target, "value": 1, "t_us": 100_000},
+        {**target, "value": 0, "t_us": 200_000},
+    ]
+    assert reconstruct_events(*reopened) == expected
+    holds = parse_events(expected)[0]
+    assert [(hold.press_t_us, hold.release_t_us) for hold in holds] == [
+        (0, 100_000),
+        (100_000, 200_000),
+    ]
+
+
+@pytest.mark.parametrize("editing", [False, True])
+@pytest.mark.parametrize("choose_button", [False, True])
+def test_macro_selector_rejects_axis_rapidfire_and_allows_correction(
+    monkeypatch,
+    editing: bool,
+    choose_button: bool,
+) -> None:
+    from keymasq.gui.widgets.key_selector import dialog as selector_module
+
+    selector_class = selector_module.KeySelectorDialog
+    selectors = []
+
+    def create_selector(*args, **kwargs):
+        picker = selector_class(*args, **kwargs)
+        monkeypatch.setattr(picker, "present", MagicMock())
+        monkeypatch.setattr(picker, "close", MagicMock())
+        selectors.append(picker)
+        return picker
+
+    monkeypatch.setattr(selector_module, "KeySelectorDialog", create_selector)
+    alert = MagicMock()
+    monkeypatch.setattr(selector_module.Adw, "AlertDialog", alert)
+    editor = _build_macro_dialog(monkeypatch)
+    if editing:
+        axis = EditableEvent("gamepad", evdev.ecodes.EV_ABS, evdev.ecodes.ABS_X, 0, 1, value=100)
+        editor._events = [axis]
+        editor._timeline._selected = axis
+        editor._on_change_key_clicked(None)
+    else:
+        editor._present_add_key_dialog(default_t_us=0, device_type="gamepad")
+    picker = selectors[0]
+    picker.rapidfire_check.set_active(True)
+    picker._on_gamepad_axis_clicked(None, "abs_x", 32767)
+
+    alert.assert_called_once()
+    assert "Turn off Rapidfire" in alert.call_args.kwargs["body"]
+    alert.return_value.present.assert_called_once_with(picker)
+    picker.close.assert_not_called()
+    assert len(editor._events) == int(editing)
+    if editing:
+        assert editor._events[0].value == 100
+
+    if choose_button:
+        picker._on_gamepad_clicked(None, "btn_south")
+    else:
+        picker.rapidfire_check.set_active(False)
+        picker._on_gamepad_axis_clicked(None, "abs_x", 32767)
+    picker.close.assert_called_once()
+    assert len(editor._events) == 1
+    event = editor._events[0]
+    assert event.rapidfire_enabled is choose_button
+    assert event.ev_type == (evdev.ecodes.EV_KEY if choose_button else evdev.ecodes.EV_ABS)
+    assert event.code == (evdev.ecodes.BTN_SOUTH if choose_button else evdev.ecodes.ABS_X)
+    if not choose_button:
+        assert event.value == 32767
+
+
+def test_regular_selector_still_supports_axis_rapidfire(monkeypatch) -> None:
+    from gi.repository import Gtk
+
+    from keymasq.gui.widgets.key_selector.dialog import KeySelectorDialog
+
+    picker = KeySelectorDialog(Gtk.Box(), "Gamepad", allowed_tabs={"gamepad"})
+    monkeypatch.setattr(picker, "close", MagicMock())
+    selected = []
+    picker.connect("key-selected", lambda _picker, action: selected.append(action))
+    picker.rapidfire_check.set_active(True)
+    picker._on_gamepad_axis_clicked(None, "abs_x", 32767)
+    assert len(selected) == 1
+    assert selected[0].action_type == ActionType.GAMEPAD_AXIS
+    assert selected[0].rapidfire_enabled
+    picker.close.assert_called_once()

--- a/tests/gui/test_macro_editor_rapidfire.py
+++ b/tests/gui/test_macro_editor_rapidfire.py
@@ -1,0 +1,134 @@
+import json
+from unittest.mock import MagicMock
+
+import evdev
+import pytest
+
+from keymasq.common.model.actions import MappingAction
+from keymasq.common.model.core import ActionType
+from keymasq.gui.widgets.macro_editor import selection, timing_ops
+from keymasq.gui.widgets.macro_editor.document import MacroDocument
+from keymasq.gui.widgets.macro_editor.model import EditableEvent, parse_events, reconstruct_events
+from tests.gui.macro_editor_dialog_support import _build_macro_dialog
+
+
+def rapidfire() -> EditableEvent:
+    return EditableEvent(
+        "gamepad",
+        evdev.ecodes.EV_KEY,
+        evdev.ecodes.BTN_SOUTH,
+        50_000,
+        150_000,
+        output_id="virtual-gamepad-3",
+        rapidfire_enabled=True,
+        rapidfire_hold_ms=10,
+        rapidfire_wait_ms=10,
+    )
+
+
+def test_save_reopen_and_copy_keep_one_routed_rapidfire_block() -> None:
+    event = rapidfire()
+    lists = ([event], [], [], [], [])
+    raw = reconstruct_events(*lists)
+    assert len(raw) == 1
+    assert raw[0]["macro_action"] == "macro_rapidfire"
+    assert raw[0]["duration_us"] == 100_000
+    document = MacroDocument.from_payload({"events": raw})
+    assert document.duration_us == 150_000
+    assert len(document.events) == 1
+    reopened = document.events[0]
+    assert reopened.rapidfire_enabled
+    assert reopened.rapidfire_hold_ms == reopened.rapidfire_wait_ms == 10
+    assert reopened.output_id == "virtual-gamepad-3"
+    assert reconstruct_events(*parse_events(raw)) == raw
+
+    selection.assign_missing_orders(lists)
+    fragment = selection.Fragment.capture(lists, [event])
+    copied = selection.Fragment.from_clipboard(json.dumps(fragment.clipboard_payload()).encode())
+    pasted = copied.paste(lists, 200_000)
+    assert len(pasted) == 1
+    assert isinstance(pasted[0], EditableEvent)
+    assert pasted[0].rapidfire_enabled
+    assert pasted[0].output_id == "virtual-gamepad-3"
+    assert selection.bounds(pasted) == (200_000, 300_000)
+
+
+def test_duration_edits_keep_rapidfire_preferences_and_recompute_the_block() -> None:
+    event = rapidfire()
+    lists = ([event], [], [], [], [])
+    selection.scale([event], 2)
+    assert (event.press_t_us, event.release_t_us) == (50_000, 250_000)
+    assert event.rapidfire_hold_ms == event.rapidfire_wait_ms == 10
+    timing_ops.trim_endpoint(*lists, 175_000)
+    raw = reconstruct_events(*lists)
+    assert len(raw) == 1
+    assert raw[0]["duration_us"] == 125_000
+
+
+def test_edit_reopens_shared_selector_with_saved_rapidfire_settings(monkeypatch) -> None:
+    from keymasq.gui.widgets.key_selector import dialog as selector_module
+
+    factory = MagicMock()
+    monkeypatch.setattr(selector_module, "KeySelectorDialog", factory)
+    dialog = _build_macro_dialog(monkeypatch)
+    event = rapidfire()
+    dialog._events = [event]
+    dialog._timeline._selected = event
+    dialog._on_change_key_clicked(None)
+    action = factory.call_args.args[2]
+    assert isinstance(action, MappingAction)
+    assert action.action_type == ActionType.GAMEPAD
+    assert action.output_id == "virtual-gamepad-3"
+    assert action.rapidfire_enabled
+    assert action.rapidfire_hold_ms == action.rapidfire_wait_ms == 10
+    assert factory.call_args.kwargs["allow_rapidfire"] is True
+    assert factory.call_args.kwargs["allow_tap"] is False
+    factory.return_value.connect.assert_called_once_with(
+        "key-selected", dialog._on_key_selected_for_edit
+    )
+
+
+@pytest.mark.parametrize(
+    ("action_type", "target", "device_type"),
+    [
+        (ActionType.KEYBOARD, "key_a", "keyboard"),
+        (ActionType.MOUSE, "btn_left", "mouse"),
+        (ActionType.GAMEPAD, "btn_south", "gamepad"),
+    ],
+)
+def test_selector_result_creates_edits_and_disables_rapidfire(
+    monkeypatch,
+    action_type: ActionType,
+    target: str,
+    device_type: str,
+) -> None:
+    dialog = _build_macro_dialog(monkeypatch)
+    action = MappingAction(
+        action_type=action_type,
+        target=target,
+        output_id="virtual-gamepad-3",
+        rapidfire_enabled=True,
+        rapidfire_hold_ms=10,
+        rapidfire_wait_ms=10,
+    )
+    dialog._on_key_selected_for_insert(dialog, action, 50_000)
+    event = dialog._events[0]
+    assert event.device_type == device_type
+    assert event.rapidfire_enabled
+    assert "Rapidfire" in dialog._prop_title.get_label()
+    dialog._duration_spin.set_value(100)
+    assert event.release_t_us == 150_000
+    assert "6 pulses" in dialog._key_info_label.get_label()
+    assert "8.000 ms" in dialog._key_info_label.get_label()
+
+    action.rapidfire_hold_ms = 5
+    dialog._on_key_selected_for_edit(dialog, action)
+    assert len(dialog._events) == 1
+    assert event.rapidfire_hold_ms == 5
+    assert event.release_t_us == 150_000
+
+    action.rapidfire_enabled = False
+    dialog._on_key_selected_for_edit(dialog, action)
+    assert not event.rapidfire_enabled
+    raw = reconstruct_events(dialog._events, [], [], [], [])
+    assert [(e["t_us"], e["value"]) for e in raw] == [(50_000, 1), (150_000, 0)]

--- a/tests/keymasqd/test_macro_rapidfire.py
+++ b/tests/keymasqd/test_macro_rapidfire.py
@@ -1,0 +1,203 @@
+import asyncio
+from collections.abc import AsyncIterator
+from dataclasses import replace
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from keymasq.keymasqd import device_manager
+from keymasq.keymasqd.device_manager import DeviceManager
+from keymasq.keymasqd.macro_file import macro_payload_from_events
+from keymasq.keymasqd.macro_store import MacroStore
+from keymasq.keymasqd.runtime.macro import scheduler
+from keymasq.keymasqd.runtime.macro.events import expand_macro_rapidfire
+
+
+def block(**fields: object) -> dict[str, object]:
+    return {
+        "macro_action": "macro_rapidfire",
+        "device_type": "keyboard",
+        "type": 1,
+        "code": 30,
+        "value": 0,
+        "t_us": 0,
+        "duration_us": 100_000,
+        "rapidfire_hold_ms": 10,
+        "rapidfire_wait_ms": 10,
+        **fields,
+    }
+
+
+async def source(events: list[dict[str, object]]) -> AsyncIterator[dict[str, object]]:
+    for event in events:
+        yield event
+
+
+@pytest.mark.asyncio
+async def test_merges_blocks_with_other_inputs_and_observes_only_stored_events() -> None:
+    control_down = dict(device_type="keyboard", type=1, code=29, value=1, t_us=0)
+    control_up = {**control_down, "value": 0, "t_us": 100_000}
+    raw = [control_down, block(), block(code=48, t_us=18_000, duration_us=20_000), control_up]
+    observed = []
+    expanded = [
+        event async for event in expand_macro_rapidfire(source(raw), observe=observed.append)
+    ]
+    assert observed == raw
+    assert [event["t_us"] for event in expanded] == sorted(event["t_us"] for event in expanded)
+    assert expanded[0] == control_down
+    assert expanded[-1] == control_up
+    assert [(e["code"], e["value"]) for e in expanded if e["t_us"] == 18_000] == [(30, 1), (48, 1)]
+    assert sum(e["code"] == 30 for e in expanded) == 12
+    assert sum(e["code"] == 48 for e in expanded) == 2
+
+
+@pytest.mark.asyncio
+async def test_large_block_expands_lazily_and_retains_gamepad_output() -> None:
+    stream = expand_macro_rapidfire(
+        source(
+            [
+                block(
+                    device_type="gamepad",
+                    output_id="virtual-gamepad-3",
+                    duration_us=10**15,
+                    rapidfire_hold_ms=0,
+                    rapidfire_wait_ms=1,
+                )
+            ]
+        )
+    )
+    try:
+        first = await anext(stream)
+        second = await anext(stream)
+        assert first["t_us"] == second["t_us"] == 0
+        assert first["output_id"] == second["output_id"] == "virtual-gamepad-3"
+        assert [first["value"], second["value"]] == [1, 0]
+    finally:
+        await stream.aclose()
+
+
+def test_storage_duration_includes_block_end_without_expansion() -> None:
+    event = block(t_us=50_000)
+    payload = macro_payload_from_events({}, [event])
+    assert payload["duration_us"] == 150_000
+    assert payload["event_count"] == 1
+    assert payload["events"] == [event]
+    assert payload["device_types"] == ["keyboard"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("speed", [0.5, 1.0, 2.0])
+async def test_scheduler_scales_pulses_and_shifts_them_for_explicit_wait(speed: float) -> None:
+    manager = DeviceManager()
+    now = 0.0
+    emitted: list[tuple[float, int, int]] = []
+
+    async def sleep(delay: float) -> None:
+        nonlocal now
+        now += delay
+
+    manager.output_state.keyboard_uinput = MagicMock()
+    manager.output_state.keyboard_uinput.write.side_effect = lambda _type, code, value: (
+        emitted.append((now, code, value))
+    )
+    deps = replace(
+        device_manager._macro_runtime_deps(),
+        asyncio_mod=SimpleNamespace(
+            sleep=sleep,
+            get_running_loop=lambda: SimpleNamespace(time=lambda: now),
+            to_thread=asyncio.to_thread,
+            CancelledError=asyncio.CancelledError,
+        ),
+    )
+    await scheduler.play_macro_task(
+        manager,
+        instance_id=1,
+        macro_events=[block(), {"macro_action": "wait", "t_us": 50_000, "duration_us": 20_000}],
+        macro_name="pulse",
+        replay_mouse_movement=True,
+        replay_mouse_clicks=True,
+        speed=speed,
+        loop_mode="none",
+        loop_count=1,
+        move_to_start=False,
+        start_x=0,
+        start_y=0,
+        block_mouse_movement=False,
+        deps=deps,
+    )
+    expected = [0, 10, 18, 28, 36, 46, 54, 64, 72, 82, 90, 100]
+    assert [time for time, _, _ in emitted] == pytest.approx(
+        [
+            milliseconds / 1000 / speed + (0.020 if milliseconds > 50 else 0)
+            for milliseconds in expected
+        ]
+    )
+    assert [(code, value) for _, code, value in emitted] == [(30, 1), (30, 0)] * 6
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("cancel", [False, True])
+async def test_pause_or_cancel_releases_active_pulse_without_leaking_outputs(cancel: bool) -> None:
+    manager = DeviceManager()
+    pressed = asyncio.Event()
+    output = MagicMock()
+    output.write.side_effect = lambda *_args: pressed.set()
+    manager.output_state.keyboard_uinput = output
+    trigger = dict(
+        macro_name="pulse",
+        load_stored_macro=False,
+        source_device="kbd",
+        source_button="key_f13",
+    )
+    try:
+        await manager.play_macro(
+            **trigger,
+            trigger_value=1,
+            loop_stop_behavior="pause_run",
+            macro_events=[block(duration_us=200_000, rapidfire_hold_ms=50, rapidfire_wait_ms=50)],
+        )
+        await asyncio.wait_for(pressed.wait(), timeout=2)
+        if cancel:
+            await manager.cancel_macro_playback()
+            assert not manager.macro_state.tasks
+        else:
+            await manager.play_macro(**trigger, trigger_value=0)
+            assert all(pause.paused for pause in manager.macro_state.pauses.values())
+        assert [call.args for call in output.write.call_args_list] == [(1, 30, 1), (1, 30, 0)]
+        if not cancel:
+            await manager.play_macro(**trigger, trigger_value=1)
+            await asyncio.wait_for(asyncio.gather(*manager.macro_state.tasks.values()), timeout=2)
+            assert [call.args for call in output.write.call_args_list] == [
+                (1, 30, 1),
+                (1, 30, 0),
+            ] * 3
+        assert not manager.macro_state.instance_held
+    finally:
+        await manager.cancel_macro_playback()
+
+
+@pytest.mark.asyncio
+async def test_stored_block_loops_from_cache_without_saving_generated_pulses(
+    tmp_path: Path,
+) -> None:
+    manager = DeviceManager()
+    output = MagicMock()
+    manager.output_state.keyboard_uinput = output
+    store = MacroStore(tmp_path / "macros")
+    event = block(duration_us=10_000, rapidfire_hold_ms=1, rapidfire_wait_ms=1)
+    store.create({"name": "pulse", "events": [event]})
+    manager.macro_store = store
+    try:
+        await manager.play_macro(macro_name="pulse", loop_mode="count", loop_count=3)
+        await asyncio.wait_for(asyncio.gather(*manager.macro_state.tasks.values()), timeout=2)
+        assert [call.args for call in output.write.call_args_list] == [(1, 30, 1), (1, 30, 0)] * 15
+        revision = store.probe_revision("pulse")
+        assert revision is not None
+        cached = manager.macro_state.replay_cache.get(revision)
+        assert cached is not None
+        assert cached.events == (event,)
+        assert cached.duration_us == 10_000
+    finally:
+        await manager.cancel_macro_playback()


### PR DESCRIPTION
## Summary

Add Rapidfire to the macro editor's existing key selector for keyboard keys, mouse buttons, and gamepad buttons. Each action stays one editable block. Hold sets the pulse length; the preferred Wait adjusts to space pulses evenly and schedule the final release at the block's end.

Store a `macro_rapidfire` action and lazily merge its pulses into normal playback. This preserves overlapping events, playback speed, waits, pause/cancel cleanup, and cached loops. The timeline shows pulses in the lower 40% of the block using the track's color.

Closes #279.

## Testing

- [x] `./scripts/check.sh`: 3,486 passed, 28 skipped.
- [x] Daemon/session VM integration passed without regressions
- [x] `scripts/update-doc-screenshots` generated dark screenshots match the tracked files, with no image diff to commit.
- Added coverage for fitted timing, rounding, short blocks, storage, lazy expansion, overlapping events, speed/waits, pause/cancel, cache loops, selector settings, and editor round trips.

## Notes

- No packaging or service configuration changes.
- Existing macros keep their behavior. Disabling Rapidfire restores a continuous hold.
