### PR TITLE
Add hardware-level default output routing for controllers

### DIFF
--- a/docs/GAMEPAD.md
+++ b/docs/GAMEPAD.md
@@ -64,8 +64,9 @@ example, a digital `BTN_TL2` remains `BTN_TL2`; it does not drive `ABS_Z`.
 `ABS_RZ` remains `ABS_RZ` even when one device calls it twist and another calls
 it a trigger. Use ordinary mappings for these exceptions.
 
-Input cards show the default destination or **No matching output**. Click an
-input to override it. Explicit mappings retain their own actions and output
+Input cards show matching output controls or **No output**. Hover over the output
+label for the destination and evdev codes. Click an input to override it.
+Explicit mappings retain their own actions and output
 destinations. A passthrough mapping cancels a lower-priority mapping and returns
 the input to the default route. Physical-controller and `same-device` output
 actions still require a passthrough clone; select the virtual destination when

--- a/docs/GAMEPAD.md
+++ b/docs/GAMEPAD.md
@@ -13,7 +13,7 @@ stick clicks, digital D-pad) are added when the controller reports them.
 Third-party uinput controllers and wheels are shown in the picker when they
 report gamepad capabilities; Keymasq's own virtual output devices stay hidden.
 
-When Keymasq grabs a physical gamepad, it creates a passthrough uinput clone
+By default, when Keymasq grabs a physical gamepad, it creates a passthrough uinput clone
 for unmapped events. That clone reuses the source controller name and input
 IDs, so Steam and other tools see it as the same controller model.
 
@@ -32,6 +32,58 @@ and leaves the passthrough clone visible. This prevents Steam, SDL games, and
 controller pickers from showing two identical controllers where one is the
 grabbed-but-silent original. The physical source is restored when Keymasq
 releases the grab or stops.
+
+## Default controller output
+
+Choose **Controller output → Default output** during hardware setup or in
+**Hardware Settings**, directly below the hardware name. Choose passthrough or
+a configured virtual controller, including custom template instances. Setup
+starts with passthrough; choosing a virtual destination opts this hardware into
+routing. Existing hardware configurations retain passthrough.
+
+The destination belongs to the hardware and stays the same across profiles.
+Routing remains active with no profiles enabled.
+
+Selecting a virtual output grabs the controller interfaces even without
+explicit mappings. Those interfaces do not create passthrough clones.
+Other interfaces on a composite device retain their normal behavior. The virtual
+controller keeps its configured identity and capabilities.
+
+Unmapped buttons use the same numeric evdev button code on the destination.
+Unmapped absolute axes use the same axis code, with linear conversion between
+the source and destination minimum and maximum values. Saved source bounds
+override device-reported bounds. Inputs with no matching destination code, or
+axes without usable source bounds, produce no output. Relative and miscellaneous
+events are not forwarded to the controller output.
+
+Routing does not infer control roles or convert between buttons and axes. For
+example, a digital `BTN_TL2` remains `BTN_TL2`; it does not drive `ABS_Z`.
+`ABS_RZ` remains `ABS_RZ` even when one device calls it twist and another calls
+it a trigger. Use ordinary mappings for these exceptions.
+
+Input cards show the default destination or **No matching output**. Click an
+input to override it. Explicit mappings retain their own actions and output
+destinations. A passthrough mapping cancels a lower-priority mapping and returns
+the input to the default route. Physical-controller and `same-device` output
+actions still require a passthrough clone; select the virtual destination when
+overriding controls on a routed controller.
+
+In the hardware config:
+
+```toml
+[hardware]
+# Existing identity and layout fields remain here.
+default_output = "virtual-gamepad-1"
+```
+
+Omit `default_output` or set it to `"passthrough"` for normal passthrough.
+Profiles only override individual inputs; they do not change this destination.
+
+An unavailable virtual destination drops default output until it is configured
+again. It does not fall back to a passthrough clone. Changing the route releases
+the previous output and reopens the affected controller interfaces. Disconnects
+and virtual-output reconfiguration also release tracked buttons and axes.
+Default routing does not add force feedback to virtual controllers.
 
 ## Button Mapping
 

--- a/docs/GAMEPAD.md
+++ b/docs/GAMEPAD.md
@@ -55,6 +55,9 @@ the source and destination minimum and maximum values. Saved source bounds
 override device-reported bounds. Inputs with no matching destination code, or
 axes without usable source bounds, produce no output. Relative and miscellaneous
 events are not forwarded to the controller output.
+Current axis positions are sent when routing starts or the virtual output is
+recreated, even if the physical axes have not moved. Mapped axes keep their
+explicit actions. Removing saved axis bounds restores the device-reported bounds.
 
 Routing does not infer control roles or convert between buttons and axes. For
 example, a digital `BTN_TL2` remains `BTN_TL2`; it does not drive `ABS_Z`.

--- a/docs/HARDWARE.md
+++ b/docs/HARDWARE.md
@@ -214,3 +214,12 @@ target = "key_1"
 Here `046d:c08b` is the hardware ID and `btn_back` is the button ID — event
 device paths never appear as profile keys. See [Profiles](PROFILES.md) for
 layering and merge behavior.
+
+## Controller output
+
+Choose passthrough or a virtual controller during setup or in Hardware Settings.
+In `[hardware]`, `default_output` defaults to `"passthrough"` and accepts virtual
+output IDs such as `"virtual-gamepad-1"`. This setting applies across profiles,
+even with none active. Virtual routing forwards
+matching button and axis codes, scales axis bounds, and drops unsupported inputs.
+Mappings override individual inputs. See [Controller output](GAMEPAD.md#default-controller-output).

--- a/docs/agents/hardware.txt
+++ b/docs/agents/hardware.txt
@@ -183,3 +183,11 @@ Virtual output IDs are `virtual-gamepad-1` through `virtual-gamepad-4`.
 Hardware gamepad output IDs are the configured hardware IDs, for example
 `045e:028e` or `045e:028e@2`. Explicit output routes are strict and do not
 fall back if unavailable.
+
+## Controller output
+
+Optional `[hardware] default_output`: `"passthrough"` by default, or a virtual
+output ID such as `"virtual-gamepad-1"`. Applies with or without active profiles.
+Virtual routing replaces the clone, forwards same-code buttons/axes, and scales
+axis bounds. Unsupported codes or unavailable outputs drop events. Explicit
+mappings override individual inputs. See GAMEPAD.md for details.

--- a/keymasq/common/controller_routing.py
+++ b/keymasq/common/controller_routing.py
@@ -1,0 +1,23 @@
+"""Controller interface selection for hardware default output routes."""
+
+from keymasq.common.devices import (
+    detect_input_classes_from_capabilities,
+    resolve_evdev_code,
+    resolve_evdev_event_type,
+)
+from keymasq.common.model.core import DeviceType
+from keymasq.common.model.hardware import EvdevDevice
+
+
+def is_controller_interface(device: EvdevDevice) -> bool:
+    if device.device_type == DeviceType.GAMEPAD:
+        return True
+    if device.device_type == DeviceType.MOTION:
+        return False
+    capabilities: dict[int, list[object]] = {}
+    for name in device.capabilities:
+        event_type = resolve_evdev_event_type(name)
+        code = resolve_evdev_code(name)
+        if event_type is not None and code is not None:
+            capabilities.setdefault(event_type, []).append(code)
+    return "gamepad" in detect_input_classes_from_capabilities(capabilities)

--- a/keymasq/common/model/hardware.py
+++ b/keymasq/common/model/hardware.py
@@ -77,6 +77,7 @@ class HardwareConfig:
     image: str | None = None
     id: str | None = None
     input_sources: list[NativeInputSource] = field(default_factory=list)
+    default_output: str = "passthrough"
 
     @property
     def hardware_id(self) -> str:

--- a/keymasq/gui/widgets/controller_output.py
+++ b/keymasq/gui/widgets/controller_output.py
@@ -1,0 +1,123 @@
+"""Hardware output selection shared by setup and settings."""
+
+from collections.abc import Callable
+
+import gi
+
+gi.require_version("Gtk", "4.0")
+gi.require_version("Adw", "1")
+from gi.repository import Adw, GObject, Gtk, Pango  # pyright: ignore[reportAttributeAccessIssue]
+
+from keymasq.common.virtual_device_templates import ResolvedVirtualDevice, resolve_virtual_devices
+from keymasq.gui.session_client import GuiTaskResult, run_gui_task
+from keymasq.gui.widgets.gamepad_output_choices import virtual_device_config, virtual_gamepad_count
+
+
+class ControllerOutputGroup(Adw.PreferencesGroup):
+    def __init__(
+        self,
+        selected: str = "passthrough",
+        on_changed: Callable[[str], None] | None = None,
+    ) -> None:
+        super().__init__(title="Controller output")
+        self.set_description(
+            "Applies to all profiles. Virtual controllers receive matching buttons and axes. "
+            "Map unmatched inputs individually."
+        )
+        self.output_id = selected
+        self._on_changed = on_changed
+        self._ids = ["passthrough"]
+        self.row = Adw.ComboRow(title="Default output")
+        self.row.set_use_subtitle(True)
+        self.row.set_subtitle_lines(0)
+        factory = Gtk.SignalListItemFactory()
+        factory.connect("setup", self._setup_choice)
+        factory.connect("bind", self._bind_choice)
+        self.row.set_list_factory(factory)
+        self.add(self.row)
+        self._populate([])
+        self.row.connect("notify::selected", self._selected)
+        run_gui_task(self._load, self._loaded)
+
+    @staticmethod
+    def _setup_choice(_factory: Gtk.SignalListItemFactory, item: Gtk.ListItem) -> None:
+        box = Gtk.Box(spacing=12)
+        box.set_margin_top(8)
+        box.set_margin_bottom(8)
+        text = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=4)
+        text.set_hexpand(True)
+        for secondary in (False, True):
+            label = Gtk.Label(xalign=0)
+            label.set_wrap(True)
+            label.set_wrap_mode(Pango.WrapMode.WORD_CHAR)
+            label.set_width_chars(28)
+            label.set_max_width_chars(38)
+            if secondary:
+                label.add_css_class("dim-label")
+                label.add_css_class("caption")
+            text.append(label)
+        box.append(text)
+        check = Gtk.Image.new_from_icon_name("object-select-symbolic")
+        item.bind_property("selected", check, "visible", GObject.BindingFlags.SYNC_CREATE)
+        box.append(check)
+        item.set_child(box)
+
+    def _bind_choice(self, _factory: Gtk.SignalListItemFactory, item: Gtk.ListItem) -> None:
+        box = item.get_child()
+        value = item.get_item()
+        if not isinstance(box, Gtk.Box) or not isinstance(value, Gtk.StringObject):
+            return
+        text = box.get_first_child()
+        if not isinstance(text, Gtk.Box):
+            return
+        title = text.get_first_child()
+        if not isinstance(title, Gtk.Label):
+            return
+        detail = title.get_next_sibling()
+        if not isinstance(detail, Gtk.Label):
+            return
+        title.set_text(value.get_string())
+        output_id = self._ids[item.get_position()]
+        detail.set_text(
+            "Keep the original controller layout" if output_id == "passthrough" else output_id
+        )
+
+    @staticmethod
+    def _load() -> list[ResolvedVirtualDevice]:
+        return list(resolve_virtual_devices(virtual_gamepad_count(), virtual_device_config()))
+
+    def _loaded(self, result: GuiTaskResult[list[ResolvedVirtualDevice]]) -> None:
+        if result.error is None:
+            self.row.handler_block_by_func(self._selected)
+            self._populate(result.value or [])
+            self.row.handler_unblock_by_func(self._selected)
+
+    def _populate(self, devices: list[ResolvedVirtualDevice]) -> None:
+        choices = [("passthrough", "Passthrough")]
+        choices.extend(
+            (
+                device.output_id,
+                f"Virtual Gamepad {device.output_id.removeprefix('virtual-gamepad-')}"
+                if device.output_id.startswith("virtual-gamepad-")
+                else device.name,
+            )
+            for device in devices
+        )
+        if all(output_id != self.output_id for output_id, _ in choices):
+            choices.append((self.output_id, f"{self.output_id} (unavailable)"))
+        self._ids = [output_id for output_id, _ in choices]
+        self.row.set_model(Gtk.StringList.new([label for _, label in choices]))
+        self.row.set_selected(self._ids.index(self.output_id))
+
+    def _selected(self, _row: Adw.ComboRow, _param: object) -> None:
+        index = self.row.get_selected()
+        if 0 <= index < len(self._ids):
+            self.output_id = self._ids[index]
+            if self._on_changed is not None:
+                self._on_changed(self.output_id)
+
+    def restore_output(self, output_id: str) -> None:
+        self.output_id = output_id
+        self.row.handler_block_by_func(self._selected)
+        self.row.set_selected(self._ids.index(output_id))
+        self.row.handler_unblock_by_func(self._selected)

--- a/keymasq/gui/widgets/device_tab/default_output.py
+++ b/keymasq/gui/widgets/device_tab/default_output.py
@@ -33,6 +33,13 @@ class DefaultOutputMixin:
         self: Any,
         control: ButtonDefinition | AnalogInputDefinition,
     ) -> str | None:
+        presentation = self._default_output_presentation(control)
+        return presentation[1] if presentation is not None else None
+
+    def _default_output_presentation(
+        self: Any,
+        control: ButtonDefinition | AnalogInputDefinition,
+    ) -> tuple[str, str] | None:
         sources = {
             device.id for device in self.device.evdev_devices if is_controller_interface(device)
         }
@@ -43,7 +50,7 @@ class DefaultOutputMixin:
             return None
         template = getattr(self, "_default_output_templates", {}).get(output_id)
         if template is None:
-            return f"Default → {output_id} (unavailable)"
+            return "Unavailable", f"Default → {output_id} (unavailable)"
         if isinstance(control, ButtonDefinition):
             names = [control.evdev]
             supported = {resolve_evdev_code(button.evdev) for button in template.buttons}
@@ -52,6 +59,17 @@ class DefaultOutputMixin:
             supported = {resolve_evdev_code(axis.evdev) for axis in template.axes}
         matched = [name.upper() for name in names if resolve_evdev_code(name) in supported]
         if not matched:
-            return "No matching output"
+            return "No output", f"No matching output on {output_id}"
         suffix = " · some axes unmatched" if len(matched) != len(names) else ""
-        return f"Default → {output_id} · {', '.join(matched)}{suffix}"
+        if isinstance(control, ButtonDefinition):
+            target = next(
+                button for button in template.buttons
+                if resolve_evdev_code(button.evdev) == resolve_evdev_code(control.evdev)
+            )
+            summary = f"→ {target.label}"
+        else:
+            summary = f"→ {', '.join(name.removeprefix('ABS_') for name in matched)}"
+        return (
+            "Partial output" if suffix else summary,
+            f"Default → {output_id} · {', '.join(matched)}{suffix}",
+        )

