### PR TITLE
Save rapidfire options without reselecting the bound key

### DIFF
--- a/docs/MACRO_EDITOR.md
+++ b/docs/MACRO_EDITOR.md
@@ -97,7 +97,9 @@ and configuration fields. Properties edit the selected action immediately;
 Enable **Rapidfire** in the key selector when adding a keyboard key, mouse
 button, or gamepad button, or use **Change Key…** on an existing action.
 The pulses stay in one editable timeline block. **Edit Rapidfire…** reopens
-the selector; disabling Rapidfire restores a continuous hold.
+the selector, with the current key or button highlighted. Adjust the timings
+and click **Save changes** to keep that target without selecting it again.
+Disabling Rapidfire and saving restores a continuous hold.
 
 **Hold** sets each press's duration and **Wait** sets the preferred gap.
 Keymasq spaces the pulses evenly, adjusting the gaps so the final release

--- a/docs/PROFILES.md
+++ b/docs/PROFILES.md
@@ -7,6 +7,10 @@ Keymasq can activate more than one profile at the same time, then merge those
 profiles into the final mapping for each device based on profile type,
 priority, and active window rules.
 
+When editing an existing key or button mapping, the selector highlights the
+bound target. Adjust Rapidfire or Tap options and click **Save changes** to keep
+that target. Selecting another key or button still replaces the mapping directly.
+
 > **Profiles are global, not per-device.** A single profile can contain
 > mappings for your keyboard, mouse, and gamepad together.
 

--- a/docs/PROFILES.md
+++ b/docs/PROFILES.md
@@ -10,6 +10,10 @@ priority, and active window rules.
 When editing an existing key or button mapping, the selector highlights the
 bound target. Adjust Rapidfire or Tap options and click **Save changes** to keep
 that target. Selecting another key or button still replaces the mapping directly.
+Gamepad axes use their existing **Map Analog** or **Map axis** button to commit
+the displayed axis value and options. Bound buttons are also highlighted in
+template and physical-output pickers, including controls loaded after opening
+the selector.
 
 > **Profiles are global, not per-device.** A single profile can contain
 > mappings for your keyboard, mouse, and gamepad together.

--- a/keymasq/gui/style.css
+++ b/keymasq/gui/style.css
@@ -249,6 +249,11 @@ button.key-button {
   min-height: 0;
 }
 
+button.bound-target {
+  background-color: alpha(@accent_color, 0.2);
+  box-shadow: inset 0 0 0 2px @accent_color;
+}
+
 /* Macro Controls: compact slot cards with tinted record/play glyphs */
 .macro-slot-card {
   min-width: 104px;

--- a/keymasq/gui/widgets/input_picker_shared.py
+++ b/keymasq/gui/widgets/input_picker_shared.py
@@ -352,6 +352,7 @@ def build_numpad_grid(owner) -> Gtk.Fixed:
         w = key_size * col_span + gap * (col_span - 1)
         h = key_size * row_span + gap * (row_span - 1)
         btn = Gtk.Button(label=label)
+        btn._evdev_name = evdev
         btn.add_css_class("key-button")
         btn.add_css_class("square-key-button")
         btn.set_can_shrink(True)

--- a/keymasq/gui/widgets/input_picker_shared.py
+++ b/keymasq/gui/widgets/input_picker_shared.py
@@ -17,6 +17,16 @@ log = logging.getLogger("keymasq.gui.widgets.input_picker_shared")
 
 RAW_TRANSPORT_KEY_GROUP_TITLES = frozenset({"Playback"})
 
+
+def mark_bound_target(button: Gtk.Button) -> None:
+    """Mark an established target without duplicating its tooltip on refresh."""
+    if button.has_css_class("bound-target"):
+        return
+    button.add_css_class("bound-target")
+    tooltip = button.get_tooltip_text()
+    button.set_tooltip_text(f"{tooltip} · Currently bound" if tooltip else "Currently bound")
+
+
 GAMEPAD_BUTTONS: dict[str, str] = {
     "A": "btn_south",
     "B": "btn_east",

--- a/keymasq/gui/widgets/key_selector/dialog.py
+++ b/keymasq/gui/widgets/key_selector/dialog.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable
+from dataclasses import replace
 from typing import Any
 
 import gi
@@ -389,6 +390,7 @@ class KeySelectorDialog(
                 self.stack.add_titled(self._build_profile_tab(), "profile", "Profile")
 
         self._set_initial_tab()
+        self._mark_current_target(self.stack)
 
         frame = Gtk.Frame()
         frame.set_vexpand(True)
@@ -476,6 +478,11 @@ class KeySelectorDialog(
         self.map_btn.connect("clicked", self._on_map_clicked)
         footer.append(self.map_btn)
 
+        self.save_changes_btn = Gtk.Button(label="Save changes")
+        self.save_changes_btn.add_css_class("suggested-action")
+        self.save_changes_btn.connect("clicked", self._on_save_changes_clicked)
+        footer.append(self.save_changes_btn)
+
         cancel_btn = Gtk.Button(label="Cancel")
         cancel_btn.connect("clicked", self._on_cancel_clicked)
         footer.append(cancel_btn)
@@ -491,6 +498,56 @@ class KeySelectorDialog(
 
         self.stack.connect("notify::visible-child", self._on_tab_changed)
         self._on_tab_changed(self.stack, None)
+
+    def _mark_current_target(self, widget: Gtk.Widget) -> None:
+        action = self._current_action
+        if action is None or action.action_type not in {
+            ActionType.KEYBOARD,
+            ActionType.MOUSE,
+            ActionType.GAMEPAD,
+        }:
+            return
+        if isinstance(widget, Gtk.Button) and getattr(widget, "_evdev_name", None) == action.target:
+            widget.add_css_class("bound-target")
+            tooltip = widget.get_tooltip_text()
+            widget.set_tooltip_text(
+                f"{tooltip} · Currently bound" if tooltip else "Currently bound"
+            )
+        child = widget.get_first_child()
+        while child is not None:
+            self._mark_current_target(child)
+            child = child.get_next_sibling()
+
+    def _can_save_current_input(self) -> bool:
+        action = self._current_action
+        if action is None:
+            return False
+        tabs = {
+            ActionType.KEYBOARD: {"keyboard", "navigation"},
+            ActionType.MOUSE: {"mouse"},
+            ActionType.GAMEPAD: {"gamepad"},
+            ActionType.GAMEPAD_AXIS: {"gamepad"},
+        }
+        return (
+            self.stack.get_visible_child_name() in tabs.get(action.action_type, set())
+            and (self._allow_rapidfire or self._allow_tap)
+            and action.target not in MEDIA_KEY_TARGETS
+        )
+
+    def _on_save_changes_clicked(self, _button: Gtk.Button) -> None:
+        if not self._can_save_current_input() or self._current_action is None:
+            return
+        action = replace(
+            self._current_action,
+            rapidfire_enabled=self._allow_rapidfire and self._rapidfire_enabled,
+            rapidfire_hold_ms=int(self.hold_spin.get_value()),
+            rapidfire_wait_ms=int(self.wait_spin.get_value()),
+            tap_enabled=self._allow_tap and self._tap_enabled,
+            tap_hold_ms=int(self.tap_spin.get_value()),
+        )
+        if action.action_type in {ActionType.GAMEPAD, ActionType.GAMEPAD_AXIS}:
+            action.output_id = self._selected_gamepad_output_id
+        self._emit_selected_action(action)
 
     def _on_search_key_pressed(
         self,
@@ -636,6 +693,7 @@ class KeySelectorDialog(
         self.options_box.set_sensitive(show_options)
         self.options_box.set_visible(show_options)
         self._update_options_visibility()
+        self.save_changes_btn.set_visible(self._can_save_current_input())
         self.map_btn.set_visible(
             is_superkey
             or is_analog_control

--- a/keymasq/gui/widgets/key_selector/dialog.py
+++ b/keymasq/gui/widgets/key_selector/dialog.py
@@ -32,6 +32,7 @@ from keymasq.gui.widgets.compositor_actions import (
     compositor_action_tab_name,
 )
 from keymasq.gui.widgets.fuzzy_search import start_search_from_keypress
+from keymasq.gui.widgets.input_picker_shared import mark_bound_target
 from keymasq.gui.widgets.mouse_move_units import speed_kpx_s_to_px_s
 from keymasq.gui.widgets.position_capture import PositionCallback, PositionCaptureController
 
@@ -508,11 +509,7 @@ class KeySelectorDialog(
         }:
             return
         if isinstance(widget, Gtk.Button) and getattr(widget, "_evdev_name", None) == action.target:
-            widget.add_css_class("bound-target")
-            tooltip = widget.get_tooltip_text()
-            widget.set_tooltip_text(
-                f"{tooltip} · Currently bound" if tooltip else "Currently bound"
-            )
+            mark_bound_target(widget)
         child = widget.get_first_child()
         while child is not None:
             self._mark_current_target(child)
@@ -526,7 +523,6 @@ class KeySelectorDialog(
             ActionType.KEYBOARD: {"keyboard", "navigation"},
             ActionType.MOUSE: {"mouse"},
             ActionType.GAMEPAD: {"gamepad"},
-            ActionType.GAMEPAD_AXIS: {"gamepad"},
         }
         return (
             self.stack.get_visible_child_name() in tabs.get(action.action_type, set())
@@ -545,7 +541,7 @@ class KeySelectorDialog(
             tap_enabled=self._allow_tap and self._tap_enabled,
             tap_hold_ms=int(self.tap_spin.get_value()),
         )
-        if action.action_type in {ActionType.GAMEPAD, ActionType.GAMEPAD_AXIS}:
+        if action.action_type == ActionType.GAMEPAD:
             action.output_id = self._selected_gamepad_output_id
         self._emit_selected_action(action)
 

--- a/keymasq/gui/widgets/virtual_device_picker.py
+++ b/keymasq/gui/widgets/virtual_device_picker.py
@@ -15,7 +15,7 @@ from keymasq.common.virtual_device_templates import (
     VirtualDeviceTemplate,
 )
 from keymasq.gui.widgets.flight_stick_artwork import FlightStickDrawing
-from keymasq.gui.widgets.input_picker_shared import _get_gamepad_image_path
+from keymasq.gui.widgets.input_picker_shared import _get_gamepad_image_path, mark_bound_target
 
 
 def axis_percent_value(axis: VirtualAxis, percent: float) -> int:
@@ -41,6 +41,7 @@ class VirtualDevicePicker(Gtk.Box):
         self.set_halign(Gtk.Align.CENTER)
         self._on_button = on_button
         self._on_axis = on_axis
+        self._current_target = current_target
         self._axes = {axis.evdev: axis for axis in template.axes}
         self._template = template
         self._unknown_rest_axes = unknown_rest_axes
@@ -256,6 +257,7 @@ class VirtualDevicePicker(Gtk.Box):
                 else f"{number} · {control.label}"
             )
             button = Gtk.Button(label=label, tooltip_text=f"{control.id} · {control.evdev}")
+            self._identify_button(button, control.evdev)
             button.set_size_request(-1, 40)
             button.set_hexpand(True)
             button.connect("clicked", self._on_button, control.evdev)
@@ -301,6 +303,11 @@ class VirtualDevicePicker(Gtk.Box):
         box.append(label)
         return box
 
+    def _identify_button(self, button: Gtk.Button, code: str) -> None:
+        button._evdev_name = code
+        if code == self._current_target:
+            mark_bound_target(button)
+
     def _button(self, label: str, code: str, tooltip: str) -> Gtk.Widget:
         numeric_code = int(getattr(evdev.ecodes, code.upper()))
         control = self._buttons.get(numeric_code)
@@ -322,6 +329,7 @@ class VirtualDevicePicker(Gtk.Box):
         button.add_css_class("key-button")
         button.set_size_request(36, 34)
         button.set_tooltip_text(f"{control.label} · {tooltip} · {code}")
+        self._identify_button(button, code)
         button.connect("clicked", self._on_button, code)
         return button
 

--- a/tests/gui/test_controller_capability_setup.py
+++ b/tests/gui/test_controller_capability_setup.py
@@ -182,6 +182,52 @@ def test_motion_interfaces_are_excluded():
     assert not config.analog_inputs
 
 
+def test_physical_selector_highlights_buttons_after_inventory_arrives(monkeypatch):
+    from types import SimpleNamespace
+
+    from gi.repository import Gtk
+
+    import keymasq.gui.widgets.key_selector.tabs as tabs
+    from keymasq.common.model.actions import MappingAction
+    from keymasq.common.model.core import ActionType
+    from keymasq.common.virtual_device_templates import VirtualDeviceConfig
+    from keymasq.gui.widgets.key_selector.dialog import KeySelectorDialog
+    from tests.gui.support import collect_widgets
+
+    config = hardware_from_interfaces([controller_interface(LOGITECH_EXTREME_3D_TEMPLATE)])
+    monkeypatch.setattr(tabs, "virtual_gamepad_count", lambda: 1)
+    monkeypatch.setattr(tabs, "virtual_device_config", VirtualDeviceConfig)
+    monkeypatch.setattr(
+        tabs, "HardwareManager", lambda: SimpleNamespace(list_hardware=lambda: [config])
+    )
+    callbacks = []
+    monkeypatch.setattr(
+        tabs, "session_request_async", lambda _request, callback: callbacks.append(callback)
+    )
+    dialog = KeySelectorDialog(
+        Gtk.Box(),
+        "Source",
+        MappingAction(
+            action_type=ActionType.GAMEPAD,
+            target="btn_trigger",
+            output_id=config.hardware_id,
+        ),
+    )
+    assert len(callbacks) == 1
+    assert not collect_widgets(dialog._template_gamepad_picker, Gtk.Button)
+    callbacks[0]({"devices": [output_inventory(config)]})
+    for _ in range(2):
+        marked = [
+            button
+            for button in collect_widgets(dialog._template_gamepad_picker, Gtk.Button)
+            if button.has_css_class("bound-target")
+        ]
+        assert len(marked) == 1
+        assert marked[0]._evdev_name == "btn_trigger"
+        assert marked[0].get_tooltip_text().count("Currently bound") == 1
+        dialog._refresh_virtual_device_picker()
+
+
 def test_physical_selector_uses_saved_flight_controls_and_ranges(monkeypatch):
     from types import SimpleNamespace
 

--- a/tests/gui/test_flight_stick_picker.py
+++ b/tests/gui/test_flight_stick_picker.py
@@ -95,6 +95,35 @@ def test_reopening_exact_axis_value_does_not_round_it_to_a_percentage():
     assert selected == [("abs_x", 673)]
 
 
+@pytest.mark.parametrize("target", ["btn_trigger", "btn_trigger_happy1"])
+def test_template_marks_bound_buttons_including_extras(target):
+    from dataclasses import replace
+
+    from keymasq.common.virtual_device_templates import VirtualButton
+    from keymasq.gui.widgets.input_picker_shared import mark_bound_target
+
+    template = replace(
+        LOGITECH_EXTREME_3D_TEMPLATE,
+        buttons=(
+            *LOGITECH_EXTREME_3D_TEMPLATE.buttons,
+            VirtualButton("gear", "Landing gear", "btn_trigger_happy1"),
+        ),
+    )
+    widget = VirtualDevicePicker(
+        template,
+        lambda *args: None,
+        lambda *args: None,
+        current_target=target,
+    )
+    marked = [button for button in buttons(widget) if button.has_css_class("bound-target")]
+    assert len(marked) == 1
+    assert marked[0]._evdev_name == target
+    tooltip = marked[0].get_tooltip_text()
+    mark_bound_target(marked[0])
+    assert marked[0].get_tooltip_text() == tooltip
+    assert tooltip.count("Currently bound") == 1
+
+
 @pytest.mark.parametrize("layout", ["flight-stick", "gamepad"])
 def test_custom_template_layout_maps_only_configured_buttons(picker, layout):
     from dataclasses import replace

--- a/tests/gui/test_key_selector_edit_options.py
+++ b/tests/gui/test_key_selector_edit_options.py
@@ -67,6 +67,91 @@ def test_save_existing_target_options(kind, target, tab, macro_edit):
     assert original.rapidfire_wait_ms == 30
 
 
+@pytest.mark.parametrize("template_axis", [False, True])
+def test_axis_commit_saves_displayed_value(monkeypatch, template_axis):
+    from gi.repository import Gtk
+
+    from keymasq.common.model.actions import MappingAction
+    from keymasq.common.model.core import ActionType
+    from keymasq.common.virtual_device_templates import (
+        LOGITECH_EXTREME_3D_TEMPLATE_ID,
+        VirtualDeviceConfig,
+        VirtualDeviceInstance,
+    )
+    from keymasq.gui.widgets.key_selector import tabs
+    from keymasq.gui.widgets.key_selector.dialog import KeySelectorDialog
+    from tests.gui.support import collect_widgets
+
+    config = (
+        VirtualDeviceConfig(
+            devices=(
+                VirtualDeviceInstance(
+                    "flight-stick",
+                    LOGITECH_EXTREME_3D_TEMPLATE_ID,
+                ),
+            )
+        )
+        if template_axis
+        else VirtualDeviceConfig()
+    )
+    monkeypatch.setattr(tabs, "virtual_device_config", lambda: config)
+    monkeypatch.setattr(tabs, "virtual_gamepad_count", lambda: 1)
+    original = MappingAction(
+        action_type=ActionType.GAMEPAD_AXIS,
+        target="abs_x",
+        axis_value=100,
+        rapidfire_enabled=True,
+        output_id="flight-stick" if template_axis else None,
+    )
+    dialog = KeySelectorDialog(Gtk.Box(), "Source", original)
+    selected = []
+    dialog.connect("key-selected", lambda _dialog, action: selected.append(action))
+    assert not dialog.save_changes_btn.get_visible()
+    if template_axis:
+        picker = dialog._template_gamepad_picker.get_first_child()
+        picker.value_spin.set_value(200)
+        label = "Map axis"
+    else:
+        dialog.gamepad_axis_value.set_value(200)
+        label = "Map Analog"
+    dialog.hold_spin.set_value(45)
+    next(
+        button
+        for button in collect_widgets(dialog.stack, Gtk.Button)
+        if button.get_label() == label
+    ).emit("clicked")
+    assert len(selected) == 1
+    assert selected[0].axis_value == 200
+    assert selected[0].target == "abs_x"
+    assert selected[0].rapidfire_hold_ms == 45
+    assert original.axis_value == 100
+
+
+def test_save_disables_rapidfire_and_enables_tap():
+    from gi.repository import Gtk
+
+    from keymasq.common.model.actions import MappingAction
+    from keymasq.common.model.core import ActionType
+    from keymasq.gui.widgets.key_selector.dialog import KeySelectorDialog
+
+    original = MappingAction(
+        action_type=ActionType.KEYBOARD,
+        target="key_a",
+        rapidfire_enabled=True,
+    )
+    dialog = KeySelectorDialog(Gtk.Box(), "Source", original)
+    results = []
+    dialog.connect("key-selected", lambda _dialog, action: results.append(action))
+    dialog.rapidfire_check.set_active(False)
+    dialog.tap_check.set_active(True)
+    dialog.tap_spin.set_value(230)
+    dialog.save_changes_btn.emit("clicked")
+    assert not results[0].rapidfire_enabled
+    assert results[0].tap_enabled
+    assert results[0].tap_hold_ms == 230
+    assert original.rapidfire_enabled
+
+
 def test_cancel_option_changes_keeps_mapping():
     from gi.repository import Gtk
 

--- a/tests/gui/test_key_selector_edit_options.py
+++ b/tests/gui/test_key_selector_edit_options.py
@@ -1,0 +1,85 @@
+import pytest
+
+pytest.importorskip("gi")
+
+
+@pytest.mark.parametrize(
+    ("kind", "target", "tab"),
+    [
+        ("keyboard", "key_space", "keyboard"),
+        ("keyboard", "key_kp7", "navigation"),
+        ("mouse", "btn_left", "mouse"),
+        ("gamepad", "btn_south", "gamepad"),
+    ],
+)
+@pytest.mark.parametrize("macro_edit", [False, True])
+def test_save_existing_target_options(kind, target, tab, macro_edit):
+    from gi.repository import Gtk
+
+    from keymasq.common.model.actions import MappingAction
+    from keymasq.common.model.core import ActionType
+    from keymasq.gui.widgets.key_selector.dialog import KeySelectorDialog
+
+    original = MappingAction(
+        action_type=ActionType(kind),
+        target=target,
+        rapidfire_enabled=True,
+        rapidfire_hold_ms=20,
+        rapidfire_wait_ms=30,
+    )
+    dialog = KeySelectorDialog(
+        Gtk.Box(),
+        "Source",
+        original,
+        initial_tab=tab,
+        allow_tap=not macro_edit,
+        allow_gamepad_axis_rapidfire=not macro_edit,
+        allowed_tabs={tab} if macro_edit else None,
+    )
+    results = []
+    dialog.connect("key-selected", lambda _dialog, action: results.append(action))
+
+    def marked_targets(widget):
+        marked = []
+        if isinstance(widget, Gtk.Button) and widget.has_css_class("bound-target"):
+            marked.append(widget._evdev_name)
+        child = widget.get_first_child()
+        while child is not None:
+            marked.extend(marked_targets(child))
+            child = child.get_next_sibling()
+        return marked
+
+    assert target in marked_targets(dialog.stack)
+    assert dialog.save_changes_btn.get_visible()
+    dialog.hold_spin.set_value(45)
+    dialog.wait_spin.set_value(65)
+    assert original.rapidfire_hold_ms == 20
+    assert results == []
+    dialog.save_changes_btn.emit("clicked")
+
+    assert len(results) == 1
+    saved = results[0]
+    assert saved.target == target
+    assert saved.action_type == original.action_type
+    assert saved.rapidfire_enabled
+    assert saved.rapidfire_hold_ms == 45
+    assert saved.rapidfire_wait_ms == 65
+    assert original.rapidfire_wait_ms == 30
+
+
+def test_cancel_option_changes_keeps_mapping():
+    from gi.repository import Gtk
+
+    from keymasq.common.model.actions import MappingAction
+    from keymasq.common.model.core import ActionType
+    from keymasq.gui.widgets.key_selector.dialog import KeySelectorDialog
+
+    original = MappingAction(action_type=ActionType.KEYBOARD, target="key_a")
+    dialog = KeySelectorDialog(Gtk.Box(), "Source", original)
+    results = []
+    dialog.connect("key-selected", lambda _dialog, action: results.append(action))
+    dialog.rapidfire_check.set_active(True)
+    dialog.hold_spin.set_value(80)
+    dialog.close()
+    assert not original.rapidfire_enabled
+    assert results == []

--- a/tests/gui/test_macro_editor_rapidfire.py
+++ b/tests/gui/test_macro_editor_rapidfire.py
@@ -238,6 +238,39 @@ def test_macro_selector_rejects_axis_rapidfire_and_allows_correction(
         assert event.value == 32767
 
 
+@pytest.mark.parametrize("enabled", [False, True])
+def test_save_selector_options_updates_real_macro_block(monkeypatch, enabled) -> None:
+    from keymasq.gui.widgets.key_selector import dialog as selector_module
+
+    selector_class = selector_module.KeySelectorDialog
+    selectors = []
+
+    def create_selector(*args, **kwargs):
+        picker = selector_class(*args, **kwargs)
+        monkeypatch.setattr(picker, "present", MagicMock())
+        selectors.append(picker)
+        return picker
+
+    monkeypatch.setattr(selector_module, "KeySelectorDialog", create_selector)
+    editor = _build_macro_dialog(monkeypatch)
+    event = rapidfire()
+    editor._events = [event]
+    editor._timeline._selected = event
+    editor._on_change_key_clicked(None)
+    picker = selectors[0]
+    picker.rapidfire_check.set_active(enabled)
+    picker.hold_spin.set_value(15)
+    picker.wait_spin.set_value(25)
+    picker.save_changes_btn.emit("clicked")
+    assert editor._events == [event]
+    assert event.code == evdev.ecodes.BTN_SOUTH
+    assert event.output_id == "virtual-gamepad-3"
+    assert (event.press_t_us, event.release_t_us) == (50_000, 150_000)
+    assert event.rapidfire_enabled is enabled
+    assert event.rapidfire_hold_ms == 15
+    assert event.rapidfire_wait_ms == 25
+
+
 def test_regular_selector_still_supports_axis_rapidfire(monkeypatch) -> None:
     from gi.repository import Gtk
 


### PR DESCRIPTION
Editing rapidfire timings previously required clicking the target key or button again. Add **Save changes** to the shared selector so existing mappings and macro blocks can keep their target while updating Rapidfire or Tap options.

Highlight the bound key or button and identify it with a "Currently bound" tooltip, including template buttons and physical-output controls loaded after opening the selector. Cancel preserves the original mapping; selecting another target keeps the existing direct-selection behavior. Gamepad axes retain their existing commit buttons, which save the displayed axis value and options.

Validation: `./scripts/check.sh` passed, including lint, type and CSS checks and 939 GUI tests. Regression coverage includes target preservation, cancellation, Rapidfire and Tap changes, both axis editors, template and asynchronously loaded physical-output highlighting, and saving through the macro editor's callback without changing the block's timing span or output routing.