--- a/keymasq/gui/widgets/device_tab/default_output.py
+++ b/keymasq/gui/widgets/device_tab/default_output.py
@@ -1,0 +1,57 @@
+"""Describe the hardware controller route on input cards."""
+
+from typing import Any
+
+from keymasq.common.controller_routing import is_controller_interface
+from keymasq.common.devices import resolve_evdev_code
+from keymasq.common.model.hardware import AnalogInputDefinition, ButtonDefinition
+from keymasq.common.virtual_device_templates import ResolvedVirtualDevice, resolve_virtual_devices
+from keymasq.gui.session_client import GuiTaskResult, run_gui_task
+from keymasq.gui.widgets.gamepad_output_choices import virtual_device_config, virtual_gamepad_count
+
+
+class DefaultOutputMixin:
+    def _refresh_default_output_templates(self: Any) -> None:
+        if not any(is_controller_interface(device) for device in self.device.evdev_devices):
+            return
+
+        def load() -> list[ResolvedVirtualDevice]:
+            return list(resolve_virtual_devices(virtual_gamepad_count(), virtual_device_config()))
+
+        def loaded(result: GuiTaskResult[list[ResolvedVirtualDevice]]) -> None:
+            if result.error is not None:
+                return
+            self._default_output_templates = {
+                device.output_id: device.template for device in result.value or []
+            }
+            for input_id in self._button_widgets:
+                self._update_button_display(input_id)
+
+        run_gui_task(load, loaded)
+
+    def _default_output_description(
+        self: Any,
+        control: ButtonDefinition | AnalogInputDefinition,
+    ) -> str | None:
+        sources = {
+            device.id for device in self.device.evdev_devices if is_controller_interface(device)
+        }
+        if not sources or control.source and control.source not in sources:
+            return None
+        output_id = self.device.default_output
+        if output_id in {None, "passthrough"}:
+            return None
+        template = getattr(self, "_default_output_templates", {}).get(output_id)
+        if template is None:
+            return f"Default → {output_id} (unavailable)"
+        if isinstance(control, ButtonDefinition):
+            names = [control.evdev]
+            supported = {resolve_evdev_code(button.evdev) for button in template.buttons}
+        else:
+            names = [axis.evdev for axis in control.axes]
+            supported = {resolve_evdev_code(axis.evdev) for axis in template.axes}
+        matched = [name.upper() for name in names if resolve_evdev_code(name) in supported]
+        if not matched:
+            return "No matching output"
+        suffix = " · some axes unmatched" if len(matched) != len(names) else ""
+        return f"Default → {output_id} · {', '.join(matched)}{suffix}"

--- a/keymasq/gui/widgets/device_tab/hardware.py
+++ b/keymasq/gui/widgets/device_tab/hardware.py
@@ -47,10 +47,15 @@ class HardwareSettingsMixin:
             self._stable_detection_status_for_evdev_device,
             self._show_device_rename_dialog,
             can_delete_profile_mappings=self.profile_manager is not None,
+            on_output_changed=self._on_hardware_output_changed,
         )
         dialog.connect("closed", self._on_hardware_settings_dialog_closed)
         self._hardware_settings_dialog = dialog
         self._present_hardware_settings_dialog(dialog, parent)
+
+    def _on_hardware_output_changed(self: Any) -> None:
+        self._request_session_async({"command": "reload"}, self._ignore_session_response)
+        self._refresh_default_output_templates()
 
     def _hardware_settings_parent(self: Any) -> Gtk.Window | None:
         root = self.main_window or self.get_root()

--- a/keymasq/gui/widgets/device_tab/hardware_settings_dialog.py
+++ b/keymasq/gui/widgets/device_tab/hardware_settings_dialog.py
@@ -199,10 +199,12 @@ class HardwareSettingsDialog(Adw.Dialog):
     def _save_output(self, output_id: str) -> None:
         config = deepcopy(self._hardware_config)
         config.default_output = output_id
-        self._output_group.set_sensitive(False)
+        self.set_sensitive(False)
+        self.set_can_close(False)
 
         def saved(result: GuiTaskResult[None]) -> None:
-            self._output_group.set_sensitive(True)
+            self.set_sensitive(True)
+            self.set_can_close(True)
             if result.error is not None:
                 self._output_group.restore_output(self._hardware_config.default_output)
                 self._status_label.set_label(f"Could not save controller output: {result.error}")
@@ -247,9 +249,6 @@ class HardwareSettingsDialog(Adw.Dialog):
 
         self._output_group = ControllerOutputGroup(
             self._hardware_config.default_output, self._save_output
-        )
-        self._output_group.set_visible(
-            any(is_controller_interface(device) for device in self._hardware_config.evdev_devices)
         )
         box.append(self._output_group)
 
@@ -320,6 +319,9 @@ class HardwareSettingsDialog(Adw.Dialog):
         self._refresh_motion_rows()
 
     def _refresh_interface_rows(self) -> None:
+        self._output_group.set_visible(
+            any(is_controller_interface(device) for device in self._hardware_config.evdev_devices)
+        )
         for row in self._interface_rows:
             self._interfaces_group.remove(row)
         self._interface_rows = []

--- a/keymasq/gui/widgets/device_tab/hardware_settings_dialog.py
+++ b/keymasq/gui/widgets/device_tab/hardware_settings_dialog.py
@@ -12,11 +12,13 @@ gi.require_version("Adw", "1")
 from gi.repository import Adw, Gtk  # pyright: ignore[reportAttributeAccessIssue]
 
 from keymasq import __version__
+from keymasq.common.controller_routing import is_controller_interface
 from keymasq.common.devices import is_keymasq_device_path
 from keymasq.common.model.core import DeviceType
 from keymasq.common.model.hardware import EvdevDevice, HardwareConfig, NativeInputSource
 from keymasq.common.model.motion import MotionSensorDefinition
-from keymasq.gui.session_client import session_request_async
+from keymasq.gui.session_client import GuiTaskResult, run_gui_task, session_request_async
+from keymasq.gui.widgets.controller_output import ControllerOutputGroup
 from keymasq.gui.widgets.device_tab.motion_calibration_dialog import (
     MotionCalibrationDialog,
 )
@@ -164,6 +166,7 @@ class HardwareSettingsDialog(Adw.Dialog):
         on_rename_device: RenameDeviceCallback,
         *,
         can_delete_profile_mappings: bool,
+        on_output_changed: Callable[[], None] | None = None,
     ) -> None:
         super().__init__(
             title="Hardware Settings",
@@ -173,6 +176,7 @@ class HardwareSettingsDialog(Adw.Dialog):
         if hasattr(self, "set_modal"):
             self.set_modal(True)
 
+        self._on_output_changed = on_output_changed
         self._parent = parent
         self._hardware_config = hardware_config
         self._hardware_manager = hardware_manager
@@ -191,6 +195,24 @@ class HardwareSettingsDialog(Adw.Dialog):
         self._updating_detection_method = False
 
         self._setup_ui()
+
+    def _save_output(self, output_id: str) -> None:
+        config = deepcopy(self._hardware_config)
+        config.default_output = output_id
+        self._output_group.set_sensitive(False)
+
+        def saved(result: GuiTaskResult[None]) -> None:
+            self._output_group.set_sensitive(True)
+            if result.error is not None:
+                self._output_group.restore_output(self._hardware_config.default_output)
+                self._status_label.set_label(f"Could not save controller output: {result.error}")
+                return
+            self._hardware_config.default_output = output_id
+            self._status_label.set_label("Controller output saved.")
+            if self._on_output_changed is not None:
+                self._on_output_changed()
+
+        run_gui_task(lambda: self._hardware_manager.save_hardware(config), saved)
 
     def _setup_ui(self) -> None:
         content = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=0)
@@ -222,6 +244,14 @@ class HardwareSettingsDialog(Adw.Dialog):
         self._identity_row = identity_row
         identity_group.add(identity_row)
         box.append(identity_group)
+
+        self._output_group = ControllerOutputGroup(
+            self._hardware_config.default_output, self._save_output
+        )
+        self._output_group.set_visible(
+            any(is_controller_interface(device) for device in self._hardware_config.evdev_devices)
+        )
+        box.append(self._output_group)
 
         self._interfaces_group = Adw.PreferencesGroup(title="Attached Event Devices")
         box.append(self._interfaces_group)

--- a/keymasq/gui/widgets/device_tab/mapping.py
+++ b/keymasq/gui/widgets/device_tab/mapping.py
@@ -380,6 +380,9 @@ class MappingMixin:
         )
 
     def _describe_passthrough_output(self: Any, button: ButtonDefinition) -> str:
+        routed = self._default_output_description(button)
+        if routed is not None:
+            return routed
         return mapping_display.describe_passthrough_output(
             button,
             label_from_evdev=self._label_from_evdev,
@@ -396,4 +399,5 @@ class MappingMixin:
             describe_mapping_for_button=self._describe_mapping,
             describe_passthrough=self._describe_passthrough_output,
             action_summary_chars=self._mapping_action_summary_chars(),
+            describe_analog_passthrough=self._default_output_description,
         )

--- a/keymasq/gui/widgets/device_tab/mapping.py
+++ b/keymasq/gui/widgets/device_tab/mapping.py
@@ -400,4 +400,5 @@ class MappingMixin:
             describe_passthrough=self._describe_passthrough_output,
             action_summary_chars=self._mapping_action_summary_chars(),
             describe_analog_passthrough=self._default_output_description,
+            describe_default_output=self._default_output_presentation,
         )

--- a/keymasq/gui/widgets/device_tab/mapping_display.py
+++ b/keymasq/gui/widgets/device_tab/mapping_display.py
@@ -153,6 +153,9 @@ def update_button_display(
     describe_passthrough: Callable[[ButtonDefinition], str],
     action_summary_chars: int,
     describe_analog_passthrough: Callable[[AnalogInputDefinition], str | None] | None = None,
+    describe_default_output: Callable[
+        [ButtonDefinition | AnalogInputDefinition], tuple[str, str] | None
+    ] | None = None,
 ) -> None:
     widget = button_widgets.get(button_id)
     if not widget:
@@ -250,6 +253,16 @@ def update_button_display(
         else:
             widget.set_tooltip_text(None)
 
+    if describe_default_output is not None and (
+        mapping is None or mapping.action_type == ActionType.PASSTHROUGH
+    ):
+        control = button or analog
+        presentation = describe_default_output(control) if control is not None else None
+        if presentation is not None:
+            summary, detail = presentation
+            set_action_label_text(action_label, summary, max_chars=action_summary_chars)
+            action_label.set_tooltip_text(detail)
+
 
 def _passthrough_label(
     button: ButtonDefinition | None,
@@ -260,8 +273,6 @@ def _passthrough_label(
 ) -> str:
     if button is not None:
         return describe_passthrough(button)
-    if analog is not None and analog.type == "axis":
-        return "Axis passthrough"
     if motion:
         return "Motion passthrough"
-    return "Analog passthrough"
+    return "Passthrough"

--- a/keymasq/gui/widgets/device_tab/mapping_display.py
+++ b/keymasq/gui/widgets/device_tab/mapping_display.py
@@ -152,6 +152,7 @@ def update_button_display(
     describe_mapping_for_button: Callable[[MappingAction, ButtonDefinition | None], str],
     describe_passthrough: Callable[[ButtonDefinition], str],
     action_summary_chars: int,
+    describe_analog_passthrough: Callable[[AnalogInputDefinition], str | None] | None = None,
 ) -> None:
     widget = button_widgets.get(button_id)
     if not widget:
@@ -194,6 +195,12 @@ def update_button_display(
 
     if mapping:
         description = describe_mapping_for_button(mapping, button)
+        if (
+            mapping.action_type == ActionType.PASSTHROUGH
+            and analog is not None
+            and describe_analog_passthrough is not None
+        ):
+            description = describe_analog_passthrough(analog) or description
         set_action_label_text(
             action_label,
             description,
@@ -225,6 +232,8 @@ def update_button_display(
             describe_passthrough,
             motion=motion is not None,
         )
+        if analog is not None and describe_analog_passthrough is not None:
+            passthrough_label = describe_analog_passthrough(analog) or passthrough_label
         set_action_label_text(
             action_label,
             passthrough_label,

--- a/keymasq/gui/widgets/device_tab/presentation.py
+++ b/keymasq/gui/widgets/device_tab/presentation.py
@@ -61,6 +61,7 @@ class ProfilePresentationMixin:
         container.append(grab_group)
 
     def _update_extra_profile_settings(self: Any) -> None:
+        self._refresh_default_output_templates()
         self._sync_always_grab_device_list()
         for hardware_id, switch_row in self.always_grab_checks.items():
             layer = self._profile_layer_for_hardware(hardware_id)

--- a/keymasq/gui/widgets/device_tab/tab.py
+++ b/keymasq/gui/widgets/device_tab/tab.py
@@ -15,6 +15,7 @@ from keymasq.common.model.hardware import HardwareConfig
 from keymasq.gui.session_client import JsonDict, session_request_async
 from keymasq.gui.widgets.device_tab.capture import CaptureMixin
 from keymasq.gui.widgets.device_tab.commit import DeferredCommitState, SelectorCommitMixin
+from keymasq.gui.widgets.device_tab.default_output import DefaultOutputMixin
 from keymasq.gui.widgets.device_tab.hardware import HardwareSettingsMixin
 from keymasq.gui.widgets.device_tab.hardware_settings_dialog import HardwareSettingsDialog
 from keymasq.gui.widgets.device_tab.inputs import InputInventoryMixin
@@ -31,6 +32,7 @@ SELECTOR_COMMIT_AFTER_CLOSE_DELAY_MS = 500
 
 
 class DeviceTab(
+    DefaultOutputMixin,
     InventoryMixin,
     InputInventoryMixin,
     MappingMixin,
@@ -95,6 +97,8 @@ class DeviceTab(
         current_action: MappingAction | None,
         **kwargs: Any,
     ) -> KeySelectorDialog:
+        if self.device.default_output != "passthrough":
+            kwargs.setdefault("default_gamepad_output_id", self.device.default_output)
         return KeySelectorDialog(parent, title, current_action, **kwargs)
 
     def _schedule_selector_commit(self, callback: Callable[[], bool]) -> int:

--- a/keymasq/gui/widgets/key_selector/dialog.py
+++ b/keymasq/gui/widgets/key_selector/dialog.py
@@ -118,6 +118,7 @@ class KeySelectorDialog(
         analog_input_type: str | None = None,
         allowed_tabs: set[str] | list[str] | tuple[str, ...] | None = None,
         initial_tab: str | None = None,
+        default_gamepad_output_id: str | None = None,
         include_mpris_controls: bool = True,
         include_mouse_button_controls: bool = True,
         include_mouse_scroll_controls: bool = True,
@@ -145,6 +146,7 @@ class KeySelectorDialog(
         self._source_type = str(source_type or "button")
         self._allowed_tabs = set(allowed_tabs) if allowed_tabs is not None else None
         self._initial_tab = initial_tab
+        self._default_gamepad_output_id = default_gamepad_output_id
         self._include_mpris_controls = include_mpris_controls
         self._include_mouse_button_controls = include_mouse_button_controls
         self._include_mouse_scroll_controls = include_mouse_scroll_controls
@@ -209,7 +211,7 @@ class KeySelectorDialog(
             current_action.output_id
             if current_action
             and current_action.action_type in (ActionType.GAMEPAD, ActionType.GAMEPAD_AXIS)
-            else None
+            else default_gamepad_output_id
         )
         self._gamepad_output_ids: list[str | None] = []
         self._gamepad_output_dropdown: Gtk.DropDown | None = None
@@ -888,6 +890,16 @@ class KeySelectorDialog(
                 self.stack.set_visible_child_name("motion_control")
             else:
                 self.stack.set_visible_child_name("motion_presets")
+            return
+        if (
+            self._default_gamepad_output_id
+            and (
+                self._current_action is None
+                or self._current_action.action_type == ActionType.PASSTHROUGH
+            )
+            and self._tab_allowed("gamepad")
+        ):
+            self.stack.set_visible_child_name("gamepad")
             return
         if not self._current_action:
             return

--- a/keymasq/gui/wizards/hardware_setup/dialog.py
+++ b/keymasq/gui/wizards/hardware_setup/dialog.py
@@ -12,6 +12,7 @@ from gi.repository import Adw, Gdk, GObject, Gtk  # pyright: ignore[reportAttrib
 
 from keymasq.common.devices import find_all_interfaces, resolve_stable_path
 from keymasq.gui.session_client import GuiTaskResult, run_gui_task
+from keymasq.gui.widgets.controller_output import ControllerOutputGroup
 from keymasq.gui.widgets.fuzzy_search import fuzzy_query_matches, install_listbox_fuzzy_filter
 from keymasq.gui.wizards.hardware_setup import templates
 from keymasq.gui.wizards.hardware_setup.flow import DiscoveryMixin
@@ -259,7 +260,13 @@ class HardwareSetupDialog(
             "Custom profile saves the selected raw evdev interface without preset "
             "buttons. Add controls later with Learn Buttons."
         )
-        self.stack.add_titled(box, "describe", "Describe Device")
+        self.controller_output = ControllerOutputGroup()
+        self.controller_output.set_visible(False)
+        box.append(self.controller_output)
+        scrolled = Gtk.ScrolledWindow()
+        scrolled.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
+        scrolled.set_child(box)
+        self.stack.add_titled(scrolled, "describe", "Describe Device")
 
     def _on_cancel_clicked(self, _button: Gtk.Button) -> None:
         self.close()

--- a/keymasq/gui/wizards/hardware_setup/persistence.py
+++ b/keymasq/gui/wizards/hardware_setup/persistence.py
@@ -16,6 +16,8 @@ from . import templates
 
 class PersistenceMixin:
     def _persist_config(self: Any, config: HardwareConfig) -> None:
+        if self._template_state.current == "gamepad":
+            config.default_output = self.controller_output.output_id
         self.hardware_manager.save_hardware(config)
         self.emit("device-created", config)
         self.close()

--- a/keymasq/gui/wizards/hardware_setup/selection.py
+++ b/keymasq/gui/wizards/hardware_setup/selection.py
@@ -167,6 +167,7 @@ class SelectionMixin:
         self.mouse_mode_info.set_visible(mode == "mouse")
         self.mouse_keyboard_mode_info.set_visible(mode == "mouse_keyboard")
         self.gamepad_mode_info.set_visible(mode == "gamepad")
+        self.controller_output.set_visible(mode == "gamepad")
         self.custom_mode_info.set_visible(mode == "custom")
         subtitle = {
             "gamepad": "Review the detected controller controls",

--- a/keymasq/keymasqd/daemon_device_commands.py
+++ b/keymasq/keymasqd/daemon_device_commands.py
@@ -18,6 +18,7 @@ class _DeviceCommandManager(Protocol):
         analog_inputs: JsonObject | None = None,
         motion_sensors: JsonObject | None = None,
         force_grab_unmapped: bool = False,
+        default_output: str | None = None,
         evdev_interfaces: list[JsonObject] | None = None,
     ) -> JsonObject: ...
 
@@ -103,6 +104,7 @@ async def handle_device_command(
             analog_inputs=cast(JsonObject, data.get("analog_inputs", {})),
             motion_sensors=cast(JsonObject, data.get("motion_sensors", {})),
             force_grab_unmapped=bool(data.get("force_grab_unmapped", False)),
+            default_output=coerce_str(data.get("default_output"), None),
             evdev_interfaces=cast(JsonObjectList, data.get("evdev_interfaces", [])),
         )
 

--- a/keymasq/keymasqd/device_manager.py
+++ b/keymasq/keymasqd/device_manager.py
@@ -315,6 +315,7 @@ class DeviceManager(CursorManagerMixin, MacroManagerMixin, ComboManagerMixin):
         analog_inputs: dict[str, object] | None = None,
         motion_sensors: dict[str, object] | None = None,
         force_grab_unmapped: bool = False,
+        default_output: str | None = None,
         evdev_interfaces: list[JsonObject] | None = None,
     ) -> JsonObject:
         async with self._op_lock:
@@ -327,6 +328,7 @@ class DeviceManager(CursorManagerMixin, MacroManagerMixin, ComboManagerMixin):
                 analog_inputs=analog_inputs,
                 motion_sensors=motion_sensors,
                 force_grab_unmapped=force_grab_unmapped,
+                default_output=default_output,
                 evdev_interfaces=evdev_interfaces,
                 update_desired=True,
             )

--- a/keymasq/keymasqd/runtime/analog/source_state.py
+++ b/keymasq/keymasqd/runtime/analog/source_state.py
@@ -1,5 +1,6 @@
 """Physical axis coordinates, independent of mappings and stroke references."""
 
+from keymasq.keymasqd.runtime.default_controller_route import controller_route
 from keymasq.keymasqd.runtime.grabbed_device.types import (
     ActionExecutionDeps,
     GrabbedDeviceRuntime,
@@ -14,8 +15,14 @@ async def read_missing_source_axes(
 ) -> bool:
     """Replace coordinates at a drained input boundary, never mix ioctl and history."""
     values = device_runtime.state.analog_source_axis_values
-    bindings = dict(device_runtime.analog_axis_bindings)
-    missing = bindings.keys() - values.keys()
+    analog_bindings = dict(device_runtime.analog_axis_bindings)
+    bindings = set(analog_bindings)
+    route = controller_route(device_runtime)
+    if route is not None:
+        bindings.update(
+            (int(deps.evdev_mod.ecodes.EV_ABS), code) for code in route.device_axis_ranges
+        )
+    missing = bindings - values.keys()
     if not missing:
         return True
     device = device_runtime.device
@@ -72,9 +79,16 @@ async def read_missing_source_axes(
     if (
         snapshot is None
         or device_runtime.device is not device
-        or device_runtime.analog_axis_bindings != bindings
+        or device_runtime.analog_axis_bindings != analog_bindings
+        or controller_route(device_runtime) is not route
     ):
         return False
     values.clear()
     values.update(snapshot)
+    if route is not None:
+        route.source_values = {code: value for (_, code), value in snapshot.items()}
+        pending = device_runtime.state.input_event_buffer
+        route.snapshot_boundary = pending[-1] if pending else None
+        if route.snapshot_boundary is None:
+            device_runtime.restore_default_output_axes()
     return not drained_axes

--- a/keymasq/keymasqd/runtime/default_controller_route.py
+++ b/keymasq/keymasqd/runtime/default_controller_route.py
@@ -1,5 +1,6 @@
 """Same-code fallback output for a grabbed controller."""
 
+import logging
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 from typing import cast
@@ -9,6 +10,8 @@ import evdev
 from keymasq.keymasqd.runtime.adapters import identity_uinput_writer
 from keymasq.keymasqd.runtime.grabbed_device.types import ActionRuntime, InputEventLike
 from keymasq.keymasqd.runtime.virtual_gamepads import GamepadOutputTarget
+
+log = logging.getLogger(__name__)
 
 
 def source_axis_ranges(capabilities: Mapping[int, Sequence[object]]) -> dict[int, tuple[int, int]]:
@@ -89,12 +92,15 @@ class DefaultControllerRoute:
             writer = identity_uinput_writer(target.uinput)
             if writer is not None:
                 neutral = target.axis_rest_values.get(code, 0)
-                writer.write(
-                    evdev.ecodes.EV_ABS,
-                    code,
-                    target.stick_output.write_base(runtime.hardware_id, code, neutral),
-                )
-                writer.syn()
+                try:
+                    writer.write(
+                        evdev.ecodes.EV_ABS,
+                        code,
+                        target.stick_output.write_base(runtime.hardware_id, code, neutral),
+                    )
+                    writer.syn()
+                except OSError as exc:
+                    log.warning("Failed to release axis %s on %s: %s", code, target.output_id, exc)
             runtime.state.held_output_abs.get(target.bucket, set()).discard(code)
             if not runtime.state.held_output_abs.get(target.bucket):
                 runtime.state.held_output_abs.pop(target.bucket, None)

--- a/keymasq/keymasqd/runtime/default_controller_route.py
+++ b/keymasq/keymasqd/runtime/default_controller_route.py
@@ -1,0 +1,106 @@
+"""Same-code fallback output for a grabbed controller."""
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from typing import cast
+
+import evdev
+
+from keymasq.keymasqd.runtime.adapters import identity_uinput_writer
+from keymasq.keymasqd.runtime.grabbed_device.types import ActionRuntime, InputEventLike
+from keymasq.keymasqd.runtime.virtual_gamepads import GamepadOutputTarget
+
+
+def source_axis_ranges(capabilities: Mapping[int, Sequence[object]]) -> dict[int, tuple[int, int]]:
+    ranges: dict[int, tuple[int, int]] = {}
+    for item in capabilities.get(evdev.ecodes.EV_ABS, ()):
+        if not isinstance(item, tuple) or len(cast(tuple[object, ...], item)) != 2:
+            continue
+        code, info = cast(tuple[int, object], item)
+        minimum, maximum = getattr(info, "min", None), getattr(info, "max", None)
+        if isinstance(minimum, int) and isinstance(maximum, int) and minimum < maximum:
+            ranges[int(code)] = (minimum, maximum)
+    return ranges
+
+
+@dataclass
+class DefaultControllerRoute:
+    output_id: str
+    axis_ranges: dict[int, tuple[int, int]] = field(default_factory=dict)
+    axes: dict[int, GamepadOutputTarget] = field(default_factory=dict)
+
+    def target(self, runtime: ActionRuntime) -> GamepadOutputTarget | None:
+        target = runtime.resolve_gamepad_output(self.output_id, "default controller route")
+        # Default routes only address virtual instances, never another source device.
+        return (
+            target
+            if isinstance(target, GamepadOutputTarget)
+            and target.is_virtual
+            and target.output_id == self.output_id
+            else None
+        )
+
+    def emit(self, runtime: ActionRuntime, event: InputEventLike, *, sync: bool) -> None:
+        target = self.target(runtime)
+        if target is None:
+            return
+        writer = identity_uinput_writer(target.uinput)
+        if writer is None:
+            return
+        code, value = int(event.code), int(event.value)
+        if event.type == evdev.ecodes.EV_KEY:
+            if code not in target.button_codes:
+                return
+            held = runtime.state.held_output_keys.setdefault(target.bucket, set())
+            if value == 1:
+                held.add(code)
+            elif value == 0:
+                held.discard(code)
+            writer.write(evdev.ecodes.EV_KEY, code, value)
+        elif event.type == evdev.ecodes.EV_ABS:
+            source_range = self.axis_ranges.get(code)
+            target_range = target.axis_ranges.get(code)
+            if source_range is None or target_range is None:
+                return
+            minimum, maximum = source_range
+            if minimum >= maximum:
+                return
+            low, high = target_range
+            fraction = (max(minimum, min(maximum, value)) - minimum) / (maximum - minimum)
+            value = round(low + fraction * (high - low))
+            writer.write(
+                evdev.ecodes.EV_ABS,
+                code,
+                target.stick_output.write_base(runtime.hardware_id, code, value),
+            )
+            self.axes[code] = target
+            runtime.state.held_output_abs.setdefault(target.bucket, set()).add(code)
+        else:
+            return
+        if sync:
+            writer.syn()
+        else:
+            runtime.state.passthrough_frame_output = target.uinput
+
+    def release_axes(self, runtime: ActionRuntime, codes: set[int] | None = None) -> None:
+        for code, target in list(self.axes.items()):
+            if codes is not None and code not in codes:
+                continue
+            writer = identity_uinput_writer(target.uinput)
+            if writer is not None:
+                neutral = target.axis_rest_values.get(code, 0)
+                writer.write(
+                    evdev.ecodes.EV_ABS,
+                    code,
+                    target.stick_output.write_base(runtime.hardware_id, code, neutral),
+                )
+                writer.syn()
+            runtime.state.held_output_abs.get(target.bucket, set()).discard(code)
+            if not runtime.state.held_output_abs.get(target.bucket):
+                runtime.state.held_output_abs.pop(target.bucket, None)
+            self.axes.pop(code, None)
+
+
+def controller_route(runtime: object) -> DefaultControllerRoute | None:
+    route = getattr(runtime, "default_route", None)
+    return route if isinstance(route, DefaultControllerRoute) else None

--- a/keymasq/keymasqd/runtime/default_controller_route.py
+++ b/keymasq/keymasqd/runtime/default_controller_route.py
@@ -31,6 +31,12 @@ class DefaultControllerRoute:
     output_id: str
     axis_ranges: dict[int, tuple[int, int]] = field(default_factory=dict)
     axes: dict[int, GamepadOutputTarget] = field(default_factory=dict)
+    device_axis_ranges: dict[int, tuple[int, int]] = field(init=False)
+    source_values: dict[int, int] = field(default_factory=dict)
+    snapshot_boundary: InputEventLike | None = None
+
+    def __post_init__(self) -> None:
+        self.device_axis_ranges = dict(self.axis_ranges)
 
     def target(self, runtime: ActionRuntime) -> GamepadOutputTarget | None:
         target = runtime.resolve_gamepad_output(self.output_id, "default controller route")
@@ -44,6 +50,8 @@ class DefaultControllerRoute:
         )
 
     def emit(self, runtime: ActionRuntime, event: InputEventLike, *, sync: bool) -> None:
+        if event.type == evdev.ecodes.EV_ABS and self.snapshot_boundary is not None:
+            return
         target = self.target(runtime)
         if target is None:
             return

--- a/keymasq/keymasqd/runtime/grab/acquisition.py
+++ b/keymasq/keymasqd/runtime/grab/acquisition.py
@@ -218,6 +218,7 @@ def construct_grabbed_device(
         event_callback=callbacks.event_callback,
         device_type=detected_type,
         device_types=detected_types,
+        default_output=request.default_output,
         verbosity=manager.verbosity,
         keyboard_uinput=manager.output_state.keyboard_uinput,
         mouse_uinput=manager.output_state.mouse_uinput,
@@ -433,6 +434,10 @@ async def finalize_grab(
     # Existing interfaces continue running their old decoding tables until all
     # newly requested interfaces have been acquired successfully.
     update_existing_devices(plan, request, deps)
+    for device in plan.existing_devices:
+        update_default_output = getattr(device, "update_default_output", None)
+        if callable(update_default_output):
+            await cast(Awaitable[None], update_default_output(request.default_output))
 
     return {
         "grabbed": True,

--- a/keymasq/keymasqd/runtime/grab/planning.py
+++ b/keymasq/keymasqd/runtime/grab/planning.py
@@ -145,6 +145,7 @@ def persist_desired_grab(
         analog_inputs=dict(plan.analog_inputs),
         motion_sensors=dict(plan.motion_sensors),
         force_grab_unmapped=bool(request.force_grab_unmapped),
+        default_output=request.default_output,
         evdev_interfaces=list(plan.raw_interfaces) if plan.evdev_interfaces_provided else [],
     )
 
@@ -416,9 +417,10 @@ def motion_input_bindings(
             if not isinstance(axes, list):
                 continue
             for value in cast(list[object], axes):
-                if isinstance(value, dict) and (
-                    code := _axis_code(cast(dict[str, object], value))
-                ) is not None:
+                if (
+                    isinstance(value, dict)
+                    and (code := _axis_code(cast(dict[str, object], value))) is not None
+                ):
                     bindings.add((int(evdev.ecodes.EV_ABS), int(code)))
     return bindings
 

--- a/keymasq/keymasqd/runtime/grab/state.py
+++ b/keymasq/keymasqd/runtime/grab/state.py
@@ -32,6 +32,7 @@ class DesiredGrabConfig:
     motion_sensors: dict[str, object] = field(default_factory=dict)
     force_grab_unmapped: bool = False
     evdev_interfaces: list[JsonObject] = field(default_factory=list)
+    default_output: str | None = None
 
 
 @dataclass
@@ -78,6 +79,7 @@ class GrabRequest:
     force_grab_unmapped: bool = False
     evdev_interfaces: list[JsonObject] | None = None
     update_desired: bool = True
+    default_output: str | None = None
 
 
 @dataclass(frozen=True)

--- a/keymasq/keymasqd/runtime/grabbed_device/device.py
+++ b/keymasq/keymasqd/runtime/grabbed_device/device.py
@@ -509,10 +509,35 @@ class GrabbedDevice:
     def _refresh_default_route_ranges(self) -> None:
         route = getattr(self, "default_route", None)
         if route is not None:
+            route.axis_ranges = dict(route.device_axis_ranges)
             for binding, bounds in self.analog_axis_ranges.items():
                 code = self.analog_axis_output_codes.get(binding)
                 if code is not None:
                     route.axis_ranges[code] = bounds
+
+    def restore_default_output_axes(self) -> None:
+        route = self.default_route
+        if route is None or route.snapshot_boundary is not None:
+            return
+        if self.input_paused_getter and self.input_paused_getter():
+            return
+        if self.inspector_suppression_getter and self.inspector_suppression_getter(
+            self.hardware_id
+        ):
+            return
+        mapping = self.mapping_getter()
+        for code, value in route.source_values.items():
+            binding = (int(evdev.ecodes.EV_ABS), code)
+            analog = self.analog_axis_bindings.get(binding)
+            motion = self.motion_axis_bindings.get(binding)
+            control_id = motion[0] if motion else analog[0] if analog else None
+            action = mapping.get(control_id) if control_id else None
+            if action is not None and action.action_type != ActionType.PASSTHROUGH:
+                continue
+            route.emit(self, evdev.InputEvent(0, 0, evdev.ecodes.EV_ABS, code, value), sync=False)
+        outputs.flush_passthrough_frame(
+            self, self.state.passthrough_frame_output, uinput_writer=identity_uinput_writer
+        )
 
     async def update_default_output(self, output_id: str | None) -> None:
         if not _is_gamepad_passthrough(self.device_type, self.device_types):

--- a/keymasq/keymasqd/runtime/grabbed_device/device.py
+++ b/keymasq/keymasqd/runtime/grabbed_device/device.py
@@ -30,6 +30,10 @@ from keymasq.keymasqd.runtime.adapters import identity_uinput_writer
 from keymasq.keymasqd.runtime.analog.binding_state import preserved_analog_state_keys
 from keymasq.keymasqd.runtime.analog.reset import reset_analog_controls
 from keymasq.keymasqd.runtime.analog.source_fuzz import update_touchpad_fuzz
+from keymasq.keymasqd.runtime.default_controller_route import (
+    DefaultControllerRoute,
+    source_axis_ranges,
+)
 from keymasq.keymasqd.runtime.grabbed_device import grab, outputs
 from keymasq.keymasqd.runtime.grabbed_device.event import pipeline
 from keymasq.keymasqd.runtime.grabbed_device.types import (
@@ -315,6 +319,7 @@ class GrabbedDevice:
         motion_sensors: dict[str, object] | None = None,
         interface_id: str | None = None,
         access_mode: InputAccessMode | None = None,
+        default_output: str | None = None,
     ) -> None:
         self.path = path
         self.resolved_event_path = os.path.realpath(path)
@@ -392,6 +397,14 @@ class GrabbedDevice:
         self.running = False
         self.source_hidden_kernel_names: list[str] = []
         self.source_pending_hidden_kernel_names: list[str] = []
+        self.default_output = (
+            default_output
+            if default_output not in {None, "passthrough"}
+            and _is_gamepad_passthrough(self.device_type, self.device_types)
+            else None
+        )
+        self.default_route: DefaultControllerRoute | None = None
+        self._default_output_change_pending = False
 
     def update_button_map(
         self,
@@ -458,6 +471,7 @@ class GrabbedDevice:
                 if calibration:
                     self.analog_axis_calibrations[(str(analog_id), role)] = calibration
         self._refresh_analog_axis_ranges()
+        self._refresh_default_route_ranges()
 
     def update_motion_sensors(self, motion_sensors: dict[str, object]) -> None:
         self.motion_sensors = dict(motion_sensors)
@@ -492,6 +506,26 @@ class GrabbedDevice:
                         coerce_float(axis.get("noise"), 0.0),
                     )
 
+    def _refresh_default_route_ranges(self) -> None:
+        route = getattr(self, "default_route", None)
+        if route is not None:
+            for binding, bounds in self.analog_axis_ranges.items():
+                code = self.analog_axis_output_codes.get(binding)
+                if code is not None:
+                    route.axis_ranges[code] = bounds
+
+    async def update_default_output(self, output_id: str | None) -> None:
+        if not _is_gamepad_passthrough(self.device_type, self.device_types):
+            return
+        output_id = output_id if output_id not in {None, "passthrough"} else None
+        if self.default_output == output_id and not self._default_output_change_pending:
+            return
+        self._default_output_change_pending = True
+        await self.release()
+        self.default_output = output_id
+        await self.grab()
+        self._default_output_change_pending = False
+
     async def reset_mapping_runtime_state(
         self,
         previous_mapping: dict[str, MappingAction] | None = None,
@@ -509,6 +543,15 @@ class GrabbedDevice:
             if previous_mapping is not None
             else set[str]()
         )
+        if self.default_route is not None:
+            mapping = self.mapping_getter()
+            consumed_axes = {
+                code
+                for (_, code), (analog_id, _) in self.analog_axis_bindings.items()
+                if (action := mapping.get(analog_id)) is not None
+                and action.action_type != ActionType.PASSTHROUGH
+            }
+            self.default_route.release_axes(self, consumed_axes)
         await self.reset_analog_controls(preserve_state_keys=preserve_analog_state_keys)
         self.reset_motion_controls()
         initialize_motion_state(self, self.mapping_getter())
@@ -600,90 +643,98 @@ class GrabbedDevice:
 
         try:
             self._refresh_analog_axis_ranges()
-            caps, ff_max_effects = _copy_passthrough_capabilities(self.device)
             is_gamepad_passthrough = _is_gamepad_passthrough(
                 self.device_type,
                 self.device_types,
             )
-
-            passthrough_name, passthrough_vendor, passthrough_product = uinput_identity(
-                _passthrough_name(
-                    self.device,
-                    self.hardware_id,
-                    self.interface_id,
-                    is_gamepad=is_gamepad_passthrough,
-                ),
-                "passthrough",
-                test_name=f"passthrough-{self.hardware_id}",
-            )
-            passthrough_vendor = _int_u16(passthrough_vendor)
-            passthrough_product = _int_u16(passthrough_product)
-            passthrough_version: int | None = None
-            passthrough_bustype: int | None = None
-            passthrough_input_props = None
-            if is_gamepad_passthrough and (
-                passthrough_vendor is None or passthrough_product is None
-            ):
-                (
-                    passthrough_vendor,
-                    passthrough_product,
-                    passthrough_version,
-                    passthrough_bustype,
-                ) = _passthrough_input_id(self.device, self.hardware_id)
-                passthrough_input_props = _passthrough_input_props(self.device)
-
-            if passthrough_vendor is None or passthrough_product is None:
-                passthrough_version = None
-                passthrough_bustype = None
-                passthrough_input_props = None
-
-            supports_max_effects = uinput_supports_max_effects(evdev.UInput)
-            if ff_max_effects > 0 and not supports_max_effects:
-                log.debug(
-                    "python-evdev UInput does not support max_effects; "
-                    "using evdev's default force-feedback capacity for %s",
-                    self.path,
+            if self.default_output is not None:
+                self.default_route = DefaultControllerRoute(
+                    self.default_output, source_axis_ranges(self.device.capabilities())
                 )
+                self._refresh_default_route_ranges()
+            else:
+                self.default_route = None
+                caps, ff_max_effects = _copy_passthrough_capabilities(self.device)
 
-            def make_passthrough_uinput(max_effects: int) -> evdev.UInput:
-                return create_uinput_with_permission_hint(
-                    "passthrough",
-                    lambda: evdev.UInput(
-                        **_passthrough_uinput_kwargs(
-                            caps=caps,
-                            passthrough_name=passthrough_name,
-                            passthrough_vendor=passthrough_vendor,
-                            passthrough_product=passthrough_product,
-                            passthrough_version=passthrough_version,
-                            passthrough_bustype=passthrough_bustype,
-                            passthrough_input_props=passthrough_input_props,
-                            ff_max_effects=max_effects,
-                            supports_max_effects=supports_max_effects,
-                        )
+                passthrough_name, passthrough_vendor, passthrough_product = uinput_identity(
+                    _passthrough_name(
+                        self.device,
+                        self.hardware_id,
+                        self.interface_id,
+                        is_gamepad=is_gamepad_passthrough,
                     ),
+                    "passthrough",
+                    test_name=f"passthrough-{self.hardware_id}",
                 )
+                passthrough_vendor = _int_u16(passthrough_vendor)
+                passthrough_product = _int_u16(passthrough_product)
+                passthrough_version: int | None = None
+                passthrough_bustype: int | None = None
+                passthrough_input_props = None
+                if is_gamepad_passthrough and (
+                    passthrough_vendor is None or passthrough_product is None
+                ):
+                    (
+                        passthrough_vendor,
+                        passthrough_product,
+                        passthrough_version,
+                        passthrough_bustype,
+                    ) = _passthrough_input_id(self.device, self.hardware_id)
+                    passthrough_input_props = _passthrough_input_props(self.device)
 
-            self.uinput = await _create_passthrough_uinput(
-                lambda: make_passthrough_uinput(ff_max_effects)
-            )
-            if force_feedback.has_passthrough_output_feedback(caps):
-                try:
-                    self._start_output_feedback_proxy()
-                except Exception:  # noqa: BLE001 - retry without advertised feedback support.
-                    log.warning(
-                        "Disabling passthrough output feedback for %s after proxy start failure",
+                if passthrough_vendor is None or passthrough_product is None:
+                    passthrough_version = None
+                    passthrough_bustype = None
+                    passthrough_input_props = None
+
+                supports_max_effects = uinput_supports_max_effects(evdev.UInput)
+                if ff_max_effects > 0 and not supports_max_effects:
+                    log.debug(
+                        "python-evdev UInput does not support max_effects; "
+                        "using evdev's default force-feedback capacity for %s",
                         self.path,
-                        exc_info=True,
                     )
-                    await asyncio.to_thread(
-                        _close_passthrough_uinput, self.uinput, context="output-feedback retry"
+
+                def make_passthrough_uinput(max_effects: int) -> evdev.UInput:
+                    return create_uinput_with_permission_hint(
+                        "passthrough",
+                        lambda: evdev.UInput(
+                            **_passthrough_uinput_kwargs(
+                                caps=caps,
+                                passthrough_name=passthrough_name,
+                                passthrough_vendor=passthrough_vendor,
+                                passthrough_product=passthrough_product,
+                                passthrough_version=passthrough_version,
+                                passthrough_bustype=passthrough_bustype,
+                                passthrough_input_props=passthrough_input_props,
+                                ff_max_effects=max_effects,
+                                supports_max_effects=supports_max_effects,
+                            )
+                        ),
                     )
-                    self.uinput = None
-                    force_feedback.disable_passthrough_output_feedback(caps)
-                    ff_max_effects = 0
-                    self.uinput = await _create_passthrough_uinput(
-                        lambda: make_passthrough_uinput(ff_max_effects)
-                    )
+
+                self.uinput = await _create_passthrough_uinput(
+                    lambda: make_passthrough_uinput(ff_max_effects)
+                )
+                if force_feedback.has_passthrough_output_feedback(caps):
+                    try:
+                        self._start_output_feedback_proxy()
+                    except Exception:  # noqa: BLE001 - retry without advertised feedback support.
+                        log.warning(
+                            "Disabling passthrough output feedback for %s "
+                            "after proxy start failure",
+                            self.path,
+                            exc_info=True,
+                        )
+                        await asyncio.to_thread(
+                            _close_passthrough_uinput, self.uinput, context="output-feedback retry"
+                        )
+                        self.uinput = None
+                        force_feedback.disable_passthrough_output_feedback(caps)
+                        ff_max_effects = 0
+                        self.uinput = await _create_passthrough_uinput(
+                            lambda: make_passthrough_uinput(ff_max_effects)
+                        )
 
             await grab.wait_for_active_keys_to_clear(
                 self,
@@ -850,6 +901,16 @@ class GrabbedDevice:
 
     def _combo_binding_output(self, evdev_name: str) -> tuple[object, int, str] | None:
         held_action = cast(MappingAction | None | object, self._combo_binding_action(evdev_name))
+        if self.default_route is not None and (
+            held_action is None
+            or isinstance(held_action, MappingAction)
+            and held_action.action_type == ActionType.PASSTHROUGH
+        ):
+            target = self.default_route.target(self)
+            code = resolve_output_code(evdev_name)
+            if target is None or code not in target.button_codes:
+                return None
+            return (target.uinput, int(code), target.bucket)
         if held_action is None:
             if not self.uinput:
                 return None
@@ -928,7 +989,9 @@ class GrabbedDevice:
             uinput_writer=identity_uinput_writer,
             bucket=bucket,
         )
-        if bucket == "passthrough":
+        if bucket == "passthrough" or (
+            self.default_route is not None and self._combo_binding_action(evdev_name) is None
+        ):
             self.state.combo_passthrough_held.add(str(evdev_name or "").lower())
 
     def combo_passthrough_binding_active(self, evdev_name: str) -> bool:

--- a/keymasq/keymasqd/runtime/grabbed_device/event/passthrough.py
+++ b/keymasq/keymasqd/runtime/grabbed_device/event/passthrough.py
@@ -20,13 +20,14 @@ def process_syn_event(
     syn_report = int(getattr(evdev_mod.ecodes, "SYN_REPORT", 0))
     syn_mt_report = int(getattr(evdev_mod.ecodes, "SYN_MT_REPORT", 0))
     if event_code == syn_report:
+        frame_output = device_runtime.state.passthrough_frame_output
         passthrough_frame_open = outputs.passthrough_frame_open(
             device_runtime,
-            device_runtime.uinput,
+            frame_output,
         )
         outputs.flush_passthrough_frame(
             device_runtime,
-            device_runtime.uinput,
+            frame_output,
             uinput_writer=identity_uinput_writer,
         )
         return "passthrough_syn" if passthrough_frame_open else "syn"
@@ -56,6 +57,14 @@ def emit_passthrough_event(
     remember_after_emit: bool = False,
 ) -> None:
     """Emit one non-SYN event through the device passthrough output."""
+
+    if (
+        getattr(device_runtime, "default_output", None) is not None
+        and event.type == evdev_mod.ecodes.EV_KEY
+        and int(event.value) == 1
+        and event_name is not None
+    ):
+        device_runtime.state.held_source_actions.setdefault(event_name, None)
 
     if remember_for_repeat and not remember_after_emit:
         if event_name is None:

--- a/keymasq/keymasqd/runtime/grabbed_device/event/pipeline.py
+++ b/keymasq/keymasqd/runtime/grabbed_device/event/pipeline.py
@@ -22,6 +22,7 @@ from keymasq.keymasqd.runtime.analog_controls import (
     observe_analog_source_event,
     process_analog_syn_event,
 )
+from keymasq.keymasqd.runtime.default_controller_route import controller_route
 from keymasq.keymasqd.runtime.grabbed_device import outputs
 from keymasq.keymasqd.runtime.grabbed_device.event.analog import dispatch_analog_event
 from keymasq.keymasqd.runtime.grabbed_device.event.classification import (
@@ -118,7 +119,7 @@ async def event_loop(
     deps = build_event_processing_deps(log=log)
 
     try:
-        if device_runtime.analog_axis_bindings:
+        if device_runtime.analog_axis_bindings or controller_route(device_runtime) is not None:
             # Establish unchanged coordinates before consuming any historical report.
             await read_missing_source_axes(device_runtime, deps=deps.action_deps)
         async for event in read_events(device_runtime):
@@ -289,6 +290,26 @@ async def process_event(
     *,
     deps: EventProcessingDeps,
 ) -> None:
+    route = controller_route(device_runtime)
+    if route is not None and route.snapshot_boundary is None:
+        if int(event.type) == int(deps.evdev_mod.ecodes.EV_ABS):
+            route.source_values[int(event.code)] = int(event.value)
+        elif int(event.type) == int(deps.evdev_mod.ecodes.EV_SYN) and int(event.code) == int(
+            deps.evdev_mod.ecodes.SYN_DROPPED
+        ):
+            route.source_values.clear()
+    await _process_ordered_event(device_runtime, event, deps=deps)
+    if route is not None and route.snapshot_boundary is event:
+        route.snapshot_boundary = None
+        device_runtime.restore_default_output_axes()
+
+
+async def _process_ordered_event(
+    device_runtime: GrabbedDeviceRuntime,
+    event: InputEventLike,
+    *,
+    deps: EventProcessingDeps,
+) -> None:
     """Keep buttons after preceding area axes until their complete report is known."""
     state = device_runtime.state
     ecodes = deps.evdev_mod.ecodes
@@ -311,7 +332,7 @@ async def process_event(
         if keys:
             outputs.flush_passthrough_frame(
                 device_runtime,
-                device_runtime.uinput,
+                state.passthrough_frame_output,
                 uinput_writer=identity_uinput_writer,
             )
 

--- a/keymasq/keymasqd/runtime/grabbed_device/outputs.py
+++ b/keymasq/keymasqd/runtime/grabbed_device/outputs.py
@@ -315,6 +315,12 @@ def passthrough(
     uinput_writer: UInputWriter,
     sync: bool = True,
 ) -> None:
+    from keymasq.keymasqd.runtime.default_controller_route import controller_route
+
+    route = controller_route(device_runtime)
+    if route is not None:
+        route.emit(device_runtime, event, sync=sync)
+        return
     if (
         device_runtime.suppress_rel_getter
         and event.type == evdev_mod.ecodes.EV_REL
@@ -470,6 +476,11 @@ def release_all_keys(
     evdev_mod: EvdevModule,
     uinput_writer: UInputWriter,
 ) -> None:
+    from keymasq.keymasqd.runtime.default_controller_route import controller_route
+
+    route = controller_route(device_runtime)
+    if route is not None:
+        route.release_axes(device_runtime)
     devices: dict[str, object | None] = {
         "passthrough": device_runtime.uinput,
         "keyboard": device_runtime.keyboard_uinput,

--- a/keymasq/keymasqd/runtime/grabbed_device/types.py
+++ b/keymasq/keymasqd/runtime/grabbed_device/types.py
@@ -313,6 +313,8 @@ class ActionRuntime(Protocol):
 
 
 class GrabbedDeviceRuntime(ActionRuntime, Protocol):
+    def restore_default_output_axes(self) -> None: ...
+
     @property
     def access_mode(self) -> InputAccessMode: ...
 

--- a/keymasq/keymasqd/runtime/repeat.py
+++ b/keymasq/keymasqd/runtime/repeat.py
@@ -395,7 +395,17 @@ def remember_passthrough_event(
     if event_type == int(evdev_mod.ecodes.EV_KEY):
         if event_value != 1:
             return
-        if normalized_name.startswith("key_"):
+        route_id = getattr(device_runtime, "default_output", None)
+        if isinstance(route_id, str):
+            target = device_runtime.resolve_gamepad_output(route_id, "remember default output")
+            if event_code not in getattr(target, "button_codes", ()):
+                return
+            action = MappingAction(
+                action_type=ActionType.GAMEPAD,
+                target=normalized_name,
+                output_id=route_id,
+            )
+        elif normalized_name.startswith("key_"):
             action = MappingAction(action_type=ActionType.KEYBOARD, target=normalized_name)
         elif normalized_name.startswith("btn_"):
             if _device_is_gamepad(device_runtime):
@@ -417,6 +427,8 @@ def remember_passthrough_event(
         )
         return
 
+    if getattr(device_runtime, "default_output", None) is not None:
+        return
     if event_type != int(evdev_mod.ecodes.EV_REL):
         return
 

--- a/keymasq/keymasqd/runtime/virtual_gamepads.py
+++ b/keymasq/keymasqd/runtime/virtual_gamepads.py
@@ -13,6 +13,7 @@ from keymasq.common.model.core import DeviceType
 from keymasq.common.output_axes import STANDARD_OUTPUT_AXES, OutputAxis, learned_output_axes
 from keymasq.common.types import JsonObject
 from keymasq.common.virtual_device_templates import (
+    XBOX_360_TEMPLATE,
     ResolvedVirtualDevice,
     template_analog_inputs,
     template_output_axes,
@@ -32,6 +33,7 @@ class GamepadOutputTarget:
     output_axes: tuple[OutputAxis, ...] | None = None
     axis_rest_values: dict[int, int] = field(default_factory=dict)
     axis_ranges: dict[int, tuple[int, int]] = field(default_factory=dict)
+    button_codes: frozenset[int] = frozenset()
 
 
 type ClearComboRuntime = Callable[[], Awaitable[None]]
@@ -208,6 +210,14 @@ class GamepadOutputRouter:
                 uinput=uinput,
                 bucket=f"gamepad:{resolved_id}",
                 is_virtual=True,
+                button_codes=frozenset(
+                    int(getattr(evdev.ecodes, button.evdev.upper()))
+                    for button in (
+                        spec.template
+                        if isinstance(spec, ResolvedVirtualDevice)
+                        else XBOX_360_TEMPLATE
+                    ).buttons
+                ),
                 stick_output=previous[1],
                 output_axes=(
                     template_output_axes(spec.template)

--- a/keymasq/keymasqd/runtime/virtual_gamepads.py
+++ b/keymasq/keymasqd/runtime/virtual_gamepads.py
@@ -212,7 +212,7 @@ class GamepadOutputRouter:
                     for axis in spec.template.axes
                 }
                 if isinstance(spec, ResolvedVirtualDevice)
-                else {}
+                else {axis.code: axis.neutral for axis in STANDARD_OUTPUT_AXES}
             )
             target = GamepadOutputTarget(
                 output_id=resolved_id,
@@ -236,7 +236,7 @@ class GamepadOutputRouter:
                 analog_inputs=(
                     template_analog_inputs(spec.template)
                     if isinstance(spec, ResolvedVirtualDevice)
-                    else {}
+                    else template_analog_inputs(XBOX_360_TEMPLATE)
                 ),
                 axis_rest_values=axis_rest_values,
                 axis_ranges=(
@@ -245,7 +245,7 @@ class GamepadOutputRouter:
                         for axis in spec.template.axes
                     }
                     if isinstance(spec, ResolvedVirtualDevice)
-                    else {}
+                    else {axis.code: (axis.minimum, axis.maximum) for axis in STANDARD_OUTPUT_AXES}
                 ),
             )
 

--- a/keymasq/keymasqd/runtime/virtual_gamepads.py
+++ b/keymasq/keymasqd/runtime/virtual_gamepads.py
@@ -147,6 +147,11 @@ async def reconfigure_virtual_gamepads(
 
     if output_devices_active:
         configure_outputs(count)
+        for devices in grabbed_devices.values():
+            for device in devices:
+                restore_axes = getattr(device, "restore_default_output_axes", None)
+                if callable(restore_axes):
+                    restore_axes()
     else:
         set_inactive_count(count)
     logger.info("Configured %d virtual gamepad output(s)", count)

--- a/keymasq/keymasqd/runtime/virtual_gamepads.py
+++ b/keymasq/keymasqd/runtime/virtual_gamepads.py
@@ -165,7 +165,7 @@ class GamepadOutputRouter:
         self._logger = logger
         self._monotonic = monotonic
         self._warning_at: dict[tuple[str, str], float] = {}
-        self._virtual_stick_outputs: dict[str, tuple[object, StickOutputState]] = {}
+        self._virtual_targets: dict[str, tuple[object, GamepadOutputTarget]] = {}
 
     def resolve(
         self,
@@ -189,14 +189,18 @@ class GamepadOutputRouter:
         ):
             uinput = outputs.get(resolved_id)
             if uinput is None:
-                self._virtual_stick_outputs.pop(resolved_id, None)
+                self._virtual_targets.pop(resolved_id, None)
                 self._warn(resolved_id, "virtual output is not configured", context, explicit)
                 return None
-            previous = self._virtual_stick_outputs.get(resolved_id)
-            if previous is None or previous[0] is not uinput:
-                previous = (uinput, StickOutputState())
-                self._virtual_stick_outputs[resolved_id] = previous
             spec = specs.get(resolved_id)
+            previous = self._virtual_targets.get(resolved_id)
+            if previous is not None and previous[1].uinput is uinput and previous[0] is spec:
+                return previous[1]
+            stick_output = (
+                previous[1].stick_output
+                if previous is not None and previous[1].uinput is uinput
+                else StickOutputState()
+            )
             axis_rest_values = (
                 {
                     int(getattr(evdev.ecodes, axis.evdev.upper())): axis.rest
@@ -205,7 +209,7 @@ class GamepadOutputRouter:
                 if isinstance(spec, ResolvedVirtualDevice)
                 else {}
             )
-            return GamepadOutputTarget(
+            target = GamepadOutputTarget(
                 output_id=resolved_id,
                 uinput=uinput,
                 bucket=f"gamepad:{resolved_id}",
@@ -218,7 +222,7 @@ class GamepadOutputRouter:
                         else XBOX_360_TEMPLATE
                     ).buttons
                 ),
-                stick_output=previous[1],
+                stick_output=stick_output,
                 output_axes=(
                     template_output_axes(spec.template)
                     if isinstance(spec, ResolvedVirtualDevice)
@@ -240,6 +244,10 @@ class GamepadOutputRouter:
                 ),
             )
 
+            self._virtual_targets[resolved_id] = (spec, target)
+            return target
+
+        self._virtual_targets.pop(resolved_id, None)
         devices = grabbed_devices.get(resolved_id)
         if not devices:
             self._warn(resolved_id, "target hardware is not grabbed", context, explicit)

--- a/keymasq/session/hardware.py
+++ b/keymasq/session/hardware.py
@@ -228,6 +228,7 @@ class HardwareManager:
             image=hw.get("image"),
             id=hardware_id or None,
             input_sources=[NativeInputSource(**source) for source in hw.get("input_sources", [])],
+            default_output=str(hw.get("default_output") or "passthrough").strip() or "passthrough",
         )
 
     @staticmethod
@@ -573,6 +574,8 @@ class HardwareManager:
                 }
                 for source in config.input_sources
             ]
+        if config.default_output != "passthrough":
+            data["hardware"]["default_output"] = config.default_output
 
         if config.image:
             data["hardware"]["image"] = config.image

--- a/keymasq/session/manager/profile/application.py
+++ b/keymasq/session/manager/profile/application.py
@@ -475,7 +475,7 @@ async def _send_set_mapping_command(
                     "hardware_id": hardware_id,
                     "mapping": prepared.payload,
                 },
-            )
+            ),
         )
         if result.status == "ok":
             _commit_device_references(manager, hardware_id, staged_refs, generation)
@@ -483,12 +483,10 @@ async def _send_set_mapping_command(
             if cancelled:
                 raise asyncio.CancelledError
             raise_if_stale_profile_apply(manager, generation)
-            manager.profile_state.last_sent_mapping_signatures[hardware_id] = (
-                mapping.signature(
-                    manager,
-                    resolved,
-                    hardware_id,
-                )
+            manager.profile_state.last_sent_mapping_signatures[hardware_id] = mapping.signature(
+                manager,
+                resolved,
+                hardware_id,
             )
             log.info(
                 "Activated resolved profiles %s for %s",
@@ -548,7 +546,11 @@ async def apply_resolved_device_profile(
             resolved,
         )
 
-    if not resolved.has_effective_mapping and not inspector_active:
+    hardware_route_active = getattr(hardware_config, "default_output", "passthrough") not in {
+        None,
+        "passthrough",
+    }
+    if not resolved.has_effective_mapping and not inspector_active and not hardware_route_active:
         operations.cancel_grab_retry(manager, hardware_id)
         manager.profile_state.grab_waiting_devices.discard(hardware_id)
         manager.profile_state.grab_status.pop(hardware_id, None)
@@ -754,7 +756,7 @@ async def update_combos(
             Command(
                 command=CommandType.SET_COMBOS,
                 data={"combos": payload},
-            )
+            ),
         )
         if result.status != "ok":
             if cancelled:
@@ -822,7 +824,7 @@ async def update_mapping(
                     "hardware_id": hardware_id,
                     "mapping": serialized_mapping,
                 },
-            )
+            ),
         )
         if result.status == "ok":
             _commit_device_references(manager, hardware_id, staged_refs, generation)

--- a/keymasq/session/manager/profile/grab_plan.py
+++ b/keymasq/session/manager/profile/grab_plan.py
@@ -4,6 +4,7 @@ import json
 import logging
 from typing import TYPE_CHECKING, cast
 
+from keymasq.common.controller_routing import is_controller_interface
 from keymasq.common.model.analog import SAME_DEVICE_OUTPUT_ID, analog_control_primary_mode
 from keymasq.common.model.core import ActionType, DeviceType
 from keymasq.common.model.hardware import HardwareConfig
@@ -41,6 +42,12 @@ def get_interfaces_to_grab(
     )
 
     sources_to_grab: set[str] = set()
+    if getattr(hardware_config, "default_output", "passthrough") not in {None, "passthrough"}:
+        sources_to_grab.update(
+            device.id
+            for device in hardware_config.evdev_devices
+            if device.id and is_controller_interface(device)
+        )
     for button_id, action in resolved.mappings.items():
         if action.action_type != ActionType.PASSTHROUGH:
             source = button_to_source.get(button_id)
@@ -214,6 +221,7 @@ def build_grab_device_payload(
     selected_sources = set(interfaces.keys())
     return {
         "hardware_id": hardware_id,
+        "default_output": getattr(hardware_config, "default_output", "passthrough"),
         "evdev_paths": list(interfaces.values()),
         "evdev_interfaces": configured_interface_descriptors(
             hardware_config,
@@ -268,6 +276,8 @@ def build_grab_device_payload(
         },
         "force_grab_unmapped": (
             bool(force_grab_unmapped)
+            or getattr(hardware_config, "default_output", "passthrough")
+            not in {None, "passthrough"}
             or bool(resolved.combo_event_count)
             or _motion_requires_gamepad_output(manager, hardware_config, resolved)
         ),
@@ -277,6 +287,7 @@ def build_grab_device_payload(
 def grab_device_payload_signature(payload: JsonObject) -> str:
     """Create a stable signature for fields that affect an active grab."""
     signature_payload = {
+        "default_output": payload.get("default_output"),
         "evdev_paths": sorted(str(path) for path in json_list(payload.get("evdev_paths"))),
         "evdev_interfaces": _signature_evdev_interfaces(payload.get("evdev_interfaces")),
         "button_map": payload.get("button_map", {}),

--- a/tests/gui/test_default_controller_route.py
+++ b/tests/gui/test_default_controller_route.py
@@ -1,0 +1,205 @@
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("gi")
+
+from keymasq.common.model.core import DeviceType
+from keymasq.common.model.hardware import (
+    AnalogAxisDefinition,
+    AnalogInputDefinition,
+    ButtonDefinition,
+    EvdevDevice,
+    HardwareConfig,
+)
+from keymasq.common.model.profiles import ProfileConfig
+from keymasq.gui.widgets.device_tab.tab import DeviceTab
+from keymasq.session.profile.types import ProfileInfo
+
+
+def test_hardware_route_descriptions_do_not_depend_on_profile():
+    hardware = HardwareConfig(
+        "1234",
+        "5678",
+        "Controller",
+        [
+            EvdevDevice("/dev/input/event0", DeviceType.GAMEPAD, "pad"),
+        ],
+        [
+            ButtonDefinition("south", "South", "btn_south", source="pad"),
+            ButtonDefinition("capture", "Capture", "btn_z", source="pad"),
+        ],
+        analog_inputs=[
+            AnalogInputDefinition(
+                "stick",
+                "Stick",
+                "stick",
+                "pad",
+                [
+                    AnalogAxisDefinition("x", "abs_x"),
+                    AnalogAxisDefinition("y", "abs_y"),
+                ],
+            ),
+        ],
+    )
+    tab = DeviceTab(hardware, None, demo_mode=True)
+    hardware.default_output = "virtual-gamepad-1"
+    from keymasq.common.virtual_device_templates import VirtualDeviceConfig, resolve_virtual_devices
+
+    tab._default_output_templates = {
+        d.output_id: d.template for d in resolve_virtual_devices(1, VirtualDeviceConfig())
+    }
+    for profile in (ProfileConfig("First"), ProfileConfig("Second")):
+        tab._selected_profile = ProfileInfo(Path("profile.toml"), profile)
+        assert "Default → virtual-gamepad-1" in tab._describe_passthrough_output(
+            hardware.buttons[0]
+        )
+        assert tab._describe_passthrough_output(hardware.buttons[1]) == "No matching output"
+        assert "ABS_X, ABS_Y" in (tab._default_output_description(hardware.analog_inputs[0]) or "")
+        assert not hasattr(tab, "_default_output_row")
+    hardware.default_output = "missing-pad"
+    assert "unavailable" in (tab._default_output_description(hardware.buttons[0]) or "")
+
+
+def test_keyboard_does_not_offer_controller_route():
+    hardware = HardwareConfig(
+        "1234",
+        "5678",
+        "Keyboard",
+        [
+            EvdevDevice("/dev/input/event0", DeviceType.KEYBOARD, "keyboard"),
+        ],
+        [],
+    )
+    tab = DeviceTab(hardware, None, demo_mode=True)
+    assert not hasattr(tab, "_default_output_row")
+
+
+def test_setup_and_hardware_settings_save_stable_output(monkeypatch, tmp_path):
+    from unittest.mock import Mock
+
+    from keymasq.common.virtual_device_templates import VirtualDeviceConfig
+    from keymasq.gui.session_client import GuiTaskResult
+    from keymasq.gui.widgets import controller_output
+    from keymasq.gui.widgets.device_tab import hardware_settings_dialog
+    from keymasq.gui.wizards.hardware_setup.dialog import HardwareSetupDialog
+    from keymasq.session.hardware import HardwareManager
+
+    def run(worker, callback):
+        callback(GuiTaskResult(value=worker()))
+
+    monkeypatch.setattr(controller_output, "run_gui_task", run)
+    monkeypatch.setattr(controller_output, "virtual_gamepad_count", lambda: 1)
+    monkeypatch.setattr(controller_output, "virtual_device_config", VirtualDeviceConfig)
+    monkeypatch.setattr(hardware_settings_dialog, "run_gui_task", run)
+    monkeypatch.setattr(HardwareSetupDialog, "_detect_devices", lambda self: None)
+    monkeypatch.setattr("keymasq.common.paths.HARDWARE_DIR", tmp_path)
+    manager = HardwareManager()
+    dialog = HardwareSetupDialog(None, manager)
+    dialog._template_state.current = "gamepad"
+    dialog._discovery_state.selected_device = {
+        "vendor_id": "1234",
+        "product_id": "5678",
+        "name": "Pad",
+    }
+    dialog._discovery_state.discovered_interfaces = {
+        "pad": {
+            "id": "pad",
+            "stable_path": "/dev/input/event0",
+            "device_types": ["gamepad"],
+        }
+    }
+    dialog._update_describe_mode_ui()
+    assert dialog.controller_output.get_visible()
+    assert dialog.controller_output.output_id == "passthrough"
+    dialog.controller_output.row.set_selected(1)
+    dialog._save_gamepad_config()
+    hardware = manager.get_hardware("1234:5678")
+    assert hardware.default_output == "virtual-gamepad-1"
+    changed = Mock()
+    settings = hardware_settings_dialog.HardwareSettingsDialog(
+        None,
+        hardware,
+        manager,
+        Mock(),
+        Mock(),
+        Mock(),
+        Mock(),
+        Mock(return_value=(True, "")),
+        Mock(),
+        can_delete_profile_mappings=False,
+        on_output_changed=changed,
+    )
+    assert settings._output_group.get_visible()
+    assert settings._output_group.row.get_selected() == 1
+    settings._output_group.row.set_selected(0)
+    assert hardware.default_output == "passthrough"
+    assert HardwareManager().get_hardware(hardware.hardware_id).default_output == "passthrough"
+    changed.assert_called_once()
+    monkeypatch.setattr(
+        hardware_settings_dialog,
+        "run_gui_task",
+        lambda worker, cb: cb(GuiTaskResult(error=OSError("disk full"))),
+    )
+    settings._output_group.row.set_selected(1)
+    assert settings._output_group.output_id == "passthrough"
+    assert settings._output_group.row.get_selected() == 0
+    assert hardware.default_output == "passthrough"
+    assert "disk full" in settings._status_label.get_label()
+    changed.assert_called_once()
+
+
+def test_unavailable_hardware_output_is_preserved(monkeypatch):
+    from keymasq.gui.session_client import GuiTaskResult
+    from keymasq.gui.widgets import controller_output
+
+    monkeypatch.setattr(
+        controller_output, "run_gui_task", lambda worker, cb: cb(GuiTaskResult(value=[]))
+    )
+    group = controller_output.ControllerOutputGroup("missing")
+    assert group.output_id == "missing"
+    assert group.row.get_selected_item().get_string() == "missing (unavailable)"
+
+
+@pytest.mark.parametrize(
+    ("route", "action_type", "action_output", "expected_tab", "expected_output"),
+    [
+        ("virtual-gamepad-2", None, None, "gamepad", "virtual-gamepad-2"),
+        ("missing-pad", None, None, "gamepad", "missing-pad"),
+        ("virtual-gamepad-2", "passthrough", None, "gamepad", "virtual-gamepad-2"),
+        ("virtual-gamepad-2", "gamepad", "virtual-gamepad-1", "gamepad", "virtual-gamepad-1"),
+        ("virtual-gamepad-2", "gamepad", None, "gamepad", None),
+        ("virtual-gamepad-2", "keyboard", None, "keyboard", "virtual-gamepad-2"),
+        ("passthrough", None, None, "special", None),
+    ],
+)
+def test_device_selector_defaults_to_hardware_output(
+    monkeypatch, route, action_type, action_output, expected_tab, expected_output
+):
+    from keymasq.common.model.actions import MappingAction
+    from keymasq.common.model.core import ActionType
+    from keymasq.common.virtual_device_templates import VirtualDeviceConfig
+    from keymasq.gui.widgets.key_selector import tabs
+
+    monkeypatch.setattr(tabs, "virtual_gamepad_count", lambda: 2)
+    monkeypatch.setattr(tabs, "virtual_device_config", VirtualDeviceConfig)
+    monkeypatch.setattr(tabs, "load_gamepad_output_hardware_configs", lambda _manager: [])
+    hardware = HardwareConfig("1234", "5678", "Controller", [], [], default_output=route)
+    tab = DeviceTab(hardware, None, demo_mode=True)
+    action = (
+        MappingAction(
+            action_type=ActionType(action_type),
+            target="key_a" if action_type == "keyboard" else "btn_south",
+            output_id=action_output,
+        )
+        if action_type
+        else None
+    )
+    dialog = tab._create_key_selector_dialog(tab, "Capture", action)
+    assert dialog.stack.get_visible_child_name() == expected_tab
+    assert dialog._selected_gamepad_output_id == expected_output
+    assert dialog._gamepad_output_dropdown is not None
+    selected = dialog._gamepad_output_dropdown.get_selected()
+    assert (dialog._gamepad_output_ids[selected] or "virtual-gamepad-1") == (
+        expected_output or "virtual-gamepad-1"
+    )

--- a/tests/gui/test_default_controller_route.py
+++ b/tests/gui/test_default_controller_route.py
@@ -148,6 +148,27 @@ def test_setup_and_hardware_settings_save_stable_output(monkeypatch, tmp_path):
     assert "disk full" in settings._status_label.get_label()
     changed.assert_called_once()
 
+    pending = []
+    monkeypatch.setattr(
+        hardware_settings_dialog, "run_gui_task", lambda worker, cb: pending.append((worker, cb))
+    )
+    settings._output_group.row.set_selected(1)
+    assert not settings.get_sensitive()
+    assert not settings.get_can_close()
+    worker, callback = pending.pop()
+    callback(GuiTaskResult(value=worker()))
+    assert settings.get_sensitive()
+    assert settings.get_can_close()
+    assert hardware.default_output == "virtual-gamepad-1"
+
+    devices = list(hardware.evdev_devices)
+    hardware.evdev_devices.clear()
+    settings._refresh_interface_rows()
+    assert not settings._output_group.get_visible()
+    hardware.evdev_devices.extend(devices)
+    settings._refresh_interface_rows()
+    assert settings._output_group.get_visible()
+
 
 def test_unavailable_hardware_output_is_preserved(monkeypatch):
     from keymasq.gui.session_client import GuiTaskResult

--- a/tests/gui/test_default_controller_route.py
+++ b/tests/gui/test_default_controller_route.py
@@ -54,9 +54,16 @@ def test_hardware_route_descriptions_do_not_depend_on_profile():
         assert "Default → virtual-gamepad-1" in tab._describe_passthrough_output(
             hardware.buttons[0]
         )
-        assert tab._describe_passthrough_output(hardware.buttons[1]) == "No matching output"
+        assert "No matching output" in tab._describe_passthrough_output(hardware.buttons[1])
         assert "ABS_X, ABS_Y" in (tab._default_output_description(hardware.analog_inputs[0]) or "")
         assert not hasattr(tab, "_default_output_row")
+        tab._update_button_display("south")
+        label = tab._button_widgets["south"]._action_label
+        assert label.get_text() == "→ A"
+        assert "virtual-gamepad-1" in label.get_tooltip_text()
+        assert "BTN_SOUTH" in label.get_tooltip_text()
+        tab._update_button_display("stick")
+        assert tab._button_widgets["stick"]._action_label.get_text() == "→ X, Y"
     hardware.default_output = "missing-pad"
     assert "unavailable" in (tab._default_output_description(hardware.buttons[0]) or "")
 

--- a/tests/keymasqd/test_default_controller_route.py
+++ b/tests/keymasqd/test_default_controller_route.py
@@ -10,6 +10,7 @@ import pytest
 from keymasq.common.model.actions import MappingAction
 from keymasq.common.model.analog import AnalogControlConfig, AnalogMouseMotionConfig
 from keymasq.common.model.core import ActionType, DeviceType
+from keymasq.common.output_axes import STANDARD_OUTPUT_AXES
 from keymasq.common.virtual_device_templates import (
     VirtualDeviceConfig,
     VirtualDeviceInstance,
@@ -186,6 +187,27 @@ async def test_missing_target_drops_output_without_clone_fallback(routed):
     await send(device, E.EV_ABS, E.ABS_X, 255)
     assert writer.writes == []
     assert device.uinput.writes == []
+
+
+@pytest.mark.parametrize("missing_specs_attribute", [False, True])
+async def test_output_without_spec_routes_axes_and_releases_to_standard_neutral(
+    routed, missing_specs_attribute
+):
+    device, writer, _, state = routed
+    if missing_specs_attribute:
+        del state.virtual_device_specs
+    else:
+        state.virtual_device_specs.pop("virtual-gamepad-1")
+    target = device.resolve_gamepad_output("virtual-gamepad-1", "test")
+    assert target.axis_ranges == {
+        axis.code: (axis.minimum, axis.maximum) for axis in STANDARD_OUTPUT_AXES
+    }
+    assert target.axis_rest_values == {axis.code: axis.neutral for axis in STANDARD_OUTPUT_AXES}
+    await send(device, E.EV_ABS, E.ABS_X, 255)
+    await send(device, E.EV_SYN, E.SYN_REPORT, 0)
+    assert writer.packets == [[(E.EV_ABS, E.ABS_X, 32767)]]
+    device.default_route.release_axes(device)
+    assert writer.packets[-1] == [(E.EV_ABS, E.ABS_X, 0)]
 
 
 @pytest.mark.parametrize("failed_operation", ["write", "syn"])

--- a/tests/keymasqd/test_default_controller_route.py
+++ b/tests/keymasqd/test_default_controller_route.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+from collections import deque
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock
 
@@ -7,6 +8,7 @@ import evdev
 import pytest
 
 from keymasq.common.model.actions import MappingAction
+from keymasq.common.model.analog import AnalogControlConfig, AnalogMouseMotionConfig
 from keymasq.common.model.core import ActionType, DeviceType
 from keymasq.common.virtual_device_templates import (
     VirtualDeviceConfig,
@@ -15,6 +17,7 @@ from keymasq.common.virtual_device_templates import (
 )
 from keymasq.keymasqd.runtime.default_controller_route import DefaultControllerRoute
 from keymasq.keymasqd.runtime.grabbed_device import device as device_module
+from keymasq.keymasqd.runtime.grabbed_device.event import pipeline
 from keymasq.keymasqd.runtime.grabbed_device.event.pipeline import process_event
 from keymasq.keymasqd.runtime.virtual_gamepads import (
     GamepadOutputRouter,
@@ -34,9 +37,13 @@ class Output(FakeUInput):
         super().__init__()
         self.frames = 0
         self.closed = False
+        self.packets = []
+        self._flushed = 0
 
     def syn(self):
         self.frames += 1
+        self.packets.append(self.writes[self._flushed:])
+        self._flushed = len(self.writes)
 
     def close(self):
         self.closed = True
@@ -168,7 +175,7 @@ async def test_output_replacement_releases_old_state_and_uses_new_instance(route
     assert (E.EV_KEY, E.BTN_SOUTH, 0) in writer.writes
     assert (E.EV_ABS, E.ABS_X, 0) in writer.writes
     await send(device, E.EV_ABS, E.ABS_X, 0)
-    assert replacement.writes == [(E.EV_ABS, E.ABS_X, -32768)]
+    assert replacement.writes == [(E.EV_ABS, E.ABS_X, 32767), (E.EV_ABS, E.ABS_X, -32768)]
 
 
 async def test_missing_target_drops_output_without_clone_fallback(routed):
@@ -264,3 +271,129 @@ async def test_grab_skips_clone_and_route_change_releases_old_output(monkeypatch
     finally:
         await device.release()
     assert not writer.closed
+
+
+async def test_deferred_routed_release_is_flushed_in_its_source_report(routed):
+    device, writer, mapping, _ = routed
+    device.device = SimpleNamespace(
+        absinfo=lambda code: evdev.AbsInfo(128, 0, 255, 0, 0, 0),
+        read_one=lambda: None,
+    )
+    device.update_analog_inputs({
+        "stick": {"type": "stick", "axes": [
+            {"role": "x", "evdev": "abs_x"},
+            {"role": "y", "evdev": "abs_y"},
+        ]},
+    })
+    mapping["stick"] = MappingAction(
+        action_type=ActionType.ANALOG_CONTROL,
+        analog_control_config=AnalogControlConfig(
+            name="Area", mouse_motion=AnalogMouseMotionConfig(enabled=True, mode="area")
+        ),
+    )
+    await send(device, E.EV_KEY, E.BTN_SOUTH, 1)
+    await send(device, E.EV_SYN, E.SYN_REPORT, 0)
+    await send(device, E.EV_ABS, E.ABS_X, 128)
+    await send(device, E.EV_KEY, E.BTN_SOUTH, 0)
+    assert device.state.analog_deferred_keys
+    assert (E.EV_KEY, E.BTN_SOUTH, 0) not in writer.writes
+    await send(device, E.EV_SYN, E.SYN_REPORT, 0)
+    assert any((E.EV_KEY, E.BTN_SOUTH, 0) in packet for packet in writer.packets)
+    assert device.state.passthrough_frame_output is None
+
+
+@pytest.mark.parametrize("action_type", [None, ActionType.PASSTHROUGH, ActionType.SUPPRESS])
+async def test_startup_and_replacement_publish_unchanged_axes(monkeypatch, routed, action_type):
+    device, writer, mapping, state = routed
+    device.default_route = DefaultControllerRoute("virtual-gamepad-1", {E.ABS_X: (0, 255)})
+    device.device = SimpleNamespace(
+        absinfo=lambda code: evdev.AbsInfo(255, 0, 255, 0, 0, 0),
+        read_one=lambda: None,
+    )
+    if action_type is None:
+        # Raw axes need initialization even without saved analog definitions.
+        device.update_analog_inputs({})
+    else:
+        mapping["stick"] = MappingAction(action_type=action_type)
+
+    async def no_new_events(runtime):
+        while runtime.state.input_event_buffer:
+            yield runtime.state.input_event_buffer.popleft()
+
+    monkeypatch.setattr(pipeline, "read_events", no_new_events)
+    device.running = True
+    await pipeline.event_loop(device, asyncio_mod=asyncio, log=logging.getLogger(__name__))
+    expected = [] if action_type == ActionType.SUPPRESS else [(E.EV_ABS, E.ABS_X, 32767)]
+    assert writer.writes == expected
+    assert writer.packets == ([expected] if expected else [])
+    replacement = Output()
+    await reconfigure_virtual_gamepads(
+        count=1, current_count=1, output_devices_active=True,
+        grabbed_devices={device.hardware_id: [device]},
+        clear_combo_runtime=AsyncMock(),
+        configure_outputs=lambda _: state.virtual_gamepad_uinputs.update(
+            {"virtual-gamepad-1": replacement}
+        ),
+        set_inactive_count=Mock(), logger=logging.getLogger(__name__),
+        configuration_changed=True,
+    )
+    assert replacement.writes == expected
+    assert replacement.packets == ([expected] if expected else [])
+
+
+async def test_initial_snapshot_does_not_replay_older_queued_axes(monkeypatch, routed):
+    device, writer, _, _ = routed
+    device.default_route = DefaultControllerRoute("virtual-gamepad-1", {E.ABS_X: (0, 255)})
+    queued = deque(evdev.InputEvent(0, 0, kind, code, value) for kind, code, value in [
+        (E.EV_ABS, E.ABS_X, 32),
+        (E.EV_KEY, E.BTN_SOUTH, 1),
+        (E.EV_SYN, E.SYN_REPORT, 0),
+        (E.EV_ABS, E.ABS_X, 64),
+        (E.EV_KEY, E.BTN_SOUTH, 0),
+        (E.EV_SYN, E.SYN_REPORT, 0),
+    ])
+    device.device = SimpleNamespace(
+        absinfo=lambda code: evdev.AbsInfo(255, 0, 255, 0, 0, 0),
+        read_one=lambda: queued.popleft() if queued else None,
+    )
+
+    async def buffered_events(runtime):
+        while runtime.state.input_event_buffer:
+            yield runtime.state.input_event_buffer.popleft()
+
+    monkeypatch.setattr(pipeline, "read_events", buffered_events)
+    device.running = True
+    await pipeline.event_loop(device, asyncio_mod=asyncio, log=logging.getLogger(__name__))
+    assert writer.writes == [
+        (E.EV_KEY, E.BTN_SOUTH, 1), (E.EV_KEY, E.BTN_SOUTH, 0),
+        (E.EV_ABS, E.ABS_X, 32767),
+    ]
+    assert writer.packets[-1] == [(E.EV_ABS, E.ABS_X, 32767)]
+    assert device.default_route.source_values[E.ABS_X] == 255
+    await send(device, E.EV_ABS, E.ABS_X, 0)
+    assert writer.writes[-1] == (E.EV_ABS, E.ABS_X, -32768)
+
+
+@pytest.mark.parametrize("replacement_code", [None, "abs_rz"])
+async def test_removing_or_rebinding_saved_axis_restores_device_bounds(routed, replacement_code):
+    device, writer, _, _ = routed
+    route = device.default_route
+    device.device = SimpleNamespace(
+        absinfo=lambda code: evdev.AbsInfo(0, 0, 255 if code == E.ABS_X else 1023, 0, 0, 0)
+    )
+
+    def definition(code):
+        return {"stick": {"type": "axis", "axes": [
+            {"role": "x", "evdev": code, "minimum": 20, "maximum": 235},
+        ]}}
+
+    device.update_analog_inputs(definition("abs_x"))
+    assert route.axis_ranges[E.ABS_X] == (20, 235)
+    device.update_analog_inputs(definition(replacement_code) if replacement_code else {})
+    await device.update_default_output("virtual-gamepad-1")
+    assert device.default_route is route
+    assert route.axis_ranges[E.ABS_X] == (0, 255)
+    if replacement_code:
+        assert route.axis_ranges[E.ABS_RZ] == (20, 235)
+    await send(device, E.EV_ABS, E.ABS_X, 128)
+    assert writer.writes == [(E.EV_ABS, E.ABS_X, 128)]

--- a/tests/keymasqd/test_default_controller_route.py
+++ b/tests/keymasqd/test_default_controller_route.py
@@ -1,0 +1,228 @@
+import asyncio
+import logging
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+
+import evdev
+import pytest
+
+from keymasq.common.model.actions import MappingAction
+from keymasq.common.model.core import ActionType, DeviceType
+from keymasq.common.virtual_device_templates import (
+    VirtualDeviceConfig,
+    VirtualDeviceInstance,
+    resolve_virtual_devices,
+)
+from keymasq.keymasqd.runtime.default_controller_route import DefaultControllerRoute
+from keymasq.keymasqd.runtime.grabbed_device import device as device_module
+from keymasq.keymasqd.runtime.grabbed_device.event.pipeline import process_event
+from keymasq.keymasqd.runtime.virtual_gamepads import (
+    GamepadOutputRouter,
+    reconfigure_virtual_gamepads,
+)
+from tests.keymasqd.device_manager_support import (
+    FakeUInput,
+    grabbed_event_processing_deps,
+    make_grabbed_device,
+)
+
+E = evdev.ecodes
+
+
+class Output(FakeUInput):
+    def __init__(self):
+        super().__init__()
+        self.frames = 0
+        self.closed = False
+
+    def syn(self):
+        self.frames += 1
+
+    def close(self):
+        self.closed = True
+
+
+@pytest.fixture
+def routed(monkeypatch):
+    writer = Output()
+    config = VirtualDeviceConfig(
+        devices=(VirtualDeviceInstance("flight", "logitech-extreme-3d-pro"),)
+    )
+    state = SimpleNamespace(
+        virtual_gamepad_uinputs={"virtual-gamepad-1": writer, "flight": Output()},
+        virtual_device_specs={spec.output_id: spec for spec in resolve_virtual_devices(1, config)},
+    )
+    router = GamepadOutputRouter(logging.getLogger(__name__))
+    mapping = {}
+    device = make_grabbed_device(
+        monkeypatch,
+        device_type=DeviceType.GAMEPAD,
+        default_output="virtual-gamepad-1",
+        button_map={"south": "btn_south"},
+        mapping_getter=lambda: mapping,
+        gamepad_output_resolver=lambda output_id, context: router.resolve(
+            state, {}, output_id, context=context
+        ),
+        analog_inputs={
+            "stick": {"type": "stick", "axes": [{"role": "x", "evdev": "abs_x"}]},
+        },
+    )
+    device.default_route = DefaultControllerRoute(
+        "virtual-gamepad-1", {E.ABS_X: (0, 255), E.ABS_RZ: (0, 1023)}
+    )
+    return device, writer, mapping, state
+
+
+async def send(device, event_type, code, value):
+    await process_event(
+        device,
+        evdev.InputEvent(0, 0, event_type, code, value),
+        deps=grabbed_event_processing_deps(),
+    )
+
+
+async def test_same_codes_only_and_source_frame_boundaries(routed):
+    device, writer, _, _ = routed
+    for code in (E.BTN_SOUTH, E.BTN_TL2, E.BTN_Z):
+        await send(device, E.EV_KEY, code, 1)
+    await send(device, E.EV_ABS, E.ABS_X, 255)
+    await send(device, E.EV_ABS, E.ABS_THROTTLE, 200)
+    await send(device, E.EV_REL, E.REL_X, 8)
+    assert writer.writes == [
+        (E.EV_KEY, E.BTN_SOUTH, 1),
+        (E.EV_KEY, E.BTN_TL2, 1),
+        (E.EV_ABS, E.ABS_X, 32767),
+    ]
+    assert writer.frames == 0
+    await send(device, E.EV_SYN, E.SYN_REPORT, 0)
+    assert writer.frames == 1
+    assert device.uinput is None
+
+
+async def test_mapping_override_and_held_release(routed):
+    device, writer, mapping, _ = routed
+    mapping["south"] = MappingAction(action_type=ActionType.KEYBOARD, target="key_enter")
+    await send(device, E.EV_KEY, E.BTN_SOUTH, 1)
+    previous = dict(mapping)
+    mapping.clear()
+    await device.reset_mapping_runtime_state(previous)
+    await send(device, E.EV_KEY, E.BTN_SOUTH, 0)
+    assert writer.writes == []
+    assert device.keyboard_uinput.writes == [
+        (E.EV_KEY, E.KEY_ENTER, 1),
+        (E.EV_KEY, E.KEY_ENTER, 0),
+    ]
+    await send(device, E.EV_KEY, E.BTN_SOUTH, 1)
+    await send(device, E.EV_KEY, E.BTN_SOUTH, 0)
+    assert writer.writes == [(E.EV_KEY, E.BTN_SOUTH, 1), (E.EV_KEY, E.BTN_SOUTH, 0)]
+
+
+async def test_axis_override_neutralizes_previous_default_output(routed):
+    device, writer, mapping, _ = routed
+    await send(device, E.EV_ABS, E.ABS_X, 255)
+    mapping["stick"] = MappingAction(action_type=ActionType.SUPPRESS)
+    await device.reset_mapping_runtime_state({})
+    await send(device, E.EV_ABS, E.ABS_X, 0)
+    assert writer.writes == [(E.EV_ABS, E.ABS_X, 32767), (E.EV_ABS, E.ABS_X, 0)]
+
+
+async def test_default_press_releases_when_a_mapping_is_added_while_held(routed):
+    device, writer, mapping, _ = routed
+    await send(device, E.EV_KEY, E.BTN_SOUTH, 1)
+    mapping["south"] = MappingAction(action_type=ActionType.SUPPRESS)
+    await device.reset_mapping_runtime_state({})
+    await send(device, E.EV_KEY, E.BTN_SOUTH, 0)
+    await send(device, E.EV_KEY, E.BTN_SOUTH, 1)
+    assert writer.writes == [(E.EV_KEY, E.BTN_SOUTH, 1), (E.EV_KEY, E.BTN_SOUTH, 0)]
+
+
+async def test_combo_recall_and_restore_use_routed_output(routed):
+    device, writer, _, _ = routed
+    await send(device, E.EV_KEY, E.BTN_SOUTH, 1)
+    assert device.combo_passthrough_binding_active("btn_south")
+    device.emit_combo_release("btn_south")
+    assert not device.combo_passthrough_binding_active("btn_south")
+    device.emit_combo_press("btn_south")
+    await send(device, E.EV_KEY, E.BTN_SOUTH, 0)
+    assert writer.writes == [(E.EV_KEY, E.BTN_SOUTH, value) for value in (1, 0, 1, 0)]
+
+
+async def test_output_replacement_releases_old_state_and_uses_new_instance(routed):
+    device, writer, _, state = routed
+    await send(device, E.EV_KEY, E.BTN_SOUTH, 1)
+    await send(device, E.EV_ABS, E.ABS_X, 255)
+    replacement = Output()
+    await reconfigure_virtual_gamepads(
+        count=1,
+        current_count=1,
+        output_devices_active=True,
+        grabbed_devices={device.hardware_id: [device]},
+        clear_combo_runtime=AsyncMock(),
+        configure_outputs=lambda _: state.virtual_gamepad_uinputs.update(
+            {"virtual-gamepad-1": replacement}
+        ),
+        set_inactive_count=Mock(),
+        logger=logging.getLogger(__name__),
+        configuration_changed=True,
+    )
+    assert (E.EV_KEY, E.BTN_SOUTH, 0) in writer.writes
+    assert (E.EV_ABS, E.ABS_X, 0) in writer.writes
+    await send(device, E.EV_ABS, E.ABS_X, 0)
+    assert replacement.writes == [(E.EV_ABS, E.ABS_X, -32768)]
+
+
+async def test_missing_target_drops_output_without_clone_fallback(routed):
+    device, writer, _, state = routed
+    state.virtual_gamepad_uinputs.clear()
+    device.uinput = Output()
+    await send(device, E.EV_KEY, E.BTN_SOUTH, 1)
+    await send(device, E.EV_ABS, E.ABS_X, 255)
+    assert writer.writes == []
+    assert device.uinput.writes == []
+
+
+async def test_flight_axis_keeps_code_and_uses_target_range_and_release(routed):
+    device, _, _, state = routed
+    device.default_output = "flight"
+    device.default_route.output_id = "flight"
+    writer = state.virtual_gamepad_uinputs["flight"]
+    await send(device, E.EV_ABS, E.ABS_RZ, 1023)
+    assert writer.writes == [(E.EV_ABS, E.ABS_RZ, 255)]
+    await device.release()
+    assert (E.EV_ABS, E.ABS_RZ, 127) in writer.writes
+    assert not writer.closed
+
+
+async def test_grab_skips_clone_and_route_change_releases_old_output(monkeypatch, routed):
+    device, writer, _, state = routed
+
+    async def input_events():
+        await asyncio.Event().wait()
+        yield evdev.InputEvent(0, 0, E.EV_SYN, E.SYN_REPORT, 0)
+
+    physical = Mock()
+    physical.capabilities.return_value = {
+        E.EV_KEY: [E.BTN_SOUTH],
+        E.EV_ABS: [(E.ABS_X, evdev.AbsInfo(0, 0, 255, 0, 0, 0))],
+    }
+    physical.absinfo.return_value = evdev.AbsInfo(0, 0, 255, 0, 0, 0)
+    physical.async_read_loop = input_events
+    monkeypatch.setattr(device_module, "_device_input", lambda _: physical)
+    clone = Mock(side_effect=AssertionError("A default route must not create a clone"))
+    monkeypatch.setattr(device_module, "_copy_passthrough_capabilities", clone)
+    monkeypatch.setattr(device_module.grab, "wait_for_active_keys_to_clear", AsyncMock())
+    monkeypatch.setattr(device_module.source_hiding, "hide_source", AsyncMock(return_value=[]))
+    await device.grab()
+    try:
+        await send(device, E.EV_KEY, E.BTN_SOUTH, 1)
+        await send(device, E.EV_ABS, E.ABS_X, 255)
+        await device.update_default_output("flight")
+        assert (E.EV_KEY, E.BTN_SOUTH, 0) in writer.writes
+        assert (E.EV_ABS, E.ABS_X, 0) in writer.writes
+        await send(device, E.EV_ABS, E.ABS_X, 255)
+        assert state.virtual_gamepad_uinputs["flight"].writes[-1] == (E.EV_ABS, E.ABS_X, 1023)
+        assert device.uinput is None
+        clone.assert_not_called()
+    finally:
+        await device.release()
+    assert not writer.closed

--- a/tests/keymasqd/test_default_controller_route.py
+++ b/tests/keymasqd/test_default_controller_route.py
@@ -181,6 +181,44 @@ async def test_missing_target_drops_output_without_clone_fallback(routed):
     assert device.uinput.writes == []
 
 
+@pytest.mark.parametrize("failed_operation", ["write", "syn"])
+async def test_closed_axis_output_does_not_interrupt_source_release(routed, failed_operation):
+    device, writer, _, _ = routed
+    await send(device, E.EV_ABS, E.ABS_X, 255)
+    physical = Mock()
+    device.device = physical
+    setattr(writer, failed_operation, Mock(side_effect=OSError("output closed")))
+    await device.release()
+    physical.ungrab.assert_called_once()
+    physical.close.assert_called_once()
+    assert device.device is None
+    assert not device.default_route.axes
+    assert not any(device.state.held_output_abs.values())
+
+
+def test_virtual_target_cache_tracks_output_and_template_replacement(routed):
+    device, writer, _, state = routed
+    def resolve():
+        return device.resolve_gamepad_output("virtual-gamepad-1", "test")
+
+    target = resolve()
+    assert resolve() is target
+    state.virtual_gamepad_uinputs["virtual-gamepad-1"] = Output()
+    replacement = resolve()
+    assert replacement is not target
+    assert replacement.uinput is not writer
+    assert replacement.stick_output is not target.stick_output
+    state.virtual_device_specs["virtual-gamepad-1"] = state.virtual_device_specs["flight"]
+    changed_template = resolve()
+    assert changed_template is not replacement
+    assert changed_template.stick_output is replacement.stick_output
+    assert changed_template.axis_ranges[E.ABS_X] == (0, 1023)
+    state.virtual_gamepad_uinputs.clear()
+    assert resolve() is None
+    state.virtual_gamepad_uinputs["virtual-gamepad-1"] = replacement.uinput
+    assert resolve() is not changed_template
+
+
 async def test_flight_axis_keeps_code_and_uses_target_range_and_release(routed):
     device, _, _, state = routed
     device.default_output = "flight"

--- a/tests/session/test_default_controller_route.py
+++ b/tests/session/test_default_controller_route.py
@@ -1,0 +1,140 @@
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+
+from keymasq.common.model.core import DeviceType
+from keymasq.common.model.hardware import EvdevDevice, HardwareConfig
+from keymasq.session.manager.profile.grab_plan import (
+    build_grab_device_payload,
+    get_interfaces_to_grab,
+    grab_device_payload_signature,
+)
+from keymasq.session.profile.codec import ProfileCodec
+from keymasq.session.profile.resolution import ProfileResolver
+from keymasq.session.profile.types import ProfileInfo, ResolvedDeviceProfile
+
+
+def test_route_alone_selects_controller_interfaces_and_changes_grab_signature():
+    hardware = HardwareConfig(
+        "1234",
+        "5678",
+        "Composite controller",
+        [
+            EvdevDevice("/dev/input/event0", DeviceType.GAMEPAD, "pad"),
+            EvdevDevice("/dev/input/event1", DeviceType.MOTION, "imu"),
+            EvdevDevice("/dev/input/event2", DeviceType.KEYBOARD, "keyboard"),
+            EvdevDevice(
+                "/dev/input/event3",
+                DeviceType.OTHER,
+                "extra",
+                capabilities=[
+                    "abs_x",
+                    "abs_y",
+                    "btn_trigger",
+                ],
+            ),
+        ],
+        [],
+    )
+    hardware.default_output = "virtual-gamepad-1"
+    resolved = ResolvedDeviceProfile(hardware.hardware_id)
+    manager = Mock()
+    manager.resolved_button_codes.return_value = {}
+    interfaces = get_interfaces_to_grab(hardware, resolved, manager=manager)
+    assert interfaces == {"pad": "/dev/input/event0", "extra": "/dev/input/event3"}
+    payload = build_grab_device_payload(
+        manager,
+        hardware.hardware_id,
+        hardware,
+        resolved,
+        interfaces,
+    )
+    assert payload["force_grab_unmapped"] is True
+    assert payload["default_output"] == "virtual-gamepad-1"
+    before = grab_device_payload_signature(payload)
+    payload["default_output"] = "flight"
+    assert grab_device_payload_signature(payload) != before
+
+
+@pytest.mark.parametrize("output", ["passthrough", "virtual-gamepad-1", "flight", "missing"])
+def test_hardware_route_roundtrip(tmp_path, monkeypatch, output):
+    from keymasq.session.hardware import HardwareManager
+
+    monkeypatch.setattr("keymasq.common.paths.HARDWARE_DIR", tmp_path)
+    manager = HardwareManager()
+    hardware = HardwareConfig("1234", "5678", "Controller", [], [], default_output=output)
+    manager.save_hardware(hardware)
+    loaded = HardwareManager().get_hardware(hardware.hardware_id)
+    assert loaded.default_output == output
+
+
+def test_profile_does_not_store_or_resolve_output():
+    codec = ProfileCodec()
+    profile = codec.decode(
+        {
+            "profile": {"name": "Test", "is_permanent": True},
+            "devices": {"pad": {"default_output": "flight"}},
+        },
+        default_name="Test",
+    ).config
+    devices = codec.encode(profile)["devices"]
+    assert isinstance(devices, dict)
+    assert "default_output" not in devices["pad"]
+    result = ProfileResolver({"Test": ProfileInfo(Path("test"), profile)}).resolve()
+    assert not result.devices["pad"].has_effective_mapping
+
+
+@pytest.mark.asyncio
+async def test_hardware_route_without_profiles_and_after_mapping_changes():
+    from unittest.mock import AsyncMock
+
+    from keymasq.common.ipc import CommandType, Response
+    from keymasq.common.model.actions import MappingAction
+    from keymasq.common.model.core import ActionType
+    from keymasq.common.model.hardware import ButtonDefinition
+    from keymasq.session.manager.core import SessionManager
+    from keymasq.session.manager.profile import coordinator
+    from keymasq.session.profile.types import ResolvedProfiles
+
+    manager = SessionManager()
+    hardware = HardwareConfig(
+        "1234",
+        "5678",
+        "Pad",
+        [
+            EvdevDevice("/dev/input/event0", DeviceType.GAMEPAD, "pad"),
+        ],
+        [ButtonDefinition("south", "South", "btn_south", source="pad")],
+        default_output="virtual-gamepad-1",
+    )
+    manager.hardware.list_hardware_ids = lambda: [hardware.hardware_id]
+    manager.hardware.get_hardware = lambda _: hardware
+    resolved = ResolvedProfiles()
+    manager.profiles.resolve_active_profiles = lambda *args, **kwargs: resolved
+    manager.client.send_command = AsyncMock(
+        return_value=Response(status="ok", data={"grabbed_count": 1, "updated": True})
+    )
+
+    await coordinator.reevaluate_profiles(manager)
+    commands = [call.args[0] for call in manager.client.send_command.await_args_list]
+    assert commands[0].command == CommandType.GRAB_DEVICE
+    assert commands[0].data["default_output"] == "virtual-gamepad-1"
+    assert hardware.hardware_id in manager.profile_state.grabbed_devices
+    manager.client.send_command.reset_mock()
+    resolved.devices[hardware.hardware_id] = ResolvedDeviceProfile(
+        hardware.hardware_id, mappings={"south": MappingAction(ActionType.SUPPRESS)}
+    )
+    await coordinator.reevaluate_profiles(manager)
+    resolved.devices.clear()
+    await coordinator.reevaluate_profiles(manager)
+    commands = [call.args[0] for call in manager.client.send_command.await_args_list]
+    assert commands
+    assert all(c.command == CommandType.SET_MAPPING for c in commands)
+    assert hardware.hardware_id in manager.profile_state.grabbed_devices
+
+    manager.client.send_command.reset_mock()
+    hardware.default_output = "passthrough"
+    await coordinator.reevaluate_profiles(manager)
+    commands = [call.args[0] for call in manager.client.send_command.await_args_list]
+    assert commands[0].command == CommandType.RELEASE_DEVICE


### PR DESCRIPTION
## Summary

Controllers can now use a configured virtual controller as their default output, selected during hardware setup or in Hardware Settings. The destination stays the same across profiles and remains active with no profiles enabled. Passthrough remains the default.

Unmapped buttons and axes route by matching evdev code, with axis bounds scaled to the destination. Unsupported inputs and unavailable outputs produce no output. Current axis positions are sent when routing starts or the destination is recreated. Individual mappings override the route. The key selector preselects the hardware's virtual output for unmapped and passthrough buttons.

## Testing

- [x] `./scripts/check.sh` passed. The latest daemon changes passed 1,354 tests, with 28 skipped. The full suite passed before those changes.
- [x] Regression coverage includes deferred button synchronization, initial and replacement axis state, queued input ordering, mapping overrides, and removal of saved axis bounds.
- [x] `daemon_session` VM integration suite passed without regressions before the review fixes.
  - GUI VM suites skipped, not needed for this change.
- [x] Docshots unchanged.

## Notes

- Packaging: no changes.
- Service: routed controller interfaces stay grabbed without active profiles and do not create passthrough clones. Changing the destination releases held output state.
- GUI: adds the controller output setting to hardware setup and settings, shows default routes on input cards, and preselects the destination in the key selector.
